### PR TITLE
Battle improvments

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -344,6 +344,10 @@ int Game_Actor::GetNextExp(int level) const {
 	}
 }
 
+int Game_Actor::GetStateProbability(int state_id) {
+	return GetStateRate(state_id, Data::actors[data.ID - 1].state_ranks[state_id - 1]);
+}
+
 const std::string& Game_Actor::GetName() const {
 	return data.name;
 }

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -345,7 +345,13 @@ int Game_Actor::GetNextExp(int level) const {
 }
 
 int Game_Actor::GetStateProbability(int state_id) {
-	return GetStateRate(state_id, Data::actors[data.ID - 1].state_ranks[state_id - 1]);
+	int rate = 3; // C - default
+
+	if (state_id <= Data::actors[data.ID - 1].state_ranks.size()) {
+		rate = Data::actors[data.ID - 1].state_ranks[state_id - 1];
+	}
+
+	return GetStateRate(state_id, rate);
 }
 
 const std::string& Game_Actor::GetName() const {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -669,6 +669,10 @@ int Game_Actor::GetBattleAnimationId() const {
 	return Data::battleranimations[Data::actors[data.ID - 1].battler_animation - 1].ID;
 }
 
+int Game_Actor::GetCriticalHitChance() const {
+	return Data::actors[data.ID - 1].critical_hit ? Data::actors[data.ID - 1].critical_hit_chance : 0;
+}
+
 Game_Battler::BattlerType Game_Actor::GetType() const {
 	return Game_Battler::Type_Ally;
 }

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -669,6 +669,10 @@ int Game_Actor::GetBattleAnimationId() const {
 	return Data::battleranimations[Data::actors[data.ID - 1].battler_animation - 1].ID;
 }
 
+int Game_Actor::GetHitChance() const {
+	return 90;
+}
+
 int Game_Actor::GetCriticalHitChance() const {
 	return Data::actors[data.ID - 1].critical_hit ? Data::actors[data.ID - 1].critical_hit_chance : 0;
 }

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -347,7 +347,7 @@ int Game_Actor::GetNextExp(int level) const {
 int Game_Actor::GetStateProbability(int state_id) {
 	int rate = 3; // C - default
 
-	if (state_id <= Data::actors[data.ID - 1].state_ranks.size()) {
+	if (state_id <= (int)Data::actors[data.ID - 1].state_ranks.size()) {
 		rate = Data::actors[data.ID - 1].state_ranks[state_id - 1];
 	}
 

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -176,6 +176,14 @@ public:
 	int GetNextExp(int level) const;
 
 	/**
+	 * Gets probability that a state can be inflicted on this actor.
+	 *
+	 * @param state_id State to test
+	 * @return Probability of state infliction
+	 */
+	int GetStateProbability(int state_id);
+
+	/**
 	 * Gets actor name.
 	 *
 	 * @return name.

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -635,6 +635,7 @@ public:
 
 	int GetBattleAnimationId() const;
 
+	int GetHitChance() const;
 	int GetCriticalHitChance() const;
 
 	BattlerType GetType() const;

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -625,6 +625,7 @@ public:
 	 * @return row for Rpg2k3 battles (-1 front, 1 back).
 	 */
 	int GetBattleRow() const;
+
 	/**
 	 * Sets battle row for Rpg2k3 battles.
 	 *
@@ -634,8 +635,9 @@ public:
 
 	int GetBattleAnimationId() const;
 
-	BattlerType GetType() const;
+	int GetCriticalHitChance() const;
 
+	BattlerType GetType() const;
 private:
 	RPG::SaveActor& data;
 

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -47,6 +47,13 @@ namespace Game_Battle {
 	int escape_fail_count;
 }
 
+namespace {
+	int turn;
+	bool message_is_fixed;
+	int message_position;
+	bool terminate;
+}
+
 void Game_Battle::Init() {
 	interpreter.reset(new Game_Interpreter_Battle(0, true));
 	spriteset.reset(new Spriteset_Battle());

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -78,6 +78,8 @@ void Game_Battle::Quit() {
 		(*it)->RemoveBattleStates();
 	}
 
+	Main_Data::game_party->ResetBattle();
+
 	Game_Message::SetPositionFixed(message_is_fixed);
 	Game_Message::SetPosition(message_position);
 }

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -60,6 +60,8 @@ void Game_Battle::Init() {
 
 	message_is_fixed = Game_Message::IsPositionFixed();
 	message_position = Game_Message::GetPosition();
+	
+	Main_Data::game_party->ResetBattle();
 }
 
 void Game_Battle::Quit() {

--- a/src/game_battle.h
+++ b/src/game_battle.h
@@ -67,11 +67,6 @@ namespace Game_Battle {
 	*/
 	Game_Interpreter& GetInterpreter();
 
-	static int turn;
-	static bool message_is_fixed;
-	static int message_position;
-	extern bool terminate;
-	extern std::string background_name;
-
 	extern int escape_fail_count;
+	extern std::string background_name;
 }

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -882,6 +882,24 @@ std::string Game_BattleAlgorithm::Escape::GetStartMessage() const {
 	return "";
 }
 
+int Game_BattleAlgorithm::Escape::GetSourceAnimationState() const {
+	if (source->GetType() == Game_Battler::Type_Ally) {
+		return AlgorithmBase::GetSourceAnimationState();
+	}
+	else {
+		return Sprite_Battler::AnimationState_Dead;
+	}
+}
+
+const RPG::Sound* Game_BattleAlgorithm::Escape::GetStartSe() const {
+	if (source->GetType() == Game_Battler::Type_Ally) {
+		return AlgorithmBase::GetStartSe();
+	}
+	else {
+		return &Data::system.escape_se;
+	}
+}
+
 bool Game_BattleAlgorithm::Escape::Execute() {
 	Reset();
 
@@ -905,9 +923,6 @@ bool Game_BattleAlgorithm::Escape::Execute() {
 
 		this->success = rand() % 100 < (int)to_hit;
 	}
-	else {
-		Output::Warning("Battle: Enemy Escape not implemented");
-	}
 
 	return this->success;
 }
@@ -915,6 +930,10 @@ bool Game_BattleAlgorithm::Escape::Execute() {
 void Game_BattleAlgorithm::Escape::Apply() {
 	if (!this->success) {
 		Game_Battle::escape_fail_count += 1;
+	}
+
+	if (source->GetType() == Game_Battler::Type_Enemy) {
+		static_cast<Game_Enemy*>(source)->SetRemoved(true);
 	}
 }
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -625,7 +625,12 @@ const RPG::Sound* Game_BattleAlgorithm::Skill::GetStartSe() const {
 		return &skill.sound_effect;
 	}
 	else {
-		return AlgorithmBase::GetStartSe();
+		if (source->GetType() == Game_Battler::Type_Enemy) {
+			return &Data::system.enemy_attack_se;
+		}
+		else {
+			return NULL;
+		}
 	}
 }
 
@@ -753,7 +758,12 @@ const RPG::Sound* Game_BattleAlgorithm::Item::GetStartSe() const {
 		return &Data::system.item_se;
 	}
 	else {
-		return AlgorithmBase::GetStartSe();
+		if (source->GetType() == Game_Battler::Type_Enemy) {
+			return &Data::system.enemy_attack_se;
+		}
+		else {
+			return NULL;
+		}
 	}
 }
 
@@ -905,7 +915,7 @@ void Game_BattleAlgorithm::SelfDestruct::Apply() {
 
 	// Only monster can self destruct
 	if (source->GetType() == Game_Battler::Type_Enemy) {
-		static_cast<Game_Enemy*>(source)->SetRemoved(true);
+		static_cast<Game_Enemy*>(source)->SetHidden(true);
 	}
 }
 
@@ -977,7 +987,7 @@ void Game_BattleAlgorithm::Escape::Apply() {
 	}
 
 	if (source->GetType() == Game_Battler::Type_Enemy) {
-		static_cast<Game_Enemy*>(source)->SetRemoved(true);
+		static_cast<Game_Enemy*>(source)->SetHidden(true);
 	}
 }
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -169,6 +169,12 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 			}
 		}
 		else {
+			if (critical_hit) {
+				out.push_back(target_is_ally ?
+					Data::terms.actor_critical :
+					Data::terms.enemy_critical);
+			}
+
 			if (GetAffectedHp() == 0) {
 				ss << (target_is_ally ?
 					Data::terms.actor_undamaged :
@@ -412,14 +418,18 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 
 	// Damage calculation
 	if (rand() % 100 < to_hit) {
-		int effect = source->GetAtk() / 2 - (*current_target)->GetDef() / 4;
+		if (rand() % 100 < source->GetCriticalHitChance()) {
+			critical_hit = true;
+		}
+
+		int effect = (source->GetAtk() / 2 - (*current_target)->GetDef() / 4);
 		if (effect < 0)
 			effect = 0;
 		int act_perc = (rand() % 40) - 20;
 		// Change rounded up
 		int change = (int)(std::ceil(effect * act_perc / 100.0));
 		effect += change;
-		this->hp = effect;
+		this->hp = effect * (critical_hit ? 3 : 1);
 
 		if ((*current_target)->GetHp() - this->hp <= 0) {
 			// Death state

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -113,19 +113,19 @@ const RPG::Animation* Game_BattleAlgorithm::AlgorithmBase::GetAnimation() const 
 	return animation;
 }
 
-bool Game_BattleAlgorithm::AlgorithmBase::GetSuccess() const {
+bool Game_BattleAlgorithm::AlgorithmBase::IsSuccess() const {
 	return success;
 }
 
-bool Game_BattleAlgorithm::AlgorithmBase::GetKilledByAttack() const {
+bool Game_BattleAlgorithm::AlgorithmBase::IsKilledByAttack() const {
 	return killed_by_attack_damage;
 }
 
-bool Game_BattleAlgorithm::AlgorithmBase::GetCriticalHit() const {
+bool Game_BattleAlgorithm::AlgorithmBase::IsCriticalHit() const {
 	return critical_hit;
 }
 
-bool Game_BattleAlgorithm::AlgorithmBase::GetFirstAttack() const {
+bool Game_BattleAlgorithm::AlgorithmBase::IsFirstAttack() const {
 	return first_attack;
 }
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -15,6 +15,7 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <cmath>
 #include <cstdlib>
 #include <sstream>
 #include "game_actor.h"

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -541,8 +541,10 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				continue;
 
 			this->success = true;
-
-			conditions.push_back(Data::states[i]);
+			
+			if (rand() % 100 <= (*current_target)->GetStateProbability(Data::states[i].ID)) {
+				conditions.push_back(Data::states[i]);
+			}
 		}
 
 		return this->success;

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -586,7 +586,9 @@ void Game_BattleAlgorithm::Skill::Apply() {
 		Main_Data::game_party->ConsumeItemUse(item->ID);
 	}
 	else {
-		source->SetSp(source->GetSp() - source->CalculateSkillCost(skill.ID));
+		if (first_attack) {
+			source->SetSp(source->GetSp() - source->CalculateSkillCost(skill.ID));
+		}
 	}
 }
 
@@ -714,7 +716,9 @@ bool Game_BattleAlgorithm::Item::Execute() {
 void Game_BattleAlgorithm::Item::Apply() {
 	AlgorithmBase::Apply();
 
-	Main_Data::game_party->RemoveItem(item.ID, 1);
+	if (first_attack) {
+		Main_Data::game_party->RemoveItem(item.ID, 1);
+	}
 }
 
 std::string Game_BattleAlgorithm::Item::GetStartMessage() const {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -851,6 +851,12 @@ bool Game_BattleAlgorithm::SelfDestruct::Execute() {
 	effect += change;
 	this->hp = effect;
 
+	if ((*current_target)->GetHp() - this->hp <= 0) {
+		// Death state
+		killed_by_attack_damage = true;
+		conditions.push_back(Data::states[0]);
+	}
+
 	success = true;
 
 	return true;

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -54,7 +54,7 @@ Game_BattleAlgorithm::AlgorithmBase::AlgorithmBase(Game_Battler* source, Game_Pa
 	source(source) {
 	Reset();
 
-	target->GetAliveBattlers(targets);
+	target->GetActiveBattlers(targets);
 	current_target = targets.begin();
 }
 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -152,24 +152,24 @@ public:
 	 *
 	 * @return if the action hit the target
 	 */
-	bool GetSuccess() const;
+	bool IsSuccess() const;
 
 	/**
 	 * See GetDeathMessage for further explanations
 	 *
 	 * @return True when the caller died because his hp reached 0 (false when a condition caused death)
 	 */
-	bool GetKilledByAttack() const;
+	bool IsKilledByAttack() const;
 
 	/**
 	 * Gets if the last action was a critical hit.
 	 */
-	bool GetCriticalHit() const;
+	bool IsCriticalHit() const;
 
 	/**
 	 * Gets if that is the first target of the action.
 	 */
-	bool GetFirstAttack() const;
+	bool IsFirstAttack() const;
 
 	/**
 	 * Executes the algorithm. Must be called before using the other functions.

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -34,7 +34,7 @@ namespace RPG {
 
 /**
  * Contains algorithms to handle the different battle attacks, skills and items.
- * The algorithms are support single targets and party targets.
+ * The algorithms support single targets and party targets.
  * For party targets the caller is responsible for retargeting using TargetNext.
  *
  * The action is simulated using Execute and the results can be applied after the
@@ -54,7 +54,7 @@ public:
 	/**
 	 * Returns the current target.
 	 *
-	 * @return current target battler 
+	 * @return current target battler
 	 */
 	Game_Battler* GetTarget() const;
 
@@ -167,6 +167,11 @@ public:
 	bool GetCriticalHit() const;
 
 	/**
+	 * Gets if that is the first target of the action.
+	 */
+	bool GetFirstAttack() const;
+
+	/**
 	 * Executes the algorithm. Must be called before using the other functions.
 	 * This function only simulates the Algorithm, call Apply to add the
 	 * changes of the last Execute call to the target.
@@ -262,6 +267,7 @@ protected:
 	int agility;
 	int switch_id;
 
+	bool first_attack;
 	bool healing;
 	bool success;
 	bool killed_by_attack_damage;
@@ -319,7 +325,6 @@ public:
 	const RPG::Sound* GetStartSe() const;
 	void GetResultMessages(std::vector<std::string>& out) const;
 
-
 private:
 	const RPG::Item& item;
 };
@@ -359,10 +364,13 @@ public:
 
 class SelfDestruct : public AlgorithmBase {
 public:
-	SelfDestruct(Game_Battler* source);
+	SelfDestruct(Game_Battler* source, Game_Party_Base* target);
 
 	std::string GetStartMessage() const;
+	int GetSourceAnimationState() const;
+	const RPG::Sound* GetStartSe() const;
 	bool Execute();
+	void Apply();
 };
 
 class Escape : public AlgorithmBase {

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -378,6 +378,8 @@ public:
 	Escape(Game_Battler* source);
 
 	std::string GetStartMessage() const;
+	int GetSourceAnimationState() const;
+	const RPG::Sound* GetStartSe() const;
 	bool Execute();
 	void Apply();
 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -288,6 +288,7 @@ public:
 
 	std::string GetStartMessage() const;
 	int GetSourceAnimationState() const;
+	const RPG::Sound* GetStartSe() const;
 };
 
 class Skill : public AlgorithmBase {
@@ -302,7 +303,7 @@ public:
 
 	std::string GetStartMessage() const;
 	int GetSourceAnimationState() const;
-	virtual const RPG::Sound* GetStartSe() const;
+	const RPG::Sound* GetStartSe() const;
 	void GetResultMessages(std::vector<std::string>& out) const;
 
 private:
@@ -334,6 +335,7 @@ public:
 	NormalDual(Game_Battler* source, Game_Battler* target);
 
 	std::string GetStartMessage() const;
+	const RPG::Sound* GetStartSe() const;
 	bool Execute();
 };
 
@@ -344,6 +346,7 @@ public:
 	std::string GetStartMessage() const;
 	int GetSourceAnimationState() const;
 	bool Execute();
+	void Apply();
 };
 
 class Observe : public AlgorithmBase {
@@ -360,6 +363,7 @@ public:
 
 	std::string GetStartMessage() const;
 	bool Execute();
+	void Apply();
 };
 
 class SelfDestruct : public AlgorithmBase {

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -32,8 +32,8 @@
 
 #define EASYRPG_GAUGE_MAX_VALUE 120000
 
-Game_Battler::Game_Battler() : gauge(EASYRPG_GAUGE_MAX_VALUE / 2) {
-	// no-op
+Game_Battler::Game_Battler() {
+	ResetBattle();
 }
 
 bool Game_Battler::HasState(int state_id) const {
@@ -272,6 +272,22 @@ void Game_Battler::RemoveAllStates() {
 	states.clear();
 }
 
+bool Game_Battler::IsCharged() const {
+	return charged;
+}
+
+void Game_Battler::SetCharged(bool charge) {
+	charged = charge;
+}
+
+bool Game_Battler::IsDefending() const {
+	return defending;
+}
+
+void Game_Battler::SetDefending(bool defend) {
+	defending = defend;
+}
+
 bool Game_Battler::IsHidden() const {
 	return false;
 }
@@ -409,4 +425,10 @@ const BattleAlgorithmRef Game_Battler::GetBattleAlgorithm() const {
 
 void Game_Battler::SetBattleAlgorithm(BattleAlgorithmRef battle_algorithm) {
 	this->battle_algorithm = battle_algorithm;
+}
+
+void Game_Battler::ResetBattle() {
+	gauge = EASYRPG_GAUGE_MAX_VALUE / 2;
+	charged = false;
+	defending = false;
 }

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -40,6 +40,16 @@ bool Game_Battler::HasState(int state_id) const {
 	return (std::find(GetStates().begin(), GetStates().end(), state_id) != GetStates().end());
 }
 
+int Game_Battler::GetSignificantRestriction() {
+	const std::vector<int16_t>& states = GetStates();
+	for (int i = 0; i < (int)states.size(); i++) {
+		const RPG::State* state = &Data::states[states[i] - 1];
+		if (state->restriction != RPG::State::Restriction_normal) {
+			return state->restriction;
+		}
+	}
+	return RPG::State::Restriction_normal;
+}
 
 bool Game_Battler::CanAct() {
 	const std::vector<int16_t>& states = GetStates();
@@ -292,8 +302,8 @@ int Game_Battler::GetAtk() const {
 
 	const std::vector<int16_t>& states = GetStates();
 	for (std::vector<int16_t>::const_iterator i = states.begin(); i != states.end(); ++i) {
-		if(Data::states[(*i)].affect_attack) {
-			n = AffectParameter(Data::states[(*i)].affect_type, base_atk);
+		if(Data::states[(*i) - 1].affect_attack) {
+			n = AffectParameter(Data::states[(*i) - 1].affect_type, base_atk);
 			break;
 		}
 	}
@@ -309,8 +319,8 @@ int Game_Battler::GetDef() const {
 
 	const std::vector<int16_t>& states = GetStates();
 	for (std::vector<int16_t>::const_iterator i = states.begin(); i != states.end(); ++i) {
-		if(Data::states[(*i)].affect_defense) {
-			n = AffectParameter(Data::states[(*i)].affect_type, base_def);
+		if(Data::states[(*i) - 1].affect_defense) {
+			n = AffectParameter(Data::states[(*i) - 1].affect_type, base_def);
 			break;
 		}
 	}
@@ -326,8 +336,8 @@ int Game_Battler::GetSpi() const {
 
 	const std::vector<int16_t>& states = GetStates();
 	for (std::vector<int16_t>::const_iterator i = states.begin(); i != states.end(); ++i) {
-		if(Data::states[(*i)].affect_spirit) {
-			n = AffectParameter(Data::states[(*i)].affect_type, base_spi);
+		if(Data::states[(*i) - 1].affect_spirit) {
+			n = AffectParameter(Data::states[(*i) - 1].affect_type, base_spi);
 			break;
 		}
 	}
@@ -343,8 +353,8 @@ int Game_Battler::GetAgi() const {
 
 	const std::vector<int16_t>& states = GetStates();
 	for (std::vector<int16_t>::const_iterator i = states.begin(); i != states.end(); ++i) {
-		if(Data::states[(*i)].affect_agility) {
-			n = AffectParameter(Data::states[(*i)].affect_type, base_agi);
+		if(Data::states[(*i) - 1].affect_agility) {
+			n = AffectParameter(Data::states[(*i) - 1].affect_type, base_agi);
 			break;
 		}
 	}

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -324,10 +324,6 @@ int Game_Battler::GetAtk() const {
 		}
 	}
 
-	if (IsCharged()) {
-		n *= 2;
-	}
-
 	n = min(max(n, 1), 999);
 
 	return n;
@@ -343,10 +339,6 @@ int Game_Battler::GetDef() const {
 			n = AffectParameter(Data::states[(*i) - 1].affect_type, base_def);
 			break;
 		}
-	}
-
-	if (IsDefending()) {
-		n *= 2;
 	}
 
 	n = min(max(n, 1), 999);

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -324,6 +324,10 @@ int Game_Battler::GetAtk() const {
 		}
 	}
 
+	if (IsCharged()) {
+		n *= 2;
+	}
+
 	n = min(max(n, 1), 999);
 
 	return n;
@@ -339,6 +343,10 @@ int Game_Battler::GetDef() const {
 			n = AffectParameter(Data::states[(*i) - 1].affect_type, base_def);
 			break;
 		}
+	}
+
+	if (IsDefending()) {
+		n *= 2;
 	}
 
 	n = min(max(n, 1), 999);

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -80,6 +80,27 @@ const RPG::State* Game_Battler::GetSignificantState() {
 	return the_state;
 }
 
+int Game_Battler::GetStateRate(int state_id, int rate) {
+	const RPG::State& state = Data::states[state_id - 1];
+
+	switch (rate) {
+	case 0:
+		return state.a_rate;
+	case 1:
+		return state.b_rate;
+	case 2:
+		return state.c_rate;
+	case 3:
+		return state.d_rate;
+	case 4:
+		return state.e_rate;
+	default:;
+	}
+
+	assert(false && "bad rate");
+	return 0;
+}
+
 bool Game_Battler::IsSkillUsable(int skill_id) const {
 	const RPG::Skill& skill = Data::skills[skill_id - 1];
 

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -60,6 +60,14 @@ public:
 	virtual std::vector<int16_t>& GetStates() = 0;
 
 	/**
+	 * Checks all states and returns the first restriction that different to
+	 * normal or normal if that is the only restriction.
+	 *
+	 * @return First non-normal restriction or normal if not restricted
+	 */
+	int GetSignificantRestriction();
+
+	/**
 	 * Tests if the battler has a "No Action" condition like sleep.
 	 *
 	 * @return can act 

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -311,6 +311,32 @@ public:
 
 	virtual int GetBattleAnimationId() const = 0;
 
+	virtual int GetCriticalHitChance() const = 0;
+
+	/**
+	 * @return If battler is charged (next attack double damages)
+	 */
+	bool IsCharged() const;
+
+	/**
+	 * Sets charge state (next attack double damages)
+	 *
+	 * @param charge new charge state
+	 */
+	void SetCharged(bool charge);
+
+	/**
+	* @return If battler is defending (next turn, defense is doubled)
+	*/
+	bool IsDefending() const;
+
+	/**
+	 * Sets defence state (next turn, defense is doubled)
+	 *
+	 * @param charge new charge state
+	 */
+	void SetDefending(bool defend);
+
 	enum BattlerType {
 		Type_Ally,
 		Type_Enemy
@@ -375,11 +401,18 @@ public:
 	 */
 	void SetBattleAlgorithm(const BattleAlgorithmRef battle_algorithm);
 
+	/**
+	 * Resets battle modifiers (gauge, defense and charge).
+	 */
+	void ResetBattle();
+
 protected:
 	/** Gauge for RPG2k3 Battle */
 	int gauge;
 
 	BattleAlgorithmRef battle_algorithm;
+	bool charged;
+	bool defending;
 };
 
 #endif

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -75,6 +75,23 @@ public:
 	const RPG::State* GetSignificantState();
 
 	/**
+	 * Gets the state probability by rate (A-E).
+	 *
+	 * @param state_id State to test
+	 * @param rate State rate to get
+	 * @return state rate (probability)
+	 */
+	int GetStateRate(int state_id, int rate);
+
+	/**
+	 * Gets probability that a state can be inflicted on this actor.
+	 * 
+	 * @param state_id State to test
+	 * @return Probability of state infliction
+	 */
+	virtual int GetStateProbability(int state_id) = 0;
+
+	/**
 	 * Gets the characters name
 	 *
 	 * @return Character name

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -230,7 +230,7 @@ public:
 	virtual bool IsHidden() const;
 	virtual bool IsImmortal() const;
 
-	bool Exists() const;
+	virtual bool Exists() const;
 	bool IsDead() const;
 
 	/**

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -311,6 +311,8 @@ public:
 
 	virtual int GetBattleAnimationId() const = 0;
 
+	virtual int GetHitChance() const = 0;
+
 	virtual int GetCriticalHitChance() const = 0;
 
 	/**

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -237,6 +237,10 @@ bool Game_Enemy::IsActionValid(const RPG::EnemyAction& action) {
 }
 
 const RPG::EnemyAction* Game_Enemy::ChooseRandomAction() {
+	if (IsCharged()) {
+		return &normal_atk;
+	}
+
 	const std::vector<RPG::EnemyAction>& actions = enemy->actions;
 	std::vector<int> valid;
 	int total = 0;

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -43,6 +43,10 @@ std::vector<int16_t>& Game_Enemy::GetStates() {
 	return states;
 }
 
+int Game_Enemy::GetStateProbability(int state_id) {
+	return GetStateRate(state_id, Data::enemies[enemy_id].state_ranks[state_id - 1]);
+}
+
 const std::string& Game_Enemy::GetName() const {
 	return enemy->name;
 }

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -166,6 +166,10 @@ int Game_Enemy::GetBattleAnimationId() const {
 	return 0;
 }
 
+int Game_Enemy::GetHitChance() const {
+	return enemy->miss ? 70 : 90;
+}
+
 int Game_Enemy::GetCriticalHitChance() const {
 	return enemy->critical_hit ? enemy->critical_hit_chance : 0;
 }

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -166,6 +166,10 @@ int Game_Enemy::GetBattleAnimationId() const {
 	return 0;
 }
 
+int Game_Enemy::GetCriticalHitChance() const {
+	return enemy->critical_hit ? enemy->critical_hit_chance : 0;
+}
+
 Game_Battler::BattlerType Game_Enemy::GetType() const {
 	return Game_Battler::Type_Enemy;
 }

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -44,7 +44,13 @@ std::vector<int16_t>& Game_Enemy::GetStates() {
 }
 
 int Game_Enemy::GetStateProbability(int state_id) {
-	return GetStateRate(state_id, Data::enemies[enemy_id].state_ranks[state_id - 1]);
+	int rate = 3; // C - default
+
+	if (state_id <= Data::enemies[enemy_id].state_ranks.size()) {
+		rate = Data::enemies[enemy_id].state_ranks[state_id - 1];
+	}
+
+	return GetStateRate(state_id, rate);
 }
 
 const std::string& Game_Enemy::GetName() const {

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -35,7 +35,6 @@ void Game_Enemy::Setup(int enemy_id) {
 	sp = GetMaxSp();
 	x = 0;
 	y = 0;
-	removed = false;
 	hidden = false;
 }
 
@@ -144,17 +143,6 @@ void Game_Enemy::SetHidden(bool _hidden) {
 
 bool Game_Enemy::IsHidden() const {
 	return hidden;
-}
-
-void Game_Enemy::SetRemoved(bool _removed) {
-	removed = _removed;
-}
-bool Game_Enemy::IsRemoved() const {
-	return removed;
-}
-
-bool Game_Enemy::Exists() const {
-	return Game_Battler::Exists() && !IsRemoved();
 }
 
 void Game_Enemy::Transform(int new_enemy_id) {

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -33,6 +33,10 @@ void Game_Enemy::Setup(int enemy_id) {
 	Transform(enemy_id);
 	hp = GetMaxHp();
 	sp = GetMaxSp();
+	x = 0;
+	y = 0;
+	removed = false;
+	hidden = false;
 }
 
 const std::vector<int16_t>& Game_Enemy::GetStates() const {
@@ -140,6 +144,17 @@ void Game_Enemy::SetHidden(bool _hidden) {
 
 bool Game_Enemy::IsHidden() const {
 	return hidden;
+}
+
+void Game_Enemy::SetRemoved(bool _removed) {
+	removed = _removed;
+}
+bool Game_Enemy::IsRemoved() const {
+	return removed;
+}
+
+bool Game_Enemy::Exists() const {
+	return Game_Battler::Exists() && !IsRemoved();
 }
 
 void Game_Enemy::Transform(int new_enemy_id) {

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -229,6 +229,10 @@ const RPG::EnemyAction* Game_Enemy::ChooseRandomAction() {
 		}
 	}
 
+	if (total == 0) {
+		return NULL;
+	}
+
 	int which = rand() % total;
 	for (std::vector<int>::const_iterator it = valid.begin(); it != valid.end(); ++it) {
 		const RPG::EnemyAction& action = actions[*it];

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -140,6 +140,7 @@ public:
 	bool IsRemoved() const;
 	void Transform(int new_enemy_id);
 
+	int GetHitChance() const;
 	int GetCriticalHitChance() const;
 	int GetBattleAnimationId() const;
 

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -133,11 +133,8 @@ public:
 	int GetSp() const;
 	void SetSp(int _sp);
 
-	bool Exists() const;
 	void SetHidden(bool _hidden);
 	bool IsHidden() const;
-	void SetRemoved(bool _removed);
-	bool IsRemoved() const;
 	void Transform(int new_enemy_id);
 
 	int GetHitChance() const;
@@ -177,8 +174,6 @@ protected:
 	int enemy_id;
 	// hidden at battle begin
 	bool hidden;
-	// removed during battle via escape/self destruct
-	bool removed;
 	int hp;
 	int sp;
 	std::vector<int16_t> states;
@@ -190,4 +185,3 @@ protected:
 };
 
 #endif
-

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -133,8 +133,11 @@ public:
 	int GetSp() const;
 	void SetSp(int _sp);
 
+	bool Exists() const;
 	void SetHidden(bool _hidden);
 	bool IsHidden() const;
+	void SetRemoved(bool _removed);
+	bool IsRemoved() const;
 	void Transform(int new_enemy_id);
 
 	int GetBattleAnimationId() const;
@@ -170,7 +173,10 @@ protected:
 	int y;
 
 	int enemy_id;
+	// hidden at battle begin
 	bool hidden;
+	// removed during battle via escape/self destruct
+	bool removed;
 	int hp;
 	int sp;
 	std::vector<int16_t> states;

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -34,6 +34,14 @@ public:
 	std::vector<int16_t>& GetStates();
 
 	/**
+	 * Gets probability that a state can be inflicted on this actor.
+	 *
+	 * @param state_id State to test
+	 * @return Probability of state infliction
+	 */
+	int GetStateProbability(int state_id);
+
+	/**
 	 * Gets the characters name
 	 *
 	 * @return Character name

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -140,6 +140,7 @@ public:
 	bool IsRemoved() const;
 	void Transform(int new_enemy_id);
 
+	int GetCriticalHitChance() const;
 	int GetBattleAnimationId() const;
 
 	int GetExp() const;

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -183,6 +183,9 @@ protected:
 	std::vector<int16_t> states;
 
 	RPG::Enemy* enemy;
+
+	// normal attack instance for use after charge
+	RPG::EnemyAction normal_atk;
 };
 
 #endif

--- a/src/game_enemyparty.cpp
+++ b/src/game_enemyparty.cpp
@@ -35,7 +35,7 @@ Game_Enemy& Game_EnemyParty::operator[] (const int index) {
 }
 
 int Game_EnemyParty::GetBattlerCount() const {
-	return enemies.size();
+	return (int)enemies.size();
 }
 
 void Game_EnemyParty::Setup(int battle_troop_id) {

--- a/src/game_enemyparty.cpp
+++ b/src/game_enemyparty.cpp
@@ -55,22 +55,13 @@ std::vector<EASYRPG_SHARED_PTR<Game_Enemy> >& Game_EnemyParty::GetEnemies() {
 	return enemies;
 }
 
-std::vector<Game_Enemy*> Game_EnemyParty::GetAliveEnemies() {
-	std::vector<Game_Enemy*> alive;
-	std::vector<EASYRPG_SHARED_PTR<Game_Enemy> >::iterator it;
-	for (it = enemies.begin(); it != enemies.end(); ++it) {
-		if (!(*it)->IsDead()) {
-			alive.push_back(it->get());
-		}
-	}
-	return alive;
-}
-
 int Game_EnemyParty::GetExp() const {
 	std::vector<EASYRPG_SHARED_PTR<Game_Enemy> >::const_iterator it;
 	int sum = 0;
 	for (it = enemies.begin(); it != enemies.end(); ++it) {
-		sum += (*it)->GetExp();
+		if ((*it)->IsDead()) {
+			sum += (*it)->GetExp();
+		}
 	}
 	return sum;
 }
@@ -79,7 +70,9 @@ int Game_EnemyParty::GetMoney() const {
 	std::vector<EASYRPG_SHARED_PTR<Game_Enemy> >::const_iterator it;
 	int sum = 0;
 	for (it = enemies.begin(); it != enemies.end(); ++it) {
-		sum += (*it)->GetMoney();
+		if ((*it)->IsDead()) {
+			sum += (*it)->GetMoney();
+		}
 	}
 	return sum;
 }
@@ -87,11 +80,13 @@ int Game_EnemyParty::GetMoney() const {
 void Game_EnemyParty::GenerateDrops(std::vector<int>& out) const {
 	std::vector<EASYRPG_SHARED_PTR<Game_Enemy> >::const_iterator it;
 	for (it = enemies.begin(); it != enemies.end(); ++it) {
-		// Only roll if the enemy has something to drop
-		if ((*it)->GetDropId() != 0) {
-			bool dropped = (rand() % 100) < (*it)->GetDropProbability();
-			if (dropped) {
-				out.push_back((*it)->GetDropId());
+		if ((*it)->IsDead()) {
+			// Only roll if the enemy has something to drop
+			if ((*it)->GetDropId() != 0) {
+				bool dropped = (rand() % 100) < (*it)->GetDropProbability();
+				if (dropped) {
+					out.push_back((*it)->GetDropId());
+				}
 			}
 		}
 	}

--- a/src/game_enemyparty.h
+++ b/src/game_enemyparty.h
@@ -53,13 +53,6 @@ public:
 	std::vector<EASYRPG_SHARED_PTR<Game_Enemy> >& GetEnemies();
 
 	/**
-	 * Gets a list with all alive party members
-	 *
-	 * @return list of alive party members
-	 */
-	std::vector<Game_Enemy*> GetAliveEnemies();
-
-	/**
 	 * Sums up the experience points of all enemy party members.
 	 *
 	 * @return All experience points

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -1700,6 +1700,7 @@ bool Game_Interpreter_Map::CommandSimulatedAttack(RPG::EventCommand const& com) 
 		 i != actors.end();
 		 ++i) {
 		Game_Actor* actor = *i;
+		actor->ResetBattle();
 		int result = atk;
 		result -= (actor->GetDef() * def) / 400;
 		result -= (actor->GetSpi() * spi) / 800;

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -44,7 +44,7 @@ Game_Actor& Game_Party::operator[] (const int index) {
 }
 
 int Game_Party::GetBattlerCount() const {
-	return GetActors().size();
+	return (int)GetActors().size();
 }
 
 void Game_Party::SetupBattleTestMembers() {
@@ -440,7 +440,7 @@ int Game_Party::GetAverageLevel() {
 		party_lvl += (*it)->GetLevel();
 	}
 
-	return party_lvl /= actors.size();
+	return party_lvl /= (int)actors.size();
 }
 
 int Game_Party::GetFatigue() {
@@ -458,5 +458,5 @@ int Game_Party::GetFatigue() {
 			100 * (*it)->GetSp() / (*it)->GetMaxSp() / 3);
 	}
 
-	return party_exh /= actors.size();
+	return party_exh /= (int)actors.size();
 }

--- a/src/game_party_base.cpp
+++ b/src/game_party_base.cpp
@@ -28,11 +28,11 @@ void Game_Party_Base::GetBattlers(std::vector<Game_Battler*>& out) {
 	}
 }
 
-void Game_Party_Base::GetAliveBattlers(std::vector<Game_Battler*>& out) {
+void Game_Party_Base::GetActiveBattlers(std::vector<Game_Battler*>& out) {
 	int count = GetBattlerCount();
 	for (int i = 0; i < count; ++i) {
 		Game_Battler* battler = &(*this)[i];
-		if (!battler->IsDead()) {
+		if (battler->Exists()) {
 			out.push_back(battler);
 		}
 	}
@@ -48,7 +48,7 @@ void Game_Party_Base::GetDeadBattlers(std::vector<Game_Battler*>& out) {
 	}
 }
 
-Game_Battler* Game_Party_Base::GetNextAliveBattler(Game_Battler* battler) {
+Game_Battler* Game_Party_Base::GetNextActiveBattler(Game_Battler* battler) {
 	std::vector<Game_Battler*> battlers;
 	GetBattlers(battlers);
 
@@ -61,7 +61,7 @@ Game_Battler* Game_Party_Base::GetNextAliveBattler(Game_Battler* battler) {
 
 	for (++it; it != battlers.end(); ++it) {
 		Game_Battler* b = *it;
-		if (!b->IsDead()) {
+		if (b->Exists()) {
 			return b;
 		}
 	}
@@ -69,7 +69,7 @@ Game_Battler* Game_Party_Base::GetNextAliveBattler(Game_Battler* battler) {
 	// None found after battler, try from the beginning now
 	for (it = battlers.begin(); *it != battler; ++it) {
 		Game_Battler* b = *it;
-		if (!b->IsDead()) {
+		if (b->Exists()) {
 			return b;
 		}
 	}
@@ -77,9 +77,9 @@ Game_Battler* Game_Party_Base::GetNextAliveBattler(Game_Battler* battler) {
 	return NULL;
 }
 
-Game_Battler* Game_Party_Base::GetRandomAliveBattler() {
+Game_Battler* Game_Party_Base::GetRandomActiveBattler() {
 	std::vector<Game_Battler*> battlers;
-	GetAliveBattlers(battlers);
+	GetActiveBattlers(battlers);
 	if (battlers.empty()) {
 		return NULL;
 	}
@@ -97,8 +97,8 @@ Game_Battler* Game_Party_Base::GetRandomDeadBattler() {
 	return battlers[rand() / (RAND_MAX / battlers.size() + 1)];
 }
 
-bool Game_Party_Base::IsAnyAlive() {
-	return GetRandomAliveBattler() != NULL;
+bool Game_Party_Base::IsAnyActive() {
+	return GetRandomActiveBattler() != NULL;
 }
 
 int Game_Party_Base::GetAverageAgility() {

--- a/src/game_party_base.cpp
+++ b/src/game_party_base.cpp
@@ -115,3 +115,18 @@ int Game_Party_Base::GetAverageAgility() {
 
 	return agi /= battlers.size();
 }
+
+bool Game_Party_Base::IsAnyControllable() {
+	std::vector<Game_Battler*> battlers;
+	GetBattlers(battlers);
+
+	std::vector<Game_Battler*>::const_iterator it;
+
+	for (it = battlers.begin(); it != battlers.end(); ++it) {
+		if ((*it)->GetSignificantRestriction() == RPG::State::Restriction_normal) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/src/game_party_base.cpp
+++ b/src/game_party_base.cpp
@@ -130,3 +130,14 @@ bool Game_Party_Base::IsAnyControllable() {
 
 	return false;
 }
+
+void Game_Party_Base::ResetBattle() {
+	std::vector<Game_Battler*> battlers;
+	GetBattlers(battlers);
+
+	std::vector<Game_Battler*>::const_iterator it;
+
+	for (it = battlers.begin(); it != battlers.end(); ++it) {
+		(*it)->ResetBattle();
+	}
+}

--- a/src/game_party_base.h
+++ b/src/game_party_base.h
@@ -99,6 +99,13 @@ public:
 	 */
 	virtual int GetAverageAgility();
 
+	/**
+	 * Tests if any party member has no state restriction.
+	 *
+	 * @return Whether any party member accepts custom battle commands.
+	 */
+	bool IsAnyControllable();
+
 private:
 
 };

--- a/src/game_party_base.h
+++ b/src/game_party_base.h
@@ -107,6 +107,11 @@ public:
 	 */
 	bool IsAnyControllable();
 
+	/**
+	 * Resets battle modifiers of all members (gauge, defense and charge).
+	 */
+	void ResetBattle();
+
 private:
 
 };

--- a/src/game_party_base.h
+++ b/src/game_party_base.h
@@ -51,11 +51,11 @@ public:
 	virtual void GetBattlers(std::vector<Game_Battler*>& out);
 
 	/**
-	 * Returns a list of all alive battlers in the party
+	 * Gets a list with all active (not dead or hidden) party members.
 	 *
-	 * @param out List of all dead battlers
+	 * @return list of all active party members
 	 */
-	virtual void GetAliveBattlers(std::vector<Game_Battler*>& out);
+	virtual void GetActiveBattlers(std::vector<Game_Battler*>& out);
 
 	/**
 	 * Returns a list of all dead battlers in the party
@@ -65,18 +65,19 @@ public:
 	virtual void GetDeadBattlers(std::vector<Game_Battler*>& out);
 
 	/**
-	 * Return the next alive battler in the party based on the passed battler.
+	 * Return the next active battler (not dead or hidden) in the party based on
+	 * the passed battler.
 	 *
 	 * @param battler Battler
 	 * @return Battler after the provided one, NULL if battler isn't in party at all.
 	 */
-	virtual Game_Battler* GetNextAliveBattler(Game_Battler* battler);
+	virtual Game_Battler* GetNextActiveBattler(Game_Battler* battler);
 
 	/**
-	 * Gets a random alive battler from the party
+	 * Gets a random active (not dead or hidden) battler from the party
 	 * @return Random alive battler
 	 */
-	virtual Game_Battler* GetRandomAliveBattler();
+	virtual Game_Battler* GetRandomActiveBattler();
 
 	/**
 	 * Gets a random dead battler from the party
@@ -86,11 +87,11 @@ public:
 	virtual Game_Battler* GetRandomDeadBattler();
 
 	/**
-	 * Tests if all party members are dead.
+	 * Tests if any party members is active (not dead or hidden)
 	 *
 	 * @return Whether all are dead.
 	 */
-	virtual bool IsAnyAlive();
+	virtual bool IsAnyActive();
 
 	/**
 	 * Gets average agility of the party (for battle)

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -40,7 +40,7 @@ void Game_Screen::CreatePicturesFromSave() {
 
 	pictures.resize(save_pics.size());
 
-	for (size_t id = 1; id < save_pics.size(); ++id) {
+	for (int id = 1; id < (int)save_pics.size(); ++id) {
 		if (!save_pics[id - 1].name.empty()) {
 			pictures[id - 1].reset(new Game_Picture(id));
 			int time_left = save_pics[id - 1].time_left;

--- a/src/game_switches.h
+++ b/src/game_switches.h
@@ -23,6 +23,8 @@
 #include "main_data.h"
 #include "output.h"
 
+#define PLAYER_VAR_LIMIT 1000000
+
 /**
  * Game_Switches class
  */
@@ -33,23 +35,26 @@ public:
 
 	std::vector<bool>::reference operator[](int switch_id) {
 		if (!isValidSwitch(switch_id)) {
-			Output::Debug("Switch index %d is invalid.", switch_id);
-			dummy.resize(1);
-			return dummy[0];
+			if (switch_id > 0 && switch_id <= PLAYER_VAR_LIMIT) {
+				Output::Debug("Resizing switch array to %d elements.", switch_id);
+				switches.resize(switch_id);
+			}
+			else {
+				Output::Debug("Switch index %d is invalid.", switch_id);
+				dummy.resize(1);
+				return dummy[0];
+			}
 		}
 
 		return switches[switch_id - 1];
 	}
 	
 	std::string GetName(int _id) {
-		if (!isValidSwitch(_id)) {
-			Output::Debug("Switch index %d is invalid.\n",
-				_id);
+		if (!(_id > 0 && _id <= (int)Data::switches.size())) {
 			return "";
 		}
 		else {
-			std::string result = Data::switches.at(_id - 1).name;
-			return result;
+			return Data::switches[_id - 1].name;
 		}
 	}
 
@@ -62,6 +67,8 @@ public:
 	}
 
 	void Reset() {
+		switches.resize(Data::switches.size());
+
 		std::fill(switches.begin(), switches.end(), false);
 	}
 
@@ -69,6 +76,8 @@ private:
 	std::vector<bool>& switches;
 	std::vector<bool> dummy;
 };
+
+#undef PLAYER_VAR_LIMIT
 
 // Global variable
 extern Game_Switches_Class Game_Switches;

--- a/src/game_variables.h
+++ b/src/game_variables.h
@@ -23,6 +23,8 @@
 #include "output.h"
 #include <vector>
 
+#define PLAYER_VAR_LIMIT 1000000
+
 /**
  * Game_Variables class.
  */
@@ -33,23 +35,28 @@ public:
 
 	int& operator[] (int variable_id) {
 		if (!isValidVar(variable_id)) {
-			Output::Debug("Variable index %d is invalid.",
-							variable_id);
-			dummy = 0;
-			return dummy;
+			if (variable_id > 0 && variable_id <= PLAYER_VAR_LIMIT) {
+				Output::Debug("Resizing variable array to %d elements.", variable_id);
+				variables.resize(variable_id);
+			}
+			else {
+				Output::Debug("Variable index %d is invalid.",
+					variable_id);
+				dummy = 0;
+				return dummy;
+			}
 		}
 
 		return (int&) variables[variable_id - 1];
 	}
 
 	std::string GetName(int _id) {
-		if (!isValidVar(_id)) {
-			Output::Debug("Variable index %d is invalid.\n",
-				_id);
+		if (!(_id > 0 && _id <= (int)Data::variables.size())) {
 			return "";
 		}
-		else
-			return Data::variables.at(_id - 1).name;
+		else {
+			return Data::variables[_id - 1].name;
+		}
 	}
 
 	bool isValidVar(int variable_id) {
@@ -61,6 +68,8 @@ public:
 	}
 
 	void Reset() {
+		variables.resize(Data::variables.size());
+
 		std::fill(variables.begin(), variables.end(), 0);
 	}
 
@@ -68,6 +77,8 @@ private:
 	std::vector<uint32_t>& variables;
 	int dummy;
 };
+
+#undef PLAYER_VAR_LIMIT
 
 // Global variable
 extern Game_Variables_Class Game_Variables;

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -398,7 +398,7 @@ void Scene_Battle::CreateEnemyActionBasic(Game_Enemy* enemy, const RPG::EnemyAct
 			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Charge>(enemy));
 			break;
 		case RPG::EnemyAction::Basic_autodestruction:
-			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::SelfDestruct>(enemy));
+			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::SelfDestruct>(enemy, Main_Data::game_party.get()));
 			break;
 		case RPG::EnemyAction::Basic_escape:
 			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Escape>(enemy));

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -214,7 +214,10 @@ void Scene_Battle::UpdateBackground() {
 }
 
 void Scene_Battle::EnemySelected() {
-	Game_Enemy* target = static_cast<Game_Enemy*>(Main_Data::game_enemyparty->GetAliveEnemies()[target_window->GetIndex()]);
+	std::vector<Game_Battler*> enemies;
+	Main_Data::game_enemyparty->GetActiveBattlers(enemies);
+
+	Game_Enemy* target = static_cast<Game_Enemy*>(enemies[target_window->GetIndex()]);
 
 	switch (previous_state) {
 		case State_SelectCommand:
@@ -379,11 +382,11 @@ void Scene_Battle::CreateEnemyActionBasic(Game_Enemy* enemy, const RPG::EnemyAct
 
 	switch (action->basic) {
 		case RPG::EnemyAction::Basic_attack:
-			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Normal>(enemy, Main_Data::game_party->GetRandomAliveBattler()));
+			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Normal>(enemy, Main_Data::game_party->GetRandomActiveBattler()));
 			break;
 		case RPG::EnemyAction::Basic_dual_attack:
 			// ToDo: Must be NormalDual, not implemented
-			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Normal>(enemy, Main_Data::game_party->GetRandomAliveBattler()));
+			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Normal>(enemy, Main_Data::game_party->GetRandomActiveBattler()));
 			break;
 		case RPG::EnemyAction::Basic_defense:
 			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Defend>(enemy));
@@ -435,10 +438,10 @@ void Scene_Battle::CreateEnemyActionSkill(Game_Enemy* enemy, const RPG::EnemyAct
 
 		switch (skill.scope) {
 		case RPG::Skill::Scope_enemy:
-			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Skill>(enemy, Main_Data::game_party->GetRandomAliveBattler(), skill));
+			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Skill>(enemy, Main_Data::game_party->GetRandomActiveBattler(), skill));
 			break;
 		case RPG::Skill::Scope_ally:
-			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Skill>(enemy, Main_Data::game_enemyparty->GetRandomAliveBattler(), skill));
+			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Skill>(enemy, Main_Data::game_enemyparty->GetRandomActiveBattler(), skill));
 			break;
 		case RPG::Skill::Scope_enemies:
 			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Skill>(enemy, Main_Data::game_party.get(), skill));

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -365,7 +365,6 @@ void Scene_Battle::CreateEnemyAction(Game_Enemy* enemy, const RPG::EnemyAction* 
 			break;
 		case RPG::EnemyAction::Kind_skill:
 			CreateEnemyActionSkill(enemy, action);
-			return;
 			break;
 		case RPG::EnemyAction::Kind_transformation:
 			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Transform>(enemy, action->enemy_id));
