### PR TITLE
Additional Audio decoders

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,6 +39,8 @@ libeasyrpg_player_la_SOURCES = \
 	src/decoder_mpg123.h \
 	src/decoder_fmmidi.cpp \
 	src/decoder_fmmidi.h \
+	src/decoder_wildmidi.cpp \
+	src/decoder_wildmidi.h \
 	src/default_graphics.h \
 	src/dirent_win.h \
 	src/docmain.h \
@@ -325,6 +327,7 @@ libeasyrpg_player_la_CXXFLAGS = \
 	$(PNG_CFLAGS) \
 	$(ZLIB_CFLAGS) \
 	$(MPG123_CFLAGS) \
+	$(WILDMIDI_CFLAGS) \
 	$(SNDFILE_CFLAGS) \
 	$(SPEEXDSP_CFLAGS)
 libeasyrpg_player_la_LIBADD = \
@@ -337,6 +340,7 @@ libeasyrpg_player_la_LIBADD = \
 	$(PNG_LIBS) \
 	$(ZLIB_LIBS) \
 	$(MPG123_LIBS) \
+	$(WILDMIDI_LIBS) \
 	$(SNDFILE_LIBS) \
 	$(SPEEXDSP_LIBS)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,8 @@ libeasyrpg_player_la_SOURCES = \
 	src/color.h \
 	src/decoder_libsndfile.cpp \
 	src/decoder_libsndfile.h \
+	src/decoder_oggvorbis.cpp \
+	src/decoder_oggvorbis.h \
 	src/decoder_mpg123.cpp \
 	src/decoder_mpg123.h \
 	src/decoder_fmmidi.cpp \
@@ -328,6 +330,7 @@ libeasyrpg_player_la_CXXFLAGS = \
 	$(ZLIB_CFLAGS) \
 	$(MPG123_CFLAGS) \
 	$(WILDMIDI_CFLAGS) \
+	$(OGGVORBIS_CFLAGS) \
 	$(SNDFILE_CFLAGS) \
 	$(SPEEXDSP_CFLAGS)
 libeasyrpg_player_la_LIBADD = \
@@ -341,6 +344,7 @@ libeasyrpg_player_la_LIBADD = \
 	$(ZLIB_LIBS) \
 	$(MPG123_LIBS) \
 	$(WILDMIDI_LIBS) \
