### PR TITLE
check fread's return value

### DIFF
--- a/src/image_bmp.cpp
+++ b/src/image_bmp.cpp
@@ -144,7 +144,11 @@ void ImageBMP::ReadBMP(FILE* stream, bool transparent,
 	long size = ftell(stream);
 	fseek(stream, 0, SEEK_SET);
 	std::vector<uint8_t> buffer(size);
-	fread((void*) &buffer.front(), 1, size, stream);
+	long size_read = fread((void*) &buffer.front(), 1, size, stream);
+	if (size_read != size) {
+		Output::Error("Error reading BMP file.");
+		return;
+	}
 	ReadBMP(&buffer.front(), (unsigned) size, transparent, width, height, pixels);
 }
 

--- a/src/image_xyz.cpp
+++ b/src/image_xyz.cpp
@@ -74,7 +74,11 @@ void ImageXYZ::ReadXYZ(FILE* stream, bool transparent,
     long size = ftell(stream);
     fseek(stream, 0, SEEK_SET);
 	std::vector<uint8_t> buffer(size);
-	fread((void*) &buffer.front(), 1, size, stream);
+    long size_read = fread((void*) &buffer.front(), 1, size, stream);
+    if (size_read != size) {
+        Output::Error("Error reading XYZ file.");
+        return;
+    }
 	ReadXYZ(&buffer.front(), (unsigned) size, transparent, width, height, pixels);
 }
 


### PR DESCRIPTION
This should fix the following warning:
```
warning: ignoring return value of ‘fread’, declared with attribute warn_unused_result [-Wunused-result]
```