### PR TITLE
Make HardLight, Saturation, Fill and FileFinder faster

### DIFF
--- a/builds/vs2015/Player.vcxproj
+++ b/builds/vs2015/Player.vcxproj
@@ -273,7 +273,6 @@
     <ClCompile Include="..\..\src\main.cpp" />
     <ClCompile Include="..\..\src\main_data.cpp" />
     <ClCompile Include="..\..\src\message_overlay.cpp" />
-    <ClCompile Include="..\..\src\message_overlay.cpp" />
     <ClCompile Include="..\..\src\midisequencer.cpp" />
     <ClCompile Include="..\..\src\midisynth.cpp" />
     <ClCompile Include="..\..\src\output.cpp" />

--- a/builds/vs2015/Player.vcxproj.filters
+++ b/builds/vs2015/Player.vcxproj.filters
@@ -70,7 +70,7 @@
     <ClCompile Include="..\..\src\midisequencer.cpp">
       <Filter>Source Files\Backend\Audio</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\midisynth.cpp"
+    <ClCompile Include="..\..\src\midisynth.cpp">
       <Filter>Source Files\Backend\Audio</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\background.cpp">
@@ -394,9 +394,6 @@
     <ClCompile Include="..\..\src\main_data.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\message_overlay.cpp">
-      <Filter>Source Files\Backend\Graphics</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\registry.cpp">
       <Filter>Source Files\Tools</Filter>
     </ClCompile>
@@ -471,6 +468,9 @@
     </ClCompile>
     <ClCompile Include="..\..\src\game_variables.cpp">
       <Filter>Source Files\Engine\Game</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\message_overlay.cpp">
+      <Filter>Source Files\Backend\Graphics</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -832,10 +832,16 @@ static pixman_color_t PixmanColor(const Color &color) {
 
 void Bitmap::Fill(const Color &color) {
 	pixman_color_t pcolor = PixmanColor(color);
-	pixman_rectangle16_t rect = {
-	0, 0, static_cast<uint16_t>(width()), static_cast<uint16_t>(height())};
+	Rect src_rect(0, 0, static_cast<uint16_t>(width()), static_cast<uint16_t>(height()));
 
-	pixman_image_fill_rectangles(PIXMAN_OP_OVER, bitmap, &pcolor, 1, &rect);
+	pixman_image_t* timage = pixman_image_create_solid_fill(&pcolor);
+
+	pixman_image_composite32(PIXMAN_OP_SRC,
+		timage, (pixman_image_t*)NULL, bitmap,
+		src_rect.x, src_rect.y,
+		0, 0,
+		0, 0,
+		src_rect.width, src_rect.height);
 
 	RefreshCallback();
 }
@@ -846,7 +852,7 @@ void Bitmap::FillRect(Rect const& dst_rect, const Color &color) {
 	static_cast<int16_t>(dst_rect.x),
 	static_cast<int16_t>(dst_rect.y),
 	static_cast<uint16_t>(dst_rect.width),
-	static_cast<uint16_t>(dst_rect.height), };
+	static_cast<uint16_t>(dst_rect.height)};
 
 	pixman_image_fill_rectangles(PIXMAN_OP_OVER, bitmap, &pcolor, 1, &rect);
 
@@ -859,6 +865,15 @@ void Bitmap::Clear() {
 	0, 0, static_cast<uint16_t>(width()), static_cast<uint16_t>(height())};
 
 	pixman_image_fill_rectangles(PIXMAN_OP_CLEAR, bitmap, &pcolor, 1, &rect);
+
+	RefreshCallback();
+
+	pixman_image_composite32(PIXMAN_OP_CLEAR,
+		bitmap, (pixman_image_t*)NULL, bitmap,
+		0, 0,
+		0, 0,
+		0, 0,
+		width(), height());
 
 	RefreshCallback();
 }

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -876,6 +876,22 @@ void Bitmap::ClearRect(Rect const& dst_rect) {
 	RefreshCallback();
 }
 
