### PR TITLE
Overclocked GPU/BUS,added shaders,disabled vsync.

### DIFF
--- a/builds/psvita/Makefile
+++ b/builds/psvita/Makefile
@@ -13,9 +13,9 @@ OBJS     := $(addsuffix .o,$(BINFILES)) $(CFILES:.c=.o) $(CPPFILES:.cpp=.o)
 
 LIBS = -lvorbisfile -logg -lvorbis -lspeexdsp -lsndfile \
 	-lvita2d -llcf -licuuc -licui18n -licudata -lpixman-1 \
-	-lSceKernel_stub -lSceDisplay_stub -lSceGxm_stub	\
-	-lSceSysmodule_stub -lSceCtrl_stub -lm \
-	-lScePgf_stub -ljpeg -lfreetype -lc \
+	-lSceLibKernel_stub -lSceDisplay_stub -lSceGxm_stub	\
+	-lvitashaders -lSceSysmodule_stub -lSceCtrl_stub -lm \
+	-lSceTouch_stub -lScePgf_stub -ljpeg -lfreetype -lc \
 	-lScePower_stub -lSceCommonDialog_stub -lpng16 -lz \
 	-lmpg123 -lSceAudio_stub
 

--- a/builds/psvita/Makefile
+++ b/builds/psvita/Makefile
@@ -12,7 +12,7 @@ BINFILES := $(foreach dir,$(DATA), $(wildcard $(dir)/*.bin))
 OBJS     := $(addsuffix .o,$(BINFILES)) $(CFILES:.c=.o) $(CPPFILES:.cpp=.o) 
 
 LIBS = -lvorbisfile -logg -lvorbis -lspeexdsp -lsndfile \
-	-lvita2d -llcf -licuuc -licui18n -licudata -lpixman-1 \
+	-lvita2d -llcf -licuuc -licui18n -licudata -lpthread -lpixman-1 \
 	-lSceLibKernel_stub -lSceDisplay_stub -lSceGxm_stub	\
 	-lvitashaders -lSceSysmodule_stub -lSceCtrl_stub -lm \
 	-lSceTouch_stub -lScePgf_stub -ljpeg -lfreetype -lc \

--- a/src/psp2_ui.h
+++ b/src/psp2_ui.h
@@ -74,14 +74,11 @@ public:
 #endif
 
 	/** @} */
-	vita2d_texture* main_texture;
 	int frame;
-	uint8_t zoom_state;
 	bool trigger_state;
 	uint64_t starttick;
-	int in_use_shader;
-	bool set_shader;
 	int touch_x_start;
+	SceUID GPU_Thread;
 	
 };
 

--- a/src/psp2_ui.h
+++ b/src/psp2_ui.h
@@ -24,9 +24,10 @@
 #include "rect.h"
 #include "system.h"
 #include <vita2d.h>
+#include <vector>
 
 /**
- * SdlUi class.
+ * Psp2Ui class.
  */
 class Psp2Ui : public BaseUi {
 public:
@@ -78,6 +79,9 @@ public:
 	uint8_t zoom_state;
 	bool trigger_state;
 	uint64_t starttick;
+	int in_use_shader;
+	bool set_shader;
+	int touch_x_start;
 	
 };
 


### PR DESCRIPTION
This pull will do four different things:

- Adds filters (aka shaders) support (at the moment there are 4 shaders available: None, Sharp Bilinear, LCD 3x, xBR). These will be interchangeable during player execution by the user by swinging the touchscreen left/right.

- Increases GPU, GPU crossbar and BUS clocks (from 111 mhz to 222 mhz) allowing shaders to get the best results.

- Disables vsync. This will produce a slight frameboost without any bad conseguence.

- Fix some typo errors and updates Makefile for new vitasdk compatibility.