### PR TITLE
Battle 2k3: Implement "Enable Combo", skill reflection, (de)buff and minor things

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -685,6 +685,20 @@ bool Game_Actor::HasStrongDefense() const {
 	return GetData().super_guard;
 }
 
+bool Game_Actor::HasPreemptiveAttack() const {
+	const RPG::Item* item = GetEquipment(RPG::Item::Type_weapon);
+	if (item && item->preemptive) {
+		return true;
+	}
+	if (HasTwoWeapons()) {
+		item = GetEquipment(RPG::Item::Type_weapon + 1);
+		if (item && item->preemptive) {
+			return true;
+		}
+	}
+	return false;
+}
+
 const std::vector<int16_t>& Game_Actor::GetSkills() const {
 	return GetData().skills;
 }
@@ -1057,23 +1071,6 @@ float Game_Actor::GetCriticalHitChance() const {
 	return Data::actors[actor_id - 1].critical_hit ? (1.0f / Data::actors[actor_id - 1].critical_hit_chance) : 0.0f;
 }
 
-void Game_Actor::ResetBattle() {
-	Game_Battler::ResetBattle();
-
-	const RPG::Item* item = GetEquipment(RPG::Item::Type_weapon);
-	if (item && item->preemptive) {
-		gauge = GetMaxGauge();
-		return;
-	}
-
-	if (HasTwoWeapons()) {
-		item = GetEquipment(RPG::Item::Type_weapon + 1);
-		if (item && item->preemptive) {
-			gauge = GetMaxGauge();
-		}
-	}
-}
-
 Game_Battler::BattlerType Game_Actor::GetType() const {
 	return Game_Battler::Type_Ally;
 }
@@ -1100,4 +1097,3 @@ void Game_Actor::RemoveInvalidEquipment() {
 		}
 	}
 }
