### PR TITLE
Interpreter: Fix Equipment command and Vehicle movement

### DIFF
--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -390,14 +390,20 @@ public:
 
 	/**
 	 * Changes the equipment of the actor.
-	 * Removes one instance of that item from the Inventory.
-	 * and adds the old one of the actor to it.
-	 * If you don't want this use SetEquipment instead.
+	 * Unequips the current inventory item and adds it to the inventory.
+	 * The new equipment is taken from the inventory (if available),
+	 * otherwise a new item is equipped.
+	 * If you don't want this behaviour use SetEquipment instead.
 	 *
 	 * @param equip_type type of equipment.
 	 * @param item_id item to equip.
 	 */
 	void ChangeEquipment(int equip_type, int item_id);
+
+	/**
+	 * Unequips the whole equipment and adds it to the inventory.
+	 */
+	void RemoveAllEquipment();
 
 	/**
 	 * Gets learned skills list.

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1261,7 +1261,7 @@ bool Game_Interpreter::CommandChangeEquipment(RPG::EventCommand const& com) { //
 				case RPG::Item::Type_armor:
 				case RPG::Item::Type_helmet:
 				case RPG::Item::Type_accessory:
-					slot = type - 1;
+					slot = type;
 					break;
 				default:
 					return true;
@@ -1269,14 +1269,20 @@ bool Game_Interpreter::CommandChangeEquipment(RPG::EventCommand const& com) { //
 			break;
 		case 1:
 			item_id = 0;
-			slot = com.parameters[3];
+			slot = com.parameters[3] + 1;
 			break;
 		default:
 			return false;
 	}
 
-	for (const auto& actor : GetActors(com.parameters[0], com.parameters[1])) {
-		actor->ChangeEquipment(slot, item_id);
+	if (slot == 6) {
+		for (const auto& actor : GetActors(com.parameters[0], com.parameters[1])) {
+			actor->RemoveAllEquipment();
+		}
+	} else {
+		for (const auto &actor : GetActors(com.parameters[0], com.parameters[1])) {
+			actor->ChangeEquipment(slot, item_id);
+		}
 	}
 
 	return true;

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -67,11 +67,11 @@ void Game_Party::SetupBattleTestMembers() {
 		it != Data::system.battletest_data.end(); ++it) {
 		AddActor(it->actor_id);
 		Game_Actor* actor = Game_Actors::GetActor(it->actor_id);
-		actor->SetEquipment(0, it->weapon_id);
-		actor->SetEquipment(1, it->shield_id);
-		actor->SetEquipment(2, it->armor_id);
-		actor->SetEquipment(3, it->helmet_id);
-		actor->SetEquipment(4, it->accessory_id);
+		actor->SetEquipment(RPG::Item::Type_weapon, it->weapon_id);
+		actor->SetEquipment(RPG::Item::Type_shield, it->shield_id);
+		actor->SetEquipment(RPG::Item::Type_armor, it->armor_id);
+		actor->SetEquipment(RPG::Item::Type_helmet, it->helmet_id);
+		actor->SetEquipment(RPG::Item::Type_accessory, it->accessory_id);
 		actor->ChangeLevel(it->level, false);
 		actor->SetHp(actor->GetMaxHp());
 		actor->SetSp(actor->GetMaxSp());

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -234,6 +234,15 @@ void Game_Player::PerformTeleport() {
 
 	teleporting = false;
 
+	// Finish (un)boarding process
+	if (location.boarding) {
+		location.boarding = false;
+		location.aboard = true;
+	} else if (location.unboarding) {
+		location.unboarding = false;
+		location.aboard = false;
+	}
+
 	if (Game_Map::GetMapId() != new_map_id) {
 		Refresh(); // Reset sprite if it was changed by a move
 		pattern = RPG::EventPage::Frame_middle;

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -400,6 +400,7 @@ bool Game_Vehicle::CanLand() const {
 
 void Game_Vehicle::Update() {
 	Game_Character::Update();
+	Game_Character::UpdateSprite();
 	SyncWithPlayer();
 
 	if (type == Airship) {

--- a/src/scene_equip.cpp
+++ b/src/scene_equip.cpp
@@ -87,13 +87,13 @@ void Scene_Equip::UpdateStatusWindow() {
 		const RPG::Item* current_item = item_window->GetItem();
 		int current_item_id = current_item ? current_item->ID : 0;
 
-		int old_item = actor.SetEquipment(equip_window->GetIndex(),
+		int old_item = actor.SetEquipment(equip_window->GetIndex() + 1,
 			current_item_id);
 
 		equipstatus_window->SetNewParameters(
 			actor.GetAtk(), actor.GetDef(), actor.GetSpi(), actor.GetAgi());
 
-		actor.SetEquipment(equip_window->GetIndex(), old_item);
+		actor.SetEquipment(equip_window->GetIndex() + 1, old_item);
 
 		equipstatus_window->Refresh();
 	}
@@ -141,7 +141,7 @@ void Scene_Equip::UpdateItemSelection() {
 		int current_item_id = current_item ? current_item->ID : 0;
 
 		actor.ChangeEquipment(
-			equip_window->GetIndex(), current_item_id);
+			equip_window->GetIndex() + 1, current_item_id);
 
 		equip_window->SetActive(true);
 		item_window->SetActive(false);

--- a/src/window_equip.cpp
+++ b/src/window_equip.cpp
@@ -41,7 +41,7 @@ void Window_Equip::Refresh() {
 	// Add the equipment of the actor to data
 	data.clear();
 	Game_Actor* actor = Game_Actors::GetActor(actor_id);
-	for (int i = 0; i < 5; ++i) {
+	for (int i = 1; i <= 5; ++i) {
 		const RPG::Item* item = actor->GetEquipment(i);
 		data.push_back(item ? item->ID : 0);
 	}

--- a/src/window_item.cpp
+++ b/src/window_item.cpp
@@ -58,7 +58,7 @@ void Window_Item::Refresh() {
 	if (Game_Temp::battle_running) {
 		// Include equipped accesories that invoke skills
 		if (actor) {
-			for (int i = 0; i < 5; ++i) {
+			for (int i = 1; i <= 5; ++i) {
 				const RPG::Item* item = actor->GetEquipment(i);
 				if (item && item->use_skill && item->skill_id > 0) {
 					data.push_back(item->ID);

--- a/src/window_shopparty.cpp
+++ b/src/window_shopparty.cpp
@@ -66,7 +66,7 @@ void Window_ShopParty::Refresh() {
 		if (equippable) {
 			//check if item is equipped by each member
 			bool is_equipped = false;
-			for (int j = 0; j < 5; ++j) {
+			for (int j = 1; j <= 5; ++j) {
 				const RPG::Item* item = actor->GetEquipment(j);
 				if (item) {
 					is_equipped |= (item->ID == item_id);


### PR DESCRIPTION
Vehicles with custom event routes were not moving at all, one function call missing.
This fixes "Dunkle Schatten" - The ship never reached our heros.

The equipment command has a function "unequip all", for some reason this was never implemented :o
This removes our "Item -1 is invalid" debugmsg ;). "Item 0 is invalid" is still generated when a variable is really 0, that's correct.
