### PR TITLE
Fix interpreter problems in smashbros, Doraemon 2,  特に理由 and Win' Wind' Windy'

### DIFF
--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -235,6 +235,8 @@ void Game_Event::ClearStarting() {
 
 void Game_Event::Setup(RPG::EventPage* new_page) {
 	bool from_null = page == NULL;
+
+	RPG::EventPage* old_page = page;
 	page = new_page;
 
 	// Free resources if needed
@@ -275,7 +277,7 @@ void Game_Event::Setup(RPG::EventPage* new_page) {
 	original_move_route = page->move_route;
 	SetOriginalMoveRouteIndex(0);
 
-	bool last_direction_fixed = IsDirectionFixed() || IsFacingLocked();
+	bool last_direction_fixed = IsDirectionFixed() || IsFacingLocked() || (old_page && old_page->character_direction != GetSpriteDirection());
 	animation_type = page->animation_type;
 
 	if (from_null || !(last_direction_fixed || IsMoving()) || IsDirectionFixed())

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -280,10 +280,10 @@ void Game_Event::Setup(RPG::EventPage* new_page) {
 	bool last_direction_fixed = IsDirectionFixed() || IsFacingLocked() || (old_page && old_page->character_direction != GetSpriteDirection());
 	animation_type = page->animation_type;
 
-	if (from_null || !(last_direction_fixed || IsMoving()) || IsDirectionFixed())
+	if (from_null || !(last_direction_fixed || IsMoving()) || IsDirectionFixed()) {
 		SetSpriteDirection(page->character_direction);
-	if (!IsMoving())
 		SetDirection(page->character_direction);
+	}
 
 	SetOpacity(page->translucent ? 160 : 255);
 	SetLayer(page->layer);

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -948,11 +948,13 @@ bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { /
 			;
 	}
 
+	int last = com.parameters[0] == 0 ? com.parameters[1] : com.parameters[2];
+
 	switch (com.parameters[0]) {
 		case 0:
 		case 1:
 			// Single and Var range
-			for (i = com.parameters[1]; i <= com.parameters[2]; i++) {
+			for (i = com.parameters[1]; i <= last; i++) {
 				switch (com.parameters[3]) {
 					case 0:
 						// Assignement

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -691,31 +691,24 @@ bool Game_Interpreter::CommandInputNumber(RPG::EventCommand const& com) { // cod
 }
 
 bool Game_Interpreter::CommandControlSwitches(RPG::EventCommand const& com) { // code 10210
-	int i;
-	switch (com.parameters[0]) {
-		case 0:
-		case 1:
-			// Single and switch range
-			for (i = com.parameters[1]; i <= com.parameters[2]; i++) {
-				if (com.parameters[3] != 2) {
-					Game_Switches[i] = com.parameters[3] == 0;
-				} else {
-					Game_Switches[i] = !Game_Switches[i];
-				}
-			}
-			break;
-		case 2:
-			// Switch from variable
+	if (com.parameters[0] >= 0 && com.parameters[0] <= 2) {
+		// Param0: 0: Single, 1: Range, 2: Indirect
+		// For Range set end to param 2, otherwise to start, this way the loop runs exactly once
+
+		int start = com.parameters[0] == 2 ? Game_Variables[com.parameters[1]] : com.parameters[1];
+		int end = com.parameters[0] == 1 ? com.parameters[2] : start;
+
+		for (int i = start; i <= end; ++i) {
 			if (com.parameters[3] != 2) {
-				Game_Switches[Game_Variables[com.parameters[1]]] = com.parameters[3] == 0;
+				Game_Switches[i] = com.parameters[3] == 0;
 			} else {
-				Game_Switches[Game_Variables[com.parameters[1]]] = !Game_Switches[Game_Variables[com.parameters[1]]];
+				Game_Switches[i] = !Game_Switches[i];
 			}
-			break;
-		default:
-			return false;
+		}
+
+		Game_Map::SetNeedRefresh(Game_Map::Refresh_All);
 	}
-	Game_Map::SetNeedRefresh(Game_Map::Refresh_All);
+
 	return true;
 }
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -948,93 +948,57 @@ bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { /
 			;
 	}
 
-	int last = com.parameters[0] == 0 ? com.parameters[1] : com.parameters[2];
+	if (com.parameters[0] >= 0 && com.parameters[0] <= 2) {
+		// Param0: 0: Single, 1: Range, 2: Indirect
+		// For Range set end to param 2, otherwise to start, this way the loop runs exactly once
 
-	switch (com.parameters[0]) {
-		case 0:
-		case 1:
-			// Single and Var range
-			for (i = com.parameters[1]; i <= last; i++) {
-				switch (com.parameters[3]) {
-					case 0:
-						// Assignement
-						Game_Variables[i] = value;
-						break;
-					case 1:
-						// Addition
-						Game_Variables[i] += value;
-						break;
-					case 2:
-						// Subtraction
-						Game_Variables[i] -= value;
-						break;
-					case 3:
-						// Multiplication
-						Game_Variables[i] *= value;
-						break;
-					case 4:
-						// Division
-						if (value != 0) {
-							Game_Variables[i] /= value;
-						}
-						break;
-					case 5:
-						// Module
-						if (value != 0) {
-							Game_Variables[i] %= value;
-						} else {
-							Game_Variables[i] = 0;
-						}
-				}
-				if (Game_Variables[i] > MaxSize) {
-					Game_Variables[i] = MaxSize;
-				}
-				if (Game_Variables[i] < MinSize) {
-					Game_Variables[i] = MinSize;
-				}
-			}
-			break;
+		int start = com.parameters[0] == 2 ? Game_Variables[com.parameters[1]] : com.parameters[1];
+		int end = com.parameters[0] == 1 ? com.parameters[2] : start;
 
-		case 2:
-			int var_index = Game_Variables[com.parameters[1]];
+		for (i = start; i <= end; ++i) {
 			switch (com.parameters[3]) {
 				case 0:
 					// Assignement
-					Game_Variables[var_index] = value;
+					Game_Variables[i] = value;
 					break;
 				case 1:
 					// Addition
-					Game_Variables[var_index] += value;
+					Game_Variables[i] += value;
 					break;
 				case 2:
 					// Subtraction
-					Game_Variables[var_index] -= value;
+					Game_Variables[i] -= value;
 					break;
 				case 3:
 					// Multiplication
-					Game_Variables[var_index] *= value;
+					Game_Variables[i] *= value;
 					break;
 				case 4:
 					// Division
 					if (value != 0) {
-						Game_Variables[var_index] /= value;
+						Game_Variables[i] /= value;
 					}
 					break;
 				case 5:
 					// Module
 					if (value != 0) {
-						Game_Variables[var_index] %= value;
+						Game_Variables[i] %= value;
+					} else {
+						Game_Variables[i] = 0;
 					}
 			}
-			if (Game_Variables[var_index] > MaxSize) {
-				Game_Variables[var_index] = MaxSize;
+
+			if (Game_Variables[i] > MaxSize) {
+				Game_Variables[i] = MaxSize;
 			}
-			if (Game_Variables[var_index] < MinSize) {
-				Game_Variables[var_index] = MinSize;
+			if (Game_Variables[i] < MinSize) {
+				Game_Variables[i] = MinSize;
 			}
+		}
+
+		Game_Map::SetNeedRefresh(Game_Map::Refresh_Map);
 	}
 
-	Game_Map::SetNeedRefresh(Game_Map::Refresh_Map);
 	return true;
 }
 

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -298,8 +298,9 @@ void Game_Player::MoveTo(int x, int y) {
 }
 
 void Game_Player::UpdateScroll() {
-	int center_x = DisplayUi->GetWidth() / 2 - TILE_SIZE / 2 - Game_Map::GetPanX() / (SCREEN_TILE_WIDTH / TILE_SIZE);
-	int center_y = DisplayUi->GetHeight() / 2 + TILE_SIZE / 2 - Game_Map::GetPanY() / (SCREEN_TILE_WIDTH / TILE_SIZE);
+	int center_x = DisplayUi->GetWidth() / 2 - TILE_SIZE / 2 - Game_Map::GetPanX() / (SCREEN_TILE_WIDTH / TILE_SIZE) + 2;
+	int center_y = DisplayUi->GetHeight() / 2 + TILE_SIZE / 2 - Game_Map::GetPanY() / (SCREEN_TILE_WIDTH / TILE_SIZE) + 2;
+
 	int dx = 0;
 	int dy = 0;
 


### PR DESCRIPTION
Visual demonstration of the off-by-two:
https://easyrpg.org/play/master/?test-play&start-position=8%201&new-game

Fixed:
https://easyrpg.org/play/pr1020/?test-play&start-position=8%201&new-game

Hold STRG (for walk everywhere) and one tile to the right. You will notice a minor scroll of two pixel which doesn't happen anymore in my PR.

And smash bros: https://easy-rpg.org/play/master/?game=smashbros

Fixed: https://easy-rpg.org/play/pr1020/?game=smashbros

Try to fall out of the bottom of the arena.


**The 2nd commit** "Don't change direction when"... has a test case here: 
[Project5.zip](https://github.com/EasyRPG/Player/files/443094/Project5.zip)

Online master: https://easyrpg.org/play/master/?game=issue_1020

Online fixed: https://easyrpg.org/play/pr1020/?game=issue_1020

In the old player the girl will always revert to bottom look instead of keeping the changed one. I found this while trying to fix Doraemon, but is unrelated.

The **3rd commit** removed these IsMoving checks and I have no idea what the side-effect of this is but **it fixes Doraemon 2 shooting.** Maybe @Zegeri has an idea. I couldn't find any regression yet but only played for a few minutes.

Online master: https://easyrpg.org/play/master/?game=nobihazard2

Online fixed: https://easyrpg.org/play/pr1020/?game=nobihazard2

Skip the intro by choosing always the bottom option when asked a question, then wait until the zombie goes through the door. Pick up the pistole, equip it in the menu, press SHIFT and shoot with enter.