@@ -436,25 +435,23 @@ void Scene_Battle::CreateEnemyActionSkill(Game_Enemy* enemy, const RPG::EnemyAct
 
 		switch (skill.scope) {
 		case RPG::Skill::Scope_enemy:
-			// ToDo
+			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Skill>(enemy, Main_Data::game_party->GetRandomAliveBattler(), skill));
 			break;
 		case RPG::Skill::Scope_ally:
-			// ToDo
+			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Skill>(enemy, Main_Data::game_enemyparty->GetRandomAliveBattler(), skill));
 			break;
 		case RPG::Skill::Scope_enemies:
 			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Skill>(enemy, Main_Data::game_party.get(), skill));
-			ActionSelectedCallback(enemy);
 			break;
 		case RPG::Skill::Scope_self:
 			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Skill>(enemy, enemy, skill));
-			ActionSelectedCallback(enemy);
 			break;
-		case RPG::Skill::Scope_party: {
+		case RPG::Skill::Scope_party:
 			enemy->SetBattleAlgorithm(EASYRPG_MAKE_SHARED<Game_BattleAlgorithm::Skill>(enemy, Main_Data::game_enemyparty.get(), skill));
-			ActionSelectedCallback(enemy);
 			break;
 		}
-	}
+
+		ActionSelectedCallback(enemy);
 }
 
 void Scene_Battle::ActionSelectedCallback(Game_Battler* for_battler) {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -338,7 +338,7 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 
 			battle_result_messages_it = battle_result_messages.begin();
 
-			if (action->GetFirstAttack()) {
+			if (action->IsFirstAttack()) {
 				if (action->GetTarget() &&
 					action->GetTarget()->GetType() == Game_Battler::Type_Enemy &&
 					action->GetAnimation()) {
@@ -357,7 +357,7 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 					Sprite_Battler::LoopState_IdleAnimationAfterFinish);
 			}
 
-			if (action->GetFirstAttack() && action->GetStartSe()) {
+			if (action->IsFirstAttack() && action->GetStartSe()) {
 				Game_System::SePlay(*action->GetStartSe());
 			}
 			
@@ -396,7 +396,7 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 				battle_message_window->Push(*battle_result_messages_it);
 				++battle_result_messages_it;
 			} else {
-				if (action->GetKilledByAttack()) {
+				if (action->IsKilledByAttack()) {
 					battle_message_window->Push(action->GetDeathMessage());
 				}
 				battle_action_state = BattleActionState_Finished;

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -313,8 +313,6 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 }
 
 bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase* action) {
-	static bool first = true;
-
 	if (Main_Data::game_screen->IsBattleAnimationWaiting()) {
 		return false;
 	}
@@ -340,7 +338,7 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 
 			battle_result_messages_it = battle_result_messages.begin();
 
-			if (first) {
+			if (action->GetFirstAttack()) {
 				if (action->GetTarget() &&
 					action->GetTarget()->GetType() == Game_Battler::Type_Enemy &&
 					action->GetAnimation()) {
@@ -354,9 +352,12 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 			source_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetSource());
 			if (source_sprite) {
 				source_sprite->Flash(Color(255, 255, 255, 100), 15);
+				source_sprite->SetAnimationState(
+					action->GetSourceAnimationState(),
+					Sprite_Battler::LoopState_IdleAnimationAfterFinish);
 			}
 
-			if (action->GetStartSe()) {
+			if (action->GetFirstAttack() && action->GetStartSe()) {
 				Game_System::SePlay(*action->GetStartSe());
 			}
 			
@@ -431,14 +432,12 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 			}
 
 			if (action->TargetNext()) {
-				first = false;
 				battle_action_state = BattleActionState_Start;
 				return false;
 			}
 
 			// Reset variables
 			battle_action_state = BattleActionState_Start;
-			first = true;
 
 			return true;
 	}

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -279,6 +279,7 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 		} else {
 			// Everybody acted
 			actor_index = 0;
+
 			SetState(State_SelectOption);
 		}
 		break;
@@ -377,7 +378,7 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 			if (battle_result_messages_it != battle_result_messages.end()) {
 				Sprite_Battler* target_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetTarget());
 				if (battle_result_messages_it == battle_result_messages.begin()) {
-					if (target_sprite) {
+					if (action->IsSuccess() && target_sprite) {
 						target_sprite->SetAnimationState(Sprite_Battler::AnimationState_Damage);
 					}
 

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -453,8 +453,6 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 		return false;
 	}
 
-	bool first = true;
-
 	switch (battle_action_state) {
 	case BattleActionState_Start:
 		ShowNotification(action->GetStartMessage());
@@ -480,7 +478,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 				Sprite_Battler::LoopState_IdleAnimationAfterFinish);
 		}
 
-		if (action->GetStartSe()) {
+		if (action->GetFirstAttack() && action->GetStartSe()) {
 			Game_System::SePlay(*action->GetStartSe());
 		}
 
@@ -488,9 +486,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 		break;
 	case BattleActionState_Result:
 		do {
-			if (first) {
-				first = false;
-			} else {
+			if (!action->GetFirstAttack()) {
 				action->Execute();
 			}
 

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -478,7 +478,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 				Sprite_Battler::LoopState_IdleAnimationAfterFinish);
 		}
 
-		if (action->GetFirstAttack() && action->GetStartSe()) {
+		if (action->IsFirstAttack() && action->GetStartSe()) {
 			Game_System::SePlay(*action->GetStartSe());
 		}
 
@@ -486,7 +486,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 		break;
 	case BattleActionState_Result:
 		do {
-			if (!action->GetFirstAttack()) {
+			if (!action->IsFirstAttack()) {
 				action->Execute();
 			}
 
@@ -502,7 +502,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 					action->GetTarget()->GetBattleX(),
 					action->GetTarget()->GetBattleY(),
 					0,
-					action->GetSuccess() && action->GetAffectedHp() != -1 ? boost::lexical_cast<std::string>(action->GetAffectedHp()) : Data::terms.miss,
+					action->IsSuccess() && action->GetAffectedHp() != -1 ? boost::lexical_cast<std::string>(action->GetAffectedHp()) : Data::terms.miss,
 					30);
 			}
 

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -491,7 +491,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 			}
 
 			Sprite_Battler* target_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetTarget());
-			if (target_sprite) {
+			if (action->IsSuccess() && target_sprite) {
 				target_sprite->SetAnimationState(Sprite_Battler::AnimationState_Damage, Sprite_Battler::LoopState_IdleAnimationAfterFinish);
 			}
 

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -119,7 +119,7 @@ void Scene_Map::Update() {
 
 	StartTeleportPlayer();
 
-	if (!Main_Data::game_party->IsAnyAlive()) {
+	if (!Main_Data::game_party->IsAnyActive()) {
 		// Empty party is allowed
 		Game_Temp::gameover = Main_Data::game_party->GetBattlerCount() > 0;
 	}

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -21,6 +21,7 @@
 #include "async_handler.h"
 #include "bitmap.h"
 #include "cache.h"
+#include "game_enemy.h"
 #include "main_data.h"
 #include "player.h"
 #include "rpg_battleranimation.h"
@@ -33,7 +34,8 @@ Sprite_Battler::Sprite_Battler(Game_Battler* battler) :
 	sprite_file(""),
 	sprite_frame(-1),
 	fade_out(255),
-	flash_counter(0) {
+	flash_counter(0),
+	old_hidden(battler->IsHidden()) {
 	
 	CreateSprite();
 }
@@ -56,7 +58,13 @@ void Sprite_Battler::Update() {
 		CreateSprite();
 	}
 
-	SetVisible(!battler->IsHidden());
+	if (!battler->IsHidden() && old_hidden != battler->IsHidden()) {
+		SetOpacity(255);
+		SetVisible(true);
+		SetAnimationState(AnimationState_Idle);
+	}
+
+	old_hidden = battler->IsHidden();
 
 	Sprite::Update();
 
@@ -70,7 +78,7 @@ void Sprite_Battler::Update() {
 			if (fade_out > 0) {
 				fade_out -= 15;
 				SetOpacity(std::max(0, fade_out));
-			}
+			} 
 		}
 		else if (anim_state == AnimationState_Damage) {
 			flash_counter = (flash_counter + 1) % 10;

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -56,6 +56,8 @@ void Sprite_Battler::Update() {
 		CreateSprite();
 	}
 
+	SetVisible(!battler->IsHidden());
+
 	Sprite::Update();
 
 	++cycle;
@@ -163,7 +165,6 @@ void Sprite_Battler::CreateSprite() {
 	SetX(battler->GetBattleX());
 	SetY(battler->GetBattleY());
 	SetZ(battler->GetBattleY()); // Not a typo
-	SetVisible(!battler->IsHidden());
 }
 
 void Sprite_Battler::OnMonsterSpriteReady(FileRequestResult* result) {

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -35,7 +35,7 @@ Sprite_Battler::Sprite_Battler(Game_Battler* battler) :
 	sprite_frame(-1),
 	fade_out(255),
 	flash_counter(0),
-	old_hidden(battler->IsHidden()) {
+	old_hidden(false) {
 	
 	CreateSprite();
 }
@@ -173,6 +173,8 @@ void Sprite_Battler::CreateSprite() {
 	SetX(battler->GetBattleX());
 	SetY(battler->GetBattleY());
 	SetZ(battler->GetBattleY()); // Not a typo
+
+	SetVisible(!battler->IsHidden());
 }
 
 void Sprite_Battler::OnMonsterSpriteReady(FileRequestResult* result) {

--- a/src/sprite_battler.h
+++ b/src/sprite_battler.h
@@ -94,6 +94,7 @@ protected:
 	int fade_out;
 	int flash_counter;
 	LoopState loop_state;
+	bool old_hidden;
 };
 
 #endif

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -59,6 +59,10 @@ Window_Message::Window_Message(int ix, int iy, int iwidth, int iheight) :
 	SetContents(Bitmap::Create(width - 16, height - 16));
 	contents->SetTransparentColor(windowskin->GetTransparentColor());
 
+	if (Data::battlecommands.transparency == RPG::BattleCommands::Transparency_transparent) {
+		SetBackOpacity(128);
+	}
+
 	visible = false;
 	SetZ(10000);
 
@@ -146,9 +150,9 @@ void Window_Message::InsertNewPage() {
 	y = Game_Message::GetRealPosition() * 80;
 
 	if (Game_Message::IsTransparent()) {
-		opacity = 0;
+		SetOpacity(0);
 	} else {
-		opacity = 255;
+		SetOpacity(255);
 	}
 
 	if (!Game_Message::GetFaceName().empty()) {


### PR DESCRIPTION
Adds:
- Single Target skills for enemy
- States respect probability (A-E)
- States are respected
- Transparent msgbox for rpg2k3
- Hidden enemies
- Enemy self destruct
- enemy escape
- Enemy charge
- Enemy defend
- Only consume multi-target skills once

Unrelated: Resizing of switch/variable array when oob

Missing: Autoheal of states after time / after hit

#477,  #330 and #399