### PR TITLE
Restructure pending movements and fix some emulation bugs

### DIFF
--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -81,7 +81,7 @@ const RPG::State* Game_Battler::GetSignificantState() {
 		if (state->ID == 1)
 			return state;
 
-		if (state->priority > priority) {
+		if (state->priority >= priority) {
 			the_state = state;
 			priority = state->priority;
 		}

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -23,8 +23,6 @@
 #include "color.h"
 #include "rpg_moveroute.h"
 
-class Game_Interpreter;
-
 /**
  * Game_Character class.
  */
@@ -407,12 +405,6 @@ public:
 	 */
 	void MoveTypeCustom();
 
-	/**
-	 * Signals the owner of the current move route that the move ended.
-	 * (or was overwritten by a new one)
-	 */
-	void EndMoveRoute();
-
 	void Turn(int dir);
 	void Move(int dir);
 
@@ -508,27 +500,13 @@ public:
 	 *
 	 * @param new_route new move route.
 	 * @param frequency frequency.
-	 * @param owner the interpreter which set the route.
 	 */
-	void ForceMoveRoute(RPG::MoveRoute* new_route, int frequency, Game_Interpreter* owner);
+	void ForceMoveRoute(RPG::MoveRoute* new_route, int frequency);
 
 	/**
 	 * Cancels a previous forced move route.
-	 *
-	 * @param owner the interpreter which set the route.
 	 */
-	void CancelMoveRoute(Game_Interpreter* owner);
-
-	/**
-	 * Tells the character to not report back to the owner.
-	 * (Usually because the owner got deleted).
-	 *
-	 * @param owner the owner of the move route;
-	 *              if the owner is not the real owner
-	 *              this function does nothing.
-	 * @return true if the owner has been detached, false otherwise
-	 */
-	bool DetachMoveRouteOwner(Game_Interpreter* owner);
+	void CancelMoveRoute();
 
 	/**
 	 * Gets screen x coordinate in pixels.
@@ -719,7 +697,6 @@ protected:
 	int animation_type;
 	
 	RPG::MoveRoute original_move_route;
-	Game_Interpreter* move_route_owner;
 	int original_move_frequency;
 	int move_type;
 	bool move_failed;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -275,7 +275,7 @@ void Game_Interpreter::CheckGameOver() {
 }
 
 // Skip to command.
-bool Game_Interpreter::SkipTo(int code, int code2, int min_indent, int max_indent) {
+bool Game_Interpreter::SkipTo(int code, int code2, int min_indent, int max_indent, bool otherwise_end) {
 	if (code2 < 0)
 		code2 = code;
 	if (min_indent < 0)
@@ -283,7 +283,8 @@ bool Game_Interpreter::SkipTo(int code, int code2, int min_indent, int max_inden
 	if (max_indent < 0)
 		max_indent = list[index].indent;
 
-	for (int idx = index; (size_t) idx < list.size(); idx++) {
+	int idx;
+	for (idx = index; (size_t) idx < list.size(); idx++) {
 		if (list[idx].indent < min_indent)
 			return false;
 		if (list[idx].indent > max_indent)
@@ -294,6 +295,9 @@ bool Game_Interpreter::SkipTo(int code, int code2, int min_indent, int max_inden
 		index = idx;
 		return true;
 	}
+
+	if (otherwise_end)
+		index = idx;
 
 	return true;
 }

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -222,7 +222,7 @@ void Game_Interpreter::Update() {
 		}
 
 		if (!Main_Data::game_player->IsTeleporting()) {
-			if (Game_Map::GetNeedRefresh()) {
+			if (main_flag && Game_Map::GetNeedRefresh()) {
 				Game_Map::Refresh();
 			}
 		}

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -102,7 +102,7 @@ protected:
 	int OperateValue(int operation, int operand_type, int operand);
 	Game_Character* GetCharacter(int character_id);
 
-	bool SkipTo(int code, int code2 = -1, int min_indent = -1, int max_indent = -1);
+	bool SkipTo(int code, int code2 = -1, int min_indent = -1, int max_indent = -1, bool otherwise_end = false);
 	void SetContinuation(ContinuationFunction func);
 
 	void CancelMenuCall();

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -56,16 +56,6 @@ Game_Interpreter_Map::Game_Interpreter_Map(int depth, bool main_flag) :
 }
 
 Game_Interpreter_Map::~Game_Interpreter_Map() {
-	std::vector<Game_Character*>::iterator it;
-	std::vector<Game_Character*> toerase;
-	for (it = pending.begin(); it != pending.end(); ++it) {
-		if ((*it)->DetachMoveRouteOwner(this))
-			toerase.push_back(*it);
-	}
-	for (it = toerase.begin(); it != toerase.end(); ++it) {
-		EndMoveRoute(*it);
-	}
-
 	list.clear();
 }
 
@@ -185,19 +175,6 @@ RPG::MoveCommand Game_Interpreter_Map::DecodeMove(std::vector<int>::const_iterat
 	}
 
 	return cmd;
-}
-
-void Game_Interpreter_Map::EndMoveRoute(Game_Character* moving_character) {
-	std::vector<Game_Character*>::iterator it;
-	for (it = pending.begin(); it != pending.end(); ++it) {
-		if ((*it) == moving_character) {
-			break;
-		}
-	}
-
-	if (it != pending.end()) {
-		pending.erase(it);
-	}
 }
 
 /**
@@ -1041,8 +1018,7 @@ bool Game_Interpreter_Map::CommandMoveEvent(RPG::EventCommand const& com) { // c
 		for (it = com.parameters.begin() + 4; it < com.parameters.end(); )
 			route->move_commands.push_back(DecodeMove(it));
 
-		event->ForceMoveRoute(route, move_freq, this);
-		pending.push_back(event);
+		event->ForceMoveRoute(route, move_freq);
 	}
 	return true;
 }
@@ -1466,13 +1442,7 @@ bool Game_Interpreter_Map::CommandChangeEncounterRate(RPG::EventCommand const& c
 }
 
 bool Game_Interpreter_Map::CommandProceedWithMovement(RPG::EventCommand const& /* com */) { // code 11340
-	std::vector<Game_Character*>::iterator it;
-	for (it = pending.begin(); it != pending.end(); ++it) {
-		if (!(*it)->IsMoveRouteRepeated()) {
-			return false;
-		}
-	}
-	return true;
+	return !Game_Map::IsAnyMovePending();
 }
 
 bool Game_Interpreter_Map::CommandPlayMovie(RPG::EventCommand const& com) { // code 11560
@@ -1833,10 +1803,7 @@ bool Game_Interpreter_Map::CommandChangeClass(RPG::EventCommand const& com) { //
 }
 
 bool Game_Interpreter_Map::CommandHaltAllMovement(RPG::EventCommand const& /* com */) { // code 11350
-	std::vector<Game_Character*>::iterator it;
-	for (it = pending.begin(); it != pending.end(); ++it)
-		(*it)->CancelMoveRoute(this);
-	pending.clear();
+	Game_Map::RemoveAllPendingMoves();
 	return true;
 }
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -980,7 +980,7 @@ bool Game_Interpreter_Map::CommandJumpToLabel(RPG::EventCommand const& com) { //
 }
 
 bool Game_Interpreter_Map::CommandBreakLoop(RPG::EventCommand const& com) { // code 12220
-	return SkipTo(Cmd::EndLoop, Cmd::EndLoop, 0, com.indent - 1);
+	return SkipTo(Cmd::EndLoop, Cmd::EndLoop, 0, com.indent - 1, true);
 }
 
 bool Game_Interpreter_Map::CommandEndLoop(RPG::EventCommand const& com) { // code 22210

--- a/src/game_interpreter_map.h
+++ b/src/game_interpreter_map.h
@@ -57,8 +57,6 @@ public:
 
 	bool ExecuteCommand();
 
-	void EndMoveRoute(Game_Character* moving_character);
-
 private:
 	bool CommandMessageOptions(RPG::EventCommand const& com);
 	bool CommandChangeExp(RPG::EventCommand const& com);

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -528,7 +528,7 @@ bool Game_Map::IsLandable(int x, int y, const Game_Character *self_event) {
 					} else if (evnt->GetTileId() >= 0 && evnt->GetLayer() == RPG::EventPage::Layers_below) {
 						// Event layer Chipset Tile
 						tile_id = i->second->GetTileId();
-						return !!(passages_down[tile_id] & bit);
+						return (passages_up[tile_id] & bit != 0);
 					}
 				}
 			}

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -189,8 +189,6 @@ void Game_Map::SetupFromSave() {
 
 void Game_Map::SetupCommon(int _id) {
 	ready = false;
-	// Execute remaining events (e.g. ones listed after a teleport)
-	Update();
 	Dispose();
 
 	location.map_id = _id;

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -520,6 +520,11 @@ namespace Game_Map {
 	void ResetPan(int speed, bool wait);
 	void UpdatePan();
 
+	bool IsAnyMovePending();
+	void AddPendingMove(Game_Character* character);
+	void RemovePendingMove(Game_Character* character);
+	void RemoveAllPendingMoves();
+
 	bool IsPanActive();
 	bool IsPanWaiting();
 	bool IsPanLocked();

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -222,6 +222,7 @@ void Game_Player::PerformTeleport() {
 
 	if (Game_Map::GetMapId() != new_map_id) {
 		Refresh(); // Reset sprite if it was changed by a move
+		Game_Map::Update(); // Execute remaining events (e.g. ones listed after a teleport)
 		Game_Map::Setup(new_map_id);
 		last_pan_x = 0;
 		last_pan_y = 0;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -563,9 +563,6 @@ void Player::LoadDatabase() {
 }
 
 static void OnMapSaveFileReady(FileRequestResult*) {
-	Main_Data::game_data.party_location.Fixup();
-	Main_Data::game_data.system.Fixup();
-	Main_Data::game_data.screen.Fixup();
 	Game_Actors::Fixup();
 
 	Game_Map::SetupFromSave();
@@ -589,6 +586,7 @@ void Player::LoadSavegame(const std::string& save_name) {
 	}
 
 	Main_Data::game_data = *save.get();
+	Main_Data::game_data.system.Fixup();
 
 	int map_id = save->party_location.map_id;
 


### PR DESCRIPTION
bd7e451 simplifies how pending movements work. It was a bit confusing with all that move_route_owner thing, which wasn't necessary. If a move route wasn't completed, but its interpreter owner did no longer exist, HaltAllMovement wouldn't stop this move route. Now all the move routes are registered in Game_Map and removed when they finish.

9bf5d9a and 0d9f17f together fix #433.

6a623cba includes the removal of Main_Data::game_data.party_location.Fixup() and Main_Data::game_data.screen.Fixup(). These Fixups aren't necessary and will be removed soon from liblcf. EasyRPG/liblcf@e119c051