### PR TITLE
Fix #723 (OFF) and #724 (VD2)

### DIFF
--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -560,12 +560,10 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 
 	this->success = false;
 
-	if (source->GetType() == Game_Battler::Type_Ally) {
-		this->healing =
-			skill.scope == RPG::Skill::Scope_ally ||
-			skill.scope == RPG::Skill::Scope_party ||
-			skill.scope == RPG::Skill::Scope_self;
-	}
+	this->healing =
+		skill.scope == RPG::Skill::Scope_ally ||
+		skill.scope == RPG::Skill::Scope_party ||
+		skill.scope == RPG::Skill::Scope_self;
 
 	if (skill.type == RPG::Skill::Type_normal ||
 		skill.type >= RPG::Skill::Type_subskill) {

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -448,7 +448,7 @@ bool Game_Battler::IsGaugeFull() const {
 }
 
 void Game_Battler::UpdateGauge(int multiplier) {
-	if (IsDead()) {
+	if (!Exists()) {
 		return;
 	}
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -921,7 +921,7 @@ bool Game_Interpreter_Map::CommandTradeEventLocations(RPG::EventCommand const& c
 }
 
 bool Game_Interpreter_Map::CommandTimerOperation(RPG::EventCommand const& com) { // code 10230
-	int timer_id = (Player::IsRPG2k()) ? 0 : com.parameters[5];
+	int timer_id = (com.parameters.size() <= 5) ? 0 : com.parameters[5];
 	int seconds;
 	bool visible, battle;
 


### PR DESCRIPTION
More battle bugs: The gauge was updated for invisible enemies, resulting in Eisen to attack directly after spawning. Eisen only has a heal spell but was handled wrong and killed him. The Battle interpreter does not expect that this can happen and does not really kill the actor before next turn -> crash if one enemy killed himself that way and somebody attacked him.
#723 

Vampires Dawn 2 one was really simple, just a out-of-bounds array read. This also explains why it was fixed in a different release. Just luck.
#724 
