### PR TITLE
Autotools: disable libtool shared build by default and silence some warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /lib/liblcf/
 /lib/TestGame/
 /lib/RTP/
+/.libs/
 .deps/
 CMakeCache.txt
 Makefile
@@ -22,6 +23,7 @@ easyrpg-player
 easyrpg-player-*.tar.gz
 install-sh
 libtool
+libeasyrpg-player.la
 missing
 stamp-h1
 test-driver
@@ -29,6 +31,8 @@ test-driver
 *.a
 *.elf
 /*.log
+/src/*.lo
+/lib/shinonome/*.lo
 *.o
 /*.trs
 *~

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AC_CONFIG_HEADERS([config.h])
 # Checks for programs.
 AM_PROG_AR
 AC_PROG_CXX
-LT_INIT
+LT_INIT([disable-shared])
 
 # Checks for libraries.
 PKG_CHECK_MODULES([LCF],[liblcf])

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -111,7 +111,7 @@ int Game_Actor::GetEquipment(int equip_type) const {
 	if (equip_type < 0 || equip_type >= (int) data.equipped.size())
 		return -1;
 	int item_id = data.equipped[equip_type];
-	return item_id <= Data::items.size() ? item_id : 0;
+	return item_id <= (int)Data::items.size() ? item_id : 0;
 }
 
 int Game_Actor::SetEquipment(int equip_type, int new_item_id) {
@@ -119,7 +119,7 @@ int Game_Actor::SetEquipment(int equip_type, int new_item_id) {
 		return -1;
 
 	int old_item_id = data.equipped[equip_type];
-	if (old_item_id > Data::items.size())
+	if (old_item_id > (int)Data::items.size())
 		old_item_id = 0;
 	
 	data.equipped[equip_type] = (short)new_item_id;
@@ -193,7 +193,7 @@ int Game_Actor::GetBaseAtk(bool mod, bool equip) const {
 
 	if (equip)
 		for (std::vector<int16_t>::const_iterator it = data.equipped.begin(); it != data.equipped.end(); ++it)
-			if (*it > 0 && *it <= Data::items.size())
+			if (*it > 0 && *it <= (int)Data::items.size())
 				n += Data::items[*it - 1].atk_points1;
 
 	return min(max(n, 1), 999);
@@ -213,7 +213,7 @@ int Game_Actor::GetBaseDef(bool mod, bool equip) const {
 
 	if (equip)
 		for (std::vector<int16_t>::const_iterator it = data.equipped.begin(); it != data.equipped.end(); ++it)
-			if (*it > 0 && *it <= Data::items.size())
+			if (*it > 0 && *it <= (int)Data::items.size())
 				n += Data::items[*it - 1].def_points1;
 
 	return min(max(n, 1), 999);
@@ -233,7 +233,7 @@ int Game_Actor::GetBaseSpi(bool mod, bool equip) const {
 
 	if (equip)
 		for (std::vector<int16_t>::const_iterator it = data.equipped.begin(); it != data.equipped.end(); ++it)
-			if (*it > 0 && *it <= Data::items.size())
+			if (*it > 0 && *it <= (int)Data::items.size())
 				n += Data::items[*it - 1].spi_points1;
 
 	return min(max(n, 1), 999);
@@ -253,7 +253,7 @@ int Game_Actor::GetBaseAgi(bool mod, bool equip) const {
 
 	if (equip)
 		for (std::vector<int16_t>::const_iterator it = data.equipped.begin(); it != data.equipped.end(); ++it)
-			if (*it > 0 && *it <= Data::items.size())
+			if (*it > 0 && *it <= (int)Data::items.size())
 				n += Data::items[*it - 1].agi_points1;
 
 	return min(max(n, 1), 999);
@@ -370,27 +370,27 @@ std::string Game_Actor::GetTitle() const {
 
 int Game_Actor::GetWeaponId() const {
 	int item_id = data.equipped[0];
-	return item_id <= Data::items.size() ? item_id : 0;
+	return item_id <= (int)Data::items.size() ? item_id : 0;
 }
 
 int Game_Actor::GetShieldId() const {
 	int item_id = data.equipped[1];
-	return item_id <= Data::items.size() ? item_id : 0;
+	return item_id <= (int)Data::items.size() ? item_id : 0;
 }
 
 int Game_Actor::GetArmorId() const {
 	int item_id = data.equipped[2];
-	return item_id <= Data::items.size() ? item_id : 0;
+	return item_id <= (int)Data::items.size() ? item_id : 0;
 }
 
 int Game_Actor::GetHelmetId() const {
 	int item_id = data.equipped[3];
-	return item_id <= Data::items.size() ? item_id : 0;
+	return item_id <= (int)Data::items.size() ? item_id : 0;
 }
 
 int Game_Actor::GetAccessoryId() const {
 	int item_id = data.equipped[4];
-	return item_id <= Data::items.size() ? item_id : 0;
+	return item_id <= (int)Data::items.size() ? item_id : 0;
 }
 
 int Game_Actor::GetLevel() const {

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -1100,7 +1100,7 @@ void Game_Character::ForceMoveRoute(RPG::MoveRoute* new_route,
 	stop_count = 256;
 }
 
-void Game_Character::CancelMoveRoute(Game_Interpreter* owner) {
+void Game_Character::CancelMoveRoute(Game_Interpreter* /* owner */) {
 	SetMoveRouteOverwritten(false);
 	move_route_owner = NULL;
 }

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -1101,6 +1101,7 @@ void Game_Character::ForceMoveRoute(RPG::MoveRoute* new_route,
 }
 
 void Game_Character::CancelMoveRoute(Game_Interpreter* /* owner */) {
+	// FIXME unused Game_Interpreter* parameter
 	SetMoveRouteOverwritten(false);
 	move_route_owner = NULL;
 }

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -44,7 +44,8 @@ Game_Event::Game_Event(int map_id, const RPG::Event& event) :
 	Refresh();
 }
 
