### PR TITLE
Emscripten: Improve UX for map loads

### DIFF
--- a/src/game_picture.cpp
+++ b/src/game_picture.cpp
@@ -22,6 +22,7 @@
 #include "game_picture.h"
 #include "player.h"
 #include "main_data.h"
+#include "game_player.h"
 
 Game_Picture::Game_Picture(int ID) :
 	id(ID),
@@ -155,6 +156,7 @@ void Game_Picture::RequestPictureSprite() {
 
 	FileRequestAsync* request = AsyncHandler::RequestFile("Picture", name);
 	request_id = request->Bind(&Game_Picture::OnPictureSpriteReady, this);
+	request->SetImportantFile(Main_Data::game_player->IsTeleporting());
 	request->Start();
 }
 

--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -20,6 +20,8 @@
 #include "cache.h"
 #include "game_map.h"
 #include "bitmap.h"
+#include "game_player.h"
+#include "main_data.h"
 
 Sprite_Character::Sprite_Character(Game_Character* character) :
 	character(character),
@@ -42,6 +44,7 @@ void Sprite_Character::Update() {
 		if (tile_id > 0) {
 			FileRequestAsync* tile_request = AsyncHandler::RequestFile("ChipSet", Game_Map::GetChipsetName());
 			request_id = tile_request->Bind(&Sprite_Character::OnTileSpriteReady, this);
+			tile_request->SetImportantFile(Main_Data::game_player->IsTeleporting());
 			tile_request->Start();
 		} else {
 			if (character_name.empty()) {
@@ -49,6 +52,7 @@ void Sprite_Character::Update() {
 			} else {
 				FileRequestAsync* char_request = AsyncHandler::RequestFile("CharSet", character_name);
 				request_id = char_request->Bind(&Sprite_Character::OnCharSpriteReady, this);
+				char_request->SetImportantFile(Main_Data::game_player->IsTeleporting());
 				char_request->Start();
 			}
 		}

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -90,6 +90,7 @@ void Spriteset_Map::Update() {
 		panorama_name = name;
 		FileRequestAsync* request = AsyncHandler::RequestFile("Panorama", panorama_name);
 		panorama_request_id = request->Bind(&Spriteset_Map::OnPanoramaSpriteReady, this);
+		request->SetImportantFile(Main_Data::game_player->IsTeleporting());
 		request->Start();
 	}
 	panorama->SetOx(Game_Map::Parallax::GetX());
@@ -130,8 +131,8 @@ Sprite_Character* Spriteset_Map::FindCharacter(Game_Character* character) const
 void Spriteset_Map::ChipsetUpdated() {
 	if (!Game_Map::GetChipsetName().empty()) {
 		FileRequestAsync* request = AsyncHandler::RequestFile("ChipSet", Game_Map::GetChipsetName());
+		request->SetImportantFile(Main_Data::game_player->IsTeleporting());
 		tilemap_request_id = request->Bind(&Spriteset_Map::OnTilemapSpriteReady, this);
-		request->SetImportantFile(true);
 		request->Start();
 	}
 	else {


### PR DESCRIPTION
Don't finish the teleport until all assets that will be required by the map are downloaded.

The purpose is to make the fade-in look correct. Currently only the ChipSet
is "important". Which means other assets are missing and will "pop-in" after
the fade-in is finished which is wrong and looks ugly.

Disadvantage is that map loading will take slightly longer because the Player
waits for all file transfers. Still faster then MV, though ;)