### PR TITLE
Android: Try to fix strange crashes (SettingsActivity = null)

### DIFF
--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
@@ -27,6 +27,7 @@ import android.widget.Toast;
 
 import org.easyrpg.player.R;
 import org.easyrpg.player.button_mapping.ButtonMappingManager;
+import org.easyrpg.player.settings.SettingsManager;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,6 +64,9 @@ public class GameBrowserActivity extends AppCompatActivity
     @Override
     public void onResume() {
         super.onResume();
+
+        // Retrieve user's preferences (for application's folder)
+        SettingsManager.init(getApplicationContext());
 
         // Display the "How to use EasyRPG" on the first startup
         GameBrowserHelper.displayHowToMessageOnFirstStartup(this);

--- a/builds/android/app/src/main/java/org/easyrpg/player/player/EasyRpgPlayerActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/player/EasyRpgPlayerActivity.java
@@ -86,6 +86,8 @@ public class EasyRpgPlayerActivity extends SDLActivity implements NavigationView
         super.onCreate(savedInstanceState);
         EasyRpgPlayerActivity.instance = this;
 
+        SettingsManager.init(getApplicationContext());
+
         // Menu configuration
         this.drawer = (DrawerLayout) findViewById(R.id.drawer_layout);
         drawer.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsAudioActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsAudioActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.CheckBox;
+import org.easyrpg.player.settings.SettingsManager;
 
 import org.easyrpg.player.R;
 
@@ -15,6 +16,8 @@ public class SettingsAudioActivity extends AppCompatActivity implements View.OnC
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_settings_audio);
+
+        SettingsManager.init(getApplicationContext());
 
         // Setting UI components
         this.enableAudioCheckbox = (CheckBox) findViewById(R.id.settings_audio);

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsGamesFoldersActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsGamesFoldersActivity.java
@@ -12,6 +12,7 @@ import android.widget.TextView;
 
 import org.easyrpg.player.DirectoryChooser;
 import org.easyrpg.player.R;
+import org.easyrpg.player.settings.SettingsManager;
 
 public class SettingsGamesFoldersActivity extends AppCompatActivity implements View.OnClickListener {
     private LinearLayout gamesFoldersListLayout;
@@ -21,6 +22,8 @@ public class SettingsGamesFoldersActivity extends AppCompatActivity implements V
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         this.setContentView(R.layout.activity_settings_games_folders);
+
+        SettingsManager.init(getApplicationContext());
 
         // Setting UI components
         gamesFoldersListLayout = (LinearLayout) findViewById(R.id.games_folders_list);

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsInputActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsInputActivity.java
@@ -20,6 +20,7 @@ import android.widget.TextView;
 import org.easyrpg.player.R;
 import org.easyrpg.player.button_mapping.ButtonMappingActivity;
 import org.easyrpg.player.button_mapping.ButtonMappingManager;
+import org.easyrpg.player.settings.SettingsManager;
 
 public class SettingsInputActivity extends AppCompatActivity implements View.OnClickListener {
     private CheckBox enableVibrationCheckBox, enableVibrateWhenSlidingCheckbox, ignoreLayoutSizeCheckbox;
@@ -33,6 +34,8 @@ public class SettingsInputActivity extends AppCompatActivity implements View.OnC
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         this.setContentView(R.layout.activity_settings_inputs);
+
+        SettingsManager.init(getApplicationContext());
 
         this.buttonMappingManager = ButtonMappingManager.getInstance(this);
 

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsVideoActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsVideoActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.CheckBox;
+import org.easyrpg.player.settings.SettingsManager;
 
 import org.easyrpg.player.R;
 
@@ -15,6 +16,8 @@ public class SettingsVideoActivity extends AppCompatActivity implements View.OnC
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         this.setContentView(R.layout.activity_settings_video);
+
+        SettingsManager.init(getApplicationContext());
 
         // Setting UI components
         this.forceLandscapeModeCheckbox = (CheckBox) findViewById(R.id.force_landscape_mode);

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -165,7 +165,9 @@ void Scene_Title::CreateCommandWindow() {
 }
 
 void Scene_Title::PlayTitleMusic() {
-	// Play music
+	// Workaround Android problem: BGM doesn't start when game is started again
+	Game_System::BgmStop();
+	// Play BGM
 	Game_System::BgmPlay(Data::system.title_music);
 }
 


### PR DESCRIPTION
No idea how this happens, probably Android memory management stuff.

I reinit now the settings when the gamebrowser (re)loads.

I ask everybody to install the Jenkins APK on your device and then just touch around and check if the "Game folders" list is empty.

Fix #1021