### PR TITLE
Fix some character movement issues and use cleaner code

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -69,7 +69,17 @@ Game_Character::~Game_Character() {
 }
 
 int Game_Character::GetSteppingSpeed() const {
-	return GetMoveSpeed();
+	int move_speed = GetMoveSpeed();
+	if (IsSpinning()) {
+		// 24, 16, 12, 8, 6, 4
+		return (move_speed < 4) ? 48 / (move_speed + 1) : 24 / (move_speed - 1);
+	} else if (IsMoving()) {
+		// 12, 10, 8, 6, 5, 4
+		return (move_speed < 4) ? 60 / (move_speed + 4) : 30 / (move_speed + 1);
+	} else {
+		// 16, 12, 10, 8, 7, 6
+		return (move_speed < 2) ? 16 : 60 / (move_speed + 3);
+	}
 }
 
 bool Game_Character::IsMoving() const {
@@ -173,7 +183,7 @@ int Game_Character::GetScreenZ(int /* height */) const {
 void Game_Character::Update() {
 	if (IsJumping()) {
 		UpdateJump();
-		anime_count += (IsSpinning() ? 1.0 : 0);
+		anime_count += (IsSpinning() ? 1 : 0);
 	} else if (IsContinuous() || IsSpinning()) {
 		UpdateMove();
 		UpdateStop();
@@ -185,7 +195,7 @@ void Game_Character::Update() {
 		}
 	}
 
-	if (anime_count > 36.0/(GetSteppingSpeed()+1)) {
+	if (anime_count >= GetSteppingSpeed()) {
 		if (IsSpinning()) {
 			SetSpriteDirection((GetSpriteDirection() + 1) % 4);
 		} else if (!IsContinuous() && IsStopping()) {
@@ -240,10 +250,8 @@ void Game_Character::UpdateMove() {
 	if (GetY() * SCREEN_TILE_WIDTH < real_y)
 		real_y = max(real_y - distance, GetY() * SCREEN_TILE_WIDTH);
 
-	anime_count += 
-		(IsSpinning() ? 1.0 :
-		(animation_type != RPG::EventPage::AnimType_fixed_graphic && walk_animation) ? 1.5 :
-		0);
+	anime_count +=
+		(animation_type != RPG::EventPage::AnimType_fixed_graphic && walk_animation) ? 1 : 0;
 }
 
 void Game_Character::UpdateJump() {
@@ -285,10 +293,8 @@ void Game_Character::UpdateSelfMovement() {
 
 void Game_Character::UpdateStop() {
 	if (pattern != original_pattern && !IsContinuous())
-		anime_count += 1.5;
-
-	//if (!starting || !IsLock())
-		stop_count += 1;
+		anime_count++;
+	stop_count++;
 }
 
 void Game_Character::MoveTypeRandom() {
@@ -1166,7 +1172,7 @@ bool Game_Character::IsFlashPending() const {
 	return GetFlashTimeLeft() > 0;
 }
 
-bool Game_Character::IsDirectionFixed() {
+bool Game_Character::IsDirectionFixed() const {
 	return
 		animation_type == RPG::EventPage::AnimType_fixed_continuous ||
 		animation_type == RPG::EventPage::AnimType_fixed_graphic ||
@@ -1174,13 +1180,13 @@ bool Game_Character::IsDirectionFixed() {
 		IsFacingLocked();
 }
 
-bool Game_Character::IsContinuous() {
+bool Game_Character::IsContinuous() const {
 	return
 		animation_type == RPG::EventPage::AnimType_continuous ||
 		animation_type == RPG::EventPage::AnimType_fixed_continuous;
 }
 
-bool Game_Character::IsSpinning() {
+bool Game_Character::IsSpinning() const {
 	return animation_type == RPG::EventPage::AnimType_spin;
 }
 

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -854,83 +854,39 @@ void Game_Character::MoveAwayFromPlayer() {
 	}
 }
 
-void Game_Character::TurnDown() {
-	SetDirection(RPG::EventPage::Direction_down);
-	SetSpriteDirection(RPG::EventPage::Direction_down);
+void Game_Character::Turn(int dir) {
+	SetDirection(dir);
+	SetSpriteDirection(dir);
 	move_failed = false;
 	stop_count = pow(2.0, 8 - GetMoveFrequency());
+}
+
+void Game_Character::TurnDown() {
+	Turn(RPG::EventPage::Direction_down);
 }
 
 void Game_Character::TurnLeft() {
-	SetDirection(RPG::EventPage::Direction_left);
-	SetSpriteDirection(RPG::EventPage::Direction_left);
-	move_failed = false;
-	stop_count = pow(2.0, 8 - GetMoveFrequency());
+	Turn(RPG::EventPage::Direction_left);
 }
 
 void Game_Character::TurnRight() {
-	SetDirection(RPG::EventPage::Direction_right);
-	SetSpriteDirection(RPG::EventPage::Direction_right);
-	move_failed = false;
-	stop_count = pow(2.0, 8 - GetMoveFrequency());
+	Turn(RPG::EventPage::Direction_right);
 }
 
 void Game_Character::TurnUp() {
-	SetDirection(RPG::EventPage::Direction_up);
-	SetSpriteDirection(RPG::EventPage::Direction_up);
-	move_failed = false;
-	stop_count = pow(2.0, 8 - GetMoveFrequency());
+	Turn(RPG::EventPage::Direction_up);
 }
 
 void Game_Character::Turn90DegreeLeft() {
-	switch (GetDirection()) {
-		case RPG::EventPage::Direction_down:
-			TurnRight();
-			break;
-		case RPG::EventPage::Direction_left:
-			TurnDown();
-			break;
-		case RPG::EventPage::Direction_right:
-			TurnUp();
-			break;
-		case RPG::EventPage::Direction_up:
-			TurnLeft();
-			break;
-	}
+	Turn((GetSpriteDirection() + 3) % 4);
 }
 
 void Game_Character::Turn90DegreeRight() {
-	switch (GetDirection()) {
-		case RPG::EventPage::Direction_down:
-			TurnLeft();
-			break;
-		case RPG::EventPage::Direction_left:
-			TurnUp();
-			break;
-		case RPG::EventPage::Direction_right:
-			TurnDown();
-			break;
-		case RPG::EventPage::Direction_up:
-			TurnRight();
-			break;
-	}
+	Turn((GetSpriteDirection() + 1) % 4);
 }
 
 void Game_Character::Turn180Degree() {
-	switch (GetDirection()) {
-		case RPG::EventPage::Direction_down:
-			TurnUp();
-			break;
-		case RPG::EventPage::Direction_left:
-			TurnRight();
-			break;
-		case RPG::EventPage::Direction_right:
-			TurnLeft();
-			break;
-		case RPG::EventPage::Direction_up:
-			TurnDown();
-			break;
-	}
+	Turn((GetSpriteDirection() + 2) % 4);
 }
 
 void Game_Character::Turn90DegreeLeftOrRight() {
@@ -973,20 +929,7 @@ void Game_Character::TurnAwayFromHero() {
 }
 
 void Game_Character::FaceRandomDirection() {
-	switch (rand() % 4) {
-	case 0:
-		TurnDown();
-		break;
-	case 1:
-		TurnLeft();
-		break;
-	case 2:
-		TurnRight();
-		break;
-	case 3:
-		TurnUp();
-		break;
-	}
+	Turn(rand() % 4);
 }
 
 void Game_Character::Wait() {

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -187,7 +187,7 @@ void Game_Character::Update() {
 
 	if (anime_count > 36.0/(GetSteppingSpeed()+1)) {
 		if (IsSpinning()) {
-			SetPrelockDirection((GetPrelockDirection() + 1) % 4);
+			SetSpriteDirection((GetSpriteDirection() + 1) % 4);
 		} else if (!IsContinuous() && IsStopping()) {
 			pattern = original_pattern;
 			last_pattern = last_pattern == RPG::EventPage::Frame_left ? RPG::EventPage::Frame_right : RPG::EventPage::Frame_left;
@@ -586,7 +586,8 @@ void Game_Character::EndMoveRoute() {
 }
 
 void Game_Character::MoveDown() {
-	if (!IsDirectionFixed()) TurnDown();
+	SetDirection(RPG::EventPage::Direction_down);
+	if (!IsDirectionFixed()) SetSpriteDirection(RPG::EventPage::Direction_down);
 
 	if (jumping) {
 		jump_plus_y++;
@@ -605,7 +606,8 @@ void Game_Character::MoveDown() {
 }
 
 void Game_Character::MoveLeft() {
-	if (!IsDirectionFixed()) TurnLeft();
+	SetDirection(RPG::EventPage::Direction_left);
+	if (!IsDirectionFixed()) SetSpriteDirection(RPG::EventPage::Direction_left);
 
 	if (jumping) {
 		jump_plus_x--;
@@ -624,7 +626,8 @@ void Game_Character::MoveLeft() {
 }
 
 void Game_Character::MoveRight() {
-	if (!IsDirectionFixed()) TurnRight();
+	SetDirection(RPG::EventPage::Direction_right);
+	if (!IsDirectionFixed()) SetSpriteDirection(RPG::EventPage::Direction_right);
 
 	if (jumping) {
 		jump_plus_x++;
@@ -643,7 +646,8 @@ void Game_Character::MoveRight() {
 }
 
 void Game_Character::MoveUp() {
-	if (!IsDirectionFixed()) TurnUp();
+	SetDirection(RPG::EventPage::Direction_up);
+	if (!IsDirectionFixed()) SetSpriteDirection(RPG::EventPage::Direction_up);
 
 	if (jumping) {
 		jump_plus_y--;
@@ -679,12 +683,12 @@ void Game_Character::MoveForward() {
 }
 
 void Game_Character::MoveDownLeft() {
-	if (!IsDirectionFixed()) {
-		if (GetDirection() % 2) {
-			TurnLeft();
-		} else {
-			TurnDown();
-		}
+	if (GetDirection() % 2) {
+		SetDirection(RPG::EventPage::Direction_left);
+		if (!IsDirectionFixed()) SetSpriteDirection(RPG::EventPage::Direction_left);
+	} else {
+		SetDirection(RPG::EventPage::Direction_down);
+		if (!IsDirectionFixed()) SetSpriteDirection(RPG::EventPage::Direction_down);
 	}
 
 	if (jumping) {
@@ -706,13 +710,14 @@ void Game_Character::MoveDownLeft() {
 }
 
 void Game_Character::MoveDownRight() {
-	if (!IsDirectionFixed()) {
-		if (GetDirection() % 2) {
-			TurnRight();
-		} else {
-			TurnDown();
-		}
+	if (GetDirection() % 2) {
+		SetDirection(RPG::EventPage::Direction_right);
+		if (!IsDirectionFixed()) SetSpriteDirection(RPG::EventPage::Direction_right);
+	} else {
+		SetDirection(RPG::EventPage::Direction_down);
+		if (!IsDirectionFixed()) SetSpriteDirection(RPG::EventPage::Direction_down);
 	}
+
 
 	if (jumping) {
 		jump_plus_x++;
@@ -734,12 +739,12 @@ void Game_Character::MoveDownRight() {
 
 
 void Game_Character::MoveUpLeft() {
-	if (!IsDirectionFixed()) {
-		if (GetDirection() % 2) {
-			TurnLeft();
-		} else {
-			TurnUp();
-		}
+	if (GetDirection() % 2) {
+		SetDirection(RPG::EventPage::Direction_left);
+		if (!IsDirectionFixed()) SetSpriteDirection(RPG::EventPage::Direction_left);
+	} else {
+		SetDirection(RPG::EventPage::Direction_up);
+		if (!IsDirectionFixed()) SetSpriteDirection(RPG::EventPage::Direction_up);
 	}
 
 	if (jumping) {
@@ -762,12 +767,12 @@ void Game_Character::MoveUpLeft() {
 
 
 void Game_Character::MoveUpRight() {
-	if (!IsDirectionFixed()) {
-		if (GetDirection() % 2) {
-			TurnRight();
-		} else {
-			TurnUp();
-		}
+	if (GetDirection() % 2) {
+		SetDirection(RPG::EventPage::Direction_right);
+		if (!IsDirectionFixed()) SetSpriteDirection(RPG::EventPage::Direction_right);
+	} else {
+		SetDirection(RPG::EventPage::Direction_up);
+		if (!IsDirectionFixed()) SetSpriteDirection(RPG::EventPage::Direction_up);
 	}
 
 	if (jumping) {
@@ -845,34 +850,30 @@ void Game_Character::MoveAwayFromPlayer() {
 
 void Game_Character::TurnDown() {
 	SetDirection(RPG::EventPage::Direction_down);
+	SetSpriteDirection(RPG::EventPage::Direction_down);
 	move_failed = false;
-	if (!IsSpinning()) {
-		stop_count = pow(2.0, 8 - GetMoveFrequency());
-	}
+	stop_count = pow(2.0, 8 - GetMoveFrequency());
 }
 
 void Game_Character::TurnLeft() {
 	SetDirection(RPG::EventPage::Direction_left);
+	SetSpriteDirection(RPG::EventPage::Direction_left);
 	move_failed = false;
-	if (!IsSpinning()) {
-		stop_count = pow(2.0, 8 - GetMoveFrequency());
-	}
+	stop_count = pow(2.0, 8 - GetMoveFrequency());
 }
 
 void Game_Character::TurnRight() {
 	SetDirection(RPG::EventPage::Direction_right);
+	SetSpriteDirection(RPG::EventPage::Direction_right);
 	move_failed = false;
-	if (!IsSpinning()) {
-		stop_count = pow(2.0, 8 - GetMoveFrequency());
-	}
+	stop_count = pow(2.0, 8 - GetMoveFrequency());
 }
 
 void Game_Character::TurnUp() {
 	SetDirection(RPG::EventPage::Direction_up);
+	SetSpriteDirection(RPG::EventPage::Direction_up);
 	move_failed = false;
-	if (!IsSpinning()) {
-		stop_count = pow(2.0, 8 - GetMoveFrequency());
-	}
+	stop_count = pow(2.0, 8 - GetMoveFrequency());
 }
 
 void Game_Character::Turn90DegreeLeft() {
@@ -1073,13 +1074,13 @@ void Game_Character::Lock() {
 	if (!IsDirectionFixed()) {
 		int prelock_dir = GetDirection();
 		TurnTowardHero();
-		SetPrelockDirection(prelock_dir);
+		SetDirection(prelock_dir);
 	}
 }
 
 void Game_Character::Unlock() {
 	if (!IsDirectionFixed()) {
-		SetDirection(GetPrelockDirection());
+		SetSpriteDirection(GetDirection());
 	}
 }
 

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -141,8 +141,8 @@ public:
 	virtual void SetLayer(int new_layer) = 0;
 
 	/**
-	 * Gets character stepping speed: the speed of the left-middle-right-middle
-	 * walking animation. Same as the movement speed, by default.
+	 * Gets character stepping speed: the number of frames between each change
+	 * of the left-middle-right-middle walking animation or the spinning animation
 	 *
 	 * @return stepping speed (the same units as movement speed)
 	 */
@@ -728,21 +728,21 @@ public:
 	 *
 	 * @return Whether direction is fixed
 	 */
-	bool IsDirectionFixed();
+	bool IsDirectionFixed() const;
 
 	/**
 	 * Tests if animation type is any continuous state.
 	 *
 	 * @return Whether animation is continuous
 	 */
-	bool IsContinuous();
+	bool IsContinuous() const;
 
 	/**
 	 * Tests if animation is of the type spin.
 	 *
 	 * @return Whether animation is spin type
 	 */
-	bool IsSpinning();
+	bool IsSpinning() const;
 
 	/**
 	 * Gets the bush depth of the tile where this character is standing
@@ -795,8 +795,8 @@ protected:
 	int jump_plus_x;
 	int jump_plus_y;
 
-	double anime_count;
-	double stop_count;
+	int anime_count;
+	int stop_count;
 	bool walk_animation;
 
 	/** used by cycle left-right, up-down */

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -85,32 +85,32 @@ public:
 	virtual void SetMapId(int new_map_id) = 0;
 
 	/**
-	 * Gets character facing direction.
+	 * Gets character's front direction.
 	 *
-	 * @return current facing direction.
+	 * @return current front direction.
 	 */
 	virtual int GetDirection() const = 0;
 
 	/**
-	 * Sets character facing direction.
+	 * Sets character's front direction.
 	 *
-	 * @param new_direction New current facing direction.
+	 * @param new_direction New current front direction.
 	 */
 	virtual void SetDirection(int new_direction) = 0;
 
 	/**
-	 * Gets facing direction before direction was locked.
+	 * Gets direction of the sprite.
 	 *
-	 * @return facing direction before lock.
+	 * @return direction of the sprite.
 	 */
-	virtual int GetPrelockDirection() const = 0;
+	virtual int GetSpriteDirection() const = 0;
 
 	/**
-	 * Sets character facing used before locking.
+	 * Sets sprite direction.
 	 *
-	 * @param new_direction New prelock facing direction.
+	 * @param new_direction New sprite direction.
 	 */
-	virtual void SetPrelockDirection(int new_direction) = 0;
+	virtual void SetSpriteDirection(int new_direction) = 0;
 
 	/**
 	 * Gets whether facing is locked.

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -769,6 +769,8 @@ protected:
 	void UpdateSelfMovement();
 	void UpdateStop();
 
+	void Turn(int dir);
+
 	int tile_id;
 	int real_x;
 	int real_y;

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -95,18 +95,15 @@ int Game_Event::GetDirection() const {
 void Game_Event::SetDirection(int new_direction) {
 	if (new_direction != -1) {
 		data.direction = new_direction;
-		if (!IsSpinning()) {
-			SetPrelockDirection(new_direction);
-		}
 	}
 }
 
-int Game_Event::GetPrelockDirection() const {
-	return data.prelock_direction;
+int Game_Event::GetSpriteDirection() const {
+	return data.sprite_direction;
 }
 
-void Game_Event::SetPrelockDirection(int new_direction) {
-	data.prelock_direction = new_direction;
+void Game_Event::SetSpriteDirection(int new_direction) {
+	data.sprite_direction = new_direction;
 }
 
 bool Game_Event::IsFacingLocked() const {
@@ -266,7 +263,7 @@ void Game_Event::Setup(RPG::EventPage* new_page) {
 
 	if (GetDirection() != page->character_direction) {
 		SetDirection(page->character_direction);
-		SetPrelockDirection(page->character_direction);
+		SetSpriteDirection(page->character_direction);
 	}
 
 	if (original_pattern != page->character_pattern) {

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -53,8 +53,8 @@ public:
 	void SetMapId(int new_map_id);
 	int GetDirection() const;
 	void SetDirection(int new_direction);
-	int GetPrelockDirection() const;
-	void SetPrelockDirection(int new_direction);
+	int GetSpriteDirection() const;
+	void SetSpriteDirection(int new_direction);
 	bool IsFacingLocked() const;
 	void SetFacingLocked(bool locked);
 	int GetLayer() const;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -686,16 +686,13 @@ bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { /
 			break;
 		case 6:
 			// Characters
-			if (com.parameters[6] != 0){
-				character = GetCharacter(com.parameters[5]);
-			} else {
-				// Special case for Player Map ID
-				character = NULL;
-				value = Game_Map::GetMapId();
-			}
-			// Other cases
+			character = GetCharacter(com.parameters[5]);
 			if (character != NULL) {
 				switch (com.parameters[6]) {
+					case 0:
+						// Map ID
+						value = character->GetMapId();
+						break;
 					case 1:
 						// X Coordinate
 						value = character->GetX();
@@ -706,7 +703,11 @@ bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { /
 						break;
 					case 3:
 						// Orientation
-						value = character->GetDirection();
+						int dir;
+						dir = character->GetSpriteDirection();
+						value = dir == 0 ? 8 :
+								dir == 1 ? 6 :
+								dir == 2 ? 2 : 4;
 						break;
 					case 4:
 						// Screen X

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -1950,7 +1950,7 @@ bool Game_Interpreter_Map::CommandConditionalBranch(RPG::EventCommand const& com
 			// Orientation of char
 			character = GetCharacter(com.parameters[1]);
 			if (character != NULL) {
-				result = character->GetDirection() == com.parameters[2];
+				result = character->GetSpriteDirection() == com.parameters[2];
 			}
 			break;
 		case 7:

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -500,6 +500,8 @@ namespace Game_Map {
 	void SubstituteDown(int old_id, int new_id);
 	void SubstituteUp(int old_id, int new_id);
 
+	bool IsPassableTile(int bit, int tile_index);
+
 	enum PanDirection {
 		PanUp,
 		PanRight,

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -72,12 +72,12 @@ void Game_Player::SetDirection(int new_direction) {
 	location.direction = new_direction;
 }
 
-int Game_Player::GetPrelockDirection() const {
-	return location.prelock_direction;
+int Game_Player::GetSpriteDirection() const {
+	return location.sprite_direction;
 }
 
-void Game_Player::SetPrelockDirection(int new_direction) {
-	location.prelock_direction = new_direction;
+void Game_Player::SetSpriteDirection(int new_direction) {
+	location.sprite_direction = new_direction;
 }
 
 bool Game_Player::IsFacingLocked() const {

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -45,8 +45,8 @@ public:
 	void SetMapId(int new_map_id);
 	int GetDirection() const;
 	void SetDirection(int new_direction);
-	int GetPrelockDirection() const;
-	void SetPrelockDirection(int new_direction);
+	int GetSpriteDirection() const;
+	void SetSpriteDirection(int new_direction);
 	bool IsFacingLocked() const;
 	void SetFacingLocked(bool locked);
 	int GetLayer() const;

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -94,7 +94,7 @@ void Game_Vehicle::SetLayer(int new_layer) {
 }
 
 int Game_Vehicle::GetSteppingSpeed() const {
-	return RPG::EventPage::MoveSpeed_eighth;
+	return 16;
 }
 
 int Game_Vehicle::GetMoveSpeed() const {

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -69,12 +69,12 @@ void Game_Vehicle::SetDirection(int new_direction) {
 	data.direction = new_direction;
 }
 
-int Game_Vehicle::GetPrelockDirection() const {
-	return data.prelock_direction;
+int Game_Vehicle::GetSpriteDirection() const {
+	return data.sprite_direction;
 }
 
-void Game_Vehicle::SetPrelockDirection(int new_direction) {
-	data.prelock_direction = new_direction;
+void Game_Vehicle::SetSpriteDirection(int new_direction) {
+	data.sprite_direction = new_direction;
 }
 
 bool Game_Vehicle::IsFacingLocked() const {

--- a/src/game_vehicle.h
+++ b/src/game_vehicle.h
@@ -50,8 +50,8 @@ public:
 	void SetMapId(int new_map_id);
 	int GetDirection() const;
 	void SetDirection(int new_direction);
-	int GetPrelockDirection() const;
-	void SetPrelockDirection(int new_direction);
+	int GetSpriteDirection() const;
+	void SetSpriteDirection(int new_direction);
 	bool IsFacingLocked() const;
 	void SetFacingLocked(bool locked);
 	int GetLayer() const;

--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -62,7 +62,7 @@ void Sprite_Character::Update() {
 	}
 
 	if (tile_id == 0) {
-		int row = (character->IsSpinning() ? character->GetPrelockDirection() : character->GetDirection());
+		int row = character->GetSpriteDirection();
 		r.Set(character->GetPattern() * chara_width, row * chara_height, chara_width, chara_height);
 		SetSrcRect(r);
 	}


### PR DESCRIPTION
Fixes:
* MoveForward acts in the right direction with events with facing locked
* The action key works correctly if the hero's facing is locked.
* Autotile 46 is now passable
* Animation speeds are a lot more accurate
* Control Variable Command can now use vehicles' map id as value
* Control Variable Command works correctly when using a event's direction as value: Down -> 2, Left -> 4, Right -> 6, Up -> 8.