### PR TITLE
Android: Update all translations for 0.5

### DIFF
--- a/builds/android/app/src/main/res/values-be/strings.xml
+++ b/builds/android/app/src/main/res/values-be/strings.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <!--GameBrowser Activity-->
+  <string name="autodetect">Аўтавыбар рэгіёна (рэкамендуецца)</string>
+  <string name="west_europe">Заходнееўрапейскі</string>
+  <string name="east_europe">Цэнтральна- ці сходнееўрапейскі</string>
+  <string name="cyrillic">Кірылічны</string>
+  <string name="japan">Японскі</string>
+  <string name="korean">Карэйскі</string>
+  <string name="chinese_simple">Кітайскі (спрошчаныя формы)</string>
+  <string name="chinese_traditional">Кітайскі (традыцыйныя формы)</string>
+  <string name="greek">Грэцкі</string>
+  <string name="turkish">Турэцкі</string>
+  <string name="hebrew">Іўрыт</string>
+  <string name="arabic">Арабскі</string>
+  <string name="baltic">Балтыйскі</string>
+  <string name="thai">Тайскі</string>
+  <string name="vietnamese">В’етнамскі</string>
+  <string name="ok">OK</string>
+  <string name="cancel">Адмена</string>
+  <string name="do_want_quit">Вы сапраўды жадаеце выйсці?</string>
+  <string name="yes">Так</string>
+  <string name="no">Не</string>
+  <string name="creating_dir_failed">Не атрымалася стварыць дырэкторыю $PATH</string>
+  <string name="path_not_readable">Немагчыма прачытаць $PATH</string>
+  <string name="no_games_found_and_explanation">Гульні для RPG Maker 2000/2003 не знойдзеныя.
+Дадатковыя дэрэкторыі для гульняў можна выбраць у наладах.</string>
+  <string name="no_external_storage">Не знойдзены знешні дыск (напр. SD-карта)</string>
+  <string name="not_valid_game">$PATH — не гульня ці не падтрымліваецца.</string>
+  <string name="select_game_region">Выбраць рэгіён гульні</string>
+  <string name="change_the_layout">Змяніць інтэрфейс</string>
+  <string name="choose_layout">Выбраць інтэрфейс</string>
+  <string name="unknown_region">Невядомы рэгіён</string>
+  <string name="region_modification_failed">Не атрымалася змяніць рэгіён</string>
+  <string name="refresh">Анавіць</string>
+  <string name="change_default_mapping">Змяніць стандартныя значэнні кнопак</string>
+  <string name="how_to_use_easy_rpg">Інструкцыя да EasyRPG Player</string>
+  <string name="how_to_use_easy_rpg_explanation">Інструкцыі па ўсталёўцы:\n\nПа змаўчанні адкрываюцца гульні з дырэкторыі /easyrpg/games. Вы можаце выбраць дадактовыя дырэкторыі ў наладах.\n\nНеабавязковае: Распакуйце RTP для RPG Maker 2000 у /easyrpg/rtp/2000, а RTP для RPG Maker 2003 у /easyrpg/rtp/2003.\n\nКаб праграма магла знайсці гульні, іх трэба распакаваць у паддырэкторыю ўсярэдзіне /easyrpg/games (па змаўчанні), напрыклад:\n\n\t/easyrpg/games/MyGame/Data/RPG_RT.ldb — правільна.\n\t/easyrpg/games/MyGame/RPG_RT.ldb — правільна.\n\t/easyrpg/games/MyGame.zip — НЯПРАВІЛЬНА. ZIP і EXE не падтрымліваюцца.</string>
+  <!--Ingame menu-->
+  <string name="toggle_fps">Паказ FPS</string>
+  <string name="toggle_ui">Паказ віртуальных кнопак</string>
+  <string name="end_game">Закончыць гульню</string>
+  <string name="report_bug">Паведаміць пра памылку</string>
+  <string name="report_bug_msg">Гэты пункт адкрые вашу паштовую праграму (напр. Gmail), каб даслаць паведамленне пра памылку.\n\nКалі вы не хочаце дасылаць паведамленне лістом, ці ў вас не налаштаваная паштовая праграма, на https://github.com/EasyRPG/Player/issues можна дадаць новае апісанне праблемы.</string>
+  <string name="report_bug_mail">Дзякуй, што падтрымліваеце EasyRPG Player.\n
+Да гэтага ліста былі даданыя лог-файл і захаваныя гульні.\n
+Калі ласка, не выдаляйце лог-файл! Нам патрэбны файл захаванай гульні недалёка ад месца, дзе зʼяўляецца праблемы.\n
+Калі ласка, падрабязна апішыце праблему.\n\n
+</string>
+  <!--Settings Activities-->
+  <string name="video">Відэа</string>
+  <string name="audio">Аўдыя</string>
+  <string name="input">Увод</string>
+  <string name="game_folders">Дырэкторыі з гульнямі</string>
+  <string name="settings">Налады</string>
+  <string name="add_game_folder">Дадаць дырэкторыю з гульнямі</string>
+  <string name="enable_vibration">Дазволіць вібрацыю</string>
+  <string name="vibrate_when_sliding_direction">Вібраваць, калі адбылося перамяшчэнне ў іншым напрамку адным дотыкам</string>
+  <string name="enable_audio">Уключыць аўдыя</string>
+  <string name="input_layout_transparency">Празорасць інтэрфейсу ўводу:</string>
+  <string name="ignore_size_settings">Не ўлічваць памер кнопак і выкарыстоўваць такі памер для ўсіх кнопак:</string>
+  <string name="no_read_access_on_dir">Няма доступу, каб прачытаць %1$s</string>
+  <string name="quick_access">Хуткі доступ</string>
+  <string name="force_landscape_mode">Зафіксаваць гарызантальную арыентацыю</string>
+  <!--InputLayout Managing-->
+  <string name="manage_input_layouts">Кіраванне інтэрфейсамі ўводу:</string>
+  <string name="add_an_input_layout">Дадаць інтэрфейс уводу</string>
+  <string name="set_as_default">Зрабіць стандартным</string>
+  <string name="edit_name">Змяніць назву</string>
+  <string name="edit_layout">Змяніць інтэрфейс</string>
+  <string name="delete">Выдаліць</string>
+  <string name="default_layout">Стандартны</string>
+  <!--ButtonMapping Activity-->
+  <string name="add_a_button">Дадаць кнопку</string>
+  <string name="reset_button_mapping">Скінуць значэнні кнопак</string>
+  <string name="exit_without_saving">Выйсці без захавання</string>
+  <string name="save_and_quit">Захаваць і выйсці</string>
+  <string name="key_enter">Enter (Z)</string>
+  <string name="key_cancel">Адмена (ESC і X)</string>
+  <string name="key_shift">Shift</string>
+  <!--GameBrowserAPI15-->
+  <string name="navigation_drawer_open">Адкрыць бакавое меню</string>
+  <string name="navigation_drawer_close">Закрыць бакавое меню</string>
+  <string name="menu">Адкрыць Android-меню</string>
+</resources>

--- a/builds/android/app/src/main/res/values-de/strings.xml
+++ b/builds/android/app/src/main/res/values-de/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <!--Preferences Keys-->
   <!--GameBrowser Activity-->
   <string name="autodetect">Region automatisch erkennen (Empfohlen)</string>
   <string name="west_europe">Westeuropa</string>
@@ -24,7 +23,8 @@
   <string name="no">Nein</string>
   <string name="creating_dir_failed">Der Ordner $PATH konnte nicht erstellt werden.</string>
   <string name="path_not_readable">$PATH ist nicht lesbar</string>
-  <string name="no_games_found_and_explanation">Keine Spiele gefunden.\nDu kannst in den Einstellungen Verzeichnisse hinzufügen.</string>
+  <string name="no_games_found_and_explanation">Keine RPG Maker 2000/2003-Spiele gefunden.
+Du kannst in den Einstellungen Spielverzeichnisse hinzufügen.</string>
   <string name="no_external_storage">Kein externer Speicher (z.B. SD-Karte) gefunden.</string>
   <string name="not_valid_game">$PATH ist kein gültiges Spiel</string>
   <string name="select_game_region">Spielregion auswählen</string>
@@ -35,32 +35,23 @@
   <string name="refresh">Aktualisieren</string>
   <string name="change_default_mapping">Standard-Tastenlayout ändern</string>
   <string name="how_to_use_easy_rpg">Wie verwende ich EasyRPG Player</string>
-  <string name="how_to_use_easy_rpg_explanation">
-Installationsanleitung:\n
-Standardmäßig werden Spiele in /easyrpg/games gesucht. Du kannst weitere Spieleordner in den Einstellungen hinzufügen.\n
-Optional: Platziere das RTP in /easyrpg/rtp/2000 für das RPG Maker 2000 RTP bzw. in /easyrpg/rtp/2003 für das RPG Maker 2003 RTP.\n
-\n
-Tipp: Damit Spiele korrekt erkannt werden, müssen sie in ein Unterverzeichnis von /easyrpg/games (Standardverzeichnis) extrahiert werden, z.B.:\n
-\t/easyrpg/games/MeinSpiel/Data/RPG_RT.ldb ist OK.\n
-\t/easyrpg/games/MeinSpiel/RPG_RT.ldb ist OK.\n
-\t/easyrpg/games/MeinSpiel.zip ist FALSCH.\n
-\n
-Spezielle Funktionen:\n
-Im Einstellungsmenü kannst du Tasten verschieben und neue hinzufügen. Drücke im Layout-Editor die Zurück-Taste deines Gerätes, um ein Menü zu öffnen.</string>
+  <string name="how_to_use_easy_rpg_explanation">Installationsanleitung:\n\nStandardmäßig werden Spiele in /easyrpg/games gesucht. Du kannst weitere Spieleordner in den Einstellungen hinzufügen.\n\nOptional: Platziere das RTP in /easyrpg/rtp/2000 für das RPG Maker 2000 RTP bzw. in /easyrpg/rtp/2003 für das RPG Maker 2003 RTP.\n\nDamit Spiele korrekt erkannt werden, müssen sie in ein Unterverzeichnis von /easyrpg/games (Standardverzeichnis) extrahiert werden, z.B.:\n\n\t/easyrpg/games/MeinSpiel/Data/RPG_RT.ldb ist OK.\n\t/easyrpg/games/MeinSpiel/RPG_RT.ldb ist OK.\n\t/easyrpg/games/MeinSpiel.zip ist FALSCH. ZIP und EXE werden nicht unterstützt.</string>
   <!--Ingame menu-->
   <string name="toggle_fps">FPS ein-/ausblenden</string>
   <string name="toggle_ui">Virtuelle Tasten ein-/ausblenden</string>
   <string name="end_game">Spiel beenden</string>
   <string name="report_bug">Fehler melden</string>
-  <string name="report_bug_msg">Diese Funktion öffnet dein E-Mail-Programm (z.B. Gmail), damit du uns einen Fehlerbericht zusenden kannst.\n
-Wenn du uns keine Mails senden möchtest oder kein Mail-Programm besitzt, kannst du auch einen neuen Bug unter https://github.com/EasyRPG/Player/issues melden.</string>
+  <string name="report_bug_msg">Diese Funktion öffnet dein E-Mail-Programm (z.B. Gmail), damit du uns einen Fehlerbericht zusenden kannst.\n\nWenn du uns keine Mails senden möchtest oder kein Mail-Programm besitzt, kannst du auch einen neuen Bug unter https://github.com/EasyRPG/Player/issues melden.</string>
   <string name="report_bug_mail">Vielen Dank für die Verwendung von EasyRPG Player.\n
 Es wurden ein Protokoll (Log) und deine Spielstände an diese E-Mail angehangen.\n
 Bitte entferne nicht das Protokoll! Einer der Spielstände sollte in der Nähe der Fehlerursache sein.\n
