### PR TITLE
RPG2k >= 1.50 and RPG2k3 >= 1.05 detection

### DIFF
--- a/resources/easyrpg-player.6.adoc
+++ b/resources/easyrpg-player.6.adoc
@@ -36,9 +36,11 @@ for some additional binary patches.
 
 *--engine* 'ENGINE'::
   Disable auto detection of the simulated engine. Possible options:
-   - 'rpg2k'   - RPG Maker 2000 engine
-   - 'rpg2k3'  - RPG Maker 2003 engine
-   - 'rpg2k3e' - RPG Maker 2003 (English release) engine
+   - 'rpg2k'      - RPG Maker 2000 engine (v1.00 - v1.10)
+   - 'rpg2kv150'  - RPG Maker 2000 engine (v1.50 - v1.51)
+   - 'rpg2k3'     - RPG Maker 2003 engine (v1.00 - v1.04)
+   - 'rpg2k3v105' - RPG Maker 2003 engine (v1.05 - v1.09a)
+   - 'rpg2k3e'    - RPG Maker 2003 (English release) engine
 
 *--fullscreen*::
   Start in fullscreen mode.

--- a/resources/unix/bash-completion/easyrpg-player
+++ b/resources/unix/bash-completion/easyrpg-player
@@ -19,7 +19,7 @@ _easyrpg-player ()
            --start-party --test-play --window -v --version -h --help'
   rpgrtopts='BattleTest battletest HideTitle hidetitle TestPlay testplay \
              Window window'
-  engines='rpg2k rpg2k3 rpg2k3e'
+  engines='rpg2k rpg2kv150 rpg2k3 rpg2k3v105 rpg2k3e'
 
   # first list all special cases
   case $prev in

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -813,3 +813,9 @@ FileFinder::Directory FileFinder::GetDirectoryMembers(const std::string& path, F
 #endif
 	return result;
 }
+
+Offset FileFinder::GetFileSize(std::string const& file) {
+	StatBuf sb;
+	int result = GetStat(file.c_str(), &sb);
+	return (result == 0) ? sb.st_size : -1;
+}

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -819,3 +819,52 @@ Offset FileFinder::GetFileSize(std::string const& file) {
 	int result = GetStat(file.c_str(), &sb);
 	return (result == 0) ? sb.st_size : -1;
 }
+
+bool FileFinder::IsMajorUpdatedTree() {
+	Offset size;
+
+	// Find an MP3 music file only when official Harmony.dll exists
+	// in the gamedir or the file doesn't exist because
+	// the detection doesn't return reliable results for games created with
+	// "RPG2k non-official English translation (older engine) + MP3 patch"
+	bool find_mp3 = true;
+	std::string harmony = FindDefault("Harmony.dll");
+	if (!harmony.empty()) {
+		size = GetFileSize(harmony);
+		if (size != -1 && size != KnownFileSize::OFFICIAL_HARMONY_DLL) {
+			Output::Debug("Non-official Harmony.dll found, skipping MP3 test");
+			find_mp3 = false;
+		}
+	}
+	if (find_mp3) {
+		const std::shared_ptr<DirectoryTree> tree = GetDirectoryTree();
+		string_map::const_iterator const music_it = tree->directories.find("music");
+		if (music_it != tree->directories.end()) {
+			string_map mem = tree->sub_members["music"];
+			for (auto& i : mem) {
+				std::string file = mem[i.first];
+				if (Utils::EndsWith(Utils::LowerCase(file), ".mp3")) {
+					Output::Debug("MP3 file (%s) found", file.c_str());
+					return true;
+				}
+			}
+		}
+	}
+
+	// Compare the size of RPG_RT.exe with threshold
+	std::string rpg_rt = FindDefault("RPG_RT.exe");
+	if (!rpg_rt.empty()) {
+		size = GetFileSize(rpg_rt);
+		if (size != -1) {
+			return size > (Player::IsRPG2k() ? RpgrtMajorUpdateThreshold::RPG2K : RpgrtMajorUpdateThreshold::RPG2K3);
+		}
+	}
+	Output::Debug("Could not get the size of RPG_RT.exe");
+
+	// Assume the most popular version
+	// Japanese or RPG2k3 games: newer engine
+	// non-Japanese RPG2k games: older engine
+	bool assume_newer = Player::IsCP932() || Player::IsRPG2k3();
+	Output::Debug("Assuming %s engine", assume_newer ? "newer" : "older");
+	return assume_newer;
+}

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -30,6 +30,10 @@
 #ifdef _WIN32
 #  include <windows.h>
 #  include <shlobj.h>
