### PR TITLE
3DS: Fix for random audio corruption with libTremor

### DIFF
--- a/src/3ds_decoder.cpp
+++ b/src/3ds_decoder.cpp
@@ -61,7 +61,7 @@ int DecodeOgg(FILE* stream, DecodedSound* Sound){
 	Sound->samplerate = my_info->rate;
 	Sound->format = CSND_ENCODING_PCM16;
 	u16 audiotype = my_info->channels;
-	Sound->audiobuf_size = ov_pcm_total(vf,-1)<<audiotype;
+	Sound->audiobuf_size = ov_time_total(vf,-1) * (my_info->rate<<1);
 	if (audiotype == 2) Sound->isStereo = true;
 	else Sound->isStereo = false;
 	Sound->bytepersample = audiotype<<1;
@@ -498,7 +498,7 @@ int OpenOgg(FILE* stream, DecodedMusic* Sound){
 	Sound->samplerate = my_info->rate;
 	Sound->format = CSND_ENCODING_PCM16;
 	u16 audiotype = my_info->channels;
-	Sound->audiobuf_size = ov_pcm_total(vf,-1)<<audiotype;
+	Sound->audiobuf_size = ov_time_total(vf,-1) * (my_info->rate<<1);
 	if (audiotype == 2) Sound->isStereo = true;
 	else Sound->isStereo = false;
 	Sound->bytepersample = audiotype<<1;


### PR DESCRIPTION
Seems like ov_pcm_total is not reliable for audio size calculation. I noticed during lpp-3ds developing that it can cause major issues leading to wrong audio size as output (bigger then it should, leading to random audio garbage being reproduced by the audio device). This commit is a little temporary fix which is less accurated (some samples will be probably dropped in some ogg files) but which is confirmed to work as intended.