### PR TITLE
Shaking things up

### DIFF
--- a/src/background.cpp
+++ b/src/background.cpp
@@ -24,6 +24,7 @@
 #include "cache.h"
 #include "background.h"
 #include "bitmap.h"
+#include "main_data.h"
 
 Background::Background(const std::string& name) :
 	visible(true),
@@ -61,7 +62,7 @@ Background::Background(int terrain_id) :
 		FileRequestAsync* request = AsyncHandler::RequestFile("Frame", terrain.background_a_name);
 		request_id = request->Bind(&Background::OnBackgroundGraphicReady, this);
 		request->Start();
-	
+
 		bg_hscroll = terrain.background_a_scrollh ? terrain.background_a_scrollh_speed : 0;
 		bg_vscroll = terrain.background_a_scrollv ? terrain.background_a_scrollv_speed : 0;
 	}
@@ -125,10 +126,14 @@ void Background::Draw() {
 		return;
 
 	BitmapRef dst = DisplayUi->GetDisplaySurface();
+	Rect dst_rect = dst->GetRect();
+
+	int shake_pos = Main_Data::game_data.screen.shake_position;
+	dst_rect.x += shake_pos;
 
 	if (bg_bitmap)
-		dst->TiledBlit(-Scale(bg_x), -Scale(bg_y), bg_bitmap->GetRect(), *bg_bitmap, dst->GetRect(), 255);
+		dst->TiledBlit(-Scale(bg_x), -Scale(bg_y), bg_bitmap->GetRect(), *bg_bitmap, dst_rect, 255);
 
 	if (fg_bitmap)
-		dst->TiledBlit(-Scale(fg_x), -Scale(fg_y), fg_bitmap->GetRect(), *fg_bitmap, dst->GetRect(), 255);
+		dst->TiledBlit(-Scale(fg_x), -Scale(fg_y), fg_bitmap->GetRect(), *fg_bitmap, dst_rect, 255);
 }

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -29,6 +29,7 @@
 #include "baseui.h"
 #include "spriteset_battle.h"
 #include "player.h"
+#include "game_temp.h"
 
 BattleAnimation::BattleAnimation(const RPG::Animation& anim) :
 	animation(anim), frame(0), frame_update(false), large(false)
@@ -104,7 +105,7 @@ void BattleAnimation::OnBattleSpriteReady(FileRequestResult* result) {
 			large = true;
 		}
 		SetBitmap(bitmap);
-		
+
 		SetSrcRect(Rect(0, 0, 0, 0));
 	}
 	else {
@@ -206,7 +207,22 @@ void BattleAnimation::ProcessAnimationTiming(const RPG::AnimationTiming& timing)
 			flash_length);
 	}
 
