### PR TITLE
Fix the Wii port compilation and warnings

### DIFF
--- a/builds/wii/Makefile
+++ b/builds/wii/Makefile
@@ -27,9 +27,9 @@ INCLUDES	:=	src
 # options for code generation
 #---------------------------------------------------------------------------------
 
-CFLAGS	= -O2 -Wall -Wextra -fno-rtti -DUSE_SDL -DHAVE_SDL_MIXER -DWORDS_BIGENDIAN -DNDEBUG $(MACHDEP) $(INCLUDE)
-CXXFLAGS	=	$(CFLAGS) -fno-exceptions -std=c++0x
-LDFLAGS	=	-g $(MACHDEP) -Wl,-Map,easyrpg-player-wii.map
+CFLAGS		= -g -O2 -Wall -Wextra -DUSE_SDL -DNDEBUG $(MACHDEP) $(INCLUDE)
+CXXFLAGS	= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
+LDFLAGS	= -g $(MACHDEP) -Wl,-Map,easyrpg-player-wii.map
 
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -22,6 +22,7 @@
 #include "system.h"
 
 #include <string>
+#include <cstdio>
 #include <ios>
 #include <unordered_map>
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -82,7 +82,7 @@ namespace {
 
 	std::string format_string(char const* fmt, va_list args) {
 		char buf[4096];
-#if __cplusplus > 199711L
+#if __cplusplus > 199711L || defined(_MSC_VER)
 		int const result = vsnprintf(buf, sizeof(buf), fmt, args);
 #else
 #  warning Using (probably insecure) `vsprintf` function!

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -82,12 +82,12 @@ namespace {
 
 	std::string format_string(char const* fmt, va_list args) {
 		char buf[4096];
-	// FIXME: devkitppc r27 seems to have broken newlib
-	#if __cplusplus > 199711L && !defined(GEKKO)
+#if __cplusplus > 199711L
 		int const result = vsnprintf(buf, sizeof(buf), fmt, args);
-	#else
+#else
+#  warning Using (probably insecure) `vsprintf` function!
 		int const result = vsprintf(buf, fmt, args);
-	#endif
+#endif
 		assert(0 <= result && result < int(sizeof(buf)));
 		return std::string(buf, result);
 	}

--- a/src/sdl_ui.cpp
+++ b/src/sdl_ui.cpp
@@ -375,10 +375,8 @@ void SdlUi::EndDisplayModeChange() {
 
 bool SdlUi::RefreshDisplayMode() {
 	uint32_t flags = current_display_mode.flags;
-	uint32_t rendered_flag;
 	int display_width = current_display_mode.width;
 	int display_height = current_display_mode.height;
-	bool is_fullscreen = (flags & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP;
 
 	if (zoom_available && current_display_mode.zoom) {
 		display_width *= 2;
@@ -432,9 +430,9 @@ bool SdlUi::RefreshDisplayMode() {
 
 		// OS X needs the rendered to be vsync
 		#if defined(__APPLE__) && defined(__MACH__)
-			rendered_flag = SDL_RENDERER_PRESENTVSYNC;
+			uint32_t rendered_flag = SDL_RENDERER_PRESENTVSYNC;
 		#else
-			rendered_flag = 0;
+			uint32_t rendered_flag = 0;
 		#endif
 
 		sdl_renderer = SDL_CreateRenderer(sdl_window, -1, rendered_flag);
@@ -457,6 +455,7 @@ bool SdlUi::RefreshDisplayMode() {
 	} else {
 		// Browser handles fast resizing for emscripten, TODO: use fullscreen API
 #ifndef EMSCRIPTEN
+		bool is_fullscreen = (flags & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP;
 		if (is_fullscreen) {
 			SDL_SetWindowFullscreen(sdl_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
 		} else {
@@ -772,24 +771,30 @@ void SdlUi::ProcessKeyDownEvent(SDL_Event &evnt) {
 		// Continue if return/enter not handled by fullscreen hotkey
 	default:
 		// Update key state
-#if SDL_MAJOR_VERSION==1
+#  if SDL_MAJOR_VERSION==1
 		keys[SdlKey2InputKey(evnt.key.keysym.sym)] = true;
-#else
+#  else
 		keys[SdlKey2InputKey(evnt.key.keysym.scancode)] = true;
 
-#endif
+#  endif
 		return;
 	}
+#else
+	/* unused */
+	(void) evnt;
 #endif
 }
 
 void SdlUi::ProcessKeyUpEvent(SDL_Event &evnt) {
 #if defined(USE_KEYBOARD) && defined(SUPPORT_KEYBOARD)
-#if SDL_MAJOR_VERSION==1
+#  if SDL_MAJOR_VERSION==1
 	keys[SdlKey2InputKey(evnt.key.keysym.sym)] = false;
-#else
+#  else
 	keys[SdlKey2InputKey(evnt.key.keysym.scancode)] = false;
-#endif
+#  endif
+#else
+	/* unused */
+	(void) evnt;
 #endif
 }
 

--- a/src/system.h
+++ b/src/system.h
@@ -45,6 +45,9 @@
 
 #ifdef GEKKO
 #  include "stdint.h"
+
+#  define HAVE_SDL_MIXER
+#  define WORDS_BIGENDIAN
 #endif
 
 #define SUPPORT_BMP


### PR DESCRIPTION
- Using `vsnprintf()` and `snprintf()` with g++ 4.8.2 is possible, but because of a quirk only with gnu extensions enabled.
- RTTI is not a C feature, so move it to `CXXFLAGS`
- Debug information might be interesting sometimes and the `boot.dol` gets them stripped anyway, so enabling (`-g`)
- `<cstdio>` is needed for `FILE*`, the jenkins script did that change for quite some time, so was forgotten :expressionless:
- Some variables were not used, so moving them or at least silence the compiler