### PR TITLE
Fix "Change Tilemap"-command and emscripten tilemap

### DIFF
--- a/src/game_picture.cpp
+++ b/src/game_picture.cpp
@@ -29,7 +29,7 @@
 
 /**
  * Picture class.
-*/
+ */
 Game_Picture::Game_Picture(int ID) :
 	data(Main_Data::game_data.pictures[ID - 1]),
 	old_map_x(0),
@@ -92,8 +92,7 @@ void Game_Picture::OnPictureSpriteReady(FileRequestResult*) {
 
 	sprite.reset(new Sprite());
 	sprite->SetBitmap(bitmap);
-	sprite->SetOx(bitmap->GetWidth() / 2);
-	sprite->SetOy(bitmap->GetHeight() / 2);
+	UpdateSprite();
 }
 
 void Game_Picture::Erase() {

--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -107,6 +107,8 @@ void Sprite_Character::OnTileSpriteReady(FileRequestResult*) {
 	SetSrcRect(r);
 	SetOx(8);
 	SetOy(16);
+
+	Update();
 }
 
 void Sprite_Character::OnCharSpriteReady(FileRequestResult*) {
@@ -119,4 +121,6 @@ void Sprite_Character::OnCharSpriteReady(FileRequestResult*) {
 	Rect r;
 	r.Set(sx, sy, chara_width * 3, chara_height * 4);
 	SetSpriteRect(r);
+
+	Update();
 }

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -35,8 +35,6 @@ Spriteset_Map::Spriteset_Map() :
 	tilemap.SetWidth(Game_Map::GetWidth());
 	tilemap.SetHeight(Game_Map::GetHeight());
 	ChipsetUpdated();
-	tilemap.SetMapDataDown(Game_Map::GetMapDataDown());
-	tilemap.SetMapDataUp(Game_Map::GetMapDataUp());
 
 	panorama.SetZ(-1000);
 
@@ -106,6 +104,7 @@ void Spriteset_Map::ChipsetUpdated() {
 	}
 	tilemap_request = AsyncHandler::RequestFile("ChipSet", Game_Map::GetChipsetName());
 	tilemap_request_id = tilemap_request->Bind(&Spriteset_Map::OnTilemapSpriteReady, this);
+	tilemap_request->SetImportantFile(true);
 	tilemap_request->Start();
 
 	tilemap.SetPassableDown(Game_Map::GetPassagesDown());
@@ -130,6 +129,8 @@ void Spriteset_Map::SubstituteUp(int old_id, int new_id) {
 
 void Spriteset_Map::OnTilemapSpriteReady(FileRequestResult*) {
 	tilemap.SetChipset(Cache::Chipset(Game_Map::GetChipsetName()));
+	tilemap.SetMapDataDown(Game_Map::GetMapDataDown());
+	tilemap.SetMapDataUp(Game_Map::GetMapDataUp());
 }
 
 void Spriteset_Map::OnPanoramaSpriteReady(FileRequestResult* result) {

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -104,7 +104,6 @@ void Spriteset_Map::ChipsetUpdated() {
 	}
 	tilemap_request = AsyncHandler::RequestFile("ChipSet", Game_Map::GetChipsetName());
 	tilemap_request_id = tilemap_request->Bind(&Spriteset_Map::OnTilemapSpriteReady, this);
-	tilemap_request->SetImportantFile(true);
 	tilemap_request->Start();
 
 	tilemap.SetPassableDown(Game_Map::GetPassagesDown());

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -522,7 +522,8 @@ BitmapRef TilemapLayer::GenerateAutotiles(int count, const std::map<uint32_t, Ti
 				
 				rect.x = (x * 2 + i) * (TILE_SIZE/2);
 				rect.y = (y * 2 + j) * (TILE_SIZE/2);
-				tiles->Blit((dst.x * 2 + i) * (TILE_SIZE/2), (dst.y * 2 + j) * (TILE_SIZE/2), *chipset, rect, 255);
+
+				tiles->Blit((dst.x * 2 + i) * (TILE_SIZE / 2), (dst.y * 2 + j) * (TILE_SIZE / 2), *chipset, rect, 255);
 			}
 		}
 	}
@@ -573,35 +574,36 @@ std::vector<short> TilemapLayer::GetMapData() const {
 }
 
 void TilemapLayer::SetMapData(const std::vector<short>& nmap_data) {
-	if (map_data != nmap_data) {
-		// Create the tiles data cache
-		CreateTileCache(nmap_data);
+	// Create the tiles data cache
+	CreateTileCache(nmap_data);
+	memset(autotiles_ab, 0, sizeof(autotiles_ab));
+	memset(autotiles_d, 0, sizeof(autotiles_d));
 
-		if (layer == 0) {
-			autotiles_ab_map.clear();
-			autotiles_d_map.clear();
-			autotiles_ab_next = 0;
-			autotiles_d_next = 0;
-			for (int y = 0; y < height; y++) {
-				for (int x = 0; x < width; x++) {
+	if (layer == 0) {
+		autotiles_ab_map.clear();
+		autotiles_d_map.clear();
+		autotiles_ab_next = 0;
+		autotiles_d_next = 0;
+		for (int y = 0; y < height; y++) {
+			for (int x = 0; x < width; x++) {
 
-					if (data_cache[x][y].ID < BLOCK_C) {
-						// If blocks A and B
+				if (data_cache[x][y].ID < BLOCK_C) {
+					// If blocks A and B
 
-						GenerateAutotileAB(data_cache[x][y].ID, 0);
-						GenerateAutotileAB(data_cache[x][y].ID, 1);
-						GenerateAutotileAB(data_cache[x][y].ID, 2);
-					} else if (data_cache[x][y].ID >= BLOCK_D && data_cache[x][y].ID < BLOCK_E) {
-						// If block D
+					GenerateAutotileAB(data_cache[x][y].ID, 0);
+					GenerateAutotileAB(data_cache[x][y].ID, 1);
+					GenerateAutotileAB(data_cache[x][y].ID, 2);
+				} else if (data_cache[x][y].ID >= BLOCK_D && data_cache[x][y].ID < BLOCK_E) {
+					// If block D
 
-						GenerateAutotileD(data_cache[x][y].ID);
-					}
+					GenerateAutotileD(data_cache[x][y].ID);
 				}
 			}
-			autotiles_ab_screen = GenerateAutotiles(autotiles_ab_next, autotiles_ab_map);
-			autotiles_d_screen = GenerateAutotiles(autotiles_d_next, autotiles_d_map);
 		}
+		autotiles_ab_screen = GenerateAutotiles(autotiles_ab_next, autotiles_ab_map);
+		autotiles_d_screen = GenerateAutotiles(autotiles_d_next, autotiles_d_map);
 	}
+
 	map_data = nmap_data;
 }
 
@@ -618,6 +620,9 @@ void TilemapLayer::SetPassable(const std::vector<unsigned char>& npassable) {
 		for (uint8_t i = 0; i < substitutions.size(); i++)
 			substitutions[i] = i;
 	}
+
+	// Recalculate z values of all tiles
+	CreateTileCache(map_data);
 }
 
 bool TilemapLayer::GetVisible() const {


### PR DESCRIPTION
Always regenerate the tile cache. Should fix "Change Tilemap"-command and emscripten black tilemap. Make tilemap "important" to make fade-in more beautiful (not black)