### PR TITLE
Fix FastWAV issues and crash in AudioDecoder-loop

### DIFF
--- a/src/audio_decoder.h
+++ b/src/audio_decoder.h
@@ -310,6 +310,8 @@ private:
 	bool looping = false;
 	int loop_count = 0;
 
+	int Decode(uint8_t* buffer, int size, int recursion_depth);
+
 	std::vector<uint8_t> mono_buffer;
 };
 

--- a/src/audio_psp2.cpp
+++ b/src/audio_psp2.cpp
@@ -27,29 +27,25 @@
 #include <cstdlib>
 #include "audio_decoder.h"
 #include <atomic>
+#include <array>
 
 // Internal stuffs
 #define AUDIO_CHANNELS 7 // PSVITA has 8 audio channels but one is used for BGM
-#define SFX_QUEUE_SIZE 8
 #define AUDIO_BUFSIZE 8192 // Max dimension of BGM/SFX buffer size
 SceUID sfx_threads[AUDIO_CHANNELS];
 uint16_t bgm_chn = 0xDEAD;
 std::unique_ptr<AudioDecoder> audio_decoder;
-std::unique_ptr<AudioDecoder> sfx_decoder[8];
 uint8_t cur_decoder = 0;
 
 // Sound block struct
-struct DecodedSound{
-	uint8_t* audiobuf;
-	uint8_t* audiobuf2;
-	uint8_t* cur_audiobuf;
-	FILE* handle;
-	bool endedOnce;
-	bool isPlaying;
-	bool isStereo;
-	int pitch;
-	int vol;
-	uint8_t id;
+struct DecodedSound {
+	uint8_t audiobuf[AUDIO_BUFSIZE] = {0};
+	uint8_t audiobuf2[AUDIO_BUFSIZE] = {0};
+	uint8_t* cur_audiobuf = nullptr;
+	bool isPlaying = true;
+	bool isFinished = true;
+	bool isStereo = false;
+	std::unique_ptr<AudioDecoder> decoder;
 };
 
 // Music block struct
@@ -72,11 +68,11 @@ DecodedMusic* BGM = NULL;
 SceUID BGM_Mutex;
 SceUID BGM_Thread;
 static int streamThread(unsigned int args, void* arg){
-	
+
 	int vol, dec_vol;
-	
+
 	for(;;) {
-		
+
 		// A pretty bad way to close thread
 		if(termStream){
 			termStream = false;
@@ -86,13 +82,13 @@ static int streamThread(unsigned int args, void* arg){
 			}
 			sceKernelExitThread(0);
 		}
-		
+
 		sceKernelWaitSema(BGM_Mutex, 1, NULL);
 		if (BGM == NULL || (!BGM->isPlaying)){
 			sceKernelSignalSema(BGM_Mutex, 1);
 			continue;
 		}
-		
+
 		// Seems like audio ports are thread dependant on PSVITA :/
 		if (BGM->isNewTrack){
 			uint8_t audio_mode = BGM->isStereo ? SCE_AUDIO_OUT_MODE_STEREO : SCE_AUDIO_OUT_MODE_MONO;
@@ -101,10 +97,10 @@ static int streamThread(unsigned int args, void* arg){
 			sceAudioOutSetConfig(bgm_chn, nsamples, 48000, audio_mode);
 			vol = BGM->vol * 327;
 			int vol_stereo[] = {vol, vol};
-			sceAudioOutSetVolume(bgm_chn, SCE_AUDIO_VOLUME_FLAG_L_CH | SCE_AUDIO_VOLUME_FLAG_R_CH, vol_stereo);	
+			sceAudioOutSetVolume(bgm_chn, SCE_AUDIO_VOLUME_FLAG_L_CH | SCE_AUDIO_VOLUME_FLAG_R_CH, vol_stereo);
 			BGM->isNewTrack = false;
 		}
-		
+
 		// Volume changes support
 		dec_vol = audio_decoder->GetVolume();
 		if (dec_vol != vol){
@@ -113,42 +109,42 @@ static int streamThread(unsigned int args, void* arg){
 			sceAudioOutSetVolume(bgm_chn, SCE_AUDIO_VOLUME_FLAG_L_CH | SCE_AUDIO_VOLUME_FLAG_R_CH, vol_stereo);
 			vol = dec_vol;
 		}
-		
-		
+
+
 		// Audio streaming feature
 		if (BGM->handle != NULL){
 			if (BGM->cur_audiobuf == BGM->audiobuf) BGM->cur_audiobuf = BGM->audiobuf2;
 			else BGM->cur_audiobuf = BGM->audiobuf;
-			audio_decoder->Decode(BGM->cur_audiobuf, AUDIO_BUFSIZE);	
+			audio_decoder->Decode(BGM->cur_audiobuf, AUDIO_BUFSIZE);
 			if (audio_decoder->GetLoopCount() > 0){ // EoF
 				BGM->endedOnce = true;
 			}
 			int res = sceAudioOutOutput(bgm_chn, BGM->cur_audiobuf);
 			if (res < 0) Output::Error("An error occurred in audio thread (0x%lX)", res);
 		}
-		
+
 		sceKernelSignalSema(BGM_Mutex, 1);
-		
+
 	}
 }
 
 // SFX audio thread
 SceUID SFX_Mutex;
+SceUID SFX_Mutex_ID;
 volatile bool mustExit = false;
-DecodedSound* sfx_sounds[SFX_QUEUE_SIZE];
-uint8_t output_idx = 0;
-uint8_t input_idx = 0;
+std::array<DecodedSound, AUDIO_CHANNELS> sfx_sounds;
+
 uint8_t sfx_exited = 0;
-std::atomic<std::uint8_t> availThreads(AUDIO_CHANNELS);
 static int sfxThread(unsigned int args, void* arg){
 	int ch = sceAudioOutOpenPort(SCE_AUDIO_OUT_PORT_TYPE_MAIN, 64, 48000, SCE_AUDIO_OUT_MODE_STEREO);
 	if (ch < 0){
 		Output::Warning("SFX Thread: Cannot open audio port");
 		sceKernelExitThread(0);
 	}
+
 	for (;;){
 		sceKernelWaitSema(SFX_Mutex, 1, NULL);
-		
+
 		// Check if the thread must be closed
 		if (mustExit){
 			sfx_exited++;
@@ -157,51 +153,62 @@ static int sfxThread(unsigned int args, void* arg){
 			sceAudioOutReleasePort(ch);
 			sceKernelExitThread(0);
 		}
-		
-		DecodedSound* sfx = sfx_sounds[output_idx++];
-		if (output_idx >= SFX_QUEUE_SIZE) output_idx = 0;
-		
+
+		// Pick the next SE that wants to be played
+		sceKernelWaitSema(SFX_Mutex_ID, 1, NULL);
+		int idx = -1;
+		for (int i = 0; i < AUDIO_CHANNELS; ++i) {
+			if (!sfx_sounds[i].isPlaying && !sfx_sounds[i].isFinished) {
+				idx = i;
+				break;
+			}
+		}
+
+		if (idx == -1) {
+			sceKernelSignalSema(SFX_Mutex_ID, 1);
+			// Shouldn't happen...
+			Output::Warning("No pending SE found");
+			continue;
+		} else {
+			sfx_sounds[idx].isPlaying = true;
+			sceKernelSignalSema(SFX_Mutex_ID, 1);
+		}
+
+		DecodedSound& sfx = sfx_sounds[idx];
+
 		// Preparing audio port
-		uint8_t audio_mode = sfx->isStereo ? SCE_AUDIO_OUT_MODE_STEREO : SCE_AUDIO_OUT_MODE_MONO;
+		uint8_t audio_mode = sfx.isStereo ? SCE_AUDIO_OUT_MODE_STEREO : SCE_AUDIO_OUT_MODE_MONO;
 		int nsamples = AUDIO_BUFSIZE / ((audio_mode+1)<<1);
 		sceAudioOutSetConfig(ch, nsamples, 48000, audio_mode);
-		int vol = sfx->vol * 327;
+		int vol = sfx.decoder->GetVolume() * 327;
 		int vol_stereo[] = {vol, vol};
-		sceAudioOutSetVolume(ch, SCE_AUDIO_VOLUME_FLAG_L_CH | SCE_AUDIO_VOLUME_FLAG_R_CH, vol_stereo);	
-		
-		// Applying pitch
-		sfx_decoder[sfx->id]->SetPitch(sfx->pitch);
-		
+		sceAudioOutSetVolume(ch, SCE_AUDIO_VOLUME_FLAG_L_CH | SCE_AUDIO_VOLUME_FLAG_R_CH, vol_stereo);
+
 		// Playing sound
-		while (!sfx->endedOnce){
-			if (sfx->cur_audiobuf == sfx->audiobuf) sfx->cur_audiobuf = sfx->audiobuf2;
-			else sfx->cur_audiobuf = sfx->audiobuf;
-			sfx_decoder[sfx->id]->Decode(sfx->cur_audiobuf, AUDIO_BUFSIZE);	
-			if (sfx_decoder[sfx->id]->IsFinished()){ // EoF
-				sfx->endedOnce = true;
+		while (!sfx.isFinished){
+			if (sfx.cur_audiobuf == sfx.audiobuf) sfx.cur_audiobuf = sfx.audiobuf2;
+			else sfx.cur_audiobuf = sfx.audiobuf;
+			sfx.decoder->Decode(sfx.cur_audiobuf, AUDIO_BUFSIZE);
+			sceAudioOutOutput(ch, sfx.cur_audiobuf);
+			if (sfx.decoder->IsFinished()) { // EoF
+				// SE slot is free again
+				sfx.isFinished = true;
+				break;
 			}
-			sceAudioOutOutput(ch, sfx->cur_audiobuf);
 		}
-		
-		// Freeing sound
-		free(sfx->audiobuf);
-		free(sfx->audiobuf2);
-		sfx_decoder[sfx->id].reset();
-		free(sfx);
-		availThreads++;
-		
 	}
-	
+
 }
 
 Psp2Audio::Psp2Audio() :
 	bgm_volume(0)
 {
-	
+
 	// Creating mutexs
 	BGM_Mutex = sceKernelCreateSema("BGM Mutex", 0, 1, 1, NULL);
 	SFX_Mutex = sceKernelCreateSema("SFX Mutex", 0, 0, 1, NULL);
-	
+	SFX_Mutex_ID = sceKernelCreateSema("SFX Mutex for ID read", 0, 1, 1, NULL);
+
 	// Starting audio thread for BGM
 	BGM_Thread = sceKernelCreateThread("BGM Thread", &streamThread, 0x10000100, 0x10000, 0, 0, NULL);
 	int res = sceKernelStartThread(BGM_Thread, sizeof(BGM_Thread), &BGM_Thread);
@@ -209,7 +216,7 @@ Psp2Audio::Psp2Audio() :
 		Output::Error("Failed to init audio thread (0x%x)", res);
 		return;
 	}
-	
+
 	// Starting audio threads for SFX
 	for (int i=0;i < AUDIO_CHANNELS; i++){
 		sfx_threads[i] = sceKernelCreateThread("SFX Thread", &sfxThread, 0x10000100, 0x10000, 0, 0, NULL);
@@ -219,15 +226,15 @@ Psp2Audio::Psp2Audio() :
 			return;
 		}
 	}
-	
+
 }
 
 Psp2Audio::~Psp2Audio() {
-	
+
 	// Just to be sure to clean up before exiting
 	SE_Stop();
 	BGM_Stop();
-	
+
 	// Closing BGM streaming thread
 	termStream = true;
 	while (termStream){} // Wait for thread exiting...
@@ -237,24 +244,24 @@ Psp2Audio::~Psp2Audio() {
 		audio_decoder.reset();
 		free(BGM);
 	}
-	
+
 	// Starting exit procedure for sfx threads
 	mustExit = true;
 	sceKernelSignalSema(SFX_Mutex, 1);
 	while (mustExit){} // Wait for threads exiting...
 	sfx_exited = 0;
-	
+
 	// Deleting mutexs and sfx threads
 	sceKernelDeleteSema(BGM_Mutex);
 	for (int i=0;i<AUDIO_CHANNELS;i++){
 		sceKernelDeleteThread(sfx_threads[i]);
 	}
 	sceKernelDeleteSema(SFX_Mutex);
-	
+	sceKernelDeleteSema(SFX_Mutex_ID);
 }
 
 void Psp2Audio::BGM_Play(std::string const& file, int volume, int pitch, int fadein) {
-	
+
 	// If a BGM is currently playing, we kill it
 	BGM_Stop();
 	sceKernelWaitSema(BGM_Mutex, 1, NULL);
@@ -265,7 +272,7 @@ void Psp2Audio::BGM_Play(std::string const& file, int volume, int pitch, int fad
 		free(BGM);
 		BGM = NULL;
 	}
-	
+
 	// Opening file
 	FILE* stream = FileFinder::fopenUTF8(file, "rb");
 	if (!stream) {
@@ -273,7 +280,7 @@ void Psp2Audio::BGM_Play(std::string const& file, int volume, int pitch, int fad
 		sceKernelSignalSema(BGM_Mutex, 1);
 		return;
 	}
-	
+
 	// Trying to use internal decoder
 	audio_decoder = AudioDecoder::Create(stream, file);
 	if (audio_decoder == NULL){
@@ -282,48 +289,48 @@ void Psp2Audio::BGM_Play(std::string const& file, int volume, int pitch, int fad
 		sceKernelSignalSema(BGM_Mutex, 1);
 		return;
 	}
-	
+
 	// Initializing internal audio decoder
 	int audiotype;
 	fseek(stream, 0, SEEK_SET);
 	if (!audio_decoder->Open(stream)) Output::Error("An error occured in audio decoder (%s)", audio_decoder->GetError().c_str());
 	audio_decoder->SetLooping(true);
 	AudioDecoder::Format int_format;
-	int samplerate;	
+	int samplerate;
 	audio_decoder->SetFormat(48000, AudioDecoder::Format::S16, 2);
 	audio_decoder->GetFormat(samplerate, int_format, audiotype);
 	if (samplerate != 48000) Output::Warning("Cannot resample music file. Music will be distorted.");
-	
+
 	// Initializing music block
 	DecodedMusic* myFile = (DecodedMusic*)malloc(sizeof(DecodedMusic));
-	
+
 	// Check for file audiocodec
 	if (audiotype == 2) myFile->isStereo = true;
 	else myFile->isStereo = false;
-	
+
 	// Setting audiobuffer size
 	myFile->audiobuf = (uint8_t*)malloc(AUDIO_BUFSIZE);
 	myFile->audiobuf2 = (uint8_t*)malloc(AUDIO_BUFSIZE);
-	myFile->cur_audiobuf = myFile->audiobuf;	
-	
+	myFile->cur_audiobuf = myFile->audiobuf;
+
 	//Setting default streaming values
 	myFile->handle = stream;
 	myFile->endedOnce = false;
-	
+
 	// Passing new music block to the audio thread
 	BGM = myFile;
-	
+
 	// Music settings
 	audio_decoder->SetFade(0, volume, fadein);
 	audio_decoder->SetPitch(pitch);
 	BGM->tick = DisplayUi->GetTicks();
 	BGM->vol = volume;
-	
+
 	// Starting BGM
 	BGM->isNewTrack = true;
 	BGM->isPlaying = true;
 	sceKernelSignalSema(BGM_Mutex, 1);
-	
+
 }
 
 void Psp2Audio::BGM_Pause() {
@@ -362,7 +369,7 @@ void Psp2Audio::BGM_Volume(int volume) {
 }
 
 void Psp2Audio::BGM_Pitch(int pitch) {
-	audio_decoder->SetPitch(pitch);	
+	audio_decoder->SetPitch(pitch);
 }
 
 void Psp2Audio::BGM_Fade(int fade) {
@@ -372,69 +379,72 @@ void Psp2Audio::BGM_Fade(int fade) {
 }
 
 void Psp2Audio::SE_Play(std::string const& file, int volume, int pitch) {
-	
-	// Allocating DecodedSound object
-	DecodedSound* myFile = (DecodedSound*)malloc(sizeof(DecodedSound));
-	
 	// Opening file
 	FILE* stream = FileFinder::fopenUTF8(file, "rb");
 	if (!stream) {
 		Output::Warning("Couldn't open sound file %s", file.c_str());
 		return;
 	}
-	
-	// Check if we have at least an available audio thread
-	if (availThreads > 0){
-		
-		// Trying to use internal decoder
-		availThreads--;
-		uint8_t id = cur_decoder++;
-		if (cur_decoder > 7) cur_decoder = 0;
-		sfx_decoder[id] = AudioDecoder::Create(stream, file);
-		if (sfx_decoder[id] == NULL){
-			fclose(stream);
-			Output::Warning("Unsupported sound format (%s)", file.c_str());
-			return;
-		}
 
-		// Initializing internal audio decoder
-		int audiotype;
-		fseek(stream, 0, SEEK_SET);
-		if (!sfx_decoder[id]->Open(stream)) Output::Error("An error occured in audio decoder (%s)", audio_decoder->GetError().c_str());
-		sfx_decoder[id]->SetLooping(false);
-		AudioDecoder::Format int_format;
-		int samplerate;	
-		sfx_decoder[id]->SetFormat(48000, AudioDecoder::Format::S16, 2);
-		sfx_decoder[id]->GetFormat(samplerate, int_format, audiotype);
-		if (samplerate != 48000) Output::Warning("Cannot resample sound file. Sound will be distorted.");
-		myFile->id = id;
-	
-		// Check for file audiocodec
-		if (audiotype == 2) myFile->isStereo = true;
-		else myFile->isStereo = false;
-	
-		// Setting audiobuffer size
-		myFile->audiobuf = (uint8_t*)malloc(AUDIO_BUFSIZE);
-		myFile->audiobuf2 = (uint8_t*)malloc(AUDIO_BUFSIZE);
-		myFile->cur_audiobuf = myFile->audiobuf;	
-	
-		//Setting default streaming values
-		myFile->handle = stream;
-		myFile->endedOnce = false;
-	
-		// Passing pitch and volume values to the object
-		myFile->pitch = pitch;
-		myFile->vol = volume;
-	
-		// Passing sound to an sfx thread
-		sfx_sounds[input_idx++] = myFile;
-		if (input_idx >= SFX_QUEUE_SIZE) input_idx = 0;
-		sceKernelSignalSema(SFX_Mutex, 1);
-	
-	}else{
-		fclose(stream);
-		Output::Warning("Cannot reproduce audio sound. No channels available.");
+	// Pick the next free SE slot.
+	// Does not need synchronisation
+	int idx = -1;
+	for (int i = 0; i < AUDIO_CHANNELS; ++i) {
+		if (sfx_sounds[i].isPlaying && sfx_sounds[i].isFinished) {
+			idx = i;
+			break;
+		}
 	}
+
+	if (idx == -1) {
+		fclose(stream);
+		Output::Warning("SE: No free channels available (%s)", file.c_str());
+		return;
+	}
+
+	DecodedSound& sfx = sfx_sounds[idx];
+
+	sfx.decoder = AudioDecoder::Create(stream, file);
+	if (sfx.decoder == nullptr){
+		fclose(stream);
+		Output::Warning("Unsupported sound format (%s)", file.c_str());
+		return;
+	}
+
+	// Initializing internal audio decoder
+	int audiotype;
+
+	AudioDecoder* decoder = sfx.decoder.get();
+
+	if (!decoder->Open(stream)) {
+		Output::Warning("Error occured in audio decoder (%s)", audio_decoder->GetError().c_str());
+		return;
+	}
+
+	decoder->SetLooping(false);
+	AudioDecoder::Format int_format;
+	int samplerate;
+	decoder->SetFormat(48000, AudioDecoder::Format::S16, 2);
+	decoder->GetFormat(samplerate, int_format, audiotype);
+	if (samplerate != 48000) Output::Warning("Cannot resample sound file. Sound will be distorted.");
+
+	// Check for file audiocodec
+	sfx.isStereo = audiotype == 2;
+
+	// Setting default streaming values
+	sfx.cur_audiobuf = sfx.audiobuf;
+
+	decoder->SetPitch(pitch);
+	decoder->SetVolume(volume);
+
+	// Wait and signal is required to prevent reordering
+	sceKernelWaitSema(SFX_Mutex_ID, 1, NULL);
+	sfx.isPlaying = false;
+	sfx.isFinished = false;
+	sceKernelSignalSema(SFX_Mutex_ID, 1);
+
+	// Start one SE thread
+	sceKernelSignalSema(SFX_Mutex, 1);
 }
 
 void Psp2Audio::SE_Stop() {

--- a/src/decoder_wav.h
+++ b/src/decoder_wav.h
@@ -50,6 +50,8 @@ private:
 	uint32_t samplerate;
 	uint16_t nchannels;
 	uint32_t audiobuf_offset;
+	uint32_t chunk_size;
+	uint32_t cur_pos;
 };
 
 #endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -286,12 +286,55 @@ std::string Utils::FromWideString(const std::wstring& str) {
 }
 
 bool Utils::IsBigEndian() {
-    union {
-        uint32_t i;
-        char c[4];
-    } d = {0x01020304};
+	static bool ran_once = false;
+	static bool is_big = false;
 
-    return(d.c[0] == 1);
+	if (ran_once) {
+		return is_big;
+	}
+
+	union {
+		uint32_t i;
+		char c[4];
+	} d = {0x01020304};
+
+	ran_once = true;
+	is_big = d.c[0] == 1;
+
+	return is_big;
+}
+
+void Utils::SwapByteOrder(uint16_t& us) {
+	if (!IsBigEndian()) {
+		return;
+	}
+
+	us =	(us >> 8) |
+			(us << 8);
+}
+
+void Utils::SwapByteOrder(uint32_t& ui) {
+	if (!IsBigEndian()) {
+		return;
+	}
+
+	ui =	(ui >> 24) |
+			((ui<<8) & 0x00FF0000) |
+			((ui>>8) & 0x0000FF00) |
+			(ui << 24);
+}
+
+void Utils::SwapByteOrder(double& d) {
+	if (!IsBigEndian()) {
+		return;
+	}
+
+	uint32_t *p = reinterpret_cast<uint32_t *>(&d);
+	SwapByteOrder(p[0]);
+	SwapByteOrder(p[1]);
+	uint32_t tmp = p[0];
+	p[0] = p[1];
+	p[1] = tmp;
 }
 
 int32_t Utils::GetRandomNumber(int32_t from, int32_t to) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -98,7 +98,6 @@ namespace Utils {
 	 */
 	std::string FromWideString(const std::wstring& str);
 
-
 	/**
 	 * Converts arithmetic types to a string.
 	 *
@@ -112,7 +111,36 @@ namespace Utils {
 		return stm.str();
 	}
 
+	/**
+	 * Checks if the platform is big endian
+	 *
+	 * @return true if big, false if little endian
+	 */
 	bool IsBigEndian();
+
+	/**
+	 * Swaps the byte order of the passed number when on big endian systems.
+	 * Does nothing otherwise.
+	 *
+	 * @param us Number to swap
+	 */
+	void SwapByteOrder(uint16_t& us);
+
+	/**
+	 * Swaps the byte order of the passed number when on big endian systems.
+	 * Does nothing otherwise.
+	 *
+	 * @param ui Number to swap
+	 */
+	void SwapByteOrder(uint32_t& ui);
+
+	/**
+	 * Swaps the byte order of the passed number when on big endian systems.
+	 * Does nothing otherwise.
+	 *
+	 * @param d Number to swap
+	 */
+	void SwapByteOrder(double& d);
 
 	/**
 	 * Gets a random number in the inclusive range from - to.


### PR DESCRIPTION
This fixes some flaws in the FASTWAV implementation:

 - Seek always returned false when "file_" was set, resulting directly in a crash in OpenAL, otherwise during the first rewind (assert triggered)
 - Bits per sample was read from the wrong field, was off by 6 bytes.
 - "data" chunk was not always found because the code assumed that the chunk position is 4-byte-aligned
 - Chunks after "data" would play as noise
 - Code was not big endian aware

The audio decoder will now only go 10 recursions deep when trying to refill the buffer after a Rewind. This fixes a typical stack overflow case.

Fix #992