### PR TITLE
Improve KeyInputProc behaviour

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -852,20 +852,6 @@ int Game_Character::DistanceYfromPlayer() const {
 	return sy;
 }
 
-void Game_Character::Lock() {
-	if (!IsDirectionFixed()) {
-		int prelock_dir = GetDirection();
-		TurnTowardHero();
-		SetDirection(prelock_dir);
-	}
-}
-
-void Game_Character::Unlock() {
-	if (!IsDirectionFixed()) {
-		SetSpriteDirection(GetDirection());
-	}
-}
-
 void Game_Character::ForceMoveRoute(RPG::MoveRoute* new_route,
 									int frequency,
 									Game_Interpreter* owner) {

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -504,16 +504,6 @@ public:
 	void EndJump();
 
 	/**
-	 * Locks character facing direction.
-	 */
-	void Lock();
-
-	/**
-	 * Unlocks character facing direction.
-	 */
-	void Unlock();
-
-	/**
 	 * Forces a new, temporary, move route.
 	 *
 	 * @param new_route new move route.

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -33,6 +33,8 @@
 
 Game_Event::Game_Event(int map_id, const RPG::Event& event) :
 	starting(false),
+	ready1(true),
+	ready2(true),
 	trigger(-1),
 	event(event),
 	page(NULL),
@@ -48,6 +50,8 @@ Game_Event::Game_Event(int map_id, const RPG::Event& event) :
 Game_Event::Game_Event(int /* map_id */, const RPG::Event& event, const RPG::SaveMapEvent& data) :
 	// FIXME unused int parameter
 	starting(false),
