### PR TITLE
Fix regression when "Abort Battle" command is used and the Encounter-command has no handler

### DIFF
--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -287,8 +287,10 @@ bool Game_Interpreter_Map::ContinuationEnemyEncounter(RPG::EventCommand const& c
 		case 1:
 			return CommandEndEventProcessing(com);
 		case 2:
-			if (!SkipTo(Cmd::EscapeHandler, Cmd::EndBattle))
+			if (!SkipTo(Cmd::EscapeHandler, Cmd::EndBattle)) {
+				index++;
 				return false;
+			}
 			index++;
 			return true;
 		default:
@@ -299,16 +301,20 @@ bool Game_Interpreter_Map::ContinuationEnemyEncounter(RPG::EventCommand const& c
 		case 0:
 			return CommandGameOver(com);
 		case 1:
-			if (!SkipTo(Cmd::DefeatHandler, Cmd::EndBattle))
+			if (!SkipTo(Cmd::DefeatHandler, Cmd::EndBattle)) {
+				index++;
 				return false;
+			}
 			index++;
 			return true;
 		default:
 			return false;
 		}
 	case Game_Temp::BattleAbort:
-		if (!SkipTo(Cmd::EndBattle))
+		if (!SkipTo(Cmd::EndBattle)) {
+			index++;
 			return false;
+		}
 		index++;
 		return true;
 	default:


### PR DESCRIPTION
Reported by mail, fighting the woodchopper in eternal legends repeats endlessly.

This basicly means that the abort handling code in the interpreter was broken since years but was dead code until I fixed the abort case for huntress of the hollow :D

When "Abort Battle" is used and there is no other handler (Victory, Escape or Defeat) for the battle moving the interpreter to "End Battle" failed and the battle repeated. The interpreter is now advanced by one line when this happens.

Also fixed this for the defeat and the escape handler but here the bug is only possible through a malformed database because the "Execute handler" settings are part of the Enemy encounter dialog, so they are always generated when these options are on.

This fixes a regression introduced in commit 11246f2a