### PR TITLE
Looping maps

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -148,11 +148,35 @@ void Game_Character::MoveTo(int x, int y) {
 }
 
 int Game_Character::GetScreenX() const {
-	return real_x / (SCREEN_TILE_WIDTH / TILE_SIZE) - Game_Map::GetDisplayX() / (SCREEN_TILE_WIDTH / TILE_SIZE) + (TILE_SIZE/2);
+	int x = real_x - Game_Map::GetDisplayX();
+	int max_width = Game_Map::GetWidth() * SCREEN_TILE_WIDTH;
+
+	if (x - max_width > 0) {
+		x -= max_width;
+	}
+	else if (x < 0) {
+		x += max_width;
+	}
+
+	x = x / (SCREEN_TILE_WIDTH / TILE_SIZE) + (TILE_SIZE/2);
+
+	return x;
+	/*return real_x / (SCREEN_TILE_WIDTH / TILE_SIZE) - Game_Map::GetDisplayX() / (SCREEN_TILE_WIDTH / TILE_SIZE) + (TILE_SIZE/2);*/
 }
 
 int Game_Character::GetScreenY() const {
-	int y = real_y / (SCREEN_TILE_WIDTH / TILE_SIZE) - Game_Map::GetDisplayY() / (SCREEN_TILE_WIDTH / TILE_SIZE) + TILE_SIZE;
+	/*int y = real_y / (SCREEN_TILE_WIDTH / TILE_SIZE) - Game_Map::GetDisplayY() / (SCREEN_TILE_WIDTH / TILE_SIZE) + TILE_SIZE;*/d
+	int y = real_y - Game_Map::GetDisplayY();
+	int max_height = Game_Map::GetHeight() * SCREEN_TILE_WIDTH;
+
+	if (y - max_height > 0) {
+		y -= max_height;
+	}
+	else if (y < 0) {
+		y += max_height;
+	}
+
+	y = y / (SCREEN_TILE_WIDTH / TILE_SIZE) + TILE_SIZE;
 
 	int n;
 	if (move_count >= jump_peak)

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -203,7 +203,7 @@ int Game_Character::GetScreenZ() const {
 	}
 
 	// Prevent underflow (not rendered in this case)
-	// ToDo: It's probably the best to rework the tilemap code
+	// ToDo: It's probably the best to rework the z-layer part of the tilemap code
 	if (z < 1) {
 		z = 1;
 	}

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -677,8 +677,8 @@ public:
 	 */
 	void SetAnimationId(int animation_id);
 
-	int DistanceXfromPlayer() const;
-	int DistanceYfromPlayer() const;
+	int GetDistanceXfromPlayer() const;
+	int GetDistanceYfromPlayer() const;
 
 	virtual bool IsInPosition(int x, int y) const;
 
@@ -768,7 +768,6 @@ protected:
 	void UpdateJump();
 	void UpdateSelfMovement();
 	void UpdateStop();
-
 	int tile_id;
 	int real_x;
 	int real_y;

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -621,14 +621,6 @@ public:
 	virtual int GetScreenZ() const;
 
 	/**
-	 * Gets screen z coordinate in pixels.
-	 *
-	 * @param height character height.
-	 * @return screen z coordinate in pixels.
-	 */
-	virtual int GetScreenZ(int height) const;
-
-	/**
 	 * Gets tile graphic ID.
 	 *
 	 * @return tile graphic ID.

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -346,7 +346,7 @@ void Game_Map::ScrollUp(int distance) {
 	map_info.position_y = dist;
 
 	if (!GetLoopVertical()) {
-		map_info.position_y = min(dist, 0);
+		map_info.position_y = max(dist, 0);
 	}
 }
 

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -466,8 +466,8 @@ namespace Game_Map {
 
 	void GetEventsXY(std::vector<Game_Event*>& events, int x, int y);
 
-	bool LoopHorizontal();
-	bool LoopVertical();
+	bool GetLoopHorizontal();
+	bool GetLoopVertical();
 
 	int RoundX(int x);
 	int RoundY(int y);
@@ -523,6 +523,9 @@ namespace Game_Map {
 	int GetParallaxX();
 	int GetParallaxY();
 	const std::string& GetParallaxName();
+
+	int WrapX(int x);
+	int WrapY(int y);
 }
 
 #endif

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -201,6 +201,13 @@ bool Game_Vehicle::IsPassable(int x, int y, int d) const {
 	int new_x = x + (d == RPG::EventPage::Direction_right ? 1 : d == RPG::EventPage::Direction_left ? -1 : 0);
 	int new_y = y + (d == RPG::EventPage::Direction_down ? 1 : d == RPG::EventPage::Direction_up ? -1 : 0);
 
+	if (Game_Map::GetLoopHorizontal()) {
+		new_x = Game_Map::WrapX(new_x);
+	}
+	if (Game_Map::GetLoopVertical()) {
+		new_y = Game_Map::WrapY(new_y);
+	}
+
 	if (!Game_Map::IsValid(new_x, new_y))
 		return false;
 

--- a/src/sprite_airshipshadow.cpp
+++ b/src/sprite_airshipshadow.cpp
@@ -69,6 +69,6 @@ void Sprite_AirshipShadow::Update() {
 
 	SetX(Main_Data::game_player->GetScreenX());
 	SetY(Main_Data::game_player->GetScreenY());
-	// TODO figure out correct Z value
-	SetZ(Main_Data::game_player->GetScreenZ(32*(TILE_SIZE/16)));
+	// Bit higher then the rest on the tilemap
+	SetZ(Main_Data::game_player->GetScreenZ() + TILE_SIZE * 2);
 }

--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -82,7 +82,7 @@ void Sprite_Character::Update() {
 
 	SetX(character->GetScreenX());
 	SetY(character->GetScreenY());
-	SetZ(character->GetScreenZ(chara_height));
+	SetZ(character->GetScreenZ());
 
 	//SetBlendType(character->GetBlendType());
 	int bush_split = 4 - character->GetBushDepth();

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -169,6 +169,10 @@ void TilemapLayer::DrawTile(Bitmap& screen, int x, int y, int row, int col, bool
 void TilemapLayer::Draw(int z_order) {
 	if (!visible) return;
 
+	// FIXME: 
+	// When the map is looping and the camera is over a map boundary the tiles
+	// on one half of the map are rendered too late.
+
 	// Get the number of tiles that can be displayed on window
 	int tiles_x = (int)ceil(DisplayUi->GetWidth() / (float)TILE_SIZE);
 	int tiles_y = (int)ceil(DisplayUi->GetHeight() / (float)TILE_SIZE);

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -184,12 +184,16 @@ void TilemapLayer::Draw(int z_order) {
 
 	for (int x = 0; x < tiles_x; x++) {
 		for (int y = 0; y < tiles_y; y++) {
-
 			// Get the real maps tile coordinates
-			int map_x = ox / TILE_SIZE + x;
-			int map_y = oy / TILE_SIZE + y;
+			int map_x = (ox / TILE_SIZE + x) % width;
+			int map_y = (oy / TILE_SIZE + y) % height;
 
-			if (width <= map_x || height <= map_y) continue;
+			if (map_x < 0) {
+				map_x += width;
+			}
+			if (map_y < 0) {
+				map_y += height;
+			}
 
 			int map_draw_x = x * TILE_SIZE - ox % TILE_SIZE;
 			int map_draw_y = y * TILE_SIZE - oy % TILE_SIZE;


### PR DESCRIPTION
Fixes #314 

Havn't tested this in any real game yet, please test Yume Nikki & co.

I wasted days with these GetScreenX-Z code to get it right but by looking at the changes it wasn't really difficult in the end :(.

Imo there is some flaw with the Z code, but I wasn't motivated to investigate the tilemap z-layer code. Tilemap rendering doesn't work correctly when over a map boundaries (tile rendered too late, but this is only a visual glitch)

- [x] Rendering issues on small maps (20x15 and 20x16) -> Needs refactor in rendering code, WONT FIX
- [ ] Panoramas rendered wrong
- [ ] Pan makes sprites dissapear