### PR TITLE
autoconf: check for specific liblcf version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ AC_PROG_CXX
 LT_INIT([disable-shared])
 
 # Checks for libraries.
-PKG_CHECK_MODULES([LCF],[liblcf])
+PKG_CHECK_MODULES([LCF],[liblcf = 0.4.0])
 PKG_CHECK_MODULES([PIXMAN],[pixman-1])
 PKG_CHECK_MODULES([FREETYPE],[freetype2])
 PKG_CHECK_MODULES([SDL],[sdl2],[AC_DEFINE(USE_SDL,[1],[Enable SDL2])],[


### PR DESCRIPTION
This prevents building Player with outdated or incorrect liblcf versions, as [reported in forums](https://easy-rpg.org/forums/viewtopic.php?p=1335).