### PR TITLE
Add HarfBuzz support to Autotools and CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/lib/liblcf/src")
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/lib/liblcf/src/generated")
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src")
 
-foreach(i Expat Freetype Pixman ZLIB PNG SDL2 Iconv)
+foreach(i Expat Freetype Harfbuzz Pixman ZLIB PNG SDL2 Iconv)
   find_package(${i} REQUIRED)
 
   string(TOUPPER ${i} i)

--- a/Makefile.am
+++ b/Makefile.am
@@ -304,6 +304,7 @@ libeasyrpg_player_la_CXXFLAGS = \
 	$(LCF_CFLAGS) \
 	$(PIXMAN_CFLAGS) \
 	$(FREETYPE_CFLAGS) \
+	$(HARFBUZZ_CFLAGS) \
 	$(SDL_CFLAGS) \
 	$(SDLMIXER_CFLAGS) \
 	$(PNG_CFLAGS) \
@@ -312,6 +313,7 @@ libeasyrpg_player_la_LIBADD = \
 	$(LCF_LIBS) \
 	$(PIXMAN_LIBS) \
 	$(FREETYPE_LIBS) \
+	$(HARFBUZZ_LIBS) \
 	$(SDL_LIBS) \
 	$(SDLMIXER_LIBS) \
 	$(PNG_LIBS) \

--- a/builds/cmake/Modules/FindHarfbuzz.cmake
+++ b/builds/cmake/Modules/FindHarfbuzz.cmake
@@ -1,0 +1,14 @@
+# HARFBUZZ_INCLUDE_DIR - harfbuzz include directory
+# Harfbuzz_FOUND - wether harfbuzz is found
+# HARFBUZZ_LIBRARY - harfbuzz library
+
+include(FindPackageHandleStandardArgs)
+
+find_path(HARFBUZZ_INCLUDE_DIR_INTERNAL harfbuzz/hb.h)
+find_library(HARFBUZZ_LIBRARY harfbuzz)
+if(EXISTS "${HARFBUZZ_INCLUDE_DIR_INTERNAL}")
+  set(HARFBUZZ_INCLUDE_DIR "${HARFBUZZ_INCLUDE_DIR_INTERNAL}/harfbuzz")
+endif()
+
+find_package_handle_standard_args(Harfbuzz
+	REQUIRED_VARS HARFBUZZ_INCLUDE_DIR HARFBUZZ_LIBRARY)

--- a/configure.ac
+++ b/configure.ac
@@ -27,9 +27,13 @@ AS_IF([test "x$EM_GAME_URL" != "x"],[
 # Checks for libraries.
 PKG_CHECK_MODULES([LCF],[liblcf])
 PKG_CHECK_MODULES([PIXMAN],[pixman-1])
-AC_ARG_WITH([freetype], AS_HELP_STRING([--without-freetype], [Disable freetype font rendering @<:@default=auto@:>@]))
+AC_ARG_WITH([freetype], AS_HELP_STRING([--without-freetype], [Disable FreeType font rendering @<:@default=auto@:>@]))
 AS_IF([test "x$with_freetype" != "xno"], [
-	PKG_CHECK_MODULES([FREETYPE],[freetype2],[AC_DEFINE(HAVE_FREETYPE,[1],[Enable freetype font rendering])],[auto_freetype=0])
+	PKG_CHECK_MODULES([FREETYPE],[freetype2],[AC_DEFINE(HAVE_FREETYPE,[1],[Enable FreeType font rendering])],[auto_freetype=0])
+	AC_ARG_WITH([harfbuzz], AS_HELP_STRING([--without-harfbuzz], [Disable HarfBuzz text shaping @<:@default=auto@:>@]))
+	AS_IF([test "x$with_harfbuzz" != "xno"], [
+		PKG_CHECK_MODULES([HARFBUZZ],[harfbuzz],[AC_DEFINE(HAVE_HARFBUZZ,[1],[Enable HarfBuzz text shaping])],[auto_harfbuzz=0])
+	])
 ])
 PKG_CHECK_MODULES([SDL],[sdl2],[AC_DEFINE(USE_SDL,[1],[Enable SDL2])],[
 	PKG_CHECK_MODULES([SDL],[sdl],[AC_DEFINE(USE_SDL,[1],[Enable SDL])])


### PR DESCRIPTION
Added in automagic mode and will won't be enabled if FreeType is disabled. 