+	$(OGGVORBIS_LIBS) \
 	$(SNDFILE_LIBS) \
 	$(SPEEXDSP_LIBS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,19 @@ AC_ARG_WITH([libmpg123],[AS_HELP_STRING([--without-libmpg123],
 AS_IF([test "x$with_libmpg123" != "xno"],[
 	PKG_CHECK_MODULES([MPG123],[libmpg123],[AC_DEFINE(HAVE_MPG123,[1],[Disable improved MP3 support provided by libmpg123])],[auto_mpg123=0])
 ])
+# wildmidi has no pkg-config support (yet), this aims to make the same features available
+AC_ARG_VAR([WILDMIDI_CFLAGS], [C compiler flags for WILDMIDI])
+AC_ARG_VAR([WILDMIDI_LIBS], [linker flags for WILDMIDI])
+AC_ARG_WITH([libwildmidi],[AS_HELP_STRING([--with-libwildmidi],
+	[Enable Midi support provided by libwildmidi. @<:@default=no@:>@])])
+AS_IF([test "x$with_libwildmidi" = "xyes"],[
+	AS_IF([test -z "$WILDMIDI_CFLAGS" -a -z "$WILDMIDI_LIBS"],[
+		AC_CHECK_LIB([WildMidi],[WildMidi_Init],[AC_DEFINE(HAVE_WILDMIDI,[1],[Enable Midi support provided by libwildmidi]) WILDMIDI_LIBS=[-lWildMidi]],[auto_wildmidi=0])
+	],[
+		AC_MSG_CHECKING([for WILDMIDI])
+		AC_MSG_RESULT([assuming yes])
+	])
+])
 AC_ARG_WITH([libsndfile],[AS_HELP_STRING([--without-libsndfile],
 	[Disable improved WAV support provided by libsndfile.  @<:@default=auto@:>@])])
 AS_IF([test "x$with_libsndfile" != "xno"],[

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,11 @@ AS_IF([test "x$with_libwildmidi" = "xyes"],[
 		AC_MSG_RESULT([assuming yes])
 	])
 ])
+AC_ARG_WITH([oggvorbis],[AS_HELP_STRING([--without-oggvorbis],
+	[Disable Ogg Vorbis support @<:@default=auto@:>@])])
+AS_IF([test "x$with_oggvorbis" != "xno"],[
+	PKG_CHECK_MODULES([OGGVORBIS],[vorbisfile],[AC_DEFINE(HAVE_OGGVORBIS,[1],[Enable Ogg Vorbis support])],[auto_oggvorbis=0])
+])
 AC_ARG_WITH([libsndfile],[AS_HELP_STRING([--without-libsndfile],
 	[Disable improved WAV support provided by libsndfile.  @<:@default=auto@:>@])])
 AS_IF([test "x$with_libsndfile" != "xno"],[

--- a/src/audio_decoder.cpp
+++ b/src/audio_decoder.cpp
@@ -21,36 +21,18 @@
 #include "audio_decoder.h"
 #include "filefinder.h"
 #include "output.h"
-
 #include "system.h"
 
-#ifdef WANT_FMMIDI
 #include "decoder_fmmidi.h"
-#endif
-
-#ifdef HAVE_MPG123
 #include "decoder_mpg123.h"
-#endif
-
-#if defined(HAVE_TREMOR) || defined(HAVE_OGGVORBIS)
 #include "decoder_oggvorbis.h"
-#endif
-
-#ifdef HAVE_WILDMIDI
 #include "decoder_wildmidi.h"
-#endif
-
-#ifdef HAVE_LIBSNDFILE
 #include "decoder_libsndfile.h"
-#endif
-
-#ifdef USE_AUDIO_RESAMPLER
 #include "audio_resampler.h"
-#endif
 
 void AudioDecoder::Pause() {
 	paused = true;
- }
+}
 
 void AudioDecoder::Resume() {
 	paused = false;

--- a/src/audio_decoder.cpp
+++ b/src/audio_decoder.cpp
@@ -32,6 +32,10 @@
 #include "decoder_mpg123.h"
 #endif
 
+#if defined(HAVE_TREMOR) || defined(HAVE_OGGVORBIS)
+#include "decoder_oggvorbis.h"
+#endif
+
 #ifdef HAVE_WILDMIDI
 #include "decoder_wildmidi.h"
 #endif
@@ -154,6 +158,16 @@ std::unique_ptr<AudioDecoder> AudioDecoder::Create(FILE* file, const std::string
 	}
 
 	// Prevent false positives by checking for common headers
+	if (!strncmp(magic, "OggS", 4)) { // OGG
+#if defined(HAVE_TREMOR) || defined(HAVE_OGGVORBIS)
+#  ifdef USE_AUDIO_RESAMPLER
+		return std::unique_ptr<AudioDecoder>(new AudioResampler(new OggVorbisDecoder()));
+#  else
+		return std::unique_ptr<AudioDecoder>(new OggVorbisDecoder());
+#  endif
+#endif
+	}
+
 	if (!strncmp(magic, "RIFF", 4) || // WAV
 		!strncmp(magic, "FORM", 4) || // WAV AIFF
 		!strncmp(magic, "OggS", 4) || // OGG

--- a/src/audio_decoder.cpp
+++ b/src/audio_decoder.cpp
@@ -273,6 +273,10 @@ int AudioDecoder::GetLoopCount() const {
 	return loop_count;
 }
 
+bool AudioDecoder::WasInited() const {
+	return true;
+}
+
 std::string AudioDecoder::GetError() const {
 	return error_message;
 }

--- a/src/audio_decoder.h
+++ b/src/audio_decoder.h
@@ -15,8 +15,8 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _EASYRPG_AUDIO_DECODER_H_
-#define _EASYRPG_AUDIO_DECODER_H_
+#ifndef EASYRPG_AUDIO_DECODER_H
+#define EASYRPG_AUDIO_DECODER_H
 
 // Headers
 #include <cstdio>

--- a/src/audio_decoder.h
+++ b/src/audio_decoder.h
@@ -173,6 +173,14 @@ public:
 	int GetLoopCount() const;
 
 	/**
+	 * Gets the status of the newly created audio decoder.
+	 * Used to make sure the underlying library is properly initialized.
+	 *
+	 * @return true if initializing was succesful, false otherwise
+	 */
+	virtual bool WasInited() const;
+
+	/**
 	 * Provides an error message when Open or a Decode function fail.
 	 *
 	 * @return Human readable error message

--- a/src/audio_resampler.cpp
+++ b/src/audio_resampler.cpp
@@ -229,6 +229,10 @@ AudioResampler::~AudioResampler() {
 	}
 }
 
+bool AudioResampler::WasInited() const {
+	return wrapped_decoder->WasInited();
+}
+
 bool AudioResampler::Open(FILE* file) {
 	if (wrapped_decoder->Open(file)) {
 		wrapped_decoder->GetFormat(input_rate, input_format, nr_of_channels);

--- a/src/audio_resampler.cpp
+++ b/src/audio_resampler.cpp
@@ -49,8 +49,7 @@ inline static int DecodeAndConvertFloat(AudioDecoder * wrapped_decoder,
 	int amount_of_samples_read = wrapped_decoder->Decode(buffer, amount_of_samples_to_read*input_samplesize);
 	if (amount_of_samples_read <= 0) {
 		return amount_of_samples_read; //error occured - or nothing read
-	}
-	else {
+	} else {
 		amount_of_samples_read /= input_samplesize;
 	}
 	//Convert the read data (amount_of_data_read is at least one at this moment)
@@ -99,7 +98,6 @@ inline static int DecodeAndConvertFloat(AudioDecoder * wrapped_decoder,
 }
 
 #if defined(HAVE_LIBSPEEXDSP)
-
 /**
  * Utility function used to convert a buffer of a arbitrary AudioDecoder::Format to a int16 buffer
  * 
@@ -123,8 +121,7 @@ inline static int DecodeAndConvertInt16(AudioDecoder * wrapped_decoder,
 	int amount_of_samples_read = wrapped_decoder->Decode(buffer, amount_of_samples_to_read*input_samplesize);
 	if (amount_of_samples_read <= 0) {
 		return amount_of_samples_read; //error occured - or nothing read
-	}
-	else {
+	} else {
 		//Convert the number of bytes to the number of samples
 		amount_of_samples_read /= input_samplesize;
 	}
@@ -266,8 +263,7 @@ bool AudioResampler::Open(FILE* file) {
 		conversion_data.input_frames_used = 0;
 		finished = false;
 		return conversion_state != 0;
-	}
-	else {
+	} else {
 		return false;
 	}
 }
@@ -325,8 +321,7 @@ bool AudioResampler::SetFormat(int freq, AudioDecoder::Format fmt, int channels)
 int AudioResampler::GetPitch() const {
 	if (pitch_handled_by_decoder) {
 		return wrapped_decoder->GetPitch();
-	}
-	else {
+	} else {
 		return pitch;
 	}
 }
@@ -334,8 +329,7 @@ int AudioResampler::GetPitch() const {
 bool AudioResampler::SetPitch(int pitch_) {
 	if (pitch_handled_by_decoder) {
 		return wrapped_decoder->SetPitch(pitch_);
-	}
-	else {
+	} else {
 		pitch = pitch_;
 		return true;
 	}
@@ -346,13 +340,11 @@ int AudioResampler::FillBuffer(uint8_t* buffer, int length) {
 	if((input_rate == output_rate) && ((pitch == STANDARD_PITCH) || pitch_handled_by_decoder)) {
 		//Do only format conversion
 		amount_filled = FillBufferSameRate(buffer, length);
-	}
-	else {
+	} else {
 		if (conversion_state == 0) {
 			error_message = "internal error: state pointer is a nullptr";
 			amount_filled = ERROR;
-		}
-		else {
+		} else {
 			//Do samplerate conversion
 			amount_filled = FillBufferDifferentRate(buffer, length);
 		}
@@ -415,8 +407,7 @@ int AudioResampler::FillBufferSameRate(uint8_t* buffer, int length) {
 			}
 
 		}
-	}
-	else {
+	} else {
 		//It is possible to work inplace as length is specified for the output samplesize.
 		switch (output_format) {
 			case AudioDecoder::Format::F32: 
@@ -431,13 +422,11 @@ int AudioResampler::FillBufferSameRate(uint8_t* buffer, int length) {
 		}
 	}
 
-
 	finished = wrapped_decoder->IsFinished();
 	if (decoded < 0) {
 		error_message = wrapped_decoder->GetError();
 		return decoded;
-	}
-	else {
+	} else {
 		return decoded*output_samplesize;
 	}
 }

--- a/src/audio_resampler.h
+++ b/src/audio_resampler.h
@@ -15,9 +15,8 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _EASYRPG_AUDIO_RESAMPLER_H_
-#define _EASYRPG_AUDIO_RESAMPLER_H_
-#if defined(HAVE_LIBSPEEXDSP) || defined(HAVE_LIBSAMPLERATE) 
+#ifndef EASYRPG_AUDIO_RESAMPLER_H
+#define EASYRPG_AUDIO_RESAMPLER_H
 
 // Headers
 #include "audio_decoder.h"
@@ -26,7 +25,7 @@
 
 #if defined(HAVE_LIBSPEEXDSP)
 #include <speex/speex_resampler.h>
-#elif  defined(HAVE_LIBSAMPLERATE)
+#elif defined(HAVE_LIBSAMPLERATE)
 #include <samplerate.h>
 #endif
 
@@ -36,7 +35,6 @@
  */
 class AudioResampler : public AudioDecoder {
 public:
-
 	/** Resampling quality */
 	enum class Quality {
 		High,
@@ -51,7 +49,7 @@ public:
 	 * @param[in] pitch_handled Defines whether the decoder handles pitch changes by itself or not. 
 	 * @param[in] quality Sets the quality rting of the resampler - higher quality implies slower filtering
 	 */
-	AudioResampler(AudioDecoder * decoder, bool pitch_handled=false,  Quality quality=Quality::Medium);
+	AudioResampler(AudioDecoder * decoder, bool pitch_handled=false, Quality quality=Quality::Medium);
 	
 	/**
 	 * Destroys the resampler as well as its owned ressources
@@ -164,6 +162,7 @@ private:
 	 * Internally used by the FillBuffer function if the output rate equals the input rate
 	 */
 	int FillBufferSameRate(uint8_t* buffer, int length);
+
 	/**
 	 * Internally used by the FillBuffer function if resampling is necessary
 	 */
@@ -200,7 +199,6 @@ private:
 	 * (In the cpp file sizeof is used therefore it can be adjusted to fit the available memory)
 	 */
 	uint8_t internal_buffer[256*sizeof(float)];
-
 };
-#endif
+
 #endif

--- a/src/audio_resampler.h
+++ b/src/audio_resampler.h
@@ -59,6 +59,14 @@ public:
 	~AudioResampler();
 
 	/**
+	 * Wraps the status querying of the contained decoder.
+	 * Used to make sure the underlying library is properly initialized.
+	 *
+	 * @return true if initializing was succesful, false otherwise
+	 */
+	bool WasInited() const;
+
+	/**
 	 * Wraps the opening function of the contained decoder
 	 * 
 	 * @param[in] file Filepointer to a file readable by the wrapped decoder

--- a/src/decoder_fmmidi.h
+++ b/src/decoder_fmmidi.h
@@ -15,8 +15,8 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _EASYRPG_AUDIO_DECODER_FMMIDI_H_
-#define _EASYRPG_AUDIO_DECODER_FMMIDI_H_
+#ifndef EASYRPG_AUDIO_DECODER_FMMIDI_H
+#define EASYRPG_AUDIO_DECODER_FMMIDI_H
 
 // Headers
 #include <string>

--- a/src/decoder_libsndfile.cpp
+++ b/src/decoder_libsndfile.cpp
@@ -25,13 +25,12 @@
 #include "decoder_libsndfile.h"
 #include "output.h"
 
-
 static sf_count_t sf_vio_get_filelen_impl(void* userdata) {
 	FILE* f = reinterpret_cast<FILE*>(userdata);
 	int fd=fileno(f); //Posix complient - should work on windows as well
 	struct stat stat_buf;
 	int rc = fstat(fd, &stat_buf);
-    return rc == 0 ? stat_buf.st_size : 0;
+	return rc == 0 ? stat_buf.st_size : 0;
 }
 
 static sf_count_t sf_vio_read_impl(void *ptr, sf_count_t count, void* userdata){
@@ -55,14 +54,13 @@ static sf_count_t sf_vio_tell_impl(void* userdata){
 	return ftell(f);
 }
 
-static  SF_VIRTUAL_IO vio = {
+static SF_VIRTUAL_IO vio = {
 	sf_vio_get_filelen_impl,
 	sf_vio_seek_impl,
 	sf_vio_read_impl,
 	sf_vio_write_impl,
 	sf_vio_tell_impl
 }; 
-
 
 LibsndfileDecoder::LibsndfileDecoder() 
 {
@@ -71,7 +69,7 @@ LibsndfileDecoder::LibsndfileDecoder()
 }
 
 LibsndfileDecoder::~LibsndfileDecoder() {
-	if(soundfile!=0){
+	if(soundfile != 0){
 		sf_close(soundfile);
 		fclose(file_);
 	}
@@ -88,7 +86,8 @@ bool LibsndfileDecoder::Open(FILE* file) {
 
 bool LibsndfileDecoder::Seek(size_t offset, Origin origin) {
 	finished = false;
-	if(soundfile==0) return false;
+	if(soundfile == 0)
+		return false;
 	return sf_seek(soundfile,offset,SEEK_SET)!=-1;
 }
 
@@ -105,7 +104,9 @@ void LibsndfileDecoder::GetFormat(int& frequency, AudioDecoder::Format& format, 
 }
 
 bool LibsndfileDecoder::SetFormat(int freq, AudioDecoder::Format fmt, int channels) {
-	if(soundfile==0) return false;
+	if(soundfile == 0)
+		return false;
+
 	switch(fmt){
 		case Format::F32:
 		case Format::S16:
@@ -118,29 +119,33 @@ bool LibsndfileDecoder::SetFormat(int freq, AudioDecoder::Format fmt, int channe
 	return soundinfo.samplerate==freq && soundinfo.channels==channels && output_format==fmt;
 }
 
-
 int LibsndfileDecoder::FillBuffer(uint8_t* buffer, int length) {
-	if(soundfile==0) return -1;
+	if(soundfile == 0)
+		return -1;
+
 	int decoded;
 	switch(output_format){
 		case Format::F32:
 			{
 				decoded=sf_read_float(soundfile,(float*)buffer,length/sizeof(float));
-				if(!decoded) finished=true;
+				if(!decoded)
+					finished=true;
 				decoded*=sizeof(float);
 			}
 			break;
 		case Format::S16:
 			{
 				decoded=sf_read_short(soundfile,(int16_t*)buffer,length/sizeof(int16_t));
-				if(!decoded) finished=true;
+				if(!decoded)
+					finished=true;
 				decoded*=sizeof(int16_t);
 			}
 			break;
 		case Format::S32:
 			{
 				decoded=sf_read_int(soundfile,(int32_t*)buffer,length/sizeof(int32_t));
-				if(!decoded) finished=true;
+				if(!decoded)
+					finished=true;
 				decoded*=sizeof(int32_t);
 			}
 			break;

--- a/src/decoder_libsndfile.h
+++ b/src/decoder_libsndfile.h
@@ -15,13 +15,15 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _EASYRPG_AUDIO_DECODER_LIBSNDFILE_H_
-#define _EASYRPG_AUDIO_DECODER_LIBSNDFILE_H_
-#ifdef HAVE_LIBSNDFILE
+#ifndef EASYRPG_AUDIO_DECODER_LIBSNDFILE_H
+#define EASYRPG_AUDIO_DECODER_LIBSNDFILE_H
+
 // Headers
 #include "audio_decoder.h"
 #include <string>
+#ifdef HAVE_LIBSNDFILE
 #include <sndfile.h>
+#endif
 #include <memory>
 
 /**
@@ -48,9 +50,10 @@ private:
 	Format output_format;
 	FILE * file_;
 	bool finished;
-
+#ifdef HAVE_LIBSNDFILE
 	SNDFILE *soundfile;
 	SF_INFO soundinfo;
-};
 #endif
+};
+
 #endif

--- a/src/decoder_mpg123.cpp
+++ b/src/decoder_mpg123.cpp
@@ -67,6 +67,10 @@ Mpg123Decoder::Mpg123Decoder() :
 Mpg123Decoder::~Mpg123Decoder() {
 }
 
+bool Mpg123Decoder::WasInited() const {
+	return init;
+}
+
 bool Mpg123Decoder::Open(FILE* file) {
 	if (!init) {
 		return false;

--- a/src/decoder_mpg123.h
+++ b/src/decoder_mpg123.h
@@ -15,13 +15,15 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _EASYRPG_AUDIO_DECODER_MPG123_H_
-#define _EASYRPG_AUDIO_DECODER_MPG123_H_
+#ifndef EASYRPG_AUDIO_DECODER_MPG123_H
+#define EASYRPG_AUDIO_DECODER_MPG123_H
 
 // Headers
 #include "audio_decoder.h"
 #include <string>
+#ifdef HAVE_MPG123
 #include <mpg123.h>
+#endif
 #include <memory>
 
 /**
@@ -49,7 +51,9 @@ public:
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 
+#ifdef HAVE_MPG123
 	std::unique_ptr<mpg123_handle, decltype(&mpg123_delete)> handle;
+#endif
 	FILE* file_handle;
 	int err = 0;
 	bool finished = false;

--- a/src/decoder_mpg123.h
+++ b/src/decoder_mpg123.h
@@ -33,6 +33,8 @@ public:
 
 	~Mpg123Decoder();
 
+	bool WasInited() const override;
+
 	bool Open(FILE* file) override;
 
 	bool Seek(size_t offset, Origin origin) override;

--- a/src/decoder_oggvorbis.cpp
+++ b/src/decoder_oggvorbis.cpp
@@ -1,0 +1,150 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "system.h"
+
+#if defined(HAVE_TREMOR) || defined(HAVE_OGGVORBIS)
+
+// Headers
+#include <cassert>
+#ifdef HAVE_TREMOR
+#include <tremor/ivorbiscodec.h>
+#include <tremor/ivorbisfile.h>
+#else
+#include <vorbis/codec.h>
+#include <vorbis/vorbisfile.h>
+#endif
+#include "audio_decoder.h"
+#include "output.h"
+#include "decoder_oggvorbis.h"
+
+OggVorbisDecoder::OggVorbisDecoder() {
+	music_type = "ogg";
+}
+
+OggVorbisDecoder::~OggVorbisDecoder() {
+	if (ovf) {
+		ov_clear(ovf);
+		delete ovf;
+	}
+}
+
+bool OggVorbisDecoder::Open(FILE* file) {
+	finished = false;
+
+	if (ovf) {
+		ov_clear(ovf);
+		delete ovf;
+	}
+	ovf = new OggVorbis_File;
+
+	int res = ov_open(file, ovf, NULL, 0);
+	if (res < 0) {
+		error_message = "OggVorbis: Error reading file";
+		delete ovf;
+		fclose(file);
+		return false;
+	}
+
+	vorbis_info *vi = ov_info(ovf, -1);
+	if (!vi) {
+		error_message = "OggVorbis: Error getting file information";
+		ov_clear(ovf);
+		delete ovf;
+		return false;
+	}
+
+	// (long)ov_pcm_total(ovf, -1)) -> decoded length in samples, maybe useful for ticks later?
+	frequency = vi->rate;
+	channels = vi->channels;
+
+	return true;
+}
+
+bool OggVorbisDecoder::Seek(size_t offset, Origin origin) {
+	if (offset == 0 && origin == Origin::Begin) {
+		if (ovf) {
+			ov_raw_seek(ovf, 0);
+		}
+		finished = false;
+		return true;
+	}
+
+	return false;
+}
+
+bool OggVorbisDecoder::IsFinished() const {
+	if (!ovf)
+		return false;
+
+	return finished;
+}
+
+void OggVorbisDecoder::GetFormat(int& freq, AudioDecoder::Format& format, int& chans) const {
+	freq = frequency;
+	format = Format::S16;
+	chans = channels;
+}
+
+bool OggVorbisDecoder::SetFormat(int freq, AudioDecoder::Format format, int chans) {
+	if (freq != frequency || chans != channels || format != Format::S16)
+		return false;
+
+	return true;
+}
+
+bool OggVorbisDecoder::SetPitch(int pitch) {
+	if (pitch != 100) {
+		return false;
+	}
+
+	return true;
+}
+
+int OggVorbisDecoder::FillBuffer(uint8_t* buffer, int length) {
+	if (!ovf)
+		return -1;
+
+	static int section;
+	int read = 0;
+	int to_read = length;
+
+	do {
+#ifdef HAVE_TREMOR
+		read = ov_read(ovf, reinterpret_cast<char*>(buffer + length - to_read), to_read, &section);
+#else
+		read = ov_read(ovf, reinterpret_cast<char*>(buffer + length - to_read), to_read, 0/*LE*/, 2/*16bit*/, 1/*signed*/, &section);
+#endif
+		// stop decoding when error or end of file
+		if (read <= 0)
+			break;
+
+		to_read -= read;
+	} while(to_read > 0);
+
+	// end of file
+	if (read == 0)
+		finished = true;
+
+	// error
+	if (read < 0)
+		return -1;
+
+	return length - to_read;
+}
+
+#endif

--- a/src/decoder_oggvorbis.h
+++ b/src/decoder_oggvorbis.h
@@ -1,0 +1,65 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EASYRPG_AUDIO_DECODER_OGGVORBIS_H
+#define EASYRPG_AUDIO_DECODER_OGGVORBIS_H
+
+// Headers
+#include <string>
+#include <memory>
+#ifdef HAVE_TREMOR
+#include <tremor/ivorbiscodec.h>
+#include <tremor/ivorbisfile.h>
+#elif HAVE_OGGVORBIS
+#include <vorbis/codec.h>
+#include <vorbis/vorbisfile.h>
+#endif
+#include "audio_decoder.h"
+
+/**
+ * Audio decoder for Ogg Vorbis powered by libTremor/libOgg+libVorbis
+ */
+class OggVorbisDecoder : public AudioDecoder {
+public:
+	OggVorbisDecoder();
+
+	~OggVorbisDecoder();
+
+	// Audio Decoder interface
+	bool Open(FILE* file) override;
+
+	bool Seek(size_t offset, Origin origin) override;
+
+	bool IsFinished() const override;
+
+	void GetFormat(int& frequency, AudioDecoder::Format& format, int& channels) const override;
+
+	bool SetFormat(int frequency, AudioDecoder::Format format, int channels) override;
+
+	bool SetPitch(int pitch) override;
+private:
+	int FillBuffer(uint8_t* buffer, int length) override;
+
+#if defined(HAVE_TREMOR) || defined(HAVE_OGGVORBIS)
+	OggVorbis_File *ovf = NULL;
+#endif
+	bool finished = false;
+	int frequency = 44100;
+	int channels = 2;
+};
+
+#endif

--- a/src/decoder_wildmidi.cpp
+++ b/src/decoder_wildmidi.cpp
@@ -42,6 +42,10 @@ WildMidiDecoder::~WildMidiDecoder() {
 		WildMidi_Shutdown();
 }
 
+bool WildMidiDecoder::WasInited() const {
+	return init;
+}
+
 bool WildMidiDecoder::Open(FILE* file) {
 	if (!init)
 		return false;

--- a/src/decoder_wildmidi.cpp
+++ b/src/decoder_wildmidi.cpp
@@ -1,0 +1,109 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "system.h"
+
+#ifdef HAVE_WILDMIDI
+
+// Headers
+#include <cassert>
+#include <wildmidi_lib.h>
+#include "audio_decoder.h"
+#include "output.h"
+#include "decoder_wildmidi.h"
+
+WildMidiDecoder::WildMidiDecoder(const std::string file_name) {
+	music_type = "midi";
+	filename = file_name;
+
+	init = (WildMidi_Init("wildmidi.cfg", frequency, WM_MO_REVERB|WM_MO_ENHANCED_RESAMPLING) == 0);
+	if (!init)
+		error_message = "Could not initialize libWildMidi";
+}
+
+WildMidiDecoder::~WildMidiDecoder() {
+	if (handle)
+		WildMidi_Close(handle);
+	if (init)
+		WildMidi_Shutdown();
+}
+
+bool WildMidiDecoder::Open(FILE* file) {
+	if (!init)
+		return false;
+
+	fclose(file);
+
+	handle = WildMidi_Open(filename.c_str());
+	if (!handle) {
+		error_message = "WildMidi: Error reading file";
+		return false;
+	}
+
+	return true;
+}
+
+bool WildMidiDecoder::Seek(size_t offset, Origin origin) {
+	if (offset == 0 && origin == Origin::Begin) {
+		if (handle) {
+			unsigned long int pos = 0;
+			WildMidi_FastSeek(handle, &pos);
+		}
+		return true;
+	}
+
+	return false;
+}
+
+bool WildMidiDecoder::IsFinished() const {
+	if (!handle)
+		return false;
+
+	struct _WM_Info* midi_info = WildMidi_GetInfo(handle);
+
+	return midi_info->current_sample >= midi_info->approx_total_samples;
+}
+
+void WildMidiDecoder::GetFormat(int& freq, AudioDecoder::Format& format, int& channels) const {
+	freq = frequency;
+	format = Format::S16;
+	channels = 2;
+}
+
+bool WildMidiDecoder::SetFormat(int freq, AudioDecoder::Format format, int channels) {
+	if (freq != frequency || channels != 2 || format != Format::S16)
+		return false;
+
+	return true;
+}
+
+bool WildMidiDecoder::SetPitch(int pitch) {
+	if (pitch != 100) {
+		return false;
+	}
+
+	return true;
+}
+
+int WildMidiDecoder::FillBuffer(uint8_t* buffer, int length) {
+	if (!handle)
+		return -1;
+
+	return WildMidi_GetOutput(handle, reinterpret_cast<char*>(buffer), length);
+}
+
+#endif

--- a/src/decoder_wildmidi.h
+++ b/src/decoder_wildmidi.h
@@ -35,6 +35,8 @@ public:
 
 	~WildMidiDecoder();
 
+	bool WasInited() const override;
+
 	// Audio Decoder interface
 	bool Open(FILE* file) override;
 

--- a/src/decoder_wildmidi.h
+++ b/src/decoder_wildmidi.h
@@ -1,0 +1,61 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EASYRPG_AUDIO_DECODER_WILDMIDI_H
+#define EASYRPG_AUDIO_DECODER_WILDMIDI_H
+
+// Headers
+#include <string>
+#include <memory>
+#ifdef HAVE_WILDMIDI
+#include <wildmidi_lib.h>
+#endif
+#include "audio_decoder.h"
+
+/**
+ * Audio decoder for MIDI powered by WildMidi
+ */
+class WildMidiDecoder : public AudioDecoder {
+public:
+	WildMidiDecoder(const std::string file_name);
+
+	~WildMidiDecoder();
+
+	// Audio Decoder interface
+	bool Open(FILE* file) override;
+
+	bool Seek(size_t offset, Origin origin) override;
+
+	bool IsFinished() const override;
+
+	void GetFormat(int& frequency, AudioDecoder::Format& format, int& channels) const override;
+
+	bool SetFormat(int frequency, AudioDecoder::Format format, int channels) override;
+
+	bool SetPitch(int pitch) override;
+private:
+	int FillBuffer(uint8_t* buffer, int length) override;
+
+	std::string filename;
+	bool init = false;
+	int frequency = 44100;
+#ifdef HAVE_WILDMIDI
+	midi* handle = NULL;
+#endif
+};
+
+#endif


### PR DESCRIPTION
What this does in detail:
- adds another decoder for midi (based on libwildmidi)
  - sounds mostly like timidity from `sdl_mixer`, but supports pitch changes through our `audio_resampler`
  - disabled by default (needs additional magic to find configuration file)
- adds an ogg vorbis decoder (based on either libtremor or libogg, libvorbis and libvorbisfile)
- can use fallback decoders, when initializing a library fails
  - currently only works for mpg123 and wildmidi
  - ogg can be played by `libsndfile` if the oggvorbis decoder is unavailable
  - mp3 will be played by `sdl_mixer` (if smpeg/libmad is available), if mpg123 fails
- reworked the other `audio_decoder`s a bit to fix some coding style and hide all internal structures.