-Game_Event::Game_Event(int map_id, const RPG::Event& event, const RPG::SaveMapEvent& data) :
+Game_Event::Game_Event(int /* map_id */, const RPG::Event& event, const RPG::SaveMapEvent& data) :
+	// FIXME unused int parameter
 	starting(false),
 	event(event),
 	page(NULL),

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -124,10 +124,10 @@ bool Game_Interpreter_Battle::CommandEnableCombo(RPG::EventCommand const& com) {
 
 	Output::Warning("Battle: Enable Combo not implemented");
 
-	int command_id = com.parameters[1];
-	int multiple = com.parameters[2];
-
 	// TODO
+	// int command_id = com.parameters[1];
+	// int multiple = com.parameters[2];
+
 	// Game_Actors::GetActor(actor_id)->EnableCombo(command_id, multiple);
 
 	return true;

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -197,7 +197,7 @@ void Game_Party::ConsumeItemUse(int item_id) {
 }
 
 bool Game_Party::IsItemUsable(int item_id) {
-	if (item_id <= 0 || item_id > Data::items.size()) {
+	if (item_id <= 0 || item_id > (int)Data::items.size()) {
 		return false;
 	}
 

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -35,10 +35,8 @@ Sprite::Sprite() :
 	flash_duration(0),
 	flash_frame(0),
 
-	bitmap_effects_valid(false),
 	needs_refresh(true),
 	bitmap_changed(true),
-	bitmap_effects_src_rect(Rect()),
 	src_rect_effect(Rect()),
 
 	opacity_top_effect(255),
@@ -53,11 +51,13 @@ Sprite::Sprite() :
 	waver_effect_depth(0),
 	waver_effect_phase(0.0),
 	flash_effect(Color(0,0,0,0)),
+	bitmap_effects_src_rect(Rect()),
+	bitmap_effects_valid(false),
 
 	current_tone(Tone()),
+	current_flash(Color(0,0,0,0)),
 	current_flip_x(false),
-	current_flip_y(false),
-	current_flash(Color(0,0,0,0)) {
+	current_flip_y(false) {
 
 	Graphics::RegisterDrawable(this);
 }


### PR DESCRIPTION
Fixes a slowdown since convenience libtool library building for tests landed because it builds both static and shared versions by default. Building only a static libeasyrpg-player.a version is enough.

Also, updated forgotten to include .gitignore files since libtool landing.

Silenced some strict warnings.