### PR TITLE
Add support for Inelukis MP3 Patch

### DIFF
--- a/src/audio_decoder.cpp
+++ b/src/audio_decoder.cpp
@@ -205,7 +205,6 @@ std::unique_ptr<AudioDecoder> AudioDecoder::Create(FILE* file, const std::string
 
 		// Parsing MP3s seems to be the only reliable way to detect them
 		if (Mpg123Decoder::IsMp3(file)) {
-			Output::Debug("MP3 heuristic: %s", filename.c_str());
 			fseek(file, 0, SEEK_SET);
 #  ifdef USE_AUDIO_RESAMPLER
 			mp3dec = new AudioResampler(new Mpg123Decoder());

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -266,7 +266,13 @@ std::string FileFinder::MakeCanonical(std::string const& path, int initial_deepn
 }
 
 std::vector<std::string> FileFinder::SplitPath(std::string const& path) {
-	return Utils::Tokenize(path, R"([\\/])");
+	// Tokens are patch delimiters ("/" and encoding aware "\")
+	std::function<bool(char32_t)> f = [](char32_t t) {
+		char32_t escape_char_back = Utils::DecodeUTF32(Player::escape_symbol).front();
+		char32_t escape_char_forward = Utils::DecodeUTF32("/").front();
+		return t == escape_char_back || t == escape_char_forward;
+	};
+	return Utils::Tokenize(path, f);
 }
 
 #ifdef _WIN32

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -25,6 +25,7 @@
 #include <cstdio>
 #include <ios>
 #include <unordered_map>
+#include <vector>
 
 /**
  * FileFinder contains helper methods for finding case
@@ -43,14 +44,14 @@ namespace FileFinder {
 	 */
 	void Quit();
 
-	/*
-	* { case lowered path, real path }
-	*/
+	/**
+	 * { case lowered path, real path }
+	 */
 	typedef std::unordered_map<std::string, std::string> string_map;
 
-	/*
-	* { case lowered directory name, non directory file list }
-	*/
+	/**
+	 * { case lowered directory name, non directory file list }
+	 */
 	typedef std::unordered_map<std::string, string_map> sub_members_type;
 
 	struct DirectoryTree {
@@ -99,7 +100,7 @@ namespace FileFinder {
 	std::string FindDefault(const DirectoryTree& tree, const std::string& dir, const std::string& name);
 
 	/**
-	 * Finds a file in the root of a custom project tree.
+	 * Finds a file from the root of a custom project tree.
 	 *
 	 * @param tree Project tree to search
 	 * @param name the path and name
@@ -183,9 +184,27 @@ namespace FileFinder {
 	 *
 	 * @param dir base directory.
 	 * @param name file name to be appended to dir.
-	 * @return normalized path string.
+	 * @return combined path
 	 */
 	std::string MakePath(std::string const& dir, std::string const& name);
+	
+	/**
+	 * Converts a path to the canonical equivalent.
+	 * This generates a path that does not contain ".." or "." directories.
+	 * 
+	 * @param path Path to normalize
+	 * @param initial_deepness How deep the passed path is relative to the game root
+	 * @return canonical path
+	 */
+	std::string MakeCanonical(std::string const& path, int initial_deepness);
+
+	/**
+	 * Splits a path in it's components.
+	 *
+	 * @param path Path to split
+	 * @return Vector containing path components
+	 */
+	std::vector<std::string> SplitPath(std::string const& path);
 
 	/**
 	 * GetDirectoryMembers member listing mode.

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -27,6 +27,8 @@
 #include "output.h"
 #include "graphics.h"
 #include "main_data.h"
+#include "player.h"
+#include "reader_util.h"
 #include "scene_save.h"
 
 namespace {
@@ -326,6 +328,7 @@ void Game_System::OnBgmReady(FileRequestResult* result) {
 
 		// The first line contains the path to the actual audio file to play
 		std::string line = Utils::ReadLine(*stream.get());
+		line = ReaderUtil::Recode(line, Player::encoding);
 		
 		Output::Debug("Ineluki link file: %s -> %s", path.c_str(), line.c_str());
 

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -317,8 +317,6 @@ void Game_System::OnBgmReady(FileRequestResult* result) {
 	}
 
 	if (Utils::EndsWith(result->file, ".link")) {
-		Output::Debug("Ineluki link file: %s", path.c_str());
-		
 		// Handle Ineluki's MP3 patch
 		std::shared_ptr<std::fstream> stream = FileFinder::openUTF8(path, std::ios_base::in);
 		if (!stream) {
@@ -329,7 +327,7 @@ void Game_System::OnBgmReady(FileRequestResult* result) {
 		// The first line contains the path to the actual audio file to play
 		std::string line = Utils::ReadLine(*stream.get());
 		
-		Output::Debug("Linking to: %s", line.c_str());		
+		Output::Debug("Ineluki link file: %s -> %s", path.c_str(), line.c_str());
 
 		#ifdef EMSCRIPTEN
 		Output::Warning("Ineluki MP3 patch unsupported in the web player");
@@ -357,7 +355,7 @@ void Game_System::OnSeReady(FileRequestResult* result, int volume, int tempo) {
 	if (item != se_request_ids.end()) {
 		se_request_ids.erase(item);
 	}
-	
+
 	std::string const path = FileFinder::FindSound(result->file);
 	if (path.empty()) {
 		Output::Debug("Sound not found: %s", result->file.c_str());

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -37,6 +37,11 @@ std::string Utils::UpperCase(const std::string& str) {
 	return result;
 }
 
+bool Utils::EndsWith(const std::string &str, const std::string &end) {
+	return str.length() >= end.length() &&
+		0 == str.compare(str.length() - end.length(), end.length(), end);
+}
+
 std::u16string Utils::DecodeUTF16(const std::string& str) {
 	std::u16string result;
 	for (auto it = str.begin(), str_end = str.end(); it < str_end; ++it) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -18,8 +18,8 @@
 // Headers
 #include "utils.h"
 #include <algorithm>
-#include <cctype>
 #include <random>
+#include <regex>
 
 namespace {
 	std::mt19937 rng;
@@ -302,4 +302,42 @@ int32_t Utils::GetRandomNumber(int32_t from, int32_t to) {
 
 void Utils::SeedRandomNumberGenerator(int32_t seed) {
 	rng.seed(seed);
+}
+
+// via https://stackoverflow.com/questions/6089231/
+std::string Utils::ReadLine(std::istream &is) {
+	std::string out;
+
+	std::istream::sentry se(is, true);
+	std::streambuf* sb = is.rdbuf();
+
+	for(;;) {
+        	int c = sb->sbumpc();
+		switch (c) {
+			case '\n':
+			return out;
+		case '\r':
+			if (sb->sgetc() == '\n') {
+				sb->sbumpc();
+			}
+			return out;
+		case EOF:
+			// Also handle the case when the last line has no line ending
+			if (out.empty()) {
+				is.setstate(std::ios::eofbit);
+			}
+			return out;
+		default:
+			out += (char)c;
+		}
+	}
+}
+
+std::vector<std::string> Utils::Tokenize(const std::string &str_to_tokenize, const std::string &token_re) {
+	std::regex reg(token_re);
+	std::sregex_token_iterator iter(str_to_tokenize.begin(), str_to_tokenize.end(), reg, -1);
+	std::sregex_token_iterator end;
+	std::vector<std::string> vec(iter, end);
+
+	return vec;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -303,6 +303,10 @@ void Utils::SeedRandomNumberGenerator(int32_t seed) {
 	rng.seed(seed);
 }
 
+#ifdef _3DS
+#  define EOF -1
+#endif
+
 // via https://stackoverflow.com/questions/6089231/
 std::string Utils::ReadLine(std::istream &is) {
 	std::string out;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -19,7 +19,6 @@
 #include "utils.h"
 #include <algorithm>
 #include <random>
-#include <regex>
 
 namespace {
 	std::mt19937 rng;
@@ -333,11 +332,22 @@ std::string Utils::ReadLine(std::istream &is) {
 	}
 }
 
-std::vector<std::string> Utils::Tokenize(const std::string &str_to_tokenize, const std::string &token_re) {
-	std::regex reg(token_re);
-	std::sregex_token_iterator iter(str_to_tokenize.begin(), str_to_tokenize.end(), reg, -1);
-	std::sregex_token_iterator end;
-	std::vector<std::string> vec(iter, end);
+std::vector<std::string> Utils::Tokenize(const std::string &str_to_tokenize, const std::function<bool(char32_t)> predicate) {
+	std::u32string text = DecodeUTF32(str_to_tokenize);
+	std::vector<std::string> tokens;
+	std::u32string cur_token;	
 
-	return vec;
+	for (char32_t& c : text) {
+		if (predicate(c)) {
+			tokens.push_back(EncodeUTF(cur_token));
+			cur_token.clear();
+			continue;
+		}
+
+		cur_token.push_back(c);
+	}
+
+	tokens.push_back(EncodeUTF(cur_token));
+
+	return tokens;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,6 +18,7 @@
 #ifndef _EASYRPG_UTILS_H_
 #define _EASYRPG_UTILS_H_
 
+#include <functional>
 #include <string>
 #include <sstream>
 #include <vector>
@@ -140,13 +141,13 @@ namespace Utils {
 	std::string ReadLine(std::istream& is);
 
 	/**
-	 * Splits a string into tokens specified by a regular expression.
+	 * Splits a string into tokens specified by a predicate function.
 	 *
 	 * @param str_to_tokenize String that is tokenized
-	 * @param token_re Regular expression specificing the token
+	 * @param token_re Predicate function, must return true when the character is used for splitting.
 	 * @return vector containing the elements between the tokens
 	 */
-	std::vector<std::string> Tokenize(const std::string& str_to_tokenize, const std::string& token_re);
+	std::vector<std::string> Tokenize(const std::string& str_to_tokenize, const std::function<bool(char32_t)> predicate);
 
 } // namespace Utils
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -20,6 +20,7 @@
 
 #include <string>
 #include <sstream>
+#include <vector>
 #include "system.h"
 
 namespace Utils {
@@ -127,6 +128,25 @@ namespace Utils {
 	 * @param seed Seed to use
 	 */
 	void SeedRandomNumberGenerator(int32_t seed);
+
+	/**
+	 * Reads a line from a stream and returns it.
+	 * Same as std::getline but handles linebreaks independent of the platform
+	 * correctly.
+	 *
+	 * @param is Input stream to read
+	 * @return Content of the read line
+	 */
+	std::string ReadLine(std::istream& is);
+
+	/**
+	 * Splits a string into tokens specified by a regular expression.
+	 *
+	 * @param str_to_tokenize String that is tokenized
+	 * @param token_re Regular expression specificing the token
+	 * @return vector containing the elements between the tokens
+	 */
+	std::vector<std::string> Tokenize(const std::string& str_to_tokenize, const std::string& token_re);
 
 } // namespace Utils
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -40,6 +40,15 @@ namespace Utils {
 	std::string UpperCase(const std::string& str);
 
 	/**
+	 * Tests if a string ends with a substring.
+	 *
+	 * @param str String to search in
+	 * @param end Substring to check at the end of str
+	 * @return true when the end matches
+	 */
+	bool EndsWith(const std::string& str, const std::string& end);
+
+	/**
 	 * Converts Utf8 to UTF-16.
 	 *
 	 * @param str string to convert.


### PR DESCRIPTION
Differences to the real patch because we use the BGM Api directly:
 - It uses our BGM Api directly, this means compared to the real patch it will not overaly with the normal BGM which must be stopped manually (Needs testing in games if this is a problem)
 - The Patch allows playing multiple MP3s at the same time, but who needs this. (and Disharmony fixed this problem)
 - No support for the "loop" statement on line 2, it will always loop.
 - Our code does not care about the format, it can play all formats we support (but nobody uses this obviously).

This patch is enabled for all games, I see no risk in doing this. In the unlikely case a game really uses a filename with ".link" and then fails, we will see this in an Android bug report ;)

Algorithm:
When .link found it reads the first line and converts that path into a canonical one using the game directory as a root and passes it to FindDefault which finds the file. Simple ^^