### PR TITLE
WebPlayer: fixes unwanted scrolling on Arrowkey press

### DIFF
--- a/resources/emscripten/emscripten-shell.html
+++ b/resources/emscripten/emscripten-shell.html
@@ -81,5 +81,14 @@
       };
     </script>
     {{{ SCRIPT }}}
+    <script>
+      //prevents scrolling on arrow key press
+      window.addEventListener("keydown", function(e) {
+          // space and arrow keys, from 112 to 123 for function keys (only works in some browsers)
+          if([32, 37, 38, 39, 40, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123].indexOf(e.keyCode) > -1) {
+              e.preventDefault();
+          }
+      }, false);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
fixes unwanted scrolling on Arrowkey press and spacebar.
For older Chrome Versions and some other browsers this fix disables the browser functions for f1 to f12