### PR TITLE
Fix #928

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -186,7 +186,7 @@ void Game_Character::Update() {
 			anime_count++;
 	} else {
 		stop_count++;
-		if (IsSpinning() || IsContinuous() || pattern != original_pattern)
+		if ((walk_animation && (IsSpinning() || IsContinuous())) || pattern != original_pattern)
 			anime_count++;
 	}
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -930,6 +930,10 @@ void Game_Map::UpdateEncounterSteps() {
 			return;
 	}
 
+	if(Main_Data::game_player->InAirship()) {
+		return;
+	}
+
 	int x = Main_Data::game_player->GetX();
 	int y = Main_Data::game_player->GetY();
 	int terrain_id = GetTerrainTag(x, y);

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -398,6 +398,7 @@ bool Game_Vehicle::CanLand() const {
 
 void Game_Vehicle::Update() {
 	Game_Character::Update();
+	SyncWithPlayer();
 
 	if (type == Airship) {
 		if (IsAscending()) {

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -389,6 +389,8 @@ bool Game_Vehicle::CanLand() const {
 	Game_Map::GetEventsXY(events, GetX(), GetY());
 	if (!events.empty())
 		return false;
+	if (!Game_Map::IsLandable(GetX(), GetY(), nullptr))
+		return false;
 	if (Game_Map::GetVehicle(Ship)->IsInPosition(GetX(), GetY()))
 		return false;
 	if (Game_Map::GetVehicle(Boat)->IsInPosition(GetX(), GetY()))


### PR DESCRIPTION
* The flickering motion was caused by a double update. `remaining_steps` got updated by the player, the player synced the airship, and then the airship updated `remaining_steps` again. When the vehicle moves fast enough, this made a visible difference during motion. Fixed with a second sync.
* In  	6768eba, I'm not sure if the brackets should go around `pattern != original_pattern` or not. When does that case occur?