### PR TITLE
Added optional dependency to libsndfile and libspeexdsp

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,6 +31,8 @@ libeasyrpg_player_la_SOURCES = \
 	src/cache.h \
 	src/color.cpp \
 	src/color.h \
+	src/decoder_libsndfile.cpp \
+	src/decoder_libsndfile.h \
 	src/decoder_mpg123.cpp \
 	src/decoder_mpg123.h \
 	src/decoder_fmmidi.cpp \
@@ -320,7 +322,8 @@ libeasyrpg_player_la_CXXFLAGS = \
 	$(SDLMIXER_CFLAGS) \
 	$(PNG_CFLAGS) \
 	$(ZLIB_CFLAGS) \
-	$(MPG123_CFLAGS)
+	$(MPG123_CFLAGS) \
+	$(SNDFILE_CFLAGS)
 libeasyrpg_player_la_LIBADD = \
 	$(LCF_LIBS) \
 	$(PIXMAN_LIBS) \
@@ -330,7 +333,8 @@ libeasyrpg_player_la_LIBADD = \
 	$(SDLMIXER_LIBS) \
 	$(PNG_LIBS) \
 	$(ZLIB_LIBS) \
-	$(MPG123_LIBS)
+	$(MPG123_LIBS) \
+	$(SNDFILE_LIBS)
 
 easyrpg_player_SOURCES = src/main.cpp
 easyrpg_player_CXXFLAGS = $(libeasyrpg_player_la_CXXFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,8 @@ libeasyrpg_player_la_SOURCES = \
 	src/audio.h \
 	src/audio_decoder.cpp \
 	src/audio_decoder.h \
+	src/audio_resampler.cpp \
+	src/audio_resampler.h \
 	src/background.cpp \
 	src/background.h \
 	src/baseui.cpp \
@@ -323,7 +325,8 @@ libeasyrpg_player_la_CXXFLAGS = \
 	$(PNG_CFLAGS) \
 	$(ZLIB_CFLAGS) \
 	$(MPG123_CFLAGS) \
-	$(SNDFILE_CFLAGS)
+	$(SNDFILE_CFLAGS) \
+	$(SPEEXDSP_CFLAGS)
 libeasyrpg_player_la_LIBADD = \
 	$(LCF_LIBS) \
 	$(PIXMAN_LIBS) \
@@ -334,7 +337,8 @@ libeasyrpg_player_la_LIBADD = \
 	$(PNG_LIBS) \
 	$(ZLIB_LIBS) \
 	$(MPG123_LIBS) \
-	$(SNDFILE_LIBS)
+	$(SNDFILE_LIBS) \
+	$(SPEEXDSP_LIBS)
 
 easyrpg_player_SOURCES = src/main.cpp
 easyrpg_player_CXXFLAGS = $(libeasyrpg_player_la_CXXFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,11 @@ AC_ARG_WITH([libsndfile],[AS_HELP_STRING([--without-libsndfile],
 AS_IF([test "x$with_libsndfile" != "xno"],[
 	PKG_CHECK_MODULES([SNDFILE],[sndfile],[AC_DEFINE(HAVE_LIBSNDFILE,[1],[Disable improved WAV support provided by libsndfile])],[auto_sndfile=0])
 ])
+AC_ARG_WITH([libspeexdsp],[AS_HELP_STRING([--without-libspeexdsp],
+	[Disable resampling support provided by libspeexdsp. Uses SDL_mixer instead which results in noise. @<:@default=auto@:>@])])
+AS_IF([test "x$with_libspeexdsp" != "xno"],[
+	PKG_CHECK_MODULES([SPEEXDSP],[speexdsp],[AC_DEFINE(HAVE_LIBSPEEXDSP,[1],[Disable resampling support provided by libspeexdsp])],[auto_speexdsp=0])
+])
 
 # Checks for header files.
 AC_CHECK_HEADERS([stdint.h stdlib.h string.h unistd.h wchar.h])

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,11 @@ AC_ARG_WITH([libmpg123],[AS_HELP_STRING([--without-libmpg123],
 AS_IF([test "x$with_libmpg123" != "xno"],[
 	PKG_CHECK_MODULES([MPG123],[libmpg123],[AC_DEFINE(HAVE_MPG123,[1],[Disable improved MP3 support provided by libmpg123])],[auto_mpg123=0])
 ])
+AC_ARG_WITH([libsndfile],[AS_HELP_STRING([--without-libsndfile],
+	[Disable improved WAV support provided by libsndfile.  @<:@default=auto@:>@])])
+AS_IF([test "x$with_libsndfile" != "xno"],[
+	PKG_CHECK_MODULES([SNDFILE],[sndfile],[AC_DEFINE(HAVE_LIBSNDFILE,[1],[Disable improved WAV support provided by libsndfile])],[auto_sndfile=0])
+])
 
 # Checks for header files.
 AC_CHECK_HEADERS([stdint.h stdlib.h string.h unistd.h wchar.h])

--- a/src/audio_decoder.cpp
+++ b/src/audio_decoder.cpp
@@ -32,6 +32,10 @@
 #include "decoder_mpg123.h"
 #endif
 
+#ifdef HAVE_LIBSNDFILE
+#include "decoder_libsndfile.h"
+#endif
+
 void AudioDecoder::Pause() {
 	paused = true;
  }
@@ -136,7 +140,11 @@ std::unique_ptr<AudioDecoder> AudioDecoder::Create(FILE* file, const std::string
 		!strncmp(magic, "OggS", 4) || // OGG
 		!strncmp(magic, "fLaC", 4) // FLAC
 		) {
+	#ifdef HAVE_LIBSNDFILE
+		return std::unique_ptr<AudioDecoder>(new LibsndfileDecoder());
+	#else
 		return nullptr;
+	#endif
 	}
 
 	// Inform about WMA issue

--- a/src/audio_decoder.cpp
+++ b/src/audio_decoder.cpp
@@ -36,6 +36,10 @@
 #include "decoder_libsndfile.h"
 #endif
 
+#ifdef USE_AUDIO_RESAMPLER
+#include "audio_resampler.h"
+#endif
+
 void AudioDecoder::Pause() {
 	paused = true;
  }
@@ -128,7 +132,11 @@ std::unique_ptr<AudioDecoder> AudioDecoder::Create(FILE* file, const std::string
 
 	if (!strncmp(magic, "MThd", 4)) {
 #if WANT_FMMIDI == 1
+	#ifdef USE_AUDIO_RESAMPLER
+		return std::unique_ptr<AudioDecoder>(new AudioResampler(new FmMidiDecoder(),true,AudioResampler::Quality::Low));
+	#else
 		return std::unique_ptr<AudioDecoder>(new FmMidiDecoder());
+	#endif
 #else
 		return nullptr;
 #endif
@@ -141,7 +149,11 @@ std::unique_ptr<AudioDecoder> AudioDecoder::Create(FILE* file, const std::string
 		!strncmp(magic, "fLaC", 4) // FLAC
 		) {
 	#ifdef HAVE_LIBSNDFILE
-		return std::unique_ptr<AudioDecoder>(new LibsndfileDecoder());
+		#ifdef USE_AUDIO_RESAMPLER
+			return std::unique_ptr<AudioDecoder>(new AudioResampler(new LibsndfileDecoder()));
+		#else
+			return std::unique_ptr<AudioDecoder>(new LibsndfileDecoder());
+		#endif
 	#else
 		return nullptr;
 	#endif
@@ -154,14 +166,22 @@ std::unique_ptr<AudioDecoder> AudioDecoder::Create(FILE* file, const std::string
 
 #ifdef HAVE_MPG123
 	if (strncmp(magic, "ID3", 3) == 0) {
-		return std::unique_ptr<AudioDecoder>(new Mpg123Decoder());
+		#ifdef USE_AUDIO_RESAMPLER
+			return std::unique_ptr<AudioDecoder>(new AudioResampler(new Mpg123Decoder()));
+		#else
+			return std::unique_ptr<AudioDecoder>(new Mpg123Decoder());
+		#endif
 	}
 
 	// Parsing MP3s seems to be the only reliable way to detect them
 	if (Mpg123Decoder::IsMp3(file)) {
 		Output::Debug("MP3 heuristic: %s", filename.c_str());
 		fseek(file, 0, SEEK_SET);
-		return std::unique_ptr<AudioDecoder>(new Mpg123Decoder());
+		#ifdef USE_AUDIO_RESAMPLER
+			return std::unique_ptr<AudioDecoder>(new AudioResampler(new Mpg123Decoder()));
+		#else
+			return std::unique_ptr<AudioDecoder>(new Mpg123Decoder());
+		#endif
 	}
 #endif
 

--- a/src/audio_resampler.cpp
+++ b/src/audio_resampler.cpp
@@ -1,0 +1,592 @@
+#include "system.h"
+
+#if defined(HAVE_LIBSPEEXDSP) || defined(HAVE_LIBSAMPLERATE) 
+
+/**************************************************************************************
+ * INCLUDES
+ **************************************************************************************/
+ 
+#include <cassert>
+#include "audio_resampler.h"
+#include "output.h"
+/**************************************************************************************
+ * IDEFINITIONS
+ **************************************************************************************/
+
+#define ERROR -1
+#define STANDARD_PITCH 100
+
+/**************************************************************************************
+ * INTERNAL FUNCTIONS
+ **************************************************************************************/
+
+/**
+ * Utility function used to convert a buffer of a arbitrary AudioDecoder::Format to a float buffer
+ * 
+ * @param[in] wrapped_decoder The decoder from which audio samples are read
+ * @param[inout] buffer The buffer which will receive the converted samples, 
+ *			has to be at least amount_of_samples_to_read*sizeof(float) bytes big.
+ * @param[in] amount_of_samples_to_read The number of samples to read.
+ * @param[in] input_samplesize The size of one sample of the decoder in it's original format - given in bytes
+ * @param[in] input_format The original format of the samples
+ * 
+ * @return The number of converted samples - if this number is smaller than amount_of_samples_to_read the wrapped decoder has reaches it's end.
+ *		If the returned value has a negative value an error occured.
+ */
+inline static int DecodeAndConvertFloat(AudioDecoder * wrapped_decoder,
+										uint8_t * buffer, 
+										int amount_of_samples_to_read, 
+										const int input_samplesize, 
+										const AudioDecoder::Format input_format){
+	float* bufferAsFloat = (float*)buffer;
+	if (wrapped_decoder->IsFinished()) return 0; //Workaround for decoders which don't detect there own end
+	int amount_of_samples_read = wrapped_decoder->Decode(buffer, amount_of_samples_to_read*input_samplesize);
+	if (amount_of_samples_read <= 0) {
+		return amount_of_samples_read; //error occured - or nothing read
+	}
+	else {
+		amount_of_samples_read /= input_samplesize;
+	}
+	//Convert the read data (amount_of_data_read is at least one at this moment)
+	switch (input_format) {
+		case AudioDecoder::Format::S8:
+			//Convert inplace (the last frames are unused if smaller)
+			for (int i = amount_of_samples_read - 1; i >= 0; i--) {
+				bufferAsFloat[i] = ((int8_t*)bufferAsFloat)[i] / 128.0;
+			}
+			break;
+		case AudioDecoder::Format::U8:
+			//Convert inplace (the last frames are unused if smaller)
+			for (int i = amount_of_samples_read - 1; i >= 0; i--) {
+				bufferAsFloat[i] = ((uint8_t*)bufferAsFloat)[i] / 128.0 - 1.0;
+			}
+			break;
+		case AudioDecoder::Format::S16:
+			//Convert inplace (the last frames are unused if smaller)
+			for (int i = amount_of_samples_read - 1; i >= 0; i--) {
+				bufferAsFloat[i] = ((int16_t*)bufferAsFloat)[i] / 32768.0;
+			}
+			break;
+		case AudioDecoder::Format::U16:
+			//Convert inplace (the last frames are unused if smaller)
+			for (int i = amount_of_samples_read - 1; i >= 0; i--) {
+				bufferAsFloat[i] = ((uint16_t*)bufferAsFloat)[i] / 32768.0 - 1.0;
+			}
+			break;
+		case AudioDecoder::Format::S32:
+			//Convert inplace (same size)
+			for (int i = amount_of_samples_read - 1; i >= 0; i--) {
+				bufferAsFloat[i] = ((int32_t*)bufferAsFloat)[i] / 2147483648.0;
+			}
+			break;
+		case AudioDecoder::Format::U32:
+			//Convert inplace (same size)
+			for (int i = amount_of_samples_read - 1; i >= 0; i--) {
+				bufferAsFloat[i] = ((uint32_t*)bufferAsFloat)[i] / 2147483648.0 - 1.0;
+			}
+			break;
+		case AudioDecoder::Format::F32:
+			//Nothing to convert
+			break;
+	}
+	return amount_of_samples_read;
+}
+
+//------------------------------------------------------------------------------------//
+
+#if defined(HAVE_LIBSPEEXDSP)
+
+/**
+ * Utility function used to convert a buffer of a arbitrary AudioDecoder::Format to a int16 buffer
+ * 
+ * @param[in] wrapped_decoder The decoder from which audio samples are read
+ * @param[inout] buffer The buffer which will receive the converted samples, 
+ *			has to be at least amount_of_samples_to_read*max(sizeof(int16_t),input_samplesize) bytes big.
+ * @param[in] amount_of_samples_to_read The number of samples to read.
+ * @param[in] input_samplesize The size of one sample of the decoder in it's original format - given in bytes
+ * @param[in] input_format The original format of the samples
+ * 
+ * @return The number of converted samples - if this number is smaller than amount_of_samples_to_read the wrapped decoder has reaches it's end.
+ *		If the returned value has a negative value an error occured.
+ */
+inline static int DecodeAndConvertInt16(AudioDecoder * wrapped_decoder, 
+										uint8_t * buffer, 
+										int amount_of_samples_to_read, 
+										const int input_samplesize, 
+										const AudioDecoder::Format input_format){
+	int16_t* bufferAsInt16 = (int16_t*)buffer;
+	if (wrapped_decoder->IsFinished()) return 0; //Workaround for decoders which don't detect there own end
+	int amount_of_samples_read = wrapped_decoder->Decode(buffer, amount_of_samples_to_read*input_samplesize);
+	if (amount_of_samples_read <= 0) {
+		return amount_of_samples_read; //error occured - or nothing read
+	}
+	else {
+		//Convert the number of bytes to the number of samples
+		amount_of_samples_read /= input_samplesize;
+	}
+	//Convert the read data (amount_of_data_read is at least one at this moment)
+	switch (input_format) {
+		case AudioDecoder::Format::S8:
+			//Convert inplace (the last frames are unused if smaller)
+			for (int i = amount_of_samples_read - 1; i >= 0; i--) {
+				bufferAsInt16[i] = ((int8_t*)bufferAsInt16)[i] << 8;
+			}
+			break;
+		case AudioDecoder::Format::U8:
+			//Convert inplace (the last frames are unused if smaller)
+			for (int i = amount_of_samples_read - 1; i >= 0; i--) {
+				bufferAsInt16[i] = (((int16_t)(((uint8_t*)bufferAsInt16)[i])) - 128) << 8;
+			}
+			break;
+		case AudioDecoder::Format::S16:
+			//Nothing to convert
+			break;
+		case AudioDecoder::Format::U16:
+			//Convert unsigned to signed
+			for (int i = amount_of_samples_read - 1; i >= 0; i--) {
+				bufferAsInt16[i] = (int16_t)(((int32_t)(((uint16_t*)bufferAsInt16)[i])) - 32768);
+			}
+			break;
+		case AudioDecoder::Format::S32:
+			//Convert inplace (from front to back to prevent overwriting the buffer)
+			for (int i = 0; i < amount_of_samples_read; i++) {
+				bufferAsInt16[i] = (int16_t)((((int32_t*)bufferAsInt16)[i]) >> 16);
+			}
+			break;
+		case AudioDecoder::Format::U32:
+			//Convert inplace (from front to back to prevent overwriting the buffer)
+			for (int i = 0; i < amount_of_samples_read; i++) {
+				bufferAsInt16[i] = (int16_t)(((int32_t)((((uint32_t*)bufferAsInt16)[i]) >> 16)) - 32768);
+			}
+			break;
+		case AudioDecoder::Format::F32:
+			//Convert inplace (from front to back to prevent overwriting the buffer)
+			for (int i = 0; i < amount_of_samples_read; i++) {
+				float number = ((((float*)bufferAsInt16)[i])*32768.0);
+				bufferAsInt16[i] = (number <= 32767.0) ? ((number >= -32768.0) ? number : -32768) : 32767;
+			}
+			break;
+	}
+	return amount_of_samples_read;
+}
+#endif
+
+/**************************************************************************************
+ * CLASS IMPLEMENTATION
+ **************************************************************************************/
+
+AudioResampler::AudioResampler(AudioDecoder * wrapped, bool pitch_handled, AudioResampler::Quality quality)
+{
+	//There is no need for a standalone resampler decoder
+	assert(wrapped != 0);
+
+	wrapped_decoder = wrapped;
+	music_type = wrapped->GetType();
+	lasterror = 0;
+	pitch_handled_by_decoder = pitch_handled;
+
+	#if defined(HAVE_LIBSPEEXDSP)
+		switch (quality) {
+			case Quality::Low:
+				sampling_quality = 1;
+				break;
+			case Quality::Medium:
+				sampling_quality = 3;
+				break;
+			case Quality::High:
+				sampling_quality = 5;
+				break;
+		}
+	#elif defined(HAVE_LIBSAMPLERATE)
+		switch (quality) {
+			case Quality::Low:
+				sampling_quality = SRC_SINC_FASTEST;
+				break;
+			case Quality::Medium:
+				sampling_quality = SRC_SINC_MEDIUM_QUALITY;
+				break;
+			case Quality::High:
+				sampling_quality = SRC_SINC_BEST_QUALITY;
+				break;
+		}
+	#endif
+
+	finished = false;
+	pitch = 100;
+
+}
+
+//------------------------------------------------------------------------------------//
+
+AudioResampler::~AudioResampler() {
+	if (conversion_state != 0) {
+	#if defined(HAVE_LIBSPEEXDSP)
+			speex_resampler_destroy(conversion_state);
+	#elif defined(HAVE_LIBSAMPLERATE)
+			src_delete(conversion_state);
+	#endif
+	}
+	if (wrapped_decoder != 0) {
+		delete wrapped_decoder;
+	}
+}
+
+//------------------------------------------------------------------------------------//
+
+bool AudioResampler::Open(FILE* file) {
+	if (wrapped_decoder->Open(file)) {
+		wrapped_decoder->GetFormat(input_rate, input_format, nr_of_channels);
+
+		//determine if the input format is supported by the resampler
+		switch (input_format) {
+			case Format::F32: output_format = input_format; break;
+		#ifdef HAVE_LIBSPEEXDSP
+			case Format::S16: output_format = input_format; break;
+		#endif
+			default: output_format = Format::F32; break;
+		}
+
+		//Set input format to output_format if possible
+		wrapped_decoder->SetFormat(input_rate, output_format, nr_of_channels);
+		//Reread format to get new values
+		wrapped_decoder->GetFormat(input_rate, input_format, nr_of_channels);
+		output_rate = input_rate;
+
+		#if defined(HAVE_LIBSPEEXDSP)
+			conversion_state = speex_resampler_init(nr_of_channels, input_rate, output_rate, sampling_quality, &lasterror);
+			conversion_data.ratio_num = input_rate;
+			conversion_data.ratio_denom = output_rate;
+			speex_resampler_skip_zeros(conversion_state);
+		#elif defined(HAVE_LIBSAMPLERATE)
+			conversion_state = src_new(sampling_quality, nr_of_channels, &lasterror);
+		#endif
+
+		//Init the conversion data structure
+		conversion_data.input_frames = 0;
+		conversion_data.input_frames_used = 0;
+		finished = false;
+		return conversion_state != 0;
+	}
+	else {
+		return false;
+	}
+}
+
+//------------------------------------------------------------------------------------//
+
+bool AudioResampler::Seek(size_t offset, Origin origin) {
+	if (wrapped_decoder->Seek(offset, origin)) {
+		//reset conversio data
+		conversion_data.input_frames = 0;
+		conversion_data.input_frames_used = 0;
+		finished = wrapped_decoder->IsFinished();
+		#if defined(HAVE_LIBSPEEXDSP)
+			speex_resampler_reset_mem(conversion_state);
+		#elif defined(HAVE_LIBSAMPLERATE)
+			src_reset(conversion_state);
+		#endif
+		return true;
+	}
+	return false;
+
+}
+
+//------------------------------------------------------------------------------------//
+
+size_t AudioResampler::Tell() {
+	return wrapped_decoder->Tell();
+}
+
+//------------------------------------------------------------------------------------//
+
+int AudioResampler::GetTicks() {
+	return wrapped_decoder->GetTicks();
+}
+
+//------------------------------------------------------------------------------------//
+
+bool AudioResampler::IsFinished() const {
+	return finished;
+}
+
+//------------------------------------------------------------------------------------//
+
+void AudioResampler::GetFormat(int& frequency, AudioDecoder::Format& format, int& channels) const {
+	frequency = output_rate;
+	format = output_format;
+	channels = nr_of_channels;
+}
+
+//------------------------------------------------------------------------------------//
+
+bool AudioResampler::SetFormat(int freq, AudioDecoder::Format fmt, int channels) {
+	if (music_type == "midi") { input_rate = freq / 2; }
+	//Check whether requested format is supported by the resampler
+	switch (fmt) {
+	case Format::F32: output_format = fmt; break;
+	#ifdef HAVE_LIBSPEEXDSP
+		case Format::S16: output_format = fmt; break;
+	#endif
+	default: break;
+	}
+	wrapped_decoder->SetFormat(input_rate, output_format, channels);
+	wrapped_decoder->GetFormat(input_rate, input_format, nr_of_channels);
+	output_rate = freq;
+	return (nr_of_channels == channels&&output_format == fmt);
+}
+
+//------------------------------------------------------------------------------------//
+
+int AudioResampler::GetPitch() const {
+	if (pitch_handled_by_decoder) {
+		return wrapped_decoder->GetPitch();
+	}
+	else {
+		return pitch;
+	}
+}
+
+//------------------------------------------------------------------------------------//
+
+bool AudioResampler::SetPitch(int pitch_) {
+	if (pitch_handled_by_decoder) {
+		return wrapped_decoder->SetPitch(pitch_);
+	}
+	else {
+		pitch = pitch_;
+		return true;
+	}
+}
+
+//------------------------------------------------------------------------------------//
+
+int AudioResampler::FillBuffer(uint8_t* buffer, int length) {
+	int amount_filled = 0;
+	if((input_rate == output_rate) && ((pitch == STANDARD_PITCH) || pitch_handled_by_decoder)) {
+		//Do only format conversion
+		amount_filled = FillBufferSameRate(buffer, length);
+	}
+	else {
+		if (conversion_state == 0) {
+			error_message = "internal error: state pointer is a nullptr";
+			amount_filled = ERROR;
+		}
+		else {
+			//Do samplerate conversion
+			amount_filled = FillBufferDifferentRate(buffer, length);
+		}
+	}
+	//Clear the remaining buffer as specified in audio_decoder.h
+	for (int i = (amount_filled > 0) ? amount_filled : 0; i < length; i++) {
+		buffer[i] = 0;
+	}
+	return amount_filled;
+}
+
+//------------------------------------------------------------------------------------//
+
+int AudioResampler::FillBufferSameRate(uint8_t* buffer, int length) {
+	const int input_samplesize = GetSamplesizeForFormat(input_format);
+	const int output_samplesize = GetSamplesizeForFormat(output_format);
+	//The buffer size has to be a multiple of a frame
+	const int buffer_size=sizeof(internal_buffer) - sizeof(internal_buffer)%(nr_of_channels*input_samplesize);
+	
+	int total_output_frames = length / (output_samplesize*nr_of_channels);
+	int amount_of_data_to_read = 0;
+	int amount_of_data_read = total_output_frames*nr_of_channels;
+	
+	int decoded = 0;
+
+	if (input_samplesize > output_samplesize) {
+		//It is necessary to use the internal_buffer to convert the samples.
+		while (total_output_frames > 0) {
+			amount_of_data_to_read = buffer_size / input_samplesize;
+			
+			//limit amount_of_data_to_read in the last loop 
+			amount_of_data_to_read = (amount_of_data_to_read > total_output_frames) ? total_output_frames : amount_of_data_to_read;
+
+			switch (output_format) {
+				case AudioDecoder::Format::F32: 
+				amount_of_data_read = DecodeAndConvertFloat(wrapped_decoder, internal_buffer, amount_of_data_to_read, input_samplesize, input_format); 
+				break;
+			#ifdef HAVE_LIBSPEEXDSP
+				case AudioDecoder::Format::S16: 
+				amount_of_data_read = DecodeAndConvertInt16(wrapped_decoder, internal_buffer, amount_of_data_to_read, input_samplesize, input_format); 
+				break;
+			#endif
+				default: error_message = "internal error: output_format is not convertable"; return ERROR;
+			}
+			if (amount_of_data_read < 0) {
+				error_message = wrapped_decoder->GetError();
+				return amount_of_data_read; //error occured
+			}
+
+			//Copy the converted samples
+			for (int i = 0; i < amount_of_data_read*output_samplesize; i++) {
+				buffer[i] = internal_buffer[i];
+			}
+			//Prepare next loop
+			total_output_frames -= amount_of_data_read;
+			decoded += amount_of_data_read;
+			buffer += amount_of_data_read*output_samplesize;
+
+			//If the end of the decoder is reached (it has finished)
+			if (amount_of_data_read < amount_of_data_to_read) {
+				break;
+			}
+
+		}
+	}
+	else {
+		//It is possible to work inplace as length is specified for the output samplesize.
+		switch (output_format) {
+			case AudioDecoder::Format::F32: 
+			decoded = DecodeAndConvertFloat(wrapped_decoder, buffer, amount_of_data_read, input_samplesize, input_format); 
+			break;
+		#ifdef HAVE_LIBSPEEXDSP
+			case AudioDecoder::Format::S16: 
+			decoded = DecodeAndConvertInt16(wrapped_decoder, buffer, amount_of_data_read, input_samplesize, input_format); 
+			break;
+		#endif
+			default: error_message = "internal error: output_format is not convertable"; return ERROR;
+		}
+	}
+
+
+	finished = wrapped_decoder->IsFinished();
+	if (decoded < 0) {
+		error_message = wrapped_decoder->GetError();
+		return decoded;
+	}
+	else {
+		return decoded*output_samplesize;
+	}
+}
+
+//------------------------------------------------------------------------------------//
+
+int AudioResampler::FillBufferDifferentRate(uint8_t* buffer, int length) {
+	const int input_samplesize = GetSamplesizeForFormat(input_format);
+	const int output_samplesize = GetSamplesizeForFormat(output_format);
+	//The buffer size has to be a multiple of a frame
+	const int buffer_size=sizeof(internal_buffer) - sizeof(internal_buffer)%(nr_of_channels*((input_samplesize>output_samplesize) ? input_samplesize : output_samplesize));
+	
+	int total_output_frames = length / (output_samplesize*nr_of_channels);
+	int amount_of_samples_to_read = 0;
+	int amount_of_samples_read = 0;
+	
+	uint8_t * advanced_input_buffer = internal_buffer;
+	int unused_frames = 0;
+	int empty_buffer_space = 0;
+	int error = 0;
+	
+	#ifdef HAVE_LIBSPEEXDSP
+		spx_uint32_t numerator = 0;
+		spx_uint32_t denominator = 0;
+	#endif
+
+	while (total_output_frames > 0) {
+		//Calculate how much frames of the last cycle are unused - to reuse them
+		unused_frames = conversion_data.input_frames - conversion_data.input_frames_used;
+		empty_buffer_space = buffer_size / output_samplesize - unused_frames*nr_of_channels;
+		
+		advanced_input_buffer = internal_buffer;
+
+		//If there is still unused data in the input_buffer order it to the front
+		for (int i = 0; i < unused_frames*nr_of_channels*output_samplesize; i++) {
+			*advanced_input_buffer = *(advanced_input_buffer + empty_buffer_space*output_samplesize);
+			advanced_input_buffer++;
+		}
+		//advanced_input_buffer is now offset to the first frame of new data!
+
+		//ensure that the input buffer is not able to overrun
+		amount_of_samples_to_read = (input_samplesize > output_samplesize) ? (empty_buffer_space*output_samplesize) / input_samplesize : empty_buffer_space;
+
+		//Read as many frames as needed to refill the buffer (filled after the conversion to float)
+		if (amount_of_samples_to_read != 0) {
+			switch (output_format) {
+				case AudioDecoder::Format::F32: amount_of_samples_read = DecodeAndConvertFloat(wrapped_decoder, advanced_input_buffer, amount_of_samples_to_read, input_samplesize, input_format); break;
+			#ifdef HAVE_LIBSPEEXDSP
+				case AudioDecoder::Format::S16:  amount_of_samples_read = DecodeAndConvertInt16(wrapped_decoder, advanced_input_buffer, amount_of_samples_to_read, input_samplesize, input_format); break;
+			#endif
+				default: error_message = "internal error: output_format is not convertable"; return ERROR;
+			}
+			if (amount_of_samples_read < 0) {
+				error_message = wrapped_decoder->GetError();
+				return amount_of_samples_read; //error occured
+			}
+		}
+		//Now we have a prepared full buffer of converted values
+
+
+		//Prepare the source data
+		conversion_data.input_frames = amount_of_samples_read / nr_of_channels + unused_frames;
+		conversion_data.output_frames = total_output_frames;
+
+		#if defined(HAVE_LIBSPEEXDSP)
+			conversion_data.input_frames_used = conversion_data.input_frames;
+			conversion_data.output_frames_gen = conversion_data.output_frames;
+
+			//libspeexdsp defines a sample rate conversion with a fraction (input/output)
+			numerator = input_rate*pitch;
+			denominator = output_rate * STANDARD_PITCH;
+			if (pitch_handled_by_decoder) {
+				numerator = input_rate;
+				denominator = output_rate;
+			}
+			if (conversion_data.ratio_num != numerator || conversion_data.ratio_denom != denominator) {
+				int err=speex_resampler_set_rate_frac(conversion_state, numerator, denominator, input_rate, output_rate);
+				conversion_data.ratio_num = numerator;
+				conversion_data.ratio_denom = denominator;
+			}
+			
+			//A pitfall from libspeexdsp if the output buffer is defined to big - everything stutters -achieved good values with the same size as the input buffer for a maximum
+			conversion_data.output_frames_gen=(conversion_data.input_frames<conversion_data.output_frames_gen) ? conversion_data.input_frames :conversion_data.output_frames_gen;
+			
+			switch (output_format) {
+			case Format::F32:
+				error = speex_resampler_process_interleaved_float(conversion_state, (float*)internal_buffer, &conversion_data.input_frames_used, (float*)buffer, &conversion_data.output_frames_gen);
+				break;
+			case Format::S16:
+				error = speex_resampler_process_interleaved_int(conversion_state, (spx_int16_t*)internal_buffer, &conversion_data.input_frames_used, (spx_int16_t*)buffer, &conversion_data.output_frames_gen);
+				break;
+			default: error_message = "internal error: output_format is not convertable"; return ERROR;
+			}
+			
+			if (error != 0) {
+				error_message = speex_resampler_strerror(error);
+				return ERROR;
+			}
+		#elif defined(HAVE_LIBSAMPLERATE)
+			conversion_data.data_in = (float*)internal_buffer;
+			conversion_data.data_out = (float*)buffer;
+			if (pitch_handled_by_decoder) {
+				conversion_data.src_ratio = (output_rate*1.0) / input_rate;
+			}
+			else {
+				conversion_data.src_ratio = (output_rate*STANDARD_PITCH *1.0) / (input_rate*pitch*1.0);
+			}
+			conversion_data.end_of_input = (wrapped_decoder->IsFinished()) ? 1 : 0;
+
+			//Now let libsamplerate filter the data
+			error = src_process(conversion_state, &conversion_data);
+
+			if (error != 0) {
+				error_message = src_strerror(error);
+				return ERROR;
+			}
+		#endif
+
+		total_output_frames -= conversion_data.output_frames_gen;
+		buffer += conversion_data.output_frames_gen*nr_of_channels*output_samplesize;
+
+		if ((conversion_data.input_frames == 0 && conversion_data.output_frames_gen <= conversion_data.output_frames) || conversion_data.output_frames_gen == 0) {
+			finished = true;
+			//There is nothing left to convert - return how much samples (in bytes) are converted! 
+			return length - total_output_frames*(output_samplesize*nr_of_channels);
+		}
+	}
+	return length;
+}
+
+#endif

--- a/src/audio_resampler.cpp
+++ b/src/audio_resampler.cpp
@@ -1,24 +1,30 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "system.h"
 
 #if defined(HAVE_LIBSPEEXDSP) || defined(HAVE_LIBSAMPLERATE) 
 
-/**************************************************************************************
- * INCLUDES
- **************************************************************************************/
- 
 #include <cassert>
 #include "audio_resampler.h"
 #include "output.h"
-/**************************************************************************************
- * IDEFINITIONS
- **************************************************************************************/
 
 #define ERROR -1
 #define STANDARD_PITCH 100
-
-/**************************************************************************************
- * INTERNAL FUNCTIONS
- **************************************************************************************/
 
 /**
  * Utility function used to convert a buffer of a arbitrary AudioDecoder::Format to a float buffer
@@ -91,8 +97,6 @@ inline static int DecodeAndConvertFloat(AudioDecoder * wrapped_decoder,
 	}
 	return amount_of_samples_read;
 }
-
-//------------------------------------------------------------------------------------//
 
 #if defined(HAVE_LIBSPEEXDSP)
 
@@ -171,10 +175,6 @@ inline static int DecodeAndConvertInt16(AudioDecoder * wrapped_decoder,
 }
 #endif
 
-/**************************************************************************************
- * CLASS IMPLEMENTATION
- **************************************************************************************/
-
 AudioResampler::AudioResampler(AudioDecoder * wrapped, bool pitch_handled, AudioResampler::Quality quality)
 {
 	//There is no need for a standalone resampler decoder
@@ -216,8 +216,6 @@ AudioResampler::AudioResampler(AudioDecoder * wrapped, bool pitch_handled, Audio
 
 }
 
-//------------------------------------------------------------------------------------//
-
 AudioResampler::~AudioResampler() {
 	if (conversion_state != 0) {
 	#if defined(HAVE_LIBSPEEXDSP)
@@ -230,8 +228,6 @@ AudioResampler::~AudioResampler() {
 		delete wrapped_decoder;
 	}
 }
-
-//------------------------------------------------------------------------------------//
 
 bool AudioResampler::Open(FILE* file) {
 	if (wrapped_decoder->Open(file)) {
@@ -272,8 +268,6 @@ bool AudioResampler::Open(FILE* file) {
 	}
 }
 
-//------------------------------------------------------------------------------------//
-
 bool AudioResampler::Seek(size_t offset, Origin origin) {
 	if (wrapped_decoder->Seek(offset, origin)) {
 		//reset conversio data
@@ -291,33 +285,23 @@ bool AudioResampler::Seek(size_t offset, Origin origin) {
 
 }
 
-//------------------------------------------------------------------------------------//
-
 size_t AudioResampler::Tell() {
 	return wrapped_decoder->Tell();
 }
-
-//------------------------------------------------------------------------------------//
 
 int AudioResampler::GetTicks() {
 	return wrapped_decoder->GetTicks();
 }
 
-//------------------------------------------------------------------------------------//
-
 bool AudioResampler::IsFinished() const {
 	return finished;
 }
-
-//------------------------------------------------------------------------------------//
 
 void AudioResampler::GetFormat(int& frequency, AudioDecoder::Format& format, int& channels) const {
 	frequency = output_rate;
 	format = output_format;
 	channels = nr_of_channels;
 }
-
-//------------------------------------------------------------------------------------//
 
 bool AudioResampler::SetFormat(int freq, AudioDecoder::Format fmt, int channels) {
 	if (music_type == "midi") { input_rate = freq / 2; }
@@ -335,8 +319,6 @@ bool AudioResampler::SetFormat(int freq, AudioDecoder::Format fmt, int channels)
 	return (nr_of_channels == channels&&output_format == fmt);
 }
 
-//------------------------------------------------------------------------------------//
-
 int AudioResampler::GetPitch() const {
 	if (pitch_handled_by_decoder) {
 		return wrapped_decoder->GetPitch();
@@ -345,8 +327,6 @@ int AudioResampler::GetPitch() const {
 		return pitch;
 	}
 }
-
-//------------------------------------------------------------------------------------//
 
 bool AudioResampler::SetPitch(int pitch_) {
 	if (pitch_handled_by_decoder) {
@@ -357,8 +337,6 @@ bool AudioResampler::SetPitch(int pitch_) {
 		return true;
 	}
 }
-
-//------------------------------------------------------------------------------------//
 
 int AudioResampler::FillBuffer(uint8_t* buffer, int length) {
 	int amount_filled = 0;
@@ -382,8 +360,6 @@ int AudioResampler::FillBuffer(uint8_t* buffer, int length) {
 	}
 	return amount_filled;
 }
-
-//------------------------------------------------------------------------------------//
 
 int AudioResampler::FillBufferSameRate(uint8_t* buffer, int length) {
 	const int input_samplesize = GetSamplesizeForFormat(input_format);
@@ -462,8 +438,6 @@ int AudioResampler::FillBufferSameRate(uint8_t* buffer, int length) {
 		return decoded*output_samplesize;
 	}
 }
-
-//------------------------------------------------------------------------------------//
 
 int AudioResampler::FillBufferDifferentRate(uint8_t* buffer, int length) {
 	const int input_samplesize = GetSamplesizeForFormat(input_format);

--- a/src/audio_resampler.h
+++ b/src/audio_resampler.h
@@ -1,0 +1,180 @@
+#ifndef _EASYRPG_AUDIO_RESAMPLER_H_
+#define _EASYRPG_AUDIO_RESAMPLER_H_
+
+// Headers
+#include "audio_decoder.h"
+#include <string>
+#include <memory>
+
+#if defined(HAVE_LIBSPEEXDSP)
+#include <speex/speex_resampler.h>
+#elif  defined(HAVE_LIBSAMPLERATE)
+#include <samplerate.h>
+#endif
+
+/**
+ * Audio resampler powered by Libspeexdsp or Libsamplerate
+ * Wraps another decoder and provides resampling.
+ */
+class AudioResampler : public AudioDecoder {
+public:
+
+	/** Resampling quality */
+	enum class Quality {
+		High,
+		Medium,
+		Low
+	};
+	
+	/**
+	 * Constructs a resampler
+	 * 
+	 * @param[in] decoder The decoder which provides samples to the resampler - will be owned by the resampler
+	 * @param[in] pitch_handled Defines whether the decoder handles pitch changes by itself or not. 
+	 * @param[in] quality Sets the quality rting of the resampler - higher quality implies slower filtering
+	 */
+	AudioResampler(AudioDecoder * decoder, bool pitch_handled=false,  Quality quality=Quality::Medium);
+	
+	/**
+	 * Destroys the resampler as well as its owned ressources
+	 */
+	~AudioResampler();
+
+	/**
+	 * Wraps the opening function of the contained decoder
+	 * 
+	 * @param[in] file Filepointer to a file readable by the wrapped decoder
+	 * 
+	 * @return Whether the operation was successful or not
+	 */
+	bool Open(FILE* file) override;
+
+	/**
+	 * Wraps the seek function of the contained decoder
+	 * @note If the seek function of the wrapped decoder is 
+	 *	somewhat corelated to time the offset is not influenced by the resampling ratio
+	 *
+	 * @param offset Offset to seek to
+	 * @param origin Position to seek from
+	 *
+	 * @return Whether seek was successful
+	 */
+	bool Seek(size_t offset, Origin origin) override;
+
+	/**
+	 * Wraps the tell function of the contained decoder
+	 *
+	 * @return Position in the stream
+	 */
+	size_t Tell() override;
+
+	/**
+	 * Wraps the GetTicks Function of the contained decoder
+	 *
+	 * @return Amount of MIDI ticks.
+	 */
+	int GetTicks() override;
+	
+	/**
+	 * Returns wheter the resampled audio stream is finished
+	 *
+	 * @return true if the stream has reached it's end
+	 */
+	bool IsFinished() const override;
+
+	/**
+	 * Retrieves the format of the audio decoder.
+	 *
+	 * @param frequency Filled with the audio frequency
+	 * @param format Filled with the audio format
+	 * @param channel Filled with the amount of channels
+	 */
+	void GetFormat(int& frequency, AudioDecoder::Format& format, int& channels) const override;
+
+	/**
+	 * Requests a certain frame format from the resampler. 
+	 * Supported formats are:
+	 *  * float,int16_t for libspeexdsp
+	 *  * float for libsamplerate
+	 * The channel setting is redirected to the wrapped decoder.
+	 * The frequency setting controls the resampler.
+	 *
+	 * @param frequency Sample rate the resampler should output
+	 * @param format Audio format the resampler should output
+	 * @param channel Number of channels
+	 * @return true when all settings were set, otherwise false (use GetFormat)
+	 */
+	bool SetFormat(int frequency, AudioDecoder::Format format, int channels) override;
+
+	/**
+	 * Gets the pitch multiplier.
+	 *
+	 * @return pitch multiplier
+	 */
+	int GetPitch() const override;
+
+	/**
+	 * Sets the pitch multiplier.
+	 * 100 = normal speed
+	 * 200 = double speed and so on
+	 * If the pitch is handled by the resampler this setting controls the resampling in conjunction with the frequency.
+	 * 
+	 * @param pitch Pitch multiplier to use
+	 * @return true if pitch was set, false otherwise
+	 */
+	bool SetPitch(int pitch) override;
+
+private:
+	/**
+	 * Called by the Decode functions to fill the buffer.
+	 *
+	 * @param buffer Buffer to fill
+	 * @param size Buffer size
+	 * @return number of bytes read or -1 on error
+	 */
+	int FillBuffer(uint8_t* buffer, int length) override;
+	
+	/**
+	 * Internally used by the FillBuffer function if the output rate equals the input rate
+	 */
+	int FillBufferSameRate(uint8_t* buffer, int length);
+	/**
+	 * Internally used by the FillBuffer function if resampling is necessary
+	 */
+	int FillBufferDifferentRate(uint8_t* buffer, int length);
+	
+	AudioDecoder * wrapped_decoder;
+	bool pitch_handled_by_decoder;
+	int pitch;
+	int sampling_quality;
+	int lasterror;
+	bool finished;
+
+	int nr_of_channels;
+	Format input_format;
+	int input_rate;
+	Format output_format;
+	int output_rate;
+	
+	#if defined(HAVE_LIBSPEEXDSP)
+		struct {
+			spx_uint32_t input_frames, output_frames;
+			spx_uint32_t input_frames_used, output_frames_gen;
+			spx_uint32_t ratio_num, ratio_denom;
+		} conversion_data;
+		SpeexResamplerState * conversion_state;
+	#elif defined(HAVE_LIBSAMPLERATE)
+		SRC_DATA conversion_data;
+		SRC_STATE * conversion_state;
+	#endif
+
+	/**
+	 * A buffer needed for operations which can't be performed in place (e.g resampling)
+	 * The size of the buffer defines the number of calls to the resampling algorithmn
+	 * (In the cpp file sizeof is used therefore it can be adjusted to fit the available memory)
+	 */
+	uint8_t internal_buffer[256*sizeof(float)];
+
+};
+
+#endif

--- a/src/audio_resampler.h
+++ b/src/audio_resampler.h
@@ -1,3 +1,20 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef _EASYRPG_AUDIO_RESAMPLER_H_
 #define _EASYRPG_AUDIO_RESAMPLER_H_
 

--- a/src/audio_resampler.h
+++ b/src/audio_resampler.h
@@ -17,6 +17,7 @@
 
 #ifndef _EASYRPG_AUDIO_RESAMPLER_H_
 #define _EASYRPG_AUDIO_RESAMPLER_H_
+#if defined(HAVE_LIBSPEEXDSP) || defined(HAVE_LIBSAMPLERATE) 
 
 // Headers
 #include "audio_decoder.h"
@@ -193,5 +194,5 @@ private:
 	uint8_t internal_buffer[256*sizeof(float)];
 
 };
-
+#endif
 #endif

--- a/src/decoder_libsndfile.cpp
+++ b/src/decoder_libsndfile.cpp
@@ -1,3 +1,20 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "system.h"
 
 #ifdef HAVE_LIBSNDFILE

--- a/src/decoder_libsndfile.cpp
+++ b/src/decoder_libsndfile.cpp
@@ -1,0 +1,136 @@
+#include "system.h"
+
+#ifdef HAVE_LIBSNDFILE
+
+// Headers
+#include <cassert>
+#include <sys/stat.h>
+#include "decoder_libsndfile.h"
+#include "output.h"
+
+
+static sf_count_t sf_vio_get_filelen_impl(void* userdata) {
+	FILE* f = reinterpret_cast<FILE*>(userdata);
+	int fd=fileno(f); //Posix complient - should work on windows as well
+	struct stat stat_buf;
+	int rc = fstat(fd, &stat_buf);
+    return rc == 0 ? stat_buf.st_size : 0;
+}
+
+static sf_count_t sf_vio_read_impl(void *ptr, sf_count_t count, void* userdata){
+	FILE* f = reinterpret_cast<FILE*>(userdata);
+	return fread(ptr, 1, count, f);
+}
+
+static sf_count_t sf_vio_write_impl(const void *ptr, sf_count_t count, void *user_data){
+	//Writing of wav files is not necessary
+	return count;
+}
+
+static sf_count_t sf_vio_seek_impl(sf_count_t offset, int seek_type, void *userdata) {
+	FILE* f = reinterpret_cast<FILE*>(userdata);
+	fseek(f, offset, seek_type);
+	return ftell(f);
+}
+
+static sf_count_t sf_vio_tell_impl(void* userdata){
+	FILE* f = reinterpret_cast<FILE*>(userdata);
+	return ftell(f);
+}
+
+static  SF_VIRTUAL_IO vio = {
+	sf_vio_get_filelen_impl,
+	sf_vio_seek_impl,
+	sf_vio_read_impl,
+	sf_vio_write_impl,
+	sf_vio_tell_impl
+}; 
+
+
+LibsndfileDecoder::LibsndfileDecoder() 
+{
+	music_type = "wav";
+	soundfile=0;
+}
+
+LibsndfileDecoder::~LibsndfileDecoder() {
+	if(soundfile!=0){
+		sf_close(soundfile);
+		fclose(file_);
+	}
+}
+
+bool LibsndfileDecoder::Open(FILE* file) {
+	file_=file;
+	soundfile=sf_open_virtual(&vio,SFM_READ,&soundinfo,file);
+	sf_command(soundfile, SFC_SET_SCALE_FLOAT_INT_READ, NULL, SF_TRUE);
+	output_format=Format::F32;
+	finished=false;
+	return soundfile!=0;
+}
+
+bool LibsndfileDecoder::Seek(size_t offset, Origin origin) {
+	if(soundfile==0) return false;
+	return sf_seek(soundfile,offset,SEEK_SET)!=-1;
+}
+
+bool LibsndfileDecoder::IsFinished() const {
+	return finished;
+}
+
+
+void LibsndfileDecoder::GetFormat(int& frequency, AudioDecoder::Format& format, int& channels) const {
+	if(soundfile==0) return;
+	frequency = soundinfo.samplerate;
+	channels = soundinfo.channels;
+	format = output_format;
+}
+
+bool LibsndfileDecoder::SetFormat(int freq, AudioDecoder::Format fmt, int channels) {
+	if(soundfile==0) return false;
+	switch(fmt){
+		case Format::F32:
+		case Format::S16:
+		case Format::S32:
+			output_format=fmt;
+			break;
+		default:
+			return false;
+	}
+	return soundinfo.samplerate==freq && soundinfo.channels==channels && output_format==fmt;
+}
+
+
+int LibsndfileDecoder::FillBuffer(uint8_t* buffer, int length) {
+	if(soundfile==0) return -1;
+	int decoded;
+	switch(output_format){
+		case Format::F32:
+			{
+				decoded=sf_read_float(soundfile,(float*)buffer,length/sizeof(float));
+				if(!decoded) finished=true;
+				decoded*=sizeof(float);
+			}
+			break;
+		case Format::S16:
+			{
+				decoded=sf_read_short(soundfile,(int16_t*)buffer,length/sizeof(int16_t));
+				if(!decoded) finished=true;
+				decoded*=sizeof(int16_t);
+			}
+			break;
+		case Format::S32:
+			{
+				decoded=sf_read_int(soundfile,(int32_t*)buffer,length/sizeof(int32_t));
+				if(!decoded) finished=true;
+				decoded*=sizeof(int32_t);
+			}
+			break;
+		default:
+			decoded=-1;
+			break;
+	}
+	return decoded;
+}
+
+#endif

--- a/src/decoder_libsndfile.h
+++ b/src/decoder_libsndfile.h
@@ -1,3 +1,20 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef _EASYRPG_AUDIO_DECODER_LIBSNDFILE_H_
 #define _EASYRPG_AUDIO_DECODER_LIBSNDFILE_H_
 

--- a/src/decoder_libsndfile.h
+++ b/src/decoder_libsndfile.h
@@ -17,13 +17,11 @@
 
 #ifndef _EASYRPG_AUDIO_DECODER_LIBSNDFILE_H_
 #define _EASYRPG_AUDIO_DECODER_LIBSNDFILE_H_
-
+#ifdef HAVE_LIBSNDFILE
 // Headers
 #include "audio_decoder.h"
 #include <string>
-#ifdef HAVE_LIBSNDFILE
 #include <sndfile.h>
-#endif
 #include <memory>
 
 /**
@@ -51,10 +49,8 @@ private:
 	FILE * file_;
 	bool finished;
 
-	#ifdef HAVE_LIBSNDFILE
 	SNDFILE *soundfile;
 	SF_INFO soundinfo;
-	#endif
 };
-
+#endif
 #endif

--- a/src/decoder_libsndfile.h
+++ b/src/decoder_libsndfile.h
@@ -1,0 +1,43 @@
+#ifndef _EASYRPG_AUDIO_DECODER_LIBSNDFILE_H_
+#define _EASYRPG_AUDIO_DECODER_LIBSNDFILE_H_
+
+// Headers
+#include "audio_decoder.h"
+#include <string>
+#ifdef HAVE_LIBSNDFILE
+#include <sndfile.h>
+#endif
+#include <memory>
+
+/**
+ * Audio decoder for WAV powered by libsndfile
+ */
+class LibsndfileDecoder : public AudioDecoder {
+public:
+	LibsndfileDecoder();
+
+	~LibsndfileDecoder();
+
+	bool Open(FILE* file) override;
+
+	bool Seek(size_t offset, Origin origin) override;
+
+	bool IsFinished() const override;
+
+	void GetFormat(int& frequency, AudioDecoder::Format& format, int& channels) const override;
+
+	bool SetFormat(int frequency, AudioDecoder::Format format, int channels) override;
+
+private:
+	int FillBuffer(uint8_t* buffer, int length) override;
+	Format output_format;
+	FILE * file_;
+	bool finished;
+
+	#ifdef HAVE_LIBSNDFILE
+	SNDFILE *soundfile;
+	SF_INFO soundinfo;
+	#endif
+};
+
+#endif

--- a/src/system.h
+++ b/src/system.h
@@ -111,4 +111,8 @@
 #  endif
 #endif
 
+#if defined(HAVE_LIBSAMPLERATE) || defined(HAVE_LIBSPEEXDSP)
+#  define USE_AUDIO_RESAMPLER
+#endif
+
 #endif


### PR DESCRIPTION
Hello,

As explained before in the [forum](https://easy-rpg.org/forums/viewtopic.php?f=4&t=633)  these are two additions to the audio layer of the player:
 
- decoder_libsndfile to enable wav playback without sdl (depends on libsndfile)
- audio_resampler to enable arbitrary resampling (depends on libspeexdsp, or libsamplerate)

The AudioResampler is meant to wrap any AudioDecoder and intersects if SetFormat or SetPitch are called.

I haven't changed anything in the sdl audio files so these changes only affect background music as sound effects don't use the AudioDecoder class.