### PR TITLE
Fix some bugs before 0.4

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -157,8 +157,12 @@ void Game_Interpreter::Update() {
 			}
 		}
 
-		if (Game_Message::message_waiting && (main_flag || Game_Message::owner_id == event_id)) {
-			break;
+		if (main_flag) {
+			if (Game_Message::message_waiting)
+				break;
+		} else {
+			if (Game_Message::visible && Game_Message::owner_id == event_id)
+				break;
 		}
 
 		if (wait_count > 0) {

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -1415,7 +1415,7 @@ bool Game_Interpreter_Map::CommandCallEvent(RPG::EventCommand const& com) { // c
 	switch (com.parameters[0]) {
 		case 0: // Common Event
 			evt_id = com.parameters[1];
-			child_interpreter->Setup(Data::commonevents[evt_id - 1].event_commands, event_id, Data::commonevents[evt_id - 1].ID, -2);
+			child_interpreter->Setup(Data::commonevents[evt_id - 1].event_commands, 0, Data::commonevents[evt_id - 1].ID, -2);
 			return true;
 		case 1: // Map Event
 			evt_id = com.parameters[1];

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -23,6 +23,7 @@
 #include "game_message.h"
 #include "game_party.h"
 #include "game_system.h"
+#include "graphics.h"
 #include "input.h"
 #include "main_data.h"
 #include "player.h"
@@ -515,6 +516,7 @@ void Game_Player::Refresh() {
 
 	SetSpriteName(actor->GetSpriteName());
 	SetSpriteIndex(actor->GetSpriteIndex());
+	pattern = RPG::EventPage::Frame_middle;
 
 	if (location.aboard)
 		GetVehicle()->SyncWithPlayer();
@@ -582,6 +584,8 @@ bool Game_Player::GetOffVehicle() {
 
 bool Game_Player::IsMovable() const {
 	if (IsMoving() || IsJumping())
+		return false;
+	if (Graphics::IsTransitionPending())
 		return false;
 	if (IsBlockedByMoveRoute())
 		return false;

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -104,12 +104,10 @@ void Scene_Map::TransitionOut() {
 }
 
 void Scene_Map::Update() {
-	if (!Main_Data::game_player->IsMoving()) {
-		if (Game_Temp::transition_processing) {
-			Game_Temp::transition_processing = false;
+	if (Game_Temp::transition_processing) {
+		Game_Temp::transition_processing = false;
 
-			Graphics::Transition(Game_Temp::transition_type, 32, Game_Temp::transition_erase);
-		}
+		Graphics::Transition(Game_Temp::transition_type, 32, Game_Temp::transition_erase);
 	}
 
 	if (auto_transition) {


### PR DESCRIPTION
* 3015228 fixes #684 and #683 .
* 7559b6d fixes #548.
* 28957a5 fixes an annoying bug in multiple games when, after a teleport, the hero will make a step even if no key is pressed at that moment (specially annoying when using the stairs in OFF). 
* 63d03e0 fixes a bug where you get stuck in an infinite loop when speaking with Marin (the girl that saves you) in Zelda: Link's Awakening.