### PR TITLE
autotools: Fix doxygen magic

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ ACLOCAL_AMFLAGS = --install -I builds/autoconf/m4
 include builds/autoconf/aminclude/doxygen.am
 
 EXTRA_DIST = builds lib Modules resources CMakeLists.txt src/platform
-MOSTLYCLEANFILES = DX_CLEANFILES
+MOSTLYCLEANFILES = $(DX_CLEANFILES)
 
 bin_PROGRAMS = easyrpg-player
 

--- a/builds/autoconf/aminclude/doxygen.am
+++ b/builds/autoconf/aminclude/doxygen.am
@@ -29,6 +29,7 @@ doxygen-doc: doxygen-run
 @DX_DOCDIR@/@PACKAGE@.tag: $(DX_CONFIG) $(pkginclude_HEADERS)
 	rm -rf @DX_DOCDIR@
 	$(DX_ENV) $(DX_DOXYGEN) $(srcdir)/$(DX_CONFIG)
+	echo Timestamp >$@
 
 DX_CLEANFILES = \
 	@DX_DOCDIR@/@PACKAGE@.tag \


### PR DESCRIPTION
This actually removes the doxygen output folder (doc) when running the *clean targets.
Also the timestamp is actually generated now, otherwise the documentation will be regenerated every time.
Related: #322 #323