+// Hard light lookup table mapping source color to destination color
+static int hard_light_lookup[256][256];
+
+static void make_hard_light_lookup() {
+	for (int i = 0; i < 256; ++i) {
+		for (int j = 0; j < 256; ++j) {
+			int res = 0;
+			if (i <= 128)
+				res = (2 * i * j) / 255;
+			else
+				res = 255 - 2 * (255 - i) * (255 - j) / 255;
+			hard_light_lookup[i][j] = res > 255 ? 255 : res < 0 ? 0 : res;
+		}
+	}
+}
+
 void Bitmap::ToneBlit(int x, int y, Bitmap const& src, Rect const& src_rect, const Tone &tone, Opacity const& opacity) {
 	if (tone == Tone(128,128,128,128)) {
 		if (&src != this) {
@@ -893,11 +909,7 @@ void Bitmap::ToneBlit(int x, int y, Bitmap const& src, Rect const& src_rect, con
 		src_rect.width, src_rect.height);
 
 	if (tone.gray != 128) {
-		DynamicFormat format(32, 8, 24, 8, 16, 8, 8, 8, 0, PF::Alpha);
-		uint32_t* pixels = new uint32_t[src_rect.width * src_rect.height];
-		Bitmap bmp(pixels, src_rect.width, src_rect.height, src_rect.width * 4, format);
-		bmp.Blit(0, 0, src, src_rect, opacity);
-		Rect dst_rect(x, y, 0, 0);
+		uint32_t* pixels = (uint32_t*)this->pixels();
 
 		int sat;
 		if (tone.gray > 128) {
@@ -907,14 +919,22 @@ void Bitmap::ToneBlit(int x, int y, Bitmap const& src, Rect const& src_rect, con
 			sat = tone.gray * 8;
 		}
 
+		int as = pixel_format.a.shift;
+		int rs = pixel_format.r.shift;
+		int gs = pixel_format.g.shift;
+		int bs = pixel_format.b.shift;
+
 		// Algorithm from OpenPDN (MIT license)
 		// Transformation in Y'CbCr color space
 		for (int i = 0; i < src_rect.width * src_rect.height; ++i) {
 			uint32_t pixel = pixels[i];
-			uint8_t r = (pixel >> 24) & 0xFF;
-			uint8_t g = (pixel >> 16) & 0xFF;
-			uint8_t b = (pixel >> 8) & 0xFF;
-			uint8_t a = pixel & 0xFF;
+			uint8_t a = (pixel >> as) & 0xFF;
+			if (a == 0) {
+				continue;
+			}
+			uint8_t r = (pixel >> rs) & 0xFF;
+			uint8_t g = (pixel >> gs) & 0xFF;
+			uint8_t b = (pixel >> bs) & 0xFF;
 			// Y' = 0.299 R' + 0.587 G' + 0.114 B'
 			uint8_t lum = (7471 * b + 38470 * g + 19595 * r) >> 16;
 			// Scale Cb/Cr by scale factor "sat"
@@ -924,35 +944,39 @@ void Bitmap::ToneBlit(int x, int y, Bitmap const& src, Rect const& src_rect, con
 			green = green > 255 ? 255 : green < 0 ? 0 : green;
 			int blue = ((lum * 1024 + (b - lum) * sat) >> 10);
 			blue = blue > 255 ? 255 : blue < 0 ? 0 : blue;
-			pixels[i] = ((uint32_t)red << 24) | ((uint32_t)green << 16) | ((uint32_t)blue << 8) | (uint32_t)a;
+			pixels[i] = ((uint32_t)red << rs) | ((uint32_t)green << gs) | ((uint32_t)blue << bs) | ((uint32_t)a << as);
 		}
-
-		pixman_image_composite32(PIXMAN_OP_OVER,
-			bmp.bitmap, src.bitmap, bitmap,
-			0, 0,
-			src_rect.x, src_rect.y,
-			x, y,
-			src_rect.width, src_rect.height);
-
-		delete[] pixels;
 	}
 
 	if (tone.red != 128 || tone.green != 128 || tone.blue != 128) {
-		pixman_color_t tcolor = {
-			static_cast<uint16_t>(tone.red << 8),
-			static_cast<uint16_t>(tone.green << 8),
-			static_cast<uint16_t>(tone.blue << 8), 0xFFFF};
+		static bool index_made = false;
+		if (!index_made) {
+			make_hard_light_lookup();
+			index_made = true;
+		}
 
-		pixman_image_t *timage = pixman_image_create_solid_fill(&tcolor);
+		int as = pixel_format.a.shift;
+		int rs = pixel_format.r.shift;
+		int gs = pixel_format.g.shift;
+		int bs = pixel_format.b.shift;
 
-		pixman_image_composite32(PIXMAN_OP_HARD_LIGHT,
-			timage, src.bitmap, bitmap,
-			0, 0,
-			src_rect.x, src_rect.y,
-			x, y,
-			src_rect.width, src_rect.height);
+		uint32_t* pixels = (uint32_t*)this->pixels();
 
-		pixman_image_unref(timage);
+		for (int i = 0; i < src_rect.width * src_rect.height; ++i) {
+			uint32_t pixel = pixels[i];
+			uint8_t a = (pixel >> as) & 0xFF;
+			if (a == 0) {
+				continue;
+			}
+			uint8_t r = (pixel >> rs) & 0xFF;
+			uint8_t g = (pixel >> gs) & 0xFF;
+			uint8_t b = (pixel >> bs) & 0xFF;
+
+			int red = hard_light_lookup[tone.red][r];
+			int green = hard_light_lookup[tone.green][g];
+			int blue = hard_light_lookup[tone.blue][b];
+			pixels[i] = ((uint32_t)red << rs) | ((uint32_t)green << gs) | ((uint32_t)blue << bs) | ((uint32_t)a << as);
+		}
 	}
 
 	RefreshCallback();

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -892,7 +892,7 @@ void Bitmap::ClearRect(Rect const& dst_rect) {
 }
 
 // Hard light lookup table mapping source color to destination color
-static int hard_light_lookup[256][256];
+static uint8_t hard_light_lookup[256][256];
 
 static void make_hard_light_lookup() {
 	for (int i = 0; i < 256; ++i) {

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -971,7 +971,9 @@ void Bitmap::ToneBlit(int x, int y, Bitmap const& src, Rect const& src_rect, con
 		for (int i = 0; i < src_rect.width * src_rect.height; ++i) {
 			uint32_t pixel = pixels[i];
 			uint8_t a = (pixel >> as) & 0xFF;
-			if (a == 0) {
+			// &src != this works around a corner case with opacity split (character in a bush)
+			// in that case a == 0 and the effect is not applied
+			if (a == 0 && &src != this) {
 				continue;
 			}
 			uint8_t r = (pixel >> rs) & 0xFF;
@@ -1007,7 +1009,7 @@ void Bitmap::ToneBlit(int x, int y, Bitmap const& src, Rect const& src_rect, con
 		for (int i = 0; i < src_rect.width * src_rect.height; ++i) {
 			uint32_t pixel = pixels[i];
 			uint8_t a = (pixel >> as) & 0xFF;
-			if (a == 0) {
+			if (a == 0 && &src != this) {
 				continue;
 			}
 			uint8_t r = (pixel >> rs) & 0xFF;

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -739,7 +739,7 @@ protected:
 	static void add_pair(pixman_format_code_t pcode, const DynamicFormat& format);
 	static pixman_format_code_t find_format(const DynamicFormat& format);
 
-	pixman_op_t GetOperator() const;
+	pixman_op_t GetOperator(pixman_image_t* mask = nullptr) const;
 	bool read_only = false;
 };
 

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -181,19 +181,42 @@ public:
 	void SetTransparentColor(Color color);
 
 	enum Flags {
+		// Special handling for system graphic.
 		Flag_System = 1 << 1,
+		// Special handling for chipset graphic.
+		// Generates a tile opacity list.
 		Flag_Chipset = 1 << 2,
-		// Bitmap will not be written to
+		// Bitmap will not be written to. This allows blit optimisations because the
+		// opacity information will not change.
 		Flag_ReadOnly = 1 << 16
 	};
 
 	enum TileOpacity {
+		// Image is full opaque and can be blitted fast
 		Opaque,
+		// Image has alpha and needs an alpha blit
 		Partial,
+		// Image is complately transparent
 		Transparent
 	};
 
+	/**
+	 * Provides opacity information about the image.
+	 * This influences the selected operator when blitting.
+	 *
+	 * @return opacity information
+	 */
 	TileOpacity GetOpacity() const;
+
+	/**
+	 * Provides opacity information about a tile on a tilemap.
+	 * This influences the selected operator when blitting a tile.
+	 *
+	 * @param row tile row
+	 * @param col tile col
+	 *
+	 * @return opacity information
+	 */
 	TileOpacity GetTileOpacity(int row, int col) const;
 
 	/**

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -88,7 +88,7 @@ namespace {
 	template<Material::Type T> BitmapRef DrawCheckerboard();
 
 	BitmapRef DummySystem() {
-		return Bitmap::Create(system_h, sizeof(system_h), true, Bitmap::System);
+		return Bitmap::Create(system_h, sizeof(system_h), true, Bitmap::Flag_System | Bitmap::Flag_ReadOnly);
 	}
 
 	std::function<BitmapRef()> backdrop_dummy_func = DrawCheckerboard<Material::Backdrop>;
@@ -185,10 +185,10 @@ namespace {
 			return BitmapRef();
 		}
 
-		BitmapRef ret = LoadBitmap(s.directory, f, transparent,
-										 T == Material::Chipset? Bitmap::Chipset:
-										 T == Material::System? Bitmap::System:
-										 0);
+		BitmapRef ret = LoadBitmap(s.directory, f, transparent, Bitmap::Flag_ReadOnly | (
+										 T == Material::Chipset? Bitmap::Flag_Chipset:
+										 T == Material::System? Bitmap::Flag_System:
+										 0));
 
 		if (!ret) {
 			Output::Warning("Image not found: %s/%s", s.directory, f.c_str());

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -188,9 +188,12 @@ const std::shared_ptr<FileFinder::DirectoryTree> FileFinder::CreateSaveDirectory
 	tree->directory_path = save_path;
 
 	Directory mem = GetDirectoryMembers(tree->directory_path, FILES);
-	for (string_map::const_iterator i = mem.members.begin(); i != mem.members.end(); ++i) {
-		(IsDirectory(MakePath(tree->directory_path, i->second)) ?
-			tree->directories : tree->files)[i->first] = i->second;
+
+	for (auto& i : mem.files) {
+		tree->files[i.first] = i.second;
+	}
+	for (auto& i : mem.directories) {
+		tree->directories[i.first] = i.second;
 	}
 
 	return tree;
@@ -207,15 +210,16 @@ std::shared_ptr<FileFinder::DirectoryTree> FileFinder::CreateDirectoryTree(std::
 	tree->directory_path = p;
 
 	Directory mem = GetDirectoryMembers(tree->directory_path, ALL);
-	for(string_map::const_iterator i = mem.members.begin(); i != mem.members.end(); ++i) {
-		(IsDirectory(MakePath(tree->directory_path, i->second))?
-		 tree->directories : tree->files)[i->first] = i->second;
+	for (auto& i : mem.files) {
+		tree->files[i.first] = i.second;
+	}
+	for (auto& i : mem.directories) {
+		tree->directories[i.first] = i.second;
 	}
 
 	if (recursive) {
-		for (string_map::const_iterator i = tree->directories.begin(); i != tree->directories.end(); ++i) {
-			GetDirectoryMembers(MakePath(tree->directory_path, i->second), RECURSIVE)
-				.members.swap(tree->sub_members[i->first]);
+		for (auto& i : mem.directories) {
+			GetDirectoryMembers(MakePath(tree->directory_path, i.second), RECURSIVE).files.swap(tree->sub_members[i.first]);
 		}
 	}
 
@@ -588,26 +592,34 @@ FileFinder::Directory FileFinder::GetDirectoryMembers(const std::string& path, F
 		std::string const name = ent->d_name;
 #endif
 		if (name == "." || name == "..") { continue; }
+
+		bool is_directory = ent->d_type == S_IFDIR;
+
 		switch(m) {
 		case FILES:
-			if(IsDirectory(MakePath(path, name))) { continue; }
+			if (is_directory) { continue; }
 		    break;
 		case DIRECTORIES:
-			if(! IsDirectory(MakePath(path, name))) { continue; }
+			if (!is_directory) { continue; }
 			break;
 		case ALL:
 			break;
 		case RECURSIVE:
-			if(IsDirectory(MakePath(path, name))) {
+			if (is_directory) {
 				Directory rdir = GetDirectoryMembers(MakePath(path, name), RECURSIVE, MakePath(parent, name));
-				result.members.insert(rdir.members.begin(), rdir.members.end());
+				result.files.insert(rdir.files.begin(), rdir.files.end());
+				result.directories.insert(rdir.directories.begin(), rdir.directories.end());
 				continue;
 			}
 
-			result.members[Utils::LowerCase(MakePath(parent, name))] = MakePath(parent, name);
+			result.files[Utils::LowerCase(MakePath(parent, name))] = MakePath(parent, name);
 			continue;
 		}
-		result.members[Utils::LowerCase(name)] = name;
+		if (is_directory) {
+			result.directories[Utils::LowerCase(name)] = name;
+		} else {
+			result.files[Utils::LowerCase(name)] = name;
+		}
 	}
 
 #ifdef _WIN32

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -156,7 +156,8 @@ namespace FileFinder {
 
 	struct Directory {
 		std::string base;
-		string_map members;
+		string_map files;
+		string_map directories;
 	}; // struct Directory
 
 	/**

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -54,9 +54,10 @@ namespace Graphics {
 	uint32_t next_fps_time;
 
 	struct State {
-		State() : zlist_dirty(false) {}
+		State() {}
 		std::list<Drawable*> drawable_list;
-		bool zlist_dirty;
+		bool zlist_dirty = false;
+		bool draw_background = true;
 	};
 
 	int real_fps;
@@ -176,7 +177,9 @@ void Graphics::DrawFrame() {
 		global_state->zlist_dirty = false;
 	}
 
-	DisplayUi->AddBackground();
+	if (state->draw_background) {
+		DisplayUi->AddBackground();
+	}
 
 	for (Drawable* drawable : state->drawable_list) {
 		drawable->Draw();
@@ -204,7 +207,9 @@ void Graphics::DrawOverlay() {
 }
 
 BitmapRef Graphics::SnapToBitmap() {
-	DisplayUi->AddBackground();
+	if (state->draw_background) {
+		DisplayUi->AddBackground();
+	}
 
 	for (Drawable* drawable : state->drawable_list) {
 		drawable->Draw();
@@ -458,9 +463,10 @@ inline bool Graphics::SortDrawableList(const Drawable* first, const Drawable* se
 	return false;
 }
 
-void Graphics::Push() {
+void Graphics::Push(bool draw_background) {
 	stack.push_back(state);
 	state.reset(new State());
+	state->draw_background = draw_background;
 }
 
 void Graphics::Pop() {

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -125,7 +125,7 @@ namespace Graphics {
 
 	void UpdateZCallback();
 
-	void Push();
+	void Push(bool draw_background = true);
 	void Pop();
 
 	unsigned SecondToFrame(float second);

--- a/src/message_overlay.cpp
+++ b/src/message_overlay.cpp
@@ -63,6 +63,9 @@ void MessageOverlay::Draw() {
 			}
 			dirty = true;
 		}
+	} else if (!show_all) {
+		// Don't render overlay when no message visible
+		return;
 	}
 
 	DisplayUi->GetDisplaySurface()->Blit(ox, oy, *bitmap, bitmap->GetRect(), 255);

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -110,7 +110,7 @@ void Scene::MainFunction() {
 
 		switch (push_pop_operation) {
 		case ScenePushed:
-			Graphics::Push();
+			Graphics::Push(Scene::instance->DrawBackground());
 			break;
 			// Graphics::Pop done in Player Loop
 		default:;
@@ -206,4 +206,8 @@ std::shared_ptr<Scene> Scene::Find(SceneType type) {
 	}
 
 	return std::shared_ptr<Scene>();
+}
+
+bool Scene::DrawBackground() {
+	return true;
 }

--- a/src/scene.h
+++ b/src/scene.h
@@ -165,6 +165,9 @@ public:
 	/** Contains name of the Scenes. For debug purposes. */
 	static const char scene_names[SceneMax][12];
 
+	/** When true tells the graphic system to draw a system color background */
+	virtual bool DrawBackground();
+
 private:
 	/** Scene stack. */
 	static std::vector<std::shared_ptr<Scene> > instances;

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -100,6 +100,10 @@ void Scene_Map::TransitionOut() {
 	}
 }
 
+bool Scene_Map::DrawBackground() {
+	return false;
+}
+
 void Scene_Map::Update() {
 	if (Game_Temp::transition_processing) {
 		Game_Temp::transition_processing = false;

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -50,11 +50,6 @@ void Scene_Map::Start() {
 	spriteset.reset(new Spriteset_Map());
 	message_window.reset(new Window_Message(0, SCREEN_TARGET_HEIGHT - 80, SCREEN_TARGET_WIDTH, 80));
 
-	// Draw background to prevent System graphic shining through
-	background.reset(new Sprite());
-	background->SetBitmap(Bitmap::Create(DisplayUi->GetWidth(), DisplayUi->GetHeight(), Color(0, 0, 0, 255)));
-	background->SetZ(-10000);
-
 	screen.reset(new Screen());
 	weather.reset(new Weather());
 	frame.reset(new Frame());

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -59,7 +59,6 @@ private:
 	void FinishTeleportPlayer();
 
 	std::unique_ptr<Window_Message> message_window;
-	std::unique_ptr<Sprite> background;
 	std::unique_ptr<Screen> screen;
 	std::unique_ptr<Weather> weather;
 	std::unique_ptr<Frame> frame;

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -37,12 +37,13 @@ public:
 	Scene_Map(bool from_save = false);
 	~Scene_Map();
 
-	void Start();
-	void Continue();
-	void Update();
-	void Resume();
-	void TransitionIn();
-	void TransitionOut();
+	void Start() override;
+	void Continue() override;
+	void Update() override;
+	void Resume() override;
+	void TransitionIn() override;
+	void TransitionOut() override;
+	bool DrawBackground() override;
 
 	void CallBattle();
 	void CallShop();

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -115,10 +115,6 @@ void Scene_Title::Update() {
 	}
 }
 
-bool Scene_Title::DrawBackground() {
-	return false;
-}
-
 void Scene_Title::CreateTitleGraphic() {
 	// Load Title Graphic
 	if (!title && !Data::system.title_name.empty()) // No need to recreate Title on Resume

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -115,6 +115,10 @@ void Scene_Title::Update() {
 	}
 }
 
+bool Scene_Title::DrawBackground() {
+	return false;
+}
+
 void Scene_Title::CreateTitleGraphic() {
 	// Load Title Graphic
 	if (!title && !Data::system.title_name.empty()) // No need to recreate Title on Resume

--- a/src/scene_title.h
+++ b/src/scene_title.h
@@ -40,7 +40,6 @@ public:
 	void Suspend() override;
 	void Resume() override;
 	void Update() override;
-	bool DrawBackground() override;
 
 	/**
 	 * Loads all databases.

--- a/src/scene_title.h
+++ b/src/scene_title.h
@@ -34,12 +34,13 @@ public:
 	 */
 	Scene_Title();
 
-	void Start();
-	void Continue();
-	void TransitionIn();
-	void Suspend();
-	void Resume();
-	void Update();
+	void Start() override;
+	void Continue() override;
+	void TransitionIn() override;
+	void Suspend() override;
+	void Resume() override;
+	void Update() override;
+	bool DrawBackground() override;
 
 	/**
 	 * Loads all databases.

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -131,9 +131,9 @@ private:
 	bool current_flip_x;
 	bool current_flip_y;
 
-	void BlitScreen(int x, int y, int ox, int oy, Rect const& src_rect);
-	void BlitScreenIntern(Bitmap const& draw_bitmap, int x, int y, int ox, int oy,
-							Rect const& src_rect, int opacity_split);
+	void BlitScreen();
+	void BlitScreenIntern(Bitmap const& draw_bitmap,
+							Rect const& src_rect, int opacity_split) const;
 	BitmapRef Refresh(Rect& rect);
 	void SetFlashEffect(const Color &color);
 };

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -26,6 +26,7 @@
 #include "game_player.h"
 #include "game_vehicle.h"
 #include "bitmap.h"
+#include "player.h"
 
 // Constructor
 Spriteset_Map::Spriteset_Map() {
@@ -138,6 +139,8 @@ void Spriteset_Map::OnTilemapSpriteReady(FileRequestResult*) {
 	tilemap.SetPassableUp(Game_Map::GetPassagesUp());
 	tilemap.SetAnimationType(Game_Map::GetAnimationType());
 	tilemap.SetAnimationSpeed(Game_Map::GetAnimationSpeed());
+
+	tilemap.SetFastBlitDown(!panorama.GetBitmap());
 }
 
 void Spriteset_Map::OnPanoramaSpriteReady(FileRequestResult* result) {
@@ -145,4 +148,6 @@ void Spriteset_Map::OnPanoramaSpriteReady(FileRequestResult* result) {
 	Game_Map::SetParallaxSize(panorama_bmp->GetWidth(), panorama_bmp->GetHeight());
 	panorama.SetBitmap(panorama_bmp);
 	Game_Map::InitializeParallax();
+
+	tilemap.SetFastBlitDown(false);
 }

--- a/src/tilemap.cpp
+++ b/src/tilemap.cpp
@@ -115,3 +115,7 @@ void Tilemap::SubstituteDown(int old_id, int new_id) {
 void Tilemap::SubstituteUp(int old_id, int new_id) {
 	layer_up.Substitute(old_id, new_id);
 }
+
+void Tilemap::SetFastBlitDown(bool fast) {
+	layer_down.SetFastBlit(fast);
+}

--- a/src/tilemap.h
+++ b/src/tilemap.h
@@ -42,8 +42,6 @@ public:
 	void SetPassableUp(std::vector<unsigned char> up);
 	std::vector<unsigned char> GetPassableDown() const;
 	void SetPassableDown(std::vector<unsigned char> down);
-	std::vector<short> GetProperties() const;
-	void SetProperties(std::vector<short> nproperties);
 	bool GetVisible() const;
 	void SetVisible(bool nvisible);
 	int GetOx() const;
@@ -60,6 +58,7 @@ public:
 	void SetAnimationType(int type);
 	void SubstituteDown(int old_id, int new_id);
 	void SubstituteUp(int old_id, int new_id);
+	void SetFastBlitDown(bool fast);
 
 private:
 	TilemapLayer layer_down, layer_up;

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -168,7 +168,7 @@ void TilemapLayer::DrawTile(Bitmap& screen, int x, int y, int row, int col, bool
 
 	BitmapRef dst = DisplayUi->GetDisplaySurface();
 
-	if (op == Bitmap::Opaque) {
+	if (fast_blit || op == Bitmap::Opaque) {
 		dst->BlitFast(x, y, screen, rect, 255);
 	} else {
 		dst->Blit(x, y, screen, rect, 255);
@@ -693,6 +693,10 @@ void TilemapLayer::Substitute(int old_id, int new_id) {
 		// Recalculate z values of all tiles
 		CreateTileCache(map_data);
 	}
+}
+
+void TilemapLayer::SetFastBlit(bool fast) {
+	fast_blit = fast;
 }
 
 TilemapSubLayer::TilemapSubLayer(TilemapLayer* tilemap, int z) :

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -160,12 +160,19 @@ TilemapLayer::TilemapLayer(int ilayer) :
 }
 
 void TilemapLayer::DrawTile(Bitmap& screen, int x, int y, int row, int col, bool autotile) {
-	if (!autotile && screen.GetTileOpacity(row, col) == Bitmap::Transparent)
+	Bitmap::TileOpacity op = screen.GetTileOpacity(row, col);
+
+	if (op == Bitmap::Transparent)
 		return;
 	Rect rect(col * TILE_SIZE, row * TILE_SIZE, TILE_SIZE, TILE_SIZE);
 
 	BitmapRef dst = DisplayUi->GetDisplaySurface();
-	dst->Blit(x, y, screen, rect, 255);
+
+	if (op == Bitmap::Opaque) {
+		dst->BlitFast(x, y, screen, rect, 255);
+	} else {
+		dst->Blit(x, y, screen, rect, 255);
+	}
 }
 
 void TilemapLayer::Draw(int z_order) {
@@ -513,6 +520,10 @@ BitmapRef TilemapLayer::GenerateAutotiles(int count, const std::map<uint32_t, Ti
 				tiles->Blit((dst.x * 2 + i) * (TILE_SIZE / 2), (dst.y * 2 + j) * (TILE_SIZE / 2), *chipset, rect, 255);
 			}
 		}
+	}
+
+	if (rows > 0) {
+		tiles->CheckPixels(Bitmap::Flag_Chipset | Bitmap::Flag_ReadOnly);
 	}
 
 	return tiles;

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -162,7 +162,7 @@ TilemapLayer::TilemapLayer(int ilayer) :
 void TilemapLayer::DrawTile(Bitmap& screen, int x, int y, int row, int col, bool autotile) {
 	Bitmap::TileOpacity op = screen.GetTileOpacity(row, col);
 
-	if (op == Bitmap::Transparent)
+	if (!fast_blit && op == Bitmap::Transparent)
 		return;
 	Rect rect(col * TILE_SIZE, row * TILE_SIZE, TILE_SIZE, TILE_SIZE);
 

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -78,8 +78,8 @@ public:
 	void SetAnimationSpeed(int speed);
 	int GetAnimationType() const;
 	void SetAnimationType(int type);
-
 	void Substitute(int old_id, int new_id);
+	void SetFastBlit(bool fast);
 
 private:
 	BitmapRef chipset;
@@ -97,6 +97,7 @@ private:
 	int animation_speed;
 	int animation_type;
 	int layer;
+	bool fast_blit = false;
 
 	void CreateTileCache(const std::vector<short>& nmap_data);
 	void GenerateAutotileAB(short ID, short animID);

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -79,6 +79,13 @@ public:
 	int GetAnimationType() const;
 	void SetAnimationType(int type);
 	void Substitute(int old_id, int new_id);
+	/**
+	 * Influences how tiles of the tilemap are blitted.
+	 * When enabled the opacity information of the tile is ignored and a opaque
+	 * tile is assumed (Faster).
+	 *
+	 * @param fast true: enable fast blit (ignores alpha)
+	 */
 	void SetFastBlit(bool fast);
 
 private:


### PR DESCRIPTION
See the commit messages for detailed info.

I also measured hard light with and without lookup table. The lookup is cache unfriendly (64kb) but is faster then direct calculation because Hard light has a 50% branch prediction miss chance per color...

For saturation would be more tricky because RGB are combined here, I "only" saved an alloc and a blit here.

Fill (AddBackground, called once per frame) is also faster now by using OP_SRC which doesn't handle alpha correctly but that doesn't matter in this case.

Branch Pred: https://stackoverflow.com/questions/11227809/why-is-processing-a-sorted-array-faster-than-an-unsorted-array

Fixes #846