### PR TITLE
CMakeLists.txt: Fix boost paths and C++11 compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,12 @@ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/lib/liblcf/src")
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/lib/liblcf/src/generated")
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src")
 
-foreach(i Expat Freetype Pixman ZLIB PNG SDL2 Boost Iconv)
+# Boost
+find_package(Boost REQUIRED)
+include_directories(${Boost_INCLUDE_DIR})
+list(APPEND EASYRPG_PLAYER_LIBRARIES ${Boost_LIBRARIES})
+
+foreach(i Expat Freetype Pixman ZLIB PNG SDL2 Iconv)
   find_package(${i} REQUIRED)
 
   string(TOUPPER ${i} i)


### PR DESCRIPTION
@take-cheeze review please?

The 'string(TOUPPER ${i} i)' directive ensures correct inclusion
of all found packages except Boost, where the variable name has
to stay in its original mixed case form (not 'BOOST' but 'Boost').
To generalize this, just include both uppercase path variables
and normal case ones.

Before, I just added 3 extra lines that find_package()'d and included boost manually, but this approach looks more general.

This patch also includes passing the `-std=c++0x` flag to the compiler, which for some reason doesn't happen on my system automatically.