### PR TITLE
Implement Pre-Emptive attack for RM2k battle

### DIFF
--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -81,6 +81,7 @@ protected:
 	int select_target_flash_count = 0;
 	bool encounter_message_first_monster = true;
 	int encounter_message_sleep_until = -1;
+	bool encounter_message_first_strike = false;
 
 	bool begin_escape = true;
 	bool escape_success = false;


### PR DESCRIPTION
When starting a battle through an event command, the last checkbox (Preemptive Attack in official 2k translation, First Strike in Don’s) allows to prevent enemies from attacking during the first turn.

This didn’t seem to had been implemented, so I’ve added it.