### PR TITLE
Nintendo 3DS: Disable khax

### DIFF
--- a/builds/3ds/Makefile
+++ b/builds/3ds/Makefile
@@ -67,7 +67,7 @@ LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map) \
 		-Wl,--gc-sections
 
 LIBS	:= -lsf2d -lctru -llcf -licuuc -licui18n -licudata \
-		-lpixman-1 -lpng -lz -lkhax -lmpg123 -lspeexdsp \
+		-lpixman-1 -lpng -lz -lmpg123 -lspeexdsp \
 		-lsndfile -lvorbisidec -logg -lmpg123 -lm
 
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -41,7 +41,6 @@
 #  include <psp2/kernel/processmgr.h>
 #elif defined(_3DS)
 #  include <3ds.h>
-#  include <khax.h>
 #endif
 
 #include "async_handler.h"
@@ -146,7 +145,6 @@ void Player::Init(int argc, char *argv[]) {
 
 	APT_SetAppCpuTimeLimit(30);
 
-	if (osGetKernelVersion() <  SYSTEM_VERSION(2, 48, 3)) khaxInit(); // Executing libkhax just to be sure...
 	consoleClear();
 
 	// Check if we already have access to csnd:SND, if not, we will perform a kernel privilege escalation


### PR DESCRIPTION
Because this crashes on many normal firmwares... :( and DSP works flawless anyway.