### PR TITLE
Audio SE performance improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,8 @@ libeasyrpg_player_la_SOURCES = \
 	src/audio_decoder.h \
 	src/audio_resampler.cpp \
 	src/audio_resampler.h \
+	src/audio_secache.cpp \
+	src/audio_secache.h \
 	src/background.cpp \
 	src/background.h \
 	src/baseui.cpp \

--- a/builds/vs2015/PlayerLib.vcxproj
+++ b/builds/vs2015/PlayerLib.vcxproj
@@ -435,6 +435,7 @@
     <ClCompile Include="..\..\src\audio_decoder.cpp" />
     <ClCompile Include="..\..\src\audio_resampler.cpp" />
     <ClCompile Include="..\..\src\audio_sdl.cpp" />
+    <ClCompile Include="..\..\src\audio_secache.cpp" />
     <ClCompile Include="..\..\src\background.cpp" />
     <ClCompile Include="..\..\src\baseui.cpp" />
     <ClCompile Include="..\..\src\battle_animation.cpp" />
@@ -583,6 +584,7 @@
     <ClInclude Include="..\..\src\audio_decoder.h" />
     <ClInclude Include="..\..\src\audio_resampler.h" />
     <ClInclude Include="..\..\src\audio_sdl.h" />
+    <ClInclude Include="..\..\src\audio_secache.h" />
     <ClInclude Include="..\..\src\background.h" />
     <ClInclude Include="..\..\src\baseui.h" />
     <ClInclude Include="..\..\src\battle_animation.h" />

--- a/builds/vs2015/PlayerLib.vcxproj.filters
+++ b/builds/vs2015/PlayerLib.vcxproj.filters
@@ -62,6 +62,9 @@
     <ClCompile Include="..\..\src\audio_sdl.cpp">
       <Filter>Source Files\Backend\Audio</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\audio_secache.cpp">
+      <Filter>Source Files\Backend\Audio</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\midisequencer.cpp">
       <Filter>Source Files\Backend\Audio</Filter>
     </ClCompile>
@@ -500,6 +503,9 @@
       <Filter>Source Files\Backend\Audio</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\audio_sdl.h">
+      <Filter>Source Files\Backend\Audio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\audio_secache.h">
       <Filter>Source Files\Backend\Audio</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\midiprogram.h">

--- a/src/audio_resampler.h
+++ b/src/audio_resampler.h
@@ -19,7 +19,9 @@
 #define EASYRPG_AUDIO_RESAMPLER_H
 
 // Headers
+// Don't remove the system.h include, prevents heap corruption for automake (preprocessor defines)
 #include "audio_decoder.h"
+#include "system.h"
 #include <string>
 #include <memory>
 

--- a/src/audio_sdl.cpp
+++ b/src/audio_sdl.cpp
@@ -23,6 +23,7 @@
 
 #ifdef HAVE_SDL_MIXER
 
+#include "audio_secache.h"
 #include "baseui.h"
 #include "audio_sdl.h"
 #include "filefinder.h"
@@ -570,19 +571,51 @@ void SdlAudio::BGS_Volume(int volume) {
 	Mix_Volume(BGS_CHANNEL_NUM, volume * MIX_MAX_VOLUME / 100);
 }
 
