### PR TITLE
Don't activate touch trigger when the player is on top of an event on the same layer

### DIFF
--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -511,6 +511,10 @@ bool Game_Event::CheckEventTriggerTouch(int x, int y) {
 		return false;
 
 	if (trigger == RPG::EventPage::Trigger_collision && !IsJumping()) {
+		if (Main_Data::game_player->IsInPosition(GetX(), GetY()) && GetLayer() == RPG::EventPage::Layers_same) {
+			return false;
+		}
+
 		if (Main_Data::game_player->IsInPosition(x, y) && !Main_Data::game_player->IsBlockedByMoveRoute()) {
 			if (Main_Data::game_player->InAirship() && GetLayer() == RPG::EventPage::Layers_same) {
 				return false;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -562,7 +562,7 @@ bool Game_Map::MakeWay(int x, int y, int d, const Game_Character& self) {
 		return false;
 
 	if (Main_Data::game_player->IsInPosition(new_x, new_y)
-			&& !Main_Data::game_player->GetThrough() && !self.GetSpriteName().empty()
+			&& !Main_Data::game_player->GetThrough()
 			&& self.GetLayer() == RPG::EventPage::Layers_same) {
 		// Update the Player to see if they'll move and recheck.
 		Main_Data::game_player->Update();


### PR DESCRIPTION
Fixes #1086, fixes #1084. Although in the latter, there are still issues besides the soft-lock.

Also fixes yet another bug in `MakeWay` :(