### PR TITLE
Make RNG portable

### DIFF
--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -202,7 +202,7 @@ void FileRequestAsync::UpdateProgress() {
 #ifndef EMSCRIPTEN
 	// Fake download for testing event handlers
 
-	if (!IsReady() && rand() % 100 == 0) {
+	if (!IsReady() && Utils::ChanceOf(1, 100)) {
 		DownloadDone(true);
 	}
 #endif

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -27,6 +27,7 @@
 #include "player.h"
 #include "rpg_skill.h"
 #include "util_macro.h"
+#include "utils.h"
 
 static int max_hp_value() {
 	return Player::IsRPG2k() ? 999 : 9999;
@@ -210,7 +211,7 @@ int Game_Actor::SetEquipment(int equip_type, int new_item_id) {
 	int old_item_id = GetData().equipped[equip_type - 1];
 	if (old_item_id > (int)Data::items.size())
 		old_item_id = 0;
-	
+
 	GetData().equipped[equip_type - 1] = (short)new_item_id;
 	return old_item_id;
 }
@@ -724,7 +725,7 @@ const std::vector<int16_t>& Game_Actor::GetSkills() const {
 const RPG::Skill& Game_Actor::GetRandomSkill() const {
 	const std::vector<int16_t>& skills = GetSkills();
 
-	return Data::skills[skills[rand() % (skills.size() + 1)] - 1];
+	return Data::skills[skills[Utils::GetRandomNumber(0, skills.size() - 1)] - 1];
 }
 
 bool Game_Actor::HasTwoWeapons() const {
@@ -955,10 +956,10 @@ const RPG::Class* Game_Actor::GetClass() const {
 void Game_Actor::SetClass(int _class_id) {
 	GetData().class_id = _class_id;
 	GetData().changed_class = _class_id > 0;
-	
+
 	// The class settings are not applied when the actor has a class on startup
 	// but only when the "Change Class" event command is used.
-	
+
 	if (GetData().changed_class) {
 		GetData().battler_animation = GetClass()->battler_animation;
 		GetData().super_guard = GetClass()->super_guard;
@@ -967,12 +968,12 @@ void Game_Actor::SetClass(int _class_id) {
 		GetData().auto_battle = GetClass()->auto_battle;
 	} else {
 		const RPG::Actor& actor = Data::actors[actor_id - 1];
-		
+
 		GetData().super_guard = actor.super_guard;
 		GetData().lock_equipment = actor.lock_equipment;
 		GetData().two_weapon = actor.two_weapon;
 		GetData().auto_battle = actor.auto_battle;
-		
+
 		GetData().battler_animation = 0;
 	}
 	MakeExpList();
@@ -1072,7 +1073,7 @@ int Game_Actor::GetBattleAnimationId() const {
 	} else {
 		anim = GetData().battler_animation;
 	}
-	
+
 	if (anim == 0) {
 		// Chunk was missing, set to proper default
 		return 1;

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -20,7 +20,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <cstdlib>
 #include "player.h"
 #include "game_battler.h"
 #include "game_actor.h"
@@ -30,6 +29,7 @@
 #include "game_switches.h"
 #include "util_macro.h"
 #include "main_data.h"
+#include "utils.h"
 
 Game_Battler::Game_Battler() {
 	ResetBattle();
@@ -157,7 +157,7 @@ bool Game_Battler::IsSkillUsable(int skill_id) const {
 	if (CalculateSkillCost(skill_id) > GetSp()) {
 		return false;
 	}
-	
+
 	// > 10 makes any skill usable
 	int smallest_physical_rate = 11;
 	int smallest_magical_rate = 11;
@@ -230,11 +230,11 @@ bool Game_Battler::UseItem(int item_id) {
 
 		return was_used;
 	}
-	
+
 	if (item.type == RPG::Item::Type_switch) {
 		return true;
 	}
-	
+
 	switch (item.type) {
 		case RPG::Item::Type_weapon:
 		case RPG::Item::Type_shield:
@@ -622,7 +622,7 @@ std::vector<int16_t> Game_Battler::NextBattleTurn() {
 			states[i] += 1;
 
 			if (states[i] >= Data::states[i].hold_turn) {
-				if (rand() % 100 < Data::states[i].auto_release_prob) {
+				if (Utils::ChanceOf(Data::states[i].auto_release_prob, 100)) {
 					healed_states.push_back(i + 1);
 					RemoveState(i + 1);
 				}
@@ -645,7 +645,7 @@ std::vector<int16_t> Game_Battler::BattlePhysicalStateHeal(int physical_rate) {
 		if (HasState(i + 1) && Data::states[i].release_by_damage > 0) {
 			int release_chance = (int)(Data::states[i].release_by_damage * physical_rate / 100.0);
 
-			if (rand() % 100 < release_chance) {
+			if (Utils::ChanceOf(release_chance, 100)) {
 				healed_states.push_back(i + 1);
 				RemoveState(i + 1);
 			}

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -26,10 +26,10 @@
 #include "main_data.h"
 #include "game_message.h"
 #include "player.h"
+#include "utils.h"
 #include "util_macro.h"
 #include <cmath>
 #include <cassert>
-#include <cstdlib>
 
 Game_Character::Game_Character() :
 	tile_id(0),
@@ -487,7 +487,7 @@ void Game_Character::MoveForward() {
 }
 
 void Game_Character::MoveRandom() {
-	Move(rand() % 4);
+	Move(Utils::GetRandomNumber(0, 3));
 }
 
 void Game_Character::MoveTowardsPlayer() {
@@ -553,9 +553,7 @@ void Game_Character::Turn180Degree() {
 }
 
 void Game_Character::Turn90DegreeLeftOrRight() {
-	int value = rand() % 2;
-
-	if (value == 0) {
+	if (Utils::ChanceOf(1,2)) {
 		Turn90DegreeLeft();
 	} else {
 		Turn90DegreeRight();
@@ -590,7 +588,7 @@ void Game_Character::TurnAwayFromHero() {
 }
 
 void Game_Character::FaceRandomDirection() {
-	Turn(rand() % 4);
+	Turn(Utils::GetRandomNumber(0, 3));
 }
 
 void Game_Character::Wait() {

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -17,7 +17,6 @@
 
 // Headers
 #include <algorithm>
-#include <cstdlib>
 #include "data.h"
 #include "rpg_enemy.h"
 #include "game_battle.h"
@@ -25,6 +24,7 @@
 #include "game_party.h"
 #include "game_switches.h"
 #include "output.h"
+#include "utils.h"
 
 Game_Enemy::Game_Enemy(int enemy_id) : Game_Battler() {
 	Setup(enemy_id);
@@ -297,7 +297,7 @@ const RPG::EnemyAction* Game_Enemy::ChooseRandomAction() {
 		return nullptr;
 	}
 
-	int which = rand() % total;
+	int which = Utils::GetRandomNumber(0, total - 1);
 	for (std::vector<int>::const_iterator it = valid.begin(); it != valid.end(); ++it) {
 		const RPG::EnemyAction& action = actions[*it];
 		if (which >= action.rating) {

--- a/src/game_enemyparty.cpp
+++ b/src/game_enemyparty.cpp
@@ -17,10 +17,10 @@
 
 // Headers
 #include <cassert>
-#include <cstdlib>
 #include "game_interpreter.h"
 #include "game_enemyparty.h"
 #include "main_data.h"
+#include "utils.h"
 
 Game_EnemyParty::Game_EnemyParty() {
 }
@@ -82,8 +82,7 @@ void Game_EnemyParty::GenerateDrops(std::vector<int>& out) const {
 		if ((*it)->IsDead()) {
 			// Only roll if the enemy has something to drop
 			if ((*it)->GetDropId() != 0) {
-				bool dropped = (rand() % 100) < (*it)->GetDropProbability();
-				if (dropped) {
+				if (Utils::ChanceOf((*it)->GetDropProbability(), 100)) {
 					out.push_back((*it)->GetDropId());
 				}
 			}

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -29,8 +29,8 @@
 #include "game_interpreter_map.h"
 #include "main_data.h"
 #include "player.h"
+#include "utils.h"
 #include <cmath>
-#include <cstdlib>
 
 Game_Event::Game_Event(int map_id, const RPG::Event& event) :
 	event(event),
@@ -557,9 +557,9 @@ void Game_Event::UpdateSelfMovement() {
 
 void Game_Event::MoveTypeRandom() {
 	int last_direction = GetDirection();
-	switch (rand() % 6) {
+	switch (Utils::GetRandomNumber(0, 5)) {
 	case 0:
-		stop_count -= rand() % (stop_count + 1);
+		stop_count -= Utils::GetRandomNumber(0, stop_count);
 		if (stop_count < 0) {
 			stop_count = 0;
 		}
@@ -575,7 +575,7 @@ void Game_Event::MoveTypeRandom() {
 		if (!(IsDirectionFixed() || IsFacingLocked()))
 			SetSpriteDirection(last_direction);
 	} else {
-		max_stop_count = max_stop_count / 5 * (rand() % 4 + 3);
+		max_stop_count = max_stop_count / 5 * Utils::GetRandomNumber(3, 6);
 	}
 }
 
@@ -605,7 +605,7 @@ void Game_Event::MoveTypeTowardsPlayer() {
 	if ( std::abs(sx) + std::abs(sy) >= 20 ) {
 		MoveRandom();
 	} else {
-		switch (rand() % 6) {
+		switch (Utils::GetRandomNumber(0, 5)) {
 		case 0:
 			MoveRandom();
 			break;
@@ -636,7 +636,7 @@ void Game_Event::MoveTypeAwayFromPlayer() {
 	if ( std::abs(sx) + std::abs(sy) >= 20 ) {
 		MoveRandom();
 	} else {
-		switch (rand() % 6) {
+		switch (Utils::GetRandomNumber(0, 5)) {
 		case 0:
 			MoveRandom();
 			break;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -17,7 +17,6 @@
 
 // Headers
 #include <algorithm>
-#include <cstdlib>
 #include <iostream>
 #include <sstream>
 #include "game_interpreter.h"
@@ -48,6 +47,7 @@
 #include "util_macro.h"
 #include "reader_util.h"
 #include "game_battle.h"
+#include "utils.h"
 
 Game_Interpreter::Game_Interpreter(int _depth, bool _main_flag) {
 	depth = _depth;
@@ -736,7 +736,7 @@ bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { /
 			int a, b;
 			a = max(com.parameters[5], com.parameters[6]);
 			b = min(com.parameters[5], com.parameters[6]);
-			value = rand() % (a-b+1)+b;
+			value = Utils::GetRandomNumber(b, a);
 			break;
 		case 4:
 			// Items
@@ -1379,7 +1379,7 @@ bool Game_Interpreter::CommandSimulatedAttack(RPG::EventCommand const& com) { //
 		result -= (actor->GetSpi() * spi) / 800;
 		if (var != 0) {
 			int rperc = var * 5;
-			int rval = rand() % (2 * rperc) - rperc;
+			int rval = Utils::GetRandomNumber(-rperc, rperc - 1);
 			result += result * rval / 100;
 		}
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -17,7 +17,6 @@
 
 // Headers
 #include <cassert>
-#include <cstdlib>
 #include <iomanip>
 #include <sstream>
 #include <algorithm>
@@ -42,6 +41,7 @@
 #include "filefinder.h"
 #include "player.h"
 #include "input.h"
+#include "utils.h"
 
 namespace {
 	RPG::SaveMapInfo& map_info = Main_Data::game_data.map_info;
@@ -772,7 +772,7 @@ int Game_Map::GetTerrainTag(int const x, int const y) {
 		chip_index = map_info.lower_tiles[chip_index - 18] + 18;
 
 	assert(chipset_index < Data::data.chipsets.size());
-	
+
 	auto& terrain_data = Data::data.chipsets[chipset_index].terrain_data;
 
 	if (terrain_data.empty()) {
@@ -973,8 +973,8 @@ void Game_Map::UpdateEncounterSteps() {
 void Game_Map::ResetEncounterSteps() {
 	int rate = GetEncounterRate();
 	if (rate > 0) {
-		int throw_one = rand() / (RAND_MAX / rate + 1);
-		int throw_two = rand() / (RAND_MAX / rate + 1);
+		int throw_one = Utils::GetRandomNumber(0, rate - 1);
+		int throw_two = Utils::GetRandomNumber(0, rate - 1);
 
 		// *100 to handle terrain rate better
 		location.encounter_steps = (throw_one + throw_two + 1) * 100;
@@ -1023,7 +1023,7 @@ bool Game_Map::PrepareEncounter() {
 		return false;
 	}
 
-	Game_Temp::battle_troop_id = encounters[rand() / (RAND_MAX / encounters.size() + 1)];
+	Game_Temp::battle_troop_id = encounters[Utils::GetRandomNumber(0, encounters.size() - 1)];
 	Game_Temp::battle_calling = true;
 
 	SetupBattle();

--- a/src/game_party_base.cpp
+++ b/src/game_party_base.cpp
@@ -16,9 +16,9 @@
  */
 
 #include <algorithm>
-#include <cstdlib>
 #include <list>
 #include "game_party_base.h"
+#include "utils.h"
 
 Game_Party_Base::~Game_Party_Base() {
 }
@@ -86,8 +86,7 @@ Game_Battler* Game_Party_Base::GetRandomActiveBattler() {
 	if (battlers.empty()) {
 		return NULL;
 	}
-	int ra = rand() / (RAND_MAX / battlers.size() + 1);
-	return battlers[ra];
+	return battlers[Utils::GetRandomNumber(0, battlers.size() - 1)];
 }
 
 Game_Battler* Game_Party_Base::GetRandomDeadBattler() {
@@ -97,7 +96,7 @@ Game_Battler* Game_Party_Base::GetRandomDeadBattler() {
 		return NULL;
 	}
 
-	return battlers[rand() / (RAND_MAX / battlers.size() + 1)];
+	return battlers[Utils::GetRandomNumber(0, battlers.size() - 1)];
 }
 
 bool Game_Party_Base::IsAnyActive() {

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -16,7 +16,6 @@
  */
 
 // Headers
-#include <cstdlib>
 #include "bitmap.h"
 #include "data.h"
 #include "game_battle.h"
@@ -26,6 +25,7 @@
 #include "game_variables.h"
 #include "main_data.h"
 #include "output.h"
+#include "utils.h"
 
 Game_Screen::Game_Screen() :
 	data(Main_Data::game_data.screen)
@@ -224,9 +224,9 @@ void Game_Screen::InitSnowRain() {
 
 	for (int i = 0; i < num_snowflakes[data.weather_strength]; i++) {
 		Snowflake f;
-		f.x = (short) (rand() * 440.0 / RAND_MAX);
-		f.y = (uint8_t) rand();
-		f.life = (uint8_t) rand();
+		f.x = (short) Utils::GetRandomNumber(0, 440);
+		f.y = (uint8_t) Utils::GetRandomNumber(0, 255);
+		f.life = (uint8_t) Utils::GetRandomNumber(0, 255);
 		snowflakes.push_back(f);
 	}
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -192,7 +192,6 @@ void Player::Init(int argc, char *argv[]) {
 	InitMiniDumpWriter();
 #endif
 
-	srand(time(NULL));
 	Utils::SeedRandomNumberGenerator(time(NULL));
 
 	ParseCommandLine(argc, argv);
@@ -523,7 +522,6 @@ void Player::ParseCommandLine(int argc, char *argv[]) {
 			if (it == args.end()) {
 				return;
 			}
-			srand(atoi((*it).c_str()));
 			Utils::SeedRandomNumberGenerator(atoi((*it).c_str()));
 		}
 		else if (*it == "--start-map-id") {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -24,6 +24,9 @@
 
 namespace {
 	std::mt19937 rng;
+
+	/** Gets a random number uniformly distributed in [0, U32_MAX] */
+	uint32_t GetRandomU32() { return rng(); }
 }
 
 std::string Utils::LowerCase(const std::string& str) {
@@ -342,7 +345,7 @@ void Utils::SwapByteOrder(double& d) {
 /** Generate a random number in the range [0,max] */
 static uint32_t GetRandomUnsigned(uint32_t max)
 {
-	if (max == 0xffffffffull) return rng();
+	if (max == 0xffffffffull) return GetRandomU32();
 
 	// Rejection sampling:
 	// 1. Divide the range of uint32 into blocks of max+1
@@ -354,7 +357,7 @@ static uint32_t GetRandomUnsigned(uint32_t max)
 	uint32_t m = max + 1;
 	uint32_t rem = -m % m; // = 2^32 mod m
 	while (true) {
-		uint32_t n = rng();
+		uint32_t n = GetRandomU32();
 		if (n >= rem)
 			return n % m;
 	}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -17,6 +17,7 @@
 
 // Headers
 #include "utils.h"
+#include <cassert>
 #include <stdio.h>
 #include <algorithm>
 #include <random>
@@ -343,6 +344,11 @@ int32_t Utils::GetRandomNumber(int32_t from, int32_t to) {
 	return dist(rng);
 }
 
+bool Utils::ChanceOf(int32_t n, int32_t m) {
+	assert(n >= 0 && m > 0);
+	return GetRandomNumber(1, m) <= n;
+}
+
 void Utils::SeedRandomNumberGenerator(int32_t seed) {
 	rng.seed(seed);
 }
@@ -383,7 +389,7 @@ std::string Utils::ReadLine(std::istream &is) {
 std::vector<std::string> Utils::Tokenize(const std::string &str_to_tokenize, const std::function<bool(char32_t)> predicate) {
 	std::u32string text = DecodeUTF32(str_to_tokenize);
 	std::vector<std::string> tokens;
-	std::u32string cur_token;	
+	std::u32string cur_token;
 
 	for (char32_t& c : text) {
 		if (predicate(c)) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -152,6 +152,15 @@ namespace Utils {
 	int32_t GetRandomNumber(int32_t from, int32_t to);
 
 	/**
+	 * Has an n/m chance of returning true. If n>m, always returns true.
+	 *
+	 * @param n number of times out of m to return true (non-negative)
+	 * @param m denominator of the probability (positive)
+	 * @return true with probability n/m, false with probability 1-n/m
+	 */
+	bool ChanceOf(int32_t n, int32_t m);
+
+	/**
 	 * Seeds the RNG used by GetRandomNumber
 	 *
 	 * @param seed Seed to use

--- a/src/utils.h
+++ b/src/utils.h
@@ -161,7 +161,7 @@ namespace Utils {
 	bool ChanceOf(int32_t n, int32_t m);
 
 	/**
-	 * Seeds the RNG used by GetRandomNumber
+	 * Seeds the RNG used by GetRandomNumber and ChanceOf.
 	 *
 	 * @param seed Seed to use
 	 */


### PR DESCRIPTION
The intention of this PR is to make random number generation totally portable by:

#### Removing `rand` and `srand`

Replacing `rand() % a` with `GetRandomNumber(0, a-1)` generally, but also

* I changed [this line](https://github.com/EasyRPG/Player/compare/master...scurest:rand?expand=1#diff-34f34f675ce52452da855f1469fc5421R728) which was probably a bug
* `rand() / (RAND_MAX / a + 1)` was replaced with `Utils::GetRandomNumber(0, a - 1)` (is this right?)
* I also added `ChanceOf` for the common case of getting a bool with a certain probability (this could also be used for the battle algorithms)

#### Removing `uniform_int_distribution`

The algorithm it uses isn't part of the standard.

My first idea was to copy the `uniform_int_distribution` from (say) GCC's stdlib here, but it's a _lot_ of code, and it's complicated because it has to deal with RNGs with non-power-of-two ranges. We only need to consume random u32s and generate random i32 ranges, so I wrote a rejection sampler for just that case.

Hopefully I didn't get any of the math wrong (please check!).

-----

The upshot is that the seed \*\**should*\*\* determine the RNG sequence and the RNG should now be reproducible.