### PR TITLE
Fix Yume2kki ugliness

### DIFF
--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -295,7 +295,10 @@ std::string FileFinder::MakeCanonical(std::string const& path, int initial_deepn
 std::vector<std::string> FileFinder::SplitPath(std::string const& path) {
 	// Tokens are patch delimiters ("/" and encoding aware "\")
 	std::function<bool(char32_t)> f = [](char32_t t) {
-		char32_t escape_char_back = Utils::DecodeUTF32(Player::escape_symbol).front();
+		char32_t escape_char_back = '\0';
+		if (!Player::escape_symbol.empty()) {
+			escape_char_back = Utils::DecodeUTF32(Player::escape_symbol).front();
+		}
 		char32_t escape_char_forward = Utils::DecodeUTF32("/").front();
 		return t == escape_char_back || t == escape_char_forward;
 	};

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -61,26 +61,13 @@ void Game_Actor::Init() {
 	SetSp(GetMaxSp());
 	SetExp(exp_list[GetLevel() - 1]);
 
-	// Filter out invalid equipment
-	int eq_types[] = { RPG::Item::Type_weapon,
-					   HasTwoWeapons() ? RPG::Item::Type_weapon : RPG::Item::Type_shield,
-					   RPG::Item::Type_armor,
-					   RPG::Item::Type_helmet,
-					   RPG::Item::Type_accessory
-	};
-
-	for (int i = 0; i < 5; ++i) {
-		const RPG::Item* item = GetEquipment(i);
-		if (item && item->type != eq_types[i]) {
-			Output::Debug("Removing invalid item %d (of type %d) from equipment slot %d (needs type %d)",
-				item->ID, item->type, i, eq_types[i]);
-			SetEquipment(i, 0);
-		}
-	}
+	RemoveInvalidEquipment();
 }
 
 void Game_Actor::Fixup() {
 	GetData().Fixup(actor_id);
+
+	RemoveInvalidEquipment();
 }
 
 int Game_Actor::GetId() const {
@@ -1065,4 +1052,24 @@ Game_Battler::BattlerType Game_Actor::GetType() const {
 
 RPG::SaveActor & Game_Actor::GetData() const {
 	return Main_Data::game_data.actors[actor_id - 1];
+}
+
+void Game_Actor::RemoveInvalidEquipment() {
+//	return;
+	// Filter out invalid equipment
+	int eq_types[] = { RPG::Item::Type_weapon,
+		HasTwoWeapons() ? RPG::Item::Type_weapon : RPG::Item::Type_shield,
+		RPG::Item::Type_armor,
+		RPG::Item::Type_helmet,
+		RPG::Item::Type_accessory
+	};
+
+	for (int i = 0; i < 5; ++i) {
+		const RPG::Item* item = GetEquipment(i);
+		if (item && item->type != eq_types[i]) {
+			Output::Debug("Actor %d: Removing invalid item %d (of type %d) from equipment slot %d (needs type %d)",
+			GetId(), item->ID, item->type, i, eq_types[i]);
+			SetEquipment(i, 0);
+		}
+	}
 }

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -23,6 +23,7 @@
 #include "game_message.h"
 #include "game_party.h"
 #include "main_data.h"
+#include "output.h"
 #include "player.h"
 #include "rpg_skill.h"
 #include "util_macro.h"
@@ -59,6 +60,23 @@ void Game_Actor::Init() {
 	SetHp(GetMaxHp());
 	SetSp(GetMaxSp());
 	SetExp(exp_list[GetLevel() - 1]);
+
+	// Filter out invalid equipment
+	int eq_types[] = { RPG::Item::Type_weapon,
+					   HasTwoWeapons() ? RPG::Item::Type_weapon : RPG::Item::Type_shield,
+					   RPG::Item::Type_armor,
+					   RPG::Item::Type_helmet,
+					   RPG::Item::Type_accessory
+	};
+
+	for (int i = 0; i < 5; ++i) {
+		const RPG::Item* item = GetEquipment(i);
+		if (item && item->type != eq_types[i]) {
+			Output::Debug("Removing invalid item %d (of type %d) from equipment slot %d (needs type %d)",
+				item->ID, item->type, i, eq_types[i]);
+			SetEquipment(i, 0);
+		}
+	}
 }
 
 void Game_Actor::Fixup() {

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -714,6 +714,12 @@ private:
 	 */
 	RPG::SaveActor& GetData() const;
 
+	/**
+	 * Removes invalid (wrong type) equipment from the equipment
+	 * slots.
+	 */
+	void RemoveInvalidEquipment();
+
 	int actor_id;
 	std::vector<int> exp_list;
 };


### PR DESCRIPTION
This game is stupid and has invalid inventory in the slots.
The weapon contains a switch e.g., RPG_RT filters this and the editor shows it as (None) but the database still contains the value. Way to go Enterbrain!

Furthermore this 350 MB games saves tons of space *cough* by crossreferencing files via
Panorama\\..\\Title\\Title3, nice, that path is now rewritten to Title\\Title3 by the FileFinder.
I also tested files directly in the root directory (Panorama\\..\\Title3), becomes Title3 :+1: 
That strange feature is only used when filefinder path != canonical, so only happens when "." or ".." is a path component which can't happen when using the editor without hex editing.
