### PR TITLE
Fixes a bug in libsndfile_decoder

### DIFF
--- a/src/decoder_libsndfile.cpp
+++ b/src/decoder_libsndfile.cpp
@@ -87,6 +87,7 @@ bool LibsndfileDecoder::Open(FILE* file) {
 }
 
 bool LibsndfileDecoder::Seek(size_t offset, Origin origin) {
+	finished = false;
 	if(soundfile==0) return false;
 	return sf_seek(soundfile,offset,SEEK_SET)!=-1;
 }


### PR DESCRIPTION
Fixes the bug described in the second post of issue #910 - NOT the original bug in the issue.

Explanation of the bug:
libsndfile_decoder was not properly reverting the finished flag when the stream was reverted, therefore the code in `audio_decoder.cpp` triggered an endless recursion when calling itself after rewinding :

```cpp
int AudioDecoder::Decode(uint8_t* buffer, int length) {
	if (paused) {
		memset(buffer, '\0', length);
		return length;
	}

	int res = FillBuffer(buffer, length);

	if (res < 0) {
		memset(buffer, '\0', length);
	} else if (res < length) {
		memset(&buffer[res], '\0', length - res);
	}

	if (IsFinished() && looping) {
		++loop_count;
		Rewind();
		if (length - res > 0) {
			int res2 = Decode(&buffer[res], length - res);
			if (res2 <= 0) {
				return res;
			}
			return res + res2;
		}
	}

	return res;
}
```
