### PR TITLE
Minor vehicle fixes

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -68,6 +68,10 @@ Game_Character::~Game_Character() {
 	}
 }
 
+int Game_Character::GetSteppingSpeed() const {
+	return GetMoveSpeed();
+}
+
 bool Game_Character::IsMoving() const {
 	if (move_count > 0) return false; //Jumping
 
@@ -181,7 +185,7 @@ void Game_Character::Update() {
 		}
 	}
 
-	if (anime_count > 36.0/(GetMoveSpeed()+1)) {
+	if (anime_count > 36.0/(GetSteppingSpeed()+1)) {
 		if (IsSpinning()) {
 			SetPrelockDirection((GetPrelockDirection() + 1) % 4);
 		} else if (!IsContinuous() && IsStopping()) {

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -141,6 +141,14 @@ public:
 	virtual void SetLayer(int new_layer) = 0;
 
 	/**
+	 * Gets character stepping speed: the speed of the left-middle-right-middle
+	 * walking animation. Same as the movement speed, by default.
+	 *
+	 * @return stepping speed (the same units as movement speed)
+	 */
+	virtual int GetSteppingSpeed() const;
+
+	/**
 	 * Gets character movement speed.
 	 *
 	 * @return character movement speed 

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -256,12 +256,6 @@ void Game_Player::MoveTo(int x, int y) {
 
 	Game_Character::MoveTo(x, y);
 	Center(x, y);
-
-	// TODO: vehicle stuff
-	/* if in_vehicle?                                    # Riding in vehicle
-      vehicle = $game_map.vehicles[@vehicle_type]     # Get vehicle
-      vehicle.refresh                                 # Refresh
-    end */
 }
 
 void Game_Player::UpdateScroll(int last_real_x, int last_real_y) {

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -357,6 +357,8 @@ void Game_Player::UpdateNonMoving(bool last_moving) {
 		// Airship has landed
 		Unboard();
 		location.vehicle = Game_Vehicle::None;
+		SetDirection(RPG::EventPage::Direction_down);
+
 	}
 
 	if (last_moving && CheckTouchEvent()) return;
@@ -519,9 +521,9 @@ bool Game_Player::GetOnVehicle() {
 
 	if (Game_Map::GetVehicle(Game_Vehicle::Airship)->IsInPosition(GetX(), GetY()))
 		type = Game_Vehicle::Airship;
-    else if (Game_Map::GetVehicle(Game_Vehicle::Ship)->IsInPosition(front_x, front_y))
+	else if (Game_Map::GetVehicle(Game_Vehicle::Ship)->IsInPosition(front_x, front_y))
 		type = Game_Vehicle::Ship;
-    else if (Game_Map::GetVehicle(Game_Vehicle::Boat)->IsInPosition(front_x, front_y))
+	else if (Game_Map::GetVehicle(Game_Vehicle::Boat)->IsInPosition(front_x, front_y))
 		type = Game_Vehicle::Boat;
 	else
 		return false;
@@ -536,6 +538,7 @@ bool Game_Player::GetOnVehicle() {
 	} else {
 		location.aboard = true;
 		SetMoveSpeed(GetVehicle()->GetMoveSpeed());
+		SetDirection(RPG::EventPage::Direction_left);
 	}
 
 	walking_bgm = Game_System::GetCurrentBGM();
@@ -558,8 +561,6 @@ bool Game_Player::GetOffVehicle() {
 		through = true;
 		MoveForward();
 		through = false;
-	} else {
-		SetDirection(RPG::EventPage::Direction_down);
 	}
 
 	return true;

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -528,7 +528,6 @@ bool Game_Player::GetOnVehicle() {
 
 	location.vehicle = type;
 	location.preboard_move_speed = GetMoveSpeed();
-	SetMoveSpeed(GetVehicle()->GetMoveSpeed());
 	if (type != Game_Vehicle::Airship) {
 		location.boarding = true;
 		through = true;
@@ -536,6 +535,7 @@ bool Game_Player::GetOnVehicle() {
 		through = false;
 	} else {
 		location.aboard = true;
+		SetMoveSpeed(GetVehicle()->GetMoveSpeed());
 	}
 
 	walking_bgm = Game_System::GetCurrentBGM();

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -528,6 +528,7 @@ bool Game_Player::GetOnVehicle() {
 
 	location.vehicle = type;
 	location.preboard_move_speed = GetMoveSpeed();
+	SetMoveSpeed(GetVehicle()->GetMoveSpeed());
 	if (type != Game_Vehicle::Airship) {
 		location.boarding = true;
 		through = true;

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -312,10 +312,11 @@ void Game_Vehicle::GetOff() {
 	if (type == Airship) {
 		walk_animation = false;
 		data.remaining_descent = SCREEN_TILE_WIDTH;
+		Main_Data::game_player->SetDirection(RPG::EventPage::Direction_left);
 	} else {
 		driving = false;
+		SetDirection(RPG::EventPage::Direction_left);
 	}
-	SetDirection(RPG::EventPage::Direction_left);
 }
 
 bool Game_Vehicle::IsInUse() const {

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -93,6 +93,10 @@ void Game_Vehicle::SetLayer(int new_layer) {
 	data.layer = new_layer;
 }
 
+int Game_Vehicle::GetSteppingSpeed() const {
+	return RPG::EventPage::MoveSpeed_eighth;
+}
+
 int Game_Vehicle::GetMoveSpeed() const {
 	return data.move_speed;
 }

--- a/src/game_vehicle.h
+++ b/src/game_vehicle.h
@@ -56,6 +56,7 @@ public:
 	void SetFacingLocked(bool locked);
 	int GetLayer() const;
 	void SetLayer(int new_layer);
+	int GetSteppingSpeed() const;
 	int GetMoveSpeed() const;
 	void SetMoveSpeed(int speed);
 	int GetMoveFrequency() const;

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -44,8 +44,7 @@ Spriteset_Map::Spriteset_Map() {
 	Game_Vehicle* vehicle;
 	for (int i = 1; i <= 3; ++i) {
 		vehicle = Game_Map::GetVehicle((Game_Vehicle::Type) i);
-		if (vehicle->IsInCurrentMap())
-			character_sprites.push_back(EASYRPG_MAKE_SHARED<Sprite_Character>(vehicle));
+		character_sprites.push_back(EASYRPG_MAKE_SHARED<Sprite_Character>(vehicle));
 	}
 
 	character_sprites.push_back


### PR DESCRIPTION
Some very minor fixes on the heels of #434.

2dfa0d5 adds a "stepping speed" to decouple the rate that characters do their left-middle-right-middle animation from their movement speed, but since it's actually the _player_'s movement speed that's faster when riding a vehicle, an alternative would be to set all the vehicle's move speeds to 1/8 and move the switch to choose higher move speeds when riding vehicles to the line changed by e7880d8. I don't think the vehicles' move speed actually affect anything but their stepping animation does it?

Was everyone ok with 10455da?