### PR TITLE
Fix bug with variable indexing.

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -803,40 +803,41 @@ bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { /
 			break;
 
 		case 2:
+			int var_index = Game_Variables[com.parameters[1]];
 			switch (com.parameters[3]) {
 				case 0:
 					// Assignement
-					Game_Variables[com.parameters[1]] = value;
+					Game_Variables[var_index] = value;
 					break;
 				case 1:
 					// Addition
-					Game_Variables[com.parameters[1]] += value;
+					Game_Variables[var_index] += value;
 					break;
 				case 2:
 					// Subtraction
-					Game_Variables[com.parameters[1]] -= value;
+					Game_Variables[var_index] -= value;
 					break;
 				case 3:
 					// Multiplication
-					Game_Variables[com.parameters[1]] *= value;
+					Game_Variables[var_index] *= value;
 					break;
 				case 4:
 					// Division
 					if (value != 0) {
-						Game_Variables[com.parameters[1]] /= value;
+						Game_Variables[var_index] /= value;
 					}
 					break;
 				case 5:
 					// Module
 					if (value != 0) {
-						Game_Variables[com.parameters[1]] %= value;
+						Game_Variables[var_index] %= value;
 					}
 			}
-			if (Game_Variables[com.parameters[1]] > MaxSize) {
-				Game_Variables[com.parameters[1]] = MaxSize;
+			if (Game_Variables[var_index] > MaxSize) {
+				Game_Variables[var_index] = MaxSize;
 			}
-			if (Game_Variables[com.parameters[1]] < MinSize) {
-				Game_Variables[com.parameters[1]] = MinSize;
+			if (Game_Variables[var_index] < MinSize) {
+				Game_Variables[var_index] = MinSize;
 			}
 	}
 


### PR DESCRIPTION
Hi,
This is a bug fix for a problem with "Variable Reference" functionality of rpgmaker 2003.
This one:
![RPG Maker 2003 variables](http://rpgmaker.net/media/content/users/3355/locker/Tutorial_Pointer2.PNG)

Here's an example project that shows the bug:

https://dl.dropboxusercontent.com/u/55372319/TestVariables.zip

Talking to the dog in RPG_RT.exe returns this:
![RPG_RT output](http://s12.postimg.org/b85ahfm25/Schermata_2015_01_03_alle_12_15_38.png)
In easyrpg-player returns this:
![EasyRPG output](http://i58.tinypic.com/2j5mlfm.jpg)

