### PR TITLE
Fix Razas battle start (Transitions in parallel interpreters)

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -63,8 +63,8 @@ Game_Interpreter::Game_Interpreter(int _depth, bool _main_flag) {
 	Clear();
 }
 
- Game_Interpreter::~Game_Interpreter() {
- }
+Game_Interpreter::~Game_Interpreter() {
+}
 
 // Clear.
 void Game_Interpreter::Clear() {

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1620,6 +1620,10 @@ bool Game_Interpreter::CommandEraseScreen(RPG::EventCommand const& com) { // cod
 	if (Game_Temp::transition_processing || Game_Message::visible)
 		return false;
 
+	if (!main_flag) {
+		Game_Map::SetTeleportDelayed(true);
+	}
+
 	Game_Temp::transition_processing = true;
 	Game_Temp::transition_erase = true;
 
@@ -1697,6 +1701,10 @@ bool Game_Interpreter::CommandEraseScreen(RPG::EventCommand const& com) { // cod
 bool Game_Interpreter::CommandShowScreen(RPG::EventCommand const& com) { // code 11020
 	if (Game_Temp::transition_processing || Game_Message::visible)
 		return false;
+
+	if (!main_flag) {
+		Game_Map::SetTeleportDelayed(true);
+	}
 
 	Game_Temp::transition_processing = true;
 	Game_Temp::transition_erase = false;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -80,6 +80,8 @@ namespace {
 	int pan_speed;
 
 	int last_map_id;
+
+	bool teleport_delay;
 }
 
 void Game_Map::Init() {
@@ -114,6 +116,8 @@ void Game_Map::Init() {
 	location.pan_current_x = 0;
 	location.pan_current_y = 0;
 	last_map_id = -1;
+
+	teleport_delay = false;
 }
 
 void Game_Map::Dispose() {
@@ -1381,6 +1385,14 @@ int Game_Map::GetParallaxY() {
 
 const std::string& Game_Map::GetParallaxName() {
 	return map_info.parallax_name;
+}
+
+bool Game_Map::IsTeleportDelayed() {
+	return teleport_delay;
+}
+
+void Game_Map::SetTeleportDelayed(bool delay) {
+	teleport_delay = delay;
 }
 
 FileRequestAsync* Game_Map::RequestMap(int map_id) {

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -599,6 +599,23 @@ namespace Game_Map {
 	int GetParallaxY();
 	const std::string& GetParallaxName();
 
+	/**
+	 * Gets if pending teleportations will be ignored.
+	 *
+	 * @return true: teleport ignored, false: teleport processed normally
+	 */
+	bool IsTeleportDelayed();
+
+	/**
+	 * Enables/Disables the processing of teleports.
+	 * This is used by Show/EraseScreen in Parallel processes to prevent
+	 * too early execution of teleports (Show/EraseScreen don't yield the
+	 * interpreter in RPG_RT).
+	 *
+	 * @param delay enable/disable delay
+	 */
+	void SetTeleportDelayed(bool delay);
+
 	FileRequestAsync* RequestMap(int map_id);
 }
 

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -167,15 +167,15 @@ namespace Game_Map {
 	 */
 	bool IsPassableVehicle(int x, int y, Game_Vehicle::Type vehicle_type);
 
-    /**
-     * Gets if a tile coordinate can be jumped to.
-     *
-     * @param x tile x.
-     * @param y tile y.
-     * @param self_event Current character attemping to jump.
-     * @return whether is posible to jump.
-     */
-    bool IsLandable(int x, int y, const Game_Character* self_event = NULL);
+	/**
+	 * Gets if a tile coordinate can be jumped to.
+	 *
+	 * @param x tile x.
+	 * @param y tile y.
+	 * @param self_event Current character attemping to jump.
+	 * @return whether is posible to jump.
+	 */
+	bool IsLandable(int x, int y, const Game_Character* self_event = NULL);
 
 	/**
 	 * Gets the bush depth at a certain tile.

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -126,10 +126,13 @@ void Scene_Map::Update() {
 	// Fade In must be done before finish teleport, otherwise chipset is not
 	// loaded and renders black while fading -> ugly
 
-	if (Main_Data::game_player->IsTeleporting()) {
+	if (!Game_Map::IsTeleportDelayed() && Main_Data::game_player->IsTeleporting()) {
 		FinishTeleportPlayer();
 		return;
 	}
+	// The delay is only needed for one frame to execute pending transitions,
+	// the interpreters continue on the old map afterwards
+	Game_Map::SetTeleportDelayed(false);
 
 	Main_Data::game_party->UpdateTimers();
 


### PR DESCRIPTION
See commit description

Also fixes the following case:
```
Teleport to Map2
HideScreen
ShowScreen
Wait 0
HideScreen
ShowScreen
```

Delete Map 2 and run that event parallel. The error "Map 2 not found" is executed at the Wait 0.0 position (before it appeared after the first HideScreen)