### PR TITLE
shell completion for BASH

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -365,6 +365,12 @@ dist_man6_MANS = resources/easyrpg-player.6
 endif
 endif
 
+# bash completion
+if HAVE_BASHCOMP
+bashcompdir = @bashcompinstdir@
+dist_bashcomp_DATA = resources/unix/bash-completion/easyrpg-player
+endif
+
 # FIXME make filefinder work without external scripting
 check_PROGRAMS = output utils directorytree
 TESTS = output utils directorytree

--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,11 @@ AS_IF([test x"$A2X" = "xno" && test ! -f "${srcdir}/resources/easyrpg-player.6"]
   AC_MSG_WARN([a2x is required to create the manual page]))
 AM_CONDITIONAL([HAVE_MANUAL], [test -f "${srcdir}/resources/easyrpg-player.6"])
 
+# bash completion
+PKG_CHECK_VAR([bashcompinstdir],[bash-completion],[completionsdir])
+AM_CONDITIONAL([HAVE_BASHCOMP], [test "x$bashcompinstdir" != "x"])
+AC_SUBST(bashcompinstdir)
+
 # Doxygen source documentation
 m4_include([builds/autoconf/m4/ax_prog_doxygen.m4])
 DX_DOXYGEN_FEATURE(OFF)

--- a/resources/unix/bash-completion/easyrpg-player
+++ b/resources/unix/bash-completion/easyrpg-player
@@ -1,0 +1,81 @@
+# bash completion script for easyrpg-player
+# (c) carstene1ns <dev f4ke de> 2016
+# available under the MIT license
+
+_easyrpg-player ()
+{
+  local cur prev
+
+  # some of this boilerplate is deprecated
+  _init_completion || return
+  COMPREPLY=()
+  cur=${COMP_WORDS[COMP_CWORD]}
+  prev=${COMP_WORDS[COMP_CWORD-1]}
+
+  # all possible options
+  ouropts='--battle-test --disable-audio --disable-rtp --encoding --engine \
+           --fullscreen --show-fps --hide-title --load-game-id --new-game \
+           --project-path --seed --start-map-id --start-position --save-path \
+           --start-party --test-play --window -v --version -h --help'
+  rpgrtopts='BattleTest battletest HideTitle hidetitle TestPlay testplay \
+             Window window'
+  engines='rpg2k rpg2k3 rpg2k3e'
+
+  # first list all special cases
+  case $prev in
+    # supported engines
+    --engine)
+      COMPREPLY=($(compgen -W "$engines" -- $cur))
+      return
+      ;;
+    # load map files
+    --start-map-id)
+      # broken, disabled for now
+      #_filedir '@(lmu|emu)'
+      return
+      ;;
+    # load save files
+    --load-game-id)
+      # broken, disabled for now
+      #_filedir '@(lsd|esd)'
+      return
+      ;;
+    # set game directory
+    --@(project-path|save-path))
+      _filedir -d
+      return
+      ;;
+    # argument required but no completions available
+    --@(battle-test|encoding|seed|start-position|start-party)| \
+    BattleTest|battletest)
+      return
+      ;;
+    # these have no argument and shall be used exclusively
+    -@(v|-version|h|-help))
+      return
+      ;;
+    # new option
+    *)
+      COMPREPLY=($(compgen -W "$ouropts $rpgrtopts" -- $cur))
+      return
+      ;;
+  esac
+
+  case $cur in
+    # RPG_RT compatible options
+    B*|b*|H*|h*|T*|t*|W*|w*)
+      COMPREPLY=($(compgen -W "$rpgrtopts" -- $cur))
+      return
+      ;;
+    # catch all single options
+    -*)
+      COMPREPLY=($(compgen -W "$ouropts" -- $cur))
+      return
+      ;;
+  esac
+
+  return
+} &&
+complete -F _easyrpg-player easyrpg-player
+
+# eof


### PR DESCRIPTION
- Options expecting arbitrary arguments (invoke parsing lcf) are not completed of course.
- `--load-game-id` and `--start-map-id` do not complete currently, because they do not respect the `--project-dir` and `--save-dir` settings yet. Therefore they are useless for out of folder invocation and disabled.
- CMake integration was not worth for now, as this is being refactored currently. 