### PR TITLE
Add enemy drops after battle

### DIFF
--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -153,6 +153,14 @@ int Game_Enemy::GetMoney() const {
 	return enemy->gold;
 }
 
+int Game_Enemy::GetDropId() const {
+	return enemy->drop_id;
+}
+
+int Game_Enemy::GetDropProbability() const {
+	return enemy->drop_prob;
+}
+
 bool Game_Enemy::IsActionValid(const RPG::EnemyAction& action) {
 	switch (action.condition_type) {
 	case RPG::EnemyAction::ConditionType_always:

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -135,6 +135,21 @@ public:
 
 	int GetMoney() const;
 
+	/**
+	 * Get's the ID of the item the enemy drops when defeated.
+	 *
+	 * @return Dropped item ID, or 0 if no drop
+	 */
+	int GetDropId() const;
+
+	/**
+	 * Get's the probability that the enemy's item will be
+	 * dropped.
+	 *
+	 * @return Probability of drop as a percent (0-100)
+	 */
+	int GetDropProbability() const;
+
 	BattlerType GetType() const;
 
 	bool IsActionValid(const RPG::EnemyAction& action);

--- a/src/game_enemyparty.cpp
+++ b/src/game_enemyparty.cpp
@@ -16,6 +16,7 @@
  */
 
 // Headers
+#include <cstdlib>
 #include "game_interpreter.h"
 #include "game_enemyparty.h"
 #include "game_enemy.h"
@@ -81,4 +82,17 @@ int Game_EnemyParty::GetMoney() const {
 		sum += (*it)->GetMoney();
 	}
 	return sum;
+}
+
+void Game_EnemyParty::GenerateDrops(std::vector<int>& out) const {
+	std::vector<EASYRPG_SHARED_PTR<Game_Enemy> >::const_iterator it;
+	for (it = enemies.begin(); it != enemies.end(); ++it) {
+		// Only roll if the enemy has something to drop
+		if ((*it)->GetDropId() != 0) {
+			bool dropped = (rand() % 100) < (*it)->GetDropProbability();
+			if (dropped) {
+				out.push_back((*it)->GetDropId());
+			}
+		}
+	}
 }

--- a/src/game_enemyparty.h
+++ b/src/game_enemyparty.h
@@ -73,6 +73,13 @@ public:
 	 */
 	int GetMoney() const;
 
+	/**
+	 * Rolls once for each enemy's drops.
+	 *
+	 * @param out List of the dropped items' IDs
+	 */
+	void GenerateDrops(std::vector<int>& out) const;
+
 private:
 	std::vector<EASYRPG_SHARED_PTR<Game_Enemy> > enemies;
 	RPG::Troop* troop;

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -748,6 +748,8 @@ bool Scene_Battle_Rpg2k::CheckWin() {
 
 		int exp = Main_Data::game_enemyparty->GetExp();
 		int money = Main_Data::game_enemyparty->GetMoney();
+		std::vector<int> drops;
+		Main_Data::game_enemyparty->GenerateDrops(drops);
 
 		Game_Message::SetPositionFixed(true);
 		Game_Message::SetPosition(2);
@@ -762,6 +764,12 @@ bool Scene_Battle_Rpg2k::CheckWin() {
 		ss << Data::terms.gold_recieved_a << " " << money << Data::terms.gold << Data::terms.gold_recieved_b;
 		Game_Message::texts.push_back(ss.str());
 
+		for (std::vector<int>::iterator it = drops.begin(); it != drops.end(); ++it) {
+			ss.str("");
+			ss << Data::items[*it - 1].name << Data::terms.item_recieved;
+			Game_Message::texts.push_back(ss.str());
+		}
+
 		Game_System::BgmPlay(Data::system.battle_end_music);
 
 		// Update attributes
@@ -774,6 +782,9 @@ bool Scene_Battle_Rpg2k::CheckWin() {
 				actor->ChangeExp(actor->GetExp() + exp, true);
 		}
 		Main_Data::game_party->GainGold(money);
+		for (std::vector<int>::iterator it = drops.begin(); it != drops.end(); ++it) {
+			Main_Data::game_party->AddItem(*it, 1);
+		}
 
 		return true;
 	}

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -581,7 +581,11 @@ void Scene_Battle_Rpg2k3::ProcessInput() {
 			// no-op
 			break;
 		case State_Victory:
-			Scene::Pop();
+			if (message_window->IsNextMessagePossible()) {
+				message_window->Update();
+			} else {
+				Scene::Pop();
+			}
 			break;
 		case State_Defeat:
 			if (Player::battle_test_flag || Game_Temp::battle_defeat_mode != 0) {
@@ -625,7 +629,11 @@ void Scene_Battle_Rpg2k3::ProcessInput() {
 			break;
 		case State_Victory:
 		case State_Defeat:
-			Scene::Pop();
+			if (message_window->IsNextMessagePossible()) {
+				message_window->Update();
+			} else {
+				Scene::Pop();
+			}
 			break;
 		case State_Escape:
 			// no-op
@@ -769,7 +777,6 @@ bool Scene_Battle_Rpg2k3::CheckWin() {
 
 		Game_Message::texts.push_back(Data::terms.victory + "\f");
 
-		// FIXME nothing after the victory message seems to be displayed
 		std::stringstream ss;
 		ss << exp << Data::terms.exp_received << "\f";
 		Game_Message::texts.push_back(ss.str());

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -764,9 +764,12 @@ bool Scene_Battle_Rpg2k3::CheckWin() {
 
 		int exp = Main_Data::game_enemyparty->GetExp();
 		int money = Main_Data::game_enemyparty->GetMoney();
+		std::vector<int> drops;
+		Main_Data::game_enemyparty->GenerateDrops(drops);
 
 		Game_Message::texts.push_back(Data::terms.victory + "\f");
 
+		// FIXME nothing after the victory message seems to be displayed
 		std::stringstream ss;
 		ss << exp << Data::terms.exp_received << "\f";
 		Game_Message::texts.push_back(ss.str());
@@ -774,6 +777,12 @@ bool Scene_Battle_Rpg2k3::CheckWin() {
 		ss.str("");
 		ss << Data::terms.gold_recieved_a << " " << money << Data::terms.gold << Data::terms.gold_recieved_b << "\f";
 		Game_Message::texts.push_back(ss.str());
+
+		for(std::vector<int>::iterator it = drops.begin(); it != drops.end(); ++it) {
+			ss.str("");
+			ss << Data::items[*it - 1].name << Data::terms.item_recieved << "\f";
+			Game_Message::texts.push_back(ss.str());
+		}
 
 		message_window->SetHeight(32);
 		Game_Message::SetPositionFixed(true);
@@ -792,6 +801,9 @@ bool Scene_Battle_Rpg2k3::CheckWin() {
 				actor->ChangeExp(actor->GetExp() + exp, true);
 		}
 		Main_Data::game_party->GainGold(money);
+		for (std::vector<int>::iterator it = drops.begin(); it != drops.end(); ++it) {
+			Main_Data::game_party->AddItem(*it, 1);
+		}
 
 		return true;
 	}


### PR DESCRIPTION
This should fix #398. Also fixes a related problem where the Gold/EXP/Level Up messages don't show at the end of an RPG2k3 battle. I'm not sure if there's a better way to do that last part though.