### PR TITLE
Implement PicPointer Patch.

### DIFF
--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -23,10 +23,9 @@
 #include "game_battler.h"
 #include "game_screen.h"
 #include "game_system.h"
+#include "game_variables.h"
 #include "main_data.h"
-#include "options.h"
-#include "sprite_battler.h"
-#include "spriteset_battle.h"
+#include "output.h"
 
 Game_Screen::Game_Screen() :
 	data(Main_Data::game_data.screen)
@@ -87,9 +86,26 @@ void Game_Screen::Reset()
 }
 
 Game_Picture* Game_Screen::GetPicture(int id) {
+	// PicPointer Patch handling
+	if (id > 10000) {
+		// Picture to point at
+		int new_id;
+		if (id > 50000) {
+			new_id = Game_Variables[id - 50000];
+		} else {
+			new_id = Game_Variables[id - 10000];
+		}
+
+		if (new_id > 0) {
+			Output::Debug("PicPointer: ID %d replaced with ID %d", id, new_id);
+			id = new_id;
+		}
+	}
+
 	if (id <= 0) {
 		return NULL;
 	}
+
 	if (id > (int)pictures.size()) {
 		// Some games use more pictures then RPG_RT officially supported
 		Main_Data::game_data.pictures.resize(id);


### PR DESCRIPTION
0.5 or 0.5.1? In my opinion 0.5 is in feature freeze... but the maintainers can decide.

Conflicts are unlikely because the picture IDs are huge, added debug output to become aware of it. DynRPG doesn't touch this region either (and we don't support it)

Today I learned: The PPP supports pointing Wait, Zoom and Transparency, too.
We can solve this in our editor by simply allowing \V everywhere ^^

Test case (Master): https://easyrpg.org/play/master/?game=picpointer
Test case (PR): https://easyrpg.org/play/pr1035/?game=picpointer