### PR TITLE
Refactor and fix for parallax BGs

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2062,18 +2062,17 @@ bool Game_Interpreter::CommandChangeMapTileset(RPG::EventCommand const& com) { /
 
 
 bool Game_Interpreter::CommandChangePBG(RPG::EventCommand const& com) { // code 11720
-	const std::string& name = com.string;
-	Game_Map::SetParallaxName(name);
+	Game_Map::Parallax::Params params;
+	params.name = com.string;
+	params.scroll_horz = com.parameters[0] != 0;
+	params.scroll_vert = com.parameters[1] != 0;
+	params.scroll_horz_auto = com.parameters[2] != 0;
+	params.scroll_horz_speed = com.parameters[3];
+	params.scroll_vert_auto = com.parameters[4] != 0;
+	params.scroll_vert_speed = com.parameters[5];
 
-	bool horz = com.parameters[0] != 0;
-	bool vert = com.parameters[1] != 0;
-	bool horz_auto = com.parameters[2] != 0;
-	int horz_speed = com.parameters[3];
-	bool vert_auto = com.parameters[4] != 0;
-	int vert_speed = com.parameters[5];
-	Game_Map::SetParallaxScroll(horz, vert,
-		horz_auto, vert_auto,
-		horz_speed, vert_speed);
+	Game_Map::Parallax::ChangeBG(params);
+
 	return true;
 }
 

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -615,15 +615,6 @@ namespace Game_Map {
 	FileRequestAsync* RequestMap(int map_id);
 
 	namespace Parallax {
-		std::string GetName();
-		int GetX();
-		int GetY();
-
-		void Initialize(int width, int height);
-		void ResetPosition();
-		void Update();
-		void Scroll(int distance_right, int distance_down);
-
 		struct Params {
 			std::string name;
 			bool scroll_horz;
@@ -633,7 +624,45 @@ namespace Game_Map {
 			bool scroll_vert_auto;
 			int scroll_vert_speed;
 		};
+
+		/**
+		 * The name of the current parallax graphic (or the empty string
+		 * if none).
+		 */
+		std::string GetName();
+
+		/**
+		 * Offset in pixels of the bitmap at the top-left of the screen.
+		 * (If the screen is shaking, at the top-left of where the screen
+		 * would be if it weren't.)
+		 */
+		int GetX();
+
+		/** Same a GetX(), but in the y-direction. */
+		int GetY();
+
+		/** Call this when you find out the width and height of the BG. */
+		void Initialize(int width, int height);
+
+		/** Reset the x- and y- position of the BG (eg. after a teleport). */
+		void ResetPosition();
+
+		/** Update autoscrolling BG (call every frame). */
+		void Update();
+
+		/**
+		 * Scrolls the BG by the correct amount when the screen scrolls
+		 * by the given distances.
+		 */
+		void Scroll(int distance_right, int distance_down);
+
+		/** Change BG (eg. with a "Change Parallax BG" command). */
 		void ChangeBG(const Params& params);
+
+		/**
+		 * Remove any changed BG. The BG goes back to what was set in
+		 * the map properties.
+		 */
 		void ClearChangedBG();
 	}
 }

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -622,6 +622,7 @@ namespace Game_Map {
 		void Initialize(int width, int height);
 		void ResetPosition();
 		void Update();
+		void Scroll(int distance_right, int distance_down);
 
 		struct Params {
 			std::string name;

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -534,14 +534,6 @@ namespace Game_Map {
 	int XwithDirection(int x, int direction);
 	int YwithDirection(int y, int direction);
 
-
-	void SetParallaxName(const std::string& name);
-	void SetParallaxScroll(bool horz, bool vert,
-						   bool horz_auto, bool vert_auto,
-						   int horz_speed, int vert_speed);
-	void SetParallaxSize(int width, int height);
-	void InitializeParallax();
-
 	/**
 	 * Gets the map index from MapInfo vector using map ID.
 	 *
@@ -603,11 +595,6 @@ namespace Game_Map {
 	int GetPanX();
 	int GetPanY();
 
-	void UpdateParallax();
-	int GetParallaxX();
-	int GetParallaxY();
-	const std::string& GetParallaxName();
-
 	/**
 	 * Gets if pending teleportations will be ignored.
 	 *
@@ -626,6 +613,28 @@ namespace Game_Map {
 	void SetTeleportDelayed(bool delay);
 
 	FileRequestAsync* RequestMap(int map_id);
+
+	namespace Parallax {
+		std::string GetName();
+		int GetX();
+		int GetY();
+
+		void Initialize(int width, int height);
+		void ResetPosition();
+		void Update();
+
+		struct Params {
+			std::string name;
+			bool scroll_horz;
+			bool scroll_horz_auto;
+			int scroll_horz_speed;
+			bool scroll_vert;
+			bool scroll_vert_auto;
+			int scroll_vert_speed;
+		};
+		void ChangeBG(const Params& params);
+		void ClearChangedBG();
+	}
 }
 
 #endif

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -295,7 +295,7 @@ void Game_Player::Center(int x, int y) {
 		Game_Map::SetPositionY(max(0, min((y * SCREEN_TILE_WIDTH - center_y), max_y)));
 	}
 
-	Game_Map::InitializeParallax();
+	Game_Map::Parallax::ResetPosition();
 }
 
 void Game_Player::MoveTo(int x, int y) {

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -84,16 +84,16 @@ void Spriteset_Map::Update() {
 		character_sprites[i]->Update();
 		character_sprites[i]->SetTone(new_tone);
 	}
-	const std::string& name = Game_Map::GetParallaxName();
+
+	std::string name = Game_Map::Parallax::GetName();
 	if (name != panorama_name) {
 		panorama_name = name;
 		FileRequestAsync* request = AsyncHandler::RequestFile("Panorama", panorama_name);
 		panorama_request_id = request->Bind(&Spriteset_Map::OnPanoramaSpriteReady, this);
 		request->Start();
 	}
-
-	panorama->SetOx(Game_Map::GetParallaxX());
-	panorama->SetOy(Game_Map::GetParallaxY());
+	panorama->SetOx(Game_Map::Parallax::GetX());
+	panorama->SetOy(Game_Map::Parallax::GetY());
 	panorama->SetTone(new_tone);
 
 	Game_Vehicle* vehicle;
@@ -173,9 +173,8 @@ void Spriteset_Map::OnTilemapSpriteReady(FileRequestResult*) {
 
 void Spriteset_Map::OnPanoramaSpriteReady(FileRequestResult* result) {
 	BitmapRef panorama_bmp = Cache::Panorama(result->file);
-	Game_Map::SetParallaxSize(panorama_bmp->GetWidth(), panorama_bmp->GetHeight());
 	panorama->SetBitmap(panorama_bmp);
-	Game_Map::InitializeParallax();
+	Game_Map::Parallax::Initialize(panorama_bmp->GetWidth(), panorama_bmp->GetHeight());
 
 	tilemap->SetFastBlitDown(false);
 }


### PR DESCRIPTION
The `parallax_*` values in the SaveMapInfo object are currently treated as "the current value of the parallax parameteres", but in RPG_RT they seem to be treated as an override, and the values in the map properties should be used if they aren't set. This PR implements this, which fixes #1071.

There's also a general refactor of the parallax handling into one namespace, more docs, and readability improvements for `Scroll{Left,Right,Up,Down}`.

