### PR TITLE
Battle 2k: Fix bugs when selecting a previous actor.

### DIFF
--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -267,13 +267,7 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 			}
 			
 			Game_BattleAlgorithm::AlgorithmBase* alg = battle_actions.front()->GetBattleAlgorithm().get();
-			if (!alg) {
-				Output::Warning("%s has no action but got a turn.", battle_actions.front()->GetName().c_str());
-				Output::Warning("Please report a bug");
-				RemoveCurrentAction();
-				return;
-			}
-			
+
 			if (ProcessBattleAction(alg)) {
 				RemoveCurrentAction();
 				battle_message_window->Clear();
@@ -742,13 +736,15 @@ void Scene_Battle_Rpg2k::SelectPreviousActor() {
 	}
 
 	actor_index--;
-	RemoveCurrentAction();
 	active_actor = allies[actor_index];
 
 	if (active_actor->IsDead()) {
 		SelectPreviousActor();
 		return;
 	}
+
+	battle_actions.back()->SetBattleAlgorithm(std::shared_ptr<Game_BattleAlgorithm::AlgorithmBase>());
+	battle_actions.pop_back();
 
 	if (active_actor->GetAutoBattle()) {
 		SelectPreviousActor();


### PR DESCRIPTION
1) Segfault when selecting a previous actor when one of the skipped actors was dead.
2) The wrong battle algorithm was removed (from the front, but actually the latest is at the back). This is the famous "Has no action but got a turn"-bug.

Fix #933

I removed the sanity check because the only way to trigger this is a bug in the code (which is found now).