### PR TITLE
Add Debug option to Scene Menu (TestPlay only)

### DIFF
--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -27,6 +27,8 @@
 #include "game_map.h"
 #include "game_system.h"
 #include "scene_debug.h"
+#include "scene_load.h"
+#include "scene_save.h"
 #include "player.h"
 #include "window_command.h"
 #include "window_varlist.h"
@@ -38,7 +40,7 @@ Scene_Debug::Scene_Debug() {
 }
 
 void Scene_Debug::Start() {
-	current_var_type = TypeSwitch;
+	current_var_type = TypeGeneral;
 	range_index = 0;
 	range_page = 0;
 	CreateRangeWindow();
@@ -78,8 +80,22 @@ void Scene_Debug::Update() {
 	} else if (Input::IsTriggered(Input::DECISION)) {
 		var_window->Refresh();
 		if (range_window->GetActive()) {
-			range_window->SetActive(false);
-			var_window->SetActive(true);
+			if (current_var_type == TypeGeneral) {
+				switch (range_window->GetIndex()) {
+					case 0:
+						Scene::PopUntil(Scene::Map);
+						Scene::Push(std::make_shared<Scene_Save>());
+						break;
+					case 1:
+						Scene::Push(std::make_shared<Scene_Load>());
+						break;
+					default:
+						break;
+				}
+			} else {
+				range_window->SetActive(false);
+				var_window->SetActive(true);
+			}
 		} else if (var_window->GetActive()) {
 			if (current_var_type == TypeSwitch && Game_Switches.IsValid(GetIndex()))
 				Game_Switches[GetIndex()] = !Game_Switches[GetIndex()];
@@ -99,21 +115,25 @@ void Scene_Debug::Update() {
 		}
 		Game_Map::SetNeedRefresh(Game_Map::Refresh_All);
 	} else if (range_window->GetActive() &&  Input::IsTriggered(Input::RIGHT)) {
-		range_page++;
+		if (current_var_type != TypeGeneral) {
+			range_page++;
+		}
 		if (current_var_type == TypeSwitch && !Game_Switches.IsValid(range_page*100+1)) {
 			range_page = 0;
-			current_var_type = TypeInt;
-			var_window->SetShowSwitch(false);
+			current_var_type++;
 		} else if (current_var_type == TypeInt && !Game_Variables.IsValid(range_page*100+1)) {
 			range_page = 0;
-			current_var_type = TypeSwitch;
-			var_window->SetShowSwitch(true);
+			current_var_type++;
+		} else if (current_var_type == TypeGeneral) {
+			current_var_type = 0;
 		}
 		var_window->UpdateList(range_page * 100 + range_index * 10 + 1);
 		UpdateRangeListWindow();
 		var_window->Refresh();
 	} else if (range_window->GetActive() && Input::IsTriggered(Input::LEFT)) {
-		range_page--;
+		if (current_var_type != TypeGeneral) {
+			range_page--;
+		}
 		if (current_var_type == TypeSwitch && range_page < 0) {
 			range_page = 0;
 			for (;;)
@@ -121,22 +141,30 @@ void Scene_Debug::Update() {
 					range_page++;
 				else
 					break;
-			current_var_type = TypeInt;
-			var_window->SetShowSwitch(false);
+			current_var_type--;
 		} else if (current_var_type == TypeInt && range_page < 0) {
 			range_page = 0;
+			current_var_type = TypeEnd - 1;
+		} else if (current_var_type == TypeGeneral) {
 			for (;;)
 				if (Game_Switches.IsValid(range_page*100 + 101))
 					range_page++;
 				else
 					break;
-			current_var_type = TypeSwitch;
-			var_window->SetShowSwitch(true);
+			current_var_type--;
 		}
 		var_window->UpdateList(range_page * 100 + range_index * 10 + 1);
 		UpdateRangeListWindow();
 		var_window->Refresh();
 	}
+
+	if (current_var_type == TypeSwitch) {
+		var_window->SetShowSwitch(true);
+	} else if (current_var_type == TypeInt) {
+		var_window->SetShowSwitch(false);
+	}
+
+	var_window->SetVisible(current_var_type != TypeGeneral);
 }
 
 void Scene_Debug::CreateRangeWindow() {
@@ -152,6 +180,16 @@ void Scene_Debug::CreateRangeWindow() {
 }
 	
 void Scene_Debug::UpdateRangeListWindow() {
+	if (current_var_type != TypeSwitch &&
+			current_var_type != TypeInt) {
+		range_window->SetItemText(0, "Save");
+		range_window->SetItemText(1, "Load");
+		for (int i = 2; i < 10; i++){
+			range_window->SetItemText(i, "");
+		}
+		return;
+	}
+
 	std::stringstream ss;
 	for (int i = 0; i < 10; i++){
 		ss.str("");
@@ -168,13 +206,14 @@ void Scene_Debug::UpdateRangeListWindow() {
 }
 
 void Scene_Debug::CreateVarListWindow() {
-	
 	std::vector<std::string> vars;
 	for (int i = 0; i < 10; i++)
 		vars.push_back("");
 	var_window.reset(new Window_VarList(vars));
 	var_window->SetX(range_window->GetWidth());
 	var_window->SetY(range_window->GetY());
+	var_window->SetVisible(false);
+
 	var_window->UpdateList(range_page * 100 + range_index * 10 + 1);
 }
 

--- a/src/scene_debug.h
+++ b/src/scene_debug.h
@@ -21,10 +21,9 @@
 // Headers
 #include <vector>
 #include "scene.h"
-
-class Window_Command;
-class Window_VarList;
-class Window_NumberInput;
+#include "window_command.h"
+#include "window_numberinput.h"
+#include "window_varlist.h"
 
 /**
  * Scene Equip class.
@@ -63,12 +62,14 @@ public:
 
 	enum VarType {
 		TypeInt,
-		TypeSwitch
+		TypeSwitch,
+		TypeGeneral,
+		TypeEnd
 	};
 
 private:
 	/** Current variables being displayed (Switches or Integers). */
-	VarType current_var_type;
+	int current_var_type;
 	/** Current Page being displayed */
 	int range_page;
 	/** Current range being displayed. */

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -158,6 +158,17 @@ void Scene_Map::Update() {
 		// Prevent calling when disabled or the main interpreter is running
 		if (Game_System::GetAllowMenu() && !Game_Map::GetInterpreter().IsRunning()) {
 			Game_Temp::menu_calling = true;
+		} else if (Player::debug_flag) {
+			if (Input::IsPressed(Input::SHIFT)) {
+				// Menu can be force called when TestPlay mode is on and cancel is pressed 5 times while holding SHIFT
+				debug_menuoverwrite_counter++;
+				if (debug_menuoverwrite_counter >= 5) {
+					Game_Temp::menu_calling = true;
+					debug_menuoverwrite_counter = 0;
+				}
+			} else {
+				debug_menuoverwrite_counter = 0;
+			}
 		}
 	}
 

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -67,6 +67,7 @@ private:
 	bool from_save;
 	bool auto_transition = false;
 	bool auto_transition_erase = false;
+	int debug_menuoverwrite_counter = 0;
 };
 
 #endif

--- a/src/scene_menu.cpp
+++ b/src/scene_menu.cpp
@@ -143,6 +143,7 @@ void Scene_Menu::CreateCommandWindow() {
 			}
 		case Wait:
 		case Quit:
+		case Debug:
 			break;
 		case Order:
 			if (Main_Data::game_party->GetActors().size() <= 1) {

--- a/src/scene_menu.cpp
+++ b/src/scene_menu.cpp
@@ -26,10 +26,10 @@
 #include "game_temp.h"
 #include "input.h"
 #include "player.h"
+#include "scene_debug.h"
 #include "scene_end.h"
 #include "scene_equip.h"
 #include "scene_item.h"
-#include "scene_map.h"
 #include "scene_skill.h"
 #include "scene_order.h"
 #include "scene_save.h"
@@ -74,16 +74,21 @@ void Scene_Menu::CreateCommandWindow() {
 	std::vector<std::string> options;
 
 	if (Player::IsRPG2k()) {
-		command_options.resize(5);
-		command_options[0] = Item;
-		command_options[1] = Skill;
-		command_options[2] = Equipment;
-		command_options[3] = Save;
-		command_options[4] = Quit;
+		command_options.push_back(Item);
+		command_options.push_back(Skill);
+		command_options.push_back(Equipment);
+		command_options.push_back(Save);
+		if (Player::debug_flag) {
+			command_options.push_back(Debug);
+		}
+		command_options.push_back(Quit);
 	} else {
 		for (std::vector<int16_t>::iterator it = Data::system.menu_commands.begin();
 			it != Data::system.menu_commands.end(); ++it) {
 				command_options.push_back((CommandOptionType)*it);
+		}
+		if (Player::debug_flag) {
+			command_options.push_back(Debug);
 		}
 		command_options.push_back(Quit);
 	}
@@ -115,6 +120,9 @@ void Scene_Menu::CreateCommandWindow() {
 			break;
 		case Wait:
 			options.push_back(Main_Data::game_data.system.atb_mode == RPG::SaveSystem::AtbMode_atb_wait ? Data::terms.wait_on : Data::terms.wait_off);
+			break;
+		case Debug:
+			options.push_back("Debug");
 			break;
 		default:
 			options.push_back(Data::terms.menu_quit);
@@ -200,6 +208,10 @@ void Scene_Menu::UpdateCommand() {
 			Main_Data::game_data.system.atb_mode = !Main_Data::game_data.system.atb_mode;
 			command_window->SetItemText(menu_index,
 				Main_Data::game_data.system.atb_mode == RPG::SaveSystem::AtbMode_atb_wait ? Data::terms.wait_on : Data::terms.wait_off);
+			break;
+		case Debug:
+			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
+			Scene::Push(std::make_shared<Scene_Debug>());
 			break;
 		case Quit:
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));

--- a/src/scene_menu.h
+++ b/src/scene_menu.h
@@ -65,7 +65,9 @@ public:
 		Row,
 		Order,
 		Wait,
-		Quit
+		Quit,
+		// EasyRPG extra
+		Debug = 100
 	};
 
 private:

--- a/src/window_varlist.cpp
+++ b/src/window_varlist.cpp
@@ -78,8 +78,10 @@ void Window_VarList::UpdateList(int first_value){
 }
 
 void Window_VarList::SetShowSwitch(bool _switch) {
-	show_switch = _switch;
-	Refresh();
+	if (show_switch != _switch) {
+		show_switch = _switch;
+		Refresh();
+	}
 }
 
 void Window_VarList::SetActive(bool nactive) {


### PR DESCRIPTION
Related #948 

All applies to TestPlay mode only:

This makes accessing our debug scene easier, when in TestPlay mode a "Debug" item will be shown in the normal menu.

The debug sceen also got 2 new options (besides var and switch editing): Save and Load, they do what the name says (and ignore "save forbidden" setting).

Some games forbid menu calling but don't worry, this can be overriden with "Shift+5x B" (when SHIFT is not pressed anymore the counter is reset).