### PR TITLE
Support RM2k v.1.61 (placeholders and word-wrapping)

### DIFF
--- a/resources/easyrpg-player.6.adoc
+++ b/resources/easyrpg-player.6.adoc
@@ -38,7 +38,7 @@ for some additional binary patches.
   Disable auto detection of the simulated engine. Possible options:
    - 'rpg2k'      - RPG Maker 2000 engine (v1.00 - v1.10)
    - 'rpg2kv150'  - RPG Maker 2000 engine (v1.50 - v1.51)
-   - 'rpg2kv161'  - RPG Maker 2000 (English release) engine (v1.61)
+   - 'rpg2ke'     - RPG Maker 2000 (English release) engine (v1.61)
    - 'rpg2k3'     - RPG Maker 2003 engine (v1.00 - v1.04)
    - 'rpg2k3v105' - RPG Maker 2003 engine (v1.05 - v1.09a)
    - 'rpg2k3e'    - RPG Maker 2003 (English release) engine

--- a/resources/easyrpg-player.6.adoc
+++ b/resources/easyrpg-player.6.adoc
@@ -38,6 +38,7 @@ for some additional binary patches.
   Disable auto detection of the simulated engine. Possible options:
    - 'rpg2k'      - RPG Maker 2000 engine (v1.00 - v1.10)
    - 'rpg2kv150'  - RPG Maker 2000 engine (v1.50 - v1.51)
+   - 'rpg2kv161'  - RPG Maker 2000 (English release) engine (v1.61)
    - 'rpg2k3'     - RPG Maker 2003 engine (v1.00 - v1.04)
    - 'rpg2k3v105' - RPG Maker 2003 engine (v1.05 - v1.09a)
    - 'rpg2k3e'    - RPG Maker 2003 (English release) engine

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -23,6 +23,7 @@
 #include <vector>
 #include <stdint.h>
 #include "rpg_saveactor.h"
+#include "rpg_learning.h"
 #include "game_battler.h"
 
 namespace RPG {
@@ -735,6 +736,9 @@ public:
 
 	int GetHitChance() const override;
 	float GetCriticalHitChance() const override;
+
+	std::string GetLevelUpMessage(int new_level) const;
+	std::string GetLearningMessage(const RPG::Learning& learn) const;
 
 	BattlerType GetType() const override;
 private:

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -302,6 +302,39 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetHpSpAbsorbedMessage(int valu
 	}
 }
 
