### PR TITLE
Android: Remove libmad linkage

### DIFF
--- a/builds/android/app/src/main/jni/src/Android.mk
+++ b/builds/android/app/src/main/jni/src/Android.mk
@@ -39,7 +39,7 @@ LOCAL_STATIC_LIBRARIES := cpufeatures
 
 LOCAL_LDLIBS := -L$(LOCAL_PATH)/../../obj/local/$(TARGET_ARCH_ABI) \
 		-L$(EASYRPG_TOOLCHAIN_DIR)/lib -lGLESv1_CM -llog -lz \
-		-llcf -lSDL2_mixer -lmad -lvorbisfile -lvorbis -logg -lmodplug \
+		-llcf -lSDL2_mixer -lvorbisfile -lvorbis -logg -lmodplug \
 		-lmpg123 -lfreetype -lpixman-1 -lpng -lspeexdsp -lsndfile \
 		-licui18n -licuuc -licudata \
 		-lcpufeatures


### PR DESCRIPTION
Needed by EasyRPG/buildscripts#10.