### PR TITLE
Fix hang introduced in 0.3.1 release

### DIFF
--- a/src/background.cpp
+++ b/src/background.cpp
@@ -34,9 +34,11 @@ Background::Background(const std::string& name) :
 
 	Graphics::RegisterDrawable(this);
 
-	FileRequestAsync* request = AsyncHandler::RequestFile("Backdrop", name);
-	request->Bind(&Background::OnBackgroundGraphicReady, this);
-	request->Start();
+	if (!name.empty()) {
+		FileRequestAsync* request = AsyncHandler::RequestFile("Backdrop", name);
+		request->Bind(&Background::OnBackgroundGraphicReady, this);
+		request->Start();
+	}
 }
 
 Background::Background(int terrain_id) :
@@ -48,16 +50,18 @@ Background::Background(int terrain_id) :
 
 	const RPG::Terrain& terrain = Data::terrains[terrain_id - 1];
 
-	if (terrain.background_type == 0) {
-		FileRequestAsync* request = AsyncHandler::RequestFile("Backdrop", terrain.background_name);
+	if (!terrain.background_name.empty()) {
+		if (terrain.background_type == 0) {
+			FileRequestAsync* request = AsyncHandler::RequestFile("Backdrop", terrain.background_name);
+			request->Bind(&Background::OnBackgroundGraphicReady, this);
+			request->Start();
+			return;
+		}
+	
+		FileRequestAsync* request = AsyncHandler::RequestFile("Frame", terrain.background_a_name);
 		request->Bind(&Background::OnBackgroundGraphicReady, this);
 		request->Start();
-		return;
 	}
-
-	FileRequestAsync* request = AsyncHandler::RequestFile("Frame", terrain.background_a_name);
-	request->Bind(&Background::OnBackgroundGraphicReady, this);
-	request->Start();
 
 	bg_hscroll = terrain.background_a_scrollh ? terrain.background_a_scrollh_speed : 0;
 	bg_vscroll = terrain.background_a_scrollv ? terrain.background_a_scrollv_speed : 0;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -237,7 +237,7 @@ void Game_Map::SetupCommon(int _id) {
 	ss.str("");
 	for (int cur = current_index;
 		GetMapIndex(Data::treemap.maps[cur].parent_map) != cur;
-		cur = Data::treemap.maps[cur].parent_map) {
+		cur = GetMapIndex(Data::treemap.maps[cur].parent_map)) {
 		if (cur != current_index) {
 			ss << " < ";
 		}

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -174,6 +174,7 @@ void Graphics::DrawFrame() {
 	}
 
 	if (screen_erased) {
+		DisplayUi->CleanDisplay();
 		return;
 	}
 

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -141,7 +141,7 @@ bool Scene_Title::CheckContinue() {
 
 void Scene_Title::CreateTitleGraphic() {
 	// Load Title Graphic
-	if (!title) // No need to recreate Title on Resume
+	if (!title && !Data::system.title_name.empty()) // No need to recreate Title on Resume
 	{
 		title.reset(new Sprite());
 		FileRequestAsync* request = AsyncHandler::RequestFile("Title", Data::system.title_name);

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -102,9 +102,15 @@ void Spriteset_Map::ChipsetUpdated() {
 	if (tilemap_request) {
 		tilemap_request->Unbind(tilemap_request_id);
 	}
-	tilemap_request = AsyncHandler::RequestFile("ChipSet", Game_Map::GetChipsetName());
-	tilemap_request_id = tilemap_request->Bind(&Spriteset_Map::OnTilemapSpriteReady, this);
-	tilemap_request->Start();
+
+	if (!Game_Map::GetChipsetName().empty()) {
+		tilemap_request = AsyncHandler::RequestFile("ChipSet", Game_Map::GetChipsetName());
+		tilemap_request_id = tilemap_request->Bind(&Spriteset_Map::OnTilemapSpriteReady, this);
+		tilemap_request->Start();
+	}
+	else {
+		OnTilemapSpriteReady(NULL);
+	}
 
 	tilemap.SetPassableDown(Game_Map::GetPassagesDown());
 	tilemap.SetPassableUp(Game_Map::GetPassagesUp());
@@ -127,7 +133,9 @@ void Spriteset_Map::SubstituteUp(int old_id, int new_id) {
 }
 
 void Spriteset_Map::OnTilemapSpriteReady(FileRequestResult*) {
-	tilemap.SetChipset(Cache::Chipset(Game_Map::GetChipsetName()));
+	if (!Game_Map::GetChipsetName().empty()) {
+		tilemap.SetChipset(Cache::Chipset(Game_Map::GetChipsetName()));
+	}
 	tilemap.SetMapDataDown(Game_Map::GetMapDataDown());
 	tilemap.SetMapDataUp(Game_Map::GetMapDataUp());
 }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -182,16 +182,6 @@ void Window::Draw() {
 		Rect src_rect(40, 16, 16, 8);
 		dst->Blit(x + width / 2 - 8, y + height - 8, *windowskin, src_rect, 255);
 	}
-
-	if (animation_frames > 0) {
-		// Open/Close Animation
-		animation_frames -= 1;
-		animation_count += animation_increment;
-		if (closing && animation_frames <= 0) {
-			visible = false;
-			closing = false;
-		}
-	}
 }
 
 void Window::RefreshBackground() {
@@ -344,6 +334,16 @@ void Window::Update() {
 		if (pause) {
 			pause_frame += 1;
 			if (pause_frame == 40) pause_frame = 0;
+		}
+	}
+
+	if (animation_frames > 0) {
+		// Open/Close Animation
+		animation_frames -= 1;
+		animation_count += animation_increment;
+		if (closing && animation_frames <= 0) {
+			visible = false;
+			closing = false;
 		}
 	}
 }


### PR DESCRIPTION
Also prevents warnings when no title/chipset/backdrop is used.

This fixes ゆめ２っき (Yume2kki) which fade-out the screen and displays a message box which never closes because the Draw code is never called.