### PR TITLE
Fix asciidoc manpage generation when using a different working folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ test-driver
 /builds/wii/*.dol
 /output
 /utils
+.buildconfig
 compile
 CPackConfig.cmake
 CPackSourceConfig.cmake

--- a/Makefile.am
+++ b/Makefile.am
@@ -366,7 +366,7 @@ easyrpg_player_LDADD = libeasyrpg-player.la
 # manual page
 if HAVE_A2X
 resources/easyrpg-player.6: resources/easyrpg-player.6.adoc
-	$(AM_V_GEN) $(A2X) -a player_version=$(PACKAGE_VERSION) -f manpage -D $(builddir)/resources $(srcdir)/$<
+	$(AM_V_GEN) $(A2X) -a player_version=$(PACKAGE_VERSION) -f manpage -D $(builddir)/resources $<
 
 dist_man6_MANS = resources/easyrpg-player.6
 MOSTLYCLEANFILES += resources/easyrpg-player.6


### PR DESCRIPTION
When trying to work with gnome-builder, this issue emerged. The change in Makefile.am seems to fix this.
Also adds the gnome-builder .buildconfig to .gitignore.