+#  include <sys/types.h>
+#  include <sys/stat.h>
+#  define StatBuf struct _stat
+#  define GetStat _stat
 #  ifdef __MINGW32__
 #    include <dirent.h>
 #  elif defined(_MSC_VER)
@@ -46,9 +50,13 @@
 #    define readdir sceIoDread
 #    define stat SceIoStat
 #    define lstat sceIoGetstat
+#    define StatBuf SceIoStat
+#    define GetStat sceIoGetstat
 #  else
 #    include <dirent.h>
 #    include <sys/stat.h>
+#    define StatBuf struct stat
+#    define GetStat stat
 #  endif
 #  include <unistd.h>
 #  include <sys/types.h>

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -268,6 +268,38 @@ namespace FileFinder {
          * @return the filesize, or -1 on error
          */
 	Offset GetFileSize(std::string const& file);
+
+	/**
+         * Known file sizes
+         */
+	enum KnownFileSize {
+		OFFICIAL_HARMONY_DLL = 473600,
+	};
+
+	/**
+	 * Checks whether the game is created with RPG2k >= 1.50 or RPG2k3 >= 1.05.
+	 *
+	 * @return true if RPG2k >= 1.50 or RPG2k3 >= 1.05, otherwise false.
+	 */
+	bool IsMajorUpdatedTree();
+
+	/** RPG_RT.exe file size thresholds
+         *
+         * 2k v1.51 (Japanese)    : 746496
+         * 2k v1.50 (Japanese)    : 745984
+         *  -- threshold (2k) --  : 735000
+         * 2k v1.10 (Japanese)    : 726016
+         *
+         * 2k3 v1.09a (Japanese)  : 950784
+         * 2k3 v1.06 (Japanese)   : 949248
+         * 2k3 v1.05 (Japanese)   : unknown
+         *  -- threshold (2k3) -- : 927000
+         * 2k3 v1.04 (Japanese)   : 913408
+         */
+	enum RpgrtMajorUpdateThreshold {
+		RPG2K = 735000,
+		RPG2K3 = 927000,
+	};
 } // namespace FileFinder
 
 #endif

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -27,6 +27,13 @@
 #include <unordered_map>
 #include <vector>
 
+#ifdef PSP2
+#  include <psp2/types.h>
+#  define Offset SceOff
+#else
+#  define Offset off_t
+#endif
+
 /**
  * FileFinder contains helper methods for finding case
  * insensitive files paths.

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -261,6 +261,13 @@ namespace FileFinder {
 	 * @return If directory tree contains a savegame
 	 */
 	bool HasSavegame();
+
+	/** Get the size of a file
+         *
+         * @param file the path to a file
+         * @return the filesize, or -1 on error
+         */
+	Offset GetFileSize(std::string const& file);
 } // namespace FileFinder
 
 #endif

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -661,7 +661,14 @@ void Player::CreateGameObjects() {
 			engine = EngineRpg2k;
 			Output::Debug("Using RPG2k Interpreter");
 		}
+		if (FileFinder::IsMajorUpdatedTree()) {
+			engine |= EngineMajorUpdated;
+			Output::Debug("RPG2k >= v1.50 / RPG2k3 >= v1.05 detected");
+		} else {
+			Output::Debug("RPG2k < v1.50 / RPG2k3 < v1.05 detected");
+		}
 	}
