### PR TITLE
wii: workaround broken newlib

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -81,7 +81,8 @@ namespace {
 
 	std::string format_string(char const* fmt, va_list args) {
 		char buf[4096];
-	#if __cplusplus > 199711L
+	// FIXME: devkitppc r27 seems to have broken newlib
+	#if __cplusplus > 199711L && !defined(GEKKO)
 		int const result = vsnprintf(buf, sizeof(buf), fmt, args);
 	#else
 		int const result = vsprintf(buf, fmt, args);


### PR DESCRIPTION
After updating devkitppc from r26 to r27, we have gcc 4.8.2 instead of 4.6.3 and newlib 2.0.0 instead of 1.2.0.
There should be proper c++11 support now and the __cplusplus version changed from `1L` to `201103L`, however there is no vsnprintf().
This should fix the wii build for now.
