### PR TITLE
Fix placeholders in 'critical hit' message in RPG2kE

### DIFF
--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -267,8 +267,8 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetCriticalHitMessage() const {
 	if (Player::IsRPG2kE()) {
 		return Utils::ReplacePlaceholders(
 			message,
-			{'S'},
-			{GetTarget()->GetName()}
+			{'S', 'O'},
+			{GetSource()->GetName(), GetTarget()->GetName()}
 		);
 	}
 	else {


### PR DESCRIPTION
Sorry, I’ve found a bug in my critical hit message code (it swapped %O and %S and didn’t have %O). This should be correct now.