### PR TITLE
Fix more emulation bugs

### DIFF
--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -49,13 +49,13 @@ void Game_CommonEvent::Refresh() {
 				interpreter.reset(battle
 								  ? static_cast<Game_Interpreter*>(new Game_Interpreter_Battle())
 								  : static_cast<Game_Interpreter*>(new Game_Interpreter_Map()));
-				Update();
 			}
 			return;
 		}
 	}
 	if (interpreter) {
-		interpreter->Clear();
+		if (!interpreter->IsRunning())
+			interpreter->Clear();
 		Game_Map::ReserveInterpreterDeletion(interpreter);
 		interpreter.reset();
 	}

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -281,14 +281,15 @@ void Game_Event::Setup(RPG::EventPage* new_page) {
 	original_move_frequency = page->move_frequency;
 	original_move_route = page->move_route;
 	SetOriginalMoveRouteIndex(0);
-	animation_type = page->animation_type;
-	SetOpacity(page->translucent ? 160 : 255);
 
-	if (from_null || IsDirectionFixed()) {
+	bool last_direction_fixed = IsDirectionFixed() || IsFacingLocked();
+	animation_type = page->animation_type;
+	if (from_null || !last_direction_fixed || IsDirectionFixed()) {
 		SetDirection(page->character_direction);
 		SetSpriteDirection(page->character_direction);
 	}
 
+	SetOpacity(page->translucent ? 160 : 255);
 	SetLayer(page->layer);
 	trigger = page->trigger;
 	list = page->event_commands;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -50,6 +50,7 @@ Game_Interpreter::Game_Interpreter(int _depth, bool _main_flag) {
 	index = 0;
 	updating = false;
 	clear_child = false;
+	runned = false;
 
 	if (depth > 100) {
 		Output::Warning("Too many event calls (over 9000)");
@@ -125,9 +126,14 @@ void Game_Interpreter::EndMoveRoute(Game_Character*) {
 	// This will only ever be called on Game_Interpreter_Map instances
 }
 
+bool Game_Interpreter::HasRunned() const {
+	return runned;
+}
+
 // Update
 void Game_Interpreter::Update() {
 	updating = true;
+	runned = false;
 	// 10000 based on: https://gist.github.com/4406621
 	for (loop_count = 0; loop_count < 10000; ++loop_count) {
 		/* If map is different than event startup time
@@ -222,6 +228,7 @@ void Game_Interpreter::Update() {
 			break;
 		}
 
+		runned = true;
 		if (!ExecuteCommand()) {
 			active = true;
 			break;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -97,9 +97,8 @@ void Game_Interpreter::Setup(const std::vector<RPG::EventCommand>& _list, int _e
 
 	CancelMenuCall();
 
-	if (main_flag) {
+	if (main_flag && depth == 0)
 		Game_Message::SetFaceName("");
-	}
 
 	if (!updating && depth == 0)
 		Update();
@@ -201,10 +200,8 @@ void Game_Interpreter::Update() {
 				break;
 		}
 
-		if (!Main_Data::game_player->IsTeleporting()) {
-			if (main_flag && Game_Map::GetNeedRefresh()) {
-				Game_Map::Refresh();
-			}
+		if (!Main_Data::game_player->IsTeleporting() && Game_Map::GetNeedRefresh()) {
+			Game_Map::Refresh();
 		}
 
 		if (list.empty()) {
@@ -355,7 +352,7 @@ bool Game_Interpreter::CommandWait(RPG::EventCommand const& com) { // code 11410
 }
 
 bool Game_Interpreter::CommandEnd() { // code 10
-	if (main_flag) {
+	if (main_flag && depth == 0) {
 		Game_Message::SetFaceName("");
 	}
 
@@ -366,7 +363,7 @@ bool Game_Interpreter::CommandEnd() { // code 10
 
 	list.clear();
 
-	if ((main_flag) && (event_id > 0)) {
+	if (main_flag && depth == 0 && event_id > 0) {
 		Game_Map::GetEvents().find(event_id)->second->StopTalkToHero();
 	}
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -344,7 +344,7 @@ bool Game_Interpreter::ExecuteCommand() {
 	}
 }
 
-bool Game_Interpreter::CommandWait(RPG::EventCommand const& com) {
+bool Game_Interpreter::CommandWait(RPG::EventCommand const& com) { // code 11410
 	if (com.parameters.size() <= 1 ||
 		(com.parameters.size() > 1 && com.parameters[1] == 0)) {
 		SetupWait(com.parameters[0]);
@@ -354,7 +354,7 @@ bool Game_Interpreter::CommandWait(RPG::EventCommand const& com) {
 	}
 }
 
-bool Game_Interpreter::CommandEnd() {
+bool Game_Interpreter::CommandEnd() { // code 10
 	if (main_flag) {
 		Game_Message::SetFaceName("");
 	}
@@ -399,7 +399,7 @@ void Game_Interpreter::GetStrings(std::vector<std::string>& ret_val) {
 }
 
 // Command Show Message
-bool Game_Interpreter::CommandShowMessage(RPG::EventCommand const& com) { // Code ShowMessage
+bool Game_Interpreter::CommandShowMessage(RPG::EventCommand const& com) { // code 10110
 	// If there's a text already, return immediately
 	if (Game_Message::message_waiting)
 		return false;
@@ -487,7 +487,7 @@ bool Game_Interpreter::ContinuationChoices(RPG::EventCommand const& com) {
 }
 
 // Command Show choices
-bool Game_Interpreter::CommandShowChoices(RPG::EventCommand const& com) { // Code ShowChoice
+bool Game_Interpreter::CommandShowChoices(RPG::EventCommand const& com) { // code 10140
 	if (!Game_Message::texts.empty()) {
 		return false;
 	}
@@ -505,7 +505,7 @@ bool Game_Interpreter::CommandShowChoices(RPG::EventCommand const& com) { // Cod
 }
 
 // Command control switches
-bool Game_Interpreter::CommandControlSwitches(RPG::EventCommand const& com) { // Code ControlSwitches
+bool Game_Interpreter::CommandControlSwitches(RPG::EventCommand const& com) { // code 10210
 	int i;
 	switch (com.parameters[0]) {
 		case 0:
@@ -535,7 +535,7 @@ bool Game_Interpreter::CommandControlSwitches(RPG::EventCommand const& com) { //
 }
 
 // Command control vars
-bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { // Code ControlVars
+bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { // code 10220
 	int i, value = 0;
 	Game_Actor* actor;
 	Game_Character* character;
@@ -911,7 +911,7 @@ bool Game_Interpreter::CommandChangeItems(RPG::EventCommand const& com) { // Cod
 }
 
 // Input Number.
-bool Game_Interpreter::CommandInputNumber(RPG::EventCommand const& com) {
+bool Game_Interpreter::CommandInputNumber(RPG::EventCommand const& com) { // code 10150
 	if (Game_Message::message_waiting) {
 		return false;
 	}

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -42,6 +42,7 @@ public:
 	void Clear();
 	void Setup(const std::vector<RPG::EventCommand>& _list, int _event_id, int dbg_x = -1, int dbg_y = -1);
 
+	bool HasRunned() const;
 	bool IsRunning() const;
 	void Update();
 
@@ -65,6 +66,7 @@ protected:
 	bool main_flag;
 
 	int loop_count;
+	bool runned;
 
 	bool move_route_waiting;
 

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -68,8 +68,6 @@ protected:
 	int loop_count;
 	bool runned;
 
-	bool move_route_waiting;
-
 	unsigned int index;
 	int map_id;
 	unsigned int event_id;
@@ -82,7 +80,8 @@ protected:
 	std::vector<RPG::EventCommand> list;
 
 	int button_timer;
-	bool active;
+	bool waiting_battle_anim;
+	bool waiting_pan_screen;
 	bool updating;
 	bool clear_child;
 
@@ -164,7 +163,6 @@ protected:
 
 	int debug_x;
 	int debug_y;
-
 };
 
 #endif

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -214,8 +214,10 @@ bool Game_Interpreter_Battle::CommandShowBattleAnimation(RPG::EventCommand const
 	bool wait = com.parameters[2] != 0;
 	bool allies = false;
 
-	if (active)
-		return !Game_Battle::IsBattleAnimationWaiting();
+	if (waiting_battle_anim) {
+		waiting_battle_anim = Game_Battle::IsBattleAnimationWaiting();
+		return !waiting_battle_anim;
+	}
 
 	if (Player::IsRPG2k3()) {
 		allies = com.parameters[3] != 0;

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -462,8 +462,11 @@ bool Game_Interpreter_Map::CommandRecallToLocation(RPG::EventCommand const& com)
 	Main_Data::game_player->ReserveTeleport(map_id, x, y);
 	Main_Data::game_player->StartTeleport();
 
-	index++;
+	// Parallel events should keep on running in 2k and 2k3, unlike in later versions
+	if (!main_flag)
+		return true;
 
+	index++;
 	return false;
 }
 
@@ -566,8 +569,11 @@ bool Game_Interpreter_Map::CommandTeleport(RPG::EventCommand const& com) { // Co
 	Main_Data::game_player->ReserveTeleport(map_id, x, y, direction);
 	Main_Data::game_player->StartTeleport();
 
-	index++;
+	// Parallel events should keep on running in 2k and 2k3, unlike in later versions
+	if (!main_flag)
+		return true;
 
+	index++;
 	return false;
 }
 
@@ -1375,7 +1381,7 @@ bool Game_Interpreter_Map::CommandCallEvent(RPG::EventCommand const& com) { // c
 
 	clear_child = false;
 
-	child_interpreter.reset(new Game_Interpreter_Map(depth + 1));
+	child_interpreter.reset(new Game_Interpreter_Map(depth + 1, main_flag));
 
 	switch (com.parameters[0]) {
 		case 0: // Common Event

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -436,6 +436,7 @@ bool Game_Interpreter_Map::CommandMemorizeLocation(RPG::EventCommand const& com)
 	Game_Variables[var_map_id] = Game_Map::GetMapId();
 	Game_Variables[var_x] = player->GetX();
 	Game_Variables[var_y] = player->GetY();
+	Game_Map::SetNeedRefresh(true);
 	return true;
 }
 
@@ -471,6 +472,7 @@ bool Game_Interpreter_Map::CommandStoreTerrainID(RPG::EventCommand const& com) {
 	int y = ValueOrVariable(com.parameters[0], com.parameters[2]);
 	int var_id = com.parameters[3];
 	Game_Variables[var_id] = Game_Map::GetTerrainTag(x, y);
+	Game_Map::SetNeedRefresh(true);
 	return true;
 }
 
@@ -481,6 +483,7 @@ bool Game_Interpreter_Map::CommandStoreEventID(RPG::EventCommand const& com) { /
 	std::vector<Game_Event*> events;
 	Game_Map::GetEventsXY(events, x, y);
 	Game_Variables[var_id] = events.size() > 0 ? events.back()->GetId() : 0;
+	Game_Map::SetNeedRefresh(true);
 	return true;
 }
 
@@ -1527,6 +1530,7 @@ bool Game_Interpreter_Map::CommandKeyInputProc(RPG::EventCommand const& com) { /
 	}
 
 	Game_Variables[var_id] = result;
+	Game_Map::SetNeedRefresh(true);
 
 	if (!wait)
 		return true;
@@ -1644,8 +1648,10 @@ bool Game_Interpreter_Map::CommandSimulatedAttack(RPG::EventCommand const& com) 
 
 		CheckGameOver();
 
-		if (com.parameters[6] != 0)
+		if (com.parameters[6] != 0) {
 			Game_Variables[com.parameters[7]] = result;
+			Game_Map::SetNeedRefresh(true);
+		}
 	}
 
 	return true;

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -540,7 +540,7 @@ bool Game_Interpreter_Map::CommandChangeMainMenuAccess(RPG::EventCommand const& 
 	return true;
 }
 
-bool Game_Interpreter_Map::CommandChangeActorFace(RPG::EventCommand const& com) {
+bool Game_Interpreter_Map::CommandChangeActorFace(RPG::EventCommand const& com) { // code 10640
 	Game_Actor* actor = Game_Actors::GetActor(com.parameters[0]);
 	if (actor != NULL) {
 		actor->SetFace(com.string, com.parameters[1]);
@@ -571,7 +571,7 @@ bool Game_Interpreter_Map::CommandTeleport(RPG::EventCommand const& com) { // Co
 	return false;
 }
 
-bool Game_Interpreter_Map::CommandEraseScreen(RPG::EventCommand const& com) {
+bool Game_Interpreter_Map::CommandEraseScreen(RPG::EventCommand const& com) { // code 11010
 	if (Game_Temp::transition_processing || Game_Message::visible)
 		return false;
 
@@ -649,7 +649,7 @@ bool Game_Interpreter_Map::CommandEraseScreen(RPG::EventCommand const& com) {
 	}
 }
 
-bool Game_Interpreter_Map::CommandShowScreen(RPG::EventCommand const& com) {
+bool Game_Interpreter_Map::CommandShowScreen(RPG::EventCommand const& com) { // code 11020
 	if (Game_Temp::transition_processing || Game_Message::visible)
 		return false;
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -1597,10 +1597,11 @@ bool Game_Interpreter_Map::CommandPanScreen(RPG::EventCommand const& com) { // c
 	int direction;
 	int distance;
 	int speed;
-	bool wait = false;
 
-	if (active)
-		return !Game_Map::IsPanWaiting();
+	if (waiting_pan_screen) {
+		waiting_pan_screen = Game_Map::IsPanWaiting();
+		return !waiting_pan_screen;
+	}
 
 	switch (com.parameters[0]) {
 	case 0: // Lock
@@ -1613,17 +1614,17 @@ bool Game_Interpreter_Map::CommandPanScreen(RPG::EventCommand const& com) { // c
 		direction = com.parameters[1];
 		distance = com.parameters[2];
 		speed = com.parameters[3];
-		wait = com.parameters[4] != 0;
-		Game_Map::StartPan(direction, distance, speed, wait);
+		waiting_pan_screen = com.parameters[4] != 0;
+		Game_Map::StartPan(direction, distance, speed, waiting_pan_screen);
 		break;
 	case 3: // Reset
 		speed = com.parameters[3];
-		wait = com.parameters[4] != 0;
-		Game_Map::ResetPan(speed, wait);
+		waiting_pan_screen = com.parameters[4] != 0;
+		Game_Map::ResetPan(speed, waiting_pan_screen);
 		break;
 	}
 
-	return !wait;
+	return !waiting_pan_screen;
 }
 
 bool Game_Interpreter_Map::CommandSimulatedAttack(RPG::EventCommand const& com) { // code 10500
@@ -1658,12 +1659,14 @@ bool Game_Interpreter_Map::CommandSimulatedAttack(RPG::EventCommand const& com) 
 }
 
 bool Game_Interpreter_Map::CommandShowBattleAnimation(RPG::EventCommand const& com) { // code 11210
-	if (active)
-		return !Game_Map::IsBattleAnimationWaiting();
+	if (waiting_battle_anim) {
+		waiting_battle_anim = Game_Map::IsBattleAnimationWaiting();
+		return !waiting_battle_anim;
+	}
 
 	int animation_id = com.parameters[0];
 	int evt_id = com.parameters[1];
-	bool wait = com.parameters[2] > 0;
+	waiting_battle_anim = com.parameters[2] > 0;
 	bool global = com.parameters[3] > 0;
 
 	if (evt_id == Game_Character::CharThisEvent)
@@ -1671,7 +1674,7 @@ bool Game_Interpreter_Map::CommandShowBattleAnimation(RPG::EventCommand const& c
 
 	Game_Map::ShowBattleAnimation(animation_id, evt_id, global);
 
-	return !wait;
+	return !waiting_battle_anim;
 }
 
 bool Game_Interpreter_Map::CommandChangeClass(RPG::EventCommand const& com) { // code 1008

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -611,13 +611,17 @@ int Game_Map::GetTerrainTag(int const x, int const y) {
 	if (!Game_Map::IsValid(x, y)) return 1;
 
 	unsigned const chipID = map->lower_layer[x + y * GetWidth()];
-	unsigned const chip_index =
+	unsigned chip_index =
 		(chipID <  3050)?  0 + chipID/1000 :
 		(chipID <  4000)?  4 + (chipID-3050)/50 :
 		(chipID <  5000)?  6 + (chipID-4000)/50 :
 		(chipID <  5144)? 18 + (chipID-5000) :
 		0;
 	unsigned const chipset_index = map_info.chipset_id - 1;
+
+	// Apply tile substitution
+	if (chip_index >= 18 && chip_index <= 144)
+		chip_index = map_info.lower_tiles[chip_index - 18] + 18;
 
 	assert(chipset_index < Data::data.chipsets.size());
 	assert(chip_index < Data::data.chipsets[chipset_index].terrain_data.size());

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -330,7 +330,7 @@ void Game_Player::UpdateScroll() {
 void Game_Player::Update() {
 	bool last_moving = IsMoving() || IsJumping();
 
-	if (IsMovable() && !Game_Map::GetInterpreter().IsRunning()) {
+	if (IsMovable() && !(Game_Map::GetInterpreter().IsRunning() || Game_Map::GetInterpreter().HasRunned())) {
 		switch (Input::dir4) {
 			case 2:
 				Move(Down);
@@ -385,9 +385,11 @@ void Game_Player::UpdateNonMoving(bool last_moving) {
 
 	if (last_moving && CheckTouchEvent()) return;
 
-	if (!Game_Message::visible && Input::IsTriggered(Input::DECISION)) {
-		if ( GetOnOffVehicle() ) return;
-		if ( CheckActionEvent() ) return;
+	if (!(Game_Map::GetInterpreter().IsRunning() || Game_Map::GetInterpreter().HasRunned())) {
+		if (!Game_Message::visible && Input::IsTriggered(Input::DECISION)) {
+			if ( GetOnOffVehicle() ) return;
+			if ( CheckActionEvent() ) return;
+		}
 	}
 
 	if (last_moving)

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -239,7 +239,7 @@ void Game_Screen::Update() {
 	}
 
 	if (data.flash_time_left > 0) {
-		data.flash_current_level = interpolate(data.flash_time_left, data.flash_current_level, 0);
+		data.flash_current_level -= data.flash_current_level / data.flash_time_left;
 		data.flash_time_left--;
 		if (data.flash_time_left <= 0)
 			data.flash_time_left = data.flash_continuous ? flash_period : 0;
@@ -298,7 +298,7 @@ Tone Game_Screen::GetTone() {
 
 Color Game_Screen::GetFlash(int& current_level, int& time_left) {
 	time_left = data.flash_time_left;
-	current_level = data.flash_time_left * 255 / 31;
+	current_level = data.flash_current_level / 31 * 255;
 	return Color(data.flash_red * 255 / 31, data.flash_green * 255 / 31, data.flash_blue * 255 / 31, 255);
 }
 


### PR DESCRIPTION
Thanks to c5093e5, the game player will be blocked if the main interpreter executed a command in its last update. Any non-empty auto starting event will block completly the game player as long as it runs. This fixes #629, [a bug where the player would trigger an event after a KeyInputProc](https://easy-rpg.org/forums/viewtopic.php?f=4&t=599) and surely other unreported bugs.

e88b886 fixes one of the bugs reported by Mr.Faq2014 [in the forums](https://easy-rpg.org/forums/viewtopic.php?f=4&t=605).
>Up to now, in EasyRPG 0.3.2 after seeing the intro (one of the backgrounds doesn't scroll properly(...)