### PR TITLE
Improve Movement Type Cycle

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -54,7 +54,6 @@ Game_Character::Game_Character() :
 	stop_count(0),
 	max_stop_count(0),
 	walk_animation(true),
-	cycle_stat(false),
 	opacity(255),
 	visible(true) {
 }

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -253,6 +253,8 @@ void Game_Character::MoveTypeCustom() {
 		active_route = &original_move_route;
 		active_route_index = GetOriginalMoveRouteIndex();
 	}
+	MoveOption option =
+		active_route->skippable ? MoveOption::IgnoreIfCantMove : MoveOption::Normal;
 
 	if (IsStopping()) {
 		move_failed = false;
@@ -292,10 +294,10 @@ void Game_Character::MoveTypeCustom() {
 			case RPG::MoveCommand::Code::move_downright:
 			case RPG::MoveCommand::Code::move_downleft:
 			case RPG::MoveCommand::Code::move_upleft:
-				Move(move_command.command_id);
+				Move(move_command.command_id, option);
 				break;
 			case RPG::MoveCommand::Code::move_random:
-				MoveRandom();
+				MoveRandom(option);
 				break;
 			case RPG::MoveCommand::Code::move_towards_hero:
 				MoveTowardsPlayer();
@@ -304,7 +306,7 @@ void Game_Character::MoveTypeCustom() {
 				MoveAwayFromPlayer();
 				break;
 			case RPG::MoveCommand::Code::move_forward:
-				MoveForward();
+				MoveForward(option);
 				break;
 			case RPG::MoveCommand::Code::face_up:
 				Turn(Up);
@@ -449,17 +451,9 @@ void Game_Character::MoveTypeCustom() {
 	}
 }
 
-void Game_Character::Move(int dir) {
+void Game_Character::Move(int dir, MoveOption option) {
 	int dx = (dir == Right || dir == UpRight || dir == DownRight) - (dir == Left || dir == DownLeft || dir == UpLeft);
 	int dy = (dir == Down || dir == DownRight || dir == DownLeft) - (dir == Up || dir == UpRight || dir == UpLeft);
-
-	SetDirection(dir);
-	if (!(IsDirectionFixed() || IsFacingLocked() || IsSpinning())) {
-		if (dir > 3) // Diagonal
-			SetSpriteDirection(GetSpriteDirection() % 2 ? -dx + 2 : dy + 1);
-		else
-			SetSpriteDirection(dir);
-	}
 
 	if (jumping) {
 		jump_plus_x += dx;
@@ -468,6 +462,17 @@ void Game_Character::Move(int dir) {
 	}
 
 	move_failed = !MakeWay(GetX(), GetY(), dir);
+
+	if (!move_failed || option == MoveOption::Normal) {
+		SetDirection(dir);
+		if (!(IsDirectionFixed() || IsFacingLocked() || IsSpinning())) {
+			if (dir > 3) // Diagonal
+				SetSpriteDirection(GetSpriteDirection() % 2 ? -dx + 2 : dy + 1);
+			else
+				SetSpriteDirection(dir);
+		}
+	}
+
 	if (move_failed) {
 		if (!CheckEventTriggerTouch(Game_Map::RoundX(GetX() + dx), Game_Map::RoundY(GetY() + dy)))
 			return;
@@ -482,12 +487,12 @@ void Game_Character::Move(int dir) {
 	max_stop_count = (GetMoveFrequency() > 7) ? 0 : pow(2.0, 9 - GetMoveFrequency());
 }
 
-void Game_Character::MoveForward() {
-	Move(GetDirection());
+void Game_Character::MoveForward(MoveOption option) {
+	Move(GetDirection(), option);
 }
 
-void Game_Character::MoveRandom() {
-	Move(Utils::GetRandomNumber(0, 3));
+void Game_Character::MoveRandom(MoveOption option) {
+	Move(Utils::GetRandomNumber(0, 3), option);
 }
 
 void Game_Character::MoveTowardsPlayer() {

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -882,3 +882,9 @@ Game_Character* Game_Character::GetCharacter(int character_id, int event_id) {
 			return Game_Map::GetEvent(character_id);
 	}
 }
+
+int Game_Character::ReverseDir(int dir) {
+	constexpr static char reversed[] =
+		{ Down, Left, Up, Right, DownLeft, UpLeft, UpRight, DownRight };
+	return reversed[dir];
+}

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -411,17 +411,23 @@ public:
 	void MoveTypeCustom();
 
 	void Turn(int dir);
-	void Move(int dir);
+
+	enum class MoveOption { Normal, IgnoreIfCantMove };
+
+	/**
+	 * Move in the direction dir.
+	 */
+	void Move(int dir, MoveOption option = MoveOption::Normal);
 
 	/**
 	 * Moves the character forward.
 	 */
-	void MoveForward();
+	void MoveForward(MoveOption option = MoveOption::Normal);
 
 	/**
 	 * Does a random movement.
 	 */
-	void MoveRandom();
+	void MoveRandom(MoveOption option = MoveOption::Normal);
 
 	/**
 	 * Does a move to the player hero.

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -683,7 +683,7 @@ public:
 		UpLeft
 	};
 
-	/** Reverses a direction, ex: RevereseDir(Up) == Down. */
+	/** Reverses a direction, ex: ReverseDir(Up) == Down. */
 	static int ReverseDir(int dir);
 
 	static Game_Character* GetCharacter(int character_id, int event_id);

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -719,9 +719,6 @@ protected:
 	int max_stop_count;
 	bool walk_animation;
 
-	/** used by cycle left-right, up-down */
-	bool cycle_stat;
-
 	int opacity;
 	bool visible;
 

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -677,6 +677,9 @@ public:
 		UpLeft
 	};
 
+	/** Reverses a direction, ex: RevereseDir(Up) == Down. */
+	static int ReverseDir(int dir);
+
 	static Game_Character* GetCharacter(int character_id, int event_id);
 
 protected:

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -583,22 +583,34 @@ void Game_Event::MoveTypeRandom() {
 	}
 }
 
-void Game_Event::MoveTypeCycleLeftRight() {
-	Move(cycle_stat ? Left : Right);
+void Game_Event::MoveTypeCycle(int default_dir) {
+	max_stop_count = (GetMoveFrequency() > 7) ? 0 : (1 << (9 - GetMoveFrequency()));
+	if (stop_count < max_stop_count) return;
+
+	int non_default_dir = ReverseDir(default_dir);
+	int move_dir = GetDirection();
+	if (!(move_dir == default_dir || move_dir == non_default_dir)) {
+		move_dir = default_dir;
+	}
+
+	Move(move_dir, MoveOption::IgnoreIfCantMove);
 
 	if (move_failed && stop_count >= max_stop_count + 20) {
-		cycle_stat = move_failed ? !cycle_stat : cycle_stat;
-		stop_count = 0;
+		if (stop_count >= max_stop_count + 60) {
+			Move(ReverseDir(move_dir));
+			stop_count = 0;
+		} else {
+			Move(ReverseDir(move_dir), MoveOption::IgnoreIfCantMove);
+		}
 	}
 }
 
-void Game_Event::MoveTypeCycleUpDown() {
-	Move(cycle_stat ? Up : Down);
+void Game_Event::MoveTypeCycleLeftRight() {
+	MoveTypeCycle(Right);
+}
 
-	if (move_failed && stop_count >= max_stop_count + 20) {
-		cycle_stat = !cycle_stat;
-		stop_count = 0;
-	}
+void Game_Event::MoveTypeCycleUpDown() {
+	MoveTypeCycle(Down);
 }
 
 void Game_Event::MoveTypeTowardsPlayer() {

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -196,7 +196,7 @@ private:
 
 	/**
 	 * Cycles between moving in default_dir and its opposite.
-	 * Tries to move the the event's movement direction, or
+	 * Tries to move in the event's movement direction, or
 	 * default_dir if this is along the wrong axis. Reverses
 	 * directions when encountering an obstacle.
 	 */

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -195,14 +195,20 @@ private:
 	void MoveTypeRandom();
 
 	/**
-	 * Moves left to right and switches direction if the
-	 * move failed.
+	 * Cycles between moving in default_dir and its opposite.
+	 * Tries to move the the event's movement direction, or
+	 * default_dir if this is along the wrong axis. Reverses
+	 * directions when encountering an obstacle.
+	 */
+	void MoveTypeCycle(int default_dir);
+
+	/**
+	 * Cycles left and right.
 	 */
 	void MoveTypeCycleLeftRight();
 
 	/**
-	 * Moves up and down and switches direction if the
-	 * move failed.
+	 * Cycles up and down.
 	 */
 	void MoveTypeCycleUpDown();
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -393,11 +393,6 @@ bool Game_Map::IsValid(int x, int y) {
 	return (x >= 0 && x < GetWidth() && y >= 0 && y < GetHeight());
 }
 
-static int ReverseDir(int d) {
-	assert(0 <= d && d < 4);
-	return (d + 2) & 3;
-}
-
 static int DirToMask(int d) {
 	switch (d)
 	{
@@ -486,7 +481,7 @@ static CollisionResult TestCollisionDuringMove(
 		if (other.IsInPosition(x,y) && (passages_up[tile_id] & DirToMask(d)) != 0) {
 			return CanStepOffCurrentTile;
 		}
-		else if (other.IsInPosition(new_x, new_y) && (passages_up[tile_id] & DirToMask(ReverseDir(d))) != 0) {
+		else if (other.IsInPosition(new_x, new_y) && (passages_up[tile_id] & DirToMask(Game_Character::ReverseDir(d))) != 0) {
 			return CanStepOntoNewTile;
 		} else {
 			return Collision;
@@ -544,7 +539,7 @@ bool Game_Map::MakeWay(int x, int y, int d, const Game_Character& self) {
 
 	return
 		(stepped_off_event || IsPassableTile(DirToMask(d), x + y * GetWidth()))
-		&& (stepped_onto_event || IsPassableTile(DirToMask(ReverseDir(d)), new_x + new_y * GetWidth()));
+		&& (stepped_onto_event || IsPassableTile(DirToMask(Game_Character::ReverseDir(d)), new_x + new_y * GetWidth()));
 }
 
 bool Game_Map::IsPassable(int x, int y, int d, const Game_Character* self_event) {


### PR DESCRIPTION
This fixes (or at least improves) the second bullet point (and only the second bullet point) in #1115. Events with movement type cycle now prefer moving forward, if possible. Basically, the algorithm is now

1. When we're ready to move, try moving forward (or in the default direction if we're facing the wrong way: Right for Left-Right, Down for Up-Down)
2. If that failed for 20 frames, keep trying to move forward, but if it fails, now try moving the opposite way too.
3. If that fails for 40 more frames, try going forward and if it fails, now move (don't just try to move) in the opposite way, and reset

By "try to move" I mean to do the same thing as doing a `Move` in a move route with the "Ignore if can't be moved" option toggled on. It turned out, though, that this also behaved differently in Player; even if you didn't move, the command wasn't totally ignored; you'd still turn to face the move direction. In RPG_RT, this doesn't happen. So I fixed this too.

The (probably totally useless in actual games) case of an event between two obstacles on either side that can't move should now also turn around with the same timing as in RPG_RT.

Yeah. Um. Do we know where in Deep 8 this was a problem? Probably be good to test it.