### PR TITLE
Improve return to title screen (F12) and fix some bugs

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -236,7 +236,7 @@ void Game_Character::Update() {
 	if (stop_count >= max_stop_count) {
 		if (IsMoveRouteOverwritten()) {
 			MoveTypeCustom();
-		} else if (!IsMessageBlocking() && !Game_Map::GetInterpreter().IsRunning()) {
+		} else if (!IsMessageBlocking() && !Game_Map::GetInterpreter().HasRunned() && !Game_Map::GetInterpreter().IsRunning()) {
 			UpdateSelfMovement();
 		}
 	}

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -222,7 +222,6 @@ void Game_Player::PerformTeleport() {
 
 	if (Game_Map::GetMapId() != new_map_id) {
 		Refresh(); // Reset sprite if it was changed by a move
-		Game_Map::Update(); // Execute remaining events (e.g. ones listed after a teleport)
 		Game_Map::Setup(new_map_id);
 		last_pan_x = 0;
 		last_pan_y = 0;

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -19,7 +19,7 @@
 #include <algorithm>
 #include <sstream>
 #include <vector>
-#include <map>
+#include <list>
 
 #include "graphics.h"
 #include "bitmap.h"
@@ -87,19 +87,6 @@ void Graphics::Init() {
 }
 
 void Graphics::Quit() {
-	std::list<Drawable*>::iterator it;
-	std::list<Drawable*> drawable_list_temp = state->drawable_list;
-
-	for (it = drawable_list_temp.begin(); it != drawable_list_temp.end(); ++it) {
-		delete *it;
-	}
-
-	drawable_list_temp = global_state->drawable_list;
-
-	for (it = drawable_list_temp.begin(); it != drawable_list_temp.end(); ++it) {
-		delete *it;
-	}
-
 	state->drawable_list.clear();
 	global_state->drawable_list.clear();
 
@@ -155,13 +142,11 @@ void Graphics::UpdateTitle() {
 }
 
 void Graphics::DrawFrame() {
-	std::list<Drawable*>::iterator it_list;
-
 	if (transition_frames_left > 0) {
 		UpdateTransition();
 
-		for (it_list = global_state->drawable_list.begin(); it_list != global_state->drawable_list.end(); ++it_list) {
-			(*it_list)->Draw();
+		for (Drawable* drawable : global_state->drawable_list) {
+			drawable->Draw();
 		}
 
 		DrawOverlay();
@@ -187,12 +172,12 @@ void Graphics::DrawFrame() {
 
 	DisplayUi->CleanDisplay();
 
-	for (it_list = state->drawable_list.begin(); it_list != state->drawable_list.end(); ++it_list) {
-		(*it_list)->Draw();
+	for (Drawable* drawable : state->drawable_list) {
+		drawable->Draw();
 	}
 
-	for (it_list = global_state->drawable_list.begin(); it_list != global_state->drawable_list.end(); ++it_list) {
-		(*it_list)->Draw();
+	for (Drawable* drawable : global_state->drawable_list) {
+		drawable->Draw();
 	}
 
 	DrawOverlay();
@@ -211,13 +196,12 @@ void Graphics::DrawOverlay() {
 BitmapRef Graphics::SnapToBitmap() {
 	DisplayUi->BeginScreenCapture();
 
-	std::list<Drawable*>::iterator it_list;
-	for (it_list = state->drawable_list.begin(); it_list != state->drawable_list.end(); ++it_list) {
-		(*it_list)->Draw();
+	for (Drawable* drawable : state->drawable_list) {
+		drawable->Draw();
 	}
 
-	for (it_list = global_state->drawable_list.begin(); it_list != global_state->drawable_list.end(); ++it_list) {
-		(*it_list)->Draw();
+	for (Drawable* drawable : global_state->drawable_list) {
+		drawable->Draw();
 	}
 
 	return DisplayUi->EndScreenCapture();
@@ -444,11 +428,14 @@ void Graphics::RegisterDrawable(Drawable* drawable) {
 }
 
 void Graphics::RemoveDrawable(Drawable* drawable) {
-	std::list<Drawable*>::iterator it = std::find(state->drawable_list.begin(), state->drawable_list.end(), drawable);
-	if (it != state->drawable_list.end()) { state->drawable_list.erase(it); }
-
-	it = std::find(global_state->drawable_list.begin(), global_state->drawable_list.end(), drawable);
-	if (it != global_state->drawable_list.end()) { global_state->drawable_list.erase(it); }
+	std::list<Drawable*>::iterator it;
+	if (drawable->IsGlobal()) {
+		it = std::find(global_state->drawable_list.begin(), global_state->drawable_list.end(), drawable);
+		if (it != global_state->drawable_list.end()) { global_state->drawable_list.erase(it); }
+	} else {
+		it = std::find(state->drawable_list.begin(), state->drawable_list.end(), drawable);
+		if (it != state->drawable_list.end()) { state->drawable_list.erase(it); }
+	}
 }
 
 void Graphics::UpdateZCallback() {

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -20,7 +20,6 @@
 
 // Headers
 #include <string>
-#include <list>
 
 #include "system.h"
 #include "drawable.h"

--- a/src/main_data.cpp
+++ b/src/main_data.cpp
@@ -91,10 +91,11 @@ void Main_Data::Init() {
 void Main_Data::Cleanup() {
 	Game_Map::Quit();
 	Game_Actors::Dispose();
-	Font::Dispose();
 
 	game_screen.reset();
 	game_player.reset();
 	game_party.reset();
 	game_enemyparty.reset();
+
+	game_data = RPG::Save();
 }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -76,10 +76,10 @@ namespace {
 	bool ignore_pause = false;
 
 	MessageOverlay& message_overlay() {
-		static MessageOverlay* overlay = NULL;
+		static std::unique_ptr<MessageOverlay> overlay;
 		assert(DisplayUi);
 		if (!overlay) {
-			overlay = new MessageOverlay();
+			overlay.reset(new MessageOverlay());
 		}
 		return *overlay;
 	}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -245,6 +245,8 @@ void Player::Update(bool update_scene) {
 		reset_flag = false;
 		if (Scene::instance->type != Scene::Logo) {
 			Scene::PopUntil(Scene::Title);
+			// Do not update this scene until it's properly set up in the next main loop
+			update_scene = false;
 		}
 	}
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -286,7 +286,7 @@ void Player::Exit() {
 	DisplayUi->UpdateDisplay();
 #endif
 
-	Main_Data::Cleanup();
+	Font::Dispose();
 	Graphics::Quit();
 	FileFinder::Quit();
 	DisplayUi.reset();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -521,13 +521,15 @@ void Player::CreateGameObjects() {
 		if (!no_rtp_flag) {
 			FileFinder::InitRtpPaths();
 		}
+	}
+	init = true;
 
+	if (Data::system.system_name != Game_System::GetSystemName()) {
 		FileRequestAsync* request = AsyncHandler::RequestFile("System", Data::system.system_name);
 		request->SetImportantFile(true);
 		request->Bind(&OnSystemFileReady);
 		request->Start();
 	}
-	init = true;
 
 	Main_Data::game_data.Setup();
 

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -68,11 +68,8 @@ void Scene::MainFunction() {
 
 	if (AsyncHandler::IsImportantFilePending() || Graphics::IsTransitionPending()) {
 		Player::Update(false);
-		return;
-	}
-
-	if (!init) {
-		// Initialization after scene switch 
+	} else if (!init) {
+		// Initialization after scene switch
 		switch (push_pop_operation) {
 		case ScenePushed:
 			Start();
@@ -91,9 +88,9 @@ void Scene::MainFunction() {
 		init = true;
 
 		return;
+	} else {
+		Player::Update();
 	}
-
-	Player::Update();
 
 	if (Scene::instance.get() != this) {
 		// Shutdown after scene switch

--- a/src/scene_load.cpp
+++ b/src/scene_load.cpp
@@ -41,8 +41,6 @@ void Scene_Load::Action(int index) {
 	std::string save_name = FileFinder::FindDefault(*tree, ss.str());
 #endif
 
-	Player::CreateGameObjects();	
-
 	Player::LoadSavegame(save_name);
 
 	Scene::Push(EASYRPG_MAKE_SHARED<Scene_Map>(true), true);

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -67,7 +67,7 @@ void Scene_Map::Start() {
 }
 
 Scene_Map::~Scene_Map() {
-	Main_Data::game_screen->Reset();
+	Main_Data::Cleanup();
 }
 
 void Scene_Map::Continue() {

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -48,12 +48,11 @@ void Screen::Update() {
 
 void Screen::Draw() {
 	BitmapRef disp = DisplayUi->GetDisplaySurface();
-	BitmapRef dst = Bitmap::Create(*disp, disp->GetRect());
 
 	Tone tone = Main_Data::game_screen->GetTone();
 
 	if (tone != default_tone) {
-		dst->ToneBlit(0, 0, *disp, Rect(0, 0, SCREEN_TARGET_WIDTH, SCREEN_TARGET_HEIGHT), tone, Opacity::opaque);
+		disp->ToneBlit(0, 0, *disp, Rect(0, 0, SCREEN_TARGET_WIDTH, SCREEN_TARGET_HEIGHT), tone, Opacity::opaque);
 	}
 
 	int flash_time_left;
@@ -66,8 +65,6 @@ void Screen::Draw() {
 		} else {
 			flash->Fill(flash_color);
 		}
-		dst->Blit(0, 0, *flash, flash->GetRect(), flash_current_level);
+		disp->Blit(0, 0, *flash, flash->GetRect(), flash_current_level);
 	}
-
-	disp->Blit(0, 0, *dst, dst->GetRect(), Opacity::opaque);
 }

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -307,7 +307,7 @@ void TilemapLayer::CreateTileCache(const std::vector<short>& nmap_data) {
 
 				} else { // Lower layer
 					int chip_index =
-						tile.ID >= BLOCK_E ? tile.ID - BLOCK_E + 18 :
+						tile.ID >= BLOCK_E ? substitutions[tile.ID - BLOCK_E] + 18 :
 						tile.ID >= BLOCK_D ? (tile.ID - BLOCK_D) / 50 + 6 :
 						tile.ID >= BLOCK_C ? (tile.ID - BLOCK_C) / 50 + 3 :
 						tile.ID / 1000;


### PR DESCRIPTION
Fixes #426
Fixes #449
Fixes #620
Fixes a crash when pressing F12 if the player was runned with --load-game-id or --new-game
Fixes a bug where event 121 in map 4 of Monigote Fantasy would start during the opening cutscene. Kudos to Ghabry, his event tracer has been very useful for this.