### PR TITLE
Place BattleAnim above Picture when "MajorUpdated" engine detected

### DIFF
--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -28,11 +28,12 @@
 #include "battle_animation.h"
 #include "baseui.h"
 #include "spriteset_battle.h"
+#include "player.h"
 
 BattleAnimation::BattleAnimation(const RPG::Animation& anim) :
 	animation(anim), frame(0), frame_update(false), large(false)
 {
-	SetZ(1040);
+	SetZ(Player::IsMajorUpdatedVersion() ? 2400 : 1040);
 
 	const std::string& name = animation.animation_name;
 	BitmapRef graphic;

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -713,7 +713,6 @@ void Bitmap::StretchBlit(Rect const& dst_rect, Bitmap const& src, Rect const& sr
 	double zoom_y = (double)src_rect.height / dst_rect.height;
 
 	Transform xform = Transform::Scale(zoom_x, zoom_y);
-	xform *= Transform::Translation(-src_rect.x, -src_rect.y);
 
 	pixman_image_set_transform(src.bitmap, &xform.matrix);
 

--- a/src/screen.h
+++ b/src/screen.h
@@ -47,7 +47,7 @@ public:
 	void SetTone(Tone tone);
 
 private:
-	static const int z = 1050;
+	static const int z = 2500;
 	static const DrawableType type = TypeScreen;
 
 	BitmapRef flash;


### PR DESCRIPTION
Simple solution based on the work of @kakurasan until I have time to polish #1062. And easier to review ;)

Screen to 2500 is save, there was nothing between pictures and screen, the next are battle windows at 3000.

Pictures are at 1050 and battleanim at 2400 for major updated, so gives buffer for more then 1000 pictures.
