### PR TITLE
Fix regression in horizontal scrolling introduced in 7f83a3bf

### DIFF
--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1432,7 +1432,7 @@ void Game_Map::Parallax::Scroll(int distance_right, int distance_down) {
 		parallax_x -=
 			std::min(
 				distance_right,
-				distance_right * (parallax_width - SCREEN_TARGET_HEIGHT) / (GetWidth() - 20) / (SCREEN_TILE_WIDTH / TILE_SIZE)
+				distance_right * (parallax_width - SCREEN_TARGET_WIDTH) / (GetWidth() - 20) / (SCREEN_TILE_WIDTH / TILE_SIZE)
 			);
 	}
 }


### PR DESCRIPTION
http://devopsreactions.tumblr.com/post/74372071314/the-code-refactoring-trap

Related #1147 (Note that the misalignment of the background on game start is not fixed by this - even exists in 0.5. What is fixed is the map after the tent-dialog-cutscene)

This also fixes the bugreport by Undertale and Earthbound lover in "Continue Stop Rise" (report was: some doors entrances are now in walls instand of the door)