-Du kannst uns auf Deutsch schreiben.\n
-Teile uns zusätzlich in Detail mit, was schiefgegangen ist.\n
-[Du kannst diesen Anweisungstext löschen]</string>
-  <!--Settings Activity-->
+Teile uns zusätzlich in Detail mit, was schiefgegangen ist.\n\n
+</string>
+  <!--Settings Activities-->
+  <string name="video">Anzeige</string>
+  <string name="audio">Audio</string>
+  <string name="input">Steuerung</string>
+  <string name="game_folders">Spielverzeichnisse</string>
   <string name="settings">Einstellungen</string>
   <string name="add_game_folder">Spielverzeichnis hinzufügen</string>
   <string name="enable_vibration">Vibrationen aktivieren</string>
@@ -69,8 +60,8 @@ Teile uns zusätzlich in Detail mit, was schiefgegangen ist.\n
   <string name="input_layout_transparency">Layout-Transparenz:</string>
   <string name="ignore_size_settings">Verwende folgende Tastengröße anstatt der Standardgröße:</string>
   <string name="no_read_access_on_dir">Keine Leserechte für %1$s</string>
-  <string name="game_folders">EasyRPG-Ordner</string>
   <string name="quick_access">Schnellzugriff</string>
+  <string name="force_landscape_mode">Querformat erzwingen</string>
   <!--InputLayout Managing-->
   <string name="manage_input_layouts">Eingabe-Layouts verwalten:</string>
   <string name="add_an_input_layout">Eingabe-Layout hinzufügen</string>
@@ -87,4 +78,8 @@ Teile uns zusätzlich in Detail mit, was schiefgegangen ist.\n
   <string name="key_enter">Bestätigen (Z)</string>
   <string name="key_cancel">Abbrechen (ESC und X)</string>
   <string name="key_shift">Umschalttaste</string>
+  <!--GameBrowserAPI15-->
+  <string name="navigation_drawer_open">Navigation einblenden</string>
+  <string name="navigation_drawer_close">Navigation ausblenden</string>
+  <string name="menu">Android-Menü öffnen</string>
 </resources>

--- a/builds/android/app/src/main/res/values-es/strings.xml
+++ b/builds/android/app/src/main/res/values-es/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <!--Preferences Keys-->
   <!--GameBrowser Activity-->
   <string name="autodetect">Autodetectar región (recomendado)</string>
   <string name="west_europe">Europa occidental</string>
@@ -24,68 +23,62 @@
   <string name="no">No</string>
   <string name="creating_dir_failed">Falló la creación de la carpeta $PATH</string>
   <string name="path_not_readable">$PATH no es legible</string>
-  <string name="no_games_found_and_explanation">No se han encontrado juegos.\nPuedes agregar más carpetas con juegos en la configuración.</string>
+  <string name="no_games_found_and_explanation">No se han encontrado juegos de RPG Maker 2000/2003.
+Puedes agregar más carpetas con juegos en la configuración.</string>
   <string name="no_external_storage">No se ha encontrado almacenamiento externo (ej. tarjeta SD)</string>
   <string name="not_valid_game">$PATH no es un juego válido</string>
   <string name="select_game_region">Seleccionar región del juego</string>
-  <string name="change_the_layout">Cambiar la distribución de los botones</string>
+  <string name="change_the_layout">Cambiar el grupo de botones</string>
   <string name="choose_layout">Elegir una distribución</string>
   <string name="unknown_region">Región desconocida</string>
   <string name="region_modification_failed">Falló el cambio de región</string>
   <string name="refresh">Refrescar</string>
-  <string name="change_default_mapping">Cambiar la asignación de botones</string>
+  <string name="change_default_mapping">Cambiar el grupo de botones</string>
   <string name="how_to_use_easy_rpg">Cómo usar EasyRPG Player</string>
-  <string name="how_to_use_easy_rpg_explanation">
-Instrucciones de instalación\n
-De forma predeterminada, las carpetas de los juegos se buscan en /easyrpg/games. Puedes añadir carpetas de juegos adicionales en la configuración.\n
-Opcional: Coloca el RTP en /easrpg/rtp/2000 para el RTP de RPG Maker 2000 y en /easyrpg/rtp/2003 para el RTP de RPG Maker 2003.\n
-\n
-Detalle: para que los juegos se detecten correctamente deben estar descomprimidos en una subcarpeta de /easyrpg/games (de forma predeterminada), por ejemplo:\n
-\t/easyrpg/games/MiJuego/Data/RPG_RT.ldb está bien.\n
-\t/easyrpg/games/MiJuego/RPG_RT.ldb está bien.\n
-\t/easyrpg/games/MiJuego/MiJuego.zip está MAL.\n
-\n
-Características especiales:\n
-Puedes agregar botones adicionales en pantalla. Toca el botón de menú para editar la posición de los botones.\n
-Una vez allí, toca en el botón atrás para acceder a un menú adicional para agregar más botones a la pantalla.</string>
+  <string name="how_to_use_easy_rpg_explanation">Instrucciones de instalación\n\nDe forma predeterminada, las carpetas de los juegos se buscan en /easyrpg/games. Puedes añadir carpetas de juegos adicionales en la configuración.\n\nOpcional: Coloca el RTP en /easrpg/rtp/2000 para el RTP de RPG Maker 2000 y en /easyrpg/rtp/2003 para el RTP de RPG Maker 2003.\n\nPara que los juegos se detecten correctamente deben estar en una subcarpeta de /easyrpg/games (de forma predeterminada), por ejemplo:\n\n\t/easyrpg/games/MiJuego/Data/RPG_RT.ldb está bien.\n\t/easyrpg/games/MiJuego/RPG_RT.ldb está bien.\n\t/easyrpg/games/MiJuego/MiJuego.zip está MAL.\n\nNo se tiene soporte para juegos comprimidos como EXE, ZIP, etc.</string>
   <!--Ingame menu-->
   <string name="toggle_fps">Ver/ocultar FPS</string>
-  <string name="toggle_ui">Ver/ocultar botones</string>
+  <string name="toggle_ui">Ver/ocultar botones en pantalla</string>
   <string name="end_game">Salir del juego</string>
   <string name="report_bug">Informar de un fallo</string>
-  <string name="report_bug_msg">Esta función abrirá tu programa de correo electrónico (por ejemplo, Gmail) para enviarnos el informe de fallo.\n
-Si no quieres enviar un correo o no tienes un programa de correo configurado puedes abrir en su lugar un informe en https://github.com/EasyRPG/Player/issues</string>
+  <string name="report_bug_msg">Esta función abrirá tu programa de correo electrónico (por ejemplo, Gmail) para enviarnos el informe de fallo.\n\nSi no quieres enviar un correo o no tienes un programa de correo configurado puedes abrir en su lugar un informe en https://github.com/EasyRPG/Player/issues</string>
   <string name="report_bug_mail">Gracias por apoyar EasyRPG Player.\n
 Se han adjuntado las partidas guardadas y un archivo de informe en este correo electrónico.\n
 No elimines el archivo del informe. Necesitamos una partida guardada que esté cerca de la ubicación del fallo.\n
-Hablamos inglés, alemán y español.\n
-Cuéntanos detalladamente qué fue mal.\n
-[Puedes eliminar este texto de instrucciones]</string>
-  <!--Settings Activity-->
+Cuéntanos detalladamente qué fue mal.\n\n</string>
+  <!--Settings Activities-->
+  <string name="video">Pantalla</string>
+  <string name="audio">Sonido</string>
+  <string name="input">Entrada</string>
+  <string name="game_folders">Carpetas de juegos</string>
   <string name="settings">Configuración</string>
   <string name="add_game_folder">Añadir una carpeta de juegos</string>
   <string name="enable_vibration">Activar vibración</string>
   <string name="vibrate_when_sliding_direction">Vibrar al desplazarse a otra dirección</string>
-  <string name="enable_audio">Activar audio</string>
+  <string name="enable_audio">Activar el sonido</string>
   <string name="input_layout_transparency">Transparencia de los botones:</string>
-  <string name="ignore_size_settings">Ignorar configuración de tamaño de los botones y usar ésta para todos:</string>
+  <string name="ignore_size_settings">Personalizar tamaño de los botones:</string>
   <string name="no_read_access_on_dir">No hay acceso de lectura en %1$s</string>
-  <string name="game_folders">Carpeta de EasyRPG</string>
   <string name="quick_access">Acceso rápido</string>
+  <string name="force_landscape_mode">Forzar pantalla horizontal</string>
   <!--InputLayout Managing-->
-  <string name="manage_input_layouts">Administrar distribuciones de botones:</string>
-  <string name="add_an_input_layout">Añadir una distribución de botones</string>
-  <string name="set_as_default">Elegir como predeterminada</string>
+  <string name="manage_input_layouts">Administrar grupos de botones:</string>
+  <string name="add_an_input_layout">Crear grupo de botones</string>
+  <string name="set_as_default">Elegir como predeterminado</string>
   <string name="edit_name">Cambiar el nombre</string>
-  <string name="edit_layout">Editar la distribución</string>
+  <string name="edit_layout">Añadir más botones</string>
   <string name="delete">Borrar</string>
-  <string name="default_layout">Predeterminada</string>
+  <string name="default_layout">Predeterminado</string>
   <!--ButtonMapping Activity-->
   <string name="add_a_button">Añadir un botón</string>
-  <string name="reset_button_mapping">Reiniciar asignación</string>
+  <string name="reset_button_mapping">Reiniciar grupo de botones</string>
   <string name="exit_without_saving">Salir sin guardar</string>
   <string name="save_and_quit">Guardar y salir</string>
   <string name="key_enter">Intro (Z)</string>
   <string name="key_cancel">Cancelar (Esc y X)</string>
   <string name="key_shift">Mayúsculas/Shift</string>
+  <!--GameBrowserAPI15-->
+  <string name="navigation_drawer_open">Abrir panel de navegación</string>
+  <string name="navigation_drawer_close">Cerrar panel de navegación</string>
+  <string name="menu">Abrir menú de Android</string>
 </resources>

--- a/builds/android/app/src/main/res/values-fr/strings.xml
+++ b/builds/android/app/src/main/res/values-fr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <!--Preferences Keys-->
   <!--GameBrowser Activity-->
   <string name="autodetect">Detection automatique de la région (Recommandé)</string>
   <string name="west_europe">Europe de l\'Ouest</string>
@@ -24,36 +23,42 @@
   <string name="no">Non</string>
   <string name="creating_dir_failed">La création du dossier $PATH a échoué</string>
   <string name="path_not_readable">$PATH non lisible</string>
+  <string name="no_games_found_and_explanation">Pas de jeu RPG Maker 2000/2003 trouvé.\nVous pouvez ajouter des dossiers de jeux dans les paramètres.</string>
   <string name="no_external_storage">Pas de stockage externe trouvé</string>
   <string name="not_valid_game">$PATH n\'est pas un jeu valide</string>
   <string name="select_game_region">Changer la région du jeu</string>
   <string name="change_the_layout">Changer les contrôles virtuels</string>
-  <string name="choose_layout">Choisir un schéma de contrôles virtuels</string>
+  <string name="choose_layout">Choisir les contrôles virtuels</string>
   <string name="unknown_region">Région inconnue</string>
   <string name="region_modification_failed">Le changement de la région a échoué</string>
   <string name="refresh">Raffraichir</string>
   <string name="change_default_mapping">Changer les boutons virtuels</string>
   <string name="how_to_use_easy_rpg">Aide</string>
