### PR TITLE
Fix lcf-size calculation for non-ascii-strings in event commands

### DIFF
--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -77,8 +77,10 @@ static int GetEventCommandSize(const std::vector<RPG::EventCommand>& commands) {
 	for (it = commands.begin(); it != commands.end(); ++it) {
 		result += LcfReader::IntSize(it->code);
 		result += LcfReader::IntSize(it->indent);
-		result += LcfReader::IntSize(it->string.size());
-		result += ReaderUtil::Recode(it->string, Player::encoding).size();
+		// Convert string to LDB encoding
+		std::string orig_string = ReaderUtil::Recode(it->string, "UTF-8", Player::encoding);
+		result += LcfReader::IntSize(orig_string.size());
+		result += orig_string.size();
 
 		int count = it->parameters.size();
 		result += LcfReader::IntSize(count);


### PR DESCRIPTION
This makes RPG_RT more happy when loading our savegames
(Stream read error)

To reproduce use a "Speicherstein" in Vampires Dawn and save in EasyRPG.
Load in RPG_RT: Old version: Stream read error. New version: Loads fine.

I'm quite sure ```int RawStruct<RPG::EventCommand>::LcfSize``` in liblcf has the same bug because reencoding with lcf2xml results in "Stream read error" again.