-

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -479,7 +479,7 @@ int Game_Actor::GetNextExp(int level) const {
 }
 
 int Game_Actor::GetStateProbability(int state_id) const {
-	int rate = 3; // C - default
+	int rate = 2; // C - default
 
 	if (state_id <= (int)Data::actors[actor_id - 1].state_ranks.size()) {
 		rate = Data::actors[actor_id - 1].state_ranks[state_id - 1];
@@ -489,7 +489,7 @@ int Game_Actor::GetStateProbability(int state_id) const {
 }
 
 int Game_Actor::GetAttributeModifier(int attribute_id) const {
-	int rate = 3; // C - default
+	int rate = 2; // C - default
 
 	if (attribute_id <= (int)Data::actors[actor_id - 1].attribute_ranks.size()) {
 		rate = Data::actors[actor_id - 1].attribute_ranks[attribute_id - 1];

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -495,6 +495,13 @@ int Game_Actor::GetAttributeModifier(int attribute_id) const {
 		rate = Data::actors[actor_id - 1].attribute_ranks[attribute_id - 1];
 	}
 
+	rate += attribute_shift[attribute_id - 1];
+	if (rate < 0) {
+		rate = 0;
+	} else if (rate > 4) {
+		rate = 4;
+	}
+
 	return GetAttributeRate(attribute_id, rate);
 }
 

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -364,6 +364,13 @@ public:
 	 * @return true if strong defense
 	 */
 	bool HasStrongDefense() const override;
+
+	/**
+	 * Tests if the battler has a weapon that grants preemption.
+	 *
+	 * @return true if a weapon is having preempt attribute
+	 */
+	bool HasPreemptiveAttack() const override;
 	
 	/**
 	 * Sets face graphic of actor.
@@ -706,11 +713,6 @@ public:
 
 	int GetHitChance() const override;
 	float GetCriticalHitChance() const override;
-
-	/**
-	 * Initializes battle related data to there default values.
-	 */
-	virtual void ResetBattle() override;
 
 	BattlerType GetType() const override;
 private:

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -75,6 +75,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Reset() {
 	killed_by_attack_damage = false;
 	critical_hit = false;
 	absorb = false;
+	reflect = -1;
 	animation = nullptr;
 	conditions.clear();
 
@@ -1038,7 +1039,14 @@ int Game_BattleAlgorithm::Skill::GetPhysicalDamageRate() const {
 }
 
 bool Game_BattleAlgorithm::Skill::IsReflected() const {
+	// Reflect must be stored because after "Apply" the return value for
+	// reflect can be incorrect when states are added.
+	if (reflect != -1) {
+		return !!reflect;
+	}
+
 	if (current_target == targets.end()) {
+		reflect = 0;
 		return false;
 	}
 
@@ -1047,6 +1055,7 @@ bool Game_BattleAlgorithm::Skill::IsReflected() const {
 
 	// Only negative skills are reflected
 	if (GetSource()->GetType() == (*current_target)->GetType()) {
+		reflect = 0;
 		return false;
 	}
 
@@ -1061,6 +1070,7 @@ bool Game_BattleAlgorithm::Skill::IsReflected() const {
 	current_target = old_current_target;
 	first_attack = old_first_attack;
 
+	reflect = has_reflect ? 1 : 0;
 	return has_reflect;
 }
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -947,7 +947,7 @@ void Game_BattleAlgorithm::Skill::Apply() {
 	}
 	else {
 		if (first_attack) {
-			source->ChangeSp(- source->CalculateSkillCost(skill.ID));
+			source->ChangeSp(-source->CalculateSkillCost(skill.ID));
 		}
 	}
 }

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -124,23 +124,25 @@ const RPG::Animation* Game_BattleAlgorithm::AlgorithmBase::GetAnimation() const 
 	return animation;
 }
 
-void Game_BattleAlgorithm::AlgorithmBase::PlayAnimation() {
-	if (!GetTarget() || !GetAnimation()) {
+void Game_BattleAlgorithm::AlgorithmBase::PlayAnimation(bool on_source) {
+	if (current_target == targets.end() || !GetAnimation()) {
+		return;
+	}
+
+	if (on_source) {
+		std::vector<Game_Battler*> anim_targets = { GetSource() };
+		Game_Battle::ShowBattleAnimation(GetAnimation()->ID, anim_targets);
 		return;
 	}
 
 	auto old_current_target = current_target;
 	bool old_first_attack = first_attack;
 
-	if (current_target == targets.end()) {
-		return;
-	}
-
 	std::vector<Game_Battler*> anim_targets;
 
 	do {
 		anim_targets.push_back(*current_target);
-	} while (TargetNext());
+	} while (TargetNextInternal());
 
 	Game_Battle::ShowBattleAnimation(
 		GetAnimation()->ID,
@@ -175,10 +177,10 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetDeathMessage() const {
 		return "";
 	}
 
-	if ((*current_target)->GetType() == Game_Battler::Type_Ally) {
-		return (*current_target)->GetName() + (*current_target)->GetSignificantState()->message_actor;
+	if (GetTarget()->GetType() == Game_Battler::Type_Ally) {
+		return GetTarget()->GetName() + GetTarget()->GetSignificantState()->message_actor;
 	} else {
-		return (*current_target)->GetName() + (*current_target)->GetSignificantState()->message_enemy;
+		return GetTarget()->GetName() + GetTarget()->GetSignificantState()->message_enemy;
 	}
 }
 
@@ -188,18 +190,18 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 	}
 
 	if (!success) {
-		out.push_back((*current_target)->GetName() + Data::terms.dodge);
+		out.push_back(GetTarget()->GetName() + Data::terms.dodge);
 	}
 
-	bool target_is_ally = (*current_target)->GetType() == Game_Battler::Type_Ally;
+	bool target_is_ally = GetTarget()->GetType() == Game_Battler::Type_Ally;
 
 	if (GetAffectedHp() != -1) {
 		std::string particle, particle2, space = "";
 		std::stringstream ss;
-		ss << (*current_target)->GetName();
+		ss << GetTarget()->GetName();
 
 		if (IsPositive()) {
-			if (!(*current_target)->IsDead()) {
+			if (!GetTarget()->IsDead()) {
 				if (Player::IsCP932()) {
 					particle = "の";
 					particle2 = "が ";
@@ -259,7 +261,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 	if (GetAffectedSp() != -1) {
 		std::string particle, particle2, space = "";
 		std::stringstream ss;
-		ss << (*current_target)->GetName();
+		ss << GetTarget()->GetName();
 
 		if (IsPositive()) {
 			if (Player::IsCP932()) {
@@ -307,7 +309,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 	if (GetAffectedAttack() != -1) {
 		std::string particle, particle2, space = "";
 		std::stringstream ss;
-		ss << (*current_target)->GetName();
+		ss << GetTarget()->GetName();
 		if (Player::IsCP932()) {
 			particle = "の";
 			particle2 = "が ";
@@ -324,7 +326,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 	if (GetAffectedDefense() != -1) {
 		std::string particle, particle2, space = "";
 		std::stringstream ss;
-		ss << (*current_target)->GetName();
+		ss << GetTarget()->GetName();
 		if (Player::IsCP932()) {
 			particle = "の";
 			particle2 = "が ";
@@ -341,7 +343,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 	if (GetAffectedSpirit() != -1) {
 		std::string particle, particle2, space = "";
 		std::stringstream ss;
-		ss << (*current_target)->GetName();
+		ss << GetTarget()->GetName();
 		if (Player::IsCP932()) {
 			particle = "の";
 			particle2 = "が ";
@@ -358,7 +360,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 	if (GetAffectedAgility() != -1) {
 		std::string particle, particle2, space = "";
 		std::stringstream ss;
-		ss << (*current_target)->GetName();
+		ss << GetTarget()->GetName();
 		if (Player::IsCP932()) {
 			particle = "の";
 			particle2 = "が ";
@@ -376,9 +378,9 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 
 	for (; it != conditions.end(); ++it) {
 		std::stringstream ss;
-		ss << (*current_target)->GetName();
+		ss << GetTarget()->GetName();
 
-		if ((*current_target)->HasState(it->ID)) {
+		if (GetTarget()->HasState(it->ID)) {
 			if (IsPositive()) {
 				ss << it->message_recovery;
 				out.push_back(ss.str());
@@ -393,7 +395,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 				continue;
 			}
 
-			if ((*current_target)->GetType() == Game_Battler::Type_Ally) {
+			if (GetTarget()->GetType() == Game_Battler::Type_Ally) {
 				ss << it->message_actor;
 			} else {
 				ss << it->message_enemy;
@@ -413,6 +415,10 @@ Game_Battler* Game_BattleAlgorithm::AlgorithmBase::GetSource() const {
 }
 
 Game_Battler* Game_BattleAlgorithm::AlgorithmBase::GetTarget() const {
+	if (IsReflected()) {
+		return source;
+	}
+
 	if (current_target == targets.end()) {
 		return NULL;
 	}
@@ -425,7 +431,7 @@ float Game_BattleAlgorithm::AlgorithmBase::GetAttributeMultiplier(const std::vec
 	int attributes_applied = 0;
 	for (unsigned int i = 0; i < attributes_set.size(); i++) {
 		if (attributes_set[i]) {
-			multiplier += (*current_target)->GetAttributeModifier(i + 1);
+			multiplier += GetTarget()->GetAttributeModifier(i + 1);
 			attributes_applied++;
 		}
 	}
@@ -454,8 +460,8 @@ void Game_BattleAlgorithm::AlgorithmBase::SetTarget(Game_Battler* target) {
 void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedHp() != -1) {
 		int hp = GetAffectedHp();
-		int target_hp = (*current_target)->GetHp();
-		(*current_target)->ChangeHp(IsPositive() ? hp : -hp);
+		int target_hp = GetTarget()->GetHp();
+		GetTarget()->ChangeHp(IsPositive() ? hp : -hp);
 		if (absorb) {
 			// Only absorb the hp that were left
 			int src_hp = std::min(target_hp, IsPositive() ? -hp : hp);
@@ -465,8 +471,8 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 
 	if (GetAffectedSp() != -1) {
 		int sp = GetAffectedSp();
-		int target_sp = (*current_target)->GetSp();
-		(*current_target)->SetSp((*current_target)->GetSp() + (IsPositive() ? sp : -sp));
+		int target_sp = GetTarget()->GetSp();
+		GetTarget()->SetSp(GetTarget()->GetSp() + (IsPositive() ? sp : -sp));
 		if (absorb) {
 			int src_sp = std::min(target_sp, IsPositive() ? -sp : sp);
 			source->ChangeSp(src_sp);
@@ -475,7 +481,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 
 	if (GetAffectedAttack() != -1) {
 		int atk = GetAffectedAttack();
-		(*current_target)->SetAtkModifier(IsPositive() ? atk : -atk);
+		GetTarget()->SetAtkModifier(IsPositive() ? atk : -atk);
 		if (absorb) {
 			source->SetAtkModifier(IsPositive() ? -atk : atk);
 		}
@@ -483,7 +489,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 
 	if (GetAffectedDefense() != -1) {
 		int def = GetAffectedDefense();
-		(*current_target)->SetDefModifier(IsPositive() ? def : -def);
+		GetTarget()->SetDefModifier(IsPositive() ? def : -def);
 		if (absorb) {
 			source->SetDefModifier(IsPositive() ? -def : def);
 		}
@@ -491,7 +497,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 
 	if (GetAffectedSpirit() != -1) {
 		int spi = GetAffectedSpirit();
-		(*current_target)->SetSpiModifier(IsPositive() ? spi : -spi);
+		GetTarget()->SetSpiModifier(IsPositive() ? spi : -spi);
 		if (absorb) {
 			source->SetSpiModifier(IsPositive() ? -spi : spi);
 		}
@@ -499,7 +505,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 
 	if (GetAffectedAgility() != -1) {
 		int agi = GetAffectedAgility();
-		(*current_target)->SetAgiModifier(IsPositive() ? agi : -agi);
+		GetTarget()->SetAgiModifier(IsPositive() ? agi : -agi);
 		if (absorb) {
 			source->SetAgiModifier(IsPositive() ? -agi : agi);
 		}
@@ -513,18 +519,18 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 
 	for (; it != conditions.end(); ++it) {
 		if (IsPositive()) {
-			if ((*current_target)->IsDead() && it->ID == 1) {
+			if (GetTarget()->IsDead() && it->ID == 1) {
 				// Was a revive skill with an effect rating of 0
-				(*current_target)->ChangeHp(1);
+				GetTarget()->ChangeHp(1);
 			}
 
-			(*current_target)->RemoveState(it->ID);
+			GetTarget()->RemoveState(it->ID);
 		}
 		else {
 			if (it->ID == 1) {
-				(*current_target)->ChangeHp(-((*current_target)->GetHp()));
+				GetTarget()->ChangeHp(-(GetTarget()->GetHp()));
 			} else {
-				(*current_target)->AddState(it->ID);
+				GetTarget()->AddState(it->ID);
 			}
 		}
 	}
@@ -540,7 +546,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	}
 }
 
-bool Game_BattleAlgorithm::AlgorithmBase::IsTargetValid() {
+bool Game_BattleAlgorithm::AlgorithmBase::IsTargetValid() const {
 	if (no_target) {
 		// Selected algorithm does not need a target because it targets
 		// the source
@@ -552,7 +558,7 @@ bool Game_BattleAlgorithm::AlgorithmBase::IsTargetValid() {
 		return false;
 	}
 
-	return (!(*current_target)->IsDead());
+	return (!GetTarget()->IsDead());
 }
 
 int Game_BattleAlgorithm::AlgorithmBase::GetSourceAnimationState() const {
@@ -570,6 +576,15 @@ void Game_BattleAlgorithm::AlgorithmBase::TargetFirst() {
 }
 
 bool Game_BattleAlgorithm::AlgorithmBase::TargetNext() {
+	if (IsReflected()) {
+		// Only source available, can't target again
+		return false;
+	}
+
+	return TargetNextInternal();
+}
+
+bool Game_BattleAlgorithm::AlgorithmBase::TargetNextInternal() const {
 	do {
 		if (current_target == targets.end() ||
 			current_target + 1 == targets.end()) {
@@ -606,7 +621,7 @@ const RPG::Sound* Game_BattleAlgorithm::AlgorithmBase::GetResultSe() const {
 	}
 	else {
 		if (current_target != targets.end()) {
-			return ((*current_target)->GetType() == Game_Battler::Type_Ally ?
+			return (GetTarget()->GetType() == Game_Battler::Type_Ally ?
 				&Game_System::GetSystemSE(Game_System::SFX_AllyDamage) :
 				&Game_System::GetSystemSE(Game_System::SFX_EnemyDamage));
 		}
@@ -616,12 +631,16 @@ const RPG::Sound* Game_BattleAlgorithm::AlgorithmBase::GetResultSe() const {
 }
 
 const RPG::Sound* Game_BattleAlgorithm::AlgorithmBase::GetDeathSe() const {
-	return ((*current_target)->GetType() == Game_Battler::Type_Ally ?
+	return (GetTarget()->GetType() == Game_Battler::Type_Ally ?
 		NULL : &Game_System::GetSystemSE(Game_System::SFX_EnemyKill));
 }
 
 int Game_BattleAlgorithm::AlgorithmBase::GetPhysicalDamageRate() const {
 	return 0;
+}
+
+bool Game_BattleAlgorithm::AlgorithmBase::IsReflected() const {
+	return false;
 }
 
 Game_BattleAlgorithm::Normal::Normal(Game_Battler* source, Game_Battler* target) :
@@ -658,14 +677,14 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 		}
 
 		if (weaponID != -1 && !Data::items[weaponID].ignore_evasion) {
-			to_hit = (int)(100 - (100 - hit_chance) * (1 + (1.0 * (*current_target)->GetAgi() / ally->GetAgi() - 1) / 2));
+			to_hit = (int)(100 - (100 - hit_chance) * (1 + (1.0 * GetTarget()->GetAgi() / ally->GetAgi() - 1) / 2));
 		} else {
 			to_hit = (int)(100 - (100 - hit_chance));
 		}
 	} else {
 		// Source is Enemy
 		int hit = source->GetHitChance();
-		to_hit = (int)(100 - (100 - hit) * (1 + (1.0 * (*current_target)->GetAgi() / source->GetAgi() - 1) / 2));
+		to_hit = (int)(100 - (100 - hit) * (1 + (1.0 * GetTarget()->GetAgi() / source->GetAgi() - 1) / 2));
 		if (!Data::animations.empty()) {
 			animation = &Data::animations[0];
 		}
@@ -677,7 +696,7 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 			critical_hit = true;
 		}
 
-		int effect = (source->GetAtk() / 2 - (*current_target)->GetDef() / 4);
+		int effect = (source->GetAtk() / 2 - GetTarget()->GetDef() / 4);
 
 		if (effect < 0)
 			effect = 0;
@@ -692,9 +711,9 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 			effect = 0;
 		}
 		this->hp = (effect * (critical_hit ? 3 : 1) * (source->IsCharged() ? 2 : 1)) /
-			((*current_target)->IsDefending() ? (*current_target)->HasStrongDefense() ? 3 : 2 : 1);
+			(GetTarget()->IsDefending() ? GetTarget()->HasStrongDefense() ? 3 : 2 : 1);
 
-		if ((*current_target)->GetHp() - this->hp <= 0) {
+		if (GetTarget()->GetHp() - this->hp <= 0) {
 			// Death state
 			killed_by_attack_damage = true;
 		}
@@ -704,7 +723,7 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 				if (weaponID != -1) {
 					RPG::Item item = Data::items[static_cast<Game_Actor*>(source)->GetWeaponId() - 1];
 					for (unsigned int i = 0; i < item.state_set.size(); i++) {
-						if (item.state_set[i] && Utils::GetRandomNumber(0, 99) < (item.state_chance * (*current_target)->GetStateProbability(Data::states[i].ID) / 100)) {
+						if (item.state_set[i] && Utils::GetRandomNumber(0, 99) < (item.state_chance * GetTarget()->GetStateProbability(Data::states[i].ID) / 100)) {
 							if (item.state_effect) {
 								healing = true;
 							}
@@ -779,7 +798,7 @@ Game_BattleAlgorithm::Skill::Skill(Game_Battler* source, const RPG::Skill& skill
 	// no-op
 }
 
-bool Game_BattleAlgorithm::Skill::IsTargetValid() {
+bool Game_BattleAlgorithm::Skill::IsTargetValid() const {
 	if (no_target) {
 		return true;
 	}
@@ -790,7 +809,7 @@ bool Game_BattleAlgorithm::Skill::IsTargetValid() {
 	
 	if (skill.scope == RPG::Skill::Scope_ally ||
 		skill.scope == RPG::Skill::Scope_party) {
-		if ((*current_target)->IsDead()) {
+		if (GetTarget()->IsDead()) {
 			// Cures death
 			return !skill.state_effects.empty() && skill.state_effects[0];
 		}
@@ -798,7 +817,7 @@ bool Game_BattleAlgorithm::Skill::IsTargetValid() {
 		return true;
 	}
 
-	return (!(*current_target)->IsDead());
+	return (!GetTarget()->IsDead());
 }
 
 bool Game_BattleAlgorithm::Skill::Execute() {
@@ -850,8 +869,8 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				source->GetAtk() * skill.physical_rate / 20 +
 				source->GetSpi() * skill.magical_rate / 40;
 			if (!skill.ignore_defense) {
-				effect -= (*current_target)->GetDef() * skill.physical_rate / 40;
-				effect -= (*current_target)->GetSpi() * skill.magical_rate / 80;
+				effect -= GetTarget()->GetDef() * skill.physical_rate / 40;
+				effect -= GetTarget()->GetSpi() * skill.magical_rate / 80;
 			}
 			effect *= GetAttributeMultiplier(skill.attribute_effects);
 
@@ -866,16 +885,16 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 
 			if (skill.affect_hp) {
 				this->hp = effect /
-					((*current_target)->IsDefending() ? (*current_target)->HasStrongDefense() ? 3 : 2 : 1);
+					(GetTarget()->IsDefending() ? GetTarget()->HasStrongDefense() ? 3 : 2 : 1);
 
-				if ((*current_target)->GetHp() - this->hp <= 0) {
+				if (GetTarget()->GetHp() - this->hp <= 0) {
 					// Death state
 					killed_by_attack_damage = true;
 				}
 			}
 
 			if (skill.affect_sp) {
-				this->sp = std::min<int>(effect, (*current_target)->GetSp());
+				this->sp = std::min<int>(effect, GetTarget()->GetSp());
 			}
 				
 			if (skill.affect_attack)
@@ -896,7 +915,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 
 			this->success = true;
 			
-			if (healing || Utils::GetRandomNumber(0, 99) <= (*current_target)->GetStateProbability(Data::states[i].ID)) {
+			if (healing || Utils::GetRandomNumber(0, 99) <= GetTarget()->GetStateProbability(Data::states[i].ID)) {
 				conditions.push_back(Data::states[i]);
 			}
 		}
@@ -911,7 +930,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 
 	absorb = skill.absorb_damage;
 	if (absorb && sp != -1) {
-		if ((*current_target)->GetSp() == 0) {
+		if (GetTarget()->GetSp() == 0) {
 			this->success = false;
 		}
 	}
@@ -977,7 +996,7 @@ const RPG::Sound* Game_BattleAlgorithm::Skill::GetStartSe() const {
 void Game_BattleAlgorithm::Skill::GetResultMessages(std::vector<std::string>& out) const {
 	if (!success) {
 		std::stringstream ss;
-		ss << (*current_target)->GetName();
+		ss << GetTarget()->GetName();
 
 		switch (skill.failure_message) {
 			case 0:
@@ -1006,6 +1025,33 @@ int Game_BattleAlgorithm::Skill::GetPhysicalDamageRate() const {
 	return skill.physical_rate * 10;
 }
 
+bool Game_BattleAlgorithm::Skill::IsReflected() const {
+	if (current_target == targets.end()) {
+		return false;
+	}
+
+	auto old_current_target = current_target;
+	bool old_first_attack = first_attack;
+
+	// Only negative skills are reflected
+	if (GetSource()->GetType() == (*current_target)->GetType()) {
+		return false;
+	}
+
+	std::vector<Game_Battler*> anim_targets;
+
+	bool has_reflect = false;
+
+	do {
+		has_reflect |= (*current_target)->HasReflectState();
+	} while (TargetNextInternal());
+
+	current_target = old_current_target;
+	first_attack = old_first_attack;
+
+	return has_reflect;
+}
+
 Game_BattleAlgorithm::Item::Item(Game_Battler* source, Game_Battler* target, const RPG::Item& item) :
 	AlgorithmBase(source, target), item(item) {
 		// no-op
@@ -1021,7 +1067,7 @@ AlgorithmBase(source), item(item) {
 	// no-op
 }
 
-bool Game_BattleAlgorithm::Item::IsTargetValid() {
+bool Game_BattleAlgorithm::Item::IsTargetValid() const {
 	if (no_target) {
 		return true;
 	}
@@ -1030,7 +1076,7 @@ bool Game_BattleAlgorithm::Item::IsTargetValid() {
 		return false;
 	}
 
-	if ((*current_target)->IsDead()) {
+	if (GetTarget()->IsDead()) {
 		// Medicine curing death
 		return item.type == RPG::Item::Type_medicine &&
 			!item.state_set.empty() &&
@@ -1059,12 +1105,12 @@ bool Game_BattleAlgorithm::Item::Execute() {
 
 		// HP recovery
 		if (item.recover_hp != 0 || item.recover_hp_rate != 0) {
-			this->hp = item.recover_hp_rate * (*current_target)->GetMaxHp() / 100 + item.recover_hp;
+			this->hp = item.recover_hp_rate * GetTarget()->GetMaxHp() / 100 + item.recover_hp;
 		}
 
 		// SP recovery
 		if (item.recover_sp != 0 || item.recover_sp_rate != 0) {
-			this->sp = item.recover_sp_rate * (*current_target)->GetMaxSp() / 100 + item.recover_sp;
+			this->sp = item.recover_sp_rate * GetTarget()->GetMaxSp() / 100 + item.recover_sp;
 		}
 
 		for (int i = 0; i < (int)item.state_set.size(); i++) {
@@ -1249,7 +1295,7 @@ bool Game_BattleAlgorithm::SelfDestruct::Execute() {
 
 	// Like a normal attack, but with double damage and always hitting
 	// Never crits, ignores charge
-	int effect = source->GetAtk() - (*current_target)->GetDef() / 2;
+	int effect = source->GetAtk() - GetTarget()->GetDef() / 2;
 
 	if (effect < 0)
 		effect = 0;
@@ -1263,9 +1309,9 @@ bool Game_BattleAlgorithm::SelfDestruct::Execute() {
 		effect = 0;
 	
 	this->hp = effect / (
-		(*current_target)->IsDefending() ? (*current_target)->HasStrongDefense() ? 3 : 2 : 1);
+		GetTarget()->IsDefending() ? GetTarget()->HasStrongDefense() ? 3 : 2 : 1);
 
-	if ((*current_target)->GetHp() - this->hp <= 0) {
+	if (GetTarget()->GetHp() - this->hp <= 0) {
 		// Death state
 		killed_by_attack_damage = true;
 	}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -950,6 +950,18 @@ void Game_BattleAlgorithm::Skill::Apply() {
 			source->ChangeSp(-source->CalculateSkillCost(skill.ID));
 		}
 	}
+
+	if (success && skill.affect_attr_defence) {
+		// Todo: When the only effect of the skill is a (de)buff and the buff
+		// did not alter anything (because was already buffed) then the attack
+		// failed (display a miss)
+
+		for (int i = 0; i < (int)skill.attribute_effects.size(); ++i) {
+			if (skill.attribute_effects[i]) {
+				GetTarget()->ShiftAttributeRate(i + 1, healing ? 1 : -1);
+			}
+		}
+	}
 }
 
 std::string Game_BattleAlgorithm::Skill::GetStartMessage() const {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -560,12 +560,13 @@ int Game_BattleAlgorithm::AlgorithmBase::GetSourceAnimationState() const {
 }
 
 void Game_BattleAlgorithm::AlgorithmBase::TargetFirst() {
-	if (current_target == targets.begin() &&
-		current_target != targets.end() &&
-		!IsTargetValid()) {
+	current_target = targets.begin();
+
+	if (!IsTargetValid()) {
 		TargetNext();
-		first_attack = true;
 	}
+
+	first_attack = true;
 }
 
 bool Game_BattleAlgorithm::AlgorithmBase::TargetNext() {

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -338,6 +338,7 @@ protected:
 	bool killed_by_attack_damage;
 	bool critical_hit;
 	bool absorb;
+	mutable int reflect;
 
 	RPG::Animation* animation;
 

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -399,12 +399,8 @@ int Game_Battler::ApplyConditions()
 		this->ChangeSp(src_sp);
 		damageTaken += src_hp;
 	}
-	if(damageTaken < 0) {
-		return -damageTaken;
-	}
-	else {
-		return damageTaken;
-	}
+
+	return damageTaken;
 }
 
 

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -654,7 +654,7 @@ std::vector<int16_t> Game_Battler::BattlePhysicalStateHeal(int physical_rate) {
 	return healed_states;
 }
 
-bool Game_Battler::HasReflectState() {
+bool Game_Battler::HasReflectState() const {
 	for (int16_t i : GetInflictedStates()) {
 		if (Data::states[i - 1].reflect_magic) {
 			return true;

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -477,11 +477,10 @@ bool Game_Battler::HasFullSp() const {
 	return GetMaxSp() == GetSp();
 }
 
-static int AffectParameter(int const type, int const val) {
+static int AffectParameter(const int type, const int val) {
 	return
 		type == 0? val / 2 :
 		type == 1? val * 2 :
-		type == 2? val :
 		val;
 }
 
@@ -489,10 +488,9 @@ int Game_Battler::GetAtk() const {
 	int base_atk = GetBaseAtk();
 	int n = min(max(base_atk, 1), 999);
 
-	const std::vector<int16_t> states = GetInflictedStates();
-	for (std::vector<int16_t>::const_iterator i = states.begin(); i != states.end(); ++i) {
-		if(Data::states[(*i) - 1].affect_attack) {
-			n = AffectParameter(Data::states[(*i) - 1].affect_type, base_atk);
+	for (int16_t i : GetInflictedStates()) {
+		if(Data::states[i - 1].affect_attack) {
+			n = AffectParameter(Data::states[i - 1].affect_type, base_atk);
 			break;
 		}
 	}
@@ -508,10 +506,9 @@ int Game_Battler::GetDef() const {
 	int base_def = GetBaseDef();
 	int n = min(max(base_def, 1), 999);
 
-	const std::vector<int16_t> states = GetInflictedStates();
-	for (std::vector<int16_t>::const_iterator i = states.begin(); i != states.end(); ++i) {
-		if(Data::states[(*i) - 1].affect_defense) {
-			n = AffectParameter(Data::states[(*i) - 1].affect_type, base_def);
+	for (int16_t i : GetInflictedStates()) {
+		if (Data::states[i - 1].affect_defense) {
+			n = AffectParameter(Data::states[i - 1].affect_type, base_def);
 			break;
 		}
 	}
@@ -527,10 +524,9 @@ int Game_Battler::GetSpi() const {
 	int base_spi = GetBaseSpi();
 	int n = min(max(base_spi, 1), 999);
 
-	const std::vector<int16_t> states = GetInflictedStates();
-	for (std::vector<int16_t>::const_iterator i = states.begin(); i != states.end(); ++i) {
-		if(Data::states[(*i) - 1].affect_spirit) {
-			n = AffectParameter(Data::states[(*i) - 1].affect_type, base_spi);
+	for (int16_t i : GetInflictedStates()) {
+		if(Data::states[i - 1].affect_spirit) {
+			n = AffectParameter(Data::states[i - 1].affect_type, base_spi);
 			break;
 		}
 	}
@@ -546,10 +542,9 @@ int Game_Battler::GetAgi() const {
 	int base_agi = GetBaseAgi();
 	int n = min(max(base_agi, 1), 999);
 
-	const std::vector<int16_t> states = GetInflictedStates();
-	for (std::vector<int16_t>::const_iterator i = states.begin(); i != states.end(); ++i) {
-		if(Data::states[(*i) - 1].affect_agility) {
-			n = AffectParameter(Data::states[(*i) - 1].affect_type, base_agi);
+	for (int16_t i : GetInflictedStates()) {
+		if(Data::states[i - 1].affect_agility) {
+			n = AffectParameter(Data::states[i - 1].affect_type, base_agi);
 			break;
 		}
 	}

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -676,6 +676,8 @@ void Game_Battler::ResetBattle() {
 	agi_modifier = 0;
 	battle_combo_command_id = -1;
 	battle_combo_times = -1;
+	attribute_shift.clear();
+	attribute_shift.resize(Data::attributes.size());
 }
 
 int Game_Battler::GetBattleTurn() const {
@@ -698,5 +700,26 @@ void Game_Battler::SetBattleCombo(int command_id, int times) {
 void Game_Battler::GetBattleCombo(int &command_id, int &times) const {
 	command_id = battle_combo_command_id;
 	times = battle_combo_times;
+}
+
+void Game_Battler::ShiftAttributeRate(int attribute_id, int shift) {
+	if (attribute_id < 1 || attribute_id > Data::attributes.size()) {
+		assert(false && "invalid attribute_id");
+	}
+
+	if (shift < -1 || shift > 1) {
+		assert(false && "Invalid shift");
+	}
+
+	if (shift == 0) {
+		return;
+	}
+
+	int& old_shift = attribute_shift[attribute_id - 1];
+	if ((old_shift == -1 || old_shift == 0) && shift == 1) {
+		++old_shift;
+	} else if ((old_shift == 1 || old_shift == 0) && shift == -1) {
+		--old_shift;
+	}
 }
 

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -659,6 +659,16 @@ std::vector<int16_t> Game_Battler::BattlePhysicalStateHeal(int physical_rate) {
 	return healed_states;
 }
 
+bool Game_Battler::HasReflectState() {
+	for (int16_t i : GetInflictedStates()) {
+		if (Data::states[i - 1].reflect_magic) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void Game_Battler::ResetBattle() {
 	gauge = GetMaxGauge() / 2;
 	charged = false;
@@ -694,3 +704,4 @@ void Game_Battler::GetBattleCombo(int &command_id, int &times) const {
 	command_id = battle_combo_command_id;
 	times = battle_combo_times;
 }
+

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -441,6 +441,10 @@ bool Game_Battler::HasStrongDefense() const {
 	return false;
 }
 
+bool Game_Battler::HasPreemptiveAttack() const {
+	return false;
+}
+
 void Game_Battler::SetDefending(bool defend) {
 	defending = defend;
 }
@@ -665,7 +669,10 @@ bool Game_Battler::HasReflectState() const {
 }
 
 void Game_Battler::ResetBattle() {
-	gauge = GetMaxGauge() / 2;
+	gauge = GetMaxGauge();
+	if (!HasPreemptiveAttack()) {
+		gauge /= 2;
+	}
 	charged = false;
 	defending = false;
 	battle_turn = 0;
@@ -722,4 +729,3 @@ void Game_Battler::ShiftAttributeRate(int attribute_id, int shift) {
 		--old_shift;
 	}
 }
-

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -673,6 +673,8 @@ void Game_Battler::ResetBattle() {
 	def_modifier = 0;
 	spi_modifier = 0;
 	agi_modifier = 0;
+	battle_combo_command_id = -1;
+	battle_combo_times = -1;
 }
 
 int Game_Battler::GetBattleTurn() const {
@@ -685,4 +687,14 @@ void Game_Battler::SetLastBattleAction(int battle_action) {
 
 int Game_Battler::GetLastBattleAction() const {
 	return last_battle_action;
+}
+
+void Game_Battler::SetBattleCombo(int command_id, int times) {
+	battle_combo_command_id = command_id;
+	battle_combo_times = times;
+}
+
+void Game_Battler::GetBattleCombo(int &command_id, int &times) const {
+	command_id = battle_combo_command_id;
+	times = battle_combo_times;
 }

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -124,6 +124,19 @@ public:
 	int GetAttributeRate(int attribute_id, int rate) const;
 
 	/**
+	 * Applies a modifier (buff/debuff) to an attribute rate.
+	 * GetAttributeModifier will use this shift in the rate lookup.
+	 * A shift of +1 changed a C to D and a -1 a C to B.
+	 * The maximum shift value is +-1.
+	 * Calling this function again applies the new shift to the previous shifts.
+	 * The shift is cleared after the battle ended.
+	 *
+	 * @param attribute_id Attribute to modify
+	 * @param shift Shift to apply.
+	 */
+	void ShiftAttributeRate(int attribute_id, int shift);
+
+	/**
 	 * Gets probability that a state can be inflicted on this actor.
 	 * 
 	 * @param state_id State to test
@@ -569,6 +582,8 @@ protected:
 	int last_battle_action;
 	int battle_combo_command_id;
 	int battle_combo_times;
+
+	std::vector<int> attribute_shift;
 };
 
 #endif

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -456,6 +456,13 @@ public:
 	virtual bool HasStrongDefense() const;
 
 	/**
+	 * Tests if the battler has a weapon that grants preemption.
+	 *
+	 * @return true if a weapon is having preempt attribute
+	 */
+	virtual bool HasPreemptiveAttack() const;
+
+	/**
 	 * Sets defence state (next turn, defense is doubled)
 	 *
 	 * @param charge new charge state

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -536,6 +536,9 @@ public:
 
 	int GetLastBattleAction() const;
 
+	void SetBattleCombo(int command_id, int times);
+	void GetBattleCombo(int& command_id, int& times) const;
+
 	/**
 	 * Initializes battle related data to there default values.
 	 */
@@ -556,6 +559,8 @@ protected:
 	int agi_modifier;
 	int battle_turn;
 	int last_battle_action;
+	int battle_combo_command_id;
+	int battle_combo_times;
 };
 
 #endif

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -389,6 +389,14 @@ public:
 	 * Removes all states.
 	 */
 	virtual void RemoveAllStates();
+
+	/**
+	 * Tests if the battler has a state that provides reflect.
+	 * Attack skills targeted at this battler will be reflected to the source.
+	 *
+	 * @return Reflect is enabled.
+	 */
+	bool HasReflectState();
 	
 	/**
 	 * Gets X position on battlefield

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -396,7 +396,7 @@ public:
 	 *
 	 * @return Reflect is enabled.
 	 */
-	bool HasReflectState();
+	bool HasReflectState() const;
 	
 	/**
 	 * Gets X position on battlefield

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -72,6 +72,13 @@ int Game_Enemy::GetAttributeModifier(int attribute_id) const {
 		rate = enemy->attribute_ranks[attribute_id - 1];
 	}
 
+	rate += attribute_shift[attribute_id - 1];
+	if (rate < 0) {
+		rate = 0;
+	} else if (rate > 4) {
+		rate = 4;
+	}
+
 	return GetAttributeRate(attribute_id, rate);
 }
 

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -138,13 +138,10 @@ bool Game_Interpreter_Battle::CommandEnableCombo(RPG::EventCommand const& com) {
 		return true;
 	}
 
-	Output::Warning("Battle: Enable Combo not implemented");
+	int command_id = com.parameters[1];
+	int multiple = com.parameters[2];
 
-	// TODO
-	// int command_id = com.parameters[1];
-	// int multiple = com.parameters[2];
-
-	// Game_Actors::GetActor(actor_id)->EnableCombo(command_id, multiple);
+	Game_Actors::GetActor(actor_id)->SetBattleCombo(command_id, multiple);
 
 	return true;
 }

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -236,7 +236,13 @@ void Scene_Battle::AllySelected() {
 void Scene_Battle::AttackSelected() {
 	Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 
-	SetState(State_SelectEnemyTarget);
+	const RPG::Item* item = active_actor->GetEquipment(RPG::Item::Type_weapon);
+	if (item && item->attack_all) {
+		active_actor->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::Normal>(active_actor, Main_Data::game_enemyparty.get()));
+		ActionSelectedCallback(active_actor);
+	} else {
+		SetState(State_SelectEnemyTarget);
+	}
 }
 
 void Scene_Battle::DefendSelected() {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -335,6 +335,10 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 			battle_action_wait = 30;
 			battle_message_window->Clear();
 
+			if (action->IsFirstAttack()) {
+				action->TargetFirst();
+			}
+
 			if (!action->IsTargetValid()) {
 				if (!action->GetTarget()) {
 					// No target but not a target-only action.
@@ -387,7 +391,7 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 			battle_action_wait = 30;
 
 			break;
-		case BattleActionState_ConditionHeal:			
+		case BattleActionState_ConditionHeal:
 			if (action->IsFirstAttack()) {
 				std::vector<int16_t> states_to_heal = action->GetSource()->NextBattleTurn();
 				std::vector<int16_t> states_remaining = action->GetSource()->GetInflictedStates();

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -759,6 +759,18 @@ void Scene_Battle_Rpg2k::SelectPreviousActor() {
 }
 
 static bool BattlerSort(Game_Battler* first, Game_Battler* second) {
+	if (first->HasPreemptiveAttack() && second->HasPreemptiveAttack()) {
+		return first->GetAgi() > second->GetAgi();
+	}
+
+	if (first->HasPreemptiveAttack()) {
+		return true;
+	}
+
+	if (second->HasPreemptiveAttack()) {
+		return false;
+	}
+
 	return first->GetAgi() > second->GetAgi();
 }
 

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -597,8 +597,8 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 					DrawFloatText(
 						b->GetBattleX(),
 						b->GetBattleY(),
-						0,
-						Utils::ToString(damageTaken),
+						damageTaken < 0 ? Font::ColorDefault : Font::ColorHeal,
+						Utils::ToString(damageTaken < 0 ? -damageTaken : damageTaken),
 						30);
 				}
 			}

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -591,17 +591,21 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 			Main_Data::game_party->GetActiveBattlers(battlers);
 			Main_Data::game_enemyparty->GetActiveBattlers(battlers);
 
-			for (auto& b : battlers) {
-				int damageTaken = b->ApplyConditions();
-				if (damageTaken != 0) {
-					DrawFloatText(
-						b->GetBattleX(),
-						b->GetBattleY(),
-						damageTaken < 0 ? Font::ColorDefault : Font::ColorHeal,
-						Utils::ToString(damageTaken < 0 ? -damageTaken : damageTaken),
-						30);
+			if (!is_combo) {
+				for (auto &b : battlers) {
+					int damageTaken = b->ApplyConditions();
+					if (damageTaken != 0) {
+						DrawFloatText(
+								b->GetBattleX(),
+								b->GetBattleY(),
+								damageTaken < 0 ? Font::ColorDefault : Font::ColorHeal,
+								Utils::ToString(damageTaken < 0 ? -damageTaken : damageTaken),
+								30);
+					}
 				}
 			}
+			is_combo = false;
+
 			if (action->GetStartSe()) {
 				Game_System::SePlay(*action->GetStartSe());
 			}
@@ -708,6 +712,8 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 
 			action->GetSource()->SetBattleCombo(combo_command_id, combo_times - 1);
 			battle_action_state = BattleActionState_Start;
+			// Necessary to track this because state damage/heal is only applied once
+			is_combo = true;
 			return false;
 		}
 

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -529,6 +529,12 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 		return false;
 	}
 
+	if (play_reflected_anim) {
+		action->PlayAnimation(true);
+		play_reflected_anim = false;
+		return false;
+	}
+
 	Sprite_Battler* source_sprite;
 	source_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetSource());
 
@@ -585,6 +591,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 		}
 
 		action->PlayAnimation();
+		play_reflected_anim = action->IsReflected();
 
 		{
 			std::vector<Game_Battler*> battlers;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -79,13 +79,11 @@ void Scene_Battle_Rpg2k3::Update() {
 		it != floating_texts.end();) {
 		int &time = (*it).remaining_time;
 
-		if ((*it).jumps) {
-			if (time % 2 == 0) {
-				int modifier = time <= 10 ? 1 :
-							   time < 20 ? 0 :
-							   -1;
-				(*it).sprite->SetY((*it).sprite->GetY() + modifier);
-			}
+		if (time % 2 == 0) {
+			int modifier = time <= 10 ? 1 :
+						   time < 20 ? 0 :
+						   -1;
+			(*it).sprite->SetY((*it).sprite->GetY() + modifier);
 		}
 
 		--time;
@@ -223,7 +221,7 @@ void Scene_Battle_Rpg2k3::UpdateCursors() {
 	}
 }
 
-void Scene_Battle_Rpg2k3::DrawFloatText(int x, int y, int color, const std::string& text, bool jump) {
+void Scene_Battle_Rpg2k3::DrawFloatText(int x, int y, int color, const std::string& text) {
 	Rect rect = Font::Default()->GetSize(text);
 
 	BitmapRef graphic = Bitmap::Create(rect.width, rect.height);
@@ -236,12 +234,11 @@ void Scene_Battle_Rpg2k3::DrawFloatText(int x, int y, int color, const std::stri
 	floating_text->SetOy(rect.height + 5);
 	floating_text->SetX(x);
 	// Move 5 pixel down because the number "jumps" with the intended y as the peak
-	floating_text->SetY(jump ? y + 5 : y);
+	floating_text->SetY(y + 5);
 	floating_text->SetZ(500 + y);
 
 	FloatText float_text;
 	float_text.sprite = floating_text;
-	float_text.jumps = jump;
 
 	floating_texts.push_back(float_text);
 }
@@ -622,8 +619,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 								b->GetBattleX(),
 								b->GetBattleY(),
 								damageTaken < 0 ? Font::ColorDefault : Font::ColorHeal,
-								Utils::ToString(damageTaken < 0 ? -damageTaken : damageTaken),
-								true);
+								Utils::ToString(damageTaken < 0 ? -damageTaken : damageTaken));
 					}
 				}
 			}
@@ -650,6 +646,8 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 				target_sprite->SetAnimationState(Sprite_Battler::AnimationState_Damage, Sprite_Battler::LoopState_DefaultAnimationAfterFinish);
 			}
 
+			Game_Battler* target = action->GetTarget();
+
 			action->Apply();
 
 			if (action->GetTarget()) {
@@ -659,8 +657,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 							action->GetTarget()->GetBattleX(),
 							action->GetTarget()->GetBattleY(),
 							action->IsPositive() ? Font::ColorHeal : Font::ColorDefault,
-							Utils::ToString(action->GetAffectedHp()),
-							true);
+							Utils::ToString(action->GetAffectedHp()));
 					}
 
 					action->GetTarget()->BattlePhysicalStateHeal(action->GetPhysicalDamageRate());
@@ -669,8 +666,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 						action->GetTarget()->GetBattleX(),
 						action->GetTarget()->GetBattleY(),
 						0,
-						Data::terms.miss,
-						false);
+						Data::terms.miss);
 				}
 
 				targets.push_back(action->GetTarget());

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -538,8 +538,6 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 
 	switch (battle_action_state) {
 	case BattleActionState_Start:
-		action->TargetFirst();
-
 		if (battle_action_need_event_refresh) {
 			action->GetSource()->NextBattleTurn();
 			NextTurn(action->GetSource());
@@ -554,6 +552,8 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 
 			return false;
 		}
+
+		action->TargetFirst();
 
 		ShowNotification(action->GetStartMessage());
 
@@ -694,6 +694,21 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 					target_sprite->DetectStateChange();
 				}
 			}
+		}
+
+		// Check if a combo is enabled and redo the whole action in that case
+		int combo_command_id;
+		int combo_times;
+
+		action->GetSource()->GetBattleCombo(combo_command_id, combo_times);
+		if (action->GetSource()->GetLastBattleAction() == combo_command_id &&
+			combo_times > 1) {
+			// TODO: Prevent combo when the combo is a skill and needs more SP
+			// then available
+
+			action->GetSource()->SetBattleCombo(combo_command_id, combo_times - 1);
+			battle_action_state = BattleActionState_Start;
+			return false;
 		}
 
 		// Must loop another time otherwise the event update happens during

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -561,7 +561,9 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 
 		action->TargetFirst();
 
-		ShowNotification(action->GetStartMessage());
+		if (combo_repeat == 1) {
+			ShowNotification(action->GetStartMessage());
+		}
 
 		if (!action->IsTargetValid()) {
 			if (!action->GetTarget()) {
@@ -598,7 +600,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 			Main_Data::game_party->GetActiveBattlers(battlers);
 			Main_Data::game_enemyparty->GetActiveBattlers(battlers);
 
-			if (!is_combo) {
+			if (combo_repeat == 1) {
 				for (auto &b : battlers) {
 					int damageTaken = b->ApplyConditions();
 					if (damageTaken != 0) {
@@ -611,7 +613,6 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 					}
 				}
 			}
-			is_combo = false;
 
 			if (action->GetStartSe()) {
 				Game_System::SePlay(*action->GetStartSe());
@@ -681,6 +682,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 			// Reset variables
 			battle_action_state = BattleActionState_Start;
 			targets.clear();
+			combo_repeat = 1;
 
 			return true;
 		}
@@ -713,14 +715,13 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 
 		action->GetSource()->GetBattleCombo(combo_command_id, combo_times);
 		if (action->GetSource()->GetLastBattleAction() == combo_command_id &&
-			combo_times > 1) {
+			combo_times > combo_repeat) {
 			// TODO: Prevent combo when the combo is a skill and needs more SP
 			// then available
 
-			action->GetSource()->SetBattleCombo(combo_command_id, combo_times - 1);
 			battle_action_state = BattleActionState_Start;
-			// Necessary to track this because state damage/heal is only applied once
-			is_combo = true;
+			// Count how often we have to repeat
+			++combo_repeat;
 			return false;
 		}
 

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -22,8 +22,6 @@
 #include "scene_battle.h"
 #include "async_handler.h"
 
-typedef std::pair<std::shared_ptr<Sprite>, int> FloatText;
-
 /**
  * Scene_Battle class.
  * Manages the battles.
@@ -44,7 +42,7 @@ protected:
 	void CreateBattleCommandWindow();
 
 	void UpdateCursors();
-	void DrawFloatText(int x, int y, int color, const std::string& text, int _duration);
+	void DrawFloatText(int x, int y, int color, const std::string& text, bool jump);
 
 	void RefreshCommandWindow();
 
@@ -75,6 +73,13 @@ protected:
 	void ShowNotification(const std::string& text);
 
 	std::unique_ptr<Sprite> ally_cursor, enemy_cursor;
+
+	struct FloatText {
+		std::shared_ptr<Sprite> sprite;
+		bool jumps;
+		int remaining_time = 30;
+	};
+
 	std::vector<FloatText> floating_texts;
 
 	int battle_action_wait;

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -42,7 +42,7 @@ protected:
 	void CreateBattleCommandWindow();
 
 	void UpdateCursors();
-	void DrawFloatText(int x, int y, int color, const std::string& text, bool jump);
+	void DrawFloatText(int x, int y, int color, const std::string& text);
 
 	void RefreshCommandWindow();
 
@@ -76,7 +76,6 @@ protected:
 
 	struct FloatText {
 		std::shared_ptr<Sprite> sprite;
-		bool jumps;
 		int remaining_time = 30;
 	};
 

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -80,6 +80,7 @@ protected:
 	int battle_action_wait;
 	int battle_action_state;
 	bool battle_action_need_event_refresh = true;
+	bool is_combo = false;
 
 	std::unique_ptr<Window_BattleStatus> enemy_status_window;
 

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -81,6 +81,7 @@ protected:
 	int battle_action_state;
 	bool battle_action_need_event_refresh = true;
 	bool is_combo = false;
+	bool play_reflected_anim = false;
 
 	std::unique_ptr<Window_BattleStatus> enemy_status_window;
 

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -80,7 +80,7 @@ protected:
 	int battle_action_wait;
 	int battle_action_state;
 	bool battle_action_need_event_refresh = true;
-	bool is_combo = false;
+	int combo_repeat = 1;
 	bool play_reflected_anim = false;
 
 	std::unique_ptr<Window_BattleStatus> enemy_status_window;

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -22,6 +22,7 @@
 #include "cache.h"
 #include "main_data.h"
 #include "player.h"
+#include "output.h"
 #include "rpg_battleranimation.h"
 #include "rpg_battleranimationextension.h"
 
@@ -179,8 +180,13 @@ void Sprite_Battler::SetAnimationState(int state, LoopState loop) {
 
 			if (ext.animation_type == RPG::BattlerAnimationExtension::AnimType_animation) {
 				SetBitmap(BitmapRef());
-				animation.reset(new BattleAnimationBattlers(Data::animations[ext.animation_id - 1], *battler));
-				animation->SetZ(GetZ());
+				if (ext.animation_id < 1 || ext.animation_id > Data::animations.size()) {
+					Output::Warning("Invalid battle animation: %d", ext.animation_id);
+					animation.reset();
+				} else {
+					animation.reset(new BattleAnimationBattlers(Data::animations[ext.animation_id - 1], *battler));
+					animation->SetZ(GetZ());
+				}
 			}
 			else {
 				animation.reset();


### PR DESCRIPTION
Enable combo simply repeats the whole action and reduces a counter.

Skill reflect is a bit more "fun" but was surprisingly easy to implement in the BattleAlgorithm (good API design): GetTarget lies to the caller and returns the source when reflected. Therefore battleAlgorithm will handle the whole damage calc and applycation automatically correct. 
The only exception is PlayAnimation because the animation is played twice: Once normal and once on the reflected target.

(De)buffing is that [x] Reduce Resistance option. When checked this buffs or debuffs the Attack Elements by 1/-1. Maximum shift is +-1 and when e.g. an actor is buffed with +1 and the enemy debuffs it becomes 0.

Related: #821

Bonus:
2k3: Damage numbers "jump" now
Multitarget attacks did not target all actors when one was dead
"Attack party" flag for weapons
Preemptive attack for 2k
