### PR TITLE
Add large CharSet support

### DIFF
--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -25,8 +25,8 @@ Sprite_Character::Sprite_Character(Game_Character* character) :
 	character(character),
 	tile_id(0),
 	character_index(0),
-	chara_width(24*(TILE_SIZE/16)),
-	chara_height(32*(TILE_SIZE/16)) {
+	chara_width(0),
+	chara_height(0) {
 	Update();
 }
 
@@ -113,7 +113,17 @@ void Sprite_Character::OnTileSpriteReady(FileRequestResult*) {
 
 void Sprite_Character::OnCharSpriteReady(FileRequestResult*) {
 	SetBitmap(Cache::Charset(character_name));
-
+	// Allow large 4x2 spriteset of 3x4 sprites
+	// when the character name starts with a $ sign.
+	// This is not exactly the VX Ace way because
+	// VX Ace uses a single 1x1 spriteset of 3x4 sprites.
+	if (character_name.size() && character_name.at(0) == '$') {
+		chara_width = GetBitmap()->GetWidth() / 4 / 3 * (TILE_SIZE / 16);
+		chara_height = GetBitmap()->GetHeight() / 2 / 4 * (TILE_SIZE / 16);
+	} else {
+		chara_width = 24 * (TILE_SIZE / 16);
+		chara_height = 32 * (TILE_SIZE / 16);
+	}
 	SetOx(chara_width / 2);
 	SetOy(chara_height);
 	int sx = (character_index % 4) * chara_width * 3;


### PR DESCRIPTION
This recovers large CharSet support removed since #137 fix,
allowing CharSet files starting with a dollar sign to be
calculated by 4x2 SpriteSets. This differs from VX Ace behavior.
The purpose of using large 4x2 spritesets instead individual
spritesets like VX Ace does is to keep reduced file access
on games wanting to use multiple large characters.
Also keeps code lesser complicated for this custom feature.

Test case to use with the PR:
[largecharset.zip](https://github.com/EasyRPG/Player/files/559675/largecharset.zip)
