### PR TITLE
Fix crash when empty chipset is used

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -224,7 +224,7 @@ BitmapRef Cache::Tile(const std::string& filename, int tile_id) {
 			sub_tile_id = tile_id - 96;
 			rect.x += 384;
 			rect.y += 128;
-		} else { // Invalid -> Use empty file (first one)
+		} else { // Invalid -> Use empty tile (first one)
 			rect.x = 288;
 			rect.y = 128;
 		}

--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -99,7 +99,16 @@ void Sprite_Character::SetCharacter(Game_Character* new_character) {
 }
 
 void Sprite_Character::OnTileSpriteReady(FileRequestResult*) {
-	BitmapRef tile = Cache::Tile(Game_Map::GetChipsetName(), tile_id);
+	std::string chipset = Game_Map::GetChipsetName();
+
+	BitmapRef tile;
+	if (!chipset.empty()) {
+		tile = Cache::Tile(Game_Map::GetChipsetName(), tile_id);
+	}
+	else {
+		tile = Bitmap::Create(16, 16, Color());
+	}
+ 
 	SetBitmap(tile);
 
 	Rect r;

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -136,6 +136,9 @@ void Spriteset_Map::OnTilemapSpriteReady(FileRequestResult*) {
 	if (!Game_Map::GetChipsetName().empty()) {
 		tilemap.SetChipset(Cache::Chipset(Game_Map::GetChipsetName()));
 	}
+	else {
+		tilemap.SetChipset(Bitmap::Create(480, 256, Color()));
+	}
 	tilemap.SetMapDataDown(Game_Map::GetMapDataDown());
 	tilemap.SetMapDataUp(Game_Map::GetMapDataUp());
 }

--- a/src/tilemap.cpp
+++ b/src/tilemap.cpp
@@ -34,11 +34,10 @@ BitmapRef const& Tilemap::GetChipset() const {
 	return layer_down.GetChipset();
 }
 void Tilemap::SetChipset(BitmapRef const& chipset) {
-	if (chipset) {
-		layer_down.SetChipset(chipset);
-		layer_up.SetChipset(chipset);
-	}
+	layer_down.SetChipset(chipset);
+	layer_up.SetChipset(chipset);
 }
+
 std::vector<short> Tilemap::GetMapDataDown() const {
 	return layer_down.GetMapData();
 }


### PR DESCRIPTION
Problem was that autotile cache read out of bounds, a black tilemap is now generated to work around all issues.

My fix in 0.3.2 had some bugs :/