### PR TITLE
Improve order of event updates

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -63,6 +63,10 @@ Game_Character::~Game_Character() {
 	Game_Map::RemovePendingMove(this);
 }
 
+bool Game_Character::IsOverlapForbidden() const {
+	return false;
+}
+
 int Game_Character::GetSteppingSpeed() const {
 	int move_speed = GetMoveSpeed();
 	if (IsSpinning()) {

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -963,8 +963,6 @@ void Game_Character::Flash(Color color, int duration) {
 
 // Gets Character
 Game_Character* Game_Character::GetCharacter(int character_id, int event_id) {
-	tEventHash::const_iterator it;
-
 	switch (character_id) {
 		case CharPlayer:
 			// Player/Hero
@@ -977,21 +975,9 @@ Game_Character* Game_Character::GetCharacter(int character_id, int event_id) {
 			return Game_Map::GetVehicle(Game_Vehicle::Airship);
 		case CharThisEvent:
 			// This event
-			it = Game_Map::GetEvents().find(event_id);
-
-			if (it == Game_Map::GetEvents().end()) {
-				return NULL;
-			}
-
-			return it->second.get();
+			return Game_Map::GetEvent(event_id);
 		default:
 			// Other events
-			it = Game_Map::GetEvents().find(character_id);
-
-			if (it == Game_Map::GetEvents().end()) {
-				return NULL;
-			}
-
-			return it->second.get();
+			return Game_Map::GetEvent(character_id);
 	}
 }

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -139,10 +139,6 @@ bool Game_Character::IsLandable(int x, int y) const
 	return true;
 }
 
-bool Game_Character::IsMessageBlocking() const {
-	return Game_Message::message_waiting && !Game_Message::GetContinueEvents();
-}
-
 void Game_Character::MoveTo(int x, int y) {
 	SetX(Game_Map::RoundX(x));
 	SetY(Game_Map::RoundY(y));
@@ -236,7 +232,8 @@ void Game_Character::Update() {
 	if (stop_count >= max_stop_count) {
 		if (IsMoveRouteOverwritten()) {
 			MoveTypeCustom();
-		} else if (!IsMessageBlocking() && !Game_Map::GetInterpreter().HasRunned() && !Game_Map::GetInterpreter().IsRunning()) {
+		} else {
+			// Only events
 			UpdateSelfMovement();
 		}
 	}
@@ -259,26 +256,7 @@ void Game_Character::UpdateJump() {
 }
 
 void Game_Character::UpdateSelfMovement() {
-	switch (move_type) {
-	case RPG::EventPage::MoveType_random:
-		MoveTypeRandom();
-		break;
-	case RPG::EventPage::MoveType_vertical:
-		MoveTypeCycleUpDown();
-		break;
-	case RPG::EventPage::MoveType_horizontal:
-		MoveTypeCycleLeftRight();
-		break;
-	case RPG::EventPage::MoveType_toward:
-		MoveTypeTowardsPlayer();
-		break;
-	case RPG::EventPage::MoveType_away:
-		MoveTypeAwayFromPlayer();
-		break;
-	case RPG::EventPage::MoveType_custom:
-		MoveTypeCustom();
-		break;
-	}
+	// no-op: Only events can have custom move routes
 }
 
 void Game_Character::UpdateStop() {

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -137,6 +137,13 @@ public:
 	virtual void SetLayer(int new_layer) = 0;
 
 	/**
+	 * Gets whether other events can be in the same tile.
+	 *
+	 * @return whether event overlap is forbidden.
+	 */
+	virtual bool IsOverlapForbidden() const;
+
+	/**
 	 * Gets character stepping speed: the number of frames between each change
 	 * of the left-middle-right-middle walking animation or the spinning animation
 	 *

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -361,13 +361,6 @@ public:
 	 */
 	virtual bool IsLandable(int x, int y) const;
 
- 	/**
-	 * Gets if a message is halting this character's processes.
-	 *
-	 * @return whether the character is halted by a message.
-	 */
-	virtual bool IsMessageBlocking() const;
-
 	/**
 	 * Moves the character to a new tile.
 	 *
@@ -692,8 +685,8 @@ public:
 
 protected:
 	void UpdateMove();
+	virtual void UpdateSelfMovement();
 	void UpdateJump();
-	void UpdateSelfMovement();
 	void UpdateStop();
 
 	int tile_id;

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -74,7 +74,7 @@ void Game_CommonEvent::Update() {
 void Game_CommonEvent::UpdateParallel() {
 	if (interpreter && parallel_running) {
 		if (!interpreter->IsRunning()) {
-			interpreter->Setup(GetList(), 0, -common_event_id, -2);
+			interpreter->Setup(GetList(), 0, false, -common_event_id, -2);
 		}
 		interpreter->Update();
 	}

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -41,8 +41,6 @@ Game_CommonEvent::Game_CommonEvent(int common_event_id, bool battle, const RPG::
 }
 
 void Game_CommonEvent::Refresh() {
-	CheckEventTriggerAuto();
-
 	if (GetTrigger() == RPG::EventPage::Trigger_parallel) {
 		if (GetSwitchFlag() ? Game_Switches[GetSwitchId()] : true) {
 			if (!interpreter) {
@@ -58,14 +56,27 @@ void Game_CommonEvent::Refresh() {
 }
 
 void Game_CommonEvent::Update() {
-	CheckEventTriggerAuto();
+	if (GetTrigger() != RPG::EventPage::Trigger_auto_start)
+		return;
 
+	for (int i = 0; i < 500; ++i) {
+		if (GetSwitchFlag() ? Game_Switches[GetSwitchId()] : true) {
+			if (!Game_Map::GetInterpreter().IsRunning()) {
+				Game_Map::GetInterpreter().SetupStartingEvent(this);
+				Game_Map::GetInterpreter().Update();
+				continue;
+			}
+		}
+		return;
+	}
+}
+
+void Game_CommonEvent::UpdateParallel() {
 	if (interpreter && parallel_running) {
 		if (!interpreter->IsRunning()) {
-			interpreter->Setup(GetList(), 0, false, -common_event_id, -2);
-		} else {
-			interpreter->Update();
+			interpreter->Setup(GetList(), 0, -common_event_id, -2);
 		}
+		interpreter->Update();
 	}
 }
 
@@ -91,17 +102,6 @@ int Game_CommonEvent::GetTrigger() const {
 
 std::vector<RPG::EventCommand>& Game_CommonEvent::GetList() {
 	return Data::commonevents[common_event_id - 1].event_commands;
-}
-
-void Game_CommonEvent::CheckEventTriggerAuto() {
-	if (GetTrigger() == RPG::EventPage::Trigger_auto_start) {
-		if (GetSwitchFlag() ? Game_Switches[GetSwitchId()] : true) {
-			//printf("%d %d\n", GetSwitchId(), (int)Game_Switches[GetSwitchId()]);
-			if (!Game_Map::GetInterpreter().IsRunning()) {
-				Game_Map::GetInterpreter().SetupStartingEvent(this);
-			}
-		}
-	}
 }
 
 RPG::SaveEventData Game_CommonEvent::GetSaveData() {

--- a/src/game_commonevent.h
+++ b/src/game_commonevent.h
@@ -55,9 +55,14 @@ public:
 	void Refresh();
 
 	/**
-	 * Updates common event interpreter.
+	 * Updates common event.
 	 */
 	void Update();
+
+	/**
+	 * Updates common event parallel interpreter.
+	 */
+	void UpdateParallel();
 
 	/**
 	 * Gets common event index.
@@ -100,7 +105,6 @@ public:
 	 * @return event commands list.
 	 */
 	std::vector<RPG::EventCommand>& GetList();
-	void CheckEventTriggerAuto();
 
 	RPG::SaveEventData GetSaveData();
 

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -125,6 +125,10 @@ void Game_Event::SetLayer(int new_layer) {
 	data.layer = new_layer;
 }
 
+bool Game_Event::IsOverlapForbidden() const {
+	return data.overlap_forbidden;
+}
+
 int Game_Event::GetMoveSpeed() const {
 	return data.move_speed;
 }
@@ -286,6 +290,7 @@ void Game_Event::Setup(RPG::EventPage* new_page) {
 
 	SetOpacity(page->translucent ? 160 : 255);
 	SetLayer(page->layer);
+	data.overlap_forbidden = page->overlap_forbidden;
 	trigger = page->trigger;
 	list = page->event_commands;
 

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -226,12 +226,6 @@ void Game_Event::SetFlashTimeLeft(int time_left) {
 	data.flash_time_left = time_left;
 }
 
-bool Game_Event::IsMessageBlocking() const {
-	return Game_Message::message_waiting &&
-		!(Game_Message::GetContinueEvents() && Game_Message::owner_id != ID) &&
-		!Game_Message::owner_parallel;
-}
-
 bool Game_Event::GetThrough() const {
 	return page == NULL || Game_Character::GetThrough();
 }
@@ -519,6 +513,35 @@ bool Game_Event::CheckEventTriggerTouch(int x, int y) {
 	}
 
 	return true;
+}
+
+void Game_Event::UpdateSelfMovement() {
+	if (running)
+		return;
+	if (!Game_Message::GetContinueEvents() &&
+		(Game_Map::GetInterpreter().IsRunning() || Game_Map::GetInterpreter().HasRunned()))
+		return;
+
+	switch (move_type) {
+	case RPG::EventPage::MoveType_random:
+		MoveTypeRandom();
+		break;
+	case RPG::EventPage::MoveType_vertical:
+		MoveTypeCycleUpDown();
+		break;
+	case RPG::EventPage::MoveType_horizontal:
+		MoveTypeCycleLeftRight();
+		break;
+	case RPG::EventPage::MoveType_toward:
+		MoveTypeTowardsPlayer();
+		break;
+	case RPG::EventPage::MoveType_away:
+		MoveTypeAwayFromPlayer();
+		break;
+	case RPG::EventPage::MoveType_custom:
+		MoveTypeCustom();
+		break;
+	}
 }
 
 void Game_Event::Update() {

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -509,10 +509,11 @@ bool Game_Event::CheckEventTriggerTouch(int x, int y) {
 		// TODO check over trigger VX differs from XP here
 		if (!IsJumping()) {
 			Start();
+			return true;
 		}
 	}
 
-	return true;
+	return false;
 }
 
 void Game_Event::UpdateSelfMovement() {
@@ -570,7 +571,7 @@ void Game_Event::UpdateParallel() {
 
 	if (interpreter) {
 		if (!interpreter->IsRunning()) {
-			interpreter->Setup(list, event.ID, -event.x, event.y);
+			interpreter->Setup(list, event.ID, started_by_decision_key, -event.x, event.y);
 		}
 		interpreter->Update();
 	}

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -84,7 +84,6 @@ public:
 	void SetFlashLevel(double flash_level);
 	int GetFlashTimeLeft() const;
 	void SetFlashTimeLeft(int time_left);
-	bool IsMessageBlocking() const;
 	/** @} */
 
 	/**
@@ -177,6 +176,8 @@ public:
 
 	const RPG::SaveMapEvent& GetSaveData();
 private:
+	void UpdateSelfMovement();
+
 	// Not a reference on purpose.
 	// Events change during map change and old are destroyed, breaking the
 	// reference.

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -60,6 +60,7 @@ public:
 	void SetFacingLocked(bool locked);
 	int GetLayer() const;
 	void SetLayer(int new_layer);
+	bool IsOverlapForbidden() const;
 	int GetMoveSpeed() const;
 	void SetMoveSpeed(int speed);
 	int GetMoveFrequency() const;

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -152,10 +152,11 @@ public:
 	 */
 	void StopTalkToHero();
 
-	void CheckEventTriggerAuto();
+	void CheckEventTriggers();
 	bool CheckEventTriggerTouch(int x, int y);
 	void Start(bool triggered_by_decision_key = false);
 	void Update();
+	void UpdateParallel();
 	bool AreConditionsMet(const RPG::EventPage& page);
 
 	/**

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -105,9 +105,6 @@ void Game_Interpreter::Setup(
 
 	if (main_flag && depth == 0)
 		Game_Message::SetFaceName("");
-
-	if (!updating && depth == 0)
-		Update();
 }
 
 void Game_Interpreter::CancelMenuCall() {

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -374,7 +374,9 @@ bool Game_Interpreter::CommandEnd() { // code 10
 	list.clear();
 
 	if (main_flag && depth == 0 && event_id > 0) {
-		Game_Map::GetEvents().find(event_id)->second->StopTalkToHero();
+		Game_Event* evnt = Game_Map::GetEvent(event_id);
+		if (evnt)
+			evnt->StopTalkToHero();
 	}
 
 	return true;
@@ -1057,8 +1059,6 @@ bool Game_Interpreter::CommandChangeEquipment(RPG::EventCommand const& com) { //
 }
 
 bool Game_Interpreter::CommandChangeHP(RPG::EventCommand const& com) { // Code 10460
-	std::vector<Game_Actor*> actors = GetActors(com.parameters[0],
-												com.parameters[1]);
 	bool remove = com.parameters[2] != 0;
 	int amount = ValueOrVariable(com.parameters[3],
 								 com.parameters[4]);

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -60,6 +60,7 @@ bool Game_Interpreter_Map::SetupFromSave(const std::vector<RPG::SaveEventCommand
 		event_id = _event_id;
 		list = save[_index].commands;
 		index = save[_index].current_command;
+		triggered_by_decision_key = save[_index].actioned;
 
 		child_interpreter.reset(new Game_Interpreter_Map());
 		bool result = static_cast<Game_Interpreter_Map*>(child_interpreter.get())->SetupFromSave(save, _event_id, _index + 1);
@@ -109,6 +110,7 @@ std::vector<RPG::SaveEventCommands> Game_Interpreter_Map::GetSaveData() const {
 		save_commands.current_command = save_interpreter->index;
 		save_commands.commands_size = GetEventCommandSize(save_commands.commands);
 		save_commands.ID = i++;
+		save_commands.actioned = triggered_by_decision_key;
 		save.push_back(save_commands);
 		save_interpreter = static_cast<Game_Interpreter_Map*>(save_interpreter->child_interpreter.get());
 	}

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -1381,8 +1381,9 @@ bool Game_Interpreter_Map::CommandEraseEvent(RPG::EventCommand const& /* com */)
 	if (event_id == 0)
 		return true;
 
-	tEventHash& events = Game_Map::GetEvents();
-	events[event_id]->SetActive(false);
+	Game_Event* evnt = Game_Map::GetEvent(event_id);
+	if (evnt)
+		evnt->SetActive(false);
 
 	return true;
 }

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -435,7 +435,13 @@ bool Game_Map::IsPassable(int x, int y, int d, const Game_Character* self_event)
 			if (*it == self_event || (*it)->GetThrough()) {
 				continue;
 			}
-			else if ((*it)->GetLayer() == self_event->GetLayer()) {
+
+			if (self_event != Main_Data::game_player.get()) {
+				if (self_event->IsOverlapForbidden() || (*it)->IsOverlapForbidden())
+					return false;
+			}
+
+			if ((*it)->GetLayer() == self_event->GetLayer()) {
 				if (self_event->IsInPosition(x, y))
 					pass = true;
 				else

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -60,15 +60,15 @@ namespace {
 
 	std::vector<unsigned char> passages_down;
 	std::vector<unsigned char> passages_up;
-	tEventHash events;
-	tCommonEventHash common_events;
+	std::vector<Game_Event> events;
+	std::vector<Game_CommonEvent> common_events;
 
 	std::auto_ptr<RPG::Map> map;
 	int scroll_direction;
 	int scroll_rest;
 	int scroll_speed;
 
-	boost::scoped_ptr<Game_Interpreter> interpreter;
+	boost::scoped_ptr<Game_Interpreter_Map> interpreter;
 	std::vector<EASYRPG_SHARED_PTR<Game_Interpreter> > free_interpreters;
 	std::vector<EASYRPG_SHARED_PTR<Game_Vehicle> > vehicles;
 	std::vector<Game_Character*> pending;
@@ -96,8 +96,9 @@ void Game_Map::Init() {
 	map_info.encounter_rate = 0;
 
 	common_events.clear();
-	for (size_t i = 0; i < Data::commonevents.size(); ++i) {
-		common_events.insert(std::make_pair(Data::commonevents[i].ID, EASYRPG_MAKE_SHARED<Game_CommonEvent>(Data::commonevents[i].ID)));
+	common_events.reserve(Data::commonevents.size());
+	for (const RPG::CommonEvent& ev : Data::commonevents) {
+		common_events.emplace_back(ev.ID);
 	}
 
 	vehicles.clear();
@@ -136,8 +137,9 @@ void Game_Map::Quit() {
 void Game_Map::Setup(int _id) {
 	SetupCommon(_id);
 
-	for (size_t i = 0; i < map->events.size(); ++i) {
-		events.insert(std::make_pair(map->events[i].ID, EASYRPG_MAKE_SHARED<Game_Event>(location.map_id, map->events[i])));
+	events.reserve(map->events.size());
+	for (const RPG::Event& ev : map->events) {
+		events.emplace_back(location.map_id, ev);
 	}
 
 	location.pan_finish_x = 0;
@@ -151,33 +153,30 @@ void Game_Map::SetupFromSave() {
 	SetupCommon(location.map_id);
 
 	// Make main interpreter "busy" if save contained events to prevent auto-events from starting
-	static_cast<Game_Interpreter_Map*>(interpreter.get())->SetupFromSave(Main_Data::game_data.events.events, 0);
+	interpreter->SetupFromSave(Main_Data::game_data.events.events, 0);
 
+	events.reserve(map->events.size());
 	for (size_t i = 0; i < map->events.size(); ++i) {
-		EASYRPG_SHARED_PTR<Game_Event> evnt;
 		if (i < map_info.events.size()) {
-			evnt = EASYRPG_MAKE_SHARED<Game_Event>(location.map_id, map->events[i], map_info.events[i]);
+			events.emplace_back(location.map_id, map->events[i], map_info.events[i]);
 		}
 		else {
-			evnt = EASYRPG_MAKE_SHARED<Game_Event>(location.map_id, map->events[i]);
+			events.emplace_back(location.map_id, map->events[i]);
 		}
 
-		events.insert(std::make_pair(map->events[i].ID, evnt));
-
-		if (evnt->IsMoveRouteOverwritten())
-			pending.push_back(evnt.get());
+		if (events.back().IsMoveRouteOverwritten())
+			pending.push_back(&events.back());
 	}
 
+	common_events.reserve(Data::commonevents.size());
 	for (size_t i = 0; i < Data::commonevents.size(); ++i) {
 		EASYRPG_SHARED_PTR<Game_CommonEvent> evnt;
 		if (i < Main_Data::game_data.common_events.size()) {
-			evnt = EASYRPG_MAKE_SHARED<Game_CommonEvent>(Data::commonevents[i].ID, false, Main_Data::game_data.common_events[i]);
+			common_events.emplace_back(Data::commonevents[i].ID, false, Main_Data::game_data.common_events[i]);
 		}
 		else {
-			evnt = EASYRPG_MAKE_SHARED<Game_CommonEvent>(Data::commonevents[i].ID, false);
+			common_events.emplace_back(Data::commonevents[i].ID, false);
 		}
-
-		common_events.insert(std::make_pair(Data::commonevents[i].ID, evnt));
 	}
 
 	for (size_t i = 0; i < 3; i++)
@@ -273,24 +272,22 @@ void Game_Map::SetupCommon(int _id) {
 }
 
 void Game_Map::PrepareSave() {
-	Main_Data::game_data.events.events =
-		static_cast<Game_Interpreter_Map*>(interpreter.get())
-			->GetSaveData();
+	Main_Data::game_data.events.events = interpreter->GetSaveData();
 	Main_Data::game_data.events.events_size = Main_Data::game_data.events.events.size();
 
 	map_info.events.clear();
-
-	for (tEventHash::iterator i = events.begin(); i != events.end(); ++i) {
-		map_info.events.push_back(i->second->GetSaveData());
+	map_info.events.reserve(events.size());
+	for (Game_Event& ev : events) {
+		map_info.events.push_back(ev.GetSaveData());
 	}
 
 	std::vector<RPG::SaveCommonEvent>& save_common_events = Main_Data::game_data.common_events;
 	save_common_events.clear();
-
-	for (tCommonEventHash::iterator i = common_events.begin(); i != common_events.end(); ++i) {
+	save_common_events.reserve(common_events.size());
+	for (Game_CommonEvent& ev : common_events) {
 		save_common_events.push_back(RPG::SaveCommonEvent());
-		save_common_events.back().ID = i->first;
-		save_common_events.back().event_data = i->second->GetSaveData();
+		save_common_events.back().ID = ev.GetIndex();
+		save_common_events.back().event_data = ev.GetSaveData();
 	}
 }
 
@@ -311,12 +308,12 @@ void Game_Map::PlayBgm() {
 
 void Game_Map::Refresh() {
 	if (location.map_id > 0) {
-		for (tEventHash::iterator i = events.begin(); i != events.end(); ++i) {
-			i->second->Refresh();
+		for (Game_Event& ev : events) {
+			ev.Refresh();
 		}
 
-		for (tCommonEventHash::iterator i = common_events.begin(); i != common_events.end(); ++i) {
-			i->second->Refresh();
+		for (Game_CommonEvent& ev : common_events) {
+			ev.Refresh();
 		}
 	}
 
@@ -527,15 +524,14 @@ bool Game_Map::IsLandable(int x, int y, const Game_Character *self_event) {
 	int bit = Passable::Down | Passable::Right | Passable::Left | Passable::Up;
 
 	if (self_event) {
-		for (tEventHash::iterator i = events.begin(); i != events.end(); ++i) {
-			Game_Event* evnt = i->second.get();
-			if (evnt != self_event && evnt->IsInPosition(x, y)) {
-				if (!evnt->GetThrough()) {
-					if (evnt->GetLayer() == RPG::EventPage::Layers_same) {
+		for (Game_Event& ev : events) {
+			if (&ev != self_event && ev.IsInPosition(x, y)) {
+				if (!ev.GetThrough()) {
+					if (ev.GetLayer() == RPG::EventPage::Layers_same) {
 						return false;
-					} else if (evnt->GetTileId() >= 0 && evnt->GetLayer() == RPG::EventPage::Layers_below) {
+					} else if (ev.GetTileId() >= 0 && ev.GetLayer() == RPG::EventPage::Layers_below) {
 						// Event layer Chipset Tile
-						tile_id = i->second->GetTileId();
+						tile_id = ev.GetTileId();
 						return (passages_up[tile_id] & bit) != 0;
 					}
 				}
@@ -625,16 +621,11 @@ bool Game_Map::AirshipLandOk(int const x, int const y) {
 }
 
 void Game_Map::GetEventsXY(std::vector<Game_Event*>& events, int x, int y) {
-	std::vector<Game_Event*> result;
-
-	tEventHash::const_iterator i;
-	for (i = Game_Map::GetEvents().begin(); i != Game_Map::GetEvents().end(); ++i) {
-		if (i->second->IsInPosition(x, y) && i->second->GetActive()) {
-			result.push_back(i->second.get());
+	for (Game_Event& ev : GetEvents()) {
+		if (ev.IsInPosition(x, y) && ev.GetActive()) {
+			events.push_back(&ev);
 		}
 	}
-
-	events.swap(result);
 }
 
 bool Game_Map::LoopHorizontal() {
@@ -670,10 +661,9 @@ int Game_Map::YwithDirection(int y, int direction) {
 }
 
 int Game_Map::CheckEvent(int x, int y) {
-	tEventHash::iterator i;
-	for (i = events.begin(); i != events.end(); ++i) {
-		if (i->second->IsInPosition(x, y)) {
-			return i->second->GetId();
+	for (const Game_Event& ev : events) {
+		if (ev.IsInPosition(x, y)) {
+			return ev.GetId();
 		}
 	}
 
@@ -723,14 +713,12 @@ void Game_Map::Update() {
 		}
 	}
 
-	for (tEventHash::iterator i = events.begin();
-		i != events.end(); ++i) {
-		i->second->Update();
+	for (Game_Event& ev : events) {
+		ev.Update();
 	}
 
-	for (tCommonEventHash::iterator i = common_events.begin();
-		i != common_events.end(); ++i) {
-		i->second->Update();
+	for (Game_CommonEvent& ev : common_events) {
+		ev.Update();
 	}
 
 	for (int i = 0; i < 3; ++i)
@@ -949,11 +937,17 @@ std::vector<short>& Game_Map::GetTerrainTags() {
 	return Data::chipsets[map_info.chipset_id - 1].terrain_data;
 }
 
-tEventHash& Game_Map::GetEvents() {
+std::vector<Game_Event>& Game_Map::GetEvents() {
 	return events;
 }
 
-tCommonEventHash& Game_Map::GetCommonEvents() {
+Game_Event* Game_Map::GetEvent(int event_id) {
+	auto it = std::find_if(events.begin(), events.end(),
+			[&event_id](Game_Event& ev) {return ev.GetId() == event_id;});
+	return it == events.end() ? nullptr : &(*it);
+}
+
+std::vector<Game_CommonEvent>& Game_Map::GetCommonEvents() {
 	return common_events;
 }
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -29,6 +29,7 @@
 #include "game_battler.h"
 #include "game_map.h"
 #include "game_interpreter_map.h"
+#include "game_switches.h"
 #include "game_temp.h"
 #include "game_player.h"
 #include "lmu_reader.h"
@@ -1031,6 +1032,20 @@ Game_Vehicle* Game_Map::GetVehicle(Game_Vehicle::Type which) {
 		return NULL;
 	}
 	return vehicles[which - 1].get();
+}
+
+bool Game_Map::IsAnyEventStarting() {
+	for (Game_Event& ev : events)
+		if (ev.GetStarting() && !ev.GetList().empty())
+			return true;
+
+	for (Game_CommonEvent& ev : common_events)
+		if ((ev.GetTrigger() == RPG::EventPage::Trigger_auto_start) &&
+			(ev.GetSwitchFlag() ? Game_Switches[ev.GetSwitchId()] : true) &&
+			(!ev.GetList().empty()))
+				return true;
+
+	return false;
 }
 
 bool Game_Map::IsAnyMovePending() {

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -28,9 +28,6 @@
 #include "rpg_encounter.h"
 #include "rpg_map.h"
 
-typedef std::map<int, EASYRPG_SHARED_PTR<Game_Event> > tEventHash;
-typedef std::map<int, EASYRPG_SHARED_PTR<Game_CommonEvent> > tCommonEventHash;
-
 class FileRequestAsync;
 
 #define SCREEN_TILE_WIDTH 256
@@ -472,14 +469,22 @@ namespace Game_Map {
 	 *
 	 * @return events list.
 	 */
-	tEventHash& GetEvents();
+	std::vector<Game_Event>& GetEvents();
+
+	/**
+	 * Gets pointer to event.
+	 *
+	 * @param event_id event ID
+	 * @return pointer to event.
+	 */
+	Game_Event* GetEvent(int event_id);
 
 	/**
 	 * Gets common events list.
 	 *
 	 * @return common events list.
 	 */
-	tCommonEventHash& GetCommonEvents();
+	std::vector<Game_CommonEvent>& GetCommonEvents();
 
 	void GetEventsXY(std::vector<Game_Event*>& events, int x, int y);
 

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -534,6 +534,14 @@ namespace Game_Map {
 	void ResetPan(int speed, bool wait);
 	void UpdatePan();
 
+	/**
+	 * Gets whether there are any starting non-parallel event or common event.
+	 * Used as a workaround for the Game Player.
+	 *
+	 * @return whether any starting non-parallel (common) event is starting
+	 */
+	bool IsAnyEventStarting();
+
 	bool IsAnyMovePending();
 	void AddPendingMove(Game_Character* character);
 	void RemovePendingMove(Game_Character* character);

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -219,8 +219,10 @@ namespace Game_Map {
 
 	/**
 	 * Updates the map state.
+	 *
+	 * @param only_parallel Update only parallel interpreters
 	 */
-	void Update();
+	void Update(bool only_parallel = false);
 
 	/**
 	 * Updates the scroll state.
@@ -400,13 +402,6 @@ namespace Game_Map {
 	 * @return need refresh flag.
 	 */
 	bool GetNeedRefresh();
-
-	/**
-	 * Gets ready flag.
-	 *
-	 * @return ready flag.
-	 */
-	bool GetReady();
 
 	/**
 	 * Gets the game interpreter.

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -223,6 +223,7 @@ void Game_Player::PerformTeleport() {
 
 	if (Game_Map::GetMapId() != new_map_id) {
 		Refresh(); // Reset sprite if it was changed by a move
+		pattern = RPG::EventPage::Frame_middle;
 		Game_Map::Setup(new_map_id);
 		last_pan_x = 0;
 		last_pan_y = 0;
@@ -516,7 +517,6 @@ void Game_Player::Refresh() {
 
 	SetSpriteName(actor->GetSpriteName());
 	SetSpriteIndex(actor->GetSpriteIndex());
-	pattern = RPG::EventPage::Frame_middle;
 
 	if (location.aboard)
 		GetVehicle()->SyncWithPlayer();

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -328,6 +328,7 @@ void Game_Player::UpdateScroll() {
 		Game_Map::ScrollUp(-dy);
 }
 
+
 void Game_Player::Update() {
 	bool last_moving = IsMoving() || IsJumping();
 
@@ -588,6 +589,8 @@ bool Game_Player::IsMovable() const {
 	if (Graphics::IsTransitionPending())
 		return false;
 	if (IsBlockedByMoveRoute())
+		return false;
+	if (Game_Map::IsAnyEventStarting())
 		return false;
 	if (location.boarding || location.unboarding)
 		return false;

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -46,6 +46,7 @@ void Scene_GameBrowser::Continue() {
 	Data::Clear();
 	Player::ResetGameObjects();
 	Player::game_title = "";
+	Player::engine = Player::EngineNone;
 
 	Game_System::SetSystemName(CACHE_DEFAULT_BITMAP);
 	Game_System::BgmStop();

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -66,6 +66,7 @@ void Scene_Map::Start() {
 	}
 
 	Player::FrameReset();
+	Game_Map::Update(true);
 }
 
 Scene_Map::~Scene_Map() {
@@ -129,12 +130,9 @@ void Scene_Map::Update() {
 		FinishTeleportPlayer();
 	}
 
-	Game_Map::GetInterpreter().Update();
-
 	Main_Data::game_party->UpdateTimers();
 
 	Game_Map::Update();
-	Main_Data::game_player->Update();
 	Main_Data::game_screen->Update();
 	spriteset->Update();
 	message_window->Update();
@@ -222,7 +220,7 @@ void Scene_Map::FinishTeleportPlayer() {
 
 	spriteset.reset(new Spriteset_Map());
 
-	Game_Map::Update();
+	Game_Map::Update(true);
 
 	if (autotransition) {
 		auto_transition = true;

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -39,9 +39,8 @@ Spriteset_Map::Spriteset_Map() :
 
 	panorama.SetZ(-1000);
 
-	tEventHash events = Game_Map::GetEvents();
-	for (tEventHash::iterator i = events.begin(); i != events.end(); ++i) {
-		character_sprites.push_back(EASYRPG_MAKE_SHARED<Sprite_Character>(i->second.get()));
+	for (Game_Event& ev : Game_Map::GetEvents()) {
+		character_sprites.push_back(EASYRPG_MAKE_SHARED<Sprite_Character>(&ev));
 	}
 
 	Game_Vehicle* vehicle;


### PR DESCRIPTION
The most important bit is in Game_Map::Update. The process in which all the events are updated is now more convoluted, but also more accurate to the output of the event tracer plugin. To make the code more digestible, I've changed the container of the events and common events from std::map<int, EASYRPG_SHARED_PTR<Game_(Common)Event>> to std::vector<Game_(Common)Event>. This means a linear search, but we don't ever search common events and there are few maps with more than a thousand events.

Some facts about the game logic update thanks to the event tracer.

1. The order of event update is: Parallel common event, parallel event, non-parallel event, non-parallel common event.
2. A keypress starts an event in the same frame it gets detected by KeyInputProc command.
3. If a parallel (common) event pushes a move route on the hero, it will start in that frame. If it's a non-parallel (common) event, the route starts in the next frame.
4. The hero move route is executed between the update of parallel events and non-parallel events.
5. The hero won't move or trigger other events by keypresses, if a non-parallel event will execute commands in that frame.
6. If a non-parallel event needs more than one frame to be executed, it'll run before any other non-parallel event in the next frame.

From (2), (3) and (4), I've concluded that the hero has to be updated before the non-parallel events, but it must be aware if there's any auto-starting or collision-triggered event because of (5). That's what the workaround function Game_Map::IsAnyEventStarting is for.

* Fixes  #692
* Fixes the combat system of Violated Heroine: The monsters do actually attack the heroine now
* Fixes being stuck speaking with Marin in Zelda's Link Awakening
* Probably more fixes in other interpreter intensive games