-	// TODO: Shake.
+	// Shake (only happens in battle).
+	if (Game_Temp::battle_running) {
+		switch (timing.screen_shake) {
+		case RPG::AnimationTiming::ScreenShake_nothing:
+			break;
+		case RPG::AnimationTiming::ScreenShake_target:
+			// TODO: shake the targets
+			break;
+		case RPG::AnimationTiming::ScreenShake_screen:
+			Game_Screen* screen = Main_Data::game_screen.get();
+			// FIXME: 8,7,3 are made up
+			screen->ShakeOnce(8, 7, 3);
+			break;
+		}
+	}
+
 }
 
 // For handling the vertical position.

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -157,7 +157,7 @@ bool Game_Battler::IsSkillUsable(int skill_id) const {
 	if (CalculateSkillCost(skill_id) > GetSp()) {
 		return false;
 	}
-	
+
 	// > 10 makes any skill usable
 	int smallest_physical_rate = 11;
 	int smallest_magical_rate = 11;
@@ -230,11 +230,11 @@ bool Game_Battler::UseItem(int item_id) {
 
 		return was_used;
 	}
-	
+
 	if (item.type == RPG::Item::Type_switch) {
 		return true;
 	}
-	
+
 	switch (item.type) {
 		case RPG::Item::Type_weapon:
 		case RPG::Item::Type_shield:
@@ -555,6 +555,15 @@ int Game_Battler::GetAgi() const {
 	n = min(max(n, 1), 999);
 
 	return n;
+}
+
+int Game_Battler::GetDisplayX() const {
+	int shake_pos = Main_Data::game_data.screen.shake_position;
+	return GetBattleX() + shake_pos;
+}
+
+int Game_Battler::GetDisplayY() const {
+	return GetBattleY();
 }
 
 int Game_Battler::GetHue() const {

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -60,7 +60,7 @@ public:
 
 	/**
 	 * Apply effects of Conditions to Battler
-	 * 
+	 *
 	 * @return Damage taken to Battler from conditions
 	 */
 	int ApplyConditions();
@@ -93,7 +93,7 @@ public:
 	/**
 	 * Tests if the battler has a "No Action" condition like sleep.
 	 *
-	 * @return can act 
+	 * @return can act
 	 */
 	bool CanAct();
 
@@ -138,7 +138,7 @@ public:
 
 	/**
 	 * Gets probability that a state can be inflicted on this actor.
-	 * 
+	 *
 	 * @param state_id State to test
 	 * @return Probability of state infliction
 	 */
@@ -410,20 +410,33 @@ public:
 	 * @return Reflect is enabled.
 	 */
 	bool HasReflectState() const;
-	
+
 	/**
-	 * Gets X position on battlefield
+	 * Gets X position against the battle background.
 	 *
 	 * @return X position in battle scene
 	 */
 	virtual int GetBattleX() const = 0;
 
 	/**
-	 * Gets Y position on battlefield
+	 * Gets Y position against the battle background.
 	 *
 	 * @return Y position in battle scene
 	 */
 	virtual int GetBattleY() const = 0;
+
+	/**
+	 * Gets X position on the screen.
+	 *
+	 * This is equal to GetBattleX, plus a displacement for
+	 * any screen shaking.
+	 */
+	int GetDisplayX() const;
+
+	/**
+	 * Gets Y position on the screen.
+	 */
+	int GetDisplayY() const;
 
 	virtual int GetHue() const;
 
@@ -449,7 +462,7 @@ public:
 	 * @return If battler is defending (next turn, defense is doubled)
 	 */
 	bool IsDefending() const;
-	
+
 	/**
 	 * @return If battler has strong defense (defense is tripled when defending)
 	 */
@@ -480,7 +493,7 @@ public:
 	 * Convenience function to access the party based on the type of this
 	 * battler. This function does not ensure that the battler is in the
 	 * party.
-	 * @return Party this member probably belongs to. 
+	 * @return Party this member probably belongs to.
 	 */
 	Game_Party_Base& GetParty() const;
 
@@ -538,7 +551,7 @@ public:
 	 */
 	void SetBattleAlgorithm(const BattleAlgorithmRef battle_algorithm);
 
-	/** 
+	/**
 	 * @return Current turn in battle
 	 */
 	int GetBattleTurn() const;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -772,7 +772,7 @@ int Game_Map::GetTerrainTag(int const x, int const y) {
 		chip_index = map_info.lower_tiles[chip_index - 18] + 18;
 
 	assert(chipset_index < Data::data.chipsets.size());
-	
+
 	auto& terrain_data = Data::data.chipsets[chipset_index].terrain_data;
 
 	if (terrain_data.empty()) {
@@ -1098,17 +1098,18 @@ void Game_Map::SetBattlebackName(std::string new_battleback_name) {
 }
 
 int Game_Map::GetDisplayX() {
-	return map_info.position_x;
+	int shake_in_pixels = Main_Data::game_data.screen.shake_position;
+	return map_info.position_x + shake_in_pixels * 16;
 }
-void Game_Map::SetDisplayX(int new_display_x) {
-	map_info.position_x = new_display_x;
+void Game_Map::SetPositionX(int new_position_x) {
+	map_info.position_x = new_position_x;
 }
 
 int Game_Map::GetDisplayY() {
 	return map_info.position_y;
 }
-void Game_Map::SetDisplayY(int new_display_y) {
-	map_info.position_y = new_display_y;
+void Game_Map::SetPositionY(int new_position_y) {
+	map_info.position_y = new_position_y;
 }
 
 Game_Map::RefreshMode Game_Map::GetNeedRefresh() {

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -402,18 +402,26 @@ namespace Game_Map {
 	void SetBattlebackName(std::string battleback_name);
 
 	/**
-	 * Gets display x.
+	 * Gets the offset of the screen from the left edge
+	 * of the map.
+	 *
+	 * If the screen is shaking, this is not necessarily
+	 * the same value that SetPositionX returns.
 	 *
 	 * @return display x.
 	 */
 	int GetDisplayX();
 
 	/**
-	 * Sets the display x.
+	 * Sets the offset of the screen from the left edge
+	 * of the map.
 	 *
-	 * @param display_x new display x.
+	 * If the screen is shaking, this is not necessarily
+	 * the same value that GetDisplayX returns.
+	 *
+	 * @param new_position_x new position x.
 	 */
-	void SetDisplayX(int display_x);
+	void SetPositionX(int new_position_x);
 
 	/**
 	 * Gets display y.
@@ -423,11 +431,12 @@ namespace Game_Map {
 	int GetDisplayY();
 
 	/**
-	 * Sets the display y.
+	 * Sets the offset of the screen from the top edge
+	 * of the map.
 	 *
-	 * @param display_y new display y.
+	 * @param new_position_y new position y.
 	 */
-	void SetDisplayY(int display_y);
+	void SetPositionY(int new_position_y);
 
 	/**
 	 * Gets need refresh flag.

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -282,17 +282,17 @@ void Game_Player::Center(int x, int y) {
 	int center_y = (DisplayUi->GetHeight() / (TILE_SIZE / 16) - TILE_SIZE) * 8 - Game_Map::GetPanY();
 
 	if (Game_Map::LoopHorizontal()) {
-		Game_Map::SetDisplayX(x*SCREEN_TILE_WIDTH - center_x);
+		Game_Map::SetPositionX(x*SCREEN_TILE_WIDTH - center_x);
 	} else {
 		int max_x = (Game_Map::GetWidth() - DisplayUi->GetWidth() / TILE_SIZE) * SCREEN_TILE_WIDTH;
-		Game_Map::SetDisplayX(max(0, min((x * SCREEN_TILE_WIDTH - center_x), max_x)));
+		Game_Map::SetPositionX(max(0, min((x * SCREEN_TILE_WIDTH - center_x), max_x)));
 	}
 
 	if (Game_Map::LoopVertical()) {
-		Game_Map::SetDisplayY(y * SCREEN_TILE_WIDTH - center_y);
+		Game_Map::SetPositionY(y * SCREEN_TILE_WIDTH - center_y);
 	} else {
 		int max_y = (Game_Map::GetHeight() - DisplayUi->GetHeight() / TILE_SIZE) * SCREEN_TILE_WIDTH;
-		Game_Map::SetDisplayY(max(0, min((y * SCREEN_TILE_WIDTH - center_y), max_y)));
+		Game_Map::SetPositionY(max(0, min((y * SCREEN_TILE_WIDTH - center_y), max_y)));
 	}
 
 	Game_Map::InitializeParallax();

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -76,7 +76,7 @@ void Game_Screen::Reset()
 	data.shake_time_left = 0;
 	data.shake_position = 0;
 	data.shake_continuous = false;
-	shake_direction = 0;
+	shake_direction = 1;
 
 	movie_filename = "";
 	movie_pos_x = 0;

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -152,6 +152,10 @@ void Sprite_Battler::Update() {
 			}
 		}
 	}
+
+	SetX(battler->GetDisplayX());
+	SetY(battler->GetDisplayY());
+	SetZ(battler->GetBattleY());
 }
 
 void Sprite_Battler::SetAnimationState(int state, LoopState loop) {
@@ -263,8 +267,8 @@ void Sprite_Battler::CreateSprite() {
 	sprite_name = battler->GetSpriteName();
 	hue = battler->GetHue();
 
-	SetX(battler->GetBattleX());
-	SetY(battler->GetBattleY());
+	SetX(battler->GetDisplayX());
+	SetY(battler->GetDisplayY());
 	SetZ(battler->GetBattleY()); // Not a typo
 
 	// Not animated -> Monster


### PR DESCRIPTION
Implements screen shaking. Fixes #565 (finally lol).

-----

Actually updating the shake variables is already done in `Game_Screen` (yay!), so I just had to wire them up to the coordinate calculations.

It's a bit hard to tell, but on the battle screen in RPG_RT, timers, damage counters, and battle animations look like they are _not_ affected by screen shaking. So I only made shaking affect the background and the enemies/heroes.