### PR TITLE
Fix Issue 453 (parallel interpreter resume) and common event save writing

### DIFF
--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -50,21 +50,17 @@ void Game_CommonEvent::Refresh() {
 								  ? static_cast<Game_Interpreter*>(new Game_Interpreter_Battle())
 								  : static_cast<Game_Interpreter*>(new Game_Interpreter_Map()));
 			}
-			return;
+			parallel_running = true;
+		} else {
+			parallel_running = false;
 		}
-	}
-	if (interpreter) {
-		if (!interpreter->IsRunning())
-			interpreter->Clear();
-		Game_Map::ReserveInterpreterDeletion(interpreter);
-		interpreter.reset();
 	}
 }
 
 void Game_CommonEvent::Update() {
 	CheckEventTriggerAuto();
 
-	if (interpreter) {
+	if (interpreter && parallel_running) {
 		if (!interpreter->IsRunning()) {
 			interpreter->Setup(GetList(), 0, -common_event_id, -2);
 		} else {

--- a/src/game_commonevent.h
+++ b/src/game_commonevent.h
@@ -107,6 +107,11 @@ public:
 private:
 	int common_event_id;
 	bool battle;
+	/**
+	 * If parallel interpreter is running (true) or suspended (false).
+	 * When switched to running it continues where it was suspended.
+	 */
+	bool parallel_running = false;
 
 	/** Interpreter for parallel common events. */
 	EASYRPG_SHARED_PTR<Game_Interpreter> interpreter;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -285,7 +285,6 @@ void Game_Map::PrepareSave() {
 
 	std::vector<RPG::SaveCommonEvent>& save_common_events = Main_Data::game_data.common_events;
 	save_common_events.clear();
-	save_common_events.resize(Data::commonevents.size());
 
 	for (tCommonEventHash::iterator i = common_events.begin(); i != common_events.end(); ++i) {
 		save_common_events.push_back(RPG::SaveCommonEvent());

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -102,7 +102,11 @@ void Output::IgnorePause(bool const val) {
 }
 
 static void WriteLog(std::string const& type, std::string const& msg, Color const& c = Color()) {
-	output_time() << type << ": " << msg << std::endl;
+	if (!Main_Data::project_path.empty()) {
+		// Only write to file when project path is initialized
+		// (happens after parsing the command line)
+		output_time() << type << ": " << msg << std::endl;
+	}
 
 #ifdef __ANDROID__
 	__android_log_print(type == "Error" ? ANDROID_LOG_ERROR : ANDROID_LOG_INFO, "EasyRPG Player", "%s", msg.c_str());

--- a/src/platform/sdl_audio.cpp
+++ b/src/platform/sdl_audio.cpp
@@ -247,13 +247,13 @@ void SdlAudio::SE_Play(std::string const& file, int volume, int /* pitch */) {
 	}
 	EASYRPG_SHARED_PTR<Mix_Chunk> sound(Mix_LoadWAV(path.c_str()), &Mix_FreeChunk);
 	if (!sound) {
-		Output::Warning("Couldn't load %s SE.\n%s\n", file.c_str(), Mix_GetError());
+		Output::Warning("Couldn't load %s SE.\n%s", file.c_str(), Mix_GetError());
 		return;
 	}
 	int channel = Mix_PlayChannel(-1, sound.get(), 0);
 	Mix_Volume(channel, volume * MIX_MAX_VOLUME / 100);
 	if (channel == -1) {
-		Output::Warning("Couldn't play %s SE.\n%s\n", file.c_str(), Mix_GetError());
+		Output::Warning("Couldn't play %s SE.\n%s", file.c_str(), Mix_GetError());
 		return;
 	}
 	sounds[channel] = sound;


### PR DESCRIPTION
" 	When the start condition (switch) of a parallel common event is not met the interpreter is now suspended instead of destroyed. Parallel common events continue where they got suspended the last time. "