-  <string name="how_to_use_easy_rpg_explanation">
-Instructions :\n
-\t1. Placer les dossiers de jeux dans le dossier /easyrpg/games créé au lancement de l\'application.\n
-\t2. Placer les dossiers de RTP de RPG Maker 2000 et 2003 dans les dossiers /easyrpg/rtp/2000 et /easyrpg/rtp/2003.\n
-\n
-Si vous ne trouvez pas le dossier /easyrpg, alors celui-ci se trouve sur un autre support (carte SD ou mémoire interne).\n
-\n
-Les dossiers de jeux doivent être décompressés et non placés dans un sous dossier afin d\'être détéctés.</string>
+  <string name="how_to_use_easy_rpg_explanation">Instruction :\n\nPar défaut les jeux sont scannés dans le dossier /easyrpg/games de l\'application.\nVous pouvez définir de nouveaux dossiers de jeux dans les paramètres.\nAttention, vos jeux doivent être sous forme de dossiers décompressés, les .zip et .exe ne sont pas supportés.\n\nOptionnel :\nPlacez les RTP dans les dossiers /easyrpg/rtp/2000 et /easyrpg/rtp/2003.</string>
   <!--Ingame menu-->
   <string name="toggle_fps">Afficher les FPS</string>
   <string name="toggle_ui">Afficher les boutons virtuels</string>
   <string name="end_game">Quitter le jeu</string>
-  <!--Settings Activity-->
+  <string name="report_bug">Rapporter un bug</string>
+  <string name="report_bug_msg">Cette fonctionnalité va ouvrir votre application d\'e-mail pour nous envoyer une rapport de bug.\nSi vous ne voulez pas nous envoyer un e-mail ou que vous n\'avez pas d\'application d\'e-mail, veuillez reporter votre bug à l\'adresse : https://github.com/EasyRPG/Player/issues</string>
+  <string name="report_bug_mail">Veuillez décrire précisément votre bug.\n\nMerci d\'aider EasyRPG !\nUn fichier de log et votre sauvegarde ont été placé en pièce jointe de cet e-mail.\nVeuillez ne pas supprimer le fichier de sauvegarde. La sauvegarde nous permet de reproduire facilement votre bug.</string>
+  <!--Settings Activities-->
+  <string name="video">Video</string>
+  <string name="audio">Audio</string>
+  <string name="input">Contrôles</string>
+  <string name="game_folders">Dossiers de jeux</string>
   <string name="settings">Préférences</string>
+  <string name="add_game_folder">Ajouter un dossier de jeu</string>
   <string name="enable_vibration">Activer les vibrations</string>
   <string name="vibrate_when_sliding_direction">Vibrer lors du glissement vers une autre direction</string>
+  <string name="enable_audio">Activer l\'audio</string>
   <string name="input_layout_transparency">Transparence des boutons virtuels :</string>
-  <string name="ignore_size_settings">Ignorer préférences individuelles et forcer la taille des boutons virtuels :</string>
+  <string name="ignore_size_settings">Ignorer les préférences et forcer la taille des boutons :</string>
+  <string name="no_read_access_on_dir">Pas de droit de lecture pour %1$s</string>
+  <string name="quick_access">Accès rapide</string>
+  <string name="force_landscape_mode">Forcer le mode paysage</string>
   <!--InputLayout Managing-->
-  <string name="manage_input_layouts">Gérer les agencements de boutons virtuels :</string>
+  <string name="manage_input_layouts">Modifier les contrôles de boutons virtuels :</string>
   <string name="add_an_input_layout">Ajouter un agencement de boutons</string>
   <string name="set_as_default">Définir par défaut</string>
   <string name="edit_name">Changer le nom</string>
@@ -65,4 +70,11 @@ Les dossiers de jeux doivent être décompressés et non placés dans un sous do
   <string name="reset_button_mapping">Réinitialiser l\'agencement</string>
   <string name="exit_without_saving">Quitter sans sauvegarder</string>
   <string name="save_and_quit">Sauvegarder et quitter</string>
+  <string name="key_enter">Entrer (A)</string>
+  <string name="key_cancel">Echap (B)</string>
+  <string name="key_shift">Shift</string>
+  <!--GameBrowserAPI15-->
+  <string name="navigation_drawer_open">Ouvrir le menu</string>
+  <string name="navigation_drawer_close">Fermer le menu</string>
+  <string name="menu">Ouvrir le menu</string>
 </resources>

--- a/builds/android/app/src/main/res/values-hu/strings.xml
+++ b/builds/android/app/src/main/res/values-hu/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <!--Preferences Keys-->
   <!--GameBrowser Activity-->
   <string name="autodetect">Terület autómatikus megállapítása (ajánlott)</string>
   <string name="west_europe">nyugat-európai</string>
@@ -34,28 +33,11 @@
   <string name="refresh">Frissítés</string>
   <string name="change_default_mapping">Alap irányítógombok megváltoztatása</string>
   <string name="how_to_use_easy_rpg">Az EasyRPG Player használata</string>
-  <string name="how_to_use_easy_rpg_explanation">
-Telepítési útmutató:\n
-\t1) Helyezze a játékok mappáit a /easyrpg/games mappába az adattároló gyökerében.\n
-\t2) Helyezze az RTP mappáit a /easyrpg/rtp/2000 mappába RPG Maker 2000 RTP esetén, a /easyrpg/rtp/2003 mappába RPG Maker 2003 RTP esetén.\n
-\n
-Ha az alkalmazás nem észlel játékokat és az ön készüléke több adattárolóval rendelkezik, próbálja az easyrpg mappát egy másik adattároló gyökerébe mozgatni, majd érintse me a frissítés gombot.\n
-\n
-Megjegyzés: Hogy a játékok biztosan felismerésre kerüljenek, NEM szabad tömörítve lenniük és NEM szabad almappákba helyezni őket vagy bennük almappákat létrehozni.\n
-Például a következő útvonalak HIBÁSAK:\n
-\t/easyrpg/games/MyGame.zip\n
-Így a HELYES:\n
-\t/easyrpg/games/MyGame/RPG_RT.ldb\n
-\t/easyrpg/games/MyGame/Data/RPG_RT.ldb\n
-\n
-Különleges szolgátatások:\n
-\tÉrintse meg a menügombot a képernyő-gombok pozíciójának szerkesztéséhez.\n
-\tAmint azon a felületen van, érintse meg a vissza gombot, hogy elérjen egy újabb menüt, melyben több gombot adhat hozzá a képernyőhöz.</string>
   <!--Ingame menu-->
   <string name="toggle_fps">FPS ki/be</string>
   <string name="toggle_ui">Virtuális gombok ki/be</string>
   <string name="end_game">Játék befejezése</string>
-  <!--Settings Activity-->
+  <!--Settings Activities-->
   <string name="settings">Beállítások</string>
   <string name="enable_vibration">Rezgés engedélyezése</string>
   <string name="vibrate_when_sliding_direction">Rezgetés új irányba húzáskor</string>
@@ -74,4 +56,5 @@ Különleges szolgátatások:\n
   <string name="reset_button_mapping">Alapértelmezett pozíció</string>
   <string name="exit_without_saving">Kilépés mentés nélkül</string>
   <string name="save_and_quit">Mentés és kilépés</string>
+  <!--GameBrowserAPI15-->
 </resources>

--- a/builds/android/app/src/main/res/values-it/strings.xml
+++ b/builds/android/app/src/main/res/values-it/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <!--Preferences Keys-->
   <!--GameBrowser Activity-->
   <string name="autodetect">Rilevamento automatico della Regione (Consigliato)</string>
   <string name="west_europe">Europa dell\'Ovest</string>
@@ -24,7 +23,8 @@
   <string name="no">No</string>
   <string name="creating_dir_failed">Creazione della cartella $PATH fallita</string>
   <string name="path_not_readable">$PATH non è leggibile</string>
-  <string name="no_games_found_and_explanation">Nessun gioco trovato.\nPuoi aggiungere cartelle di gioco aggiuntive dalle impostazioni.</string>
+  <string name="no_games_found_and_explanation">Nessun gioco per RPG Maker 2000/2003 rilevato.
+Puoi aggiungere cartelle di gioco addizionali nelle impostazioni.</string>
   <string name="no_external_storage">Nessun archivio rimovibile (es. SD card) rilevato.</string>
   <string name="not_valid_game">$PATH non è un gioco valido</string>
   <string name="select_game_region">Seleziona Regione di Gioco</string>
@@ -35,48 +35,39 @@
   <string name="refresh">Aggiorna</string>
   <string name="change_default_mapping">Cambia il mapping dei tasti predefinito</string>
   <string name="how_to_use_easy_rpg">Come utilizzare EasyRPG Player</string>
-  <string name="how_to_use_easy_rpg_explanation">
-Istruzioni per l\'installazione:\n
-Normalmente le cartelle di gioco sono ricercate in /easyrpg/games. Puoi aggiungere cartelle addizionali dalle impostazioni.\n Opzionale: Colloca il RTP di RPG Maker 2000 in /easyrpg/rtp/2000 e il RTP di RPG Maker 2003 in /easyrpg/rtp/2003.\n
-\n
-Nota: i giochi devono essere decompressi in una sotto-cartella di /easyrpg/games (predefinito) per essere correttamente rilevati, ad esempio:\n
-\t/easyrpg/games/MyGame/Data/RPG_RT.ldb è GIUSTO.\n
-\t/easyrpg/games/MyGame/RPG_RT.ldb è GIUSTO.\n
-\t/easyrpg/games/MyGame.zip è SBAGLIATO.\n
-\n
-Funzionalità speciali:\n
-Puoi aggiungere tasti virtuali su schermo aggiuntivi. Tocca il tasto menù per modificare la posizione dei tasti.\n
-Dopodichè tocca il tasto indietro per accedere ad un menù addizionale per l\'aggiunta di nuovi tasti su schermo.</string>
+  <string name="how_to_use_easy_rpg_explanation">Istruzioni per l\'installazione:\n\nNormalmente i giochi vengono ricercati in /easyrpg/games. Puoi aggiungere cartelle di gioco addizionali nelle impostazioni.\n\nOpzionale: Posiziona i RTP in /easyrpg/rtp/2000 per RPG Maker 2000 e in /easyrpg/rtp/2003 per RPG Maker 2003.\n\nPer far si che i gichi siano rilevati correttamente, devono essere posizionati in sottocartelle di /easyrpg/games, es.:\n\n\t/easyrpg/games/MyGame/Data/RPG_RT.ldb va bene.\n\t/easyrpg/games/MyGame/RPG_RT.ldb va bene\n\t/easyrpg/games/MyGame.zip è SBAGLIATO. ZIP ed EXE non sono supportati.</string>
   <!--Ingame menu-->
   <string name="toggle_fps">Mostra FPS</string>
   <string name="toggle_ui">Mostra Tasti Virtuali</string>
   <string name="end_game">Esci dal Gioco</string>
   <string name="report_bug">Segnala un bug</string>
