### PR TITLE
Layered common events misbehave

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -64,7 +64,6 @@ Game_Interpreter::~Game_Interpreter() {
 void Game_Interpreter::Clear() {
 	map_id = 0;						// map ID when starting up
 	event_id = 0;					// event ID
-	StateAftercall=-1;
 	//Game_Message::message_waiting = false;	// waiting for message to end
 	move_route_waiting = false;		// waiting for move completion
 	button_input_variable_id = 0;	// button input variable ID
@@ -225,19 +224,6 @@ void Game_Interpreter::Update() {
 		// faster then Player does.
 		// No idea if any game depends on this special case.
 		index++;
-		
-		// If you are a father and do not have child after an stack call 
-		// reduce index
-		if(((StateAftercall!=(-1))&&(!child_interpreter))&&((index)==(StateAftercall+2)))
-		{
-		index=StateAftercall+1;
-		StateAftercall=-1;
-		}
-		//the setup got correctly  set so remove the stack info
-		if(((StateAftercall!=(-1))&&(!child_interpreter))&&((index)==(StateAftercall+1)))
-		{
-		StateAftercall=-1;
-		}
 	} // for
 
 	// Executed Events Count exceeded (10000)

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -37,7 +37,6 @@ class Game_CommonEvent;
 class Game_Interpreter
 {
 public:
-	int StateAftercall;
 	Game_Interpreter(int _depth = 0, bool _main_flag = false);
 	virtual ~Game_Interpreter();
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -251,7 +251,6 @@ bool Game_Interpreter_Map::ExecuteCommand() {
 		case Cmd::ChangeMapTileset:
 			return CommandChangeMapTileset(com);
 		case Cmd::CallEvent:
-				StateAftercall=index;
 			return CommandCallEvent(com);
 		case Cmd::ChangeEncounterRate:
 			return CommandChangeEncounterRate(com);

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -245,7 +245,7 @@ void Window_Message::Update() {
 	Window_Selectable::Update();
 	number_input_window->Update();
 
-	if (visible && !Game_Message::visible) {
+	if (!IsNextMessagePossible() && visible && !Game_Message::visible) {
 		// The Event Page ended but the MsgBox was used in this Event
 		// It can be closed now.
 		TerminateMessage();


### PR DESCRIPTION
This is a bit of a difficult issue to work out, so I apologise if I am unclear.

I have a dialogue tree where one option leads to separate common events (this event itself is a common event) controlled by conditional branches and labels, another displays text and includes a label, and the last is to close the tree.

In the original player, the internal common event can be started, and will lead back to the original event like so:
Start if x, go to 1 -> label 1 -> inner event plays out -> go to 99 -> 99 is at the start again

However with EasyRPG player, the inner event will loop until the last command is executed: There’s a yes/no branch, an exp check, and then no events should follow after some effects and messages, or an “insufficient exp” alert, but it takes the last event in the list (outside the “<> End” of the branches) to actually return to the outer event – the message that plays via “No” that sits at the end of the code.
Secondly, this cancel instead leads onto the next dialogue option in the outer event, instead of the go to that proceeds the Call common event command.

This diagram may be of more assistance:
[](http://i.imgur.com/lvYsn.png)
