### PR TITLE
Removed useless delay thread call in renderer thd.

### DIFF
--- a/src/psp2_ui.cpp
+++ b/src/psp2_ui.cpp
@@ -116,8 +116,6 @@ static int renderThread(unsigned int args, void* arg){
 		vita2d_wait_rendering_done();
 		vita2d_swap_buffers();
 		sceKernelSignalSema(GPU_Cleanup_Mutex, 1);
-		
-		sceKernelDelayThread(1000);
 	
 	}
 	


### PR DESCRIPTION
Such call is completely useless since rescheduling is already performed with sceKernelWaitSema calls and produces unnecessary slowdowns in the renderer thread.