### PR TITLE
Fix regression when original_index = 0

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -266,6 +266,9 @@ void Game_Character::MoveTypeCustom() {
 					looped_around = true;
 					active_route_index = 0;
 					SetMoveRouteRepeated(true);
+					if (original_index == 0) {
+						break;
+					}
 				} else {
 					break;
 				}


### PR DESCRIPTION
Fixes the regression in 葬 (and probably many others :) from #913.

(Sorry!)