### PR TITLE
Tileset Bug (SDL/Pixman BMP handler broken)

### DIFF
--- a/src/image_bmp.cpp
+++ b/src/image_bmp.cpp
@@ -59,6 +59,7 @@ void ImageBMP::ReadBMP(const uint8_t* data, unsigned len, bool transparent,
 	// 6	2	reserved
 	// 8	2	reserved
 	// 10	4	offset to bitmap data
+	static const uint BITMAPFILEHEADER_SIZE = 14;
 
 	if (len < 64 || strncmp((char*) &data[0], "BM", 2) != 0) {
 		Output::Error("Not a valid BMP file.");
@@ -88,56 +89,56 @@ void ImageBMP::ReadBMP(const uint8_t* data, unsigned len, bool transparent,
 	// 36	4	number of important palette colors
 	// 40 ... palette
 
-	data += 14;
-
 	static const unsigned BITMAPINFOHEADER_SIZE = 40;
-	if (get_4(&data[0]) != BITMAPINFOHEADER_SIZE) {
+	if (get_4(&data[BITMAPFILEHEADER_SIZE + 0]) != BITMAPINFOHEADER_SIZE) {
 		Output::Error("Incorrect BMP header size.");
 		return;
 	}
 
-	width = (int) get_4(&data[4]);
-	height = (int) get_4(&data[8]);
+	width = (int) get_4(&data[BITMAPFILEHEADER_SIZE + 4]);
+	height = (int) get_4(&data[BITMAPFILEHEADER_SIZE + 8]);
 
 	bool vflip = height > 0;
 	if (!vflip)
 		height = -height;
 
-	const int planes = (int) get_2(&data[12]);
+	const int planes = (int) get_2(&data[BITMAPFILEHEADER_SIZE + 12]);
 	if (planes != 1) {
 		Output::Error("BMP planes is not 1.");
 		return;
 	}
 
-	const int depth = (int) get_2(&data[14]);
+	const int depth = (int) get_2(&data[BITMAPFILEHEADER_SIZE + 14]);
 	if (depth != 8) {
 		Output::Error("BMP image is not 8-bit.");
 		return;
 	}
 
-	const int compression = get_4(&data[16]);
+	const int compression = get_4(&data[BITMAPFILEHEADER_SIZE + 16]);
 	static const int BI_RGB = 0;
 	if (compression != BI_RGB) {
 		Output::Error("BMP image is compressed.");
 		return;
 	}
 
-	int image_size = get_4(&data[20]);
+	int image_size = get_4(&data[BITMAPFILEHEADER_SIZE + 20]);
 	if (image_size != 0 && image_size != width * height) {
 		Output::Error("Invalid BMP image size.");
 		return;
 	}
 
-	int num_colors = std::min(256U, (bits_offset - 54) / 4);
-	uint8_t (*palette)[4] = (uint8_t(*)[4]) &data[40];
+	int num_colors = std::min(256U, get_4(&data[BITMAPFILEHEADER_SIZE + 36]));
+	uint8_t (*palette)[4] = (uint8_t(*)[4]) &data[BITMAPFILEHEADER_SIZE + 40];
 	const uint8_t* src_pixels = &data[bits_offset];
 
 	// Ensure no palette entry is an exact duplicate of #0
-	for (int i = 1; i < num_colors; i++)
+	for (int i = 1; i < num_colors; i++) {
 		if (palette[i][0] == palette[0][0] &&
 			palette[i][1] == palette[0][1] &&
-			palette[i][2] == palette[0][2])
+			palette[i][2] == palette[0][2]) {
 			palette[i][0] ^= 1;
+		}
+	}
 
 	pixels = malloc(width * height * 4);
 
@@ -158,9 +159,9 @@ void ImageBMP::ReadBMP(const uint8_t* data, unsigned len, bool transparent,
 ////////////////////////////////////////////////////////////
 void ImageBMP::ReadBMP(FILE* stream, bool transparent,
 					int& width, int& height, void*& pixels) {
-    fseek(stream, 0, SEEK_END);
-    long size = ftell(stream);
-    fseek(stream, 0, SEEK_SET);
+	fseek(stream, 0, SEEK_END);
+	long size = ftell(stream);
+	fseek(stream, 0, SEEK_SET);
 	std::vector<uint8_t> buffer(size);
 	fread((void*) &buffer.front(), 1, size, stream);
 	ReadBMP(&buffer.front(), (unsigned) size, transparent, width, height, pixels);


### PR DESCRIPTION
I've found this bug, and I know the reason,
if in the chipset folder there is
2 tilesets with the same name (for example)
cave.png
cave.bmp

In easy appear like this: and in 2k3 only read 1 chipset and look well.

![](http://img607.imageshack.us/img607/8577/88666356.png)
