### PR TITLE
Tone: Performance improvements

### DIFF
--- a/src/plane.cpp
+++ b/src/plane.cpp
@@ -38,10 +38,23 @@ Plane::~Plane() {
 void Plane::Draw() {
 	if (!visible || !bitmap) return;
 
+	if (needs_refresh) {
+		needs_refresh = false;
+
+		if (!tone_bitmap) {
+			tone_bitmap = Bitmap::Create(bitmap->GetWidth(), bitmap->GetHeight());
+		}
+
+		tone_bitmap->Clear();
+		tone_bitmap->ToneBlit(0, 0, *bitmap, bitmap->GetRect(), tone_effect, Opacity::opaque);
+	}
+
+	BitmapRef source = tone_effect == Tone() ? bitmap : tone_bitmap;
+
 	BitmapRef dst = DisplayUi->GetDisplaySurface();
 	Rect dst_rect(0, 0, DisplayUi->GetWidth(), DisplayUi->GetHeight());
 
-	dst->TiledBlit(-ox, -oy, bitmap->GetRect(), *bitmap, dst_rect, 255);
+	dst->TiledBlit(-ox, -oy, source->GetRect(), *source, dst_rect, 255);
 }
 
 BitmapRef const& Plane::GetBitmap() const {
@@ -49,6 +62,8 @@ BitmapRef const& Plane::GetBitmap() const {
 }
 void Plane::SetBitmap(BitmapRef const& nbitmap) {
 	bitmap = nbitmap;
+
+	needs_refresh = true;
 }
 
 bool Plane::GetVisible() const {
@@ -75,6 +90,17 @@ int Plane::GetOy() const {
 }
 void Plane::SetOy(int noy) {
 	oy = noy;
+}
+
+Tone Plane::GetTone() const {
+	return tone_effect;
+}
+
+void Plane::SetTone(Tone tone) {
+	if (tone_effect != tone) {
+		tone_effect = tone;
+		needs_refresh = true;
+	}
 }
 
 DrawableType Plane::GetType() const {

--- a/src/plane.h
+++ b/src/plane.h
@@ -44,6 +44,8 @@ public:
 	void SetOx(int ox);
 	int GetOy() const;
 	void SetOy(int oy);
+	Tone GetTone() const;
+	void SetTone(Tone tone);
 
 	DrawableType GetType() const override;
 
@@ -51,11 +53,16 @@ private:
 	DrawableType type;
 
 	BitmapRef bitmap;
+	BitmapRef tone_bitmap;
+
+	Tone tone_effect;
 
 	bool visible;
 	int z;
 	int ox;
 	int oy;
+
+	bool needs_refresh = false;
 };
 
 #endif

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -86,8 +86,6 @@ void Scene_Battle::Start() {
 
 	CreateUi();
 
-	screen.reset(new Screen());
-
 	Game_System::BgmPlay(Game_System::GetSystemBGM(Game_System::BGM_Battle));
 
 	SetState(State_Start);

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -29,7 +29,6 @@
 #include "game_actor.h"
 #include "game_enemy.h"
 #include "scene.h"
-#include "screen.h"
 #include "spriteset_battle.h"
 #include "window_help.h"
 #include "window_item.h"
@@ -173,7 +172,6 @@ protected:
 	int skill_id;
 	int pending_command;
 
-
 	int actor_index;
 	Game_Actor* active_actor;
 
@@ -189,8 +187,6 @@ protected:
 	/** Displays allies status */
 	std::unique_ptr<Window_BattleStatus> status_window;
 	std::unique_ptr<Window_Message> message_window;
-
-	std::unique_ptr<Screen> screen;
 
 	std::deque<Game_Battler*> battle_actions;
 

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -50,10 +50,6 @@ void Scene_Map::Start() {
 	spriteset.reset(new Spriteset_Map());
 	message_window.reset(new Window_Message(0, SCREEN_TARGET_HEIGHT - 80, SCREEN_TARGET_WIDTH, 80));
 
-	screen.reset(new Screen());
-	weather.reset(new Weather());
-	frame.reset(new Frame());
-
 	// Called here instead of Scene Load, otherwise wrong graphic stack
 	// is used.
 	if (from_save) {

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -21,8 +21,6 @@
 // Headers
 #include "scene.h"
 #include "spriteset_map.h"
-#include "weather.h"
-#include "frame.h"
 #include "window_message.h"
 #include "window_varlist.h"
 
@@ -60,9 +58,6 @@ private:
 	void FinishTeleportPlayer();
 
 	std::unique_ptr<Window_Message> message_window;
-	std::unique_ptr<Screen> screen;
-	std::unique_ptr<Weather> weather;
-	std::unique_ptr<Frame> frame;
 
 	bool from_save;
 	bool auto_transition = false;

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -47,6 +47,10 @@ void Screen::Update() {
 void Screen::Draw() {
 	BitmapRef disp = DisplayUi->GetDisplaySurface();
 
+	if (tone_effect != Tone()) {
+		disp->ToneBlit(0, 0, *disp, Rect(0, 0, SCREEN_TARGET_WIDTH, SCREEN_TARGET_HEIGHT), tone_effect, Opacity::opaque);
+	}
+
 	int flash_time_left;
 	int flash_current_level;
 	Color flash_color = Main_Data::game_screen->GetFlash(flash_current_level, flash_time_left);
@@ -59,4 +63,12 @@ void Screen::Draw() {
 		}
 		disp->Blit(0, 0, *flash, flash->GetRect(), flash_current_level);
 	}
+}
+
+Tone Screen::GetTone() const {
+	return tone_effect;
+}
+
+void Screen::SetTone(Tone tone) {
+	tone_effect = tone;
 }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -27,8 +27,6 @@
 
 Screen::Screen() {
 	Graphics::RegisterDrawable(this);
-
-	default_tone = Tone(128, 128, 128, 128);
 }
 
 Screen::~Screen() {
@@ -48,12 +46,6 @@ void Screen::Update() {
 
 void Screen::Draw() {
 	BitmapRef disp = DisplayUi->GetDisplaySurface();
-
-	Tone tone = Main_Data::game_screen->GetTone();
-
-	if (tone != default_tone) {
-		disp->ToneBlit(0, 0, *disp, Rect(0, 0, SCREEN_TARGET_WIDTH, SCREEN_TARGET_HEIGHT), tone, Opacity::opaque);
-	}
 
 	int flash_time_left;
 	int flash_current_level;

--- a/src/screen.h
+++ b/src/screen.h
@@ -47,7 +47,6 @@ private:
 	static const int z = 1050;
 	static const DrawableType type = TypeScreen;
 
-	Tone default_tone;
 	BitmapRef flash;
 };
 

--- a/src/screen.h
+++ b/src/screen.h
@@ -43,11 +43,16 @@ public:
 	int GetZ() const override;
 	DrawableType GetType() const override;
 
+	Tone GetTone() const;
+	void SetTone(Tone tone);
+
 private:
 	static const int z = 1050;
 	static const DrawableType type = TypeScreen;
 
 	BitmapRef flash;
+
+	Tone tone_effect;
 };
 
 #endif

--- a/src/spriteset_battle.cpp
+++ b/src/spriteset_battle.cpp
@@ -57,10 +57,15 @@ Spriteset_Battle::Spriteset_Battle() {
 	timer1.reset(new Sprite_Timer(0));
 	timer2.reset(new Sprite_Timer(1));
 
+	screen.reset(new Screen());
+
 	Update();
 }
 
 void Spriteset_Battle::Update() {
+	// Battle is not as resource heavy as map, always use screen tone
+	screen->SetTone(Main_Data::game_screen->GetTone());
+
 	// Handle background change
 	if (background_name != Game_Battle::background_name) {
 		background_name = Game_Battle::background_name;

--- a/src/spriteset_battle.h
+++ b/src/spriteset_battle.h
@@ -20,6 +20,7 @@
 
 // Headers
 #include "background.h"
+#include "screen.h"
 #include "sprite_battler.h"
 #include "sprite_character.h"
 #include "sprite_timer.h"
@@ -39,6 +40,7 @@ protected:
 	std::unique_ptr<Background> background;
 	std::vector<std::shared_ptr<Sprite_Battler>> sprites;
 	std::string background_name;
+	std::unique_ptr<Screen> screen;
 
 	std::unique_ptr<Sprite_Timer> timer1;
 	std::unique_ptr<Sprite_Timer> timer2;

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -30,12 +30,14 @@
 
 // Constructor
 Spriteset_Map::Spriteset_Map() {
-	tilemap.SetWidth(Game_Map::GetWidth());
-	tilemap.SetHeight(Game_Map::GetHeight());
-	
-	ChipsetUpdated();
+	tilemap.reset(new Tilemap());
+	tilemap->SetWidth(Game_Map::GetWidth());
+	tilemap->SetHeight(Game_Map::GetHeight());
 
-	panorama.SetZ(-1000);
+	panorama.reset(new Plane());
+	panorama->SetZ(-1000);
+
+	ChipsetUpdated();
 
 	for (Game_Event& ev : Game_Map::GetEvents()) {
 		character_sprites.push_back(std::make_shared<Sprite_Character>(&ev));
@@ -56,10 +58,10 @@ Spriteset_Map::Spriteset_Map() {
 void Spriteset_Map::Update() {
 	Tone tone = Main_Data::game_screen->GetTone();
 
-	tilemap.SetOx(Game_Map::GetDisplayX() / (SCREEN_TILE_WIDTH / TILE_SIZE));
-	tilemap.SetOy(Game_Map::GetDisplayY() / (SCREEN_TILE_WIDTH / TILE_SIZE));
-	tilemap.SetTone(tone);
-	tilemap.Update();
+	tilemap->SetOx(Game_Map::GetDisplayX() / (SCREEN_TILE_WIDTH / TILE_SIZE));
+	tilemap->SetOy(Game_Map::GetDisplayY() / (SCREEN_TILE_WIDTH / TILE_SIZE));
+	tilemap->SetTone(tone);
+	tilemap->Update();
 
 	for (size_t i = 0; i < character_sprites.size(); i++) {
 		character_sprites[i]->Update();
@@ -73,8 +75,9 @@ void Spriteset_Map::Update() {
 		request->Start();
 	}
 
-	panorama.SetOx(Game_Map::GetParallaxX());
-	panorama.SetOy(Game_Map::GetParallaxY());
+	panorama->SetOx(Game_Map::GetParallaxX());
+	panorama->SetOy(Game_Map::GetParallaxY());
+	panorama->SetTone(tone);
 
 	Game_Vehicle* vehicle;
 	int map_id = Game_Map::GetMapId();
@@ -123,37 +126,37 @@ void Spriteset_Map::SystemGraphicUpdated() {
 
 void Spriteset_Map::SubstituteDown(int old_id, int new_id) {
 	Game_Map::SubstituteDown(old_id, new_id);
-	tilemap.SubstituteDown(old_id, new_id);
+	tilemap->SubstituteDown(old_id, new_id);
 }
 
 void Spriteset_Map::SubstituteUp(int old_id, int new_id) {
 	Game_Map::SubstituteUp(old_id, new_id);
-	tilemap.SubstituteUp(old_id, new_id);
+	tilemap->SubstituteUp(old_id, new_id);
 }
 
 void Spriteset_Map::OnTilemapSpriteReady(FileRequestResult*) {
 	if (!Game_Map::GetChipsetName().empty()) {
-		tilemap.SetChipset(Cache::Chipset(Game_Map::GetChipsetName()));
+		tilemap->SetChipset(Cache::Chipset(Game_Map::GetChipsetName()));
 	}
 	else {
-		tilemap.SetChipset(Bitmap::Create(480, 256));
+		tilemap->SetChipset(Bitmap::Create(480, 256));
 	}
 
-	tilemap.SetMapDataDown(Game_Map::GetMapDataDown());
-	tilemap.SetMapDataUp(Game_Map::GetMapDataUp());
-	tilemap.SetPassableDown(Game_Map::GetPassagesDown());
-	tilemap.SetPassableUp(Game_Map::GetPassagesUp());
-	tilemap.SetAnimationType(Game_Map::GetAnimationType());
-	tilemap.SetAnimationSpeed(Game_Map::GetAnimationSpeed());
+	tilemap->SetMapDataDown(Game_Map::GetMapDataDown());
+	tilemap->SetMapDataUp(Game_Map::GetMapDataUp());
+	tilemap->SetPassableDown(Game_Map::GetPassagesDown());
+	tilemap->SetPassableUp(Game_Map::GetPassagesUp());
+	tilemap->SetAnimationType(Game_Map::GetAnimationType());
+	tilemap->SetAnimationSpeed(Game_Map::GetAnimationSpeed());
 
-	tilemap.SetFastBlitDown(!panorama.GetBitmap());
+	tilemap->SetFastBlitDown(!panorama->GetBitmap());
 }
 
 void Spriteset_Map::OnPanoramaSpriteReady(FileRequestResult* result) {
 	BitmapRef panorama_bmp = Cache::Panorama(result->file);
 	Game_Map::SetParallaxSize(panorama_bmp->GetWidth(), panorama_bmp->GetHeight());
-	panorama.SetBitmap(panorama_bmp);
+	panorama->SetBitmap(panorama_bmp);
 	Game_Map::InitializeParallax();
 
-	tilemap.SetFastBlitDown(false);
+	tilemap->SetFastBlitDown(false);
 }

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -54,11 +54,16 @@ Spriteset_Map::Spriteset_Map() {
 
 // Update
 void Spriteset_Map::Update() {
+	Tone tone = Main_Data::game_screen->GetTone();
+
 	tilemap.SetOx(Game_Map::GetDisplayX() / (SCREEN_TILE_WIDTH / TILE_SIZE));
 	tilemap.SetOy(Game_Map::GetDisplayY() / (SCREEN_TILE_WIDTH / TILE_SIZE));
+	tilemap.SetTone(tone);
 	tilemap.Update();
+
 	for (size_t i = 0; i < character_sprites.size(); i++) {
 		character_sprites[i]->Update();
+		character_sprites[i]->SetTone(tone);
 	}
 	const std::string& name = Game_Map::GetParallaxName();
 	if (name != panorama_name) {
@@ -67,6 +72,7 @@ void Spriteset_Map::Update() {
 		panorama_request_id = request->Bind(&Spriteset_Map::OnPanoramaSpriteReady, this);
 		request->Start();
 	}
+
 	panorama.SetOx(Game_Map::GetParallaxX());
 	panorama.SetOy(Game_Map::GetParallaxY());
 

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -62,9 +62,8 @@ Spriteset_Map::Spriteset_Map() {
 void Spriteset_Map::Update() {
 	Tone new_tone = Main_Data::game_screen->GetTone();
 
-	if (new_tone != last_tone || Main_Data::game_screen->GetWeatherType() != Game_Screen::Weather_None) {
+	if (new_tone != last_tone) {
 		// Could be a gradient change, just updating the display is faster
-		// With weather also have to take this path because weather operations can't be cached
 		screen->SetTone(new_tone);
 		last_tone = new_tone;
 
@@ -112,6 +111,8 @@ void Spriteset_Map::Update() {
 
 	timer1->Update();
 	timer2->Update();
+
+	weather->SetTone(new_tone);
 }
 
 // Finds the sprite for a specific character

--- a/src/spriteset_map.h
+++ b/src/spriteset_map.h
@@ -19,13 +19,16 @@
 #define _SPRITESET_MAP_H_
 
 // Headers
+#include <string>
+#include "async_handler.h"
+#include "frame.h"
+#include "plane.h"
+#include "screen.h"
 #include "sprite_airshipshadow.h"
 #include "sprite_timer.h"
 #include "system.h"
 #include "tilemap.h"
-#include <string>
-#include "async_handler.h"
-#include "plane.h"
+#include "weather.h"
 
 class Sprite_Character;
 class Game_Character;
@@ -73,6 +76,9 @@ protected:
 	std::unique_ptr<Sprite_AirshipShadow> airship_shadow;
 	std::unique_ptr<Sprite_Timer> timer1;
 	std::unique_ptr<Sprite_Timer> timer2;
+	std::unique_ptr<Screen> screen;
+	std::unique_ptr<Weather> weather;
+	std::unique_ptr<Frame> frame;
 
 	void OnTilemapSpriteReady(FileRequestResult*);
 	void OnPanoramaSpriteReady(FileRequestResult* result);
@@ -81,5 +87,7 @@ protected:
 	FileRequestBinding tilemap_request_id;
 
 	bool vehicle_loaded[3] = {};
+
+	Tone last_tone;
 };
 #endif

--- a/src/spriteset_map.h
+++ b/src/spriteset_map.h
@@ -23,9 +23,9 @@
 #include "sprite_timer.h"
 #include "system.h"
 #include "tilemap.h"
-#include "plane.h"
 #include <string>
 #include "async_handler.h"
+#include "plane.h"
 
 class Sprite_Character;
 class Game_Character;
@@ -66,8 +66,8 @@ public:
 	void SubstituteUp(int old_id, int new_id);
 
 protected:
-	Tilemap tilemap;
-	Plane panorama;
+	std::unique_ptr<Tilemap> tilemap;
+	std::unique_ptr<Plane> panorama;
 	std::string panorama_name;
 	std::vector<std::shared_ptr<Sprite_Character> > character_sprites;
 	std::unique_ptr<Sprite_AirshipShadow> airship_shadow;

--- a/src/tilemap.cpp
+++ b/src/tilemap.cpp
@@ -119,3 +119,8 @@ void Tilemap::SubstituteUp(int old_id, int new_id) {
 void Tilemap::SetFastBlitDown(bool fast) {
 	layer_down.SetFastBlit(fast);
 }
+
+void Tilemap::SetTone(Tone tone) {
+	layer_down.SetTone(tone);
+	layer_up.SetTone(tone);
+}

--- a/src/tilemap.h
+++ b/src/tilemap.h
@@ -22,6 +22,7 @@
 #include <vector>
 #include "system.h"
 #include "tilemap_layer.h"
+#include "tone.h"
 
 /**
  * Tilemap class
@@ -59,6 +60,7 @@ public:
 	void SubstituteDown(int old_id, int new_id);
 	void SubstituteUp(int old_id, int new_id);
 	void SetFastBlitDown(bool fast);
+	void SetTone(Tone tone);
 
 private:
 	TilemapLayer layer_down, layer_up;

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -229,10 +229,10 @@ void TilemapLayer::Draw(int z_order) {
 						}
 
 						// Create tone changed tile
-						if (tone_changed_tiles.find(tile.ID) == tone_changed_tiles.end()) {
+						if (chipset_tone_tiles.find(id) == chipset_tone_tiles.end()) {
 							Rect r(col * TILE_SIZE, row * TILE_SIZE, TILE_SIZE, TILE_SIZE);
 							chipset_effect->ToneBlit(col * TILE_SIZE, row * TILE_SIZE, *chipset, r, tone, Opacity::opaque);
-							tone_changed_tiles.insert(tile.ID);
+							chipset_tone_tiles.insert(id);
 						}
 
 						DrawTile(*chipset_effect, map_draw_x, map_draw_y, row, col);
@@ -244,10 +244,10 @@ void TilemapLayer::Draw(int z_order) {
 						int row = 4 + animation_step_c;
 
 						// Create tone changed tile
-						if (tone_changed_tiles.find(tile.ID) == tone_changed_tiles.end()) {
+						if (chipset_tone_tiles.find(tile.ID + (animation_step_c << 12)) == chipset_tone_tiles.end()) {
 							Rect r(col * TILE_SIZE, row * TILE_SIZE, TILE_SIZE, TILE_SIZE);
 							chipset_effect->ToneBlit(col * TILE_SIZE, row * TILE_SIZE, *chipset, r, tone, Opacity::opaque);
-							tone_changed_tiles.insert(tile.ID);
+							chipset_tone_tiles.insert(tile.ID + (animation_step_c << 12));
 						}
 
 						// Draw the tile
@@ -259,10 +259,10 @@ void TilemapLayer::Draw(int z_order) {
 						TileXY pos = GetCachedAutotileAB(tile.ID, animation_step_ab);
 
 						// Create tone changed tile
-						if (tone_changed_tiles.find(tile.ID) == tone_changed_tiles.end()) {
+						if (autotiles_ab_screen_tone_tiles.find(tile.ID + (animation_step_ab << 12)) == autotiles_ab_screen_tone_tiles.end()) {
 							Rect r(pos.x * TILE_SIZE, pos.y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
 							autotiles_ab_screen_effect->ToneBlit(pos.x * TILE_SIZE, pos.y * TILE_SIZE, *autotiles_ab_screen, r, tone, Opacity::opaque);
-							tone_changed_tiles.insert(tile.ID);
+							autotiles_ab_screen_tone_tiles.insert(tile.ID + (animation_step_ab << 12));
 						}
 
 						DrawTile(*autotiles_ab_screen_effect, map_draw_x, map_draw_y, pos.y, pos.x);
@@ -273,10 +273,10 @@ void TilemapLayer::Draw(int z_order) {
 						TileXY pos = GetCachedAutotileD(tile.ID);
 
 						// Create tone changed tile
-						if (tone_changed_tiles.find(tile.ID) == tone_changed_tiles.end()) {
+						if (autotiles_d_screen_tone_tiles.find(tile.ID) == autotiles_d_screen_tone_tiles.end()) {
 							Rect r(pos.x * TILE_SIZE, pos.y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
 							autotiles_d_screen_effect->ToneBlit(pos.x * TILE_SIZE, pos.y * TILE_SIZE, *autotiles_d_screen, r, tone, Opacity::opaque);
-							tone_changed_tiles.insert(tile.ID);
+							autotiles_d_screen_tone_tiles.insert(tile.ID);
 						}
 
 						DrawTile(*autotiles_d_screen_effect, map_draw_x, map_draw_y, pos.y, pos.x);
@@ -301,10 +301,10 @@ void TilemapLayer::Draw(int z_order) {
 						}
 
 						// Create tone changed tile
-						if (tone_changed_tiles.find(tile.ID) == tone_changed_tiles.end()) {
+						if (chipset_tone_tiles.find(id) == chipset_tone_tiles.end()) {
 							Rect r(col * TILE_SIZE, row * TILE_SIZE, TILE_SIZE, TILE_SIZE);
 							chipset_effect->ToneBlit(col * TILE_SIZE, row * TILE_SIZE, *chipset, r, tone, Opacity::opaque);
-							tone_changed_tiles.insert(tile.ID);
+							chipset_tone_tiles.insert(id);
 						}
 
 						// Draw the tile
@@ -597,15 +597,18 @@ BitmapRef const& TilemapLayer::GetChipset() const {
 
 void TilemapLayer::SetChipset(BitmapRef const& nchipset) {
 	chipset = nchipset;
-	chipset_effect = Bitmap::Create(*chipset, chipset->GetRect());
-	chipset_effect->Clear();
+	chipset_effect = Bitmap::Create(chipset->width(), chipset->height());
+	chipset_tone_tiles.clear();
 
 	if (autotiles_ab_next != 0 && autotiles_d_screen != 0 && layer == 0) {
 		autotiles_ab_screen = GenerateAutotiles(autotiles_ab_next, autotiles_ab_map);
 		autotiles_d_screen = GenerateAutotiles(autotiles_d_next, autotiles_d_map);
 
-		autotiles_ab_screen_effect = Bitmap::Create(*autotiles_ab_screen, autotiles_ab_screen->GetRect());
-		autotiles_d_screen_effect = Bitmap::Create(*autotiles_d_screen, autotiles_d_screen->GetRect());
+		autotiles_ab_screen_effect = Bitmap::Create(autotiles_ab_screen->width(), autotiles_ab_screen->height());
+		autotiles_d_screen_effect = Bitmap::Create(autotiles_d_screen->width(), autotiles_d_screen->height());
+
+		autotiles_ab_screen_tone_tiles.clear();
+		autotiles_d_screen_tone_tiles.clear();
 	}
 }
 
@@ -643,8 +646,11 @@ void TilemapLayer::SetMapData(const std::vector<short>& nmap_data) {
 		autotiles_ab_screen = GenerateAutotiles(autotiles_ab_next, autotiles_ab_map);
 		autotiles_d_screen = GenerateAutotiles(autotiles_d_next, autotiles_d_map);
 
-		autotiles_ab_screen_effect = Bitmap::Create(*autotiles_ab_screen, autotiles_ab_screen->GetRect());
-		autotiles_d_screen_effect = Bitmap::Create(*autotiles_d_screen, autotiles_d_screen->GetRect());
+		autotiles_ab_screen_effect = Bitmap::Create(autotiles_ab_screen->width(), autotiles_ab_screen->height());
+		autotiles_d_screen_effect = Bitmap::Create(autotiles_d_screen->width(), autotiles_d_screen->height());
+
+		autotiles_ab_screen_tone_tiles.clear();
+		autotiles_d_screen_tone_tiles.clear();
 	}
 
 	map_data = nmap_data;
@@ -779,5 +785,16 @@ void TilemapLayer::SetTone(Tone tone) {
 
 	this->tone = tone;
 
-	tone_changed_tiles.clear();
+	if (autotiles_d_screen_effect) {
+		autotiles_d_screen_effect->Clear();
+		autotiles_d_screen_tone_tiles.clear();
+	}
+	if (autotiles_ab_screen_effect) {
+		autotiles_ab_screen_effect->Clear();
+		autotiles_ab_screen_tone_tiles.clear();
+	}
+	if (chipset_effect) {
+		chipset_effect->Clear();
+		chipset_tone_tiles.clear();
+	}
 }

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -95,6 +95,8 @@ public:
 private:
 	BitmapRef chipset;
 	BitmapRef chipset_effect;
+	std::set<short> chipset_tone_tiles;
+
 	std::vector<short> map_data;
 	std::vector<uint8_t> passable;
 	std::vector<uint8_t> substitutions;
@@ -131,8 +133,10 @@ private:
 	TileXY GetCachedAutotileD(short ID);
 	BitmapRef autotiles_ab_screen;
 	BitmapRef autotiles_ab_screen_effect;
+	std::set<short> autotiles_ab_screen_tone_tiles;
 	BitmapRef autotiles_d_screen;
 	BitmapRef autotiles_d_screen_effect;
+	std::set<short> autotiles_d_screen_tone_tiles;
 
 	int autotiles_ab_next = -1;
 	int autotiles_d_next = -1;
@@ -149,7 +153,6 @@ private:
 	};
 	std::vector<std::vector<TileData> > data_cache;
 	std::vector<std::shared_ptr<TilemapSubLayer> > sublayers;
-	std::set<int> tone_changed_tiles;
 
 	Tone tone;
 };

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -21,8 +21,10 @@
 // Headers
 #include <vector>
 #include <map>
+#include <set>
 #include "system.h"
 #include "drawable.h"
+#include "tone.h"
 
 class TilemapLayer;
 
@@ -88,8 +90,11 @@ public:
 	 */
 	void SetFastBlit(bool fast);
 
+	void SetTone(Tone tone);
+
 private:
 	BitmapRef chipset;
+	BitmapRef chipset_effect;
 	std::vector<short> map_data;
 	std::vector<uint8_t> passable;
 	std::vector<uint8_t> substitutions;
@@ -125,10 +130,12 @@ private:
 	TileXY GetCachedAutotileAB(short ID, short animID);
 	TileXY GetCachedAutotileD(short ID);
 	BitmapRef autotiles_ab_screen;
+	BitmapRef autotiles_ab_screen_effect;
 	BitmapRef autotiles_d_screen;
+	BitmapRef autotiles_d_screen_effect;
 
-	int autotiles_ab_next;
-	int autotiles_d_next;
+	int autotiles_ab_next = -1;
+	int autotiles_d_next = -1;
 
 	TileXY autotiles_ab[3][3][16][47];
 	TileXY autotiles_d[12][50];
@@ -142,6 +149,9 @@ private:
 	};
 	std::vector<std::vector<TileData> > data_cache;
 	std::vector<std::shared_ptr<TilemapSubLayer> > sublayers;
+	std::set<int> tone_changed_tiles;
+
+	Tone tone;
 };
 
 #endif

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -122,6 +122,9 @@ static const int snowflake_visible = 150;
 void Weather::DrawRain() {
 	if (!rain_bitmap) {
 		rain_bitmap = Bitmap::Create(rain_image, sizeof(rain_image));
+		if (tone_effect != Tone()) {
+			rain_bitmap->ToneBlit(0, 0, *rain_bitmap, rain_bitmap->GetRect(), tone_effect, Opacity::opaque);
+		}
 	}
 
 	Rect rect = rain_bitmap->GetRect();
@@ -142,7 +145,11 @@ void Weather::DrawRain() {
 void Weather::DrawSnow() {
 	if (!snow_bitmap) {
 		snow_bitmap = Bitmap::Create(snow_image, sizeof(snow_image));
+		if (tone_effect != Tone()) {
+			snow_bitmap->ToneBlit(0, 0, *snow_bitmap, snow_bitmap->GetRect(), tone_effect, Opacity::opaque);
+		}
 	}
+
 
 	static const int wobble[2][18] = {
 		{-1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0},
@@ -183,4 +190,16 @@ void Weather::DrawSandstorm() {
 	// TODO
 
 	dirty = true;
+}
+
+Tone Weather::GetTone() const {
+	return tone_effect;
+}
+
+void Weather::SetTone(Tone tone) {
+	if (tone != tone_effect) {
+		tone_effect = tone;
+		rain_bitmap.reset();
+		snow_bitmap.reset();
+	}
 }

--- a/src/weather.h
+++ b/src/weather.h
@@ -46,7 +46,6 @@ private:
 	static const int z = 1001;
 	static const DrawableType type = TypeWeather;
 
-	//std::unique_ptr<Plane> weather_plane;
 	BitmapRef weather_surface;
 	BitmapRef snow_bitmap;
 	BitmapRef rain_bitmap;

--- a/src/weather.h
+++ b/src/weather.h
@@ -37,6 +37,9 @@ public:
 	int GetZ() const override;
 	DrawableType GetType() const override;
 
+	Tone GetTone() const;
+	void SetTone(Tone tone);
+
 private:
 	void DrawRain();
 	void DrawSnow();
@@ -49,6 +52,8 @@ private:
 	BitmapRef weather_surface;
 	BitmapRef snow_bitmap;
 	BitmapRef rain_bitmap;
+
+	Tone tone_effect;
 
 	bool dirty;
 };


### PR DESCRIPTION
Tone change of the screen is now calculated per sprite. This means the tone is only calculated once and afterwards the Blit is normal speed as if no tone is changed. Special case is a "gradient change", when the tone changes per frame. In that case it uses the old behaviour because is faster for that case.

Gives a significant speed boost on slow hardware for that case obviously ;)
