### PR TITLE
Use hiragana and katakana only for Japanese games in hero name scene and support Hangul

### DIFF
--- a/src/scene_name.cpp
+++ b/src/scene_name.cpp
@@ -53,16 +53,16 @@ void Scene_Name::Update() {
 		if (name_window->Get().size() > 0) {
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cancel));
 			name_window->Erase();
-		}
-		else
+		} else {
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Buzzer));
+		}
 	} else if (Input::IsTriggered(Input::DECISION)) {
 		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 		std::string const& s = kbd_window->GetSelected();
 
 		assert(!s.empty());
 
-		if(s == Window_Keyboard::DONE || s == Window_Keyboard::DONE_JP) {
+		if (s == Window_Keyboard::DONE || s == Window_Keyboard::DONE_JP) {
 			Game_Temp::hero_name = name_window->Get();
 			Game_Actor* actor = Game_Actors::GetActor(Game_Temp::hero_name_id);
 			if (actor != NULL) {
@@ -74,15 +74,15 @@ void Scene_Name::Update() {
 					Scene::Pop();
 				}
 			}
-		} else if(s == Window_Keyboard::TO_SYMBOL) {
+		} else if (s == Window_Keyboard::TO_SYMBOL) {
 			kbd_window->SetMode(Window_Keyboard::Symbol);
-		} else if(s == Window_Keyboard::TO_LETTER) {
+		} else if (s == Window_Keyboard::TO_LETTER) {
 			kbd_window->SetMode(Window_Keyboard::Letter);
-		} else if(s == Window_Keyboard::TO_HIRAGANA) {
+		} else if (s == Window_Keyboard::TO_HIRAGANA) {
 			kbd_window->SetMode(Window_Keyboard::Hiragana);
-		} else if(s == Window_Keyboard::TO_KATAKANA) {
+		} else if (s == Window_Keyboard::TO_KATAKANA) {
 			kbd_window->SetMode(Window_Keyboard::Katakana);
-		} else if(s == Window_Keyboard::SPACE) {
+		} else if (s == Window_Keyboard::SPACE) {
 			name_window->Append(" ");
 		} else { name_window->Append(s); }
 	}

--- a/src/scene_name.cpp
+++ b/src/scene_name.cpp
@@ -15,14 +15,14 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Headers
+#include <cassert>
+
 #include "scene_name.h"
 #include "game_actors.h"
 #include "game_system.h"
 #include "game_temp.h"
 #include "input.h"
-
-#include <cassert>
+#include "player.h"
 
 Scene_Name::Scene_Name() {
 	Scene::type = Scene::Name;
@@ -40,7 +40,11 @@ void Scene_Name::Start() {
 	face_window->Refresh();
 
 	kbd_window.reset(new Window_Keyboard(32, 72, 256, (SCREEN_TARGET_WIDTH/2)));
-	kbd_window->SetMode(Window_Keyboard::Mode(Game_Temp::hero_name_charset));
+	if (Player::IsCP932()) {
+		kbd_window->SetMode(Window_Keyboard::Mode(Game_Temp::hero_name_charset));
+	} else {
+		kbd_window->SetMode(Window_Keyboard::Mode(Game_Temp::hero_name_charset + Window_Keyboard::Letter));
+	}
 	kbd_window->Refresh();
 	kbd_window->UpdateCursorRect();
 }

--- a/src/scene_name.cpp
+++ b/src/scene_name.cpp
@@ -40,8 +40,13 @@ void Scene_Name::Start() {
 	face_window->Refresh();
 
 	kbd_window.reset(new Window_Keyboard(32, 72, 256, (SCREEN_TARGET_WIDTH/2)));
+	// Japanese pages
 	if (Player::IsCP932()) {
 		kbd_window->SetMode(Window_Keyboard::Mode(Game_Temp::hero_name_charset));
+	// Korean pages
+	} else if (Player::IsCP949()) {
+		kbd_window->SetMode(Window_Keyboard::Mode(Game_Temp::hero_name_charset + Window_Keyboard::Hangul1));
+	// ASCII pages
 	} else {
 		kbd_window->SetMode(Window_Keyboard::Mode(Game_Temp::hero_name_charset + Window_Keyboard::Letter));
 	}
@@ -66,7 +71,8 @@ void Scene_Name::Update() {
 
 		assert(!s.empty());
 
-		if (s == Window_Keyboard::DONE || s == Window_Keyboard::DONE_JP) {
+		if (s == Window_Keyboard::DONE || s == Window_Keyboard::DONE_JP
+			|| s == Window_Keyboard::DONE_KO) {
 			Game_Temp::hero_name = name_window->Get();
 			Game_Actor* actor = Game_Actors::GetActor(Game_Temp::hero_name_id);
 			if (actor != NULL) {
@@ -86,6 +92,10 @@ void Scene_Name::Update() {
 			kbd_window->SetMode(Window_Keyboard::Hiragana);
 		} else if (s == Window_Keyboard::TO_KATAKANA) {
 			kbd_window->SetMode(Window_Keyboard::Katakana);
+		} else if (s == Window_Keyboard::TO_HANGUL_1) {
+			kbd_window->SetMode(Window_Keyboard::Hangul1);
+		} else if (s == Window_Keyboard::TO_HANGUL_2) {
+			kbd_window->SetMode(Window_Keyboard::Hangul2);
 		} else if (s == Window_Keyboard::SPACE) {
 			name_window->Append(" ");
 		} else { name_window->Append(s); }

--- a/src/scene_name.h
+++ b/src/scene_name.h
@@ -18,7 +18,6 @@
 #ifndef _SCENE_NAME_H_
 #define _SCENE_NAME_H_
 
-// Headers
 #include "scene.h"
 #include "window_name.h"
 #include "window_face.h"

--- a/src/window_keyboard.cpp
+++ b/src/window_keyboard.cpp
@@ -33,7 +33,7 @@ const char* const Window_Keyboard::TO_HIRAGANA = "<かな>";
 const char* const Window_Keyboard::DONE_JP = "<決定>";
 
 /*
- * hiragana -> katakana -> letter -> symbol -> hiragana -> ...
+ * hiragana <-> katakana; letter <-> symbol
  */
 
 std::string Window_Keyboard::items[Window_Keyboard::MODE_END][9][10] = {
@@ -58,7 +58,7 @@ std::string Window_Keyboard::items[Window_Keyboard::MODE_END][9][10] = {
 		{"ハ", "ヒ", "フ", "ヘ", "ホ", "ァ", "ィ", "ゥ", "ェ", "ォ"},
 		{"マ", "ミ", "ム", "メ", "モ", "ッ", "ャ", "ュ", "ョ", "ヮ"},
 		{"ヤ", "ユ", "ヨ", "ワ", "ン", "ー", "～", "・", "＝", "☆"},
-		{"ラ", "リ", "ル", "レ", "ロ", "ヲ", Window_Keyboard::TO_LETTER, "", Window_Keyboard::DONE_JP}
+		{"ラ", "リ", "ル", "レ", "ロ", "ヲ", Window_Keyboard::TO_HIRAGANA, "", Window_Keyboard::DONE_JP}
 	},
 
 	{ // Letter
@@ -82,7 +82,7 @@ std::string Window_Keyboard::items[Window_Keyboard::MODE_END][9][10] = {
 		{"$Z",  "" ,  "" ,  "" ,  "" , "$z"},
 		{},
 		{},
-		{ "" ,  "" ,  "" ,  "" ,  "" ,  "" , Window_Keyboard::TO_HIRAGANA, "", Window_Keyboard::DONE},
+		{ "" ,  "" ,  "" ,  "" ,  "" ,  "" , Window_Keyboard::TO_LETTER, "", Window_Keyboard::DONE},
 	},
 };
 

--- a/src/window_keyboard.cpp
+++ b/src/window_keyboard.cpp
@@ -32,8 +32,12 @@ const char* const Window_Keyboard::TO_KATAKANA = "<カナ>";
 const char* const Window_Keyboard::TO_HIRAGANA = "<かな>";
 const char* const Window_Keyboard::DONE_JP = "<決定>";
 
+const char* const Window_Keyboard::TO_HANGUL_1 = "<앞P>";
+const char* const Window_Keyboard::TO_HANGUL_2 = "<뒤P>";
+const char* const Window_Keyboard::DONE_KO = "<결정>";
+
 /*
- * hiragana <-> katakana; letter <-> symbol
+ * hiragana <-> katakana; hangul 1 <-> hangul 2; letter <-> symbol
  */
 
 std::string Window_Keyboard::items[Window_Keyboard::MODE_END][9][10] = {
@@ -59,6 +63,30 @@ std::string Window_Keyboard::items[Window_Keyboard::MODE_END][9][10] = {
 		{"マ", "ミ", "ム", "メ", "モ", "ッ", "ャ", "ュ", "ョ", "ヮ"},
 		{"ヤ", "ユ", "ヨ", "ワ", "ン", "ー", "～", "・", "＝", "☆"},
 		{"ラ", "リ", "ル", "レ", "ロ", "ヲ", Window_Keyboard::TO_HIRAGANA, "", Window_Keyboard::DONE_JP}
+	},
+
+	{ // Hangul 1
+		{"가", "갸", "거", "겨", "고", "교", "구", "계", "그", "기"},
+		{"나", "냐", "너", "녀", "노", "뇨", "누", "뉴", "느", "녹"},
+		{"다", "댜", "더", "뎌", "도", "됴", "두", "듀", "드", "디"},
+		{"라", "랴", "러", "려", "로", "료", "루", "류", "르", "리"},
+		{"마", "먀", "머", "며", "모", "묘", "무", "물", "므", "미"},
+		{"바", "뱌", "버", "벼", "보", "뵤", "부", "뷰", "비", "밤"},
+		{"사", "색", "서", "세", "소", "쇼", "수", "슈", "신", "심"},
+		{"아", "야", "어", "여", "오", "요", "우", "유", "으", "이"},
+		{"〜", "·", ".", "☆", Window_Keyboard::SPACE, "", Window_Keyboard::TO_HANGUL_2, "", Window_Keyboard::DONE_KO}
+	},
+
+	{ // Hangul 2
+		{"자", "쟈", "저", "져", "조", "죠", "주", "쥬", "즈", "지"},
+		{"차", "챠", "처", "쳐", "초", "쵸", "추", "츄", "츠", "치"},
+		{"카", "캬", "커", "켜", "코", "쿄", "쿠", "큐", "크", "키"},
+		{"타", "탸", "터", "텨", "토", "툐", "투", "튜", "트", "티"},
+		{"파", "퍄", "퍼", "펴", "포", "표", "푸", "퓨", "프", "피"},
+		{"하", "햐", "허", "혀", "호", "효", "후", "휴", "흐", "해"},
+		{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0"},
+		{"진", "녘", "의", "민", "예", "건", "현", "운", "걔", "임"},
+		{"영", "은", "성", "준", Window_Keyboard::SPACE, "", Window_Keyboard::TO_HANGUL_1, "", Window_Keyboard::DONE_KO}
 	},
 
 	{ // Letter

--- a/src/window_keyboard.cpp
+++ b/src/window_keyboard.cpp
@@ -15,7 +15,6 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Headers
 #include <string>
 
 #include "window_keyboard.h"
@@ -39,51 +38,51 @@ const char* const Window_Keyboard::DONE_JP = "<決定>";
 
 std::string Window_Keyboard::items[Window_Keyboard::MODE_END][9][10] = {
 	{ // Hiragana
-	{"あ","い","う","え","お","が","ぎ","ぐ","げ","ご"},
-	{"か","き","く","け","こ","ざ","じ","ず","ぜ","ぞ"},
-	{"さ","し","す","せ","そ","だ","ぢ","づ","で","ど"},
-	{"た","ち","つ","て","と","ば","び","ぶ","べ","ぼ"},
-	{"な","に","ぬ","ね","の","ぱ","ぴ","ぷ","ぺ","ぽ"},
-	{"は","ひ","ふ","へ","ほ","ぁ","ぃ","ぅ","ぇ","ぉ"},
-	{"ま","み","む","め","も","っ","ゃ","ゅ","ょ","ゎ"},
-	{"や","ゆ","よ","わ","ん","ー","～","・","＝","☆"},
-	{"ら","り","る","れ","ろ","を",Window_Keyboard::TO_KATAKANA,"",Window_Keyboard::DONE_JP}
+		{"あ", "い", "う", "え", "お", "が", "ぎ", "ぐ", "げ", "ご"},
+		{"か", "き", "く", "け", "こ", "ざ", "じ", "ず", "ぜ", "ぞ"},
+		{"さ", "し", "す", "せ", "そ", "だ", "ぢ", "づ", "で", "ど"},
+		{"た", "ち", "つ", "て", "と", "ば", "び", "ぶ", "べ", "ぼ"},
+		{"な", "に", "ぬ", "ね", "の", "ぱ", "ぴ", "ぷ", "ぺ", "ぽ"},
+		{"は", "ひ", "ふ", "へ", "ほ", "ぁ", "ぃ", "ぅ", "ぇ", "ぉ"},
+		{"ま", "み", "む", "め", "も", "っ", "ゃ", "ゅ", "ょ", "ゎ"},
+		{"や", "ゆ", "よ", "わ", "ん", "ー", "～", "・", "＝", "☆"},
+		{"ら", "り", "る", "れ", "ろ", "を", Window_Keyboard::TO_KATAKANA, "", Window_Keyboard::DONE_JP}
 	},
 
 	{ // Katakana
-	{"ア","イ","ウ","エ","オ","ガ","ギ","グ","ゲ","ゴ"},
-	{"カ","キ","ク","ケ","コ","ザ","ジ","ズ","ゼ","ゾ"},
-	{"サ","シ","ス","セ","ソ","ダ","ヂ","ヅ","デ","ド"},
-	{"タ","チ","ツ","テ","ト","バ","ビ","ブ","ベ","ボ"},
-	{"ナ","ニ","ヌ","ネ","ノ","パ","ピ","プ","ペ","ポ"},
-	{"ハ","ヒ","フ","ヘ","ホ","ァ","ィ","ゥ","ェ","ォ"},
-	{"マ","ミ","ム","メ","モ","ッ","ャ","ュ","ョ","ヮ"},
-	{"ヤ","ユ","ヨ","ワ","ン","ー","～","・","＝","☆"},
-	{"ラ","リ","ル","レ","ロ","ヲ",Window_Keyboard::TO_LETTER,"",Window_Keyboard::DONE_JP}
+		{"ア", "イ", "ウ", "エ", "オ", "ガ", "ギ", "グ", "ゲ", "ゴ"},
+		{"カ", "キ", "ク", "ケ", "コ", "ザ", "ジ", "ズ", "ゼ", "ゾ"},
+		{"サ", "シ", "ス", "セ", "ソ", "ダ", "ヂ", "ヅ", "デ", "ド"},
+		{"タ", "チ", "ツ", "テ", "ト", "バ", "ビ", "ブ", "ベ", "ボ"},
+		{"ナ", "ニ", "ヌ", "ネ", "ノ", "パ", "ピ", "プ", "ペ", "ポ"},
+		{"ハ", "ヒ", "フ", "ヘ", "ホ", "ァ", "ィ", "ゥ", "ェ", "ォ"},
+		{"マ", "ミ", "ム", "メ", "モ", "ッ", "ャ", "ュ", "ョ", "ヮ"},
+		{"ヤ", "ユ", "ヨ", "ワ", "ン", "ー", "～", "・", "＝", "☆"},
+		{"ラ", "リ", "ル", "レ", "ロ", "ヲ", Window_Keyboard::TO_LETTER, "", Window_Keyboard::DONE_JP}
 	},
 
 	{ // Letter
-	{"A","B","C","D","E","a","b","c","d","e"},
-	{"F","G","H","I","J","f","g","h","i","j"},
-	{"K","L","M","N","O","k","l","m","n","o"},
-	{"P","Q","R","S","T","p","q","r","s","t"},
-	{"U","V","W","X","Y","u","v","w","x","y"},
-	{"Z","" ,"" ,"" ,"" ,"z",},
-	{"0","1","2","3","4","5","6","7","8","9"},
-	{Window_Keyboard::SPACE},
-	{"","","","","","",Window_Keyboard::TO_SYMBOL,"",Window_Keyboard::DONE},
+		{"A", "B", "C", "D", "E", "a", "b", "c", "d", "e"},
+		{"F", "G", "H", "I", "J", "f", "g", "h", "i", "j"},
+		{"K", "L", "M", "N", "O", "k", "l", "m", "n", "o"},
+		{"P", "Q", "R", "S", "T", "p", "q", "r", "s", "t"},
+		{"U", "V", "W", "X", "Y", "u", "v", "w", "x", "y"},
+		{"Z", "" ,"" ,"" ,"" ,"z",},
+		{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},
+		{Window_Keyboard::SPACE},
+		{"" ,  "" ,  "" ,  "" ,  "" ,  "" , Window_Keyboard::TO_SYMBOL, "", Window_Keyboard::DONE},
 	},
 
 	{ // Symbol
-	{"$A","$B","$C","$D","$E","$a","$b","$c","$d","$e"},
-	{"$F","$G","$H","$I","$J","$f","$g","$h","$i","$j"},
-	{"$K","$L","$M","$N","$O","$k","$l","$m","$n","$o"},
-	{"$P","$Q","$R","$S","$T","$p","$q","$r","$s","$t"},
-	{"$U","$V","$W","$X","$Y","$u","$v","$w","$x","$y"},
-	{"$Z",""  ,""  ,""  ,""  ,"$z"},
-	{},
-	{},
-	{"","","","","","",Window_Keyboard::TO_HIRAGANA,"",Window_Keyboard::DONE},
+		{"$A", "$B", "$C", "$D", "$E", "$a", "$b", "$c", "$d", "$e"},
+		{"$F", "$G", "$H", "$I", "$J", "$f", "$g", "$h", "$i", "$j"},
+		{"$K", "$L", "$M", "$N", "$O", "$k", "$l", "$m", "$n", "$o"},
+		{"$P", "$Q", "$R", "$S", "$T", "$p", "$q", "$r", "$s", "$t"},
+		{"$U", "$V", "$W", "$X", "$Y", "$u", "$v", "$w", "$x", "$y"},
+		{"$Z",  "" ,  "" ,  "" ,  "" , "$z"},
+		{},
+		{},
+		{ "" ,  "" ,  "" ,  "" ,  "" ,  "" , Window_Keyboard::TO_HIRAGANA, "", Window_Keyboard::DONE},
 	},
 };
 
@@ -149,7 +148,7 @@ void Window_Keyboard::Update() {
 			play_cursor = true;
 			row = (row + 1) % row_max;
 
-			if(col > 0 && GetSelected().empty() && !items[mode][row][col - 1].empty()) {
+			if (col > 0 && GetSelected().empty() && !items[mode][row][col - 1].empty()) {
 				col--;
 			}
 		}
@@ -157,7 +156,7 @@ void Window_Keyboard::Update() {
 			play_cursor = true;
 			row = (row + row_max - 1) % row_max;
 
-			if(col > 0 && GetSelected().empty() && !items[mode][row][col - 1].empty()) {
+			if (col > 0 && GetSelected().empty() && !items[mode][row][col - 1].empty()) {
 				col--;
 			}
 		}
@@ -166,7 +165,7 @@ void Window_Keyboard::Update() {
 			col += 1;
 			if (col >= col_max) {
 				col = 0;
-				if(mode == Letter) { row = (row + 1) % row_max; }
+				if (mode == Letter) { row = (row + 1) % row_max; }
 			}
 		}
 		if (Input::IsRepeated(Input::LEFT)) {
@@ -174,18 +173,18 @@ void Window_Keyboard::Update() {
 			col -= 1;
 			if (col < 0) {
 				col = col_max - 1;
-				if(mode == Letter) { row = (row + row_max - 1) % row_max; }
+				if (mode == Letter) { row = (row + row_max - 1) % row_max; }
 			}
 		}
 
 	}
 
-	if(GetSelected().empty()) {
+	if (GetSelected().empty()) {
 		Update();
 		return;
 	}
 
-	if(play_cursor) {
+	if (play_cursor) {
 		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cursor));
 		play_cursor = false;
 	}

--- a/src/window_keyboard.h
+++ b/src/window_keyboard.h
@@ -39,9 +39,11 @@ public:
 	enum Mode {
 		Hiragana = 0,
 		Katakana = 1,
-		Letter = 2,
-		Symbol = 3,
-		MODE_END = 4
+		Hangul1 = 2,
+		Hangul2 = 3,
+		Letter = 4,
+		Symbol = 5,
+		MODE_END = 6
 	};
 
 	void UpdateCursorRect();
@@ -59,6 +61,10 @@ public:
 	static const char* const TO_KATAKANA;
 	static const char* const TO_HIRAGANA;
 	static const char* const DONE_JP;
+
+	static const char* const TO_HANGUL_1;
+	static const char* const TO_HANGUL_2;
+	static const char* const DONE_KO;
 
 protected:
 	static const int border_x = 8;

--- a/src/window_keyboard.h
+++ b/src/window_keyboard.h
@@ -18,7 +18,6 @@
 #ifndef _WINDOW_KEYBOARD_H_
 #define _WINDOW_KEYBOARD_H_
 
-// Headers
 #include "window_base.h"
 
 /**


### PR DESCRIPTION
This is a workaround which fixes #364.

The proposed approach displays hiragana and katakana for CP932 games and basic latin and symbols for the rest of encodings. Japanese games lose access to the symbol table, but original RPG_RT also does not support this.

This also adds limited Hangul script to the scene.