### PR TITLE
Don't half fmmidi frequency twice

### DIFF
--- a/src/audio_resampler.cpp
+++ b/src/audio_resampler.cpp
@@ -304,7 +304,6 @@ void AudioResampler::GetFormat(int& frequency, AudioDecoder::Format& format, int
 }
 
 bool AudioResampler::SetFormat(int freq, AudioDecoder::Format fmt, int channels) {
-	if (music_type == "midi") { input_rate = freq / 2; }
 	//Check whether requested format is supported by the resampler
 	switch (fmt) {
 	case Format::F32: output_format = fmt; break;


### PR DESCRIPTION
The FMMIDI frequency was already being halved from 44100 to 22050. The line removed was halving MIDI again (22050 to 11025 Hz), doing FMMIDI playback too much phone-like.

The half frequency in FFMIDI is for performance purposes on low end ports (used for synthesizing, saves a lot of CPU), not needing to be resampled later (which spends additional CPU).