-  <string name="report_bug_msg">Questa funzione aprirà il tuo client di posta elettronica (es. Gmail) per inviarci una segnalazione.\n
-Se non vuoi inviarci una mail o non possiedi un client di posta elettronica configurato opportunamente, puoi aprire una nuova issue al link https://github.com/EasyRPG/Player/issues .</string>
+  <string name="report_bug_msg">Questa funzione aprirà il tuo client di posta elettronica (es. Gmail) per inviarci una segnalazione.\n\nSe non vuoi inviarci una mail o non possiedi un client di posta elettronica configurato opportunamente, puoi aprire una nuova issue al link https://github.com/EasyRPG/Player/issues .</string>
   <string name="report_bug_mail">Grazie per aver aiutato lo sviluppo di EasyRPG Player.\n
 Un file di log ed i tuoi salvataggi saranno allegati a questa mail.\n
 Per favore non rimuovere il file di log! Abbiamo bisogno inoltre di un salvataggio relativamente vicino al luogo nel quale si è verificato il bug.\n
-Puoi scriverci in Inglese, Tedesco o Spagnolo.\n
-Per favore spiegaci in dettaglio in cosa consiste il bug.\n
-[Puoi rimuovere queste istruzioni]</string>
-  <!--Settings Activity-->
+Per favore spiegaci in dettaglio in cosa consiste il bug.\n\n
+</string>
+  <!--Settings Activities-->
+  <string name="video">Video</string>
+  <string name="audio">Audio</string>
+  <string name="input">Input</string>
+  <string name="game_folders">Cartelle di gioco</string>
   <string name="settings">Impostazioni</string>
   <string name="add_game_folder">Aggiungi una cartella di gioco</string>
   <string name="enable_vibration">Attiva vibrazione</string>
   <string name="vibrate_when_sliding_direction">Vibra durante lo scorrimento verso un\'altra direzione</string>
   <string name="enable_audio">Attiva audio</string>
-  <string name="input_layout_transparency">Opacità Tasti Virtuali:</string>
-  <string name="ignore_size_settings">Ignora la dimensione dei tasti ed usa questo valore per qualsiasi tasto:</string>
+  <string name="input_layout_transparency">Trasparenza del layout di input:</string>
+  <string name="ignore_size_settings">Ignora impostazione per la dimensione dei tasti ed usa invece:</string>
   <string name="no_read_access_on_dir">%1$s non accessibile in lettura</string>
-  <string name="game_folders">Cartella di EasyRPG</string>
   <string name="quick_access">Accesso rapido</string>
+  <string name="force_landscape_mode">Forza orientamento del paesaggio</string>
   <!--InputLayout Managing-->
-  <string name="manage_input_layouts">Modifica Tasti Virtuali:</string>
-  <string name="add_an_input_layout">Aggiungi nuova disposizione tasti</string>
+  <string name="manage_input_layouts">Gestisci i layout di input:</string>
+  <string name="add_an_input_layout">Aggiungi un layout di input</string>
   <string name="set_as_default">Imposta come predefinito</string>
   <string name="edit_name">Modifica nome</string>
-  <string name="edit_layout">Modifica la disposizione</string>
+  <string name="edit_layout">Modifica layout</string>
   <string name="delete">Elimina</string>
   <string name="default_layout">Predefinito</string>
   <!--ButtonMapping Activity-->
@@ -87,4 +78,8 @@ Per favore spiegaci in dettaglio in cosa consiste il bug.\n
   <string name="key_enter">Invio (Z)</string>
   <string name="key_cancel">Annulla (ESC ed X)</string>
   <string name="key_shift">Shift</string>
+  <!--GameBrowserAPI15-->
+  <string name="navigation_drawer_open">Apri menù di navigazione</string>
+  <string name="navigation_drawer_close">Chiudi menù di navigazione</string>
+  <string name="menu">Apri Menù Android</string>
 </resources>

--- a/builds/android/app/src/main/res/values-ja/strings.xml
+++ b/builds/android/app/src/main/res/values-ja/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <!--Preferences Keys-->
   <!--GameBrowser Activity-->
   <string name="autodetect">自動検出(推奨設定)</string>
   <string name="west_europe">西ヨーロッパ</string>
@@ -24,10 +23,11 @@
   <string name="no">いいえ</string>
   <string name="creating_dir_failed">ディレクトリ $PATH の作成に失敗しました。</string>
   <string name="path_not_readable">$PATH が読み込めませんでした。</string>
-  <string name="no_games_found_and_explanation">ゲームが見つかりません。\n設定で、追加のゲームディレクトリを追加することができます。</string>
+  <string name="no_games_found_and_explanation">RPG ツクール 2000/2003 ゲームが見つかりません。
+設定で、追加のゲームディレクトリを追加することができます。</string>
   <string name="no_external_storage">外部ストレージ(SDカードなど)が見つかりませんでした。</string>
   <string name="not_valid_game">$PATHのゲームは対応していません。</string>
-  <string name="select_game_region">ゲームの言語地域を選択</string>
+  <string name="select_game_region">ゲームの地域を選択</string>
   <string name="change_the_layout">レイアウトの変更</string>
   <string name="choose_layout">レイアウトの選択</string>
   <string name="unknown_region">不明な言語地域</string>
@@ -35,49 +35,38 @@
   <string name="refresh">リフレッシュ</string>
   <string name="change_default_mapping">デフォルトのボタン配置に変更</string>
   <string name="how_to_use_easy_rpg">EasyRPG Playerの使い方</string>
-  <string name="how_to_use_easy_rpg_explanation">
-インストール方法:\n
-デフォルトでは、ゲームフォルダーは /easyrpg/games 内で検索されます。設定で、追加のゲームディレクトリを追加することができます。\n
-オプション: RPGツクール2000 RTP 用の /easyrpg/rtp/2000 および RPGツクール2003 RTP用の /easyrpg/rtp/2003 に RTP を入れてください。\n
-\n
-ヒント: ゲームを正しく検出するためには、それらを (デフォルトで) /easyrpg/games のサブディレクトリに解凍する必要があります。例:\n
-\t/easyrpg/games/MyGame/Data/RPG_RT.ldb は OK。\n
-\t/easyrpg/games/MyGame/RPG_RT.ldb は OK。\n
-\t/easyrpg/games/MyGame.zip は間違い。\n
-\n
-特別な機能:\n
-追加の画面ボタンを追加することができます。画面ボタンの位置を編集するには、メニューボタンをタップしてください。\n
-そこから、さらにボタンを追加するために、追加メニューにアクセスするには、戻るボタンをタップしてください。</string>
+  <string name="how_to_use_easy_rpg_explanation">インストール手順:\n\nデフォルトでは、ゲームは /easyrpg/games 内で検索されます。設定で、追加のゲームディレクトリを追加することができます。\n\nオプション: RPGツクール2000 RTP 用の /easyrpg/rtp/2000 および RPGツクール2003 RTP用の /easyrpg/rtp/2003 に RTP を入れてください。\n\nゲームを正しく検出するために、(デフォルトでは) /easyrpg/games のサブディレクトリに入れる必要があります。例:\n\n\t/easyrpg/games/MyGame/Data/RPG_RT.ldb は OK。\n\t/easyrpg/games/MyGame/RPG_RT.ldb は OK。\n\t/easyrpg/games/MyGame.zip は間違い。EXE はサポートしていません。</string>
   <!--Ingame menu-->
   <string name="toggle_fps">FPSの表示</string>
-  <string name="toggle_ui">仮想ボタンの表示</string>
-  <string name="end_game">終了</string>
+  <string name="toggle_ui">仮想ボタンの切り替え</string>
+  <string name="end_game">ゲームを終了</string>
   <string name="report_bug">バグを報告</string>
-  <string name="report_bug_msg">この機能は、私たちにバグ報告を送信するためにメールプログラム (例えば Gmail) を開きます。\n
-メールを送信したくないか、メールプログラムを持っていない場合は https://github.com/EasyRPG/Player/issues instead で新しい問題を開くことができます。</string>
+  <string name="report_bug_msg">この機能は、私たちにバグ報告を送信するためにメールプログラム (例えば Gmail) を開きます。\n\nメールを送信したくないか、メールプログラムを持っていない場合は、代わりに https://github.com/EasyRPG/Player/issues instead で新しい問題を開くことができます。</string>
   <string name="report_bug_mail">EasyRPG プレーヤーをご支援いただきありがとうございます。\n
 ログファイルとセーブしたゲームが、このメールに添付されました。\n
 ログファイルを削除しないでください! 私たちが、バグの箇所に近づくためにセーブデータが必要です。\n
-私たちは、英語、ドイツ語、スペイン語を話します。\n
-何の問題があったのかを詳細に教えてください。\n
-[この手順のテキストは削除することができます]</string>
-  <!--Settings Activity-->
+何の問題があったのかを詳細に教えてください。\n\n</string>
+  <!--Settings Activities-->
+  <string name="video">ビデオ</string>
+  <string name="audio">オーディオ</string>
+  <string name="input">入力</string>
+  <string name="game_folders">ゲームフォルダー</string>
   <string name="settings">設定</string>
   <string name="add_game_folder">ゲームフォルダーを追加</string>
   <string name="enable_vibration">バイブレーションの使用</string>
   <string name="vibrate_when_sliding_direction">スライドで別方向を押した時に振動させる</string>
   <string name="enable_audio">オーディオを有効にする</string>
   <string name="input_layout_transparency">入力レイアウトの透過:</string>
-  <string name="ignore_size_settings">個々のボタン設定を無視し全てこのボタンサイズを使用する:</string>
+  <string name="ignore_size_settings">ボタンサイズの設定を無視して、代わりに使用:</string>
   <string name="no_read_access_on_dir">%1$s に読み取りアクセス権限がありません</string>
-  <string name="game_folders">EasyRPG フォルダー</string>
   <string name="quick_access">クイック アクセス</string>
+  <string name="force_landscape_mode">強制的に横置きにする</string>
   <!--InputLayout Managing-->
-  <string name="manage_input_layouts">入力レイアウトの管理</string>
+  <string name="manage_input_layouts">入力レイアウトの管理:</string>
   <string name="add_an_input_layout">入力レイアウトの追加</string>
   <string name="set_as_default">デフォルトに設定</string>
   <string name="edit_name">名前の変更</string>
-  <string name="edit_layout">レイアウトの作成</string>
+  <string name="edit_layout">レイアウトの編集</string>
   <string name="delete">削除</string>
   <string name="default_layout">デフォルト</string>
   <!--ButtonMapping Activity-->
@@ -88,4 +77,8 @@
   <string name="key_enter">入力 (Z)</string>
   <string name="key_cancel">キャンセル (ESC および X)</string>
   <string name="key_shift">Shift</string>
+  <!--GameBrowserAPI15-->
+  <string name="navigation_drawer_open">ナビゲーションドロワーを開く</string>
+  <string name="navigation_drawer_close">ナビゲーションドロワーを閉じる</string>
+  <string name="menu">Android メニューを開く</string>
 </resources>

--- a/builds/android/app/src/main/res/values-ko/strings.xml
+++ b/builds/android/app/src/main/res/values-ko/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <!--Preferences Keys-->
   <!--GameBrowser Activity-->
   <string name="autodetect">언어 자동인식 (권장)</string>
   <string name="west_europe">서유럽어</string>
@@ -24,7 +23,8 @@
   <string name="no">아니요</string>
   <string name="creating_dir_failed">$PATH 디렉토리를 만들 수 없습니다.</string>
   <string name="path_not_readable">$PATH 디렉토리를 읽을 수 없습니다.</string>
-  <string name="no_games_found_and_explanation">게임이 없습니다.\n설정에서 게임 디렉토리를 추가해보세요.</string>
+  <string name="no_games_found_and_explanation">RPG 만들기 2000/2003 게임이 없습니다.
+설정에서 게임 디렉토리를 추가해보세요.</string>
   <string name="no_external_storage">외부 저장소(예: SD 카드)가 없습니다.</string>
   <string name="not_valid_game">$PATH 디렉토리의 게임은 지원하지 않습니다.</string>
   <string name="select_game_region">게임 언어 고르기</string>
