### PR TITLE
Android: Add the direct edit of the buttons layout after creation

### DIFF
--- a/builds/android/app/src/main/java/org/easyrpg/player/SettingsActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/SettingsActivity.java
@@ -334,7 +334,7 @@ public class SettingsActivity extends Activity {
 					layout.setButton_list(
 							ButtonMappingModel.InputLayout.getDefaultButtonList(getApplicationContext()));
 					mapping_model.add(layout);
-
+					editInputLayout(layout) ;
 					refreshAndSaveLayoutList();
 				}
 			}


### PR DESCRIPTION
So, that may be just a little mess from me ('cause, i've got some problems when things are not really logical), but for me, it's really impractical to not be able to modify the button layout directly after having create it. Until now, when the users want to create a layout, they need to click on "Add an input layout", create the layout and click again on an other button to edit the layout. With just adding the edit after the creation, you save time and it's like... More practical ? 

(For now, i've only test it with the android emulator 'cause my phone hate me, but i plan to test it with an other phone, though that should work). 