### PR TITLE
Replace boost::flat_map in FileFinder

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -329,8 +329,8 @@ endif
 endif
 
 # FIXME make filefinder work without external scripting
-check_PROGRAMS = output utils
-TESTS = output utils
+check_PROGRAMS = output utils directorytree
+TESTS = output utils directorytree
 #filefinder_SOURCES = tests/filefinder.cpp
 #filefinder_CXXFLAGS = $(libeasyrpg_player_la_CXXFLAGS)
 #filefinder_LDADD = $(easyrpg_player_LDADD)
@@ -340,6 +340,9 @@ output_LDADD = $(easyrpg_player_LDADD)
 utils_SOURCES = tests/utils.cpp
 utils_CXXFLAGS = $(libeasyrpg_player_la_CXXFLAGS)
 utils_LDADD = $(easyrpg_player_LDADD)
+directorytree_SOURCES = tests/directorytree.cpp
+directorytree_CXXFLAGS = $(libeasyrpg_player_la_CXXFLAGS)
+directorytree_LDADD = $(easyrpg_player_LDADD)
 
 # Some tests will create this file
 # make distcheck will fail if it is not cleaned after runing these tests

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -23,7 +23,7 @@
 
 #include <string>
 #include <ios>
-#include <boost/container/flat_map.hpp>
+#include <unordered_map>
 
 /**
  * FileFinder contains helper methods for finding case
@@ -45,12 +45,12 @@ namespace FileFinder {
 	/*
 	* { case lowered path, real path }
 	*/
-	typedef boost::container::flat_map<std::string, std::string> string_map;
+	typedef std::unordered_map<std::string, std::string> string_map;
 
 	/*
 	* { case lowered directory name, non directory file list }
 	*/
-	typedef boost::container::flat_map<std::string, string_map> sub_members_type;
+	typedef std::unordered_map<std::string, string_map> sub_members_type;
 
 	struct DirectoryTree {
 		std::string directory_path;

--- a/tests/directorytree.cpp
+++ b/tests/directorytree.cpp
@@ -1,0 +1,14 @@
+#include <cstdlib>
+#include "filefinder.h"
+#include "player.h"
+#include "main_data.h"
+
+int main(int argc, char** argv) {
+	Player::ParseCommandLine(argc, argv);
+	Main_Data::Init();
+
+	FileFinder::CreateDirectoryTree(Main_Data::GetProjectPath());
+	FileFinder::Quit();
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The initialization of FileFinder has been very slow. Games with more than ten thousand of files may take a couple seconds just creating the directory tree. It might take even longer in the least powerful devices we support. This has to change.

I've added a new test with the purpose of benchmarking FileFinder's directory tree creation. Then I've compared three containers using perf. For that I've created two test projects that you can [download here](https://dl.dropboxusercontent.com/u/30277047/directorytree%20tests.7z). Both projects have 8000 files in the folder Picture, but directorytree-1 has them in multiple subfolders, while in directorytree-2 they're all in the same folder.

``` perf stat -r 20 -d ./directorytree --project-path ~/easyrpg/directorytree-1 ```

                      | boost::flat_map    | std::map          | std::unordered_map
------------------|--------------------|-------------------|-------------------
task-clock (msec) | 254,953806         | 73,426195         | 68,471957
time elapsed (sec)| 0,261099 (+-0,45%) | 0,075484 (+-0,36%)| 0,072304 (+-0,30%)

``` perf stat -r 20 -d ./directorytree --project-path ~/easyrpg/directorytree-2 ```

                  | boost::flat_map    | std::map          | std::unordered_map
------------------|--------------------|-------------------|-------------------
task-clock (msec) | 312,441164         | 53,571473         | 52,867727
time elapsed (sec)| 0,312310 (+-0,25%) | 0,057725 (+-0,61%)| 0,054723 (+-0,45%)

boost::flat_map is the clear loser. The difference in performance of the creation of std::map and std::unordered_map is small, but I've decided to go with unordered_map because its search has constant-time complexity and we don't iterate over it. This [stackoverflow answer](http://stackoverflow.com/a/25027750) goes more in-depth about this topic.