@@ -33,61 +33,53 @@
   <string name="unknown_region">알 수 없는 언어</string>
   <string name="region_modification_failed">언어를 바꾸지 못하였습니다.</string>
   <string name="refresh">새로고침</string>
-  <string name="change_default_mapping">기본 버튼 맵핑 바꾸기</string>
+  <string name="change_default_mapping">버튼 지정 바꾸기</string>
   <string name="how_to_use_easy_rpg">EasyRPG 플레이어 사용법</string>
-  <string name="how_to_use_easy_rpg_explanation">
-설치안내:\n
-기본적으로는 /easyrpg/games 아래의 게임 폴더를 찾아줍니다. 설정에서 다른 디렉토리를 추가할 수도 있습니다.\n
-선택: RPG 만들기 2000의 RTP는 /easyrpg/rtp/2000에, RPG 만들기 2003의 RTP는 /easyrpg/rtp/2003 디렉토리에 넣어주세요.\n
-\n
-힌트: 게임을 제대로 인식하려면 압축을 풀어서 /easyrpg/games (기본설정) 아래의 디렉토리에 넣어주어야 합니다. 예를 들어:\n
-\t/easyrpg/games/MyGame/Data/RPG_RT.ldb 는 괜찮습니다.\n
-\t/easyrpg/games/MyGame/RPG_RT.ldb 도 괜찮습니다.\n
-\t/easyrpg/games/MyGame.zip 은 안 됩니다.\n
-\n
-특수기능:\n
-화면에 더 많은 버튼을 넣을 수 있습니다. 먼저 메뉴 버튼을 누르고 레이아웃 바꾸기로 들어갑니다.\n
-여기에서 뒤로가기를 누르면 버튼 추가하기 메뉴로 들어갑니다.
-</string>
+  <string name="how_to_use_easy_rpg_explanation">설치안내:\n\n기본적으로 /easyrpg/games 안쪽의 게임 폴더를 찾도록 되어 있으며, 설정에서 다른 디렉토리를 추가할 수도 있습니다.\n\n선택사항: RPG 만들기 2000의 RTP는 /easyrpg/rtp/2000, RPG 만들기 2003의 RTP는 /easyrpg/rtp/2003 디렉토리에 넣어주세요.\n\n게임을 제대로 인식하려면 /easyrpg/games (기본설정) 아래의 서브 디렉토리에 넣어주어야 합니다. 예를 들어:\n\n\t/easyrpg/games/MyGame/Data/RPG_RT.ldb 는 괜찮습니다.\n\t/easyrpg/games/MyGame/RPG_RT.ldb 도 괜찮습니다.\n\t/easyrpg/games/MyGame.zip 은 안 됩니다. ZIP과 EXE는 지원하지 않습니다.</string>
   <!--Ingame menu-->
   <string name="toggle_fps">FPS 표시</string>
   <string name="toggle_ui">가상버튼 표시</string>
   <string name="end_game">게임 끝내기</string>
   <string name="report_bug">오류 보고하기</string>
-  <string name="report_bug_msg">이 기능은 이메일 프로그램(예: Gmail)을 연 다음 개발자에게 오류 보고서를 보내도록 되어 있습니다.\n
-메일로 쓰고 싶지 않거나 메일 프로그램이 설정되어 있지 않다면 https://github.com/EasyRPG/Player/issues 에 이슈를 올려주셔도 됩니다.
-</string>
+  <string name="report_bug_msg">이 기능은 이메일 프로그램(예: Gmail)을 연 다음 개발자에게 오류 보고서를 보내도록 되어 있습니다.\n\n메일로 쓰고 싶지 않거나 메일 프로그램이 설정되어 있지 않다면 https://github.com/EasyRPG/Player/issues 에 이슈를 올려주셔도 됩니다.</string>
   <string name="report_bug_mail">EasyRPG 플레이어를 도와주시는 점 감사드립니다.\n
 이 메일에는 로그화일과 세이브게임이 첨부되었습니다.\n
 로그화일은 지우지 말아주세요! 오류와 가까운 지점의 세이브게임도 필요합니다.\n
-내용은 영어, 독일어, 혹은 스페인어로 보내주시면 됩니다.\n
-잘못된 부분에 대해 자세히 적어주시길 부탁드립니다.\n
-[이 안내문은 지우셔도 상관없습니다]
+잘못된 부분에 대해 자세히 적어주시길 부탁드립니다.\n\n
 </string>
-  <!--Settings Activity-->
+  <!--Settings Activities-->
+  <string name="video">영상</string>
+  <string name="audio">음성</string>
+  <string name="input">입력</string>
+  <string name="game_folders">게임 폴더</string>
   <string name="settings">설정</string>
   <string name="add_game_folder">게임 폴더 추가하기</string>
   <string name="enable_vibration">진동 사용하기</string>
   <string name="vibrate_when_sliding_direction">다른 방향으로 미끄러지면 진동하기</string>
+  <string name="enable_audio">소리 듣기</string>
   <string name="input_layout_transparency">입력 레이아웃 투명도:</string>
   <string name="ignore_size_settings">버튼 크기 설정은 무시하고 이 비율로 고정:</string>
   <string name="no_read_access_on_dir">%1$s의 읽기 권한이 없습니다.</string>
-  <string name="game_folders">EasyRPG 폴더</string>
   <string name="quick_access">바로가기</string>
+  <string name="force_landscape_mode">가로 화면 고정하기</string>
   <!--InputLayout Managing-->
   <string name="manage_input_layouts">입력 레이아웃 바꾸기:</string>
   <string name="add_an_input_layout">입력 레이아웃 추가하기</string>
-  <string name="set_as_default">기본으로 설정</string>
+  <string name="set_as_default">기본으로 정하기</string>
   <string name="edit_name">이름 바꾸기</string>
   <string name="edit_layout">레이아웃 바꾸기</string>
   <string name="delete">지우기</string>
   <string name="default_layout">기본</string>
   <!--ButtonMapping Activity-->
   <string name="add_a_button">버튼 추가하기</string>
-  <string name="reset_button_mapping">버튼 맵핑 초기화</string>
+  <string name="reset_button_mapping">버튼 지정 초기화</string>
   <string name="exit_without_saving">저장하지 않고 나가기</string>
   <string name="save_and_quit">저장하고 나가기</string>
   <string name="key_enter">확인 (Z)</string>
   <string name="key_cancel">취소 (ESC 및 X)</string>
   <string name="key_shift">쉬프트</string>
+  <!--GameBrowserAPI15-->
+  <string name="navigation_drawer_open">메뉴 열기</string>
+  <string name="navigation_drawer_close">메뉴 닫기</string>
+  <string name="menu">안드로이드 메뉴 열기</string>
 </resources>

--- a/builds/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/builds/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <!--Preferences Keys-->
   <!--GameBrowser Activity-->
   <string name="autodetect">Automático (Recomendado)</string>
   <string name="west_europe">Europeu Ocidental</string>
@@ -24,7 +23,8 @@
   <string name="no">Não</string>
   <string name="creating_dir_failed">Criação de diretório $PATH falhou</string>
   <string name="path_not_readable">$PATH não legível</string>
-  <string name="no_games_found_and_explanation">Games não encontrados.\nVocê pode adicionar diretório de games nas configurações.</string>
+  <string name="no_games_found_and_explanation">Não foram encontrados jogos de RPG Maker 2000/2003.
+Você pode adicionar novos diretórios de jogos nas configurações.</string>
   <string name="no_external_storage">Mídia externa não encontrada (Ex. cartão SD)</string>
   <string name="not_valid_game">$PATH não é um jogo válido</string>
   <string name="select_game_region">Escolha a região do jogo</string>
@@ -35,27 +35,17 @@
   <string name="refresh">Recarregar</string>
   <string name="change_default_mapping">Reconfigurar botões</string>
   <string name="how_to_use_easy_rpg">Como usar o EasyRPG player</string>
-  <string name="how_to_use_easy_rpg_explanation">
-Instruções de instalação:\n
-\t1. Coloque as pastas dos jogos em /easyrpg/games no armazenamento root do dispositivo.\n
-\t2. Coloque pastas RTP em /easyrpg/rtp/2000 para o RPG Maker 2000 RTP e /easyrpg/rtp/2003 para o RPG Maker 2003 RTP.\n
-\n
-Se os jogos não forem detectados e seu dispositivo tiver mais de um armazenamento disponível, tente mover a pasta easyrpg em outra pasta root de armazenamento e toque no botão de recarregar.\n
-\n
-Dica: para obter jogos corretamente detectados eles devem ser descompactados, por exemplo:\n
-\t/easyrpg/games/MyGame/Data/RPG_RT.ldb está CORRETO.\n
-\t/easyrpg/games/MyGame/RPG_RT.ldb está CORRETO.\n
-\t/easyrpg/games/MyGame.zip está ERRADO.\n
-\n
-Características especiais:\n
-\tToque no botão menu para editar posição de botões da tela.\n
-\tUma vez lá, toque no botão voltar para adicionar a um menu adicional para colocar mais botões na tela.</string>
+  <string name="how_to_use_easy_rpg_explanation">Instruções de Instalação\n\nPor padrão, O EasyRPG Player busca os jogos no diretório /easyrpg/games. Você pode adicionar novos diretórios de jogos nas configurações.\n\nOpcional: Cole o RTP no diretório /easyrpg/rtp/2000 para o RPG Maker 2000 e em /easyrpg/rtp/2003 para o RPG Maker 2003.\n\nPara ter acesso aos jogos, eles devem ser colocados em um subdiretório de /easyrpg/games (por padrão), ex.:\n\n\t/easyrpg/games/MeuJogo.\n\t</string>
   <!--Ingame menu-->
   <string name="toggle_fps">Alternar FPS</string>
   <string name="toggle_ui">Alternar botões virtuais</string>
   <string name="end_game">Finalizar Jogo</string>
   <string name="report_bug">Reportar erro</string>
-  <!--Settings Activity-->
+  <!--Settings Activities-->
+  <string name="video">Vídeo</string>
+  <string name="audio">Audio</string>
+  <string name="input">Input</string>
+  <string name="game_folders">Pastas de Jogo</string>
   <string name="settings">Configurações</string>
   <string name="add_game_folder">Adicionar uma pasta contendo game</string>
   <string name="enable_vibration">Habilitar vibrações</string>
@@ -64,8 +54,8 @@ Características especiais:\n
   <string name="input_layout_transparency">Transparência do layout de entrada</string>
   <string name="ignore_size_settings">Ignorar configurações do tamanho dos botões e usar isso para todos botões</string>
   <string name="no_read_access_on_dir">Sem acesso de leitura em %1$s</string>
-  <string name="game_folders">Pasta EasyRpg</string>
   <string name="quick_access">Acesso rápido</string>
+  <string name="force_landscape_mode">Forçar modo de orientação Paisagem</string>
   <!--InputLayout Managing-->
   <string name="manage_input_layouts">Gerenciar layouts de entrada</string>
   <string name="add_an_input_layout">Adicionar layout de entrada</string>
@@ -80,4 +70,5 @@ Características especiais:\n
   <string name="exit_without_saving">Sair sem salvar</string>
   <string name="save_and_quit">Salvar e sair</string>
   <string name="key_cancel">Cancelar (ESC e X)</string>
+  <!--GameBrowserAPI15-->
 </resources>

