### PR TITLE
Implement multi-use items.

### DIFF
--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -562,7 +562,7 @@ void Game_BattleAlgorithm::Skill::Apply() {
 	AlgorithmBase::Apply();
 
 	if (item) {
-		Main_Data::game_party->RemoveItem(item->ID, 1);
+		Main_Data::game_party->ConsumeItemUse(item->ID);
 	}
 	else {
 		source->SetSp(source->GetSp() - source->CalculateSkillCost(skill.ID));

--- a/src/game_party.h
+++ b/src/game_party.h
@@ -142,6 +142,14 @@ public:
 	void RemoveItem(int item_id, int amount);
 
 	/**
+	 * Consumes one use of an item (eg. for multi-use items).
+	 * Doesn't actually do anything with the item, just uses up one use.
+	 *
+	 * @param item_id database item ID
+	 */
+	void ConsumeItemUse(int item_id);
+
+	/**
 	 * Gets if item can be used.
 	 *
 	 * @param item_id database item ID.


### PR DESCRIPTION
When using an item, only one "use" should be used up now.

A quick test in RM2K showed
* the number of uses resets when an item is removed
* the number of uses stays the same when an item is added, even if the player already had x99 of the item

Also, for the same reason as #399, using a special item in battle consumes a number of uses equal to the number of targets, currently.