### PR TITLE
Fix off-screen panning

### DIFF
--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -60,9 +60,6 @@ namespace {
 	std::vector<Game_CommonEvent> common_events;
 
 	std::unique_ptr<RPG::Map> map;
-	int scroll_direction;
-	int scroll_rest;
-	int scroll_speed;
 
 	std::unique_ptr<Game_Interpreter_Map> interpreter;
 	std::vector<std::shared_ptr<Game_Interpreter> > free_interpreters;
@@ -88,9 +85,6 @@ void Game_Map::Init() {
 	refresh_type = Refresh_All;
 
 	location.map_id = 0;
-	scroll_direction = 0;
-	scroll_rest = 0;
-	scroll_speed = 0;
 	interpreter.reset(new Game_Interpreter_Map(0, true));
 	map_info.encounter_rate = 0;
 
@@ -237,10 +231,6 @@ void Game_Map::SetupCommon(int _id) {
 	}
 
 	refresh_type = Refresh_All;
-
-	scroll_direction = 2;
-	scroll_rest = 0;
-	scroll_speed = 4;
 
 	int current_index = GetMapIndex(location.map_id);
 	map_info.encounter_rate = Data::treemap.maps[current_index].encounter_steps;
@@ -810,40 +800,8 @@ int Game_Map::CheckEvent(int x, int y) {
 	return 0;
 }
 
-void Game_Map::StartScroll(int direction, int distance, int speed) {
-	scroll_direction = direction;
-	scroll_rest = distance * SCREEN_TILE_WIDTH;
-	scroll_speed = speed;
-}
-
-bool Game_Map::IsScrolling() {
-	return scroll_rest > 0;
-}
-
-void Game_Map::UpdateScroll() {
-	if (scroll_rest > 0) {
-		int distance = (1 << scroll_speed) / 2;
-		switch (scroll_direction) {
-			case 2:
-				ScrollDown(distance);
-				break;
-			case 4:
-				ScrollLeft(distance);
-				break;
-			case 6:
-				ScrollRight(distance);
-				break;
-			case 8:
-				ScrollUp(distance);
-				break;
-		}
-		scroll_rest -= distance;
-	}
-}
-
 void Game_Map::Update(bool only_parallel) {
 	if (GetNeedRefresh() != Refresh_None) Refresh();
-	UpdateScroll();
 	UpdatePan();
 	Parallax::Update();
 	if (animation) {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1251,6 +1251,14 @@ int Game_Map::GetPanY() {
 	return location.pan_current_y;
 }
 
+int Game_Map::GetTargetPanX() {
+	return location.pan_finish_x;
+}
+
+int Game_Map::GetTargetPanY() {
+	return location.pan_finish_y;
+}
+
 bool Game_Map::IsTeleportDelayed() {
 	return teleport_delay;
 }

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -573,6 +573,8 @@ namespace Game_Map {
 	bool IsPanLocked();
 	int GetPanX();
 	int GetPanY();
+	int GetTargetPanX();
+	int GetTargetPanY();
 
 	/**
 	 * Gets if pending teleportations will be ignored.

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -223,32 +223,11 @@ namespace Game_Map {
 	int CheckEvent(int x, int y);
 
 	/**
-	 * Starts map scrolling.
-	 *
-	 * @param direction scroll direction.
-	 * @param distance scroll distance in tiles.
-	 * @param speed scroll speed.
-	 */
-	void StartScroll(int direction, int distance, int speed);
-
-	/**
-	 * Gets if the map is currently scrolling.
-	 *
-	 * @return whether the map view is scrolling.
-	 */
-	bool IsScrolling();
-
-	/**
 	 * Updates the map state.
 	 *
 	 * @param only_parallel Update only parallel interpreters
 	 */
 	void Update(bool only_parallel = false);
-
-	/**
-	 * Updates the scroll state.
-	 */
-	void UpdateScroll();
 
 	/**
 	 * Gets current map.

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -30,7 +30,10 @@
 
 class FileRequestAsync;
 
-#define SCREEN_TILE_WIDTH 256
+// These are in sixteenths of a pixel.
+constexpr int SCREEN_TILE_WIDTH = 256;
+constexpr int SCREEN_WIDTH = 20 * SCREEN_TILE_WIDTH;
+constexpr int SCREEN_HEIGHT = 15 * SCREEN_TILE_WIDTH;
 
 /**
  * Game_Map namespace
@@ -94,32 +97,30 @@ namespace Game_Map {
 	void Refresh();
 
 	/**
-	 * Scrolls the map view down.
-	 *
-	 * @param distance number of tiles to scroll.
-	 */
-	void ScrollDown(int distance);
-
-	/**
-	 * Scrolls the map view left.
-	 *
-	 * @param distance number of tiles to scroll.
-	 */
-	void ScrollLeft(int distance);
-
-	/**
 	 * Scrolls the map view right.
 	 *
-	 * @param distance number of tiles to scroll.
+	 * @param distance scroll amount in sixteenths of a pixel
 	 */
 	void ScrollRight(int distance);
 
 	/**
-	 * Scrolls the map view up.
+	 * Scrolls the map view down.
 	 *
-	 * @param distance number of tiles to scroll.
+	 * @param distance scroll amount in sixteenths of a pixel
 	 */
-	void ScrollUp(int distance);
+	void ScrollDown(int distance);
+
+	/**
+	 * Adds inc, a distance in sixteenths of a pixel, to screen_x, the
+	 * x-position of a screen. The sum is clamped (for non-looping maps)
+	 * and wrapped (for looping maps) to fit in the map range. If the
+	 * sum is clamped, inc is updated to be actual amount that it
+	 * changed by.
+	 */
+	void AddScreenX(int& screen_x, int& inc);
+
+	/** Same as AddScreenX, but for the Y-direction. */
+	void AddScreenY(int& screen_y, int& inc);
 
 	/**
 	 * Gets if a tile coordinate is valid.
@@ -382,30 +383,29 @@ namespace Game_Map {
 
 	/**
 	 * Gets the offset of the screen from the left edge
-	 * of the map.
-	 *
-	 * If the screen is shaking, this is not necessarily
-	 * the same value that SetPositionX returns.
-	 *
-	 * @return display x.
+	 * of the map, ignoring screen shaking.
+	 */
+	int GetPositionX();
+
+	/**
+	 * Gets the offset of the screen from the left edge
+	 * of the map, taking shaking into account.
 	 */
 	int GetDisplayX();
 
 	/**
 	 * Sets the offset of the screen from the left edge
-	 * of the map.
-	 *
-	 * If the screen is shaking, this is not necessarily
-	 * the same value that GetDisplayX returns.
-	 *
-	 * @param new_position_x new position x.
+	 * of the map, as given by GetPositionX.
 	 */
 	void SetPositionX(int new_position_x);
 
 	/**
 	 * Gets display y.
-	 *
-	 * @return display y.
+	 */
+	int GetPositionY();
+
+	/**
+	 * Gets display y.
 	 */
 	int GetDisplayY();
 

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -309,8 +309,8 @@ void Game_Player::MoveTo(int x, int y) {
 void Game_Player::UpdateScroll() {
 	// First, update for the player's movement...
 
-	int center_x = DisplayUi->GetWidth() / 2 - TILE_SIZE / 2 - Game_Map::GetPanX() / (SCREEN_TILE_WIDTH / TILE_SIZE) + 2;
-	int center_y = DisplayUi->GetHeight() / 2 + TILE_SIZE / 2 - Game_Map::GetPanY() / (SCREEN_TILE_WIDTH / TILE_SIZE) + 2;
+	int center_x = DisplayUi->GetWidth() / 2 - TILE_SIZE / 2 - actual_pan_x / (SCREEN_TILE_WIDTH / TILE_SIZE) + 2;
+	int center_y = DisplayUi->GetHeight() / 2 + TILE_SIZE / 2 - actual_pan_y / (SCREEN_TILE_WIDTH / TILE_SIZE) + 2;
 
 	int dx = 0;
 	int dy = 0;

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -287,8 +287,8 @@ void Game_Player::Center() {
 	Game_Map::AddScreenX(x, dist_to_screen_left);
 	Game_Map::AddScreenY(y, dist_to_screen_top);
 
-	int actual_pan_x = Game_Map::GetPanX();
-	int actual_pan_y = Game_Map::GetPanY();
+	actual_pan_x = Game_Map::GetPanX();
+	actual_pan_y = Game_Map::GetPanY();
 
 	Game_Map::AddScreenX(x, actual_pan_x);
 	Game_Map::AddScreenY(y, actual_pan_y);
@@ -307,6 +307,8 @@ void Game_Player::MoveTo(int x, int y) {
 }
 
 void Game_Player::UpdateScroll() {
+	// First, update for the player's movement...
+
 	int center_x = DisplayUi->GetWidth() / 2 - TILE_SIZE / 2 - Game_Map::GetPanX() / (SCREEN_TILE_WIDTH / TILE_SIZE) + 2;
 	int center_y = DisplayUi->GetHeight() / 2 + TILE_SIZE / 2 - Game_Map::GetPanY() / (SCREEN_TILE_WIDTH / TILE_SIZE) + 2;
 
@@ -344,15 +346,33 @@ void Game_Player::UpdateScroll() {
 		}
 	}
 
+	Game_Map::ScrollRight(dx);
+	Game_Map::ScrollDown(dy);
+
+	// Second, update for the change in pan...
+
 	int pan_x = Game_Map::GetPanX();
 	int pan_y = Game_Map::GetPanY();
-	dx += pan_x - last_pan_x;
-	dy += pan_y - last_pan_y;
+	int pan_dx = pan_x - last_pan_x;
+	int pan_dy = pan_y - last_pan_y;
 	last_pan_x = pan_x;
 	last_pan_y = pan_y;
 
-	Game_Map::ScrollRight(dx);
-	Game_Map::ScrollDown(dy);
+	// Change pan_dx/pan_dy to account for hitting the edges
+	int screen_x = Game_Map::GetPositionX();
+	int screen_y = Game_Map::GetPositionY();
+	Game_Map::AddScreenX(screen_x, pan_dx);
+	Game_Map::AddScreenY(screen_y, pan_dy);
+
+	// Only move for the pan if we're closer to the target pan than we were before.
+	if (std::abs(actual_pan_x + pan_dx - Game_Map::GetTargetPanX()) < std::abs(actual_pan_x - Game_Map::GetTargetPanX())) {
+		Game_Map::ScrollRight(pan_dx);
+		actual_pan_x += pan_dx;
+	}
+	if (std::abs(actual_pan_y + pan_dy - Game_Map::GetTargetPanY()) < std::abs(actual_pan_y - Game_Map::GetTargetPanY())) {
+		Game_Map::ScrollDown(pan_dy);
+		actual_pan_y += pan_dy;
+	}
 }
 
 

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -277,25 +277,24 @@ bool Game_Player::IsTeleporting() const {
 	return teleporting;
 }
 
-void Game_Player::Center(int x, int y) {
-	int center_x = (DisplayUi->GetWidth() / (TILE_SIZE / 16) - TILE_SIZE * 2) * 8 - Game_Map::GetPanX();
-	int center_y = (DisplayUi->GetHeight() / (TILE_SIZE / 16) - TILE_SIZE) * 8 - Game_Map::GetPanY();
+void Game_Player::Center() {
+	int x = GetRealX() + SCREEN_TILE_WIDTH;
+	int y = GetRealY() + SCREEN_TILE_WIDTH / 2;
 
-	if (Game_Map::LoopHorizontal()) {
-		Game_Map::SetPositionX(x*SCREEN_TILE_WIDTH - center_x);
-	} else {
-		int max_x = (Game_Map::GetWidth() - DisplayUi->GetWidth() / TILE_SIZE) * SCREEN_TILE_WIDTH;
-		Game_Map::SetPositionX(max(0, min((x * SCREEN_TILE_WIDTH - center_x), max_x)));
-	}
+	int dist_to_screen_left = -SCREEN_WIDTH / 2;
+	int dist_to_screen_top = -SCREEN_HEIGHT / 2;
 
-	if (Game_Map::LoopVertical()) {
-		Game_Map::SetPositionY(y * SCREEN_TILE_WIDTH - center_y);
-	} else {
-		int max_y = (Game_Map::GetHeight() - DisplayUi->GetHeight() / TILE_SIZE) * SCREEN_TILE_WIDTH;
-		Game_Map::SetPositionY(max(0, min((y * SCREEN_TILE_WIDTH - center_y), max_y)));
-	}
+	Game_Map::AddScreenX(x, dist_to_screen_left);
+	Game_Map::AddScreenY(y, dist_to_screen_top);
 
-	Game_Map::Parallax::ResetPosition();
+	int actual_pan_x = Game_Map::GetPanX();
+	int actual_pan_y = Game_Map::GetPanY();
+
+	Game_Map::AddScreenX(x, actual_pan_x);
+	Game_Map::AddScreenY(y, actual_pan_y);
+
+	Game_Map::SetPositionX(x);
+	Game_Map::SetPositionY(y);
 }
 
 void Game_Player::MoveTo(int x, int y) {
@@ -303,7 +302,8 @@ void Game_Player::MoveTo(int x, int y) {
 	y = max(0, min(y, Game_Map::GetHeight() - 1));
 
 	Game_Character::MoveTo(x, y);
-	Center(x, y);
+	Center();
+	Game_Map::Parallax::ResetPosition();
 }
 
 void Game_Player::UpdateScroll() {
@@ -344,22 +344,15 @@ void Game_Player::UpdateScroll() {
 		}
 	}
 
-	if (Game_Map::GetPanX() != last_pan_x || Game_Map::GetPanY() != last_pan_y) {
-		dx += Game_Map::GetPanX() - last_pan_x;
-		dy += Game_Map::GetPanY() - last_pan_y;
+	int pan_x = Game_Map::GetPanX();
+	int pan_y = Game_Map::GetPanY();
+	dx += pan_x - last_pan_x;
+	dy += pan_y - last_pan_y;
+	last_pan_x = pan_x;
+	last_pan_y = pan_y;
 
-		last_pan_x = Game_Map::GetPanX();
-		last_pan_y = Game_Map::GetPanY();
-	}
-
-	if (dx > 0)
-		Game_Map::ScrollRight(dx);
-	else if (dx < 0)
-		Game_Map::ScrollLeft(-dx);
-	if (dy > 0)
-		Game_Map::ScrollDown(dy);
-	else if (dy < 0)
-		Game_Map::ScrollUp(-dy);
+	Game_Map::ScrollRight(dx);
+	Game_Map::ScrollDown(dy);
 }
 
 

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -116,7 +116,7 @@ public:
 	Game_Vehicle* GetVehicle() const;
 	bool CanWalk(int x, int y);
 
-	/* Workaround used to avoid blocking the player with move routes that are completable in a single frame */
+	/* Workaround used to avoid blocking the player with move routes that are completeable in a single frame */
 	bool IsBlockedByMoveRoute() const;
 
 private:
@@ -124,8 +124,13 @@ private:
 
 	bool teleporting = false;
 	int new_map_id = 0, new_x = 0, new_y = 0, new_direction = 0;
+
 	int last_pan_x = 0, last_pan_y = 0;
 	int last_remaining_move = 0, last_remaining_jump = 0;
+	// These track how much of the pan has actually occurred, which
+	// may be less than the pan values if the pan went off the map.
+	int actual_pan_x = 0, actual_pan_y = 0;
+
 	RPG::Music walking_bgm;
 
 	void UpdateScroll();

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -100,7 +100,7 @@ public:
 	void ReserveTeleport(const RPG::SaveTarget& target);
 	void StartTeleport();
 	void PerformTeleport();
-	void Center(int x, int y);
+	void Center();
 	void MoveTo(int x, int y) override;
 	void Update() override;
 


### PR DESCRIPTION
I think this is ready....

Keep track of how much we've actually panned so we know not to go past where the pan should be.

Should fix #1169. It don't think it fixes _any_ other panning problems though. Matching RPG_RT turned out to be a nightmare -_-;;

I needed a non-negative mod function. Ghabry added a proper one in 59b4b54, so the `mod` function I added should be changed to use that whenever both of them make in into master.