### PR TITLE
Class handling

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -119,7 +119,7 @@ bool Game_Actor::IsSkillUsable(int skill_id) const {
 
 	// Actor must have all attributes of the skill equipped as weapons
 	const RPG::Item* item = GetEquipment(0);
-	const RPG::Item* item2 = GetTwoSwordsStyle() ? GetEquipment(1) : nullptr;
+	const RPG::Item* item2 = HasTwoWeapons() ? GetEquipment(1) : nullptr;
 
 	for (size_t i = 0; i < skill.attribute_effects.size(); ++i) {
 		bool required = skill.attribute_effects[i] && Data::attributes[i].type == RPG::Attribute::Type_physical;
@@ -142,7 +142,7 @@ bool Game_Actor::IsSkillUsable(int skill_id) const {
 }
 
 int Game_Actor::CalculateSkillCost(int skill_id) const {
-	int start = GetTwoSwordsStyle() ? 1 : 0;
+	int start = HasTwoWeapons() ? 1 : 0;
 	int sp_mod = 1;
 
 	for (int i = start; i < 5; ++i) {
@@ -637,7 +637,7 @@ void Game_Actor::ChangeLevel(int new_level, bool level_up_message) {
 }
 
 bool Game_Actor::IsEquippable(int item_id) const {
-	if (GetTwoSwordsStyle() &&
+	if (HasTwoWeapons() &&
 		Data::items[item_id - 1].type == RPG::Item::Type_shield) {
 			return false;
 	}
@@ -663,7 +663,7 @@ const RPG::Skill& Game_Actor::GetRandomSkill() const {
 	return Data::skills[skills[rand() % (skills.size() + 1)] - 1];
 }
 
-bool Game_Actor::GetTwoSwordsStyle() const {
+bool Game_Actor::HasTwoWeapons() const {
 	return GetData().two_weapon;
 }
 
@@ -1029,7 +1029,7 @@ void Game_Actor::ResetBattle() {
 		return;
 	}
 
-	if (GetTwoSwordsStyle()) {
+	if (HasTwoWeapons()) {
 		item = GetEquipment(1);
 		if (item && item->preemptive) {
 			gauge = GetMaxGauge();

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -637,7 +637,7 @@ void Game_Actor::ChangeLevel(int new_level, bool level_up_message) {
 }
 
 bool Game_Actor::IsEquippable(int item_id) const {
-	if (GetData().two_weapon &&
+	if (GetTwoSwordsStyle() &&
 		Data::items[item_id - 1].type == RPG::Item::Type_shield) {
 			return false;
 	}
@@ -647,6 +647,10 @@ bool Game_Actor::IsEquippable(int item_id) const {
 
 bool Game_Actor::IsEquipmentFixed() const {
 	return GetData().lock_equipment;
+}
+
+bool Game_Actor::HasStrongDefense() const {
+	return GetData().mighty_guard;
 }
 
 const std::vector<int16_t>& Game_Actor::GetSkills() const {
@@ -887,9 +891,24 @@ const RPG::Class* Game_Actor::GetClass() const {
 void Game_Actor::SetClass(int _class_id) {
 	GetData().class_id = _class_id;
 	GetData().changed_class = _class_id > 0;
+	
+	// The class settings are not applied when the actor has a class on startup
+	// but only when the "Change Class" event command is used.
+	
 	if (GetData().changed_class) {
 		GetData().battler_animation = GetClass()->battler_animation;
+		GetData().mighty_guard = GetClass()->super_guard;
+		GetData().lock_equipment = GetClass()->fix_equipment;
+		GetData().two_weapon = GetClass()->two_swords_style;
+		GetData().auto_battle = GetClass()->auto_battle;
 	} else {
+		const RPG::Actor& actor = Data::actors[actor_id - 1];
+		
+		GetData().mighty_guard = actor.super_guard;
+		GetData().lock_equipment = actor.fix_equipment;
+		GetData().two_weapon = actor.two_swords_style;
+		GetData().auto_battle = actor.auto_battle;
+		
 		GetData().battler_animation = 0;
 	}
 	MakeExpList();

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -993,7 +993,9 @@ int Game_Actor::GetBattleAnimationId() const {
 	if (GetData().battler_animation <= 0) {
 		// Earlier versions of EasyRPG didn't save this value correctly
 
-		if (GetData().class_id > 0) {
+		// The battle animation of the class only matters when the class was
+		// changed by event "Change Class"
+		if (GetData().changed_class && GetClass()) {
 			anim = GetClass()->battler_animation;
 		} else {
 			anim = Data::battleranimations[Data::actors[actor_id - 1].battler_animation - 1].ID;

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -650,7 +650,7 @@ bool Game_Actor::IsEquipmentFixed() const {
 }
 
 bool Game_Actor::HasStrongDefense() const {
-	return GetData().mighty_guard;
+	return GetData().super_guard;
 }
 
 const std::vector<int16_t>& Game_Actor::GetSkills() const {
@@ -897,16 +897,16 @@ void Game_Actor::SetClass(int _class_id) {
 	
 	if (GetData().changed_class) {
 		GetData().battler_animation = GetClass()->battler_animation;
-		GetData().mighty_guard = GetClass()->super_guard;
-		GetData().lock_equipment = GetClass()->fix_equipment;
-		GetData().two_weapon = GetClass()->two_swords_style;
+		GetData().super_guard = GetClass()->super_guard;
+		GetData().lock_equipment = GetClass()->lock_equipment;
+		GetData().two_weapon = GetClass()->two_weapon;
 		GetData().auto_battle = GetClass()->auto_battle;
 	} else {
 		const RPG::Actor& actor = Data::actors[actor_id - 1];
 		
-		GetData().mighty_guard = actor.super_guard;
-		GetData().lock_equipment = actor.fix_equipment;
-		GetData().two_weapon = actor.two_swords_style;
+		GetData().super_guard = actor.super_guard;
+		GetData().lock_equipment = actor.lock_equipment;
+		GetData().two_weapon = actor.two_weapon;
 		GetData().auto_battle = actor.auto_battle;
 		
 		GetData().battler_animation = 0;

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -356,7 +356,7 @@ public:
 	 * 
 	 * @return true if strong defense
 	 */
-	bool HasStrongDefense() const;
+	bool HasStrongDefense() const override;
 	
 	/**
 	 * Sets face graphic of actor.

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -586,7 +586,7 @@ public:
 	 *
 	 * @return true if actor has two weapons.
 	 */
-	bool GetTwoSwordsStyle() const;
+	bool HasTwoWeapons() const;
 
 	/**
 	 * Gets if actor does auto battle.

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -350,7 +350,14 @@ public:
 	 * @return true if fixed
 	 */
 	bool IsEquipmentFixed() const;
-
+	
+	/**
+	 * Checks if the actors defense skill is stronger the usual.
+	 * 
+	 * @return true if strong defense
+	 */
+	bool HasStrongDefense() const;
+	
 	/**
 	 * Sets face graphic of actor.
 	 * @param file_name file containing new face.

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -601,7 +601,8 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 		if(effect < 0) {
 			effect = 0;
 		}
-		this->hp = (effect * (critical_hit ? 3 : 1) * (source->IsCharged() ? 2 : 1)) / ((*current_target)->IsDefending() ? 2 : 1);
+		this->hp = (effect * (critical_hit ? 3 : 1) * (source->IsCharged() ? 2 : 1)) /
+			((*current_target)->IsDefending() ? (*current_target)->HasStrongDefense() ? 3 : 2 : 1);
 
 		if ((*current_target)->GetHp() - this->hp <= 0) {
 			// Death state
@@ -771,7 +772,8 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				effect = 0;
 
 			if (skill.affect_hp) {
-				this->hp = effect / ((*current_target)->IsDefending() ? 2 : 1);
+				this->hp = effect /
+					((*current_target)->IsDefending() ? (*current_target)->HasStrongDefense() ? 3 : 2 : 1);
 
 				if ((*current_target)->GetHp() - this->hp <= 0) {
 					// Death state
@@ -1162,7 +1164,8 @@ bool Game_BattleAlgorithm::SelfDestruct::Execute() {
 	if (effect < 0)
 		effect = 0;
 	
-	this->hp = effect / ((*current_target)->IsDefending() ? 2 : 1);;
+	this->hp = effect / (
+		(*current_target)->IsDefending() ? (*current_target)->HasStrongDefense() ? 3 : 2 : 1);
 
 	if ((*current_target)->GetHp() - this->hp <= 0) {
 		// Death state

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -442,6 +442,10 @@ bool Game_Battler::IsDefending() const {
 	return defending;
 }
 
+bool Game_Battler::HasStrongDefense() const {
+	return false;
+}
+
 void Game_Battler::SetDefending(bool defend) {
 	defending = defend;
 }

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -425,9 +425,14 @@ public:
 	void SetCharged(bool charge);
 
 	/**
-	* @return If battler is defending (next turn, defense is doubled)
-	*/
+	 * @return If battler is defending (next turn, defense is doubled)
+	 */
 	bool IsDefending() const;
+	
+	/**
+	 * @return If battler has strong defense (defense is tripled when defending)
+	 */
+	virtual bool HasStrongDefense() const;
 
 	/**
 	 * Sets defence state (next turn, defense is doubled)

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -237,7 +237,7 @@ void Window_Base::DrawEquipmentType(Game_Actor* actor, int cx, int cy, int type)
 		name = Data::terms.weapon;
 		break;
 	case 1:
-		if (actor->GetTwoSwordsStyle()) {
+		if (actor->HasTwoWeapons()) {
 			name = Data::terms.weapon;
 		} else {
 			name = Data::terms.shield;

--- a/src/window_equipitem.cpp
+++ b/src/window_equipitem.cpp
@@ -29,7 +29,7 @@ Window_EquipItem::Window_EquipItem(int actor_id, int equip_type) :
 	}
 
 	if (this->equip_type == Window_EquipItem::shield &&
-		Game_Actors::GetActor(actor_id)->GetTwoSwordsStyle()) {
+		Game_Actors::GetActor(actor_id)->HasTwoWeapons()) {
 
 		this->equip_type = Window_EquipItem::weapon;
 	}


### PR DESCRIPTION
Classes are handled silly in RPG Maker 2003. The class settings don't matter at all on startup (it only shows the class name in the status scene), everything else is only applied when "Change Class" event is used...

The naming in liblcf is really inconsistent what do you think about adjusting this?

mighty_guard <-> super_guard
lock_equipment <-> fix_equipment
two_weapon <-> two_swords_style