### PR TITLE
Always draw equipment stats (even when 'empty' item is chosen)

### DIFF
--- a/src/window_equipstatus.cpp
+++ b/src/window_equipstatus.cpp
@@ -63,12 +63,10 @@ void Window_EquipStatus::SetNewParameters(
 
 	dirty = true;
 
-	if (dirty) {
-		atk = new_atk;
-		def = new_def;
-		spi = new_spi;
-		agi = new_agi;
-	}
+	atk = new_atk;
+	def = new_def;
+	spi = new_spi;
+	agi = new_agi;
 }
 
 void Window_EquipStatus::ClearParameters() {


### PR DESCRIPTION
Closes #329

Please note that this changes to RPG_RT behaviour, not the behaviour described in #329. In RPG_RT, stats are **always shown** for empty items, while #329 suggests stats are **never** shown for empty items.
