### PR TITLE
Fix lack of transparency after rotating

### DIFF
--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -739,7 +739,7 @@ void Bitmap::TransformBlit(Rect const& dst_rect, Bitmap const& src, Rect const& 
 
 	pixman_image_t* mask = CreateMask(opacity, src.GetRect(), &xform);
 
-	pixman_image_composite32(src.GetOperator(mask),
+	pixman_image_composite32(PIXMAN_OP_OVER,
 							 src.bitmap, mask, bitmap,
 							 dst_rect.x, dst_rect.y,
 							 dst_rect.x, dst_rect.y,


### PR DESCRIPTION
This is a regression introduced with the performance optimisations for bitmap blits.
In this case getting rid of the fast path doesn't hurt much because is only taken when a rotation happens.

Related: #898