### PR TITLE
Fixes for Rainbow Treasure OP

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -1018,7 +1018,11 @@ int Game_Character::BeginJump(const RPG::MoveRoute* current_route, int current_i
 int Game_Character::EndJump(const RPG::MoveRoute* current_route, int current_index) {
 	jumping = false;
 
-	if (!IsLandable(jump_x + jump_plus_x, jump_y + jump_plus_y)) {
+	if (
+		// A character can always land on a tile they were already standing on
+		!(jump_plus_x == 0 && jump_plus_y == 0) &&
+		!IsLandable(jump_x + jump_plus_x, jump_y + jump_plus_y)
+	) {
 		// Reset to begin jump command and try again...
 		move_failed = true;
 

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -142,11 +142,11 @@ void Game_Character::MoveTo(int x, int y) {
 }
 
 int Game_Character::GetScreenX() const {
-	return (real_x - Game_Map::GetDisplayX() + 3) / (SCREEN_TILE_WIDTH / TILE_SIZE) + (TILE_SIZE/2);
+	return real_x / (SCREEN_TILE_WIDTH / TILE_SIZE) - Game_Map::GetDisplayX() / (SCREEN_TILE_WIDTH / TILE_SIZE) + (TILE_SIZE/2);
 }
 
 int Game_Character::GetScreenY() const {
-	int y = (real_y - Game_Map::GetDisplayY() + 3) / (SCREEN_TILE_WIDTH / TILE_SIZE) + TILE_SIZE;
+	int y = real_y / (SCREEN_TILE_WIDTH / TILE_SIZE) - Game_Map::GetDisplayY() / (SCREEN_TILE_WIDTH / TILE_SIZE) + TILE_SIZE;
 
 	int n;
 	if (move_count >= jump_peak)

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1020,7 +1020,7 @@ void Game_Map::UpdateParallax() {
 		if (map_info.parallax_horz_auto) {
 			int step =
 				(map_info.parallax_horz_speed > 0) ? 1 << map_info.parallax_horz_speed :
-				(map_info.parallax_horz_speed < 0) ? 1 << -map_info.parallax_horz_speed :
+				(map_info.parallax_horz_speed < 0) ? -(1 << -map_info.parallax_horz_speed) :
 				0;
 			parallax_auto_x += step;
 		}
@@ -1032,7 +1032,7 @@ void Game_Map::UpdateParallax() {
 		if (map_info.parallax_vert_auto) {
 			int step =
 				(map_info.parallax_vert_speed > 0) ? 1 << map_info.parallax_vert_speed :
-				(map_info.parallax_vert_speed < 0) ? 1 << -map_info.parallax_vert_speed :
+				(map_info.parallax_vert_speed < 0) ? -(1 << -map_info.parallax_vert_speed) :
 				0;
 			parallax_auto_y += step;
 		}

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -977,7 +977,7 @@ void Game_Map::UpdatePan() {
 	if (!IsPanActive())
 		return;
 
-	int step = 2 << (pan_speed - 1);
+	int step = (SCREEN_TILE_WIDTH/128) << (pan_speed + 1);
 	int dx = location.pan_finish_x - location.pan_current_x;
 	int dy = location.pan_finish_y - location.pan_current_y;
 
@@ -1016,11 +1016,12 @@ void Game_Map::UpdateParallax() {
 	if (map_info.parallax_name.empty())
 		return;
 
+	const int base = SCREEN_TILE_WIDTH / 128;
 	if (map_info.parallax_horz) {
 		if (map_info.parallax_horz_auto) {
 			int step =
-				(map_info.parallax_horz_speed > 0) ? 1 << map_info.parallax_horz_speed :
-				(map_info.parallax_horz_speed < 0) ? -(1 << -map_info.parallax_horz_speed) :
+				(map_info.parallax_horz_speed > 0) ? base << map_info.parallax_horz_speed :
+				(map_info.parallax_horz_speed < 0) ? -(base << -map_info.parallax_horz_speed) :
 				0;
 			parallax_auto_x += step;
 		}
@@ -1031,8 +1032,8 @@ void Game_Map::UpdateParallax() {
 	if (map_info.parallax_vert) {
 		if (map_info.parallax_vert_auto) {
 			int step =
-				(map_info.parallax_vert_speed > 0) ? 1 << map_info.parallax_vert_speed :
-				(map_info.parallax_vert_speed < 0) ? -(1 << -map_info.parallax_vert_speed) :
+				(map_info.parallax_vert_speed > 0) ? base << map_info.parallax_vert_speed :
+				(map_info.parallax_vert_speed < 0) ? -(base << -map_info.parallax_vert_speed) :
 				0;
 			parallax_auto_y += step;
 		}

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -201,8 +201,6 @@ void Game_Player::ReserveTeleport(int map_id, int x, int y) {
 	new_map_id = map_id;
 	new_x = x;
 	new_y = y;
-	last_pan_x = 0;
-	last_pan_y = 0;
 }
 
 void Game_Player::StartTeleport() {
@@ -217,6 +215,8 @@ void Game_Player::PerformTeleport() {
 	if (Game_Map::GetMapId() != new_map_id) {
 		Refresh(); // Reset sprite if it was changed by a move
 		Game_Map::Setup(new_map_id);
+		last_pan_x = 0;
+		last_pan_y = 0;
 	}
 
 	Main_Data::game_player->SetOpacity(255);


### PR DESCRIPTION
Fixes the errors I noticed in the Rainbow Treasure OP.

##### Character placement off  f1fe079

![tear](https://cloud.githubusercontent.com/assets/11024420/6385990/c19ef2d6-bd37-11e4-8bd2-b2309360efd9.png)

Some events are drawn off by one pixel. Caused by the formula in `Game_Character::GetScreenX()` and `Y()`. Changed to take the difference in pixels, not real coordinates, which I _think_ is correct. Can someone check?

##### Pan speed too slow  be05554

![pan](https://cloud.githubusercontent.com/assets/11024420/6385993/cbf07f84-bd37-11e4-8b73-9e3e35fa9874.png)

The pan drags behind the characters during the OP. Changed just by increasing the pan speed, but also changed to use `SCREEN_TILE_WIDTH / 128` instead of `2`, like for characters, I think it goes here too: @Ghabry, you made that change for character speed, what do you think?

##### Pan jumps after map teleport  8efd1a5

![copper](https://cloud.githubusercontent.com/assets/11024420/6385998/d35b7e04-bd37-11e4-95ee-b84b525f5154.png)

Caused by the pan in `Game_Character` being reset too early. I think this also fixes a bug where the pan is lost when teleporting within the same map (?).

##### Parallax BGs don't scroll backwards  28cedf8

![manganese](https://cloud.githubusercontent.com/assets/11024420/6385999/d938c868-bd37-11e4-80f6-f60e40dedf26.png)

Manganese's OP uses a parallax background to make it look like she's walking, but it goes the wrong way! Just a missing sign in `UpdateParallax` but I also used `SCREEN_TILE_WIDTH / 128` here and sped it up.

##### Jumping in place 716623d

![jump](https://cloud.githubusercontent.com/assets/11024420/6386002/e0356f22-bd37-11e4-94a1-986389d8ee5c.png)

Discussed [here](https://github.com/EasyRPG/Player/issues/344#issuecomment-75355015).

--------------

There's also #356 and one more I just noticed—the old man in front of the chest's sweat drop is drawn behind him when it should be drawn in front—that I didn't fix.