### PR TITLE
Crash fixes + ATB

### DIFF
--- a/src/audio_sdl.cpp
+++ b/src/audio_sdl.cpp
@@ -205,8 +205,7 @@ void SdlAudio::BGM_Pause() {
 	// Midi pause is not supported... (for some systems -.-)
 #if SDL_MAJOR_VERSION>1
 	// SDL2_mixer bug, see above
-	Mix_MusicType mtype = Mix_GetMusicType(bgm.get());
-	if (mtype == MUS_WAV || mtype == MUS_OGG) {
+	if (bgs_playing) {
 		BGS_Pause();
 		return;
 	}
@@ -217,8 +216,7 @@ void SdlAudio::BGM_Pause() {
 void SdlAudio::BGM_Resume() {
 #if SDL_MAJOR_VERSION>1
 	// SDL2_mixer bug, see above
-	Mix_MusicType mtype = Mix_GetMusicType(bgm.get());
-	if (mtype == MUS_WAV || mtype == MUS_OGG) {
+	if (bgs_playing) {
 		BGS_Resume();
 		return;
 	}
@@ -229,8 +227,7 @@ void SdlAudio::BGM_Resume() {
 void SdlAudio::BGM_Stop() {
 #if SDL_MAJOR_VERSION>1
 	// SDL2_mixer bug, see above
-	Mix_MusicType mtype = Mix_GetMusicType(bgm.get());
-	if (mtype == MUS_WAV || mtype == MUS_OGG) {
+	if (bgs_playing) {
 		BGS_Stop();
 		return;
 	}
@@ -269,8 +266,7 @@ void SdlAudio::BGM_Fade(int fade) {
 
 #if SDL_MAJOR_VERSION>1
 	// SDL2_mixer bug, see above
-	Mix_MusicType mtype = Mix_GetMusicType(bgm.get());
-	if (mtype == MUS_WAV || mtype == MUS_OGG) {
+	if (bgs_playing) {
 		BGS_Fade(fade);
 		return;
 	}

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1179,7 +1179,7 @@ bool Game_Interpreter::CommandFlashScreen(RPG::EventCommand const& com) { // cod
 	int tenths = com.parameters[4];
 	bool wait = com.parameters[5] != 0;
 
-	if (Player::IsRPG2k()) {
+	if (com.parameters.size() <= 6) {
 		screen->FlashOnce(r, g, b, s, tenths);
 		if (wait)
 			SetupWait(tenths);

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -1831,7 +1831,11 @@ bool Game_Interpreter_Map::CommandOpenLoadMenu(RPG::EventCommand const& com) {
 }
 
 bool Game_Interpreter_Map::CommandExitGame(RPG::EventCommand const& com) {
-	Player::exit_flag = true;
+	if (Scene::Find(Scene::GameBrowser)) {
+		Scene::PopUntil(Scene::GameBrowser);
+	} else {
+		Player::exit_flag = true;
+	}
 	return true;
 }
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -1836,7 +1836,7 @@ bool Game_Interpreter_Map::CommandExitGame(RPG::EventCommand const& com) {
 }
 
 bool Game_Interpreter_Map::CommandToggleAtbMode(RPG::EventCommand const& com) {
-	Output::Warning("Command Toggle ATB mode not supported");
+	Main_Data::game_data.system.atb_mode = !Main_Data::game_data.system.atb_mode;
 	return true;
 }
 
@@ -2017,8 +2017,8 @@ bool Game_Interpreter_Map::CommandConditionalBranch(RPG::EventCommand const& com
 					result = Player::debug_flag;
 					break;
 				case 2:
-					// Is ATB wait?
-					Output::Warning("Branch: Is ATB wait not implemented");
+					// Is ATB wait on?
+					result = Main_Data::game_data.system.atb_mode == RPG::SaveSystem::AtbMode_atb_wait;
 					break;
 				case 3:
 					// Is Fullscreen active?

--- a/src/game_temp.cpp
+++ b/src/game_temp.cpp
@@ -50,7 +50,6 @@ int Game_Temp::battle_escape_mode;
 int Game_Temp::battle_defeat_mode;
 bool Game_Temp::battle_first_strike;
 int Game_Temp::battle_result;
-bool Game_Temp::battle_wait;
 
 void Game_Temp::Init() {
 	menu_calling = false;
@@ -81,5 +80,4 @@ void Game_Temp::Init() {
 	battle_escape_mode = -1;
 	battle_defeat_mode = 0;
 	battle_first_strike = false;
-	battle_wait = false;
 }

--- a/src/game_temp.h
+++ b/src/game_temp.h
@@ -22,7 +22,6 @@
 #include <string>
 #include "game_battler.h"
 #include "graphics.h"
-#include "rpg_music.h"
 
 /**
  * Game Temp static class.
@@ -75,7 +74,6 @@ public:
 	static int battle_defeat_mode;
 	static bool battle_first_strike;
 	static int battle_result;
-	static bool battle_wait;
 
 	enum BattleResult {
 		BattleVictory,

--- a/src/scene_end.cpp
+++ b/src/scene_end.cpp
@@ -48,7 +48,6 @@ void Scene_End::Update() {
 		switch (command_window->GetIndex()) {
 		case 0: // Yes
 			Audio().BGM_Fade(800);
-			Audio().BGS_Fade(800);
 			Scene::PopUntil(Scene::Title);
 			break;
 		case 1: // No

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -168,7 +168,7 @@ void Scene_GameBrowser::BootGame() {
 
 	if (browser_dir.empty())
 		browser_dir = Main_Data::GetProjectPath();
-	Main_Data::SetProjectPath(gamelist_window->GetGamePath());
+	Main_Data::SetProjectPath(path);
 
 	EASYRPG_SHARED_PTR<FileFinder::DirectoryTree> tree = FileFinder::CreateDirectoryTree(path);
 	FileFinder::SetDirectoryTree(tree);

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -23,6 +23,7 @@
 #include "player.h"
 #include "scene_title.h"
 #include "bitmap.h"
+#include "audio.h"
 
 #ifdef _WIN32
 	#define WIN32_LEAN_AND_MEAN
@@ -46,6 +47,7 @@ void Scene_GameBrowser::Continue() {
 #ifdef _WIN32
 	SetCurrentDirectory(L"..");
 #endif
+	Audio().BGM_Fade(800);
 
 	Main_Data::SetProjectPath(browser_dir);
 

--- a/src/scene_menu.cpp
+++ b/src/scene_menu.cpp
@@ -114,7 +114,7 @@ void Scene_Menu::CreateCommandWindow() {
 			options.push_back(Data::terms.order);
 			break;
 		case Wait:
-			options.push_back(Game_Temp::battle_wait ? Data::terms.wait_on : Data::terms.wait_off);
+			options.push_back(Main_Data::game_data.system.atb_mode == RPG::SaveSystem::AtbMode_atb_wait ? Data::terms.wait_on : Data::terms.wait_off);
 			break;
 		default:
 			options.push_back(Data::terms.menu_quit);
@@ -197,8 +197,9 @@ void Scene_Menu::UpdateCommand() {
 			break;
 		case Wait:
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
-			Game_Temp::battle_wait = !Game_Temp::battle_wait;
-			command_window->SetItemText(menu_index, Game_Temp::battle_wait ? Data::terms.wait_on : Data::terms.wait_off);
+			Main_Data::game_data.system.atb_mode = !Main_Data::game_data.system.atb_mode;
+			command_window->SetItemText(menu_index,
+				Main_Data::game_data.system.atb_mode == RPG::SaveSystem::AtbMode_atb_wait ? Data::terms.wait_on : Data::terms.wait_off);
 			break;
 		case Quit:
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -53,7 +53,6 @@ void Scene_Title::Continue() {
 	// Fade out all audio and clear the cache when the game returns to the
 	// title screen e.g. by pressing F12
 	Audio().BGM_Fade(800);
-	Audio().BGS_Fade(800);
 
 	Cache::Clear();
 
@@ -200,7 +199,6 @@ void Scene_Title::CommandContinue() {
 
 void Scene_Title::CommandShutdown() {
 	Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
-	Audio().BGS_Fade(800);
 	Graphics::Transition(Graphics::TransitionFadeOut, 32, true);
 	Scene::Pop();
 }

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -109,10 +109,10 @@ void Window_Base::DrawActorState(Game_Battler* actor, int cx, int cy) {
 	std::vector<int16_t> states = actor->GetStates();
 
 	// Unit has Normal state if no state is set
-	if (states.size() == 0) {
+	const RPG::State* state = actor->GetSignificantState();
+	if (!state) {
 		contents->TextDraw(cx, cy, Font::ColorDefault, Data::terms.normal_status);
 	} else {
-		const RPG::State* state = actor->GetSignificantState();
 		contents->TextDraw(cx, cy, state->color, state->name);
 	}
 }


### PR DESCRIPTION
Fixes some crashes (opening the menu in some cases, reported via Android bug mails...).

Adds saving/loading the ATB flag.

End Game returns to game browser now and music fade out works for ADPCM files (SDL ~.~)