+	Output::Debug("Engine configured as: 2k=%d 2k3=%d 2k3Legacy=%d MajorUpdated=%d 2k3E=%d", Player::IsRPG2k(), Player::IsRPG2k3(), Player::IsRPG2k3Legacy(), Player::IsMajorUpdatedVersion(), Player::IsRPG2k3E());
 
 	if (!no_rtp_flag) {
 		FileFinder::InitRtpPaths();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -548,11 +548,17 @@ void Player::ParseCommandLine(int argc, char *argv[]) {
 			if (*it == "rpg2k" || *it == "2000") {
 				engine = EngineRpg2k;
 			}
+			else if (*it == "rpg2kv150" || *it == "2000v150") {
+				engine = EngineRpg2k | EngineMajorUpdated;
+			}
 			else if (*it == "rpg2k3" || *it == "2003") {
 				engine = EngineRpg2k3;
 			}
+			else if (*it == "rpg2k3v105" || *it == "2003v105") {
+				engine = EngineRpg2k3 | EngineMajorUpdated;
+			}
 			else if (*it == "rpg2k3e") {
-				engine = EngineRpg2k3 | EngineRpg2k3E;
+				engine = EngineRpg2k3 | EngineMajorUpdated | EngineRpg2k3E;
 			}
 		}
 		else if (*it == "--encoding") {
@@ -886,9 +892,11 @@ Options:
                            Use "auto" for automatic detection.
       --engine ENGINE      Disable auto detection of the simulated engine.
                            Possible options:
-                            rpg2k   - RPG Maker 2000 engine
-                            rpg2k3  - RPG Maker 2003 engine
-                            rpg2k3e - RPG Maker 2003 (English release) engine
+                            rpg2k      - RPG Maker 2000 engine (v1.00 - v1.10)
+                            rpg2kv150  - RPG Maker 2000 engine (v1.50 - v1.51)
+                            rpg2k3     - RPG Maker 2003 engine (v1.00 - v1.04)
+                            rpg2k3v105 - RPG Maker 2003 engine (v1.05 - v1.09a)
+                            rpg2k3e    - RPG Maker 2003 (English release) engine
       --fullscreen         Start in fullscreen mode.
       --show-fps           Enable frames per second counter.
       --hide-title         Hide the title background image and center the
@@ -932,16 +940,20 @@ Alex, EV0001 and the EasyRPG authors wish you a lot of fun!)" << std::endl;
 }
 
 bool Player::IsRPG2k() {
-	return engine == EngineRpg2k;
+	return (engine & EngineRpg2k) == EngineRpg2k;
 }
 
 
 bool Player::IsRPG2k3Legacy() {
-	return engine == EngineRpg2k3;
+	return (engine == EngineRpg2k3 || engine == (EngineRpg2k3 | EngineMajorUpdated));
 }
 
 bool Player::IsRPG2k3() {
 	return (engine & EngineRpg2k3) == EngineRpg2k3;
+}
+
+bool Player::IsMajorUpdatedVersion() {
+	return (engine & EngineMajorUpdated) == EngineMajorUpdated;
 }
 
 bool Player::IsRPG2k3E() {

--- a/src/player.h
+++ b/src/player.h
@@ -33,8 +33,10 @@ namespace Player {
 		EngineRpg2k = 1,
 		/** All versions of RPG Maker 2003 */
 		EngineRpg2k3 = 2,
+		/** RPG Maker 2000 v1.50 or newer, 2003 v1.05 or newer */
+		EngineMajorUpdated = 4,
 		/** RPG Maker 2003 v1.10 or newer (Official English translation) */
-		EngineRpg2k3E = 4
+		EngineRpg2k3E = 8
 	};
 
 	/**
@@ -134,14 +136,19 @@ namespace Player {
 	bool IsRPG2k();
 
 	/**
-	 * @return If engine is RPG2k3 v1.09 or older
+	 * @return If engine is RPG2k3 v1.09a or older
 	 */
 	bool IsRPG2k3Legacy();
 
 	/**
-	 * @return If engine is RPG2k3 or newer
+	 * @return If engine is RPG2k3
 	 */
 	bool IsRPG2k3();
+
+	/**
+	 * @return If engine is RPG2k v1.50 or newer, or RPG2k3 v1.05 or newer
+	 */
+	bool IsMajorUpdatedVersion();
 
 	/**
 	 * @return If engine is the official English release (v1.10) or newer.


### PR DESCRIPTION
This adds RPG2k >= 1.50 and RPG2k3 >= 1.05 detection (Related: #1031).

Usage:
```cxx
if (Player::IsMajorUpdatedVersion()) {
	// RPG2k >= 1.50 / RPG2k3 >= 1.05
} else {
	// RPG2k < 1.50 / RPG2k3 < 1.05
}
```

Engine overrides:

option|version
---|---
--engine rpg2kv150|RPG2k v1.50 - 1.51
--engine rpg2k3v105|RPG2k3 v1.05 - v1.09a