### PR TITLE
crash fix in stop_count + utf8 on Windows

### DIFF
--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -557,7 +557,10 @@ void Game_Event::MoveTypeRandom() {
 	int last_direction = GetDirection();
 	switch (rand() % 6) {
 	case 0:
-		stop_count -= rand() % stop_count;
+		stop_count -= rand() % (stop_count + 1);
+		if (stop_count < 0) {
+			stop_count = 0;
+		}
 		return;
 	case 1:
 		MoveForward();

--- a/src/rtp_table.cpp
+++ b/src/rtp_table.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of EasyRPG Player.
  *
  * EasyRPG Player is free software: you can redistribute it and/or modify

--- a/src/window_keyboard.cpp
+++ b/src/window_keyboard.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of EasyRPG Player.
  *
  * EasyRPG Player is free software: you can redistribute it and/or modify


### PR DESCRIPTION
VS2015 wants a BOM now otherwise it will compile utf8 strings incorrectly :(.
This worked in older Version of VS :/

Also fix that div/0 that carstene1ns encountered in UiD

![screenshot_0](https://cloud.githubusercontent.com/assets/1331889/14900242/f26c652a-0d8f-11e6-85d5-a275ba730af2.png)