-void SdlAudio::SE_Play(std::string const& file, int volume, int /* pitch */) {
-	std::shared_ptr<Mix_Chunk> sound(Mix_LoadWAV(file.c_str()), &Mix_FreeChunk);
-	if (!sound) {
-		Output::Warning("Couldn't load %s SE.\n%s", file.c_str(), Mix_GetError());
-		return;
+void SdlAudio::SE_Play(std::string const& file, int volume, int pitch) {
+	std::unique_ptr<AudioSeCache> cache = AudioSeCache::Create(file);
+	std::shared_ptr<Mix_Chunk> sound;
+	AudioSeRef se_ref = nullptr;
+
+	if (cache) {
+		int audio_rate;
+		Uint16 sdl_format;
+		int audio_channels;
+		if (!Mix_QuerySpec(&audio_rate, &sdl_format, &audio_channels)) {
+			Output::Warning("Couldn't query mixer spec.\n%s", Mix_GetError());
+			return;
+		}
+		AudioDecoder::Format audio_format = sdl_format_to_format(sdl_format);
+
+		// When this fails the resampler is probably not compiled in and output will be garbage, just use SDL
+		if (cache->SetFormat(audio_rate, audio_format, audio_channels)) {
+			cache->SetPitch(pitch);
+
+			se_ref = cache->Decode();
+
+			sound.reset(Mix_QuickLoad_RAW(se_ref->buffer.data(), se_ref->buffer.size()), &Mix_FreeChunk);
+
+			if (!sound) {
+				Output::Warning("Couldn't load %s SE.\n%s", file.c_str(), Mix_GetError());
+			}
+		}
 	}
+
+	if (!sound) {
+		sound.reset(Mix_LoadWAV(file.c_str()), &Mix_FreeChunk);
+		if (!sound) {
+			Output::Warning("Couldn't load %s SE.\n%s", file.c_str(), Mix_GetError());
+			return;
+		}
+	}
+
 	int channel = Mix_PlayChannel(-1, sound.get(), 0);
 	Mix_Volume(channel, volume * MIX_MAX_VOLUME / 100);
 	if (channel == -1) {
 		Output::Warning("Couldn't play %s SE.\n%s", file.c_str(), Mix_GetError());
 		return;
 	}
-	sounds[channel] = sound;
+	sounds[channel].first = sound;
+	sounds[channel].second = se_ref;
 }
 
 void SdlAudio::SE_Stop() {

--- a/src/audio_sdl.h
+++ b/src/audio_sdl.h
@@ -20,6 +20,7 @@
 
 #include "audio.h"
 #include "audio_decoder.h"
+#include "audio_secache.h"
 
 #include <map>
 
@@ -66,7 +67,7 @@ private:
 	bool bgs_stop = true;
 	bool played_once = false;
 
-	typedef std::map<int, std::shared_ptr<Mix_Chunk> > sounds_type;
+	typedef std::map<int, std::pair<std::shared_ptr<Mix_Chunk>, AudioSeRef>> sounds_type;
 	sounds_type sounds;
 
 	std::unique_ptr<AudioDecoder> audio_decoder;

--- a/src/audio_secache.cpp
+++ b/src/audio_secache.cpp
@@ -31,7 +31,7 @@ namespace {
 
 	cache_type cache;
 
-	const int cache_limit = 5 * 1024 * 1024;
+	const int cache_limit = 1 * 1024 * 1024;
 	int cache_size = 0;
 
 	void FreeCacheMemory() {

--- a/src/audio_secache.cpp
+++ b/src/audio_secache.cpp
@@ -1,0 +1,281 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Headers
+#include <cassert>
+#include <cstring>
+#include <map>
+#include <set>
+#include "audio_resampler.h"
+#include "audio_secache.h"
+#include "baseui.h"
+#include "filefinder.h"
+#include "output.h"
+
+namespace {
+	typedef std::map<std::string, AudioSeRef> cache_type;
+
+	cache_type cache;
+
+	const int cache_limit = 5 * 1024 * 1024;
+	int cache_size = 0;
+
+	void FreeCacheMemory() {
+		int32_t cur_ticks = DisplayUi->GetTicks();
+
+		for (auto it = cache.begin(); it != cache.end(); ) {
+			if (it->second.use_count() > 1) {
+				// Somebody uses this SE right now
+				++it;
+				continue;
+			}
+
+			if (cur_ticks - it->second->last_access < 5000) {
+				// Last access < 5s
+				++it;
+				continue;
+			}
+
+			//Output::Debug("SE: Freeing memory of %s", it->first.c_str());
+
+			cache_size -= it->second->buffer.size();
+
+			it = cache.erase(it);
+		}
+	}
+}
+
+std::unique_ptr<AudioSeCache> AudioSeCache::Create(const std::string& filename) {
+	std::unique_ptr<AudioSeCache> se;
+
+	cache_type::iterator const it = cache.find(filename);
+
+	se.reset(new AudioSeCache());
+	se->filename = filename;
+
+	if (it == cache.end()) {
+		// Not in cache
+
+		FILE *f = FileFinder::fopenUTF8(filename, "rb");
+
+		if (!f) {
+			se.reset();
+			return se;
+		}
+
+		se->audio_decoder = AudioDecoder::Create(f, filename);
+
+		if (se->audio_decoder) {
+			if (!se->audio_decoder->Open(f)) {
+				se->audio_decoder.reset();
+			}
+		}
+
+		if (!se->audio_decoder) {
+			se.reset();
+			return se;
+		}
+	} else {
+		Output::Debug("Cache hit %s", filename.c_str());
+	}
+
+	return se;
+}
+
+void AudioSeCache::GetFormat(int& frequency, AudioDecoder::Format& format, int& channels) const {
+	if (!audio_decoder) {
+		if (!GetCachedFormat(frequency, format, channels)) {
+			frequency = 0;
+			channels = 0;
+			format = AudioDecoder::Format::S16;
+		}
+
+		return;
+	}
+
+	audio_decoder->GetFormat(frequency, format, channels);
+}
+
+bool AudioSeCache::SetFormat(int frequency, AudioDecoder::Format format, int channels) {
+	if (!audio_decoder) {
+		// This file is already cached, don't allow uncached format changes
+		int cfrequency;
+		AudioDecoder::Format cformat;
+		int cchannels;
+
+		if (GetCachedFormat(cfrequency, cformat, cchannels)) {
+			return frequency == cfrequency &&
+					format == cformat &&
+					channels == cchannels;
+		}
+	}
+
+	return audio_decoder->SetFormat(frequency, format, channels);
+}
+
+int AudioSeCache::GetPitch() const {
+	return pitch;
+}
+
+bool AudioSeCache::SetPitch(int pitch) {
+#ifdef USE_AUDIO_RESAMPLER
+	this->pitch = pitch;
+
+	return pitch > 0;
+#else
+	return pitch == 100;
+#endif
+}
+
+bool AudioSeCache::IsCached() const {
+	return cache.find(filename) != cache.end();
+}
+
+bool AudioSeCache::GetCachedFormat(int& frequency, AudioDecoder::Format& format, int& channels) const {
+	cache_type::const_iterator it = cache.find(filename);
+
+	if (it != cache.end()) {
+		frequency = (*it).second->frequency;
+		format = (*it).second->format;
+		channels = (*it).second->channels;
+
+		return true;
+	}
+
+	return false;
+}
+
+class MemoryPitchResampler : public AudioDecoder {
+public:
+	MemoryPitchResampler(const AudioSeRef se) :
+		se(se) {
+		// no-op
+	}
+
+	bool Open(FILE* file) {
+		// No file operations needed
+		return true;
+	}
+
+	bool IsFinished() const {
+		return offset >= se->buffer.size();
+	}
+
+	void GetFormat(int& frequency, Format& format, int& channels) const {
+		frequency = se->frequency;
+		format = se->format;
+		channels = se->channels;
+	}
+
+private:
+	int FillBuffer(uint8_t* buffer, int size) {
+		int real_size = size;
+
+		if (offset + size > se->buffer.size()) {
+			real_size = se->buffer.size() - offset;
+		}
+
+		memcpy(buffer, se->buffer.data() + offset, real_size);
+		offset += real_size;
+
+		return real_size;
+	}
+
+	const AudioSeRef se;
+	int offset = 0;
+};
+
+AudioSeRef AudioSeCache::Decode() {
+	// Writes a SE with pitch = 100 to the cache if it is not cached yet,
+	// otherwise returns the cached result
+	// For pitch != 100 the cached result is pitch-adjusted and returned.
+
+	AudioSeRef se;
+
+	if (IsCached()) {
+		se = cache.find(filename)->second;
+		se->last_access = DisplayUi->GetTicks();
+
+		if (GetPitch() == 100) {
+			// Nothing extra to do
+			return se;
+		}
+
+#ifdef USE_AUDIO_RESAMPLER
+		// Code path is only taken with a resampler, otherwise pitch is always 100 here
+		// Falls through to the decoding logic but does not overwrite the cache
+
+		// Don't overwrite our real cached entry
+		se.reset(new AudioSeData());
+		GetCachedFormat(se->frequency, se->format, se->channels);
+
+		audio_decoder.reset(new AudioResampler(new MemoryPitchResampler(cache.find(filename)->second)));
+		audio_decoder->Open(nullptr);
+#else
+		assert(false && "SeCache: Unexpected code path taken");
+#endif
+	}
+
+	if (!se) {
+		se.reset(new AudioSeData());
+	}
+
+	audio_decoder->GetFormat(se->frequency, se->format, se->channels);
+
+	if (IsCached()) {
+		audio_decoder->SetPitch(GetPitch());
+	} else {
+		audio_decoder->SetPitch(100);
+	}
+
+	const int buffer_size = 8192;
+	se->buffer.resize(buffer_size);
+
+	while (!audio_decoder->IsFinished()) {
+		int read = audio_decoder->Decode(se->buffer.data() + se->buffer.size() - buffer_size, buffer_size);
+		if (read < 8192) {
+			se->buffer.resize(se->buffer.size() - (buffer_size - read));
+			break;
+		}
+
+		se->buffer.resize(se->buffer.size() + buffer_size);
+	}
+
+	if (!IsCached()) {
+		// Write normal pitched sample to cache
+		// This codepath is only taken the first time upon cache miss
+		cache.insert(std::make_pair(filename, se));
+
+		se->last_access = DisplayUi->GetTicks();
+
+		cache_size += se->buffer.size();
+
+		if (cache_size > cache_limit) {
+			FreeCacheMemory();
+		}
+
+		//Output::Debug("cache %f", cache_size / 1024.0f / 1024.0f);
+
+		if (GetPitch() != 100) {
+			// Also handle a requested resampling
+			// Takes the "IsCached" codepath now
+			return Decode();
+		}
+	}
+
+	return se;
+}

--- a/src/audio_secache.cpp
+++ b/src/audio_secache.cpp
@@ -307,3 +307,8 @@ AudioSeRef AudioSeCache::Decode() {
 
 	return se;
 }
+
+void AudioSeCache::Clear() {
+	cache_size = 0;
+	cache.clear();
+}

--- a/src/audio_secache.h
+++ b/src/audio_secache.h
@@ -1,0 +1,142 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EASYRPG_AUDIO_SECACHE_H
+#define EASYRPG_AUDIO_SECACHE_H
+
+// Headers
+#include <cstdio>
+#include <string>
+#include <vector>
+#include <memory>
+#include <map>
+
+#include "audio_decoder.h"
+
+/**
+ * AudioSeData is the decoded sample of AudioSeCache.
+ * Format changes and pitch are already applied to the buffer.
+ */
+class AudioSeData {
+public:
+	std::vector<uint8_t> buffer;
+	int frequency;
+	AudioDecoder::Format format;
+	int channels;
+	int last_access;
+};
+
+typedef std::shared_ptr<AudioSeData> AudioSeRef;
+
+/**
+ * AudioSeCache provides an interface for accessing sound effects.
+ * It also provides an automatic cache management, any SE is only decoded
+ * once, otherwise returned from the cache.
+ * The cache is flushed from recently (>10 seconds by default) unused
+ * samples when it reaches the memory limit (5 MB by default).
+ * Uses an internal AudioDecoder for handling the decoding.
+ */
+class AudioSeCache {
+public:
+	/**
+	 * Opens the passed filename with the internal audio decoder.
+	 *
+	 * @param filename Path to the file
+	 * @return An AudioSeCache instance when the format was detected, otherwise null
+	 */
+	static std::unique_ptr<AudioSeCache> Create(const std::string& filename);
+
+	/**
+	 * Retrieves the format of the internal audio decoder.
+	 * It is guaranteed that these settings will stay constant the whole time.
+	 *
+	 * @param frequency Filled with the audio frequency
+	 * @param format Filled with the audio format
+	 * @param channel Filled with the amount of channels
+	 */
+	void GetFormat(int& frequency, AudioDecoder::Format& format, int& channels) const;
+
+	/**
+	 * Requests a prefered format from the internal audio decoder. Not all decoders
+	 * support everything and it's recommended to use the audio hardware
+	 * for audio processing.
+	 * When false is returned use GetFormat to get the real format of the
+	 * output data.
+	 *
+	 * @param frequency Audio frequency
+	 * @param format Audio format
+	 * @param channel Number of channels
+	 * @return true when all settings were set, otherwise false (use GetFormat)
+	 */
+	bool SetFormat(int frequency, AudioDecoder::Format format, int channels);
+
+	/**
+	 * Gets the pitch multiplier of the internal audio decoder.
+	 *
+	 * @return pitch multiplier
+	 */
+	int GetPitch() const;
+
+	/**
+	 * Sets the pitch multiplier of the internal audio decoder.
+	 * 100 = normal speed
+	 * 200 = double speed and so on
+	 * 
+	 * @param pitch Pitch multiplier to use
+	 * @return true if pitch was set, false otherwise
+	 */
+	bool SetPitch(int pitch);
+
+	/**
+	 * Tells if Decode will have a cache hit when executed.
+	 * SetFormat will fail when this returns true.
+	 *
+	 * @return true if SE is already in cache, false otherwise.
+	 */
+	bool IsCached() const;
+
+	/**
+	 * Retrieves the format of the cached file.
+	 * It is guaranteed that these settings will stay constant the whole time.
+	 * When the format is not cached (false returned) the arguments are not
+	 * populated.
+	 *
+	 * @param frequency Filled with the audio frequency
+	 * @param format Filled with the audio format
+	 * @param channel Filled with the amount of channels
+	 * @return true when format was cached, the values were populated
+	 */
+	bool GetCachedFormat(int& frequency, AudioDecoder::Format& format, int& channels) const;
+
+	/**
+	 * Decodes the whole sample with the settings specified by SetFormat and
+	 * SetPitch (uses default settings of the audio file if not used).
+	 * In case of a cache hit the decoding is skipped.
+	 * Calling Decode multiple times with different settings is supported.
+	 *
+	 * @return Decoded sound effect
+	 */
+	AudioSeRef Decode();
+private:
+	int pitch = 100;
+
+	std::unique_ptr<AudioDecoder> audio_decoder;
+
+	std::string filename;
+};
+
+#endif

--- a/src/audio_secache.h
+++ b/src/audio_secache.h
@@ -131,6 +131,8 @@ public:
 	 * @return Decoded sound effect
 	 */
 	AudioSeRef Decode();
+
+	static void Clear();
 private:
 	int pitch = 100;
 

--- a/src/audio_secache.h
+++ b/src/audio_secache.h
@@ -137,6 +137,8 @@ private:
 	std::unique_ptr<AudioDecoder> audio_decoder;
 
 	std::string filename;
+
+	bool mono_to_stereo_resample = false;
 };
 
 #endif

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -17,6 +17,7 @@
 
 // Headers
 #include "scene_gamebrowser.h"
+#include "audio_secache.h"
 #include "cache.h"
 #include "game_system.h"
 #include "input.h"
@@ -50,6 +51,9 @@ void Scene_GameBrowser::Continue() {
 	Audio().BGM_Fade(800);
 
 	Main_Data::SetProjectPath(browser_dir);
+
+	Cache::Clear();
+	AudioSeCache::Clear();
 
 	Data::Clear();
 	Player::ResetGameObjects();

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -20,13 +20,13 @@
 #include <vector>
 #include "scene_title.h"
 #include "audio.h"
+#include "audio_secache.h"
 #include "cache.h"
 #include "game_screen.h"
 #include "game_system.h"
 #include "graphics.h"
 #include "input.h"
 #include "main_data.h"
-#include "options.h"
 #include "output.h"
 #include "player.h"
 #include "scene_battle.h"
@@ -53,6 +53,7 @@ void Scene_Title::Continue() {
 	// Clear the cache when the game returns to the
 	// title screen e.g. by pressing F12
 	Cache::Clear();
+	AudioSeCache::Clear();
 
 	Player::ResetGameObjects();
 


### PR DESCRIPTION
Audio SE cache. Sound effects are cached now in a ~~5~~ 1 MB cache, only the first access does a cache miss. Afterwards it takes the decoded buffer directly. This also gives AudioDecoder for SE the first time. Should fix 24bit Pom Gets Wifi SEs and gives proper playback speed for the Wii that has a broken SDL resampler \o/.

3DS and PSVita don't use the cache yet.

Cache clearing strategy:
When the cache limit is reached all entries not being accessed in the last 10 seconds are removed.

Fixes #895.