### PR TITLE
Fix some little annoyances

### DIFF
--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -989,7 +989,7 @@ void Bitmap::ToneBlit(int x, int y, Bitmap const& src, Rect const& src_rect, con
 	}
 
 	// Only needed here, other codepaths are sanity checked by pixman
-	if (x < 0 || y < 0 || x > width() || y > height()) {
+	if (x < 0 || y < 0 || x >= width() || y >= height()) {
 		return;
 	}
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -352,7 +352,7 @@ void Game_Map::ScrollDown(int distance) {
 		map_info.position_y = (map_info.position_y + distance + height) % height;
 		parallax_y -= map_info.parallax_vert ? distance / 2 : 0;
 	} else {
-		if (map_info.position_y + distance <= (GetHeight() - 15) * SCREEN_TILE_WIDTH) {
+		if (map_info.position_y + distance < (GetHeight() - 15) * SCREEN_TILE_WIDTH) {
 			map_info.position_y += distance;
 			if (map_info.parallax_vert)
 				parallax_y -= distance / 2;
@@ -386,7 +386,7 @@ void Game_Map::ScrollRight(int distance) {
 		map_info.position_x = (map_info.position_x + distance + width) % width;
 		parallax_x -= map_info.parallax_horz ? distance / 2 : 0;
 	} else {
-		if (map_info.position_x + distance <= (GetWidth() - 20) * SCREEN_TILE_WIDTH) {
+		if (map_info.position_x + distance < (GetWidth() - 20) * SCREEN_TILE_WIDTH) {
 			map_info.position_x += distance;
 			if (map_info.parallax_horz)
 				parallax_x -= distance / 2;

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -202,6 +202,8 @@ void Graphics::DrawOverlay() {
 		Player::fps_flag) {
 		std::stringstream text;
 		text << "FPS: " << real_fps;
+		Rect rect = DisplayUi->GetDisplaySurface()->GetFont()->GetSize(text.str());
+		DisplayUi->GetDisplaySurface()->Blit(1, 2, *black_screen, Rect(0, 0, rect.width + 1, rect.height - 1), 128);
 		DisplayUi->GetDisplaySurface()->TextDraw(2, 2, Color(255, 255, 255, 255), text.str());
 	}
 }

--- a/src/input_buttons.h
+++ b/src/input_buttons.h
@@ -55,6 +55,8 @@ namespace Input {
 		TOGGLE_FPS,
 		TAKE_SCREENSHOT,
 		SHOW_LOG,
+		PAGE_UP,
+		PAGE_DOWN,
 		BUTTON_COUNT
 	};
 

--- a/src/input_buttons_desktop.cpp
+++ b/src/input_buttons_desktop.cpp
@@ -77,6 +77,8 @@ void Input::InitButtons() {
 	buttons[TAKE_SCREENSHOT].push_back(Keys::F10);
 	buttons[TOGGLE_FPS].push_back(Keys::F2);
 	buttons[SHOW_LOG].push_back(Keys::F3);
+	buttons[PAGE_UP].push_back(Keys::PGUP);
+	buttons[PAGE_DOWN].push_back(Keys::PGDN);
 
 #if defined(USE_MOUSE) && defined(SUPPORT_MOUSE)
 	buttons[DECISION].push_back(Keys::MOUSE_LEFT);

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -139,9 +139,10 @@ void Scene_File::Update() {
 
 	unsigned int old_top_index = top_index;
 	unsigned int old_index = index;
+	unsigned int max_index = file_windows.size() - 1;
 
 	if (Input::IsRepeated(Input::DOWN)) {
-		if (Input::IsTriggered(Input::DOWN) || index < file_windows.size() - 1) {
+		if (Input::IsTriggered(Input::DOWN) || index < max_index) {
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cursor));
 			index = (index + 1) % file_windows.size();
 		}
@@ -151,10 +152,19 @@ void Scene_File::Update() {
 	if (Input::IsRepeated(Input::UP)) {
 		if (Input::IsTriggered(Input::UP) || index >= 1) {
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cursor));
-			index = (index + file_windows.size() - 1) % file_windows.size();
+			index = (index + max_index) % file_windows.size();
 		}
 
 		//top_index = std::min(top_index, index);
+	}
+
+	if (Input::IsRepeated(Input::PAGE_DOWN) && index < max_index) {
+		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cursor));
+		index = (index + 3 <= max_index) ? index + 3 : max_index;
+	}
+	if (Input::IsRepeated(Input::PAGE_UP) && index >= 1) {
+		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cursor));
+		index = (index > 3) ? index - 3 : 0;
 	}
 
 	if (index > top_index + 2) {

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -137,6 +137,19 @@ void Window_Selectable::Update() {
 				index = (index - column_max + item_max) % item_max;
 			}
 		}
+		// page up/down is limited to selectables with one column
+		if (column_max == 1) {
+			if (Input::IsRepeated(Input::PAGE_DOWN) && index < item_max - 1) {
+				Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cursor));
+				int new_pos = index + GetPageRowMax();
+				index = (new_pos <= item_max - 1) ? new_pos : item_max - 1;
+			}
+			if (Input::IsRepeated(Input::PAGE_UP) && index > 0) {
+				Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cursor));
+				int new_pos = index - GetPageRowMax();
+				index = (new_pos >= 0) ? new_pos : 0;
+			}
+		}
 		if (Input::IsRepeated(Input::RIGHT)) {
 			if (column_max >= 2 && index < item_max - 1) {
 				Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cursor));


### PR DESCRIPTION
![screenshot_0](https://cloud.githubusercontent.com/assets/4691314/19052779/660617ca-89b8-11e6-9cbd-570ad5f7fb08.png) ![screenshot_1](https://cloud.githubusercontent.com/assets/4691314/19052762/5a17109a-89b8-11e6-8420-23aafbfc6b29.png)
![20161003-222836](https://cloud.githubusercontent.com/assets/4691314/19052888/c4781024-89b8-11e6-9b6a-7d24351894e4.png) ![20161003-223142](https://cloud.githubusercontent.com/assets/4691314/19052974/310c5308-89b9-11e6-861a-81030c95ecd3.png)

- Menu in *Mystic Star* is accessible
- Background in *Embric* changes correctly
- FPS counter is more visible on bright background
- Scrolling through long lists is now easier with `Page up`/`Page down` buttons