### PR TITLE
RPG2k battle message fixes

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -28,6 +28,11 @@
 #include "rpg_skill.h"
 #include "util_macro.h"
 
+/** Interprets char literals as utf-8 */
+#ifdef _MSC_VER
+#pragma execution_character_set("utf-8")
+#endif
+
 static int max_hp_value() {
 	return Player::IsRPG2k() ? 999 : 9999;
 }
@@ -598,12 +603,15 @@ void Game_Actor::ChangeLevel(int new_level, bool level_up_message) {
 	if (new_level > old_level) {
 		if (level_up_message) {
 			std::stringstream ss;
-			ss << GetData().name << " ";
+			ss << GetData().name;
 			if (Player::IsRPG2k3E()) {
-				ss << Data::terms.level_up << " ";
-				ss << Data::terms.level << " " << new_level;
+				ss << " " << Data::terms.level_up << " ";
+				ss << " " << Data::terms.level << " " << new_level;
 			} else {
-				ss << Data::terms.level << " " << new_level;
+				if (Player::IsCP932())
+					ss << "は" << Data::terms.level << " " << new_level << " ";
+				else
+					ss << " " << Data::terms.level << " " << new_level;
 				ss << Data::terms.level_up;
 			}
 			Game_Message::texts.push_back(ss.str());

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -608,11 +608,16 @@ void Game_Actor::ChangeLevel(int new_level, bool level_up_message) {
 				ss << " " << Data::terms.level_up << " ";
 				ss << " " << Data::terms.level << " " << new_level;
 			} else {
-				if (Player::IsCP932())
-					ss << "は" << Data::terms.level << " " << new_level << " ";
-				else
-					ss << " " << Data::terms.level << " " << new_level;
-				ss << Data::terms.level_up;
+				std::string particle, space = "";
+				if (Player::IsCP932()) {
+					particle = "は";
+					space += " ";
+				}
+				else {
+					particle = " ";
+				}
+				ss << particle << Data::terms.level << " ";
+				ss << new_level << space << Data::terms.level_up;
 			}
 			Game_Message::texts.push_back(ss.str());
 			level_up = true;

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -251,7 +251,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 					Data::terms.enemy_hp_absorbed);
 			}
 			else {
-				ss << " " << Data::terms.attack << " " << GetAffectedSp();
+				ss << " " << Data::terms.spirit_points << " " << GetAffectedSp();
 			}
 		}
 		out.push_back(ss.str());

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -199,16 +199,22 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 	bool target_is_ally = (*current_target)->GetType() == Game_Battler::Type_Ally;
 
 	if (GetAffectedHp() != -1) {
+		std::string particle, particle2, space = "";
 		std::stringstream ss;
 		ss << (*current_target)->GetName();
 
 		if (IsPositive()) {
 			if (!(*current_target)->IsDead()) {
-				if (Player::IsCP932())
-					ss << "の" << Data::terms.health_points << "が " << GetAffectedHp() << " ";
-				else
-					ss << " " << Data::terms.health_points << " " << GetAffectedHp();
-				ss << Data::terms.hp_recovery;
+				if (Player::IsCP932()) {
+					particle = "の";
+					particle2 = "が ";
+					space += " ";
+				}
+				else {
+					particle = particle2 = " ";
+				}
+				ss << particle << Data::terms.health_points << particle2;
+				ss << GetAffectedHp() << space << Data::terms.hp_recovery;
 				out.push_back(ss.str());
 			}
 		}
@@ -226,19 +232,26 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 			}
 			else {
 				if (absorb) {
-					if (Player::IsCP932())
-						ss << (target_is_ally ? "は" : "の") << Data::terms.health_points << "を " << GetAffectedHp() << " ";
-					else
-						ss << " " << Data::terms.health_points << " " << GetAffectedHp();
-					ss << (target_is_ally ?
+					if (Player::IsCP932()) {
+						particle = (target_is_ally ? "は" : "の");
+						particle2 = "を ";
+						space += " ";
+					} else {
+						particle = particle2 = " ";
+					}
+					ss << particle << Data::terms.health_points << particle2;
+					ss << GetAffectedHp() << space << (target_is_ally ?
 						Data::terms.actor_hp_absorbed :
 						Data::terms.enemy_hp_absorbed);
 				}
 				else {
-					if (Player::IsCP932())
-						ss << (target_is_ally ? "は" : "に") << " " << GetAffectedHp() << " ";
-					else
-						ss << " " << GetAffectedHp();
+					if (Player::IsCP932()) {
+						particle = (target_is_ally ? "は " : "に ");
+						space += " ";
+					} else {
+						particle = " ";
+					}
+					ss << particle << GetAffectedHp() << space;
 					ss << (target_is_ally ?
 						Data::terms.actor_damaged :
 						Data::terms.enemy_damaged);
@@ -249,85 +262,118 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 	}
 
 	if (GetAffectedSp() != -1) {
+		std::string particle, particle2, space = "";
 		std::stringstream ss;
 		ss << (*current_target)->GetName();
 
 		if (IsPositive()) {
-			if (Player::IsCP932())
-				ss << "の" << Data::terms.spirit_points << "が " << GetAffectedSp() << " ";
-			else
-				ss << " " << Data::terms.spirit_points << GetAffectedSp();
-			ss << Data::terms.hp_recovery;
+			if (Player::IsCP932()) {
+				particle = "の";
+				particle2 = "が ";
+				space += " ";
+			}
+			else {
+				particle = particle2 = " ";
+			}
+			ss << particle << Data::terms.spirit_points << particle2;
+			ss << GetAffectedSp() << space << Data::terms.hp_recovery;
 		}
 		else {
 			if (absorb) {
-				if (Player::IsCP932())
-					ss << (target_is_ally ? "は" : "の") << Data::terms.spirit_points << "を " << GetAffectedSp() << " ";
-				else
-					ss << " " << Data::terms.spirit_points << " " << GetAffectedSp();
-				ss << (target_is_ally ?
+				if (Player::IsCP932()) {
+					particle = (target_is_ally ? "は" : "の");
+					particle2 = "を ";
+					space += " ";
+				}
+				else {
+					particle = particle2 = " ";
+				}
+				ss << particle << Data::terms.spirit_points << particle2;
+				ss << GetAffectedSp() << space << (target_is_ally ?
 					Data::terms.actor_hp_absorbed :
 					Data::terms.enemy_hp_absorbed);
 			}
 			else {
-				if (Player::IsCP932())
-					ss << "の" << Data::terms.spirit_points << "が " << GetAffectedSp() << " " << Data::terms.parameter_decrease;
-				else
-					ss << " " << Data::terms.spirit_points << " " << GetAffectedSp();
+				if (Player::IsCP932()) {
+					particle = "の";
+					particle2 = "が ";
+					space += " ";
+				}
+				else {
+					particle = particle2 = " ";
+				}
+				ss << particle << Data::terms.spirit_points << particle2;
+				ss << GetAffectedSp() << space << Data::terms.parameter_decrease;
 			}
 		}
 		out.push_back(ss.str());
 	}
 
 	if (GetAffectedAttack() != -1) {
+		std::string particle, particle2, space = "";
 		std::stringstream ss;
 		ss << (*current_target)->GetName();
-		if (Player::IsCP932())
-		{
-			ss << "の" << Data::terms.attack << "が " << GetAffectedAttack();
-			ss << " " << (IsPositive() ? Data::terms.parameter_increase : Data::terms.parameter_decrease);
+		if (Player::IsCP932()) {
+			particle = "の";
+			particle2 = "が ";
+			space += " ";
 		}
-		else
-			ss << " " << Data::terms.attack << " " << GetAffectedAttack();
+		else {
+			particle = particle2 = " ";
+		}
+		ss << particle << Data::terms.attack << particle2 << GetAffectedAttack() << space;
+		ss << (IsPositive() ? Data::terms.parameter_increase : Data::terms.parameter_decrease);
 		out.push_back(ss.str());
 	}
 
 	if (GetAffectedDefense() != -1) {
+		std::string particle, particle2, space = "";
 		std::stringstream ss;
 		ss << (*current_target)->GetName();
-		if (Player::IsCP932())
-		{
-			ss << "の" << Data::terms.defense << "が " << GetAffectedDefense();
-			ss << " " << (IsPositive() ? Data::terms.parameter_increase : Data::terms.parameter_decrease);
+		if (Player::IsCP932()) {
+			particle = "の";
+			particle2 = "が ";
+			space += " ";
 		}
-		else
-			ss << " " << Data::terms.defense << " " << GetAffectedDefense();
+		else {
+			particle = particle2 = " ";
+		}
+		ss << particle << Data::terms.defense << particle2 << GetAffectedDefense() << space;
+		ss << (IsPositive() ? Data::terms.parameter_increase : Data::terms.parameter_decrease);
 		out.push_back(ss.str());
 	}
 
 	if (GetAffectedSpirit() != -1) {
+		std::string particle, particle2, space = "";
 		std::stringstream ss;
 		ss << (*current_target)->GetName();
-		if (Player::IsCP932())
-		{
-			ss << "の" << Data::terms.spirit << "が " << GetAffectedSpirit();
-			ss << " " << (IsPositive() ? Data::terms.parameter_increase : Data::terms.parameter_decrease);
+		if (Player::IsCP932()) {
+			particle = "の";
+			particle2 = "が ";
+			space += " ";
 		}
-		else
-			ss << " " << Data::terms.spirit << " " << GetAffectedSpirit();
+		else {
+			particle = particle2 = " ";
+		}
+		ss << particle << Data::terms.spirit << particle2 << GetAffectedSpirit() << space;
+		ss << (IsPositive() ? Data::terms.parameter_increase : Data::terms.parameter_decrease);
 		out.push_back(ss.str());
 	}
 
 	if (GetAffectedAgility() != -1) {
+		std::string particle, particle2, space = "";
 		std::stringstream ss;
 		ss << (*current_target)->GetName();
-		if (Player::IsCP932())
-		{
-			ss << "の" << Data::terms.agility << "が " << GetAffectedAgility();
-			ss << " " << (IsPositive() ? Data::terms.parameter_increase : Data::terms.parameter_decrease);
+		if (Player::IsCP932()) {
+			particle = "の";
+			particle2 = "が ";
+			space += " ";
 		}
-		else
-			ss << " " << Data::terms.agility << " " << GetAffectedAgility();
+		else {
+			particle = particle2 = " ";
+		}
+		ss << particle << Data::terms.agility << particle2 << GetAffectedAgility() << space;
+		ss << (IsPositive() ? Data::terms.parameter_increase : Data::terms.parameter_decrease);
 		out.push_back(ss.str());
 	}
 
@@ -1049,10 +1095,12 @@ void Game_BattleAlgorithm::Item::Apply() {
 
 std::string Game_BattleAlgorithm::Item::GetStartMessage() const {
 	if (Player::IsRPG2k()) {
+		std::string particle;
 		if (Player::IsCP932())
-			return source->GetName() + "は" + item.name + Data::terms.use_item;
+			particle = "は";
 		else
-			return source->GetName() + " " + item.name + Data::terms.use_item;
+			particle = " ";
+		return source->GetName() + particle + item.name + Data::terms.use_item;
 	}
 	else {
 		return item.name;

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -260,7 +260,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 	if (GetAffectedAttack() != -1) {
 		std::stringstream ss;
 		ss << (*current_target)->GetName();
-		ss << " " << Data::terms.attack << " " << GetAffectedSp();
+		ss << " " << Data::terms.attack << " " << GetAffectedAttack();
 		out.push_back(ss.str());
 	}
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -948,6 +948,10 @@ bool Player::IsRPG2k3E() {
 	return (engine & EngineRpg2k3E) == EngineRpg2k3E;
 }
 
+bool Player::IsCP932() {
+	return (encoding == "ibm-943_P15A-2003" || encoding == "932");
+}
+
 #if (defined(_WIN32) && defined(NDEBUG) && defined(WINVER) && WINVER >= 0x0600)
 // Minidump code for Windows
 // Original Author: Oleg Starodumov (www.debuginfo.com)

--- a/src/player.h
+++ b/src/player.h
@@ -148,6 +148,11 @@ namespace Player {
 	 */
 	bool IsRPG2k3E();
 
+	/**
+         * @return if encoding is CP932 or not
+	 */
+	bool IsCP932();
+
 	/** Output program version on stdout */
 	void PrintVersion();
 


### PR DESCRIPTION
Some RPG2k battle messages are incorrect. Also, lots of Japanese messages are broken.

#### Fix wrong uses of Data::terms.*

Wine + RPG_RT.exe:
![wine-ally-critical](https://cloud.githubusercontent.com/assets/10556453/19218487/40d39284-8e36-11e6-81cb-57e4b4ebb15c.png)
Unpatched ("会心の一撃！！" is expected in this game, not "痛恨の一撃！！"):
![unpatched-ally-critical](https://cloud.githubusercontent.com/assets/10556453/19218485/40d1cb2a-8e36-11e6-82c9-b9a4d68113d4.png)
Patched:
![patched-ally-critical](https://cloud.githubusercontent.com/assets/10556453/19218484/40ceede2-8e36-11e6-97dc-d0abda5d1cf0.png)

#### Fix broken Japanese messages if the encoding is CP932

Wine + RPG_RT.exe:
![wine-ally-1mplost](https://cloud.githubusercontent.com/assets/10556453/19218488/40d3b61a-8e36-11e6-8730-856b10338f0b.png)
Unpatched (Broken Japanese message. Also, "攻撃力 (ATK)" is incorrect):
![unpatched-ally-1mplost](https://cloud.githubusercontent.com/assets/10556453/19218486/40d30026-8e36-11e6-895b-0624bbdf9e3f.png)
Patched:
![patched-ally-1mplost](https://cloud.githubusercontent.com/assets/10556453/19218483/40ca0034-8e36-11e6-9376-70f5e56c82c1.png)