--- a/builds/android/app/src/main/res/values-ru/strings.xml
+++ b/builds/android/app/src/main/res/values-ru/strings.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <!--GameBrowser Activity-->
+  <string name="autodetect">Автовыбор региона (рекоммендуется)</string>
+  <string name="west_europe">Западноевропейский</string>
+  <string name="east_europe">Центрально- или восточноевропейский</string>
+  <string name="cyrillic">Кириллический</string>
+  <string name="japan">Японский</string>
+  <string name="korean">Корейский</string>
+  <string name="chinese_simple">Китайский (упрощённые формы)</string>
+  <string name="chinese_traditional">Китайский (традиционные формы)</string>
+  <string name="greek">Греческий</string>
+  <string name="turkish">Турецкий</string>
+  <string name="hebrew">Иврит</string>
+  <string name="arabic">Арабский</string>
+  <string name="baltic">Балтийский</string>
+  <string name="thai">Тайский</string>
+  <string name="vietnamese">Вьетнамский</string>
+  <string name="ok">OK</string>
+  <string name="cancel">Отмена</string>
+  <string name="do_want_quit">Вы действительно хотите выйти?</string>
+  <string name="yes">Да</string>
+  <string name="no">Нет</string>
+  <string name="creating_dir_failed">Не удалось создать директорию $PATH</string>
+  <string name="path_not_readable">Невозможно прочитать $PATH</string>
+  <string name="no_games_found_and_explanation">Не найдены игры для RPG Maker 2000/2003.
+Дополнительные папки с играми можно задать в настройках.</string>
+  <string name="no_external_storage">Не найден внешний диск (например, SD-карта)</string>
+  <string name="not_valid_game">$PATH не является поддерживаемой игрой</string>
+  <string name="select_game_region">Выбрать регион игры</string>
+  <string name="change_the_layout">Изменить интерфейс</string>
+  <string name="choose_layout">Выбрать интерфейс</string>
+  <string name="unknown_region">Неизвестный регион</string>
+  <string name="region_modification_failed">Не удалось изменить регион</string>
+  <string name="refresh">Обновить</string>
+  <string name="change_default_mapping">Изменить стандартные значения кнопок</string>
+  <string name="how_to_use_easy_rpg">Как использовать EasyRPG Player</string>
+  <string name="how_to_use_easy_rpg_explanation">Инструкции по установке:\n\nПо умолчанию игры ищутся в  /easyrpg/games. Вы можете указать дополнительные директории с играми в настройках.\n\nНеобязательно: Разместите RTP в /easyrpg/rtp/2000 (RPG Maker 2000 RTP) и в /easyrpg/rtp/2003 (RPG Maker 2003 RTP).\n\nЧтобы игры правильно определялись, они должны находиться в поддиректории внутри /easyrpg/games (по умолчанию), например:\n\n\t/easyrpg/games/MyGame/Data/RPG_RT.ldb — правильно.\n\t/easyrpg/games/MyGame/RPG_RT.ldb — правильно.\n\t/easyrpg/games/MyGame.zip — НЕВЕРНО. Файлы ZIP и EXE не поддерживаются.</string>
+  <!--Ingame menu-->
+  <string name="toggle_fps">Показ FPS</string>
+  <string name="toggle_ui">Показ виртуальных кнопок</string>
+  <string name="end_game">Закончить игру</string>
+  <string name="report_bug">Сообщить об ошибке</string>
+  <string name="report_bug_msg">Эта функция откроет почтовую программу (напр. Gmail), чтобы послать сообщение об ошибке.\n\nЕсли вы не хотите отправлять письмо, или у вас не настроена почтовая программа, можно создать новое описание проблемы на https://github.com/EasyRPG/Player/issues</string>
+  <string name="report_bug_mail">Спасибо за поддержку EasyRPG Player!\n
+К этому письмо прикреплены журнальный файл и сохранённые игры.\n
+Пожалуйста, не удаляйте журнальный файл! Нам нужно сохранение рядом с тем местом, где происходит ошибка.\n
+Пожалуйста, подробно опишите, в чём проблема.\n\n
+</string>
+  <!--Settings Activities-->
+  <string name="video">Видео</string>
+  <string name="audio">Аудио</string>
+  <string name="input">Ввод</string>
+  <string name="game_folders">Папки с играми</string>
+  <string name="settings">Настройки</string>
+  <string name="add_game_folder">Добавить папку с играми</string>
+  <string name="enable_vibration">Включить вибрацию</string>
+  <string name="vibrate_when_sliding_direction">Вибрировать, когда произошло перемещение в другом направлении одним прикосновением</string>
+  <string name="enable_audio">Включить аудио</string>
+  <string name="input_layout_transparency">Прозрачность интерфейса ввода:</string>
+  <string name="ignore_size_settings">Игнорировать размер кнопок и установить его таким:</string>
+  <string name="no_read_access_on_dir">Нет доступа для чтения к %1$s</string>
+  <string name="quick_access">Быстрый доступ</string>
+  <string name="force_landscape_mode">Зафиксировать горизонтальную ориентацию</string>
+  <!--InputLayout Managing-->
+  <string name="manage_input_layouts">Управление интерфейсами ввода:</string>
+  <string name="add_an_input_layout">Добавить интерфейс ввода</string>
+  <string name="set_as_default">Установить по умолчанию</string>
+  <string name="edit_name">Изменить название</string>
+  <string name="edit_layout">Изменить интерфейс</string>
+  <string name="delete">Удалить</string>
+  <string name="default_layout">По умолчанию</string>
+  <!--ButtonMapping Activity-->
+  <string name="add_a_button">Добавить кнопку</string>
+  <string name="reset_button_mapping">Сбросить значения кнопок</string>
+  <string name="exit_without_saving">Выйти без сохранения</string>
+  <string name="save_and_quit">Сохранить и выйти</string>
+  <string name="key_enter">Enter (Z)</string>
+  <string name="key_cancel">Отмена (ESC и X)</string>
+  <string name="key_shift">Shift</string>
+  <!--GameBrowserAPI15-->
+  <string name="navigation_drawer_open">Открыть боковое меню</string>
+  <string name="navigation_drawer_close">Закрыть боковое меню</string>
+  <string name="menu">Открыть меню Android</string>
+</resources>

--- a/builds/android/app/src/main/res/values-th/strings.xml
+++ b/builds/android/app/src/main/res/values-th/strings.xml
@@ -1,98 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<!--Preferences Keys-->
-	<!--GameBrowser Activity-->
-	<string name="autodetect">เลือกภูมิภาคอัตโนมัติ (Recommended)</string>
-	<string name="west_europe">ยุโรปตะวันตก</string>
-	<string name="east_europe">ยุโรปกลาง/ตะวันออก</string>
-	<string name="cyrillic">ซีริลลิก</string>
-	<string name="japan">ญี่ปุ่น</string>
-	<string name="korean">เกาหลี</string>
-	<string name="chinese_simple">จีนตัวย่อ</string>
-	<string name="chinese_traditional">จีนตัวเต็ม</string>
-	<string name="greek">กรีก</string>
-	<string name="turkish">ตุรกี</string>
-	<string name="hebrew">ฮีบรู</string>
-	<string name="arabic">อาราบิก</string>
-	<string name="baltic">บอลติก</string>
-	<string name="thai">ไทย</string>
-	<string name="vietnamese">เวียดนาม</string>
-	<string name="ok">ตกลง</string>
-	<string name="cancel">ยกเลิก</string>
-	<string name="do_want_quit">คุณต้องการที่จะออกหรือไม่?</string>
-	<string name="yes">ใช่</string>
-	<string name="no">ไม่</string>
-	<string name="creating_dir_failed">สร้างโฟลเดอร์ $PATH ล้มเหลว</string>
-	<string name="path_not_readable">$PATH ไม่สามารถอ่านได้</string>
-	<string name="no_games_found_and_explanation">ไม่พบเกม\nคุณสามารถเพิ่มโฟลเดอร์เกมส์ได้ในการตั้งค่า</string>
-	<string name="no_external_storage">ไม่พบที่เก็บข้อมูลภายนอก (เช่น การ์ด SD)</string>
-	<string name="not_valid_game">$PATH ไม่ใช่เกมที่ถูกต้อง</string>
-	<string name="select_game_region">เลือกภูมิภาคของเกม</string>
-	<string name="change_the_layout">เปลี่ยนเค้าโครง</string>
-	<string name="choose_layout">เลือกเค้าโครง</string>
-	<string name="unknown_region">ภูมิภาคไม่รู้จัก</string>
-	<string name="region_modification_failed">เปลี่ยนภูมิภาคล้มเหลว</string>
-	<string name="refresh">รีเฟรช</string>
-	<string name="change_default_mapping">เปลี่ยนค่าเริ่มต้นการทำงานปุ่ม</string>
-	<string name="how_to_use_easy_rpg">วิธีการใช้งาน EasyRPG Player</string>
-	<string name="how_to_use_easy_rpg_explanation">
-วิธีการติดตั้ง:\n
-โดยเริ่มต้นแล้วโฟลเดอร์เกมจะอยู่ที่ /easyrpg/games คุณสามารเพิ่มโฟลเดอร์เกมได้ที่หน้าตั้งค่า\n
-เพิ่มเติม: วาง RTP ไว้ที่ /easyrpg/rtp/2000 สำหรับ RPG Maker 2000 RTP และใน /easyrpg/rtp/2003 สำหรับ RPG Maker 2003 RTP.\n
-\n
-แนะนำ: เกมที่จะตรวจพบควรจะเป็นรูปแบบที่ไม่ถูกบีบอัดในโฟลเดอร์ย่อยของ /easyrpg/games (โดยเริ่มต้น) ตัวอย่างเช่น:\n
-\t/easyrpg/games/MyGame/Data/RPG_RT.ldb ใช้ได้\n
-\t/easyrpg/games/MyGame/RPG_RT.ldb ใช้ได้\n
-\t/easyrpg/games/MyGame.zip is ผิด\n
-\n
-ความสามารถเพิ่มเติม:\n
-คุณสามารถเพิ่มปุ่มบนหน้าจอได้โดยการแตะที่ปุ่มแก้ไขตำแหน่งปุ่มบนหน้าจอ\n
-หลังจากนั้นแตตะปุ่มกลับเพื่อเลือกปุ่มเพิ่มเติมสำหรับเพิ่มปุ่มไปยังหน้าจอ
-	</string>
-	
-	<!--Ingame menu-->
-	<string name="toggle_fps">เปลี่ยน FPS</string>
-	<string name="toggle_ui">สลับปุ่มบนหน้าจอ</string>
-	<string name="end_game">ปิดเกม</string>
-	<string name="report_bug">รายงานปัญหา</string>
-	<string name="report_bug_msg">ความสามารถนี้จะโปรแกรมอีเมลของคุณ (เช่น Gmail) เพื่อส่งรายงานปัญหา\n
-ถ้าคุณไม่ต้องการส่งอีเมลหรือไม่มีโปรแกรมที่ใช้อีเมลคุณยังสามารถรายงานปัญหาได้ที่ https://github.com/EasyRPG/Player/issues
-	</string>
-	<string name="report_bug_mail">ขอบคุณที่สนับสนุน EasyRPG Player.\n
+  <!--GameBrowser Activity-->
+  <string name="autodetect">เลือกภูมิภาคอัตโนมัติ (Recommended)</string>
+  <string name="west_europe">ยุโรปตะวันตก</string>
+  <string name="east_europe">ยุโรปกลาง/ตะวันออก</string>
+  <string name="cyrillic">ซีริลลิก</string>
+  <string name="japan">ญี่ปุ่น</string>
+  <string name="korean">เกาหลี</string>
+  <string name="chinese_simple">จีนตัวย่อ</string>
+  <string name="chinese_traditional">จีนตัวเต็ม</string>
+  <string name="greek">กรีก</string>
+  <string name="turkish">ตุรกี</string>
+  <string name="hebrew">ฮีบรู</string>
+  <string name="arabic">อาราบิก</string>
+  <string name="baltic">บอลติก</string>
+  <string name="thai">ไทย</string>
+  <string name="vietnamese">เวียดนาม</string>
+  <string name="ok">ตกลง</string>
+  <string name="cancel">ยกเลิก</string>
+  <string name="do_want_quit">คุณต้องการที่จะออกหรือไม่?</string>
+  <string name="yes">ใช่</string>
+  <string name="no">ไม่</string>
+  <string name="creating_dir_failed">สร้างโฟลเดอร์ $PATH ล้มเหลว</string>
+  <string name="path_not_readable">$PATH ไม่สามารถอ่านได้</string>
+  <string name="no_external_storage">ไม่พบที่เก็บข้อมูลภายนอก (เช่น การ์ด SD)</string>
+  <string name="not_valid_game">$PATH ไม่ใช่เกมที่ถูกต้อง</string>
+  <string name="select_game_region">เลือกภูมิภาคของเกม</string>
+  <string name="change_the_layout">เปลี่ยนเค้าโครง</string>
+  <string name="choose_layout">เลือกเค้าโครง</string>
+  <string name="unknown_region">ภูมิภาคไม่รู้จัก</string>
+  <string name="region_modification_failed">เปลี่ยนภูมิภาคล้มเหลว</string>
+  <string name="refresh">รีเฟรช</string>
+  <string name="change_default_mapping">เปลี่ยนค่าเริ่มต้นการทำงานปุ่ม</string>
+  <string name="how_to_use_easy_rpg">วิธีการใช้งาน EasyRPG Player</string>
+  <!--Ingame menu-->
+  <string name="toggle_fps">เปลี่ยน FPS</string>
+  <string name="toggle_ui">สลับปุ่มบนหน้าจอ</string>
+  <string name="end_game">ปิดเกม</string>
+  <string name="report_bug">รายงานปัญหา</string>
+  <string name="report_bug_msg">ความสามารถนี้จะโปรแกรมอีเมลของคุณ (เช่น Gmail) เพื่อส่งรายงานปัญหา\n\nถ้าคุณไม่ต้องการส่งอีเมลหรือไม่มีโปรแกรมที่ใช้อีเมลคุณยังสามารถรายงานปัญหาได้ที่ https://github.com/EasyRPG/Player/issues</string>
+  <string name="report_bug_mail">ขอบคุณที่สนับสนุน EasyRPG Player.\n
 ไฟล์ประวัติการทำงานและบันทึกเกมของคุณจะถูกแนบไปกับอีเมลนี้\n
 ได้โปรดอย่านำไฟล์ประวัติออก พวกเราต้องการข้อมูลเหล่านี้ในการหาข้อผอดพลาด\n