+std::string Game_BattleAlgorithm::AlgorithmBase::GetDamagedMessage() const {
+	bool target_is_ally = (GetTarget()->GetType() ==
+			Game_Battler::Type_Ally);
+	const std::string& message = target_is_ally ?
+		Data::terms.actor_damaged :
+		Data::terms.enemy_damaged;
+	int value = GetAffectedHp();
+
+	std::stringstream ss;
+
+	if (Player::IsRPG2kE()) {
+		ss << value;
+		return Utils::ReplacePlaceholders(
+			message,
+			{'S', 'V', 'U'},
+			{GetTarget()->GetName(), ss.str(), Data::terms.health_points}
+		);
+	}
+	else {
+		std::string particle, space = "";
+		ss << GetTarget()->GetName();
+
+		if (Player::IsCP932()) {
+			particle = (target_is_ally ? "は " : "に ");
+			space += " ";
+		} else {
+			particle = " ";
+		}
+		ss << particle << value << space << message;
+		return ss.str();
+	}
+}
+
 void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::string>& out) const {
 	if (current_target == targets.end()) {
 		return;
@@ -333,22 +366,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 					out.push_back(GetHpSpAbsorbedMessage(GetAffectedHp(), Data::terms.health_points));
 				}
 				else {
-					std::stringstream ss;
-					std::string particle, particle2, space = "";
-
-					ss << GetTarget()->GetName();
-
-					if (Player::IsCP932()) {
-						particle = (target_is_ally ? "は " : "に ");
-						space += " ";
-					} else {
-						particle = " ";
-					}
-					ss << particle << GetAffectedHp() << space;
-					ss << (target_is_ally ?
-						Data::terms.actor_damaged :
-						Data::terms.enemy_damaged);
-					out.push_back(ss.str());
+					out.push_back(GetDamagedMessage());
 				}
 			}
 		}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1302,7 +1302,14 @@ Game_BattleAlgorithm::Defend::Defend(Game_Battler* source) :
 }
 
 std::string Game_BattleAlgorithm::Defend::GetStartMessage() const {
-	if (Player::IsRPG2k()) {
+	if (Player::IsRPG2kE()) {
+		return Utils::ReplacePlaceholders(
+			Data::terms.defending,
+			{'S'},
+			{source->GetName()}
+		);
+	}
+	else if (Player::IsRPG2k()) {
 		return source->GetName() + Data::terms.defending;
 	}
 	else {
@@ -1328,7 +1335,14 @@ AlgorithmBase(source) {
 }
 
 std::string Game_BattleAlgorithm::Observe::GetStartMessage() const {
-	if (Player::IsRPG2k()) {
+	if (Player::IsRPG2kE()) {
+		return Utils::ReplacePlaceholders(
+			Data::terms.observing,
+			{'S'},
+			{source->GetName()}
+		);
+	}
+	else if (Player::IsRPG2k()) {
 		return source->GetName() + Data::terms.observing;
 	}
 	else {
@@ -1347,7 +1361,14 @@ AlgorithmBase(source) {
 }
 
 std::string Game_BattleAlgorithm::Charge::GetStartMessage() const {
-	if (Player::IsRPG2k()) {
+	if (Player::IsRPG2kE()) {
+		return Utils::ReplacePlaceholders(
+			Data::terms.focus,
+			{'S'},
+			{source->GetName()}
+		);
+	}
+	else if (Player::IsRPG2k()) {
 		return source->GetName() + Data::terms.focus;
 	}
 	else {
@@ -1369,7 +1390,14 @@ AlgorithmBase(source, target) {
 }
 
 std::string Game_BattleAlgorithm::SelfDestruct::GetStartMessage() const {
-	if (Player::IsRPG2k()) {
+	if (Player::IsRPG2kE()) {
+		return Utils::ReplacePlaceholders(
+			Data::terms.autodestruction,
+			{'S'},
+			{source->GetName()}
+		);
+	}
+	else if (Player::IsRPG2k()) {
 		return source->GetName() + Data::terms.autodestruction;
 	}
 	else {
@@ -1431,9 +1459,15 @@ Game_BattleAlgorithm::Escape::Escape(Game_Battler* source) :
 }
 
 std::string Game_BattleAlgorithm::Escape::GetStartMessage() const {
-	if (Player::IsRPG2k()) {
-		// Only monsters can escape during a battle phase
-
+	// Only monsters can escape during a battle phase
+	if (Player::IsRPG2kE()) {
+		return Utils::ReplacePlaceholders(
+			Data::terms.enemy_escape,
+			{'S'},
+			{source->GetName()}
+		);
+	}
+	else if (Player::IsRPG2k()) {
 		if (source->GetType() == Game_Battler::Type_Enemy) {
 			return source->GetName() + Data::terms.enemy_escape;
 		}
@@ -1513,7 +1547,14 @@ AlgorithmBase(source), new_monster_id(new_monster_id) {
 }
 
 std::string Game_BattleAlgorithm::Transform::GetStartMessage() const {
-	if (Player::IsRPG2k()) {
+	if (Player::IsRPG2kE()) {
+		return Utils::ReplacePlaceholders(
+			Data::terms.enemy_transform,
+			{'S', 'O'},
+			{source->GetName(), Data::enemies[new_monster_id - 1].name}
+		);
+	}
+	else if (Player::IsRPG2k()) {
 		return source->GetName() + Data::terms.enemy_transform;
 	}
 	else {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -335,6 +335,40 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetDamagedMessage() const {
 	}
 }
 
+
+std::string Game_BattleAlgorithm::AlgorithmBase::GetParameterChangeMessage(bool is_positive, int value, const std::string& points) const {
+	const std::string& message = is_positive ?
+		Data::terms.parameter_increase :
+		Data::terms.parameter_decrease;
+	std::stringstream ss;
+
+	if (Player::IsRPG2kE()) {
+		ss << value;
+		return Utils::ReplacePlaceholders(
+			message,
+			{'S', 'V', 'U'},
+			{GetTarget()->GetName(), ss.str(), points}
+		);
+	}
+	else {
+		std::string particle, particle2, space = "";
+		ss << GetTarget()->GetName();
+
+		if (Player::IsCP932()) {
+			particle = "の";
+			particle2 = "が ";
+			space += " ";
+		}
+		else {
+			particle = particle2 = " ";
+		}
+		ss << particle << points << particle2 << value << space;
+		ss << message;
+
+		return ss.str();
+	}
+}
+
 void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::string>& out) const {
 	if (current_target == targets.end()) {
 		return;
@@ -381,92 +415,25 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 				out.push_back(GetHpSpAbsorbedMessage(GetAffectedSp(), Data::terms.spirit_points));
 			}
 			else {
-				std::string particle, particle2, space = "";
-				std::stringstream ss;
-				ss << GetTarget()->GetName();
-
-				if (Player::IsCP932()) {
-					particle = "の";
-					particle2 = "が ";
-					space += " ";
-				}
-				else {
-					particle = particle2 = " ";
-				}
-				ss << particle << Data::terms.spirit_points << particle2;
-				ss << GetAffectedSp() << space << Data::terms.parameter_decrease;
-
-				out.push_back(ss.str());
+				out.push_back(GetParameterChangeMessage(false, GetAffectedSp(), Data::terms.spirit_points));
 			}
 		}
 	}
 
 	if (GetAffectedAttack() != -1) {
-		std::string particle, particle2, space = "";
-		std::stringstream ss;
-		ss << GetTarget()->GetName();
-		if (Player::IsCP932()) {
-			particle = "の";
-			particle2 = "が ";
-			space += " ";
-		}
-		else {
-			particle = particle2 = " ";
-		}
-		ss << particle << Data::terms.attack << particle2 << GetAffectedAttack() << space;
-		ss << (IsPositive() ? Data::terms.parameter_increase : Data::terms.parameter_decrease);
-		out.push_back(ss.str());
+		out.push_back(GetParameterChangeMessage(IsPositive(), GetAffectedAttack(), Data::terms.attack));
 	}
 
 	if (GetAffectedDefense() != -1) {
-		std::string particle, particle2, space = "";
-		std::stringstream ss;
-		ss << GetTarget()->GetName();
-		if (Player::IsCP932()) {
-			particle = "の";
-			particle2 = "が ";
-			space += " ";
-		}
-		else {
-			particle = particle2 = " ";
-		}
-		ss << particle << Data::terms.defense << particle2 << GetAffectedDefense() << space;
-		ss << (IsPositive() ? Data::terms.parameter_increase : Data::terms.parameter_decrease);
-		out.push_back(ss.str());
+		out.push_back(GetParameterChangeMessage(IsPositive(), GetAffectedDefense(), Data::terms.defense));
 	}
 
 	if (GetAffectedSpirit() != -1) {
-		std::string particle, particle2, space = "";
-		std::stringstream ss;
-		ss << GetTarget()->GetName();
-		if (Player::IsCP932()) {
-			particle = "の";
-			particle2 = "が ";
-			space += " ";
-		}
-		else {
-			particle = particle2 = " ";
-		}
-		ss << particle << Data::terms.spirit << particle2 << GetAffectedSpirit() << space;
-		ss << (IsPositive() ? Data::terms.parameter_increase : Data::terms.parameter_decrease);
-		out.push_back(ss.str());
+		out.push_back(GetParameterChangeMessage(IsPositive(), GetAffectedSpirit(), Data::terms.spirit));
 	}
 
 	if (GetAffectedAgility() != -1) {
-		std::string particle, particle2, space = "";
-		std::stringstream ss;
-		ss << GetTarget()->GetName();
-		if (Player::IsCP932()) {
-			particle = "の";
-			particle2 = "が ";
-			space += " ";
-		}
-		else {
-			particle = particle2 = " ";
-		}
-		ss << particle << Data::terms.agility << particle2 << GetAffectedAgility() << space;
-		ss << (IsPositive() ? Data::terms.parameter_increase : Data::terms.parameter_decrease);
-		out.push_back(ss.str());
+		out.push_back(GetParameterChangeMessage(IsPositive(), GetAffectedAgility(), Data::terms.agility));
 	}
 
 	std::vector<RPG::State>::const_iterator it = conditions.begin();

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -198,8 +198,7 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetDodgeMessage() const {
 	}
 }
 
-std::string Game_BattleAlgorithm::AlgorithmBase::GetHPMPRecoveredMessage(int value, const std::string& points) const {
-	std::string particle, particle2, space = "";
+std::string Game_BattleAlgorithm::AlgorithmBase::GetHpSpRecoveredMessage(int value, const std::string& points) const {
 	std::stringstream ss;
 
 	if (Player::IsRPG2kE()) {
@@ -211,6 +210,8 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetHPMPRecoveredMessage(int val
 		);
 	}
 	else {
+		std::string particle, particle2, space = "";
+
 		ss << GetTarget()->GetName();
 		if (Player::IsCP932()) {
 			particle = "の";
@@ -266,7 +267,7 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetCriticalHitMessage() const {
 }
 
 
-std::string Game_BattleAlgorithm::AlgorithmBase::GetHPMPAbsorbedMessage(int value, const std::string& points) const {
+std::string Game_BattleAlgorithm::AlgorithmBase::GetHpSpAbsorbedMessage(int value, const std::string& points) const {
 	bool target_is_ally = (GetTarget()->GetType() ==
 			Game_Battler::Type_Ally);
 	const std::string& message = target_is_ally ?
@@ -316,7 +317,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 
 		if (IsPositive()) {
 			if (!GetTarget()->IsDead()) {
-				out.push_back(GetHPMPRecoveredMessage(GetAffectedHp(), Data::terms.health_points));
+				out.push_back(GetHpSpRecoveredMessage(GetAffectedHp(), Data::terms.health_points));
 			}
 		}
 		else {
@@ -329,7 +330,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 			}
 			else {
 				if (absorb) {
-					out.push_back(GetHPMPAbsorbedMessage(GetAffectedHp(), Data::terms.health_points));
+					out.push_back(GetHpSpAbsorbedMessage(GetAffectedHp(), Data::terms.health_points));
 				}
 				else {
 					std::stringstream ss;
@@ -355,11 +356,11 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 
 	if (GetAffectedSp() != -1) {
 		if (IsPositive()) {
-			out.push_back(GetHPMPRecoveredMessage(GetAffectedSp(), Data::terms.spirit_points));
+			out.push_back(GetHpSpRecoveredMessage(GetAffectedSp(), Data::terms.spirit_points));
 		}
 		else {
 			if (absorb) {
-				out.push_back(GetHPMPAbsorbedMessage(GetAffectedSp(), Data::terms.spirit_points));
+				out.push_back(GetHpSpAbsorbedMessage(GetAffectedSp(), Data::terms.spirit_points));
 			}
 			else {
 				std::string particle, particle2, space = "";

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -185,16 +185,16 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetDeathMessage() const {
 	}
 }
 
-std::string Game_BattleAlgorithm::AlgorithmBase::GetDodgeMessage() const {
+std::string Game_BattleAlgorithm::AlgorithmBase::GetAttackFailureMessage(const std::string& message) const {
 	if (Player::IsRPG2kE()) {
 		return Utils::ReplacePlaceholders(
-			Data::terms.dodge,
+			message,
 			{'S', 'O'},
 			{GetSource()->GetName(), GetTarget()->GetName()}
 		);
 	}
 	else {
-		return GetTarget()->GetName() + Data::terms.dodge;
+		return GetTarget()->GetName() + message;
 	}
 }
 
@@ -375,7 +375,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 	}
 
 	if (!success) {
-		out.push_back(GetDodgeMessage());
+		out.push_back(GetAttackFailureMessage(Data::terms.dodge));
 	}
 
 	bool target_is_ally = GetTarget()->GetType() == Game_Battler::Type_Ally;
@@ -1078,26 +1078,22 @@ const RPG::Sound* Game_BattleAlgorithm::Skill::GetStartSe() const {
 
 void Game_BattleAlgorithm::Skill::GetResultMessages(std::vector<std::string>& out) const {
 	if (!success) {
-		std::stringstream ss;
-		ss << GetTarget()->GetName();
-
 		switch (skill.failure_message) {
 			case 0:
-				ss << Data::terms.skill_failure_a;
+				out.push_back(AlgorithmBase::GetAttackFailureMessage(Data::terms.skill_failure_a));
 				break;
 			case 1:
-				ss << Data::terms.skill_failure_b;
+				out.push_back(AlgorithmBase::GetAttackFailureMessage(Data::terms.skill_failure_b));
 				break;
 			case 2:
-				ss << Data::terms.skill_failure_c;
+				out.push_back(AlgorithmBase::GetAttackFailureMessage(Data::terms.skill_failure_c));
 				break;
 			case 3:
-				ss << Data::terms.dodge;
+				out.push_back(AlgorithmBase::GetAttackFailureMessage(Data::terms.dodge));
 				break;
 			default:
-				ss << " BUG: INVALID SKILL FAIL MSG";
+				out.push_back("BUG: INVALID SKILL FAIL MSG");
 		}
-		out.push_back(ss.str());
 		return;
 	}
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -226,6 +226,45 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetHPMPRecoveredMessage(int val
 	}
 }
 
+
+std::string Game_BattleAlgorithm::AlgorithmBase::GetUndamagedMessage() const {
+	bool target_is_ally = (GetTarget()->GetType() ==
+			Game_Battler::Type_Ally);
+	const std::string& message = target_is_ally ?
+		Data::terms.actor_undamaged :
+		Data::terms.enemy_undamaged;
+
+	if (Player::IsRPG2kE()) {
+		return Utils::ReplacePlaceholders(
+			message,
+			{'S'},
+			{GetTarget()->GetName()}
+		);
+	}
+	else {
+		return GetTarget()->GetName() + message;
+	}
+}
+
+std::string Game_BattleAlgorithm::AlgorithmBase::GetCriticalHitMessage() const {
+	bool target_is_ally = (GetTarget()->GetType() ==
+			Game_Battler::Type_Ally);
+	const std::string& message = target_is_ally ?
+		Data::terms.actor_critical :
+		Data::terms.enemy_critical;
+
+	if (Player::IsRPG2kE()) {
+		return Utils::ReplacePlaceholders(
+			message,
+			{'S'},
+			{GetTarget()->GetName()}
+		);
+	}
+	else {
+		return GetTarget()->GetName() + message;
+	}
+}
+
 void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::string>& out) const {
 	if (current_target == targets.end()) {
 		return;
@@ -250,15 +289,11 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 
 			ss << GetTarget()->GetName();
 			if (critical_hit) {
-				out.push_back(target_is_ally ?
-					Data::terms.actor_critical :
-					Data::terms.enemy_critical);
+				out.push_back(GetCriticalHitMessage());
 			}
 
 			if (GetAffectedHp() == 0) {
-				ss << (target_is_ally ?
-					Data::terms.actor_undamaged :
-					Data::terms.enemy_undamaged);
+				out.push_back(GetUndamagedMessage());
 			}
 			else {
 				if (absorb) {
@@ -286,8 +321,8 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 						Data::terms.actor_damaged :
 						Data::terms.enemy_damaged);
 				}
-			}
 			out.push_back(ss.str());
+			}
 		}
 	}
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -191,7 +191,19 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 	}
 
 	if (!success) {
-		out.push_back(GetTarget()->GetName() + Data::terms.dodge);
+		if (Player::IsRPG2kE()) {
+			//TODO: check if this is word-wrapped
+			out.push_back(
+				Utils::ReplacePlaceholders(
+					Data::terms.dodge,
+					{'S', 'O'},
+					{GetSource()->GetName(), GetTarget()->GetName()}
+				)
+			);
+		}
+		else {
+			out.push_back(GetTarget()->GetName() + Data::terms.dodge);
+		}
 	}
 
 	bool target_is_ally = GetTarget()->GetType() == Game_Battler::Type_Ally;
@@ -758,7 +770,16 @@ void Game_BattleAlgorithm::Normal::Apply() {
 
 std::string Game_BattleAlgorithm::Normal::GetStartMessage() const {
 	if (Player::IsRPG2k()) {
-		return source->GetName() + Data::terms.attacking;
+		if (Player::IsRPG2kE()) {
+			return Utils::ReplacePlaceholders(
+				Data::terms.attacking,
+				{'S'},
+				{source->GetName()}
+			);
+		}
+		else {
+			return source->GetName() + Data::terms.attacking;
+		}
 	}
 	else {
 		return "";

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1230,7 +1230,14 @@ void Game_BattleAlgorithm::Item::Apply() {
 }
 
 std::string Game_BattleAlgorithm::Item::GetStartMessage() const {
-	if (Player::IsRPG2k()) {
+	if (Player::IsRPG2kE()) {
+		return Utils::ReplacePlaceholders(
+			Data::terms.use_item,
+			{'S', 'O'},
+			{source->GetName(), item.name}
+		);
+	}
+	else if (Player::IsRPG2k()) {
 		std::string particle;
 		if (Player::IsCP932())
 			particle = "は";

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1041,7 +1041,16 @@ std::string Game_BattleAlgorithm::Skill::GetStartMessage() const {
 			// Use item message
 			return Item(source, *item).GetStartMessage();
 		}
-		return source->GetName() + skill.using_message1 + '\n' + skill.using_message2;
+		if (Player::IsRPG2kE()) {
+			return Utils::ReplacePlaceholders(
+				skill.using_message1 + '\n' + skill.using_message2,
+				{'S', 'O', 'U'},
+				{GetSource()->GetName(), GetTarget()->GetName(), skill.name}
+			);
+		}
+		else {
+			return source->GetName() + skill.using_message1 + '\n' + skill.using_message2;
+		}
 	}
 	else {
 		return skill.name;

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -311,6 +311,7 @@ protected:
 	std::string GetHpSpAbsorbedMessage(int value, const std::string& points) const;
 	std::string GetDamagedMessage() const;
 	std::string GetParameterChangeMessage(bool is_positive, int value, const std::string& points) const;
+	std::string GetStateMessage(const std::string& message) const;
 
 	float GetAttributeMultiplier(const std::vector<bool>& attributes_set) const;
 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -304,6 +304,9 @@ protected:
 	AlgorithmBase(Game_Battler* source, Game_Battler* target);
 	AlgorithmBase(Game_Battler* source, Game_Party_Base* target);
 
+	std::string GetDodgeMessage() const;
+	std::string GetHPMPRecoveredMessage(int value, const std::string& points) const;
+
 	float GetAttributeMultiplier(const std::vector<bool>& attributes_set) const;
 
 	void Reset();

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -310,6 +310,7 @@ protected:
 	std::string GetCriticalHitMessage() const;
 	std::string GetHpSpAbsorbedMessage(int value, const std::string& points) const;
 	std::string GetDamagedMessage() const;
+	std::string GetParameterChangeMessage(bool is_positive, int value, const std::string& points) const;
 
 	float GetAttributeMultiplier(const std::vector<bool>& attributes_set) const;
 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -309,6 +309,7 @@ protected:
 	std::string GetUndamagedMessage() const;
 	std::string GetCriticalHitMessage() const;
 	std::string GetHpSpAbsorbedMessage(int value, const std::string& points) const;
+	std::string GetDamagedMessage() const;
 
 	float GetAttributeMultiplier(const std::vector<bool>& attributes_set) const;
 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -304,7 +304,7 @@ protected:
 	AlgorithmBase(Game_Battler* source, Game_Battler* target);
 	AlgorithmBase(Game_Battler* source, Game_Party_Base* target);
 
-	std::string GetDodgeMessage() const;
+	std::string GetAttackFailureMessage(const std::string& points) const;
 	std::string GetHpSpRecoveredMessage(int value, const std::string& points) const;
 	std::string GetUndamagedMessage() const;
 	std::string GetCriticalHitMessage() const;

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -308,6 +308,7 @@ protected:
 	std::string GetHPMPRecoveredMessage(int value, const std::string& points) const;
 	std::string GetUndamagedMessage() const;
 	std::string GetCriticalHitMessage() const;
+	std::string GetHPMPAbsorbedMessage(int value, const std::string& points) const;
 
 	float GetAttributeMultiplier(const std::vector<bool>& attributes_set) const;
 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -305,10 +305,10 @@ protected:
 	AlgorithmBase(Game_Battler* source, Game_Party_Base* target);
 
 	std::string GetDodgeMessage() const;
-	std::string GetHPMPRecoveredMessage(int value, const std::string& points) const;
+	std::string GetHpSpRecoveredMessage(int value, const std::string& points) const;
 	std::string GetUndamagedMessage() const;
 	std::string GetCriticalHitMessage() const;
-	std::string GetHPMPAbsorbedMessage(int value, const std::string& points) const;
+	std::string GetHpSpAbsorbedMessage(int value, const std::string& points) const;
 
 	float GetAttributeMultiplier(const std::vector<bool>& attributes_set) const;
 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -306,6 +306,8 @@ protected:
 
 	std::string GetDodgeMessage() const;
 	std::string GetHPMPRecoveredMessage(int value, const std::string& points) const;
+	std::string GetUndamagedMessage() const;
+	std::string GetCriticalHitMessage() const;
 
 	float GetAttributeMultiplier(const std::vector<bool>& attributes_set) const;
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -393,20 +393,58 @@ bool Game_Interpreter_Map::CommandShowInn(RPG::EventCommand const& com) { // cod
 
 	switch (inn_type) {
 		case 0:
-			out << Data::terms.inn_a_greeting_1
-				<< " " << Game_Temp::inn_price
-				<< " " << Data::terms.gold
-				<< Data::terms.inn_a_greeting_2;
-			Game_Message::texts.push_back(out.str());
-			Game_Message::texts.push_back(Data::terms.inn_a_greeting_3);
+			if (Player::IsRPG2kE()) {
+				out << Game_Temp::inn_price;
+				Game_Message::texts.push_back(
+					Utils::ReplacePlaceholders(
+						Data::terms.inn_a_greeting_1,
+						{'V', 'U'},
+						{out.str(), Data::terms.gold}
+					)
+				);
+				Game_Message::texts.push_back(
+					Utils::ReplacePlaceholders(
+						Data::terms.inn_a_greeting_3,
+						{'V', 'U'},
+						{out.str(), Data::terms.gold}
+					)
+				);
+			}
+			else {
+				out << Data::terms.inn_a_greeting_1
+					<< " " << Game_Temp::inn_price
+					<< " " << Data::terms.gold
+					<< Data::terms.inn_a_greeting_2;
+				Game_Message::texts.push_back(out.str());
+				Game_Message::texts.push_back(Data::terms.inn_a_greeting_3);
+			}
 			break;
 		case 1:
-			out << Data::terms.inn_b_greeting_1
-				<< " " << Game_Temp::inn_price
-				<< " " << Data::terms.gold
-				<< Data::terms.inn_b_greeting_2;
-			Game_Message::texts.push_back(out.str());
-			Game_Message::texts.push_back(Data::terms.inn_b_greeting_3);
+			if (Player::IsRPG2kE()) {
+				out << Game_Temp::inn_price;
+				Game_Message::texts.push_back(
+					Utils::ReplacePlaceholders(
+						Data::terms.inn_b_greeting_1,
+						{'V', 'U'},
+						{out.str(), Data::terms.gold}
+					)
+				);
+				Game_Message::texts.push_back(
+					Utils::ReplacePlaceholders(
+						Data::terms.inn_b_greeting_3,
+						{'V', 'U'},
+						{out.str(), Data::terms.gold}
+					)
+				);
+			}
+			else {
+				out << Data::terms.inn_b_greeting_1
+					<< " " << Game_Temp::inn_price
+					<< " " << Data::terms.gold
+					<< Data::terms.inn_b_greeting_2;
+				Game_Message::texts.push_back(out.str());
+				Game_Message::texts.push_back(Data::terms.inn_b_greeting_3);
+			}
 			break;
 		default:
 			return false;

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -177,6 +177,7 @@ int Game_Message::GetRealPosition() {
 int Game_Message::WordWrap(const std::string& line, int limit, const std::function<void(const std::string &line)> callback) {
 	int start = 0, lastfound = 0;
 	int line_count = 0;
+	bool end_of_string = false;
 	FontRef font = Font::Default();
 	Rect size;
 
@@ -185,6 +186,7 @@ int Game_Message::WordWrap(const std::string& line, int limit, const std::functi
 		int found = line.find(" ", start);
 		std::string wrapped = line.substr(start, found - start);
 		size = font->GetSize(wrapped);
+		end_of_string = false;
 		do {
 			lastfound = found;
 			found = line.find(" ", lastfound + 1);
@@ -194,14 +196,15 @@ int Game_Message::WordWrap(const std::string& line, int limit, const std::functi
 			wrapped = line.substr(start, found - start);
 			size = font->GetSize(wrapped);
 		} while (found < line.size() - 1 && size.width < limit);
-		if (size.width < limit) {
+		if (found >= line.size() - 1) {
 			// It's end of the string, not a word-break
 			lastfound = found;
+			end_of_string = true;
 		}
 		wrapped = line.substr(start, lastfound - start);
 		callback(wrapped);
 		start = lastfound + 1;
-	} while (start < line.size() && size.width >= limit);
+	} while (start < line.size() && !end_of_string);
 
 	return line_count;
 }

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -20,6 +20,7 @@
 #include "game_player.h"
 #include "game_temp.h"
 #include "main_data.h"
+#include "font.h"
 #include "player.h"
 
 namespace Game_Message {
@@ -169,4 +170,35 @@ int Game_Message::GetRealPosition() {
 			return disp >= (16 * 10) ? 0 : 2;
 		};
 	}
+}
+
+int Game_Message::PushWordWrappedLine(const std::string& line, int limit, std::vector<std::string>& lines) {
+	int start = 0, lastfound = 0;
+	int line_count = 0;
+	FontRef font = Font::Default();
+	Rect size;
+
+	do {
+		line_count++;
+		int found = line.find(" ", start);
+		std::string wrapped = line.substr(start, found - start);
+		size = font->GetSize(wrapped);
+		do {
+			lastfound = found;
+			found = line.find(" ", lastfound + 1);
+			if (found == std::string::npos) {
+				found = line.size();
+			}
+			wrapped = line.substr(start, found - start);
+			size = font->GetSize(wrapped);
+		} while (found < line.size() - 1 && size.width < limit);
+		if (size.width < limit) {
+			// It's end of the string, not a word-break
+			lastfound = found;
+		}
+		lines.push_back(line.substr(start, lastfound - start));
+		start = lastfound + 1;
+	} while (start < line.size() && size.width >= limit);
+
+	return line_count;
 }

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -25,6 +25,7 @@
 
 namespace Game_Message {
 	std::vector<std::string> texts;
+	bool is_word_wrapped;
 
 	unsigned int owner_id;
 
@@ -60,6 +61,7 @@ void Game_Message::SemiClear() {
 	num_input_start = -1;
 	num_input_variable_id = 0;
 	num_input_digits_max = 0;
+	is_word_wrapped = false;
 }
 
 void Game_Message::FullClear() {
@@ -172,7 +174,7 @@ int Game_Message::GetRealPosition() {
 	}
 }
 
-int Game_Message::PushWordWrappedLine(const std::string& line, int limit, std::vector<std::string>& lines) {
+int Game_Message::WordWrap(const std::string& line, int limit, const std::function<void(const std::string &line)> callback) {
 	int start = 0, lastfound = 0;
 	int line_count = 0;
 	FontRef font = Font::Default();
@@ -196,7 +198,8 @@ int Game_Message::PushWordWrappedLine(const std::string& line, int limit, std::v
 			// It's end of the string, not a word-break
 			lastfound = found;
 		}
-		lines.push_back(line.substr(start, lastfound - start));
+		wrapped = line.substr(start, lastfound - start);
+		callback(wrapped);
 		start = lastfound + 1;
 	} while (start < line.size() && size.width >= limit);
 

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -168,6 +168,27 @@ namespace Game_Message {
 	int GetRealPosition();
 
 	/**
+	 * Breaks the line into lines, each of which is equal 
+	 * or less than a specified limit in pixels in the
+	 * given font (except in cases when breaking by spaces
+	 * can't produce a short line), and pushes the result
+	 * into a specified vector of strings.
+	 * 
+	 * Font::Default() will be used to determine the word breaking.
+	 * The caller is responsible for ensuring that Font::Default()
+	 * either does not change between calling this function and
+	 * displaying the results, or at least that the changed font
+	 * has same metrics as the font used to calculate the line sizes.
+	 *
+	 * @param[in] line The line that will be broken into lines
+	 * and added into the lines vector.
+	 * @param[in] limit maximum size of each line after word-breaking.
+	 * @param[out] lines A vector of lines, into which the resulting
+	 * lines will be added using the push_back method.
+	 */
+	int PushWordWrappedLine(const std::string& line, int limit, std::vector<std::string>& lines);
+
+	/**
 	 * Number of lines before the start
 	 * of selection options.
 	 * +-----------------------------------+

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -21,6 +21,7 @@
 #include <vector>
 #include <bitset>
 #include <string>
+#include <functional>
 
 namespace Game_Message {
 
@@ -171,8 +172,8 @@ namespace Game_Message {
 	 * Breaks the line into lines, each of which is equal 
 	 * or less than a specified limit in pixels in the
 	 * given font (except in cases when breaking by spaces
-	 * can't produce a short line), and pushes the result
-	 * into a specified vector of strings.
+	 * can't produce a short line), and calls the callback
+	 * for each resulting line.
 	 * 
 	 * Font::Default() will be used to determine the word breaking.
 	 * The caller is responsible for ensuring that Font::Default()
@@ -183,10 +184,14 @@ namespace Game_Message {
 	 * @param[in] line The line that will be broken into lines
 	 * and added into the lines vector.
 	 * @param[in] limit maximum size of each line after word-breaking.
-	 * @param[out] lines A vector of lines, into which the resulting
-	 * lines will be added using the push_back method.
+	 * @param callback a function to be called for each word-wrapped line
 	 */
-	int PushWordWrappedLine(const std::string& line, int limit, std::vector<std::string>& lines);
+	int WordWrap(const std::string& line, int limit, const std::function<void(const std::string &line)> callback);
+
+	/**
+	 * @var whether the texts are word-wrapped;
+	 */
+	extern bool is_word_wrapped;
 
 	/**
 	 * Number of lines before the start

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -169,7 +169,7 @@ namespace Game_Message {
 	int GetRealPosition();
 
 	/**
-	 * Breaks the line into lines, each of which is equal 
+	 * Breaks the line into lines, each of which is equal
 	 * or less than a specified limit in pixels in the
 	 * given font (except in cases when breaking by spaces
 	 * can't produce a short line), and calls the callback

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -533,6 +533,9 @@ void Player::ParseCommandLine(int argc, char *argv[]) {
 			else if (*it == "rpg2kv150" || *it == "2000v150") {
 				engine = EngineRpg2k | EngineMajorUpdated;
 			}
+			else if (*it == "rpg2kv161" || *it == "2000v161") {
+				engine = EngineRpg2k | EngineMajorUpdated | EngineMessagePlaceholders;
+			}
 			else if (*it == "rpg2k3" || *it == "2003") {
 				engine = EngineRpg2k3;
 			}
@@ -656,6 +659,10 @@ void Player::CreateGameObjects() {
 		} else {
 			engine = EngineRpg2k;
 			Output::Debug("Using RPG2k Interpreter");
+			if (Data::data.version >= 1) {
+				engine |= EngineMessagePlaceholders;
+				Output::Debug("RM2k >= v.1.61 (English release) detected");
+			}
 		}
 		if (FileFinder::IsMajorUpdatedTree()) {
 			engine |= EngineMajorUpdated;
@@ -664,7 +671,7 @@ void Player::CreateGameObjects() {
 			Output::Debug("RPG2k < v1.50 / RPG2k3 < v1.05 detected");
 		}
 	}
-	Output::Debug("Engine configured as: 2k=%d 2k3=%d 2k3Legacy=%d MajorUpdated=%d 2k3E=%d", Player::IsRPG2k(), Player::IsRPG2k3(), Player::IsRPG2k3Legacy(), Player::IsMajorUpdatedVersion(), Player::IsRPG2k3E());
+	Output::Debug("Engine configured as: 2k=%d 2k3=%d 2k3Legacy=%d MajorUpdated=%d 2k3E=%d MsgPlaceholders=%d", Player::IsRPG2k(), Player::IsRPG2k3(), Player::IsRPG2k3Legacy(), Player::IsMajorUpdatedVersion(), Player::IsRPG2k3E(), Player::SupportsMessagePlaceholders());
 
 	if (!no_rtp_flag) {
 		FileFinder::InitRtpPaths();
@@ -905,6 +912,7 @@ Options:
                            Possible options:
                             rpg2k      - RPG Maker 2000 engine (v1.00 - v1.10)
                             rpg2kv150  - RPG Maker 2000 engine (v1.50 - v1.51)
+                            rpg2kv161  - RPG Maker 2000 (English release) engine (v1.61)
                             rpg2k3     - RPG Maker 2003 engine (v1.00 - v1.04)
                             rpg2k3v105 - RPG Maker 2003 engine (v1.05 - v1.09a)
                             rpg2k3e    - RPG Maker 2003 (English release) engine
@@ -974,6 +982,10 @@ bool Player::IsMajorUpdatedVersion() {
 
 bool Player::IsRPG2k3E() {
 	return (engine & EngineRpg2k3E) == EngineRpg2k3E;
+}
+
+bool Player::SupportsMessagePlaceholders() {
+	return (engine & EngineMessagePlaceholders) == EngineMessagePlaceholders;
 }
 
 bool Player::IsCP932() {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -533,8 +533,8 @@ void Player::ParseCommandLine(int argc, char *argv[]) {
 			else if (*it == "rpg2kv150" || *it == "2000v150") {
 				engine = EngineRpg2k | EngineMajorUpdated;
 			}
-			else if (*it == "rpg2kv161" || *it == "2000v161") {
-				engine = EngineRpg2k | EngineMajorUpdated | EngineMessagePlaceholders;
+			else if (*it == "rpg2ke" || *it == "2000e") {
+				engine = EngineRpg2k | EngineMajorUpdated | EngineEnglish;
 			}
 			else if (*it == "rpg2k3" || *it == "2003") {
 				engine = EngineRpg2k3;
@@ -543,7 +543,7 @@ void Player::ParseCommandLine(int argc, char *argv[]) {
 				engine = EngineRpg2k3 | EngineMajorUpdated;
 			}
 			else if (*it == "rpg2k3e") {
-				engine = EngineRpg2k3 | EngineMajorUpdated | EngineRpg2k3E;
+				engine = EngineRpg2k3 | EngineMajorUpdated | EngineEnglish;
 			}
 		}
 		else if (*it == "--record-input") {
@@ -653,25 +653,27 @@ void Player::CreateGameObjects() {
 					Output::Debug("Using RPG2k3 Interpreter");
 				}
 			} else {
-				engine |= EngineRpg2k3E;
+				engine |= EngineEnglish;
 				Output::Debug("Using RPG2k3 (English release, v1.11) Interpreter");
 			}
 		} else {
 			engine = EngineRpg2k;
 			Output::Debug("Using RPG2k Interpreter");
 			if (Data::data.version >= 1) {
-				engine |= EngineMessagePlaceholders;
+				engine |= EngineEnglish | EngineMajorUpdated;
 				Output::Debug("RM2k >= v.1.61 (English release) detected");
 			}
 		}
-		if (FileFinder::IsMajorUpdatedTree()) {
-			engine |= EngineMajorUpdated;
-			Output::Debug("RPG2k >= v1.50 / RPG2k3 >= v1.05 detected");
-		} else {
-			Output::Debug("RPG2k < v1.50 / RPG2k3 < v1.05 detected");
+		if (!(engine & EngineMajorUpdated)) {
+			if (FileFinder::IsMajorUpdatedTree()) {
+				engine |= EngineMajorUpdated;
+				Output::Debug("RPG2k >= v1.50 / RPG2k3 >= v1.05 detected");
+			} else {
+				Output::Debug("RPG2k < v1.50 / RPG2k3 < v1.05 detected");
+			}
 		}
 	}
-	Output::Debug("Engine configured as: 2k=%d 2k3=%d 2k3Legacy=%d MajorUpdated=%d 2k3E=%d MsgPlaceholders=%d", Player::IsRPG2k(), Player::IsRPG2k3(), Player::IsRPG2k3Legacy(), Player::IsMajorUpdatedVersion(), Player::IsRPG2k3E(), Player::SupportsMessagePlaceholders());
+	Output::Debug("Engine configured as: 2k=%d 2k3=%d 2k3Legacy=%d MajorUpdated=%d Eng=%d", Player::IsRPG2k(), Player::IsRPG2k3(), Player::IsRPG2k3Legacy(), Player::IsMajorUpdatedVersion(), Player::IsEnglish());
 
 	if (!no_rtp_flag) {
 		FileFinder::InitRtpPaths();
@@ -912,7 +914,7 @@ Options:
                            Possible options:
                             rpg2k      - RPG Maker 2000 engine (v1.00 - v1.10)
                             rpg2kv150  - RPG Maker 2000 engine (v1.50 - v1.51)
-                            rpg2kv161  - RPG Maker 2000 (English release) engine (v1.61)
+                            rpg2ke     - RPG Maker 2000 (English release) engine (v1.61)
                             rpg2k3     - RPG Maker 2003 engine (v1.00 - v1.04)
                             rpg2k3v105 - RPG Maker 2003 engine (v1.05 - v1.09a)
                             rpg2k3e    - RPG Maker 2003 (English release) engine
@@ -981,11 +983,17 @@ bool Player::IsMajorUpdatedVersion() {
 }
 
 bool Player::IsRPG2k3E() {
-	return (engine & EngineRpg2k3E) == EngineRpg2k3E;
+	return ((engine & EngineRpg2k3) == EngineRpg2k3)
+		&& ((engine & EngineEnglish) == EngineEnglish);
 }
 
-bool Player::SupportsMessagePlaceholders() {
-	return (engine & EngineMessagePlaceholders) == EngineMessagePlaceholders;
+bool Player::IsRPG2kE() {
+	return ((engine & EngineRpg2k) == EngineRpg2k)
+		&& ((engine & EngineEnglish) == EngineEnglish);
+}
+
+bool Player::IsEnglish() {
+	return (engine & EngineEnglish) == EngineEnglish;
 }
 
 bool Player::IsCP932() {

--- a/src/player.h
+++ b/src/player.h
@@ -35,10 +35,9 @@ namespace Player {
 		EngineRpg2k3 = 2,
 		/** RPG Maker 2000 v1.50 or newer, 2003 v1.05 or newer */
 		EngineMajorUpdated = 4,
-		/** RPG Maker 2003 v1.10 or newer (Official English translation) */
-		EngineRpg2k3E = 8,
-		/** RPG Maker 2000 v1.61 or newer (Official English translation) */
-		EngineMessagePlaceholders = 16
+		/** Official English translation (RPG Maker 2003 v1.10 or newer,
+		 * or RPG Maker 2000 v.1.61 or newer) */
+		EngineEnglish = 8
 	};
 
 	/**
@@ -153,16 +152,22 @@ namespace Player {
 	bool IsMajorUpdatedVersion();
 
 	/**
-	 * @return If engine is the official English release (v1.10) or newer.
+	 * @return If engine is the official English RM2k3 release (v1.10) or newer.
 	 */
 	bool IsRPG2k3E();
 
 
 	/**
-	 * @return If engine supports placeholders in the glossary messages, i.e.
-	 * if it is RPG2k v.1.61 or newer.
+	 * @return If engine is the official English RM2k release v.1.61 or newer.
+	 * False if engine is RM2k3, Japanese, unofficial or v.1.60.
 	 */
-	bool SupportsMessagePlaceholders();
+	bool IsRPG2kE();
+
+	/**
+	 * @return If engine is the official English release (and not RM2k v.1.60,
+	 * which is hard to detect).
+	 */
+	bool IsEnglish();
 
 	/**
 	 * @return true if encoding is CP932 (Shift-JIS, used for Japanese),

--- a/src/player.h
+++ b/src/player.h
@@ -36,7 +36,9 @@ namespace Player {
 		/** RPG Maker 2000 v1.50 or newer, 2003 v1.05 or newer */
 		EngineMajorUpdated = 4,
 		/** RPG Maker 2003 v1.10 or newer (Official English translation) */
-		EngineRpg2k3E = 8
+		EngineRpg2k3E = 8,
+		/** RPG Maker 2000 v1.61 or newer (Official English translation) */
+		EngineMessagePlaceholders = 16
 	};
 
 	/**
@@ -154,6 +156,13 @@ namespace Player {
 	 * @return If engine is the official English release (v1.10) or newer.
 	 */
 	bool IsRPG2k3E();
+
+
+	/**
+	 * @return If engine supports placeholders in the glossary messages, i.e.
+	 * if it is RPG2k v.1.61 or newer.
+	 */
+	bool SupportsMessagePlaceholders();
 
 	/**
 	 * @return true if encoding is CP932 (Shift-JIS, used for Japanese),

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -860,7 +860,9 @@ bool Scene_Battle_Rpg2k::DisplayMonstersInMessageWindow() {
 		if (battle_message_window->IsPageFilled()) {
 			battle_message_window->NextPage();
 		}
-		battle_message_window->ShowHiddenLines(1);
+		else {
+			battle_message_window->ShowHiddenLines(1);
+		}
 		SetWaitForEnemyAppearanceMessages();
 		return false;
 	}

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -834,7 +834,13 @@ bool Scene_Battle_Rpg2k::DisplayMonstersInMessageWindow() {
 		battle_message_window->NextPage();
 	}
 
-	battle_message_window->Push((*enemy_iterator)->GetName() + Data::terms.encounter);
+	std::string enemy_name = (*enemy_iterator)->GetName();
+	if (Player::IsRPG2kE()) {
+		battle_message_window->Push(Utils::ReplacePlaceholders(Data::terms.encounter, {'S'}, {enemy_name}));
+	}
+	else {
+		battle_message_window->Push(enemy_name + Data::terms.encounter);
+	}
 
 	++enemy_iterator;
 

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -16,8 +16,6 @@
  */
 
 
-#include <iostream>
-//^^removeme
 #include <algorithm>
 #include <sstream>
 #include "input.h"

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -962,6 +962,7 @@ bool Scene_Battle_Rpg2k::CheckWin() {
 		std::vector<int> drops;
 		Main_Data::game_enemyparty->GenerateDrops(drops);
 
+		Game_Message::is_word_wrapped = Player::IsRPG2kE();
 		Game_Message::texts.push_back(Data::terms.victory);
 
 		std::stringstream ss;
@@ -1002,6 +1003,7 @@ bool Scene_Battle_Rpg2k::CheckLose() {
 		Game_Message::SetPosition(2);
 		Game_Message::SetTransparent(false);
 
+		Game_Message::is_word_wrapped = Player::IsRPG2kE();
 		Game_Message::texts.push_back(Data::terms.defeat);
 
 		Game_System::BgmPlay(Game_System::GetSystemBGM(Game_System::BGM_GameOver));

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -423,13 +423,13 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 					battle_message_window->Clear();
 					for (auto state : states_to_heal) {
 						if (!Data::states[state - 1].message_recovery.empty()) {
-							battle_message_window->Push(action->GetSource()->GetName() + Data::states[state- 1].message_recovery);
+							battle_message_window->PushWithSubject(Data::states[state- 1].message_recovery, action->GetSource()->GetName());
 							message_to_show = true;
 						}
 					}
 					for (auto state : states_remaining) {
 						if (!Data::states[state - 1].message_affected.empty()) {
-							battle_message_window->Push(action->GetSource()->GetName() + Data::states[state- 1].message_affected);
+							battle_message_window->PushWithSubject(Data::states[state- 1].message_affected, action->GetSource()->GetName());
 							message_to_show = true;
 						}
 					}
@@ -885,7 +885,7 @@ bool Scene_Battle_Rpg2k::DisplayMonstersInMessageWindow() {
 	if (battle_message_window->IsPageFilled()) {
 		battle_message_window->NextPage();
 	}
-	battle_message_window->EnemyAppeared((*enemy_iterator)->GetName());
+	battle_message_window->PushWithSubject(Data::terms.encounter, (*enemy_iterator)->GetName());
 	++enemy_iterator;
 
 	SetWaitForEnemyAppearanceMessages();

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -333,7 +333,9 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 				return false;
 			}
 			battle_action_wait = 30;
-			battle_message_window->Clear();
+			if (battle_message_window->NextPage()) {
+				return false;
+			}
 
 			if (action->IsFirstAttack()) {
 				action->TargetFirst();
@@ -828,8 +830,8 @@ bool Scene_Battle_Rpg2k::DisplayMonstersInMessageWindow() {
 		}
 	}
 
-	if (battle_message_window->GetLineCount() == 4) {
-		battle_message_window->Clear();
+	if (battle_message_window->IsPageFilled()) {
+		battle_message_window->NextPage();
 	}
 
 	battle_message_window->Push((*enemy_iterator)->GetName() + Data::terms.encounter);
@@ -837,7 +839,7 @@ bool Scene_Battle_Rpg2k::DisplayMonstersInMessageWindow() {
 	++enemy_iterator;
 
 	if (enemy_iterator == Main_Data::game_enemyparty->GetEnemies().end() ||
-		battle_message_window->GetLineCount() == 4) {
+		battle_message_window->IsPageFilled()) {
 		// Half second sleep
 		encounter_message_sleep_until = Player::GetFrames() + 60 / 2;
 	} else {

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -98,6 +98,22 @@ protected:
 	 */
 	void SetWaitForEnemyAppearanceMessages();
 
+
+	/**
+	 * Gets the time during before hiding a windowful of
+	 * text.
+	 *
+	 * @return int seconds to wait
+	 */
+	int GetDelayForWindow();
+
+	/**
+	 * Gets delay between showing two lines of text.
+	 *
+	 * @return int seconds to wait
+	 */
+	int GetDelayForLine();
+
 	void CreateExecutionOrder();
 	void CreateEnemyActions();
 

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -58,6 +58,31 @@ protected:
 	bool ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase* action);
 	void ProcessInput() override;
 
+	/**
+	 * Adds a message about the gold received into
+	 * Game_Message::texts.
+	 *
+	 * @param Number of gold to display.
+	 */
+	void PushGoldReceivedMessage(int money);
+
+	/**
+	 * Adds a message about the experience received into
+	 * Game_Message::texts.
+	 *
+	 * @param Number of experience to display.
+	 */
+	void PushExperienceGainedMessage(int exp);
+
+
+	/**
+	 * Adds messages about the items obtained after the battle
+	 * into Game_Message::texts.
+	 *
+	 * @param Vector of item IDs
+	 */
+	void PushItemRecievedMessages(std::vector<int> drops);
+
 	void OptionSelected();
 	void CommandSelected();
 
@@ -65,6 +90,13 @@ protected:
 
 	void SelectNextActor();
 	void SelectPreviousActor();
+
+	/**
+	 * Sets the encounter message sleep time (encounter_message_sleep_until)
+	 * depending on whether the last character is shown or not, whether
+	 * the page is filled or not.
+	 */
+	void SetWaitForEnemyAppearanceMessages();
 
 	void CreateExecutionOrder();
 	void CreateEnemyActions();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <algorithm>
 #include <random>
+#include <cctype>
 
 namespace {
 	std::mt19937 rng;
@@ -437,4 +438,34 @@ std::vector<std::string> Utils::Tokenize(const std::string &str_to_tokenize, con
 	tokens.push_back(EncodeUTF(cur_token));
 
 	return tokens;
+}
+
+
+std::string Utils::ReplacePlaceholders(std::string& text_template, std::vector<char> types, std::vector<std::string> values) {
+	std::string str = text_template;
+	size_t index = str.find("%");
+	while (index != std::string::npos) {
+		if (index + 1 < str.length()) {
+			char type = str[index + 1];
+			if (type == '%') {
+				++index;
+			}
+			else {
+				auto v_it = values.begin();
+				for (auto t_it = types.begin();
+					t_it != types.end(), v_it != values.end();
+					++t_it, ++v_it) {
+					if (std::toupper(type) == *t_it) {
+						str.replace(index, 2, *v_it);
+						index += (*v_it).length() - 2;
+						break;
+					}
+				}
+			}
+		}
+
+		index = str.find("%", index + 1);
+	}
+
+	return str;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -441,7 +441,7 @@ std::vector<std::string> Utils::Tokenize(const std::string &str_to_tokenize, con
 }
 
 
-std::string Utils::ReplacePlaceholders(std::string& text_template, std::vector<char> types, std::vector<std::string> values) {
+std::string Utils::ReplacePlaceholders(const std::string& text_template, std::vector<char> types, std::vector<std::string> values) {
 	std::string str = text_template;
 	size_t index = str.find("%");
 	while (index != std::string::npos) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -447,10 +447,7 @@ std::string Utils::ReplacePlaceholders(const std::string& text_template, std::ve
 	while (index != std::string::npos) {
 		if (index + 1 < str.length()) {
 			char type = str[index + 1];
-			if (type == '%') {
-				++index;
-			}
-			else {
+			if (type != '%') {
 				auto v_it = values.begin();
 				for (auto t_it = types.begin();
 					t_it != types.end(), v_it != values.end();

--- a/src/utils.h
+++ b/src/utils.h
@@ -186,6 +186,19 @@ namespace Utils {
 	 */
 	std::vector<std::string> Tokenize(const std::string& str_to_tokenize, const std::function<bool(char32_t)> predicate);
 
+	/**
+	 * Replaces placeholders (like %S, %O, %V, %U) in strings.
+	 *
+	 * @param text_template String with placeholders to replace.
+	 * @param types Vector of uppercase characters like 'S',
+	 * 'O', 'V', 'U'. Should have the same number of elements
+	 * as the values param.
+	 * @param values Vector of replacements strings,
+	 * should match types in number of elements and order.
+	 * @return A new string with placeholders replaced.
+	 */
+	std::string ReplacePlaceholders(std::string& text_template, std::vector<char> types, std::vector<std::string> values);
+
 } // namespace Utils
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -197,7 +197,7 @@ namespace Utils {
 	 * should match types in number of elements and order.
 	 * @return A new string with placeholders replaced.
 	 */
-	std::string ReplacePlaceholders(std::string& text_template, std::vector<char> types, std::vector<std::string> values);
+	std::string ReplacePlaceholders(const std::string& text_template, std::vector<char> types, std::vector<std::string> values);
 
 } // namespace Utils
 

--- a/src/window_battlemessage.cpp
+++ b/src/window_battlemessage.cpp
@@ -41,7 +41,8 @@ void Window_BattleMessage::Push(const std::string& message) {
 	hidden_lines = 0;
 	while (getline(smessage, line)) {
 		if (Player::IsRPG2kE()) {
-			PushWordWrappedLine(line);
+			int line_count = Game_Message::PushWordWrappedLine(line, GetWidth() - 24, lines);
+			hidden_lines = line_count - 1;
 		}
 		else {
 			lines.push_back(line);
@@ -49,40 +50,6 @@ void Window_BattleMessage::Push(const std::string& message) {
 	}
 
 	needs_refresh = true;
-}
-
-int Window_BattleMessage::PushWordWrappedLine(const std::string& line) {
-	FontRef font = Font::Default();
-
-	int start = 0, lastfound = 0;
-	int limit = GetWidth() - 24;
-	int line_count = 0;
-	Rect size;
-
-	do {
-		line_count++;
-		int found = line.find(" ", start);
-		std::string wrapped = line.substr(start, found - start);
-		size = font->GetSize(wrapped);
-		do {
-			lastfound = found;
-			found = line.find(" ", lastfound + 1);
-			if (found == std::string::npos) {
-				found = line.size();
-			}
-			wrapped = line.substr(start, found - start);
-			size = font->GetSize(wrapped);
-		} while (found < line.size() - 1 && size.width < limit);
-		if (size.width < limit) {
-			// It's end of the string, not a word-break
-			lastfound = found;
-		}
-		lines.push_back(line.substr(start, lastfound - start));
-		start = lastfound + 1;
-	} while (start < line.size() && size.width >= limit);
-	hidden_lines = line_count - 1;
-
-	return line_count;
 }
 
 void Window_BattleMessage::EnemyAppeared(const std::string& enemy_name) {

--- a/src/window_battlemessage.cpp
+++ b/src/window_battlemessage.cpp
@@ -72,8 +72,6 @@ void Window_BattleMessage::PushWithSubject(const std::string& message, const std
 	}
 }
 
-
-
 void Window_BattleMessage::Pop() {
 	lines.pop_back();
 	needs_refresh = true;

--- a/src/window_battlemessage.cpp
+++ b/src/window_battlemessage.cpp
@@ -59,16 +59,16 @@ void Window_BattleMessage::Push(const std::string& message) {
 	needs_refresh = true;
 }
 
-void Window_BattleMessage::EnemyAppeared(const std::string& enemy_name) {
+void Window_BattleMessage::PushWithSubject(const std::string& message, const std::string& subject) {
 	if (Player::IsRPG2kE()) {
 		Push(Utils::ReplacePlaceholders(
-			Data::terms.encounter,
+			message,
 			{'S'},
-			{enemy_name}
+			{subject}
 		));
 	}
 	else {
-		Push(enemy_name + Data::terms.encounter);
+		Push(subject + message);
 	}
 }
 

--- a/src/window_battlemessage.cpp
+++ b/src/window_battlemessage.cpp
@@ -41,7 +41,14 @@ void Window_BattleMessage::Push(const std::string& message) {
 	hidden_lines = 0;
 	while (getline(smessage, line)) {
 		if (Player::IsRPG2kE()) {
-			int line_count = Game_Message::PushWordWrappedLine(line, GetWidth() - 24, lines);
+			std::vector<std::string>& wrapped_lines = lines;
+			int line_count = Game_Message::WordWrap(
+								line,
+								GetWidth() - 24,
+								[&wrapped_lines](const std::string& line) {
+									wrapped_lines.push_back(line);
+								}
+							);
 			hidden_lines = line_count - 1;
 		}
 		else {

--- a/src/window_battlemessage.cpp
+++ b/src/window_battlemessage.cpp
@@ -122,7 +122,7 @@ bool Window_BattleMessage::NextPage() {
 		return false;
 	}
 	else {
-		lines.erase(lines.begin(), lines.begin() + linesPerPage);
+		lines.erase(lines.begin(), lines.begin() + linesPerPage - 1);
 		needs_refresh = true;
 		return true;
 	}
@@ -135,7 +135,7 @@ void Window_BattleMessage::Refresh() {
 
 	std::vector<std::string>::const_iterator it;
 	int i = 0;
-	for (it = lines.begin(); it != lines.end() - hidden_lines; ++it) {
+	for (it = lines.begin(); it < lines.end() - hidden_lines; ++it) {
 		contents->TextDraw(0, contents_y, Font::ColorDefault, *it);
 		contents_y += 16;
 

--- a/src/window_battlemessage.h
+++ b/src/window_battlemessage.h
@@ -114,21 +114,6 @@ private:
 	int hidden_lines;
 
 	bool needs_refresh;
-
-	/**
-	 * Adds a line to the lines vector. If the line is too long to
-	 * be displayed in the message and contains space characters, then
-	 * it will be broken into several lines.
-	 *
-	 * When the line is word-wrapped, only the first line is shown. The
-	 * other lines are initially hidden. The number of hidden lines can
-	 * be retrieved wih GetHiddenLineCount, and shown usign 
-	 * ShowHiddenLines.
-	 *
-	 * @param line String without newline characters.
-	 * @return Number of lines added after word-wrapping.
-	 **/
-	int PushWordWrappedLine(const std::string& line);
 };
 
 #endif

--- a/src/window_battlemessage.h
+++ b/src/window_battlemessage.h
@@ -97,7 +97,7 @@ public:
 	void ShowHiddenLines(int count);
 
 	/**
-	 * How much lines would fit into a window of battle messages.
+	 * How many lines would fit into a window of battle messages.
 	 */
 	static const int linesPerPage = 4;
 
@@ -105,7 +105,7 @@ private:
 	std::vector<std::string> lines;
 
 	/**
-	 * How much lines are hidden right now.
+	 * How many lines are hidden right now.
 	 *
 	 * Hidden lines are added by PushWordWrappedLine when
 	 * the pushed line doesn't fit one line. Such lines are

--- a/src/window_battlemessage.h
+++ b/src/window_battlemessage.h
@@ -29,7 +29,25 @@ class Window_BattleMessage : public Window_Base {
 public:
 	Window_BattleMessage(int ix, int iy, int iwidth, int iheight);
 
+	/**
+	 * Adds message to be displayed.
+	 *
+	 * If hidden lines exist prior to pushing the message, they
+	 * are shown. However, the newly-added lines message might
+	 * be initially hidden if the engine supports word-wrapping
+	 * and the line is long, only the first line is shown, and
+	 * other lines are hidden unless ShowHiddenLines is called.
+	 *
+	 * @param message The text to be displayed.
+	 */
 	void Push(const std::string& message);
+
+	/**
+	 * Pushes an 'Enemy appeared' message into the message list.
+	 *
+	 * @param string Enemy name that will be displayed in the message.
+	 */
+	void EnemyAppeared(const std::string& enemy_name);
 
 	void Pop();
 
@@ -57,6 +75,28 @@ public:
 	bool IsPageFilled();
 
 	/**
+	 * Number of lines that are hidden right now.
+	 *
+	 * Hidden lines are added when the text is word-wrapped:
+	 * only the first line is shown, and others are hidden.
+	 *
+	 * @return number of hidden lines
+	 */
+	int GetHiddenLineCount();
+
+	/**
+	 * Displays the given number of hidden lines.
+	 *
+	 * Hidden lines are added when a word-wrapped line is pushed:
+	 * then, only the first line is displayed, and others are
+	 * considered hidden.
+	 *
+	 * @param Number of lines to display. If -1
+	 * is passed, all the hidden lines are displayed.
+	 */
+	void ShowHiddenLines(int count);
+
+	/**
 	 * How much lines would fit into a window of battle messages.
 	 */
 	static const int linesPerPage = 4;
@@ -64,12 +104,26 @@ public:
 private:
 	std::vector<std::string> lines;
 
+	/**
+	 * How much lines are hidden right now.
+	 *
+	 * Hidden lines are added by PushWordWrappedLine when
+	 * the pushed line doesn't fit one line. Such lines are
+	 * hidden until ShowHiddenLines is called.
+	 */
+	int hidden_lines;
+
 	bool needs_refresh;
 
 	/**
 	 * Adds a line to the lines vector. If the line is too long to
 	 * be displayed in the message and contains space characters, then
 	 * it will be broken into several lines.
+	 *
+	 * When the line is word-wrapped, only the first line is shown. The
+	 * other lines are initially hidden. The number of hidden lines can
+	 * be retrieved wih GetHiddenLineCount, and shown usign 
+	 * ShowHiddenLines.
 	 *
 	 * @param line String without newline characters.
 	 * @return Number of lines added after word-wrapping.

--- a/src/window_battlemessage.h
+++ b/src/window_battlemessage.h
@@ -43,11 +43,14 @@ public:
 	void Push(const std::string& message);
 
 	/**
-	 * Pushes an 'Enemy appeared' message into the message list.
+	 * Pushes a message, either prepending the subject to it,
+	 * or replacing all the occurences of %S with subject, depending
+	 * on the engine version.
 	 *
-	 * @param string Enemy name that will be displayed in the message.
+	 * @param string Message to be displayed.
+	 * @param string Subject that will be displayed in the message.
 	 */
-	void EnemyAppeared(const std::string& enemy_name);
+	void PushWithSubject(const std::string& message, const std::string& subject);
 
 	void Pop();
 

--- a/src/window_battlemessage.h
+++ b/src/window_battlemessage.h
@@ -35,16 +35,46 @@ public:
 
 	void Clear();
 
+	/**
+	 * Remove 4 lines (determined by linesPerPage) of the battle
+	 * messages, thus proceeding to the next page.
+	 *
+	 * @return True if there is something left to show, false is the
+	 * previous page was the last one.
+	 */
+	bool NextPage();
+
 	int GetLineCount();
 
 	void Refresh();
 
 	void Update() override;
 
+	/**
+	 * @return true is the message window is filled, false if there
+	 * is space for at least one line on the first page.
+	 */
+	bool IsPageFilled();
+
+	/**
+	 * How much lines would fit into a window of battle messages.
+	 */
+	static const int linesPerPage = 4;
+
 private:
 	std::vector<std::string> lines;
 
 	bool needs_refresh;
+
+	/**
+	 * Adds a line to the lines vector. If the line is too long to
+	 * be displayed in the message and contains space characters, then
+	 * it will be broken into several lines.
+	 *
+	 * @param line String without newline characters.
+	 * @return Number of lines added after word-wrapping.
+	 **/
+	int PushWordWrappedLine(const std::string& line);
 };
 
 #endif

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -81,7 +81,22 @@ void Window_Message::StartMessageProcessing() {
 	contents->Clear();
 	text.clear();
 	for (const std::string& line : Game_Message::texts) {
-		text.append(Utils::DecodeUTF32(line)).append(1, U'\n');
+		/* TODO: do \n[x] \v[x] replacement before word-wrapping */
+		/* TODO: don't take commands like \> \< into account when word-wrapping */
+		if (Game_Message::is_word_wrapped) {
+			std::vector<std::string> wrapped_lines;
+			std::u32string& wrapped_text = text;
+			Game_Message::WordWrap(
+					line,
+					width - 24,
+					[&wrapped_text](const std::string& wrapped_line) {
+						wrapped_text.append(Utils::DecodeUTF32(wrapped_line)).append(1, U'\n');
+					}
+			);
+		}
+		else {
+			text.append(Utils::DecodeUTF32(line)).append(1, U'\n');
+		}
 	}
 	Game_Message::texts.clear();
 	item_max = min(4, Game_Message::choice_max);

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -77,7 +77,7 @@ Window_Message::~Window_Message() {
 	Game_Message::visible = false;
 }
 
-void Window_Message::ApplyTextInseringCommands() {
+void Window_Message::ApplyTextInsertingCommands() {
 	text_index = text.end();
 	end = text.end();
 
@@ -128,10 +128,10 @@ void Window_Message::StartMessageProcessing() {
 		for (const std::string& line : Game_Message::texts) {
 			/* TODO: don't take commands like \> \< into account when word-wrapping */
 			if (Game_Message::is_word_wrapped) {
-				// since ApplyTextInseringCommands works for the text variable,
+				// since ApplyTextInsertingCommands works for the text variable,
 				// we store line into text and use wrapped_text for the real 'text'
 				text = Utils::DecodeUTF32(line);
-				ApplyTextInseringCommands();
+				ApplyTextInsertingCommands();
 				Game_Message::WordWrap(
 						Utils::EncodeUTF(text),
 						width - 24,
@@ -152,7 +152,7 @@ void Window_Message::StartMessageProcessing() {
 	Game_Message::texts.clear();
 	item_max = min(4, Game_Message::choice_max);
 
-	ApplyTextInseringCommands();
+	ApplyTextInsertingCommands();
 	text_index = text.begin();
 
 	InsertNewPage();

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -134,7 +134,7 @@ public:
 	 * Doesn't return anything. The result is stored into
 	 * the text variable.
 	 */
-	void ApplyTextInseringCommands();
+	void ApplyTextInsertingCommands();
 
 	/**
 	 * Stub. For choice.

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -126,6 +126,16 @@ public:
 	 */
 	std::string ParseCommandCode(bool& success);
 
+
+	/**
+	 * Updates the text variable, replacing the commands
+	 * \N[x] and \V[x] in it.
+	 *
+	 * Doesn't return anything. The result is stored into
+	 * the text variable.
+	 */
+	void ApplyTextInseringCommands();
+
 	/**
 	 * Stub. For choice.
 	 */


### PR DESCRIPTION
This pull request adds support for placeholders (%S, %O, %V, %U) and word-wrapping introduced in the English release of RPG Maker 2000 v. 1.61.

Word-wrapping is currently **still measuring** invisible codes like ``\C[x]``, ``\S[x]``, ``\<``, so ``\C[2]\S[5]Hello`` is longer than ``Hello``. This is what RPG Maker 2000 is doing, so I’m not introducing new incompatibility here. The current code for displaying messages (e.g. for parsing parameters) has too many side effects, and changing it was a bit too complex for me, so I’ve decided not to do it right now.

Word-wrapping is currently only applied to the battle messages, like in RPG Maker 2000 v. 1.61. However, in future it can be used in other cases:

* When game translatability with LcfTrans is finished (#797), it would make sense to enable this setting for translated games.
* And when the Editor is finished, it would probably make sense to turn it on for the games made with the editor.

The word-wrapping is enabled by setting ``Game_Message::is_word_wrapped`` to true.

This pull request is related to issue #985 HH3: some sounds, animations, actions (events?) not appearing or appearing incorrectly: this should fix "Martyr%S attacks the enemy" (but I havenʼt tested this very game).

Fix #588 - Support RPG Maker 2000 v1.60 and v1.61: this adds all the features from v1.61, but not from v.1.60
Fix #1138 - Engine naming for RM2k v1.61: I've used ``EngineEnglish`` and ``rpg2ke``