### PR TITLE
Improve frame skipping code. Fixes #287

### DIFF
--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -55,7 +55,6 @@ void Game_System::BgmPlay(RPG::Music const& bgm) {
 		Audio().BGM_Stop();
 	}
 	data.current_music = bgm;
-	Graphics::FrameReset();
 }
 
 void Game_System::BgmStop() {

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -42,20 +42,17 @@ namespace Graphics {
 
 	/**
 	 * Updates the screen.
+	 * The rendering is skipped when time_left is false.
+	 *
+	 * @param time_left Whether time is left to render the frame.
 	 */
-	void Update();
+	void Update(bool time_left);
 
 	/**
-	 * Resets the fps count, should be called after an
-	 * expensive operation.
+	 * Resets the fps count.
+	 * Don't call this function directly, use Player::FrameReset.
 	 */
 	void FrameReset();
-
-	/**
-	 * Waits frames.
-	 * @param duration frames to wait.
-	 */
-	void Wait(int duration);
 
 	/**
 	 * Gets a bitmap with the actual contents of the screen.
@@ -124,20 +121,6 @@ namespace Graphics {
 	 */
 	void Freeze();
 
-	/**
-	 * Gets frame count.
-	 *
-	 * @return frame count since player started.
-	 */
-	int GetFrameCount();
-
-	/**
-	 * Sets frame count.
-	 *
-	 * @param framecount frame count since player started.
-	 */
-	void SetFrameCount(int framecount);
-
 	void RegisterDrawable(Drawable* drawable);
 	void RemoveDrawable(Drawable* drawable);
 
@@ -149,6 +132,13 @@ namespace Graphics {
 	void Pop();
 
 	unsigned SecondToFrame(float second);
+
+	/**
+	 * Gets target frame rate.
+	 *
+	 * @return target frame rate
+	 */
+	int GetDefaultFps();
 }
 
 #endif

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -142,9 +142,6 @@ static void HandleErrorOutput(const std::string& err) {
 
 		Input::Update();
 	}
-	Input::ResetKeys();
-	Graphics::FrameReset();
-	DisplayUi->UpdateDisplay();
 }
 
 bool Output::TakeScreenshot() {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -89,10 +89,14 @@ namespace Player {
 	std::string escape_symbol;
 	EngineType engine;
 	std::string game_title;
+	double start_time;
+	double next_frame;
+	int frames;
 }
 
 void Player::Init(int argc, char *argv[]) {
 	static bool init = false;
+	frames = 0;
 
 	if (init) return;
 
@@ -155,7 +159,7 @@ void Player::Run() {
 	reset_flag = false;
 
 	// Reset frames before starting
-	Graphics::FrameReset();
+	FrameReset();
 
 	// Main loop
 #ifdef EMSCRIPTEN
@@ -185,10 +189,32 @@ void Player::Pause() {
 void Player::Resume() {
 	Input::ResetKeys();
 	Audio().BGM_Resume();
-	Graphics::FrameReset();
+	FrameReset();
 }
 
-void Player::Update() {
+void Player::Update(bool update_scene) {
+	// available ms per frame, game logic expects 60 fps
+	static const double framerate_interval = 1000.0 / Graphics::GetDefaultFps();
+	next_frame = start_time + framerate_interval;
+
+	// Time left before next frame? Let's render the current frame.
+	if (start_time > (double)DisplayUi->GetTicks()) {
+		Graphics::Update(true);
+
+		double cur_time = (double)DisplayUi->GetTicks();
+		// Still time after graphic update? Yield until it's time for next one.
+		if (cur_time < next_frame) {
+#ifdef EMSCRIPTEN
+			return;
+#else
+			DisplayUi->Sleep((uint32_t)(next_frame - cur_time));
+#endif
+		}
+	} else {
+		Graphics::Update(false);
+	}
+
+	// Normal logic update
 	if (Input::IsTriggered(Input::TOGGLE_FPS)) {
 		Graphics::fps_on_screen = !Graphics::fps_on_screen;
 	}
@@ -209,6 +235,32 @@ void Player::Update() {
 			Scene::PopUntil(Scene::Title);
 		}
 	}
+
+	Audio().Update();
+	Input::Update();
+	if (update_scene) {
+		Scene::instance->Update();
+	}
+
+	start_time = next_frame;
+	++frames;
+}
+
+void Player::FrameReset() {
+	// When update started
+	start_time = (double)DisplayUi->GetTicks();
+
+	// available ms per frame, game logic expects 60 fps
+	static const double framerate_interval = 1000.0 / Graphics::GetDefaultFps();
+
+	// When next frame is expected
+	static double next_frame = start_time + framerate_interval;
+
+	Graphics::FrameReset();
+}
+
+int Player::GetFrames() {
+	return frames;
 }
 
 void Player::Exit() {
@@ -431,7 +483,7 @@ void Player::CreateGameObjects() {
 	Main_Data::game_player.reset(new Game_Player());
 	Main_Data::game_screen.reset(new Game_Screen());
 
-	Graphics::FrameReset();
+	FrameReset();
 }
 
 void Player::LoadDatabase() {

--- a/src/player.h
+++ b/src/player.h
@@ -59,8 +59,24 @@ namespace Player {
 
 	/**
 	 * Updates EasyRPG Player.
+	 *
+	 * @param update_scene Whether to update the current scene.
 	 */
-	void Update();
+	void Update(bool update_scene = true);
+
+	/**
+	 * Returns executed game frames since player start.
+	 * Should be 60 fps when game ran fast enough.
+	 *
+	 * @return Update frames since player start
+	 */
+	int GetFrames();
+
+	/**
+	 * Resets the fps count (both updates and frames per second).
+	 * Should be called after an expensive operation.
+	 */
+	void FrameReset();
 
 	/**
 	 * Exits EasyRPG Player.

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -66,8 +66,7 @@ void Scene::MainFunction() {
 	static bool init = false;
 
 	if (Graphics::IsTransitionPending()) {
-		Player::Update();
-		Graphics::Update();
+		Player::Update(false);
 		return;
 	}
 
@@ -93,19 +92,14 @@ void Scene::MainFunction() {
 		return;
 	}
 
-	// Update scene
 	Player::Update();
-	Graphics::Update();
-	Audio().Update();
-	Input::Update();
-	Update();
 
 	if (Scene::instance.get() != this) {
 		// Shutdown after scene switch
 		assert(Scene::instance == instances.back() &&
 			"Don't set Scene::instance directly, use Push instead!");
 
-		Graphics::Update();
+		Graphics::Update(true);
 
 		Suspend();
 		TransitionOut();

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -708,7 +708,7 @@ bool Scene_Battle_Rpg2k::DisplayMonstersInMessageWindow() {
 	}
 
 	if (sleep_until > -1) {
-		if (Graphics::GetFrameCount() >= sleep_until) {
+		if (Player::GetFrames() >= sleep_until) {
 			// Sleep over
 			sleep_until = -1;
 		} else {
@@ -730,10 +730,10 @@ bool Scene_Battle_Rpg2k::DisplayMonstersInMessageWindow() {
 
 	if (battle_message_window->GetLineCount() == 4) {
 		// Half second sleep
-		sleep_until = Graphics::GetFrameCount() + 60 / 2;
+		sleep_until = Player::GetFrames() + 60 / 2;
 	} else {
 		// 1/10 second sleep
-		sleep_until = Graphics::GetFrameCount() + 60 / 10;
+		sleep_until = Player::GetFrames() + 60 / 10;
 	}
 
 	++enemy_iterator;

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -57,7 +57,7 @@ void Scene_Map::Start() {
 		Main_Data::game_screen->CreatePicturesFromSave();
 	}
 
-	Graphics::FrameReset();
+	Player::FrameReset();
 }
 
 Scene_Map::~Scene_Map() {

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -192,7 +192,6 @@ bool Scene_Title::CheckValidPlayerLocation() {
 void Scene_Title::PrepareBattleTest() {
 	Player::CreateGameObjects();
 
-
 	Scene::Push(Scene_Battle::Create(), true);
 }
 
@@ -202,7 +201,6 @@ void Scene_Title::CommandNewGame() {
 	} else {
 		Game_System::SePlay(Main_Data::game_data.system.decision_se);
 		Game_System::BgmStop();
-		Graphics::SetFrameCount(0);
 		Player::SetupPlayerSpawn();
 		Scene::Push(EASYRPG_MAKE_SHARED<Scene_Map>());
 	}

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -303,7 +303,7 @@ void Window_Message::UpdateMessage() {
 	}
 
 	if (sleep_until > -1) {
-		if (Graphics::GetFrameCount() >= sleep_until) {
+		if (Player::GetFrames() >= sleep_until) {
 			// Sleep over
 			sleep_until = -1;
 		} else {
@@ -396,13 +396,13 @@ void Window_Message::UpdateMessage() {
 				break;
 			case '.':
 				// 1/4 second sleep
-				sleep_until = Graphics::GetFrameCount() + 60 / 4;
+				sleep_until = Player::GetFrames() + 60 / 4;
 				++text_index;
 				return;
 				break;
 			case '|':
 				// Second sleep
-				sleep_until = Graphics::GetFrameCount() + 60;
+				sleep_until = Player::GetFrames() + 60;
 				++text_index;
 				return;
 				break;


### PR DESCRIPTION
The new code takes into account that the non-graphic updates take some time, too and only when there is time in the current frame left the graphic is rendered. The game logic always runs at 60 updates per sec.

Don't merge before I verified that this works under emscripten ;)