-พวกเราพูดภาษาอังกฤษ เยอรมันและสเปน\n
-กรุณาบอกพวกเราเกีี่ยวกับข้อผิดพลาดเพิ่มเติมด้วย\n
-[คุณสามารถนำข้อความแนะนำนี้ออกได้]
-	</string>
-
-	<!--Settings Activity-->
-	<string name="settings">การตั้งค่า</string>
-	<string name="add_game_folder">เพิ่มโฟลเดอร์เกม</string>
-	<string name="enable_vibration">เปิดการสั่น</string>
-	<string name="vibrate_when_sliding_direction">สั่นเมื่อเลื่อนไปอีกทาง</string>
-	<string name="enable_audio">เปิดเสียง</string>
-	<string name="input_layout_transparency">ความโปร่งใส่ของเค้าโครงรับค่า:</string>
-	<string name="ignore_size_settings">เพิกเฉยต่อการตั้งค่าขนาดปุ่มและนำทั้งหมดนี้ไปใช้กับปุ่มทั้งหมด:</string>
-	<string name="no_read_access_on_dir">ไม่มีสิทธิ์การอ่านที่ %1$s</string>
-	<string name="game_folders">โฟลเดอร์ EasyRPG</string>
-	<string name="quick_access">เข้าถึงอย่างรวดเร็ว</string>
-	
-	<!--InputLayout Managing-->
-	<string name="manage_input_layouts">จัดการเค้าโครงรับค่า:</string>
-	<string name="add_an_input_layout">เพิ่มเค้าโครงรับค่า</string>
-	<string name="set_as_default">ตั้งเป็นค่าเริ่มต้น</string>
-	<string name="edit_name">แก้ไขชื่อ</string>
-	<string name="edit_layout">แก้ไขเค้าโครง</string>
-	<string name="delete">ลบ</string>
-	<string name="default_layout">ค่าเริ่มต้น</string>
-
-	<!--ButtonMapping Activity-->
-	<string name="add_a_button">เพิ่มปุ่ม</string>
-	<string name="reset_button_mapping">รีเซ็ตการตั้งค่าปุ่ม</string>
-	<string name="exit_without_saving">ออกโดยไม่บันทึก</string>
-	<string name="save_and_quit">บันทึกและออก</string>
-	<string name="key_enter">Enter (Z)</string>
-	<string name="key_cancel">Cancel (ESC and X)</string>
-	<string name="key_shift">Shift</string>
+กรุณาบอกพวกเราเกีี่ยวกับข้อผิดพลาดเพิ่มเติมด้วย\n\n
+</string>
+  <!--Settings Activities-->
+  <string name="settings">การตั้งค่า</string>
+  <string name="add_game_folder">เพิ่มโฟลเดอร์เกม</string>
+  <string name="enable_vibration">เปิดการสั่น</string>
+  <string name="vibrate_when_sliding_direction">สั่นเมื่อเลื่อนไปอีกทาง</string>
+  <string name="enable_audio">เปิดเสียง</string>
+  <string name="input_layout_transparency">ความโปร่งใส่ของเค้าโครงรับค่า:</string>
+  <string name="ignore_size_settings">เพิกเฉยต่อการตั้งค่าขนาดปุ่มและนำทั้งหมดนี้ไปใช้กับปุ่มทั้งหมด:</string>
+  <string name="no_read_access_on_dir">ไม่มีสิทธิ์การอ่านที่ %1$s</string>
+  <string name="quick_access">เข้าถึงอย่างรวดเร็ว</string>
+  <!--InputLayout Managing-->
+  <string name="manage_input_layouts">จัดการเค้าโครงรับค่า:</string>
+  <string name="add_an_input_layout">เพิ่มเค้าโครงรับค่า</string>
+  <string name="set_as_default">ตั้งเป็นค่าเริ่มต้น</string>
+  <string name="edit_name">แก้ไขชื่อ</string>
+  <string name="edit_layout">แก้ไขเค้าโครง</string>
+  <string name="delete">ลบ</string>
+  <string name="default_layout">ค่าเริ่มต้น</string>
+  <!--ButtonMapping Activity-->
+  <string name="add_a_button">เพิ่มปุ่ม</string>
+  <string name="reset_button_mapping">รีเซ็ตการตั้งค่าปุ่ม</string>
+  <string name="exit_without_saving">ออกโดยไม่บันทึก</string>
+  <string name="save_and_quit">บันทึกและออก</string>
+  <string name="key_enter">Enter (Z)</string>
+  <string name="key_cancel">Cancel (ESC and X)</string>
+  <string name="key_shift">Shift</string>
+  <!--GameBrowserAPI15-->
 </resources>

--- a/builds/android/app/src/main/res/values-uk/strings.xml
+++ b/builds/android/app/src/main/res/values-uk/strings.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <!--GameBrowser Activity-->
+  <string name="autodetect">Автовибір регіону (рекомендовано)</string>
+  <string name="west_europe">Західноєвропейський</string>
+  <string name="east_europe">Центрально- і східноєвропейський</string>
+  <string name="cyrillic">Кіриличний</string>
+  <string name="japan">Японський</string>
+  <string name="korean">Корейський</string>
+  <string name="chinese_simple">Китайський (спрощені форми)</string>
+  <string name="chinese_traditional">Китайський (традиційні форми)</string>
+  <string name="greek">Грецький</string>
+  <string name="turkish">Турецький</string>
+  <string name="hebrew">Іврит</string>
+  <string name="arabic">Арабський</string>
+  <string name="baltic">Балтійський</string>
+  <string name="thai">Тайський</string>
+  <string name="vietnamese">В’єтнамський</string>
+  <string name="ok">OK</string>
+  <string name="cancel">Відміна</string>
+  <string name="do_want_quit">Ви справді бажаєте вийти?</string>
+  <string name="yes">Так</string>
+  <string name="no">Ні</string>
+  <string name="creating_dir_failed">Не вийшло створити директорію $PATH</string>
+  <string name="path_not_readable">Неможливо прочитать $PATH</string>
+  <string name="no_games_found_and_explanation">Не знайдено ігор для RPG Maker 2000/2003.
+Додаткові директорії для ігор можна вказати в налаштуваннях.</string>
+  <string name="no_external_storage">Не знайдено зовнішнього диску (напр., SD-картки)</string>
+  <string name="not_valid_game">$PATH не є правильною грою</string>
+  <string name="select_game_region">Вибрати регіон гри</string>
+  <string name="change_the_layout">Змінити інтерфейс</string>
+  <string name="choose_layout">Вибрати інтерфейс</string>
+  <string name="unknown_region">Невідомий регіон</string>
+  <string name="region_modification_failed">Не вийшло змінити регіон</string>
+  <string name="refresh">Обновити</string>
+  <string name="change_default_mapping">Змінити стандартні значення кнопок</string>
+  <string name="how_to_use_easy_rpg">Як використовувати EasyRPG Player</string>
+  <string name="how_to_use_easy_rpg_explanation">Інструкції для встановлення:\n\nТипово ігри шукаються в /easyrpg/games. Ви можете вказати додаткові директорії з іграми в налаштуваннях.\n\nНеобовʼязково: Перенесіть RTP в /easyrpg/rtp/2000, (RPG Maker 2000 RTP) і в /easyrpg/rtp/2003 (RPG Maker 2003 RTP).\n\nЩоб програма могла знайти ігри, їх треба розмістити в піддиректорії всередені /easyrpg/games (типово), напр.:\n\n\t/easyrpg/games/MyGame/Data/RPG_RT.ldb — правильно.\n\t/easyrpg/games/MyGame/RPG_RT.ldb — правильно.\n\t/easyrpg/games/MyGame.zip — НЕПРАВИЛЬНО. Файли ZIP і EXE не підтримуються.</string>
+  <!--Ingame menu-->
+  <string name="toggle_fps">Показ FPS</string>
+  <string name="toggle_ui">Показ віртуальних кнопок</string>
+  <string name="end_game">Закінчити гру</string>
+  <string name="report_bug">Повідомити про помилку</string>
+  <string name="report_bug_msg">Ця функція відкриє вашу поштову програму (напр. Gmail), щоб дослати повідомлення про помилку.\n\nЯкщо ви не хочете досилати повідомлення поштою, або ваша поштова програма не налаштована, можна додати новий опис проблеми на https://github.com/EasyRPG/Player/issues</string>
+  <string name="report_bug_mail">Дякую за падтримку EasyRPG Player!\n
+До цього листа було додано лог-файл та збережені ігри.\n
+Будь ласка, не видаляйте лог-файл! Нам потрібне збереження недалеко від місця, де відбувається помилка.\n
+Будь ласка, детально опишіть, що саме не працює.\n\n</string>
+  <!--Settings Activities-->
+  <string name="video">Відео</string>
+  <string name="audio">Аудіо</string>
+  <string name="input">Увід</string>
+  <string name="game_folders">Директорії з іграми</string>
+  <string name="settings">Налаштування</string>
+  <string name="add_game_folder">Додати директорію з іграми</string>
+  <string name="enable_vibration">Дозволити вібрацію</string>
+  <string name="vibrate_when_sliding_direction">Вібрувати підчас переходу в іншому напрямку за один дотик</string>
+  <string name="enable_audio">Увімкнути аудіо</string>
+  <string name="input_layout_transparency">Прозорість інтерфейсу вводу:</string>
+  <string name="ignore_size_settings">Ігнорувати розміри кнопок і встановити їх всіх такими:</string>
+  <string name="no_read_access_on_dir">Немає доступу для читання до %1$s</string>
+  <string name="quick_access">Швидкий доступ</string>
+  <string name="force_landscape_mode">Зафіксувати горизонтальну орієнтацію</string>
+  <!--InputLayout Managing-->
+  <string name="manage_input_layouts">Керування інтерфейсами вводу:</string>
+  <string name="add_an_input_layout">Додати інтерфейс вводу</string>
+  <string name="set_as_default">Встановити стандартним</string>
+  <string name="edit_name">Змінити назву</string>
+  <string name="edit_layout">Змінити інтерфейс</string>
+  <string name="delete">Видалити</string>
+  <string name="default_layout">Стандартний</string>
+  <!--ButtonMapping Activity-->
+  <string name="add_a_button">Додати кнопку</string>
+  <string name="reset_button_mapping">Відкинути значення кнопок</string>
+  <string name="exit_without_saving">Вийти без збереження</string>
+  <string name="save_and_quit">Зберегти й вийти</string>
+  <string name="key_enter">Enter (Z)</string>
+  <string name="key_cancel">Відміна (ESC і X)</string>
+  <string name="key_shift">Shift</string>
+  <!--GameBrowserAPI15-->
+  <string name="navigation_drawer_open">Відкрити бокове меню</string>
+  <string name="navigation_drawer_close">Закрити бокове меню</string>
+  <string name="menu">Відкрити меню Android</string>
+</resources>

