### PR TITLE
Fix deadlocks in RPG2k3 battle and other VD2 battle problems

### DIFF
--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -47,6 +47,8 @@ public:
 	void SetFrame(int);
 	bool IsDone() const;
 
+	Sprite* GetSprite();
+
 protected:
 	virtual void Flash(Color c) = 0;
 	virtual bool ShouldScreenFlash() const = 0;
@@ -57,7 +59,7 @@ protected:
 	void OnBattle2SpriteReady(FileRequestResult* result);
 
 	const RPG::Animation& animation;
-	BitmapRef screen;
+	std::unique_ptr<Sprite> sprite;
 	int frame;
 	int z;
 	bool frame_update;

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -892,6 +892,7 @@ void Game_Actor::ChangeHp(int hp) {
 
 	if (GetData().current_hp == 0) {
 		// Death
+		SetGauge(0);
 		RemoveAllStates();
 		SetDefending(false);
 		SetCharged(false);

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -411,6 +411,11 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 
 	for (; it != conditions.end(); ++it) {
 		if (IsPositive()) {
+			if ((*current_target)->IsDead() && it->ID == 1) {
+				// Was a revive skill with an effect rating of 0
+				(*current_target)->ChangeHp(1);
+			}
+
 			(*current_target)->RemoveState(it->ID);
 		}
 		else {
@@ -633,6 +638,11 @@ bool Game_BattleAlgorithm::Skill::IsTargetValid() {
 	if (source->GetType() == Game_Battler::Type_Ally) {
 		if (skill.scope == RPG::Skill::Scope_ally ||
 			skill.scope == RPG::Skill::Scope_party) {
+			if ((*current_target)->IsDead()) {
+				// Cures death
+				return !skill.state_effects.empty() && skill.state_effects[0];
+			}
+
 			return true;
 		}
 	}
@@ -846,6 +856,13 @@ bool Game_BattleAlgorithm::Item::IsTargetValid() {
 
 	if (current_target == targets.end()) {
 		return false;
+	}
+
+	if ((*current_target)->IsDead()) {
+		// Medicine curing death
+		return item.type == RPG::Item::Type_medicine &&
+			!item.state_set.empty() &&
+			item.state_set[0];
 	}
 
 	return item.type == RPG::Item::Type_medicine;

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -568,6 +568,9 @@ bool Game_Battler::IsGaugeFull() const {
 
 void Game_Battler::UpdateGauge(int multiplier) {
 	if (!Exists()) {
+		if (IsDead()) {
+			SetGauge(0);
+		}
 		return;
 	}
 

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -49,8 +49,8 @@ std::vector<int16_t>& Game_Enemy::GetStates() {
 int Game_Enemy::GetStateProbability(int state_id) {
 	int rate = 3; // C - default
 
-	if (state_id <= (int)Data::enemies[enemy_id].state_ranks.size()) {
-		rate = Data::enemies[enemy_id].state_ranks[state_id - 1];
+	if (state_id <= (int)enemy->state_ranks.size()) {
+		rate = enemy->state_ranks[state_id - 1];
 	}
 
 	return GetStateRate(state_id, rate);

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -113,6 +113,7 @@ void Game_Enemy::ChangeHp(int hp) {
 
 	if (this->hp == 0) {
 		// Death
+		SetGauge(0);
 		SetDefending(false);
 		SetCharged(false);
 		RemoveAllStates();

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -34,6 +34,7 @@
 #include "scene_battle_rpg2k.h"
 #include "scene_battle.h"
 #include "scene_gameover.h"
+#include "output.h"
 
 Scene_Battle_Rpg2k::Scene_Battle_Rpg2k() : Scene_Battle(),
 battle_action_wait(0),
@@ -320,6 +321,13 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 			battle_message_window->Clear();
 
 			if (!action->IsTargetValid()) {
+				if (!action->GetTarget()) {
+					// No target but not a target-only action.
+					// Maybe a bug report will help later
+					Output::Warning("Battle: BattleAction without valid target.");
+					return true;
+				}
+
 				action->SetTarget(action->GetTarget()->GetParty().GetNextActiveBattler(action->GetTarget()));
 
 				if (!action->IsTargetValid()) {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -158,12 +158,16 @@ void Scene_Battle_Rpg2k3::UpdateCursors() {
 			ally_cursor->SetVisible(true);
 			Main_Data::game_party->GetBattlers(actors);
 			const Game_Battler* actor = actors[ally_index];
-			const Sprite_Battler* sprite = Game_Battle::GetSpriteset().FindBattler(actor);
+			Sprite_Battler* sprite = Game_Battle::GetSpriteset().FindBattler(actor);
 			ally_cursor->SetX(actor->GetBattleX());
 			ally_cursor->SetY(actor->GetBattleY() - sprite->GetHeight() / 2);
 			static const int frames[] = { 0, 1, 2, 1 };
 			int frame = frames[(cycle / 15) % 4];
 			ally_cursor->SetSrcRect(Rect(frame * 16, 16, 16, 16));
+
+			if (cycle % 60 == 0) {
+				sprite->Flash(Color(255, 255, 255, 100), 15);
+			}
 		}
 
 		if (enemy_index >= 0) {
@@ -610,15 +614,22 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 		battle_action_wait = 30;
 
 		for (it = targets.begin(); it != targets.end(); it++) {
+			Sprite_Battler* target_sprite = Game_Battle::GetSpriteset().FindBattler(*it);
+
 			if ((*it)->IsDead()) {
 				if (action->GetDeathSe()) {
 					Game_System::SePlay(*action->GetDeathSe());
 				}
 
-				Sprite_Battler* target_sprite = Game_Battle::GetSpriteset().FindBattler(*it);
-
 				if (target_sprite) {
 					target_sprite->SetAnimationState(Sprite_Battler::AnimationState_Dead);
+				}
+			} else {
+				if (target_sprite) {
+					if (!target_sprite->IsIdling()) {
+						// Was revived or some other deadlock situation :/
+						target_sprite->SetAnimationState(Sprite_Battler::AnimationState_Idle, Sprite_Battler::LoopState_DefaultAnimationAfterFinish);
+					}
 				}
 			}
 		}
@@ -936,7 +947,7 @@ bool Scene_Battle_Rpg2k3::CheckResultConditions() {
 
 void Scene_Battle_Rpg2k3::SelectNextActor() {
 	std::vector<Game_Battler*> battler;
-	Main_Data::game_party->GetActiveBattlers(battler);
+	Main_Data::game_party->GetBattlers(battler);
 
 	int i = 0;
 	for (std::vector<Game_Battler*>::iterator it = battler.begin();

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -509,6 +509,13 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 		ShowNotification(action->GetStartMessage());
 
 		if (!action->IsTargetValid()) {
+			if (!action->GetTarget()) {
+				// No target but not a target-only action.
+				// Maybe a bug report will help later
+				Output::Warning("Battle: BattleAction without valid target.");
+				return true;
+			}
+
 			action->SetTarget(action->GetTarget()->GetParty().GetNextActiveBattler(action->GetTarget()));
 
 			if (!action->IsTargetValid()) {

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -34,8 +34,8 @@ public:
 
 	void Draw();
 
-	void Flash(int duration);
-	void Flash(Color color, int duration);
+	virtual void Flash(int duration);
+	virtual void Flash(Color color, int duration);
 	void Update();
 
 	int GetWidth() const;

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -197,6 +197,22 @@ bool Sprite_Battler::IsIdling() {
 	return idling;
 }
 
+void Sprite_Battler::Flash(int duration) {
+	if (animation) {
+		animation->GetSprite()->Flash(duration);
+	} else {
+		Sprite::Flash(duration);
+	}
+}
+
+void Sprite_Battler::Flash(Color color, int duration) {
+	if (animation) {
+		animation->GetSprite()->Flash(color, duration);
+	} else {
+		Sprite::Flash(color, duration);
+	}
+}
+
 void Sprite_Battler::CreateSprite() {
 	sprite_name = battler->GetSpriteName();
 	hue = battler->GetHue();

--- a/src/sprite_battler.h
+++ b/src/sprite_battler.h
@@ -79,6 +79,9 @@ public:
 	 */
 	bool IsIdling();
 
+	void Flash(int duration) override;
+	void Flash(Color color, int duration) override;
+
 protected:
 	void CreateSprite();
 	void OnMonsterSpriteReady(FileRequestResult* result);


### PR DESCRIPTION
This basicly fixes all issues reported in the E-Mail. Really bad bugs :(, but great that finally somebody helped us finding them. Few hours before 0.4.1.

> No enable to select the right char for items or skills in battle

VD2 does not have a cursor graphic for ally select in System2. RPG_RT also flashes, the flash was added. This needed a change to the BattleAnimation drawable because I needed a Sprite that can flash.

> healing a charakter in battle could give an dead char life. So if it is his turn the battle stops and you couldnt do something.

Reviving dead actors was not resetting the dead state correctly. It was also possible that a dead actor had a full gauge (because he died the same time his turn is), then the dead actor will deadlock the game when his Action starts.
Also VD2s revive item "Trank der Ewigkeit" has a rating of 0, so 0 HP are restored. Reviving in battle sets now the HP to 1 in that case.

> Game breaks while the battle against the beast on the bridge near Asgars Castle.

This was probably because one of the actors died and due to a bug in SelectNextActor this deadlocked... This was a horrible bug, basicly broke any RPG2k3 battle when someone dies (Except if it's the last one in the Party) :(