### PR TITLE
Fix some issues in Wolfenhain

### DIFF
--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -286,7 +286,7 @@ bool Game_Battle::AreConditionsMet(const RPG::TroopPageCondition& condition) {
 	}
 
 	if (condition.flags.command_actor &&
-		condition.command_id != Game_Actors::GetActor(condition.turn_actor_id)->GetLastBattleAction())
+		condition.command_id != Game_Actors::GetActor(condition.command_actor_id)->GetLastBattleAction())
 		return false;
 
 	return true;

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -254,46 +254,43 @@ bool Game_Battler::UseSkill(int skill_id) {
 
 	bool was_used = false;
 
-	switch (skill.type) {
-		case RPG::Skill::Type_normal:
-		case RPG::Skill::Type_subskill:
-			// Only takes care of healing skills outside of battle,
-			// the other skill logic is in Game_BattleAlgorithm
+	if (skill.type == RPG::Skill::Type_normal || skill.type >= RPG::Skill::Type_subskill) {
+		// Only takes care of healing skills outside of battle,
+		// the other skill logic is in Game_BattleAlgorithm
 
-			if (!(skill.scope == RPG::Skill::Scope_ally ||
-				skill.scope == RPG::Skill::Scope_party ||
-				skill.scope == RPG::Skill::Scope_self)) {
-				return false;
-			}
+		if (!(skill.scope == RPG::Skill::Scope_ally ||
+			  skill.scope == RPG::Skill::Scope_party ||
+			  skill.scope == RPG::Skill::Scope_self)) {
+			return false;
+		}
 
-			// Skills only increase hp and sp outside of battle
-			if (skill.power > 0 && skill.affect_hp && !HasFullHp()) {
-				was_used = true;
-				ChangeHp(skill.power);
-			}
+		// Skills only increase hp and sp outside of battle
+		if (skill.power > 0 && skill.affect_hp && !HasFullHp()) {
+			was_used = true;
+			ChangeHp(skill.power);
+		}
 
-			if (skill.power > 0 && skill.affect_sp && !HasFullSp()) {
-				was_used = true;
-				ChangeSp(skill.power);
-			}
+		if (skill.power > 0 && skill.affect_sp && !HasFullSp()) {
+			was_used = true;
+			ChangeSp(skill.power);
+		}
 
-			for (int i = 0; i < (int)skill.state_effects.size(); i++) {
-				if (skill.state_effects[i]) {
-					if (skill.state_effect) {
-						was_used |= !HasState(Data::states[i].ID);
-						AddState(Data::states[i].ID);
-					} else {
-						was_used |= HasState(Data::states[i].ID);
-						RemoveState(Data::states[i].ID);
-					}
+		for (int i = 0; i < (int) skill.state_effects.size(); i++) {
+			if (skill.state_effects[i]) {
+				if (skill.state_effect) {
+					was_used |= !HasState(Data::states[i].ID);
+					AddState(Data::states[i].ID);
+				} else {
+					was_used |= HasState(Data::states[i].ID);
+					RemoveState(Data::states[i].ID);
 				}
 			}
-		case RPG::Skill::Type_teleport:
-		case RPG::Skill::Type_escape:
-			return true;
-		case RPG::Skill::Type_switch:
-			Game_Switches[skill.switch_id] = true;
-			return true;
+		}
+	} else if (skill.type == RPG::Skill::Type_teleport || skill.type == RPG::Skill::Type_escape) {
+		was_used = true;
+	} else if (skill.type == RPG::Skill::Type_switch) {
+		Game_Switches[skill.switch_id] = true;
+		was_used = true;
 	}
 
 	return was_used;

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -156,7 +156,7 @@ void Game_Party::AddItem(int item_id, int amount) {
 		// (Adding an item never changes the number of uses, even when
 		// you already have x99 of them.)
 		if (amount < 0) {
-			data.item_usage[i] = (uint8_t)Data::items[item_id - 1].uses;
+			data.item_usage[i] = 0;
 		}
 
 		return;
@@ -171,7 +171,7 @@ void Game_Party::AddItem(int item_id, int amount) {
 	data.item_ids.push_back((int16_t)item_id);
 	data.items_size = data.item_ids.size();
 	data.item_counts.push_back((uint8_t)std::min(amount, 99));
-	data.item_usage.push_back((uint8_t)Data::items[item_id - 1].uses);
+	data.item_usage.push_back(0);
 }
 
 void Game_Party::RemoveItem(int item_id, int amount) {
@@ -199,14 +199,14 @@ void Game_Party::ConsumeItemUse(int item_id) {
 		if (data.item_ids[i] != item_id)
 			continue;
 
-		if (data.item_usage[i] == 0) {
-			// Limitless uses
+		if (Data::items[i].uses == 0) {
+			// Unlimited uses
 			return;
 		}
 
-		data.item_usage[i]--;
+		data.item_usage[i]++;
 
-		if (data.item_usage[i] == 0) {
+		if (data.item_usage[i] >= Data::items[i].uses) {
 			if (data.item_counts[i] == 1) {
 				// We just used up the last one
 				data.item_ids.erase(data.item_ids.begin() + i);
@@ -215,7 +215,7 @@ void Game_Party::ConsumeItemUse(int item_id) {
 				data.item_usage.erase(data.item_usage.begin() + i);
 			} else {
 				data.item_counts[i]--;
-				data.item_usage[i] = (uint8_t)Data::items[item_id - 1].uses;
+				data.item_usage[i] = 0;
 			}
 		}
 		return;

--- a/src/scene_actortarget.cpp
+++ b/src/scene_actortarget.cpp
@@ -100,7 +100,7 @@ void Scene_ActorTarget::UpdateItem() {
 
 void Scene_ActorTarget::UpdateSkill() {
 	if (Input::IsTriggered(Input::DECISION)) {
-		Game_Actor* actor = static_cast<Game_Actor*>(&(*Main_Data::game_party)[actor_index]);
+		Game_Actor* actor = &(*Main_Data::game_party)[actor_index];
 
 		if (actor->GetSp() < actor->CalculateSkillCost(id)) {
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Buzzer));


### PR DESCRIPTION
The test for Battle Commands was completely wrong (only worked for 1st actor)

The subskill fix is the same one used in other places: The check must be >=.
The diff is a mess because of the identation change, the only relevant change is from
```
case RPG::Skill::Type_normal:
case RPG::Skill::Type_subskill:
```
to
```
if (skill.type == RPG::Skill::Type_normal || skill.type >= RPG::Skill::Type_subskill) {
```

The item_usage change will cause minor issues when loading EasyRPG savegames: Items with more than one use will have an incorrect usage count until the usage limit is reached once.
Unlimited and Single use items are not affected. Unlimited doesn't care about uses at all and Single will wrap on first use (because 2 >= 1)