### PR TITLE
Replace "を" and "ヲ" with "ヴ" in the "Enter Hero name" scene

### DIFF
--- a/src/window_keyboard.cpp
+++ b/src/window_keyboard.cpp
@@ -50,7 +50,7 @@ std::string Window_Keyboard::items[Window_Keyboard::MODE_END][9][10] = {
 		{"は", "ひ", "ふ", "へ", "ほ", "ぁ", "ぃ", "ぅ", "ぇ", "ぉ"},
 		{"ま", "み", "む", "め", "も", "っ", "ゃ", "ゅ", "ょ", "ゎ"},
 		{"や", "ゆ", "よ", "わ", "ん", "ー", "～", "・", "＝", "☆"},
-		{"ら", "り", "る", "れ", "ろ", "を", Window_Keyboard::TO_KATAKANA, "", Window_Keyboard::DONE_JP}
+		{"ら", "り", "る", "れ", "ろ", "ヴ", Window_Keyboard::TO_KATAKANA, "", Window_Keyboard::DONE_JP}
 	},
 
 	{ // Katakana
@@ -62,7 +62,7 @@ std::string Window_Keyboard::items[Window_Keyboard::MODE_END][9][10] = {
 		{"ハ", "ヒ", "フ", "ヘ", "ホ", "ァ", "ィ", "ゥ", "ェ", "ォ"},
 		{"マ", "ミ", "ム", "メ", "モ", "ッ", "ャ", "ュ", "ョ", "ヮ"},
 		{"ヤ", "ユ", "ヨ", "ワ", "ン", "ー", "～", "・", "＝", "☆"},
-		{"ラ", "リ", "ル", "レ", "ロ", "ヲ", Window_Keyboard::TO_HIRAGANA, "", Window_Keyboard::DONE_JP}
+		{"ラ", "リ", "ル", "レ", "ロ", "ヴ", Window_Keyboard::TO_HIRAGANA, "", Window_Keyboard::DONE_JP}
 	},
 
 	{ // Hangul 1


### PR DESCRIPTION
On Windows (+ RPG_RT) there is not "を" or "ヲ" in the "Enter Hero name" scene and there is "ヴ" instead.

Hiragana:
![RPG_RT on Windows (hiragana)](https://cloud.githubusercontent.com/assets/10556453/26584501/7d81f93c-4538-11e7-8b8b-0dfb648b1c27.png)
Katakana:
![RPG_RT on Windows (katakana)](https://cloud.githubusercontent.com/assets/10556453/26584498/7d55086e-4538-11e7-8529-0082ad9c2b38.png)

EasyRPG Player (unpatched)
![EasyRPG Player (unpatched)](https://cloud.githubusercontent.com/assets/10556453/26584500/7d7de3ec-4538-11e7-9299-858e0c42d427.png)

This patch replaces "を" and "ヲ" with "ヴ", and allows users to input "ヴ".

EasyRPG Player (patched)
![EasyRPG Player (patched)](https://cloud.githubusercontent.com/assets/10556453/26584499/7d55d622-4538-11e7-94f9-cf2ba408880b.png)

