### PR TITLE
Specify C++11 for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 project(EasyRPG_Player CXX C)
 


### PR DESCRIPTION
Building with CMake is broken, because C++11 is used, but `CXX_STANDARD` isn't specified.

This does bump the minimum required version of CMake though.