### PR TITLE
Make freetype an optional dep

### DIFF
--- a/builds/android/app/src/main/jni/src/Android.mk
+++ b/builds/android/app/src/main/jni/src/Android.mk
@@ -43,7 +43,7 @@ LOCAL_LDLIBS := -L$(LOCAL_PATH)/../../obj/local/$(TARGET_ARCH_ABI) \
 		-lpixman-1 -lpng -licui18n -licuuc -licudata -lcpufeatures
 
 LOCAL_CFLAGS := -O2 -Wall -Wextra -fno-rtti -DUSE_SDL \
-		-DHAVE_SDL_MIXER -DLCF_SUPPORT_ICU
+		-DHAVE_FREETYPE -DHAVE_SDL_MIXER -DLCF_SUPPORT_ICU
 
 		LOCAL_CPPFLAGS	=	$(LOCAL_C_FLAGS) -std=c++11
 

--- a/builds/vs2015/PropertySheet.props
+++ b/builds/vs2015/PropertySheet.props
@@ -32,7 +32,7 @@
     <ClCompile>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <DisableSpecificWarnings>4996;4512</DisableSpecificWarnings>
-      <PreprocessorDefinitions>UNICODE;_CRT_SECURE_NO_WARNINGS;MSVC;USE_SDL;HAVE_SDL_MIXER;WINVER=0x0601;_WIN32_WINNT=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>UNICODE;_CRT_SECURE_NO_WARNINGS;MSVC;USE_SDL;HAVE_SDL_MIXER;HAVE_FREETYPE;WINVER=0x0601;_WIN32_WINNT=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalIncludeDirectories>..\..\lib\liblcf\src;..\..\lib\liblcf\src\generated;..\..\lib\shinonome;$(EASYDEV_MSVC)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/builds/wii/Makefile
+++ b/builds/wii/Makefile
@@ -35,7 +35,7 @@ LDFLAGS	= -g $(MACHDEP) -Wl,-Map,easyrpg-player-wii.map
 # any extra libraries we wish to link with the project
 #---------------------------------------------------------------------------------
 
-LIBS	:=	 -llcf -lexpat -lSDL_mixer -lSDL -lpixman-1 -lpng -lfreetype -lmad \
+LIBS	:=	 -llcf -lexpat -lSDL_mixer -lSDL -lpixman-1 -lpng -lmad \
 			-liconv -lvorbisidec -lz -lfat -lwiiuse -lbte -logc -lm -lwiikeyboard
 
 #---------------------------------------------------------------------------------
@@ -93,7 +93,6 @@ export INCLUDE	:=	$(foreach dir,$(INCLUDES), -I$(TOPDIR)/$(dir)) \
 					-I$(PORTLIBS)/include \
 					-I$(LIBOGC_INC)/SDL \
 					-I$(PORTLIBS)/include/pixman-1 \
-					-I$(PORTLIBS)/include/freetype2 \
 					-I$(PORTLIBS)/include/liblcf
 
 #---------------------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,10 @@ AS_IF([test "x$EM_GAME_URL" != "x"],[
 # Checks for libraries.
 PKG_CHECK_MODULES([LCF],[liblcf])
 PKG_CHECK_MODULES([PIXMAN],[pixman-1])
-PKG_CHECK_MODULES([FREETYPE],[freetype2])
+AC_ARG_WITH([freetype], AS_HELP_STRING([--without-freetype], [Disable freetype font rendering @<:@default=auto@:>@]))
+AS_IF([test "x$with_freetype" != "xno"], [
+	PKG_CHECK_MODULES([FREETYPE],[freetype2],[AC_DEFINE(HAVE_FREETYPE,[1],[Enable freetype font rendering])],[auto_freetype=0])
+])
 PKG_CHECK_MODULES([SDL],[sdl2],[AC_DEFINE(USE_SDL,[1],[Enable SDL2])],[
 	PKG_CHECK_MODULES([SDL],[sdl],[AC_DEFINE(USE_SDL,[1],[Enable SDL])])
 ])


### PR DESCRIPTION
This makes freetype automagic on when available. Otherwise it defaults to off (I hope, copy-pasted from that gentoo article *g*)

Removed freetype from Wii, not sure if we will ever need it for this platform...