+	ready1(true),
+	ready2(true),
 	event(event),
 	page(NULL),
 	from_save(true) {
@@ -454,7 +458,7 @@ bool Game_Event::GetActive() const {
 
 void Game_Event::Start() {
 	// RGSS scripts consider list empty if size <= 1. Why?
-	if (list.empty() || !data.active)
+	if (list.empty() || !data.active || !ready1 || !ready2)
 		return;
 
 	starting = true;
@@ -486,6 +490,8 @@ void Game_Event::StopTalkToHero() {
 	if (!IsDirectionFixed()) {
 		SetSpriteDirection(GetDirection());
 	}
+
+	ready1 = true;
 }
 
 bool Game_Event::CheckEventTriggerTouch(int x, int y) {
@@ -506,6 +512,12 @@ void Game_Event::Update() {
 	if (!data.active) {
 		return;
 	}
+
+	// Workaround to make sure the event can't start again in the same frame it ended.
+	// TODO: Find a better way to do this. See: https://github.com/EasyRPG/Player/pull/469
+	ready2 = ready1;
+	ready1 = true;
+
 	Game_Character::Update();
 
 	CheckEventTriggerAuto();

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -474,6 +474,20 @@ std::vector<RPG::EventCommand>& Game_Event::GetList() {
 	return list;
 }
 
+void Game_Event::StartTalkToHero() {
+	if (!IsDirectionFixed()) {
+		int prelock_dir = GetDirection();
+		TurnTowardHero();
+		SetDirection(prelock_dir);
+	}
+}
+
+void Game_Event::StopTalkToHero() {
+	if (!IsDirectionFixed()) {
+		SetSpriteDirection(GetDirection());
+	}
+}
+
 bool Game_Event::CheckEventTriggerTouch(int x, int y) {
 	if (Game_Map::GetInterpreter().IsRunning())
 		return false;

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -134,6 +134,16 @@ public:
 	 */
 	std::vector<RPG::EventCommand>& GetList();
 
+	/**
+	 * Event's sprite looks towards the hero but its original direction is remembered.
+	 */
+	void StartTalkToHero();
+
+	/**
+	 * Event returns to its original direction before talking to the hero.
+	 */
+	void StopTalkToHero();
+
 	void CheckEventTriggerAuto();
 	bool CheckEventTriggerTouch(int x, int y);
 	void Start();

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -175,6 +175,7 @@ private:
 
 	unsigned int ID;
 	bool starting;
+	bool ready1, ready2;
 	int trigger;
 	RPG::Event event;
 	RPG::EventPage* page;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -72,7 +72,6 @@ void Game_Interpreter::Clear() {
 	CloseMessageWindow();
 	event_id = 0;					// event ID
 	move_route_waiting = false;		// waiting for move completion
-	button_input_variable_id = 0;	// button input variable ID
 	wait_count = 0;					// wait count
 	continuation = NULL;			// function to execute to resume command
 	button_timer = 0;
@@ -183,11 +182,6 @@ void Game_Interpreter::Update() {
 				}
 			}
 			move_route_waiting = false;
-		}
-
-		if (button_input_variable_id > 0) {
-			InputButton();
-			break;
 		}
 
 		if (wait_count > 0) {
@@ -373,24 +367,6 @@ bool Game_Interpreter::CommandWait(RPG::EventCommand const& com) {
 		return true;
 	} else {
 		return Input::IsAnyTriggered();
-	}
-}
-
-void Game_Interpreter::InputButton() {
-	int n;
-	for (n = Input::UP; n != Input::N0; ++n) {
-		if (Input::IsTriggered((Input::InputButton) n)) {
-			break;
-		}
-	}
-
-	// If a button was pressed
-	if (n != Input::N0) {
-		// Set variable
-		Game_Variables[button_input_variable_id] = n;
-		Game_Map::SetNeedRefresh(true);
-		button_input_variable_id = 0;
-		Input::ResetKeys();
 	}
 }
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -384,7 +384,7 @@ bool Game_Interpreter::CommandEnd() {
 	list.clear();
 
 	if ((main_flag) && (event_id > 0)) {
-		Game_Map::GetEvents().find(event_id)->second->Unlock();
+		Game_Map::GetEvents().find(event_id)->second->StopTalkToHero();
 	}
 
 	return true;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -43,8 +43,6 @@
 #include "player.h"
 #include "util_macro.h"
 
-// Forward declarations.
-
 Game_Interpreter::Game_Interpreter(int _depth, bool _main_flag) {
 	depth = _depth;
 	main_flag = _main_flag;

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -66,10 +66,9 @@ protected:
 	bool main_flag;
 
 	int loop_count;
-	
+
 	bool move_route_waiting;
 
-	int button_input_variable_id;
 	unsigned int index;
 	int map_id;
 	unsigned int event_id;

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -594,9 +594,9 @@ bool Game_Interpreter_Map::CommandTeleport(RPG::EventCommand const& com) { // Co
 	int map_id = com.parameters[0];
 	int x = com.parameters[1];
 	int y = com.parameters[2];
-	// FIXME: RPG2K3 => facing direction = com.parameters[3]
+	int direction = com.parameters[3] - 1;
 
-	Main_Data::game_player->ReserveTeleport(map_id, x, y);
+	Main_Data::game_player->ReserveTeleport(map_id, x, y, direction);
 	Main_Data::game_player->StartTeleport();
 
 	index++;
@@ -1521,6 +1521,7 @@ bool Game_Interpreter_Map::CommandKeyInputProc(RPG::EventCommand const& com) { /
 	int result = 0;
 	size_t param_size = com.parameters.size();
 
+	// Use a function pointer to check triggered keys if it waits for input and pressed keys otherwise
 	bool (*check)(Input::InputButton) = wait ? Input::IsTriggered : Input::IsPressed;
 
 	if (Player::IsRPG2k()) {

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -1598,8 +1598,7 @@ bool Game_Interpreter_Map::CommandKeyInputProc(RPG::EventCommand const& com) { /
 
 	button_timer = 0;
 
-	++index;
-	return false;
+	return true;
 }
 
 bool Game_Interpreter_Map::CommandChangeVehicleGraphic(RPG::EventCommand const& com) { // code 10650

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -1500,6 +1500,12 @@ bool Game_Interpreter_Map::CommandKeyInputProc(RPG::EventCommand const& com) { /
 	int var_id = com.parameters[0];
 	bool wait = com.parameters[1] != 0;
 
+	// Wait the first frame so that it ignores keys that were pressed before this command started.
+	if (wait && button_timer == 0) {
+		button_timer++;
+		return false;
+	}
+
 	bool time = false;
 	int time_id = 0;
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -1515,6 +1515,8 @@ bool Game_Interpreter_Map::CommandKeyInputProc(RPG::EventCommand const& com) { /
 	int result = 0;
 	size_t param_size = com.parameters.size();
 
+	bool (*check)(Input::InputButton) = wait ? Input::IsTriggered : Input::IsPressed;
+
 	if (Player::IsRPG2k()) {
 		if (param_size < 6) {
 			// For Rpg2k <1.50
@@ -1547,37 +1549,37 @@ bool Game_Interpreter_Map::CommandKeyInputProc(RPG::EventCommand const& com) { /
 		}
 	}
 
-	if (check_down && Input::IsTriggered(Input::DOWN)) {
+	if (check_down && check(Input::DOWN)) {
 		result = 1;
 	}
-	if (check_left && Input::IsTriggered(Input::LEFT)) {
+	if (check_left && check(Input::LEFT)) {
 		result = 2;
 	}
-	if (check_right && Input::IsTriggered(Input::RIGHT)) {
+	if (check_right && check(Input::RIGHT)) {
 		result = 3;
 	}
-	if (check_up && Input::IsTriggered(Input::UP)) {
+	if (check_up && check(Input::UP)) {
 		result = 4;
 	}
-	if (check_decision && Input::IsTriggered(Input::DECISION)) {
+	if (check_decision && check(Input::DECISION)) {
 		result = 5;
 	}
-	if (check_cancel && Input::IsTriggered(Input::CANCEL)) {
+	if (check_cancel && check(Input::CANCEL)) {
 		result = 6;
 	}
-	if (check_shift && Input::IsTriggered(Input::SHIFT)) {
+	if (check_shift && check(Input::SHIFT)) {
 		result = 7;
 	}
 	if (check_numbers) {
 		for (int i = 0; i < 10; ++i) {
-			if (Input::IsTriggered((Input::InputButton)(Input::N0 + i))) {
+			if (check((Input::InputButton)(Input::N0 + i))) {
 				result = 10 + i;
 			}
 		}
 	}
 	if (check_arith) {
 		for (int i = 0; i < 5; ++i) {
-			if (Input::IsTriggered((Input::InputButton)(Input::PLUS + i))) {
+			if (check((Input::InputButton)(Input::PLUS + i))) {
 				result = 20 + i;
 			}
 		}

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -452,7 +452,7 @@ bool Game_Player::CheckEventTriggerThere(const std::vector<int>& triggers) {
 		)
 		{
 			if (!(*i)->GetList().empty()) {
-				(*i)->Lock();
+				(*i)->StartTalkToHero();
 			}
 			(*i)->Start();
 			result = true;
@@ -472,7 +472,7 @@ bool Game_Player::CheckEventTriggerThere(const std::vector<int>& triggers) {
 			)
 			{
 				if (!(*i)->GetList().empty()) {
-					(*i)->Lock();
+					(*i)->StartTalkToHero();
 				}
 				(*i)->Start();
 				result = true;
@@ -496,7 +496,7 @@ bool Game_Player::CheckEventTriggerTouch(int x, int y) {
 			((*i)->GetTrigger() == RPG::EventPage::Trigger_touched ||
 			(*i)->GetTrigger() == RPG::EventPage::Trigger_collision) ) {
 			if (!(*i)->GetList().empty()) {
-				(*i)->Lock();
+				(*i)->StartTalkToHero();
 			}
 			(*i)->Start();
 			result = true;

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -200,10 +200,11 @@ void Game_Player::SetFlashTimeLeft(int time_left) {
 	location.flash_time_left = time_left;
 }
 
-void Game_Player::ReserveTeleport(int map_id, int x, int y) {
+void Game_Player::ReserveTeleport(int map_id, int x, int y, int direction) {
 	new_map_id = map_id;
 	new_x = x;
 	new_y = y;
+	new_direction = direction;
 
 	FileRequestAsync* request = Game_Map::RequestMap(new_map_id);
 	request->SetImportantFile(true);
@@ -229,6 +230,11 @@ void Game_Player::PerformTeleport() {
 	SetOpacity(255);
 
 	MoveTo(new_x, new_y);
+	if (new_direction >= 0) {
+		SetDirection(new_direction);
+		SetSpriteDirection(new_direction);
+	}
+
 	if (InVehicle())
 		GetVehicle()->MoveTo(new_x, new_y);
 }

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -80,7 +80,16 @@ public:
 	/** @} */
 
 	bool IsTeleporting() const;
-	void ReserveTeleport(int map_id, int x, int y);
+
+	/**
+	 * Sets the map, position and direction that the game player must have after the teleport is over
+	 *
+	 * @param map_id Id of the target map
+	 * @param x new x position after teleport
+	 * @param y new y position after teleport
+	 * @param direction New direction after teleport. If -1, the direction isn't changed.
+	 */
+	void ReserveTeleport(int map_id, int x, int y, int direction = -1);
 	void StartTeleport();
 	void PerformTeleport();
 	void Center(int x, int y);
@@ -103,7 +112,7 @@ private:
 	RPG::SavePartyLocation& location;
 
 	bool teleporting;
-	int new_map_id, new_x, new_y;
+	int new_map_id, new_x, new_y, new_direction;
 	int last_pan_x, last_pan_y;
 	RPG::Music walking_bgm;
 


### PR DESCRIPTION
You can now play everyone's favourite: the Nasu minigame of Yume Nikki!

The hardest issue is, without breaking anything, avoiding restarting an action-triggered event when one of its last commands is a KeyInputProc waiting for the action key. There're three relevant moments that run in the following order: the update of the main interpreter, the update of the event and the update of the game player. Suppose we have an event running a KeyInputProc waiting for the action key. This is what it should happen:

Frame | Main Interpreter | Event | Game Player
-------- | -------------------- | ------- | ----------------
1 | Player presses Action Key. Event reaches command end. | - | Action key triggers event. The interpreter ran commands from this event in this frame, so its commands are not loaded
2 | - | - | Player can trigger again the event

This is what happens without the workaround 08100c3:

Frame | Main Interpreter | Event | Game Player
-------- | -------------------- | ------- | ----------------
1 | Player press Action Key. Event reaches command end. | - | Action key triggers event. The interpreter is free, so its commands are loaded
2 | It runs the event's commands | - | -

This is how it looks with the workaround:

Frame | Main Interpreter | Event | Game Player
-------- | -------------------- | ------- | ----------------
1 | Player presses Action Key. Event reaches command end. ready1 = false; | ready1 = true; ready2 = false; | Action key triggers event. ready2 == false, so its commands are not loaded
2 | - | ready2 = false; | Player can trigger again the event

The workaround is ugly, but it works until we come up with a better solution.