### PR TITLE
Refactor/Bug fixes for Pictures

### DIFF
--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -622,9 +622,6 @@ static void AdjustParams(Game_Picture::Params& params) {
 }
 
 static void AdjustShowParams(int& pic_id, Game_Picture::ShowParams& params) {
-	AdjustId(pic_id);
-	AdjustParams(params);
-
 	// Adjust name
 	if (pic_id >= 50000) {
 		// Name substitution is pic_id + 1
@@ -642,6 +639,9 @@ static void AdjustShowParams(int& pic_id, Game_Picture::ShowParams& params) {
 			params.name = new_pic_name;
 		}
 	}
+
+	AdjustId(pic_id);
+	AdjustParams(params);
 }
 
 static void AdjustMoveParams(int& pic_id, Game_Picture::MoveParams& params) {

--- a/src/game_picture.cpp
+++ b/src/game_picture.cpp
@@ -103,8 +103,6 @@ void Game_Picture::Move(const MoveParams& params) {
 	SetNonEffectParams(params);
 	data.time_left = params.duration * DEFAULT_FPS / 10;
 
-	// TODO: Do something special for RM2k here
-
 	// Note that data.effect_mode doesn't necessarily reflect the
 	// last effect set. Possible states are:
 	//
@@ -118,6 +116,14 @@ void Game_Picture::Move(const MoveParams& params) {
 	//   Picture was set to rotate.
 	// * effect_mode == 2 && finish_effect != 0
 	//   Picture was set to waver.
+
+	bool started_with_no_effect =
+		data.effect_mode == 0 && data.finish_effect == 0.0;
+	if (Player::IsRPG2k() && started_with_no_effect) {
+		// Possibly a bug(?) in RM2k: if Show Picture command has no
+		// effect, a Move Picture command cannot add one
+		return;
+	}
 
 	if (data.effect_mode == 0 && params.effect_mode == 0) {
 		// Nothing to do

--- a/src/game_picture.cpp
+++ b/src/game_picture.cpp
@@ -15,7 +15,6 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Headers
 #include "bitmap.h"
 #include "options.h"
 #include "cache.h"
@@ -24,15 +23,12 @@
 #include "player.h"
 #include "main_data.h"
 
-/**
- * Picture class.
- */
 Game_Picture::Game_Picture(int ID) :
 	id(ID),
 	old_map_x(0),
 	old_map_y(0)
 {
-	SetTransition(0);
+	RequestPictureSprite();
 }
 
 Game_Picture::~Game_Picture() {
@@ -42,7 +38,7 @@ Game_Picture::~Game_Picture() {
 		return;
 	}
 
-	GetData().name = "";
+	GetData().name.clear();
 }
 
 void Game_Picture::UpdateSprite() {
@@ -75,29 +71,38 @@ void Game_Picture::UpdateSprite() {
 						 (int) (data.current_sat * 128 / 100)));
 }
 
-void Game_Picture::Show(const std::string& _name, bool _transparency) {
+void Game_Picture::Show(const ShowParams& params) {
 	RPG::SavePicture& data = GetData();
 
-	data.name = _name;
-	data.transparency = _transparency;
+	data.name = params.name;
+	data.transparency = params.transparency;
+	data.fixed_to_map = params.fixed_to_map;
+	SetNonEffectParams(params);
+	data.effect_mode = params.effect_mode;
+	if (data.effect_mode == 0) {
+		data.finish_effect = 0.0;
+	} else {
+		data.finish_effect = params.effect_power;
+	}
+	SyncCurrentToFinish();
+	data.current_rotation = 0.0;
+	data.current_waver = 0;
 	data.time_left = 0;
 
-	FileRequestAsync* request = AsyncHandler::RequestFile("Picture", data.name);
-	request_id = request->Bind(&Game_Picture::OnPictureSpriteReady, this);
-	request->Start();
+	RequestPictureSprite();
+	UpdateSprite();
 
 	old_map_x = Game_Map::GetDisplayX();
 	old_map_y = Game_Map::GetDisplayY();
 }
 
-void Game_Picture::OnPictureSpriteReady(FileRequestResult*) {
+void Game_Picture::Move(const MoveParams& params) {
 	RPG::SavePicture& data = GetData();
 
-	BitmapRef bitmap = Cache::Picture(data.name, data.transparency);
+	SetNonEffectParams(params);
+	data.time_left = params.duration * DEFAULT_FPS / 10;
 
-	sprite.reset(new Sprite());
-	sprite->SetBitmap(bitmap);
-	UpdateSprite();
+	// PLACEHOLDER
 }
 
 void Game_Picture::Erase() {
@@ -109,92 +114,23 @@ void Game_Picture::Erase() {
 	sprite.reset();
 }
 
-void Game_Picture::SetFixedToMap(bool flag) {
-	RPG::SavePicture& data = GetData();
+void Game_Picture::RequestPictureSprite() {
+	const std::string& name = GetData().name;
+	if (name.empty()) return;
 
-	data.fixed_to_map = flag;
+	FileRequestAsync* request = AsyncHandler::RequestFile("Picture", name);
+	request_id = request->Bind(&Game_Picture::OnPictureSpriteReady, this);
+	request->Start();
 }
 
-void Game_Picture::SetMovementEffect(int x, int y) {
+void Game_Picture::OnPictureSpriteReady(FileRequestResult*) {
 	RPG::SavePicture& data = GetData();
 
-	data.finish_x = x;
-	data.finish_y = y;
-}
+	BitmapRef bitmap = Cache::Picture(data.name, data.transparency);
 
-void Game_Picture::SetColorEffect(int r, int g, int b, int s) {
-	RPG::SavePicture& data = GetData();
-
-	data.finish_red = r;
-	data.finish_green = g;
-	data.finish_blue = b;
-	data.finish_sat = s;
-}
-
-void Game_Picture::SetZoomEffect(int scale) {
-	RPG::SavePicture& data = GetData();
-
-	data.finish_magnify = scale;
-}
-
-void Game_Picture::SetTransparencyEffect(int top, int bottom) {
-	RPG::SavePicture& data = GetData();
-
-	data.finish_top_trans = top;
-	data.finish_bot_trans = bottom;
-}
-
-void Game_Picture::SetRotationEffect(int speed) {
-	RPG::SavePicture& data = GetData();
-
-	if (!data.time_left || Player::IsRPG2k3()) {
-		if (data.effect_mode != 1)
-			data.current_rotation = 0;
-		data.effect_mode = 1;
-	}
-	data.finish_effect = speed;
-}
-
-void Game_Picture::SetWaverEffect(int depth) {
-	RPG::SavePicture& data = GetData();
-
-	if (!data.time_left || Player::IsRPG2k3()) {
-		if (data.effect_mode != 2)
-			data.current_waver = 0;
-		data.effect_mode = 2;
-	}
-	data.finish_effect = depth;
-}
-
-void Game_Picture::StopEffects() {
-	RPG::SavePicture& data = GetData();
-
-	if (!data.time_left || Player::IsRPG2k3())
-		data.effect_mode = 0;
-}
-
-void Game_Picture::SetTransition(int tenths) {
-	RPG::SavePicture& data = GetData();
-
-	data.time_left = tenths * DEFAULT_FPS / 10;
-
-	if (tenths == 0) {
-		data.current_x			= data.finish_x;
-		data.current_y			= data.finish_y;
-		data.current_red		= data.finish_red;
-		data.current_green		= data.finish_green;
-		data.current_blue		= data.finish_blue;
-		data.current_sat		= data.finish_sat;
-		data.current_magnify	= data.finish_magnify;
-		data.current_top_trans	= data.finish_top_trans;
-		data.current_bot_trans	= data.finish_bot_trans;
-		data.current_effect		= data.finish_effect;
-		UpdateSprite();
-	}
-}
-
-static double interpolate(double d, double x0, double x1) {
-	return (x0 * (d - 1) + x1) / d;
+	sprite.reset(new Sprite());
+	sprite->SetBitmap(bitmap);
+	UpdateSprite();
 }
 
 void Game_Picture::Update() {
@@ -229,24 +165,58 @@ void Game_Picture::Update() {
 	if (data.effect_mode == 2)
 		data.current_waver += 10;
 
-	if (data.time_left > 0) {
-		double k = data.time_left;
+	if (data.time_left == 0) {
+		SyncCurrentToFinish();
+	} else {
+		auto interpolate = [=](double& current, double finish) {
+			double d = data.time_left;
+			current = (current * (d - 1) + finish) / d;
+		};
 
-		data.current_x			= interpolate(k, data.current_x,			data.finish_x);
-		data.current_y			= interpolate(k, data.current_y,			data.finish_y);
-		data.current_red		= interpolate(k, data.current_red,			data.finish_red);
-		data.current_green		= interpolate(k, data.current_green,		data.finish_green);
-		data.current_blue		= interpolate(k, data.current_blue,			data.finish_blue);
-		data.current_sat		= interpolate(k, data.current_sat,			data.finish_sat);
-		data.current_magnify	= interpolate(k, data.current_magnify,		data.finish_magnify);
-		data.current_top_trans	= interpolate(k, data.current_top_trans,	data.finish_top_trans);
-		data.current_bot_trans	= interpolate(k, data.current_bot_trans,	data.finish_bot_trans);
-		data.current_effect		= interpolate(k, data.current_effect,		data.finish_effect);
+		interpolate(data.current_x, data.finish_x);
+		interpolate(data.current_y, data.finish_y);
+		interpolate(data.current_red, data.finish_red);
+		interpolate(data.current_green, data.finish_green);
+		interpolate(data.current_blue, data.finish_blue);
+		interpolate(data.current_sat, data.finish_sat);
+		interpolate(data.current_magnify, data.finish_magnify);
+		interpolate(data.current_top_trans, data.finish_top_trans);
+		interpolate(data.current_bot_trans, data.finish_bot_trans);
+		interpolate(data.current_effect, data.finish_effect);
 
 		data.time_left--;
 	}
 
 	UpdateSprite();
+}
+
+void Game_Picture::SetNonEffectParams(const Params& params) {
+	RPG::SavePicture& data = GetData();
+
+	data.finish_x = params.position_x;
+	data.finish_y = params.position_y;
+	data.finish_magnify = params.magnify;
+	data.finish_top_trans = params.top_trans;
+	data.finish_bot_trans = params.bottom_trans;
+	data.finish_red = params.red;
+	data.finish_green = params.green;
+	data.finish_blue = params.blue;
+	data.finish_sat = params.saturation;
+}
+
+void Game_Picture::SyncCurrentToFinish() {
+	RPG::SavePicture& data = GetData();
+
+	data.current_x = data.finish_x;
+	data.current_y = data.finish_y;
+	data.current_red = data.finish_red;
+	data.current_green = data.finish_green;
+	data.current_blue = data.finish_blue;
+	data.current_sat = data.finish_sat;
+	data.current_magnify = data.finish_magnify;
+	data.current_top_trans = data.finish_top_trans;
+	data.current_bot_trans = data.finish_bot_trans;
+	data.current_effect = data.finish_effect;
 }
 
 RPG::SavePicture& Game_Picture::GetData() const {

--- a/src/game_picture.h
+++ b/src/game_picture.h
@@ -21,59 +21,68 @@
 // Headers
 #include <string>
 #include "async_handler.h"
-#include "system.h"
 #include "rpg_save.h"
 #include "sprite.h"
+
+class Sprite;
 
 /**
  * Picture class.
  */
-class Sprite;
-
 class Game_Picture {
 public:
-	Game_Picture(int ID);
+	explicit Game_Picture(int ID);
 	~Game_Picture();
 
-	void Show(const std::string& name, bool transparency);
+	struct Params {
+		int position_x;
+		int position_y;
+		int magnify;
+		int top_trans;
+		int bottom_trans;
+		int red;
+		int green;
+		int blue;
+		int saturation;
+		int effect_mode;
+		int effect_power;
+	};
+	struct ShowParams : Params {
+		std::string name;
+		bool transparency;
+		bool fixed_to_map;
+	};
+	struct MoveParams : Params {
+		int duration;
+	};
+
+	void Show(const ShowParams& params);
+	void Move(const MoveParams& params);
 	void Erase();
-	void SetFixedToMap(bool flag);
-	void SetMovementEffect(int x, int y);
-	void SetColorEffect(int r, int g, int b, int s);
-	void SetZoomEffect(int scale);
-	void SetTransparencyEffect(int top, int bottom);
-	void SetRotationEffect(int speed);
-	void SetWaverEffect(int depth);
-	void StopEffects();
-	void SetTransition(int tenths);
 
 	void Update();
 
 private:
 	int id;
-
-	static const int waver_speed = 10;
-
 	std::unique_ptr<Sprite> sprite;
+	FileRequestBinding request_id;
+	int old_map_x;
+	int old_map_y;
 
 	void UpdateSprite();
-
+	void SetNonEffectParams(const Params& params);
+	void SyncCurrentToFinish();
+	void RequestPictureSprite();
 	void OnPictureSpriteReady(FileRequestResult*);
-
 	/**
 	 * Compared to other classes picture doesn't hold a direct reference.
 	 * Resizing the picture vector when the ID is larger then the vector can
 	 * result in a memmove on resize, resulting in data pointers pointing into
 	 * garbage.
 	 *
-	 * @return Reference to the SavePicture data 
+	 * @return Reference to the SavePicture data
 	 */
 	RPG::SavePicture& GetData() const;
-
-	int old_map_x;
-	int old_map_y;
-
-	FileRequestBinding request_id;
 };
 
 #endif

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -41,9 +41,6 @@ void Game_Screen::CreatePicturesFromSave() {
 	for (int id = 1; id < (int)save_pics.size(); ++id) {
 		if (!save_pics[id - 1].name.empty()) {
 			pictures[id - 1].reset(new Game_Picture(id));
-			int time_left = save_pics[id - 1].time_left;
-			pictures[id - 1]->Show(save_pics[id - 1].name, save_pics[id - 1].transparency);
-			pictures[id - 1]->SetTransition(time_left * DEFAULT_FPS / 10);
 		}
 	}
 }

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -83,22 +83,6 @@ void Game_Screen::Reset()
 }
 
 Game_Picture* Game_Screen::GetPicture(int id) {
-	// PicPointer Patch handling
-	if (id > 10000) {
-		// Picture to point at
-		int new_id;
-		if (id > 50000) {
-			new_id = Game_Variables[id - 50000];
-		} else {
-			new_id = Game_Variables[id - 10000];
-		}
-
-		if (new_id > 0) {
-			Output::Debug("PicPointer: ID %d replaced with ID %d", id, new_id);
-			id = new_id;
-		}
-	}
-
 	if (id <= 0) {
 		return NULL;
 	}

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -116,7 +116,7 @@ Game_Picture* Game_Screen::GetPicture(int id) {
 
 		pictures.resize(id);
 	}
-	std::shared_ptr<Game_Picture>& p = pictures[id - 1];
+	std::unique_ptr<Game_Picture>& p = pictures[id - 1];
 	if (!p)
 		p.reset(new Game_Picture(id));
 	return p.get();
@@ -276,10 +276,9 @@ void Game_Screen::Update() {
 			data.shake_time_left--;
 	}
 
-	std::vector<std::shared_ptr<Game_Picture> >::const_iterator it;
-	for (it = pictures.begin(); it != pictures.end(); ++it) {
-		if (*it) {
-			(*it)->Update();
+	for (const auto& picture : pictures) {
+		if (picture) {
+			picture->Update();
 		}
 	}
 

--- a/src/game_screen.h
+++ b/src/game_screen.h
@@ -95,7 +95,7 @@ public:
 	};
 
 private:
-	std::vector<std::shared_ptr<Game_Picture> > pictures;
+	std::vector<std::unique_ptr<Game_Picture>> pictures;
 
 	RPG::SaveScreen& data;
 	int flash_sat;		// RPGMaker bug: this isn't saved


### PR DESCRIPTION
Fixes #1046, fixes #1063. There are also some other small fixes to picture behavior.

`Game_Picture` was refactored substantially. `Command{Show,Move}Picture` now have much less responsibility, and the public surface area of `Game_Picture` was reduced. Some tiny changes to PicPointerPatch handling were also made.