### PR TITLE
Fix the windows build.

### DIFF
--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -27,15 +27,14 @@
 
 #include <boost/optional.hpp>
 
-#ifdef __MINGW32__
-#  include <dirent.h>
-#elif defined(_MSC_VER)
-#  include "dirent_win.h"
-#endif
-
 #ifdef _WIN32
 #  include <windows.h>
 #  include <shlobj.h>
+#  ifdef __MINGW32__
+#    include <dirent.h>
+#  elif defined(_MSC_VER)
+#    include "dirent_win.h"
+#  endif
 #else
 #  include <dirent.h>
 #  include <unistd.h>


### PR DESCRIPTION
Now my question is, why did MSVC not blow up on the PR builder for this one?
It should really not have cached the `filefinder.cpp`, as the file changed in cc2d2e67453caa7d3db32c8b85635089b801285b.