### PR TITLE
Add opus support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(PLAYER_SRCS
 	src/decoder_libsndfile.cpp
 	src/decoder_mpg123.cpp
 	src/decoder_oggvorbis.cpp
+	src/decoder_opus.cpp
 	src/decoder_wav.cpp
 	src/decoder_wildmidi.cpp
 	src/decoder_xmp.cpp
@@ -227,7 +228,7 @@ if(PLAYER_BUILD_LIBLCF)
 	set(LIBLCF_PATH "${CMAKE_CURRENT_SOURCE_DIR}/lib/liblcf")
 	find_package(Git REQUIRED)
 	if(NOT EXISTS ${LIBLCF_PATH})
-	execute_process(COMMAND ${GIT_EXECUTABLE} clone "--depth=1" 
+	execute_process(COMMAND ${GIT_EXECUTABLE} clone "--depth=1"
 		"${PLAYER_BUILD_LIBLCF_GIT}"
 		"${LIBLCF_PATH}")
 	endif()
@@ -357,13 +358,20 @@ if(${PLAYER_AUDIO_BACKEND} MATCHES "^SDL.*$")
 		add_definitions(-DHAVE_LIBSNDFILE)
 	endif()
 	
-	# libogg
-	option(PLAYER_WITH_OGGVORBIS "Play OGG audio with libogg." ON)	
+	# libvorbis
+	option(PLAYER_WITH_OGGVORBIS "Play Ogg Vorbis audio with libvorbis." ON)
 	find_lib("OggVorbis" PLAYER_WITH_OGGVORBIS)
 	if(OggVorbis_FOUND)
 		add_definitions(-DHAVE_OGGVORBIS)
 	endif()
-	
+
+	# opusfile
+	option(PLAYER_WITH_OPUS "Play Opus audio with opusfile." ON)
+	find_lib("Opus" PLAYER_WITH_OPUS)
+	if(Opus_FOUND)
+		add_definitions(-DHAVE_OPUS)
+	endif()
+
 	# xmp (lite)
 	option(PLAYER_WITH_XMP "Play MOD audio with libxmp." ON)
 	find_lib("XMP" PLAYER_WITH_XMP)
@@ -400,11 +408,11 @@ set(EXE_FILES "src/main.cpp")
 
 # Add prefix (CMAKE_CURRENT_SOURCE_DIR) to list elements
 FUNCTION(PREPEND var prefix)
-   SET(listVar "")
-   FOREACH(f ${ARGN})
-      LIST(APPEND listVar "${prefix}/${f}")
-   ENDFOREACH(f)
-   SET(${var} "${listVar}" PARENT_SCOPE)
+	SET(listVar "")
+	FOREACH(f ${ARGN})
+		LIST(APPEND listVar "${prefix}/${f}")
+	ENDFOREACH(f)
+	SET(${var} "${listVar}" PARENT_SCOPE)
 ENDFUNCTION(PREPEND)
 
 PREPEND(PLAYER_SRCS ${CMAKE_CURRENT_SOURCE_DIR} ${PLAYER_SRCS})
@@ -518,7 +526,7 @@ endif()
 message(STATUS "Audio backend: ${PLAYER_AUDIO_BACKEND}")
 if(${PLAYER_AUDIO_BACKEND} MATCHES "^SDL2.*$")
 	message(STATUS "")
-	
+
 	if(SndFile_FOUND)
 		message(STATUS "WAV playback:  libsndfile")
 	else()
@@ -543,7 +551,7 @@ if(${PLAYER_AUDIO_BACKEND} MATCHES "^SDL2.*$")
 			message(STATUS "MIDI playback: None")
 		endif()
 	endif()
-	
+
 	if(mpg123_FOUND)
 		message(STATUS "MP3 playback:  mpg123")
 	elseif(SDL2_mixer_FOUND)
@@ -552,16 +560,16 @@ if(${PLAYER_AUDIO_BACKEND} MATCHES "^SDL2.*$")
 	else()
 		message(STATUS "MP3 playback:  None")
 	endif()
-	
+
 	if(OggVorbis_FOUND)
-		message(STATUS "OGG playback:  libogg")
+		message(STATUS "Ogg Vorbis playback: libvorbis")
 	elseif(SDL2_mixer_FOUND)
 		set(SDL_MIXER_USED ON)
-		message(STATUS "OGG playback:  SDL2_mixer")
+		message(STATUS "Ogg Vorbis playback: SDL2_mixer")
 	else()
-		message(STATUS "OGG playback:  None")
+		message(STATUS "Ogg Vorbis playback: None")
 	endif()
-	
+
 	if(XMP_FOUND)
 		message(STATUS "MOD playback:  libxmp")
 	elseif(SDL2_mixer_FOUND)
@@ -570,7 +578,13 @@ if(${PLAYER_AUDIO_BACKEND} MATCHES "^SDL2.*$")
 	else()
 		message(STATUS "MOD playback:  None")
 	endif()
-	
+
+	if(Opus_FOUND)
+		message(STATUS "Opus playback: opusfile")
+	else()
+		message(STATUS "Opus playback: None")
+	endif()
+
 	if(speexdsp_FOUND)
 		message(STATUS "Resampler:     speexdsp")
 	elseif(SDL2_mixer_FOUND)
@@ -579,7 +593,7 @@ if(${PLAYER_AUDIO_BACKEND} MATCHES "^SDL2.*$")
 	else()
 		message(STATUS "Resampler:     None")
 	endif()
-	
+
 	if(SDL_MIXER_USED)
 		message(STATUS "")
 		message(STATUS "WARNING:")

--- a/Makefile.am
+++ b/Makefile.am
@@ -41,10 +41,12 @@ libeasyrpg_player_la_SOURCES = \
 	src/color.h \
 	src/decoder_libsndfile.cpp \
 	src/decoder_libsndfile.h \
-	src/decoder_oggvorbis.cpp \
-	src/decoder_oggvorbis.h \
 	src/decoder_mpg123.cpp \
 	src/decoder_mpg123.h \
+	src/decoder_oggvorbis.cpp \
+	src/decoder_oggvorbis.h \
+	src/decoder_opus.cpp \
+	src/decoder_opus.h \
 	src/decoder_fmmidi.cpp \
 	src/decoder_fmmidi.h \
 	src/decoder_wav.cpp \
@@ -350,6 +352,7 @@ libeasyrpg_player_la_CXXFLAGS = \
 	$(MPG123_CFLAGS) \
 	$(WILDMIDI_CFLAGS) \
 	$(OGGVORBIS_CFLAGS) \
+	$(OPUS_CFLAGS) \
 	$(SNDFILE_CFLAGS) \
 	$(XMP_CFLAGS) \
 	$(SPEEXDSP_CFLAGS)
@@ -365,6 +368,7 @@ libeasyrpg_player_la_LIBADD = \
 	$(MPG123_LIBS) \
 	$(WILDMIDI_LIBS) \
 	$(OGGVORBIS_LIBS) \
+	$(OPUS_LIBS) \
 	$(SNDFILE_LIBS) \
 	$(XMP_LIBS) \
 	$(SPEEXDSP_LIBS)

--- a/README.md
+++ b/README.md
@@ -27,14 +27,17 @@ Documentation is available at the documentation wiki: https://wiki.easyrpg.org
 - FreeType2 for external font support (+ HarfBuzz for Unicode text shaping)
 - mpg123 for better MP3 audio support
 - WildMIDI for better MIDI audio support
-- Ogg+Vorbis/Tremor for OGG audio support
+- Libvorbis / Tremor for Ogg Vorbis audio support
+- opusfile for Opus audio support
 - libsndfile for better WAVE audio support
+- libxmp for better tracker music support
 - SpeexDSP for proper audio resampling
 - SDL2_mixer for audio mixing. Used as a fallback when none of the provided
   audio libraries support the format. Due to API limitations not all audio
   effects are possible through SDL2_mixer audio.
 
-SDL and SDL_mixer 1.2 are still supported, but deprecated.
+SDL 1.2 and SDL_mixer 1.2 are still supported, but deprecated.
+
 
 ## Daily builds
 
@@ -151,6 +154,7 @@ Available options:
 
 EasyRPG Player is free software available under the GPLv3 license. See the file
 COPYING for license conditions.
+
 
 ### 3rd party software
 

--- a/builds/cmake/Modules/FindOpus.cmake
+++ b/builds/cmake/Modules/FindOpus.cmake
@@ -1,0 +1,13 @@
+find_path(OPUS_INCLUDE_DIR_INTERNAL opus/opusfile.h)
+find_library(OPUS_LIBRARY NAMES opusfile libopusfile)
+if(EXISTS "${OPUS_INCLUDE_DIR_INTERNAL}")
+  set(OPUS_INCLUDE_DIR "${OPUS_INCLUDE_DIR_INTERNAL}/opus")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Opus DEFAULT_MSG OPUS_INCLUDE_DIR OPUS_LIBRARY)
+
+set(OPUS_INCLUDE_DIRS ${OPUS_INCLUDE_DIR})
+set(OPUS_LIBRARIES ${OPUS_LIBRARY})
+
+mark_as_advanced(OPUS_INCLUDE_DIR OPUS_LIBRARY)

--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,11 @@ AC_ARG_WITH([oggvorbis],[AS_HELP_STRING([--without-oggvorbis],
 AS_IF([test "x$with_oggvorbis" != "xno"],[
 	PKG_CHECK_MODULES([OGGVORBIS],[vorbisfile],[AC_DEFINE(HAVE_OGGVORBIS,[1],[Enable Ogg Vorbis support])],[auto_oggvorbis=0])
 ])
+AC_ARG_WITH([opus],[AS_HELP_STRING([--without-opus],
+	[Disable Opus support @<:@default=auto@:>@])])
+AS_IF([test "x$with_opus" != "xno"],[
+	PKG_CHECK_MODULES([OPUS],[opusfile],[AC_DEFINE(HAVE_OPUS,[1],[Enable Opus support])],[auto_opus=0])
+])
 AC_ARG_WITH([libsndfile],[AS_HELP_STRING([--without-libsndfile],
 	[Disable improved WAV support provided by libsndfile.  @<:@default=auto@:>@])])
 AS_IF([test "x$with_libsndfile" != "xno"],[

--- a/src/decoder_opus.cpp
+++ b/src/decoder_opus.cpp
@@ -1,0 +1,103 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "system.h"
+
+#ifdef HAVE_OPUS
+
+#include <opus/opusfile.h>
+#include "audio_decoder.h"
+#include "decoder_opus.h"
+#include "output.h"
+
+static int custom_read(void *stream, unsigned char *ptr, int nbytes) {
+	FILE* f = reinterpret_cast<FILE*>(stream);
+	return fread(ptr, 1, nbytes, f);
+}
+
+OpusDecoder::OpusDecoder() {
+	music_type = "opus";
+}
+
+OpusDecoder::~OpusDecoder() {
+	if (oof) {
+		op_free(oof);
+	}
+}
+
+bool OpusDecoder::Open(FILE* file) {
+	finished = false;
+
+	int res;
+	OpusFileCallbacks callbacks = {custom_read, nullptr, nullptr, nullptr};
+
+	oof = op_open_callbacks(file, &callbacks, nullptr, 0, &res);
+	if (res != 0) {
+		error_message = "Opus: Error reading file";
+		op_free(oof);
+		fclose(file);
+		return false;
+	}
+
+	return true;
+}
+
+bool OpusDecoder::Seek(size_t offset, Origin origin) {
+	if (offset == 0 && origin == Origin::Begin) {
+		if (oof) {
+			op_raw_seek(oof, 0);
+		}
+		finished = false;
+		return true;
+	}
+
+	return false;
+}
+
+bool OpusDecoder::IsFinished() const {
+	if (!oof)
+		return false;
+
+	return finished;
+}
+
+void OpusDecoder::GetFormat(int& freq, AudioDecoder::Format& format, int& chans) const {
+	freq = frequency;
+	format = Format::S16;
+	chans = channels;
+}
+
+bool OpusDecoder::SetFormat(int freq, AudioDecoder::Format format, int chans) {
+	if (freq != frequency || chans != channels || format != Format::S16)
+		return false;
+
+	return true;
+}
+
+int OpusDecoder::FillBuffer(uint8_t* buffer, int length) {
+	if (!oof)
+		return -1;
+
+	int ret = op_read_stereo(oof, reinterpret_cast<opus_int16*>(buffer), length / 2);
+
+	if (ret < 0)
+		return ret;
+
+	return ret * 4;
+}
+
+#endif

--- a/src/decoder_opus.h
+++ b/src/decoder_opus.h
@@ -1,0 +1,56 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EASYRPG_AUDIO_DECODER_OPUS_H
+#define EASYRPG_AUDIO_DECODER_OPUS_H
+
+#ifdef HAVE_OPUS
+#include <opus/opusfile.h>
+#endif
+#include "audio_decoder.h"
+
+/**
+ * Audio decoder for Opus powered by opusfile
+ */
+class OpusDecoder : public AudioDecoder {
+public:
+	OpusDecoder();
+
+	~OpusDecoder();
+
+	// Audio Decoder interface
+	bool Open(FILE* file) override;
+
+	bool Seek(size_t offset, Origin origin) override;
+
+	bool IsFinished() const override;
+
+	void GetFormat(int& frequency, AudioDecoder::Format& format, int& channels) const override;
+
+	bool SetFormat(int frequency, AudioDecoder::Format format, int channels) override;
+private:
+	int FillBuffer(uint8_t* buffer, int length) override;
+
+#ifdef HAVE_OPUS
+	OggOpusFile* oof;
+#endif
+	bool finished = false;
+	int frequency = 48000;
+	int channels = 2;
+};
+
+#endif

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -637,7 +637,7 @@ std::string FileFinder::FindMusic(const std::string& name) {
 #endif
 
 	static const char* MUSIC_TYPES[] = {
-		".ogg", ".wav", ".mid", ".midi", ".mp3", ".wma", nullptr };
+		".opus", ".oga", ".ogg", ".wav", ".mid", ".midi", ".mp3", ".wma", nullptr };
 	return FindFile("Music", name, MUSIC_TYPES);
 }
 
@@ -647,7 +647,7 @@ std::string FileFinder::FindSound(const std::string& name) {
 #endif
 
 	static const char* SOUND_TYPES[] = {
-		".ogg", ".wav", ".mp3", ".wma", nullptr };
+		".opus", ".oga", ".ogg", ".wav", ".mp3", ".wma", nullptr };
 	return FindFile("Sound", name, SOUND_TYPES);
 }
 


### PR DESCRIPTION
This tries to add Opus decoder support to Player (fix #1159).

The FillBuffer code is probably wrong currently. There are no crashes with current settings here so far.

It currently does some minor buffer related noise, I guess it gets unhappy with the resampler buffering mechanism, somewhere the buffer may be too tight or some delay involved in underruns.

Amendments to this PR are totally welcome.