### PR TITLE
Always draw event sprites, even for tile_id = 0

### DIFF
--- a/src/sprite_character.h
+++ b/src/sprite_character.h
@@ -68,6 +68,9 @@ private:
 	int chara_width;
 	int chara_height;
 
+	/** Returns true for charset sprites; false for tiles. */
+	bool UsesCharset() const;
+
 	void OnTileSpriteReady(FileRequestResult*);
 	void OnCharSpriteReady(FileRequestResult*);
 


### PR DESCRIPTION
This fixes the first part of #1169, with the invisible event. I'm PRing it separately because this one should be much easier to review than the fix for the second part.