### PR TITLE
De-magic-numbify some Z layer settings and BattleAnim-Picture-Render Order

### DIFF
--- a/src/background.h
+++ b/src/background.h
@@ -37,7 +37,7 @@ public:
 	DrawableType GetType() const override;
 
 private:
-	static const int z = -1000;
+	static const int z = PriorityBackground;
 	static const DrawableType type = TypeBackground;
 
 	static void Update(int& rate, int& value);

--- a/src/background.h
+++ b/src/background.h
@@ -37,7 +37,7 @@ public:
 	DrawableType GetType() const override;
 
 private:
-	static const int z = PriorityBackground;
+	static const int z = Priority_Background;
 	static const DrawableType type = TypeBackground;
 
 	static void Update(int& rate, int& value);

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -34,7 +34,7 @@
 BattleAnimation::BattleAnimation(const RPG::Animation& anim) :
 	animation(anim), frame(0), frame_update(false), large(false)
 {
-	SetZ(PriorityBattleAnimation);
+	SetZ(Priority_BattleAnimation);
 
 	const std::string& name = animation.animation_name;
 	BitmapRef graphic;

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -34,7 +34,7 @@
 BattleAnimation::BattleAnimation(const RPG::Animation& anim) :
 	animation(anim), frame(0), frame_update(false), large(false)
 {
-	SetZ(Player::IsMajorUpdatedVersion() ? 2400 : 1040);
+	SetZ(PriorityBattleAnimation);
 
 	const std::string& name = animation.animation_name;
 	BitmapRef graphic;

--- a/src/drawable.h
+++ b/src/drawable.h
@@ -33,21 +33,22 @@ enum DrawableType {
 };
 
 enum Priority {
-	PriorityBackground = 10 << 24,
-	PriorityPanorama = 15 << 24,
-	PriorityMap = 20 << 24, // Map and Battle are two different scenes...
-	PriorityBattle = 20 << 24, // ...will never conflict
-	PriorityBattleUi = 25 << 24,
-	PriorityAirshipShadow = 25 << 24,
-	PriorityPictureNew = 30 << 24, // Pictures in RPG2k Value! and RPG2k3 >=1.05
-	PriorityBattleAnimation = 35 << 24,
-	PriorityPictureOld = 40 << 24, // Picture in RPG2k <1.5 and RPG2k3 <1.05
-	PriorityWeather = 45 << 24,
-	PriorityScreen = 50 << 24,
-	PriorityTimer = 55 << 24,
-	PriorityWindow = 60 << 24,
-	PriorityFrame = 65 << 24,
-	PriorityMessageOverlay = 70 << 24
+	Priority_Background = 5 << 24,
+	Priority_TilesetBelow = 10 << 24,
+	Priority_EventsBelow = 15 << 24,
+	Priority_Player = 20 << 24, // In Map, shared with "same as hero" events
+	Priority_Battler = 20 << 24, // In Battle (includes animations)
+	Priority_TilesetAbove = 25 << 24,
+	Priority_EventsAbove = 30 << 24,
+	Priority_Weather = 35 << 24,
+	Priority_Screen = 40 << 24,
+	Priority_PictureNew = 45 << 24, // Pictures in RPG2k Value! and RPG2k3 >=1.05, shared
+	Priority_BattleAnimation = 50 << 24,
+	Priority_PictureOld = 55 << 24, // Picture in RPG2k <1.5 and RPG2k3 <1.05, shared
+	Priority_Window = 60 << 24,
+	Priority_Timer = 65 << 24,
+	Priority_Frame = 70 << 24,
+	Priority_Overlay = 75 << 24
 };
 
 /**

--- a/src/drawable.h
+++ b/src/drawable.h
@@ -35,17 +35,18 @@ enum DrawableType {
 enum Priority {
 	PriorityBackground = 10 << 24,
 	PriorityPanorama = 15 << 24,
-	PriorityMap = 25 << 24,
-	PriorityBattle = 26 << 24,
+	PriorityMap = 20 << 24, // Map and Battle are two different scenes...
+	PriorityBattle = 20 << 24, // ...will never conflict
+	PriorityAirshipShadow = 25 << 24,
 	PriorityPictureNew = 30 << 24, // Pictures in RPG2k Value! and RPG2k3 >=1.05
 	PriorityBattleAnimation = 35 << 24,
 	PriorityPictureOld = 40 << 24, // Picture in RPG2k <1.5 and RPG2k3 <1.05
-	PriorityWeather = 25 << 24,
-	PriorityScreen = 30 << 24,
-	PriorityTimer = 35 << 24,
-	PriorityWindow = 40 << 24,
-	PriorityFrame = 45 << 24,
-	PriorityMessageOverlay = 50 << 24
+	PriorityWeather = 45 << 24,
+	PriorityScreen = 50 << 24,
+	PriorityTimer = 55 << 24,
+	PriorityWindow = 60 << 24,
+	PriorityFrame = 65 << 24,
+	PriorityMessageOverlay = 70 << 24
 };
 
 /**

--- a/src/drawable.h
+++ b/src/drawable.h
@@ -29,7 +29,24 @@ enum DrawableType {
 	TypeFrame,
 	TypeWeather,
 	TypeOverlay,
-	TypeDefault};
+	TypeDefault
+};
+
+enum Priority {
+	PriorityBackground = 10 << 24,
+	PriorityPanorama = 15 << 24,
+	PriorityMap = 25 << 24,
+	PriorityBattle = 26 << 24,
+	PriorityPictureNew = 30 << 24, // Pictures in RPG2k Value! and RPG2k3 >=1.05
+	PriorityBattleAnimation = 35 << 24,
+	PriorityPictureOld = 40 << 24, // Picture in RPG2k <1.5 and RPG2k3 <1.05
+	PriorityWeather = 25 << 24,
+	PriorityScreen = 30 << 24,
+	PriorityTimer = 35 << 24,
+	PriorityWindow = 40 << 24,
+	PriorityFrame = 45 << 24,
+	PriorityMessageOverlay = 50 << 24
+};
 
 /**
  * Drawable virtual

--- a/src/drawable.h
+++ b/src/drawable.h
@@ -37,6 +37,7 @@ enum Priority {
 	PriorityPanorama = 15 << 24,
 	PriorityMap = 20 << 24, // Map and Battle are two different scenes...
 	PriorityBattle = 20 << 24, // ...will never conflict
+	PriorityBattleUi = 25 << 24,
 	PriorityAirshipShadow = 25 << 24,
 	PriorityPictureNew = 30 << 24, // Pictures in RPG2k Value! and RPG2k3 >=1.05
 	PriorityBattleAnimation = 35 << 24,

--- a/src/fps_overlay.cpp
+++ b/src/fps_overlay.cpp
@@ -26,7 +26,7 @@
 
 FpsOverlay::FpsOverlay() :
 	type(TypeOverlay),
-	z(200) {
+	z(Priority_Overlay + 100) {
 
 	Graphics::RegisterDrawable(this);
 }

--- a/src/frame.h
+++ b/src/frame.h
@@ -39,7 +39,7 @@ public:
 
 private:
 
-	static const int z = PriorityFrame;
+	static const int z = Priority_Frame;
 	static const DrawableType type = TypeFrame;
 
 	void OnFrameGraphicReady(FileRequestResult* result);

--- a/src/frame.h
+++ b/src/frame.h
@@ -39,7 +39,7 @@ public:
 
 private:
 
-	static const int z = 11000;
+	static const int z = PriorityFrame;
 	static const DrawableType type = TypeFrame;
 
 	void OnFrameGraphicReady(FileRequestResult* result);

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -160,7 +160,7 @@ int Game_Character::GetScreenY() const {
 }
 
 int Game_Character::GetScreenZ() const {
-	int z = this == Main_Data::game_player.get() ? 1 : 0;
+	int z = PriorityMap + this == Main_Data::game_player.get() ? 1 : 0;
 
 	// For events on the screen, this should be inside a 0-40 range
 	z += GetScreenY() >> 3;

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -160,12 +160,18 @@ int Game_Character::GetScreenY() const {
 }
 
 int Game_Character::GetScreenZ() const {
-	int z = PriorityMap + this == Main_Data::game_player.get() ? 1 : 0;
+	int z = 0;
+
+	if (GetLayer() == RPG::EventPage::Layers_same) {
+		z = Priority_Player;
+	} else if (GetLayer() == RPG::EventPage::Layers_below) {
+		z = Priority_EventsBelow;
+	} else if (GetLayer() == RPG::EventPage::Layers_above) {
+		z = Priority_EventsAbove;
+	}
 
 	// For events on the screen, this should be inside a 0-40 range
 	z += GetScreenY() >> 3;
-
-	z += GetLayer() * 50;
 
 	return z;
 }

--- a/src/game_picture.cpp
+++ b/src/game_picture.cpp
@@ -51,19 +51,17 @@ void Game_Picture::UpdateSprite() {
 
 	sprite->SetX((int)data.current_x);
 	sprite->SetY((int)data.current_y);
-	if (Player::IsRPG2k3()) { // TODO: Including new RPG2k
+	if (Player::IsMajorUpdatedVersion()) {
 		// Battle Animations are above pictures
-		// ToDo: Include RPG Maker 2000 1.5 Value! and newer (How to detect?)
-		// ToDo: Exclude RPG Maker 2003 <1.05 (How to detect?)
-		sprite->SetZ(PriorityPictureNew + data.ID);
+		sprite->SetZ(Priority_PictureNew + data.ID);
 	} else {
 		// Battle Animations are below pictures
-		sprite->SetZ(PriorityPictureOld + data.ID);
+		sprite->SetZ(Priority_PictureOld + data.ID);
 	}
 	sprite->SetZoomX(data.current_magnify / 100.0);
 	sprite->SetZoomY(data.current_magnify / 100.0);
-	sprite->SetOx((int)(sprite->GetBitmap()->GetWidth() / 2));
-	sprite->SetOy((int)(sprite->GetBitmap()->GetHeight() / 2));
+	sprite->SetOx(sprite->GetBitmap()->GetWidth() / 2);
+	sprite->SetOy(sprite->GetBitmap()->GetHeight() / 2);
 
 	sprite->SetAngle(data.effect_mode != 2 ? data.current_rotation * 360 / 256 : 0.0);
 	sprite->SetWaverPhase(data.effect_mode == 2 ? data.current_waver : 0.0);

--- a/src/game_picture.cpp
+++ b/src/game_picture.cpp
@@ -51,7 +51,15 @@ void Game_Picture::UpdateSprite() {
 
 	sprite->SetX((int)data.current_x);
 	sprite->SetY((int)data.current_y);
-	sprite->SetZ(1100 + data.ID);
+	if (Player::IsRPG2k3()) { // TODO: Including new RPG2k
+		// Battle Animations are above pictures
+		// ToDo: Include RPG Maker 2000 1.5 Value! and newer (How to detect?)
+		// ToDo: Exclude RPG Maker 2003 <1.05 (How to detect?)
+		sprite->SetZ(PriorityPictureNew + data.ID);
+	} else {
+		// Battle Animations are below pictures
+		sprite->SetZ(PriorityPictureOld + data.ID);
+	}
 	sprite->SetZoomX(data.current_magnify / 100.0);
 	sprite->SetZoomY(data.current_magnify / 100.0);
 	sprite->SetOx((int)(sprite->GetBitmap()->GetWidth() / 2));

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -55,6 +55,12 @@ void Game_Player::SetY(int new_y) {
 	location.position_y = new_y;
 }
 
+int Game_Player::GetScreenZ() const {
+	// Player is always slightly above events
+	// (and always on "same layer as hero" obviously)
+	return Game_Character::GetScreenZ() + 1;
+}
+
 int Game_Player::GetMapId() const {
 	return location.map_id;
 }

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -44,6 +44,7 @@ public:
 	void SetX(int new_x) override;
 	int GetY() const override;
 	void SetY(int new_y) override;
+	int GetScreenZ() const override;
 	int GetMapId() const override;
 	void SetMapId(int new_map_id) override;
 	int GetDirection() const override;

--- a/src/message_overlay.cpp
+++ b/src/message_overlay.cpp
@@ -25,7 +25,7 @@
 
 MessageOverlay::MessageOverlay() :
 	type(TypeOverlay),
-	z(100),
+	z(Priority_Overlay),
 	ox(0),
 	oy(0),
 	text_height(12),
@@ -33,7 +33,7 @@ MessageOverlay::MessageOverlay() :
 	dirty(false),
 	counter(0),
 	show_all(false) {
-	
+
 	black = Bitmap::Create(DisplayUi->GetWidth(), text_height, Color());
 
 	bitmap = Bitmap::Create(DisplayUi->GetWidth(), text_height * message_max, true);

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -127,7 +127,7 @@ void Scene_Battle::CreateUi() {
 	status_window.reset(new Window_BattleStatus(0, (SCREEN_TARGET_HEIGHT-80), SCREEN_TARGET_WIDTH - 76, 80));
 
 	message_window.reset(new Window_Message(0, (SCREEN_TARGET_HEIGHT - 80), SCREEN_TARGET_WIDTH, 80));
-	message_window->SetZ(PriorityWindow + 20);
+	message_window->SetZ(Priority_Window + 20);
 }
 
 void Scene_Battle::Update() {

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -127,7 +127,6 @@ void Scene_Battle::CreateUi() {
 	status_window.reset(new Window_BattleStatus(0, (SCREEN_TARGET_HEIGHT-80), SCREEN_TARGET_WIDTH - 76, 80));
 
 	message_window.reset(new Window_Message(0, (SCREEN_TARGET_HEIGHT - 80), SCREEN_TARGET_WIDTH, 80));
-	message_window->SetZ(Priority_Window + 20);
 }
 
 void Scene_Battle::Update() {

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -127,7 +127,7 @@ void Scene_Battle::CreateUi() {
 	status_window.reset(new Window_BattleStatus(0, (SCREEN_TARGET_HEIGHT-80), SCREEN_TARGET_WIDTH - 76, 80));
 
 	message_window.reset(new Window_Message(0, (SCREEN_TARGET_HEIGHT - 80), SCREEN_TARGET_WIDTH, 80));
-	message_window->SetZ(PriorityWindow + 3002);
+	message_window->SetZ(PriorityWindow + 20);
 }
 
 void Scene_Battle::Update() {

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -127,7 +127,7 @@ void Scene_Battle::CreateUi() {
 	status_window.reset(new Window_BattleStatus(0, (SCREEN_TARGET_HEIGHT-80), SCREEN_TARGET_WIDTH - 76, 80));
 
 	message_window.reset(new Window_Message(0, (SCREEN_TARGET_HEIGHT - 80), SCREEN_TARGET_WIDTH, 80));
-	message_window->SetZ(3002);
+	message_window->SetZ(PriorityWindow + 3002);
 }
 
 void Scene_Battle::Update() {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -84,6 +84,7 @@ void Scene_Battle_Rpg2k::CreateBattleTargetWindow() {
 	target_window.reset(new Window_Command(commands, 136, 4));
 	target_window->SetHeight(80);
 	target_window->SetY(SCREEN_TARGET_HEIGHT-80);
+	// Above other windows
 	target_window->SetZ(Priority_Window + 10);
 }
 

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -84,7 +84,7 @@ void Scene_Battle_Rpg2k::CreateBattleTargetWindow() {
 	target_window.reset(new Window_Command(commands, 136, 4));
 	target_window->SetHeight(80);
 	target_window->SetY(SCREEN_TARGET_HEIGHT-80);
-	target_window->SetZ(3001);
+	target_window->SetZ(PriorityWindow + 3001);
 }
 
 void Scene_Battle_Rpg2k::CreateBattleCommandWindow() {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -84,7 +84,7 @@ void Scene_Battle_Rpg2k::CreateBattleTargetWindow() {
 	target_window.reset(new Window_Command(commands, 136, 4));
 	target_window->SetHeight(80);
 	target_window->SetY(SCREEN_TARGET_HEIGHT-80);
-	target_window->SetZ(PriorityWindow + 3001);
+	target_window->SetZ(PriorityWindow + 10);
 }
 
 void Scene_Battle_Rpg2k::CreateBattleCommandWindow() {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -84,7 +84,7 @@ void Scene_Battle_Rpg2k::CreateBattleTargetWindow() {
 	target_window.reset(new Window_Command(commands, 136, 4));
 	target_window->SetHeight(80);
 	target_window->SetY(SCREEN_TARGET_HEIGHT-80);
-	target_window->SetZ(PriorityWindow + 10);
+	target_window->SetZ(Priority_Window + 10);
 }
 
 void Scene_Battle_Rpg2k::CreateBattleCommandWindow() {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -106,11 +106,11 @@ void Scene_Battle_Rpg2k3::OnSystem2Ready(FileRequestResult* result) {
 	BitmapRef system2 = Cache::System2(result->file);
 
 	ally_cursor->SetBitmap(system2);
-	ally_cursor->SetZ(999);
+	ally_cursor->SetZ(PriorityBattle + 999);
 	ally_cursor->SetVisible(false);
 
 	enemy_cursor->SetBitmap(system2);
-	enemy_cursor->SetZ(999);
+	enemy_cursor->SetZ(PriorityBattle + 999);
 	enemy_cursor->SetVisible(false);
 }
 
@@ -237,7 +237,7 @@ void Scene_Battle_Rpg2k3::DrawFloatText(int x, int y, int color, const std::stri
 	floating_text->SetX(x);
 	// Move 5 pixel down because the number "jumps" with the intended y as the peak
 	floating_text->SetY(y + 5);
-	floating_text->SetZ(500 + y);
+	floating_text->SetZ(PriorityBattle + 500 + y);
 
 	FloatText float_text;
 	float_text.sprite = floating_text;
@@ -259,7 +259,7 @@ void Scene_Battle_Rpg2k3::CreateBattleTargetWindow() {
 	target_window.reset(new Window_Command(commands, 136, 4));
 	target_window->SetHeight(80);
 	target_window->SetY(SCREEN_TARGET_HEIGHT-80);
-	target_window->SetZ(3001);
+	target_window->SetZ(PriorityWindow + 3001);
 
 	if (Data::battlecommands.battle_type != RPG::BattleCommands::BattleType_traditional) {
 		int transp = Data::battlecommands.transparency == RPG::BattleCommands::Transparency_transparent ? 128 : 255;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -106,11 +106,11 @@ void Scene_Battle_Rpg2k3::OnSystem2Ready(FileRequestResult* result) {
 	BitmapRef system2 = Cache::System2(result->file);
 
 	ally_cursor->SetBitmap(system2);
-	ally_cursor->SetZ(PriorityBattle + 999);
+	ally_cursor->SetZ(PriorityBattleUi);
 	ally_cursor->SetVisible(false);
 
 	enemy_cursor->SetBitmap(system2);
-	enemy_cursor->SetZ(PriorityBattle + 999);
+	enemy_cursor->SetZ(PriorityBattleUi);
 	enemy_cursor->SetVisible(false);
 }
 
@@ -237,7 +237,7 @@ void Scene_Battle_Rpg2k3::DrawFloatText(int x, int y, int color, const std::stri
 	floating_text->SetX(x);
 	// Move 5 pixel down because the number "jumps" with the intended y as the peak
 	floating_text->SetY(y + 5);
-	floating_text->SetZ(PriorityBattle + 500 + y);
+	floating_text->SetZ(PriorityBattleUi + y);
 
 	FloatText float_text;
 	float_text.sprite = floating_text;
@@ -259,7 +259,7 @@ void Scene_Battle_Rpg2k3::CreateBattleTargetWindow() {
 	target_window.reset(new Window_Command(commands, 136, 4));
 	target_window->SetHeight(80);
 	target_window->SetY(SCREEN_TARGET_HEIGHT-80);
-	target_window->SetZ(PriorityWindow + 3001);
+	target_window->SetZ(PriorityWindow + 10);
 
 	if (Data::battlecommands.battle_type != RPG::BattleCommands::BattleType_traditional) {
 		int transp = Data::battlecommands.transparency == RPG::BattleCommands::Transparency_transparent ? 128 : 255;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -106,11 +106,11 @@ void Scene_Battle_Rpg2k3::OnSystem2Ready(FileRequestResult* result) {
 	BitmapRef system2 = Cache::System2(result->file);
 
 	ally_cursor->SetBitmap(system2);
-	ally_cursor->SetZ(PriorityBattleUi);
+	ally_cursor->SetZ(Priority_Window);
 	ally_cursor->SetVisible(false);
 
 	enemy_cursor->SetBitmap(system2);
-	enemy_cursor->SetZ(PriorityBattleUi);
+	enemy_cursor->SetZ(Priority_Window);
 	enemy_cursor->SetVisible(false);
 }
 
@@ -237,7 +237,7 @@ void Scene_Battle_Rpg2k3::DrawFloatText(int x, int y, int color, const std::stri
 	floating_text->SetX(x);
 	// Move 5 pixel down because the number "jumps" with the intended y as the peak
 	floating_text->SetY(y + 5);
-	floating_text->SetZ(PriorityBattleUi + y);
+	floating_text->SetZ(Priority_Window + y);
 
 	FloatText float_text;
 	float_text.sprite = floating_text;
@@ -259,7 +259,7 @@ void Scene_Battle_Rpg2k3::CreateBattleTargetWindow() {
 	target_window.reset(new Window_Command(commands, 136, 4));
 	target_window->SetHeight(80);
 	target_window->SetY(SCREEN_TARGET_HEIGHT-80);
-	target_window->SetZ(PriorityWindow + 10);
+	target_window->SetZ(Priority_Window + 10);
 
 	if (Data::battlecommands.battle_type != RPG::BattleCommands::BattleType_traditional) {
 		int transp = Data::battlecommands.transparency == RPG::BattleCommands::Transparency_transparent ? 128 : 255;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -259,6 +259,7 @@ void Scene_Battle_Rpg2k3::CreateBattleTargetWindow() {
 	target_window.reset(new Window_Command(commands, 136, 4));
 	target_window->SetHeight(80);
 	target_window->SetY(SCREEN_TARGET_HEIGHT-80);
+	// Above other windows
 	target_window->SetZ(Priority_Window + 10);
 
 	if (Data::battlecommands.battle_type != RPG::BattleCommands::BattleType_traditional) {

--- a/src/screen.h
+++ b/src/screen.h
@@ -47,7 +47,7 @@ public:
 	void SetTone(Tone tone);
 
 private:
-	static const int z = 2500;
+	static const int z = PriorityScreen;
 	static const DrawableType type = TypeScreen;
 
 	BitmapRef flash;

--- a/src/screen.h
+++ b/src/screen.h
@@ -28,7 +28,7 @@
  * A special drawable for handling screen effects.
  * This basically works by taking the screen surface and drawing on itself.
  * Sounds a bit dirty, but works.
- * 
+ *
  * The z index is chosen in a way that battle animations and message boxes
  * are not colorized.
  */
@@ -47,7 +47,7 @@ public:
 	void SetTone(Tone tone);
 
 private:
-	static const int z = PriorityScreen;
+	static const int z = Priority_Screen;
 	static const DrawableType type = TypeScreen;
 
 	BitmapRef flash;

--- a/src/sprite_airshipshadow.cpp
+++ b/src/sprite_airshipshadow.cpp
@@ -70,6 +70,5 @@ void Sprite_AirshipShadow::Update() {
 
 	SetX(Main_Data::game_player->GetScreenX());
 	SetY(Main_Data::game_player->GetScreenY());
-	// Higher than the events in the upper layer
-	SetZ(PriorityMap + 151);
+	SetZ(PriorityAirshipShadow);
 }

--- a/src/sprite_airshipshadow.cpp
+++ b/src/sprite_airshipshadow.cpp
@@ -71,5 +71,5 @@ void Sprite_AirshipShadow::Update() {
 	SetX(Main_Data::game_player->GetScreenX());
 	SetY(Main_Data::game_player->GetScreenY());
 	// Higher than the events in the upper layer
-	SetZ(151);
+	SetZ(PriorityMap + 151);
 }

--- a/src/sprite_airshipshadow.cpp
+++ b/src/sprite_airshipshadow.cpp
@@ -70,5 +70,5 @@ void Sprite_AirshipShadow::Update() {
 
 	SetX(Main_Data::game_player->GetScreenX());
 	SetY(Main_Data::game_player->GetScreenY());
-	SetZ(PriorityAirshipShadow);
+	SetZ(airship->GetScreenZ());
 }

--- a/src/sprite_airshipshadow.cpp
+++ b/src/sprite_airshipshadow.cpp
@@ -70,5 +70,6 @@ void Sprite_AirshipShadow::Update() {
 
 	SetX(Main_Data::game_player->GetScreenX());
 	SetY(Main_Data::game_player->GetScreenY());
+	// Synchronized with airship priority
 	SetZ(airship->GetScreenZ());
 }

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -269,7 +269,8 @@ void Sprite_Battler::CreateSprite() {
 
 	SetX(battler->GetDisplayX());
 	SetY(battler->GetDisplayY());
-	SetZ(PriorityBattle + battler->GetBattleY()); // Battlers at the bottom appear above battlers at the top
+	// Battlers at the bottom appear above battlers at the top
+	SetZ(Priority_Battler + battler->GetBattleY());
 
 	// Not animated -> Monster
 	if (battler->GetBattleAnimationId() == 0) {

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -269,7 +269,7 @@ void Sprite_Battler::CreateSprite() {
 
 	SetX(battler->GetDisplayX());
 	SetY(battler->GetDisplayY());
-	SetZ(battler->GetBattleY()); // Not a typo
+	SetZ(PriorityBattle + battler->GetBattleY()); // Battlers at the bottom appear above battlers at the top
 
 	// Not animated -> Monster
 	if (battler->GetBattleAnimationId() == 0) {

--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -73,7 +73,7 @@ void Sprite_Character::Update() {
 
 	SetX(character->GetScreenX());
 	SetY(character->GetScreenY());
-	SetZ(character->GetScreenZ());
+	SetZ(PriorityMap + character->GetScreenZ());
 
 	//SetBlendType(character->GetBlendType());
 	int bush_split = 4 - character->GetBushDepth();

--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -73,7 +73,7 @@ void Sprite_Character::Update() {
 
 	SetX(character->GetScreenX());
 	SetY(character->GetScreenY());
-	SetZ(PriorityMap + character->GetScreenZ());
+	SetZ(character->GetScreenZ());
 
 	//SetBlendType(character->GetBlendType());
 	int bush_split = 4 - character->GetBushDepth();

--- a/src/sprite_timer.cpp
+++ b/src/sprite_timer.cpp
@@ -129,7 +129,7 @@ void Sprite_Timer::Update() {
 		SetY(4);
 	}
 
-	SetZ(10000);
+	SetZ(PriorityTimer);
 }
 
 void Sprite_Timer::CreateSprite() {

--- a/src/sprite_timer.cpp
+++ b/src/sprite_timer.cpp
@@ -129,7 +129,7 @@ void Sprite_Timer::Update() {
 		SetY(4);
 	}
 
-	SetZ(PriorityTimer);
+	SetZ(Priority_Timer);
 }
 
 void Sprite_Timer::CreateSprite() {

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -35,7 +35,7 @@ Spriteset_Map::Spriteset_Map() {
 	tilemap->SetHeight(Game_Map::GetHeight());
 
 	panorama.reset(new Plane());
-	panorama->SetZ(PriorityPanorama);
+	panorama->SetZ(Priority_Background);
 
 	ChipsetUpdated();
 

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -35,7 +35,7 @@ Spriteset_Map::Spriteset_Map() {
 	tilemap->SetHeight(Game_Map::GetHeight());
 
 	panorama.reset(new Plane());
-	panorama->SetZ(-1000);
+	panorama->SetZ(PriorityPanorama);
 
 	ChipsetUpdated();
 

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -154,10 +154,10 @@ TilemapLayer::TilemapLayer(int ilayer) :
 
 	// SubLayer for the tiles with Wall or Above passability
 	// Its z-value should be between the z of the events in the upper layer and the hero
-	sublayers.push_back(std::make_shared<TilemapSubLayer>(this, PriorityMap + 98 + layer));
+	sublayers.push_back(std::make_shared<TilemapSubLayer>(this, Priority_TilesetAbove));
 	// SubLayer for the tiles without Wall or Above passability
 	// Its z-value should be under z of the events in the lower layer
-	sublayers.push_back(std::make_shared<TilemapSubLayer>(this, PriorityMap + -2 + layer));
+	sublayers.push_back(std::make_shared<TilemapSubLayer>(this, Priority_TilesetBelow));
 }
 
 /** Draws a black tile at (x,y) (for OOB tiles) */
@@ -368,15 +368,15 @@ void TilemapLayer::CreateTileCache(const std::vector<short>& nmap_data) {
 			// Get the tile ID
 			tile.ID = nmap_data[x + y * width];
 
-			tile.z = PriorityMap;
+			tile.z = Priority_TilesetBelow;
 
 			// Calculate the tile Z
 			if (!passable.empty()) {
 				if (tile.ID >= BLOCK_F) { // Upper layer
 					if ((passable[substitutions[tile.ID - BLOCK_F]] & Passable::Above) != 0)
-						tile.z = PriorityMap + 99; // Upper sublayer
+						tile.z = Priority_TilesetAbove;// + 99; // Upper sublayer
 					else
-						tile.z = PriorityMap + -1; // Lower sublayer
+						tile.z = Priority_TilesetBelow;// + -1; // Lower sublayer
 
 				} else { // Lower layer
 					int chip_index =
@@ -385,9 +385,9 @@ void TilemapLayer::CreateTileCache(const std::vector<short>& nmap_data) {
 						tile.ID >= BLOCK_C ? (tile.ID - BLOCK_C) / 50 + 3 :
 						tile.ID / 1000;
 					if ((passable[chip_index] & (Passable::Wall | Passable::Above)) != 0)
-						tile.z = PriorityMap + 98; // Upper sublayer
+						tile.z = Priority_TilesetAbove;// + 98; // Upper sublayer
 					else
-						tile.z = PriorityMap + -2; // Lower sublayer
+						tile.z = Priority_TilesetBelow;// + -2; // Lower sublayer
 
 				}
 			}

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -374,9 +374,9 @@ void TilemapLayer::CreateTileCache(const std::vector<short>& nmap_data) {
 			if (!passable.empty()) {
 				if (tile.ID >= BLOCK_F) { // Upper layer
 					if ((passable[substitutions[tile.ID - BLOCK_F]] & Passable::Above) != 0)
-						tile.z = Priority_TilesetAbove;// + 99; // Upper sublayer
+						tile.z = Priority_TilesetAbove; // Upper sublayer
 					else
-						tile.z = Priority_TilesetBelow;// + -1; // Lower sublayer
+						tile.z = Priority_TilesetBelow; // Lower sublayer
 
 				} else { // Lower layer
 					int chip_index =
@@ -385,9 +385,9 @@ void TilemapLayer::CreateTileCache(const std::vector<short>& nmap_data) {
 						tile.ID >= BLOCK_C ? (tile.ID - BLOCK_C) / 50 + 3 :
 						tile.ID / 1000;
 					if ((passable[chip_index] & (Passable::Wall | Passable::Above)) != 0)
-						tile.z = Priority_TilesetAbove;// + 98; // Upper sublayer
+						tile.z = Priority_TilesetAbove; // Upper sublayer
 					else
-						tile.z = Priority_TilesetBelow;// + -2; // Lower sublayer
+						tile.z = Priority_TilesetBelow; // Lower sublayer
 
 				}
 			}

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -154,10 +154,10 @@ TilemapLayer::TilemapLayer(int ilayer) :
 
 	// SubLayer for the tiles with Wall or Above passability
 	// Its z-value should be between the z of the events in the upper layer and the hero
-	sublayers.push_back(std::make_shared<TilemapSubLayer>(this, 98+layer));
+	sublayers.push_back(std::make_shared<TilemapSubLayer>(this, PriorityMap + 98 + layer));
 	// SubLayer for the tiles without Wall or Above passability
 	// Its z-value should be under z of the events in the lower layer
-	sublayers.push_back(std::make_shared<TilemapSubLayer>(this, -2+layer));
+	sublayers.push_back(std::make_shared<TilemapSubLayer>(this, PriorityMap + -2 + layer));
 }
 
 /** Draws a black tile at (x,y) (for OOB tiles) */
@@ -368,15 +368,15 @@ void TilemapLayer::CreateTileCache(const std::vector<short>& nmap_data) {
 			// Get the tile ID
 			tile.ID = nmap_data[x + y * width];
 
-			tile.z = 0;
+			tile.z = PriorityMap;
 
 			// Calculate the tile Z
 			if (!passable.empty()) {
 				if (tile.ID >= BLOCK_F) { // Upper layer
 					if ((passable[substitutions[tile.ID - BLOCK_F]] & Passable::Above) != 0)
-						tile.z = 99; // Upper sublayer
+						tile.z = PriorityMap + 99; // Upper sublayer
 					else
-						tile.z = -1; // Lower sublayer
+						tile.z = PriorityMap + -1; // Lower sublayer
 
 				} else { // Lower layer
 					int chip_index =
@@ -385,9 +385,9 @@ void TilemapLayer::CreateTileCache(const std::vector<short>& nmap_data) {
 						tile.ID >= BLOCK_C ? (tile.ID - BLOCK_C) / 50 + 3 :
 						tile.ID / 1000;
 					if ((passable[chip_index] & (Passable::Wall | Passable::Above)) != 0)
-						tile.z = 98; // Upper sublayer
+						tile.z = PriorityMap + 98; // Upper sublayer
 					else
-						tile.z = -2; // Lower sublayer
+						tile.z = PriorityMap + -2; // Lower sublayer
 
 				}
 			}

--- a/src/weather.h
+++ b/src/weather.h
@@ -46,7 +46,7 @@ private:
 	void DrawFog();
 	void DrawSandstorm();
 
-	static const int z = PriorityWeather;
+	static const int z = Priority_Weather;
 	static const DrawableType type = TypeWeather;
 
 	BitmapRef weather_surface;

--- a/src/weather.h
+++ b/src/weather.h
@@ -46,7 +46,7 @@ private:
 	void DrawFog();
 	void DrawSandstorm();
 
-	static const int z = 1001;
+	static const int z = PriorityWeather;
 	static const DrawableType type = TypeWeather;
 
 	BitmapRef weather_surface;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -38,7 +38,7 @@ Window::Window():
 	y(0),
 	width(0),
 	height(0),
-	z(PriorityWindow),
+	z(Priority_Window),
 	ox(0),
 	oy(0),
 	border_x(8),

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -38,7 +38,7 @@ Window::Window():
 	y(0),
 	width(0),
 	height(0),
-	z(0),
+	z(PriorityWindow),
 	ox(0),
 	oy(0),
 	border_x(8),

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -39,7 +39,7 @@ Window_Base::Window_Base(int x, int y, int width, int height) {
 	SetWidth(width);
 	SetHeight(height);
 	SetStretch(Game_System::GetMessageStretch() == RPG::System::Stretch_stretch);
-	SetZ(PriorityWindow + 3000);
+	SetZ(PriorityWindow);
 }
 
 void Window_Base::Update() {

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -39,7 +39,7 @@ Window_Base::Window_Base(int x, int y, int width, int height) {
 	SetWidth(width);
 	SetHeight(height);
 	SetStretch(Game_System::GetMessageStretch() == RPG::System::Stretch_stretch);
-	SetZ(PriorityWindow);
+	SetZ(Priority_Window);
 }
 
 void Window_Base::Update() {

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -39,7 +39,7 @@ Window_Base::Window_Base(int x, int y, int width, int height) {
 	SetWidth(width);
 	SetHeight(height);
 	SetStretch(Game_System::GetMessageStretch() == RPG::System::Stretch_stretch);
-	SetZ(3000);
+	SetZ(PriorityWindow + 3000);
 }
 
 void Window_Base::Update() {

--- a/src/window_battlemessage.cpp
+++ b/src/window_battlemessage.cpp
@@ -32,7 +32,7 @@ Window_BattleMessage::Window_BattleMessage(int ix, int iy, int iwidth, int iheig
 	SetContents(Bitmap::Create(width - 16, height - 16));
 
 	visible = false;
-	SetZ(PriorityWindow + 3001);
+	SetZ(PriorityWindow + 10);
 }
 
 void Window_BattleMessage::Push(const std::string& message) {

--- a/src/window_battlemessage.cpp
+++ b/src/window_battlemessage.cpp
@@ -32,7 +32,7 @@ Window_BattleMessage::Window_BattleMessage(int ix, int iy, int iwidth, int iheig
 	SetContents(Bitmap::Create(width - 16, height - 16));
 
 	visible = false;
-	SetZ(PriorityWindow + 10);
+	SetZ(Priority_Window + 10);
 }
 
 void Window_BattleMessage::Push(const std::string& message) {

--- a/src/window_battlemessage.cpp
+++ b/src/window_battlemessage.cpp
@@ -32,7 +32,8 @@ Window_BattleMessage::Window_BattleMessage(int ix, int iy, int iwidth, int iheig
 	SetContents(Bitmap::Create(width - 16, height - 16));
 
 	visible = false;
-	SetZ(Priority_Window + 10);
+	// Above other windows but below the messagebox
+	SetZ(Priority_Window + 50);
 }
 
 void Window_BattleMessage::Push(const std::string& message) {

--- a/src/window_battlemessage.cpp
+++ b/src/window_battlemessage.cpp
@@ -32,7 +32,7 @@ Window_BattleMessage::Window_BattleMessage(int ix, int iy, int iwidth, int iheig
 	SetContents(Bitmap::Create(width - 16, height - 16));
 
 	visible = false;
-	SetZ(3001);
+	SetZ(PriorityWindow + 3001);
 }
 
 void Window_BattleMessage::Push(const std::string& message) {

--- a/src/window_keyboard.cpp
+++ b/src/window_keyboard.cpp
@@ -122,7 +122,6 @@ Window_Keyboard::Window_Keyboard(int ix, int iy, int iwidth, int iheight)
 	col = 0;
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
-	SetZ(PriorityWindow + 9999);
 
 	row_spacing = 16;
 	col_spacing = (contents->GetWidth() - 2 * border_x) / col_max;

--- a/src/window_keyboard.cpp
+++ b/src/window_keyboard.cpp
@@ -122,7 +122,7 @@ Window_Keyboard::Window_Keyboard(int ix, int iy, int iwidth, int iheight)
 	col = 0;
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
-	SetZ(9999);
+	SetZ(PriorityWindow + 9999);
 
 	row_spacing = 16;
 	col_spacing = (contents->GetWidth() - 2 * border_x) / col_max;

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -58,7 +58,7 @@ Window_Message::Window_Message(int ix, int iy, int iwidth, int iheight) :
 	}
 
 	visible = false;
-	SetZ(PriorityWindow + 10000);
+		SetZ(PriorityWindow + 10);
 
 	escape_char = Utils::DecodeUTF32(Player::escape_symbol).front();
 	active = false;

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -58,7 +58,7 @@ Window_Message::Window_Message(int ix, int iy, int iwidth, int iheight) :
 	}
 
 	visible = false;
-	SetZ(10000);
+	SetZ(PriorityWindow + 10000);
 
 	escape_char = Utils::DecodeUTF32(Player::escape_symbol).front();
 	active = false;

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -58,7 +58,8 @@ Window_Message::Window_Message(int ix, int iy, int iwidth, int iheight) :
 	}
 
 	visible = false;
-		SetZ(Priority_Window + 10);
+	// Above other windows
+	SetZ(Priority_Window + 100);
 
 	escape_char = Utils::DecodeUTF32(Player::escape_symbol).front();
 	active = false;

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -58,7 +58,7 @@ Window_Message::Window_Message(int ix, int iy, int iwidth, int iheight) :
 	}
 
 	visible = false;
-		SetZ(PriorityWindow + 10);
+		SetZ(Priority_Window + 10);
 
 	escape_char = Utils::DecodeUTF32(Player::escape_symbol).front();
 	active = false;

--- a/src/window_numberinput.cpp
+++ b/src/window_numberinput.cpp
@@ -35,7 +35,7 @@ Window_NumberInput::Window_NumberInput(int ix, int iy, int iwidth, int iheight) 
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 	cursor_width = 14;
-	SetZ(PriorityWindow + 10001);
+	SetZ(PriorityWindow + 20);
 	opacity = 0;
 	index = 0;
 	active = false;

--- a/src/window_numberinput.cpp
+++ b/src/window_numberinput.cpp
@@ -35,7 +35,8 @@ Window_NumberInput::Window_NumberInput(int ix, int iy, int iwidth, int iheight) 
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 	cursor_width = 14;
-	SetZ(Priority_Window + 20);
+	// Above the message window
+	SetZ(Priority_Window + 150);
 	opacity = 0;
 	index = 0;
 	active = false;

--- a/src/window_numberinput.cpp
+++ b/src/window_numberinput.cpp
@@ -35,7 +35,7 @@ Window_NumberInput::Window_NumberInput(int ix, int iy, int iwidth, int iheight) 
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 	cursor_width = 14;
-	SetZ(10001);
+	SetZ(PriorityWindow + 10001);
 	opacity = 0;
 	index = 0;
 	active = false;

--- a/src/window_numberinput.cpp
+++ b/src/window_numberinput.cpp
@@ -35,7 +35,7 @@ Window_NumberInput::Window_NumberInput(int ix, int iy, int iwidth, int iheight) 
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 	cursor_width = 14;
-	SetZ(PriorityWindow + 20);
+	SetZ(Priority_Window + 20);
 	opacity = 0;
 	index = 0;
 	active = false;
@@ -91,7 +91,7 @@ int Window_NumberInput::GetMaxDigits() {
 void Window_NumberInput::SetMaxDigits(int idigits_max) {
 	// Only accepts values between 1 and 6 (or 7) as RPG2K (or RPG2k3)
 	int top = Player::IsRPG2k() ? 6 : 7;
-	digits_max = 
+	digits_max =
 		(idigits_max > top) ? top :
 		(idigits_max <= 0) ? 1 :
 		idigits_max;

--- a/src/window_savefile.cpp
+++ b/src/window_savefile.cpp
@@ -30,7 +30,7 @@ Window_SaveFile::Window_SaveFile(int ix, int iy, int iwidth, int iheight) :
 	index(0), hero_hp(0), hero_level(0), corrupted(false), has_save(false) {
 
 	SetContents(Bitmap::Create(width - 8, height - 16));
-	SetZ(9999);
+	SetZ(PriorityWindow + 9999);
 
 	Refresh();
 	UpdateCursorRect();

--- a/src/window_savefile.cpp
+++ b/src/window_savefile.cpp
@@ -30,7 +30,6 @@ Window_SaveFile::Window_SaveFile(int ix, int iy, int iwidth, int iheight) :
 	index(0), hero_hp(0), hero_level(0), corrupted(false), has_save(false) {
 
 	SetContents(Bitmap::Create(width - 8, height - 16));
-	SetZ(PriorityWindow + 9999);
 
 	Refresh();
 	UpdateCursorRect();


### PR DESCRIPTION
I hope I got all Z layer usages and didn't break something :/
The Z layers are now categorized in categories and the category marker are the upper 8 bit minus the sign bit. So 127 categories are possible (like a IPv4 Class A network ;)).

I didn't touch the Map Z layer stuff because I don't want to break the event order rendering... (but is in theory possible to figure out now because is all in PriorityMap)

The order has some limitations. See game_picture.cpp comments.

Fix #1195