### PR TITLE
Exit player when image is missing (regression fix for #32)

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -32,6 +32,7 @@
 #include "exfont.h"
 #include "bitmap.h"
 #include "output.h"
+#include "player.h"
 
 ////////////////////////////////////////////////////////////
 namespace {
@@ -53,6 +54,15 @@ namespace {
 
 		if (it == cache.end() || it->second.expired()) {
 			std::string const path = FileFinder::FindImage(folder_name, filename);
+
+			if (path.empty()) {
+				// TODO:
+				// Load a dummy image with correct size (issue #32)
+				Output::Warning("Image not found: %s/%s\n\nPlayer will exit now.", folder_name.c_str(), filename.c_str());
+				// Delayed termination, otherwise it segfaults in Graphics::Quit
+				Player::exit_flag = true;
+			}
+
 			return (cache[key] = path.empty()
 					? Bitmap::Create(16, 16, Color())
 					: Bitmap::Create(path, transparent, flags)


### PR DESCRIPTION
Better then rendering a garbage image... better solution will be added later...
