### PR TITLE
emscripten: disable _readdir_r patch

### DIFF
--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -47,7 +47,7 @@ namespace {
 #ifdef EMSCRIPTEN
 	void download_success(unsigned, void* userData, const char*) {
 		FileRequestAsync* req = static_cast<FileRequestAsync*>(userData);
-		//Output::Debug("DL Success: %s", req->GetPath().c_str());
+		Output::Debug("DL Success: %s", req->GetPath().c_str());
 		req->DownloadDone(true);
 	}
 
@@ -71,7 +71,7 @@ FileRequestAsync* AsyncHandler::RequestFile(const std::string& folder_name, cons
 	FileRequestAsync req(folder_name, file_name);
 	RegisterRequest(path, req);
 
-	//Output::Debug("Waiting for %s", path.c_str());
+	Output::Debug("Waiting for %s", path.c_str());
 
 	return GetRequest(path);
 }

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -512,9 +512,7 @@ bool FileFinder::IsDirectory(std::string const& dir) {
 	struct stat sb;
 #   ifdef GEKKO
 	BOOST_VERIFY(::stat(dir.c_str(), &sb) != -1);
-#   else
-	BOOST_VERIFY(::lstat(dir.c_str(), &sb) != -1);
-#endif
+#   endif
 	return S_ISDIR(sb.st_mode);
 #endif
 }

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -530,6 +530,7 @@ bool FileFinder::IsDirectory(std::string const& dir) {
 	::lstat(dir.c_str(), &sb);
 #      else
 	BOOST_VERIFY(::lstat(dir.c_str(), &sb) != -1);
+#      endif
 #   endif
 	return S_ISDIR(sb.st_mode);
 #endif

--- a/src/platform/emscripten-post.js
+++ b/src/platform/emscripten-post.js
@@ -32,7 +32,6 @@ function parseargs() {
 Module.arguments.push("easyrpg-player");
 Module.arguments = Module.arguments.concat(parseargs());
 
-/*
 function _readdir_r(dirp, entry, result) {
     // int readdir_r(DIR *dirp, struct dirent *entry, struct dirent **result);
     // http://pubs.opengroup.org/onlinepubs/007908799/xsh/readdir_r.html
@@ -80,4 +79,3 @@ function _readdir_r(dirp, entry, result) {
     HEAP32[((result)>>2)]=entry;
     return 0;
 }
-*/

--- a/src/platform/emscripten-post.js
+++ b/src/platform/emscripten-post.js
@@ -32,6 +32,7 @@ function parseargs() {
 Module.arguments.push("easyrpg-player");
 Module.arguments = Module.arguments.concat(parseargs());
 
+/*
 function _readdir_r(dirp, entry, result) {
     // int readdir_r(DIR *dirp, struct dirent *entry, struct dirent **result);
     // http://pubs.opengroup.org/onlinepubs/007908799/xsh/readdir_r.html
@@ -79,3 +80,4 @@ function _readdir_r(dirp, entry, result) {
     HEAP32[((result)>>2)]=entry;
     return 0;
 }
+*/


### PR DESCRIPTION
Emscripten 1.34.3 merged the musl+syscall branch, which should fix the readdir issue. The monkey _readdir_r monkey patch is not working after the merge. Now trying without the patch.