--- a/builds/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/builds/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <!--Preferences Keys-->
   <!--GameBrowser Activity-->
   <string name="autodetect">自動偵測 (推薦)</string>
   <string name="west_europe">西歐</string>
@@ -24,7 +23,8 @@
   <string name="no">否</string>
   <string name="creating_dir_failed">建立 $PATH 路徑失敗</string>
   <string name="path_not_readable">無法讀取 $PATH</string>
-  <string name="no_games_found_and_explanation">沒有找到遊戲。/n可以在設定中新增額外的遊戲儲存資料夾。</string>
+  <string name="no_games_found_and_explanation">沒有找到 RPG Maker 2000/2003 的遊戲。
+在設定中可以增加額外的遊戲資料夾。</string>
   <string name="no_external_storage">沒有找到儲存空間 (如SD卡)</string>
   <string name="not_valid_game">$PATH 不是個遊戲資料夾</string>
   <string name="select_game_region">選擇遊戲地區編碼</string>
@@ -35,47 +35,36 @@
   <string name="refresh">重新整理</string>
   <string name="change_default_mapping">修改預設的按鍵配置</string>
   <string name="how_to_use_easy_rpg">EasyRPG Player 使用方式</string>
-  <string name="how_to_use_easy_rpg_explanation">
-遊戲安裝說明：\n
-預設情況下，EasyRPG Player 會在 /easyrpg/games 裡面尋找遊戲。在設定裡面可以加入其他遊戲儲存位置。\n
-RTP方面，RPG Maker 2000 RTP 要放在 /easyrpg/rtp/2000 裡面，2003 的則要放在 /easyrpg/rtp/2003 裡面。\n
-\n
-遊戲必須要被解壓縮後放進遊戲儲存位置中 (預設為 /easyrpg/games)，例如：\n
-\t/easyrpg/games/遊戲名/Data/RPG_RT.ldb (O)\n
-\t/easyrpg/games/遊戲名/RPG_RT.ldb (O)\n
-\t/easyrpg/games/遊戲名 (X)\n
-\n
-其他功能：\n
-可以在設定中增加或編輯按鈕配置，以便新增額外的按鈕。\n
-增加了按鈕配置後，在遊戲旁的齒輪圖示中可以選擇要使用的按鈕配置。</string>
   <!--Ingame menu-->
   <string name="toggle_fps">開關 FPS 顯示</string>
   <string name="toggle_ui">隱藏 / 顯示虛擬按鈕</string>
   <string name="end_game">結束遊戲</string>
   <string name="report_bug">回報問題</string>
-  <string name="report_bug_msg">這將會開啟您的 e-mail 程式 (如Gmail) 來寄錯誤回報給我們。\n
-如果不想要寄信或是沒有可用的 e-mail 程式的話，可以到 https://github.com/EasyRPG/Player/issues 來開一個新的 issue。</string>
+  <string name="report_bug_msg">這將會開啟您的 e-mail 程式 (如Gmail) 來寄錯誤回報給我們。\n\n如果不想要寄信或是沒有可用的 e-mail 程式的話，可以到 https://github.com/EasyRPG/Player/issues 來開一個新的 issue。</string>
   <string name="report_bug_mail">謝謝您支持 EasyRPG Player。\n
 一個紀錄 (logfile) 以及您的存檔已經附加到此 e-mail 上。\n
 請不要移除它們！我們需要存檔以便知道是在遊戲中何處出錯。\n
-我們能說英文，德文與西班牙文。\n
-請詳細地告訴我們發生了什麼事。\n
-[這一段話請放心移除]</string>
-  <!--Settings Activity-->
+請詳細地告訴我們發生了什麼事。\n\n
+</string>
+  <!--Settings Activities-->
+  <string name="video">影像</string>
+  <string name="audio">音效</string>
+  <string name="input">輸入</string>
+  <string name="game_folders">遊戲資料夾</string>
   <string name="settings">設定</string>
   <string name="add_game_folder">新增遊戲儲存位置</string>
   <string name="enable_vibration">啟用振動</string>
   <string name="vibrate_when_sliding_direction">在滑動至另一方向時振動</string>
   <string name="enable_audio">啟用聲音</string>
   <string name="input_layout_transparency">按鍵透明度：</string>
-  <string name="ignore_size_settings">忽略按鍵的大小設定而為所有按鈕使用此項：</string>
+  <string name="ignore_size_settings">忽略按鈕個別的大小設定，全部使用此數值：</string>
   <string name="no_read_access_on_dir">沒有 %1$s 的讀取權限</string>
-  <string name="game_folders">EasyRPG 資料夾</string>
   <string name="quick_access">快速存取</string>
+  <string name="force_landscape_mode">強制橫向顯示</string>
   <!--InputLayout Managing-->
   <string name="manage_input_layouts">按鍵配置管理：</string>
   <string name="add_an_input_layout">新增按鍵配置</string>
-  <string name="set_as_default">設為預設直</string>
+  <string name="set_as_default">設為預設值</string>
   <string name="edit_name">修改名稱</string>
   <string name="edit_layout">編輯配置內容</string>
   <string name="delete">刪除</string>
@@ -83,9 +72,13 @@ RTP方面，RPG Maker 2000 RTP 要放在 /easyrpg/rtp/2000 裡面，2003 的則�
   <!--ButtonMapping Activity-->
   <string name="add_a_button">新增按鈕</string>
   <string name="reset_button_mapping">重設按鈕</string>
-  <string name="exit_without_saving">直接退出 (不存檔)</string>
-  <string name="save_and_quit">存檔後退出</string>
+  <string name="exit_without_saving">直接退出 (不儲存)</string>
+  <string name="save_and_quit">儲存後退出</string>
   <string name="key_enter">確認鍵 (Z)</string>
   <string name="key_cancel">取消 / 目錄鍵 (ESC 與 X)</string>
   <string name="key_shift">Shift</string>
+  <!--GameBrowserAPI15-->
+  <string name="navigation_drawer_open">開啟側邊欄</string>
+  <string name="navigation_drawer_close">關閉側邊欄</string>
+  <string name="menu">開啟 Android 選單</string>
 </resources>

--- a/builds/android/app/src/main/res/values-zh/strings.xml
+++ b/builds/android/app/src/main/res/values-zh/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <!--Preferences Keys-->
   <!--GameBrowser Activity-->
   <string name="autodetect">自动选择语言(推荐)</string>
   <string name="west_europe">西欧语区</string>
@@ -34,29 +33,11 @@
   <string name="refresh">刷新</string>
   <string name="change_default_mapping">更改默认按键映射</string>
   <string name="how_to_use_easy_rpg">EasyRPG模拟器使用教程</string>
-  <string name="how_to_use_easy_rpg_explanation">
-安装说明：\n
-1. 把game文件夹创建在/easyrpg的根目录里如/easyrpg/game。\n
-\n
-2.把游戏RTP放入到/easyrpg/rtp/2000和/easyrpg/rtp/2003文件里。\n
-\n
-如果模拟器不能检测到游戏的话，也许需要放在另一个储存卡里(内部存储卡/SD卡)\n
-尝试把easyrpg文件夹移动到另一个储存卡根目录里并点击“刷新”按钮。\n
-\n
-提示：为了保证模拟器检测到这个游戏，所以游戏文件不能是压缩的，\n
-并且不能被放在子文件夹里。\n
-例如:/easyrpg/games/MyGame/Data/RPG_RT.ldb 这样是正确的。\n
-/easyrpg/games/MyGame/RPG_RT.ldb 这样是正确的。\n
-/easyrpg/games/MyGame.zip 这样是错误的。\n
-\n
-特殊功能：\n
-在设置游戏按键的时候，点击手机菜单按钮可以设置游戏按键，\n
-在这个界面的时候，点击手机返回键也可以设置游戏按键。</string>
   <!--Ingame menu-->
   <string name="toggle_fps">切换FPS</string>
   <string name="toggle_ui">设置虚拟按钮</string>
   <string name="end_game">结束游戏</string>
-  <!--Settings Activity-->
+  <!--Settings Activities-->
   <string name="settings">设置</string>
   <string name="enable_vibration">开启震动</string>
   <string name="vibrate_when_sliding_direction">在往另一个方向滑动时震动</string>
@@ -75,4 +56,5 @@
   <string name="reset_button_mapping">重置按钮</string>
   <string name="exit_without_saving">不保存并退出</string>
   <string name="save_and_quit">保存并退出</string>
+  <!--GameBrowserAPI15-->
 </resources>


### PR DESCRIPTION
- This adds `Belarusian`, `Ukrainian` and `Russian`
- Ignore the whitespace change in `Thai`, it was simply forgotten to change before...
- One string is still missing in `Chinese (Taiwan)`, hope this gets added before the deadline (will rebase this then)
- GitHub does not render the `Korean` symbols for me here. I can assure they are there in the file/repository.

Note, that I removed some `how_to_use_easy_rpg_explanation` strings... These have been outdated for roughly 8 months. I added an issue on transifex shortly after the app could read from multiple folders and would recurse in subfolders, but these were never changed over half a year later. I think having a complete and correct english text is better than having a broken and outdated translation in the main "FAQ".
This only affects the incomplete (<80%) translations on transifex of course (their maintainers gone M.I.A.).