### PR TITLE
Improve the Output system

### DIFF
--- a/src/audio_generic.cpp
+++ b/src/audio_generic.cpp
@@ -154,7 +154,7 @@ void GenericAudio::SE_Play(std::string const &file, int volume, int pitch) {
 		}
 	}
 
-	Output::Warning("Couldn't play %s SE.\nNo free channel available", FileFinder::GetPathInsideGamePath(file).c_str());
+	Output::Warning("Couldn't play %s SE. No free channel available", FileFinder::GetPathInsideGamePath(file).c_str());
 }
 
 void GenericAudio::SE_Stop() {
@@ -193,7 +193,7 @@ bool GenericAudio::PlayOnChannel(BgmChannel& chan, const std::string& file, int 
 
 		return true;
 	} else {
-		Output::Warning("Couldn't play BGM %s.\nFormat not supported", FileFinder::GetPathInsideGamePath(file).c_str());
+		Output::Warning("Couldn't play BGM %s. Format not supported", FileFinder::GetPathInsideGamePath(file).c_str());
 		fclose(filehandle);
 	}
 
@@ -216,7 +216,7 @@ bool GenericAudio::PlayOnChannel(SeChannel& chan, const std::string& file, int v
 
 		return true;
 	} else {
-		Output::Warning("Couldn't play SE %s.\nFormat not supported", FileFinder::GetPathInsideGamePath(file).c_str());
+		Output::Warning("Couldn't play SE %s. Format not supported", FileFinder::GetPathInsideGamePath(file).c_str());
 	}
 
 	return false;

--- a/src/audio_generic.cpp
+++ b/src/audio_generic.cpp
@@ -154,7 +154,7 @@ void GenericAudio::SE_Play(std::string const &file, int volume, int pitch) {
 		}
 	}
 
-	Output::Warning("Couldn't play %s SE: No free channel available", file.c_str());
+	Output::Warning("Couldn't play %s SE.\nNo free channel available", FileFinder::GetPathInsideGamePath(file).c_str());
 }
 
 void GenericAudio::SE_Stop() {
@@ -179,7 +179,7 @@ bool GenericAudio::PlayOnChannel(BgmChannel& chan, const std::string& file, int 
 
 	FILE* filehandle = FileFinder::fopenUTF8(file, "rb");
 	if (!filehandle) {
-		Output::Warning("BGM file not readable: %s", file.c_str());
+		Output::Warning("BGM file not readable: %s", FileFinder::GetPathInsideGamePath(file).c_str());
 		return false;
 	}
 
@@ -193,7 +193,7 @@ bool GenericAudio::PlayOnChannel(BgmChannel& chan, const std::string& file, int 
 
 		return true;
 	} else {
-		Output::Warning("Couldn't play BGM %s: Format not supported", file.c_str());
+		Output::Warning("Couldn't play BGM %s.\nFormat not supported", FileFinder::GetPathInsideGamePath(file).c_str());
 		fclose(filehandle);
 	}
 
@@ -216,7 +216,7 @@ bool GenericAudio::PlayOnChannel(SeChannel& chan, const std::string& file, int v
 
 		return true;
 	} else {
-		Output::Warning("Couldn't play SE %s: Format not supported", file.c_str());
+		Output::Warning("Couldn't play SE %s.\nFormat not supported", FileFinder::GetPathInsideGamePath(file).c_str());
 	}
 
 	return false;

--- a/src/audio_sdl_mixer.cpp
+++ b/src/audio_sdl_mixer.cpp
@@ -69,7 +69,7 @@ namespace {
 
 		out_len = audio->GetDecoder()->Decode(buffer.data(), out_len);
 		if (out_len == -1) {
-			Output::Warning("Couldn't decode BGM.\n%s", audio->GetDecoder()->GetError().c_str());
+			Output::Warning("Couldn't decode BGM. %s", audio->GetDecoder()->GetError().c_str());
 			Mix_HookMusic(nullptr, nullptr);
 			return;
 		}
@@ -306,7 +306,7 @@ void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int
 			return;
 		}
 #endif
-		Output::Warning("Couldn't load %s BGM.\n%s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
+		Output::Warning("Couldn't load %s BGM. %s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
 		return;
 	}
 
@@ -331,7 +331,7 @@ void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int
 		Mix_FadeInMusic(bgm.get(), 0, fadein)
 #endif
 		== -1) {
-			Output::Warning("Couldn't play %s BGM.\n%s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
+			Output::Warning("Couldn't play %s BGM. %s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
 			return;
 	}
 
@@ -340,7 +340,7 @@ void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int
 
 void SdlMixerAudio::SetupAudioDecoder(FILE* handle, const std::string& file, int volume, int pitch, int fadein) {
 	if (!audio_decoder->Open(handle)) {
-		Output::Warning("Couldn't play %s BGM.\n%s", FileFinder::GetPathInsideGamePath(file).c_str(), audio_decoder->GetError().c_str());
+		Output::Warning("Couldn't play %s BGM. %s", FileFinder::GetPathInsideGamePath(file).c_str(), audio_decoder->GetError().c_str());
 		audio_decoder.reset();
 		return;
 	}
@@ -364,7 +364,7 @@ void SdlMixerAudio::SetupAudioDecoder(FILE* handle, const std::string& file, int
 	Uint16 sdl_format;
 	int audio_channels;
 	if (!Mix_QuerySpec(&audio_rate, &sdl_format, &audio_channels)) {
-		Output::Warning("Couldn't query mixer spec.\n%s", Mix_GetError());
+		Output::Warning("Couldn't query mixer spec. %s", Mix_GetError());
 		return;
 	}
 	AudioDecoder::Format audio_format = sdl_format_to_format(sdl_format);
@@ -521,14 +521,14 @@ void SdlMixerAudio::BGM_Fade(int fade) {
 void SdlMixerAudio::BGS_Play(std::string const& file, int volume, int /* pitch */, int fadein) {
 	bgs.reset(Mix_LoadWAV(file.c_str()), &Mix_FreeChunk);
 	if (!bgs) {
-		Output::Warning("Couldn't load %s BGS.\n%s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
+		Output::Warning("Couldn't load %s BGS. %s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
 		return;
 	}
 
 	Mix_Volume(BGS_CHANNEL_NUM, volume * MIX_MAX_VOLUME / 100);
 	int channel = Mix_FadeInChannel(BGS_CHANNEL_NUM, bgs.get(), 0, fadein);
 	if (channel != 0) {
-		Output::Warning("Couldn't play %s BGS.\n%s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
+		Output::Warning("Couldn't play %s BGS. %s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
 		return;
 	}
 	bgs_playing = true;
@@ -577,7 +577,7 @@ void SdlMixerAudio::SE_Play(std::string const& file, int volume, int pitch) {
 		Uint16 sdl_format;
 		int audio_channels;
 		if (!Mix_QuerySpec(&audio_rate, &sdl_format, &audio_channels)) {
-			Output::Warning("Couldn't query mixer spec.\n%s", Mix_GetError());
+			Output::Warning("Couldn't query mixer spec. %s", Mix_GetError());
 			return;
 		}
 		AudioDecoder::Format audio_format = sdl_format_to_format(sdl_format);
@@ -591,7 +591,7 @@ void SdlMixerAudio::SE_Play(std::string const& file, int volume, int pitch) {
 			sound.reset(Mix_QuickLoad_RAW(se_ref->buffer.data(), se_ref->buffer.size()), &Mix_FreeChunk);
 
 			if (!sound) {
-				Output::Warning("Couldn't load %s SE.\n%s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
+				Output::Warning("Couldn't load %s SE. %s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
 			}
 		}
 	}
@@ -599,7 +599,7 @@ void SdlMixerAudio::SE_Play(std::string const& file, int volume, int pitch) {
 	if (!sound) {
 		sound.reset(Mix_LoadWAV(file.c_str()), &Mix_FreeChunk);
 		if (!sound) {
-			Output::Warning("Couldn't load %s SE.\n%s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
+			Output::Warning("Couldn't load %s SE. %s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
 			return;
 		}
 	}
@@ -607,7 +607,7 @@ void SdlMixerAudio::SE_Play(std::string const& file, int volume, int pitch) {
 	int channel = Mix_PlayChannel(-1, sound.get(), 0);
 	Mix_Volume(channel, volume * MIX_MAX_VOLUME / 100);
 	if (channel == -1) {
-		Output::Warning("Couldn't play %s SE.\n%s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
+		Output::Warning("Couldn't play %s SE. %s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
 		return;
 	}
 	sounds[channel].first = sound;

--- a/src/audio_sdl_mixer.cpp
+++ b/src/audio_sdl_mixer.cpp
@@ -126,7 +126,7 @@ namespace {
 
 	AudioDecoder::Format sdl_format_to_format(Uint16 format) {
 		switch (format) {
-		case AUDIO_U8: 
+		case AUDIO_U8:
 			return AudioDecoder::Format::U8;
 		case AUDIO_S8:
 			return AudioDecoder::Format::S8;
@@ -251,7 +251,7 @@ void SdlMixerAudio::BGM_OnPlayedOnce() {
 void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int fadein) {
 	FILE* filehandle = FileFinder::fopenUTF8(file, "rb");
 	if (!filehandle) {
-		Output::Warning("Music not readable: %s", file.c_str());
+		Output::Warning("Music not readable: %s", FileFinder::GetPathInsideGamePath(file).c_str());
 		return;
 	}
 	audio_decoder = AudioDecoder::Create(filehandle, file);
@@ -285,7 +285,7 @@ void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int
 		char magic[4] = { 0 };
 		filehandle = FileFinder::fopenUTF8(file, "rb");
 		if (!filehandle) {
-			Output::Warning("Music not readable: %s", file.c_str());
+			Output::Warning("Music not readable: %s", FileFinder::GetPathInsideGamePath(file).c_str());
 			return;
 		}
 		fread(magic, 4, 1, filehandle);
@@ -306,7 +306,7 @@ void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int
 			return;
 		}
 #endif
-		Output::Warning("Couldn't load %s BGM.\n%s", file.c_str(), Mix_GetError());
+		Output::Warning("Couldn't load %s BGM.\n%s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
 		return;
 	}
 
@@ -331,7 +331,7 @@ void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int
 		Mix_FadeInMusic(bgm.get(), 0, fadein)
 #endif
 		== -1) {
-			Output::Warning("Couldn't play %s BGM.\n%s", file.c_str(), Mix_GetError());
+			Output::Warning("Couldn't play %s BGM.\n%s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
 			return;
 	}
 
@@ -340,11 +340,11 @@ void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int
 
 void SdlMixerAudio::SetupAudioDecoder(FILE* handle, const std::string& file, int volume, int pitch, int fadein) {
 	if (!audio_decoder->Open(handle)) {
-		Output::Warning("Couldn't play %s BGM.\n%s", file.c_str(), audio_decoder->GetError().c_str());
+		Output::Warning("Couldn't play %s BGM.\n%s", FileFinder::GetPathInsideGamePath(file).c_str(), audio_decoder->GetError().c_str());
 		audio_decoder.reset();
 		return;
 	}
-	
+
 	// Can't use BGM_Stop here because it destroys the audio_decoder
 #if SDL_MAJOR_VERSION>1
 	// SDL2_mixer bug, see above
@@ -384,7 +384,7 @@ void SdlMixerAudio::SetupAudioDecoder(FILE* handle, const std::string& file, int
 
 	// Don't care if successful, always build cvt
 	SDL_BuildAudioCVT(&cvt, format_to_sdl_format(device_format), (int)device_channels, device_rate, sdl_format, audio_channels, audio_rate);
-	
+
 	audio_decoder->SetFade(0, volume, fadein);
 	audio_decoder->SetPitch(pitch);
 
@@ -521,14 +521,14 @@ void SdlMixerAudio::BGM_Fade(int fade) {
 void SdlMixerAudio::BGS_Play(std::string const& file, int volume, int /* pitch */, int fadein) {
 	bgs.reset(Mix_LoadWAV(file.c_str()), &Mix_FreeChunk);
 	if (!bgs) {
-		Output::Warning("Couldn't load %s BGS.\n%s", file.c_str(), Mix_GetError());
+		Output::Warning("Couldn't load %s BGS.\n%s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
 		return;
 	}
 
 	Mix_Volume(BGS_CHANNEL_NUM, volume * MIX_MAX_VOLUME / 100);
 	int channel = Mix_FadeInChannel(BGS_CHANNEL_NUM, bgs.get(), 0, fadein);
 	if (channel != 0) {
-		Output::Warning("Couldn't play %s BGS.\n%s", file.c_str(), Mix_GetError());
+		Output::Warning("Couldn't play %s BGS.\n%s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
 		return;
 	}
 	bgs_playing = true;
@@ -591,7 +591,7 @@ void SdlMixerAudio::SE_Play(std::string const& file, int volume, int pitch) {
 			sound.reset(Mix_QuickLoad_RAW(se_ref->buffer.data(), se_ref->buffer.size()), &Mix_FreeChunk);
 
 			if (!sound) {
-				Output::Warning("Couldn't load %s SE.\n%s", file.c_str(), Mix_GetError());
+				Output::Warning("Couldn't load %s SE.\n%s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
 			}
 		}
 	}
@@ -599,7 +599,7 @@ void SdlMixerAudio::SE_Play(std::string const& file, int volume, int pitch) {
 	if (!sound) {
 		sound.reset(Mix_LoadWAV(file.c_str()), &Mix_FreeChunk);
 		if (!sound) {
-			Output::Warning("Couldn't load %s SE.\n%s", file.c_str(), Mix_GetError());
+			Output::Warning("Couldn't load %s SE.\n%s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
 			return;
 		}
 	}
@@ -607,7 +607,7 @@ void SdlMixerAudio::SE_Play(std::string const& file, int volume, int pitch) {
 	int channel = Mix_PlayChannel(-1, sound.get(), 0);
 	Mix_Volume(channel, volume * MIX_MAX_VOLUME / 100);
 	if (channel == -1) {
-		Output::Warning("Couldn't play %s SE.\n%s", file.c_str(), Mix_GetError());
+		Output::Warning("Couldn't play %s SE.\n%s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
 		return;
 	}
 	sounds[channel].first = sound;

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -533,9 +533,9 @@ void FileFinder::InitRtpPaths(bool warn_no_rtp_found) {
 	}
 
 	if (warn_no_rtp_found && search_paths.empty()) {
-		Output::Warning("RTP not found. This may create missing file errors.\n"
-			"Install RTP files or check they are installed fine.\n"
-			"If this game really does not require RTP, then add\n"
+		Output::Warning("RTP not found. This may create missing file errors. "
+			"Install RTP files or check they are installed fine. "
+			"If this game really does not require RTP, then add "
 			"FullPackageFlag=1 line to the RPG_RT.ini game file.");
 	}
 }

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -94,8 +94,8 @@ namespace {
 	std::string fonts_path;
 
 	std::string FindFile(FileFinder::DirectoryTree const& tree,
-										  std::string const& dir,
-										  std::string const& name,
+										  const std::string& dir,
+										  const std::string& name,
 										  char const* exts[])
 	{
 		using namespace FileFinder;
@@ -160,11 +160,11 @@ namespace {
 
 	bool is_not_ascii_char(uint8_t c) { return c > 0x80; }
 
-	bool is_not_ascii_filename(std::string const& n) {
+	bool is_not_ascii_filename(const std::string& n) {
 		return std::find_if(n.begin(), n.end(), &is_not_ascii_char) != n.end();
 	}
 
-	std::string const& translate_rtp(std::string const& dir, std::string const& name) {
+	const std::string& translate_rtp(const std::string& dir, const std::string& name) {
 		rtp_table_type const& table =
 			Player::IsRPG2k() ? RTP::RTP_TABLE_2000 : RTP::RTP_TABLE_2003;
 
@@ -194,7 +194,7 @@ namespace {
 		std::string const ret = FindFile(*tree, dir, name, exts);
 		if (!ret.empty()) { return ret; }
 
-		std::string const& rtp_name = translate_rtp(dir, name);
+		const std::string& rtp_name = translate_rtp(dir, name);
 
 		for(search_path_list::const_iterator i = search_paths.begin(); i != search_paths.end(); ++i) {
 			if (! *i) { continue; }
@@ -241,7 +241,7 @@ void FileFinder::SetDirectoryTree(std::shared_ptr<FileFinder::DirectoryTree> dir
 	game_directory_tree = directory_tree;
 }
 
-std::shared_ptr<FileFinder::DirectoryTree> FileFinder::CreateDirectoryTree(std::string const& p, bool recursive) {
+std::shared_ptr<FileFinder::DirectoryTree> FileFinder::CreateDirectoryTree(const std::string& p, bool recursive) {
 	if(! (Exists(p) && IsDirectory(p))) { return std::shared_ptr<DirectoryTree>(); }
 	std::shared_ptr<DirectoryTree> tree = std::make_shared<DirectoryTree>();
 	tree->directory_path = p;
@@ -262,7 +262,7 @@ std::shared_ptr<FileFinder::DirectoryTree> FileFinder::CreateDirectoryTree(std::
 	return tree;
 }
 
-std::string FileFinder::MakePath(const std::string &dir, std::string const& name) {
+std::string FileFinder::MakePath(const std::string& dir, const std::string& name) {
 	std::string str = dir.empty()? name : dir + "/" + name;
 #ifdef _WIN32
 	std::replace(str.begin(), str.end(), '/', '\\');
@@ -272,10 +272,10 @@ std::string FileFinder::MakePath(const std::string &dir, std::string const& name
 	return str;
 }
 
-std::string FileFinder::MakeCanonical(std::string const& path, int initial_deepness) {
+std::string FileFinder::MakeCanonical(const std::string& path, int initial_deepness) {
 	std::vector<std::string> path_components = SplitPath(path);
 	std::vector<std::string> path_can;
-	
+
 	for (std::string path_comp : path_components) {
 		if (path_comp == "..") {
 			if (path_can.size() > 0) {
@@ -297,11 +297,11 @@ std::string FileFinder::MakeCanonical(std::string const& path, int initial_deepn
 	for (std::string s : path_can) {
 		ret = MakePath(ret, s);
 	}
-	
+
 	return ret;
 }
 
-std::vector<std::string> FileFinder::SplitPath(std::string const& path) {
+std::vector<std::string> FileFinder::SplitPath(const std::string& path) {
 	// Tokens are patch delimiters ("/" and encoding aware "\")
 	std::function<bool(char32_t)> f = [](char32_t t) {
 		char32_t escape_char_back = '\0';
@@ -339,7 +339,7 @@ std::string GetFontsPath() {
 	}
 }
 
-std::string GetFontFilename(std::string const& name) {
+std::string GetFontFilename(const std::string& name) {
 	std::string real_name = Registry::ReadStrValue(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts", name + " (TrueType)");
 	if (real_name.length() > 0) {
 		if (FileFinder::Exists(real_name))
@@ -394,7 +394,7 @@ std::string FileFinder::FindFont(const std::string& name) {
 #endif
 }
 
-static void add_rtp_path(std::string const& p) {
+static void add_rtp_path(const std::string& p) {
 	using namespace FileFinder;
 	std::shared_ptr<DirectoryTree> tree(CreateDirectoryTree(p));
 	if(tree) {
@@ -452,7 +452,7 @@ void FileFinder::InitRtpPaths(bool warn_no_rtp_found) {
 	jclass cls = env->GetObjectClass(sdl_activity);
 	jmethodID jni_getRtpPath = env->GetMethodID(cls , "getRtpPath", "()Ljava/lang/String;");
 	jstring return_string = (jstring)env->CallObjectMethod(sdl_activity, jni_getRtpPath);
-	
+
 	const char *js = env->GetStringUTFChars(return_string, NULL);
 	std::string cs(js);
 
@@ -563,7 +563,7 @@ std::string FileFinder::FindDefault(const std::string& dir, const std::string& n
 	return FindFile(dir, name, no_exts);
 }
 
-std::string FileFinder::FindDefault(std::string const& name) {
+std::string FileFinder::FindDefault(const std::string& name) {
 	return FindDefault(*GetDirectoryTree(), name);
 }
 
@@ -651,7 +651,7 @@ std::string FileFinder::FindSound(const std::string& name) {
 	return FindFile("Sound", name, SOUND_TYPES);
 }
 
-bool FileFinder::Exists(std::string const& filename) {
+bool FileFinder::Exists(const std::string& filename) {
 #ifdef _WIN32
 	return ::GetFileAttributesW(Utils::ToWideString(filename).c_str()) != (DWORD)-1;
 #elif defined(GEKKO)
@@ -659,9 +659,9 @@ bool FileFinder::Exists(std::string const& filename) {
 	return ::stat(filename.c_str(), &sb) == 0;
 #elif defined(_3DS)
 	FILE* tmp = fopen(filename.c_str(),"r");
-	if (tmp == NULL){ 
+	if (tmp == NULL){
 		DIR* tmp2 = opendir(filename.c_str());
-		if (tmp2 == NULL){ 
+		if (tmp2 == NULL){
 			std::string tmp_str = filename + "/";
 			tmp2 = opendir(tmp_str.c_str());
 			if (tmp2 == NULL) return false;
@@ -685,7 +685,7 @@ bool FileFinder::Exists(std::string const& filename) {
 #endif
 }
 
-bool FileFinder::IsDirectory(std::string const& dir) {
+bool FileFinder::IsDirectory(const std::string& dir) {
 #ifdef _3DS
 	DIR* d = opendir(dir.c_str());
 	if(d) {
@@ -789,10 +789,10 @@ FileFinder::Directory FileFinder::GetDirectoryMembers(const std::string& path, F
 				Output::Debug("Directory parsing will be slower.");
 				has_fast_dir_stat = false;
 			}
-			
+
 			continue;
 		}
-		
+
 		switch(m) {
 		case FILES:
 			if (is_directory) { continue; }
@@ -834,7 +834,7 @@ FileFinder::Directory FileFinder::GetDirectoryMembers(const std::string& path, F
 	return result;
 }
 
-Offset FileFinder::GetFileSize(std::string const& file) {
+Offset FileFinder::GetFileSize(const std::string& file) {
 	StatBuf sb;
 	int result = GetStat(file.c_str(), &sb);
 	return (result == 0) ? sb.st_size : -1;

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -314,6 +314,24 @@ std::vector<std::string> FileFinder::SplitPath(const std::string& path) {
 	return Utils::Tokenize(path, f);
 }
 
+std::string FileFinder::GetPathInsidePath(const std::string& path_to, const std::string& path_in) {
+	if (!Utils::StartsWith(path_in, path_to)) {
+		return "";
+	}
+
+	std::string path_out = path_in.substr(path_to.size());
+	if (!path_out.empty() && (path_out[0] == '/' || path_out[0] == '\\')) {
+		path_out = path_out.substr(1);
+	}
+
+	return path_out;
+}
+
+std::string FileFinder::GetPathInsideGamePath(const std::string& path_in) {
+	return FileFinder::GetPathInsidePath(GetDirectoryTree()->directory_path, path_in);
+}
+
+
 #if defined(_WIN32) && !defined(_ARM_)
 std::string GetFontsPath() {
 	static std::string fonts_path = "";

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -214,6 +214,26 @@ namespace FileFinder {
 	std::vector<std::string> SplitPath(const std::string& path);
 
 	/**
+	 * Returns the part of "path_in" that is inside "path_to".
+	 * e.g. Input: /h/e/game, /h/e/game/Music/a.wav; Output: Music/a.wav
+	 *
+	 * @param path_to Path to a primary folder of path_in
+	 * @param path_in Absolute path to the file, must start with path_to
+	 *
+	 * @return The part of path_in that is inside path_to. path_in when the path is not in path_to
+	 */
+	std::string GetPathInsidePath(const std::string& path_to, const std::string& path_in);
+
+	/**
+	 * Return the part of "path_in" that is inside the current games directory.
+	 *
+	 * @see GetPathInsidePath
+	 * @param path_in An absolute path inside the game directory
+	 * @return The part of path_in that is inside the game directory, path_in when it's not in the directory
+	 */
+	std::string GetPathInsideGamePath(const std::string& path_in);
+
+	/**
 	 * GetDirectoryMembers member listing mode.
 	 */
 	enum Mode {

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -175,7 +175,7 @@ namespace FileFinder {
 	 * @param file file to check.
 	 * @return true if file is directory, otherwise false.
 	 */
-	bool IsDirectory(std::string const& file);
+	bool IsDirectory(const std::string& file);
 
 	/**
 	 * Checks whether passed file exists.
@@ -184,7 +184,7 @@ namespace FileFinder {
 	 * @param file file to check
 	 * @return true if file exists, otherwise false.
 	 */
-	bool Exists(std::string const& file);
+	bool Exists(const std::string& file);
 
 	/**
 	 * Appends name to directory.
@@ -193,17 +193,17 @@ namespace FileFinder {
 	 * @param name file name to be appended to dir.
 	 * @return combined path
 	 */
-	std::string MakePath(std::string const& dir, std::string const& name);
-	
+	std::string MakePath(const std::string& dir, const std::string& name);
+
 	/**
 	 * Converts a path to the canonical equivalent.
 	 * This generates a path that does not contain ".." or "." directories.
-	 * 
+	 *
 	 * @param path Path to normalize
 	 * @param initial_deepness How deep the passed path is relative to the game root
 	 * @return canonical path
 	 */
-	std::string MakeCanonical(std::string const& path, int initial_deepness);
+	std::string MakeCanonical(const std::string& path, int initial_deepness);
 
 	/**
 	 * Splits a path in it's components.
@@ -211,7 +211,7 @@ namespace FileFinder {
 	 * @param path Path to split
 	 * @return Vector containing path components
 	 */
-	std::vector<std::string> SplitPath(std::string const& path);
+	std::vector<std::string> SplitPath(const std::string& path);
 
 	/**
 	 * GetDirectoryMembers member listing mode.
@@ -231,7 +231,7 @@ namespace FileFinder {
 	 * @param parent name of current relative folder (used if m is RECURSIVE)
 	 * @return member list.
 	 */
-	Directory GetDirectoryMembers(std::string const& dir, Mode m = ALL, std::string const& parent = "");
+	Directory GetDirectoryMembers(const std::string& dir, Mode m = ALL, const std::string& parent = "");
 
 	/**
 	 * Sets the directory tree that is used for executing the current RPG Maker
@@ -263,15 +263,15 @@ namespace FileFinder {
 	bool HasSavegame();
 
 	/** Get the size of a file
-         *
-         * @param file the path to a file
-         * @return the filesize, or -1 on error
-         */
-	Offset GetFileSize(std::string const& file);
+	 *
+	 * @param file the path to a file
+	 * @return the filesize, or -1 on error
+	 */
+	Offset GetFileSize(const std::string& file);
 
 	/**
-         * Known file sizes
-         */
+	 * Known file sizes
+	 */
 	enum KnownFileSize {
 		OFFICIAL_HARMONY_DLL = 473600,
 	};

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -225,8 +225,7 @@ Rect FTFont::GetSize(std::u32string const& txt) const {
 	int const s = Font::Default()->GetSize(txt).width;
 
 	if (s == -1) {
-		Output::Warning("Text contains invalid chars.\n"\
-			"Is the encoding correct?");
+		Output::Warning("Text contains invalid chars. Is the encoding correct?");
 
 		return Rect(0, 0, pixel_size() * txt.length() / 2, pixel_size());
 	} else {

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -858,7 +858,7 @@ bool Game_Interpreter_Map::CommandPlayMovie(RPG::EventCommand const& com) { // c
 	int res_x = com.parameters[3];
 	int res_y = com.parameters[4];
 
-	Output::Warning("Couldn't play movie: %s.\nMovie playback is not implemented (yet).", filename.c_str());
+	Output::Warning("Couldn't play movie: %s. Movie playback is not implemented (yet).", filename.c_str());
 
 	Main_Data::game_screen->PlayMovie(filename, pos_x, pos_y, res_x, res_y);
 

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -175,17 +175,17 @@ int Game_Message::GetRealPosition() {
 }
 
 int Game_Message::WordWrap(const std::string& line, int limit, const std::function<void(const std::string &line)> callback) {
-	int start = 0, lastfound = 0;
+	size_t start = 0;
+	size_t lastfound = 0;
 	int line_count = 0;
-	bool end_of_string = false;
+	bool end_of_string;
 	FontRef font = Font::Default();
 	Rect size;
 
 	do {
 		line_count++;
-		int found = line.find(" ", start);
+		size_t found = line.find(" ", start);
 		std::string wrapped = line.substr(start, found - start);
-		size = font->GetSize(wrapped);
 		end_of_string = false;
 		do {
 			lastfound = found;
@@ -198,8 +198,12 @@ int Game_Message::WordWrap(const std::string& line, int limit, const std::functi
 		} while (found < line.size() - 1 && size.width < limit);
 		if (found >= line.size() - 1) {
 			// It's end of the string, not a word-break
-			lastfound = found;
-			end_of_string = true;
+			if (size.width < limit) {
+				// And the last word of the string fits on the line
+				// (otherwise do another word-break)
+				lastfound = found;
+				end_of_string = true;
+			}
 		}
 		wrapped = line.substr(start, lastfound - start);
 		callback(wrapped);

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -176,7 +176,7 @@ void Game_Party::ConsumeItemUse(int item_id) {
 	}
 
 	if (item_id < 1 || item_id > (int) Data::items.size()) {
-		Output::Warning("Can't use up item.\n%04d is not a valid item ID.",
+		Output::Warning("Can't use up item. %04d is not a valid item ID.",
 						item_id);
 		return;
 	}

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -118,7 +118,7 @@ void Game_Party::LoseGold(int n) {
 
 void Game_Party::AddItem(int item_id, int amount) {
 	if (item_id < 1 || item_id > (int) Data::items.size()) {
-		Output::Debug("Can't add item to party.\n%04d is not a valid item ID.",
+		Output::Debug("Can't add item to party. %04d is not a valid item ID.",
 						item_id);
 		return;
 	}

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -118,8 +118,8 @@ void Game_System::SePlay(RPG::Sound const& se) {
 	if (se.name.length() >= end.length() &&
 		0 == se.name.compare(se.name.length() - end.length(), end.length(), end)) {
 		if (!ineluki_warning_shown) {
-			Output::Warning("This game seems to use Ineluki's key patch to support\n"
-				"additional keys, mouse or scripts. Such patches are\n"
+			Output::Warning("This game seems to use Ineluki's key patch to support "
+				"additional keys, mouse or scripts. Such patches are "
 				"unsupported, so this functionality will not work!");
 			ineluki_warning_shown = true;
 		}
@@ -370,7 +370,7 @@ void Game_System::OnBgmReady(FileRequestResult* result) {
 		// The first line contains the path to the actual audio file to play
 		std::string line = Utils::ReadLine(*stream.get());
 		line = ReaderUtil::Recode(line, Player::encoding);
-		
+
 		Output::Debug("Ineluki link file: %s -> %s", path.c_str(), line.c_str());
 
 		#ifdef EMSCRIPTEN
@@ -378,19 +378,19 @@ void Game_System::OnBgmReady(FileRequestResult* result) {
 		return;
 		#else
 		std::string line_canonical = FileFinder::MakeCanonical(line, 1);
-		
+
 		std::string ineluki_path = FileFinder::FindDefault(line_canonical);
 		if (ineluki_path.empty()) {
 			Output::Debug("Music not found: %s", line_canonical.c_str());
 			return;
 		}
-		
+
 		Audio().BGM_Play(ineluki_path, data.current_music.volume, data.current_music.tempo, data.current_music.fadein);
-		
+
 		return;
 		#endif
 	}
-	
+
 	Audio().BGM_Play(path, data.current_music.volume, data.current_music.tempo, data.current_music.fadein);
 }
 

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -136,6 +136,8 @@ void Graphics::Update(bool time_left) {
 
 	fps_overlay->Update();
 	fps_overlay->AddUpdate();
+
+	message_overlay->Update();
 }
 
 void Graphics::UpdateTitle() {

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -79,8 +79,6 @@ void Graphics::Init() {
 	screen_erased = false;
 	transition_frames_left = 0;
 
-	black_screen = Bitmap::Create(DisplayUi->GetWidth(), DisplayUi->GetHeight(), Color(0,0,0,255));
-
 	state.reset(new State());
 	global_state.reset(new State());
 
@@ -222,6 +220,10 @@ void Graphics::Freeze() {
 }
 
 void Graphics::Transition(TransitionType type, int duration, bool erase) {
+	if (!black_screen) {
+		black_screen = Bitmap::Create(DisplayUi->GetWidth(), DisplayUi->GetHeight(), Color(0, 0, 0, 255));
+	}
+
 	if (screen_erased && erase) {
 		// Don't allow another erase when already erased
 		return;

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -31,6 +31,7 @@
 #include "output.h"
 #include "player.h"
 #include "fps_overlay.h"
+#include "message_overlay.h"
 
 namespace Graphics {
 	void UpdateTitle();
@@ -65,6 +66,7 @@ namespace Graphics {
 
 	bool SortDrawableList(const Drawable* first, const Drawable* second);
 
+	std::unique_ptr<MessageOverlay> message_overlay;
 	std::unique_ptr<FpsOverlay> fps_overlay;
 }
 
@@ -83,6 +85,7 @@ void Graphics::Init() {
 	global_state.reset(new State());
 
 	// Is a drawable, must be init after state
+	message_overlay.reset(new MessageOverlay());
 	fps_overlay.reset(new FpsOverlay());
 
 	next_fps_time = 0;
@@ -94,7 +97,9 @@ void Graphics::Quit() {
 
 	frozen_screen.reset();
 	black_screen.reset();
+
 	fps_overlay.reset();
+	message_overlay.reset();
 
 	Cache::Clear();
 }
@@ -471,4 +476,8 @@ void Graphics::Pop() {
 
 int Graphics::GetDefaultFps() {
 	return DEFAULT_FPS;
+}
+
+MessageOverlay& Graphics::GetMessageOverlay() {
+	return *message_overlay;
 }

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -24,6 +24,8 @@
 #include "system.h"
 #include "drawable.h"
 
+class MessageOverlay;
+
 /**
  * Graphics namespace.
  * Handles screen drawing.
@@ -134,6 +136,14 @@ namespace Graphics {
 	 * @return target frame rate
 	 */
 	int GetDefaultFps();
+
+	/**
+	 * Returns a handle to the message overlay.
+	 * Only used by Output to put messages.
+	 *
+	 * @return message overlay
+	 */
+	MessageOverlay& GetMessageOverlay();
 }
 
 #endif

--- a/src/message_overlay.cpp
+++ b/src/message_overlay.cpp
@@ -52,19 +52,7 @@ bool MessageOverlay::IsGlobal() const {
 void MessageOverlay::Draw() {
 	std::deque<MessageOverlayItem>::iterator it;
 
-	if (IsAnyMessageVisible()) {
-		++counter;
-		if (counter > 150) {
-			counter = 0;
-			for (it = messages.begin(); it != messages.end(); ++it) {
-				if (!it->hidden) {
-					it->hidden = true;
-					break;
-				}
-			}
-			dirty = true;
-		}
-	} else if (!show_all) {
+	if (!IsAnyMessageVisible() && !show_all) {
 		// Don't render overlay when no message visible
 		return;
 	}
@@ -77,15 +65,15 @@ void MessageOverlay::Draw() {
 
 	int i = 0;
 
-	for (it = messages.begin(); it != messages.end(); ++it) {
-		if (!it->hidden || show_all) {
+	for (auto& message : messages) {
+		if (!message.hidden || show_all) {
 			bitmap->Blit(0, i * text_height, *black, black->GetRect(), 128);
 			bitmap->TextDraw(Rect(2,
 						i * text_height,
 						bitmap->GetWidth(),
 						text_height),
-				it->color,
-				it->text);
+				message.color,
+				message.text);
 			++i;
 		}
 	}
@@ -115,6 +103,22 @@ void MessageOverlay::AddMessage(const std::string& message, Color color) {
 		messages.pop_front();
 	}
 	dirty = true;
+}
+
+void MessageOverlay::Update() {
+	if (IsAnyMessageVisible()) {
+		++counter;
+		if (counter > 150) {
+			counter = 0;
+			for (auto& message : messages) {
+				if (!message.hidden) {
+					message.hidden = true;
+					break;
+				}
+			}
+			dirty = true;
+		}
+	}
 }
 
 void MessageOverlay::SetShowAll(bool show_all) {

--- a/src/message_overlay.cpp
+++ b/src/message_overlay.cpp
@@ -33,12 +33,7 @@ MessageOverlay::MessageOverlay() :
 	dirty(false),
 	counter(0),
 	show_all(false) {
-
-	black = Bitmap::Create(DisplayUi->GetWidth(), text_height, Color());
-
-	bitmap = Bitmap::Create(DisplayUi->GetWidth(), text_height * message_max, true);
-
-	Graphics::RegisterDrawable(this);
+	// Graphics::RegisterDrawable is in the Update function
 }
 
 MessageOverlay::~MessageOverlay() {
@@ -50,8 +45,6 @@ bool MessageOverlay::IsGlobal() const {
 }
 
 void MessageOverlay::Draw() {
-	std::deque<MessageOverlayItem>::iterator it;
-
 	if (!IsAnyMessageVisible() && !show_all) {
 		// Don't render overlay when no message visible
 		return;
@@ -97,7 +90,7 @@ void MessageOverlay::AddMessage(const std::string& message, Color color) {
 		strs.push_back(str);
 
 	for (size_t i = 0; i < strs.size(); i++)
-		messages.push_back(MessageOverlayItem(strs[i], color));
+		messages.emplace_back(strs[i], color);
 
 	while (messages.size() > (unsigned)message_max) {
 		messages.pop_front();
@@ -106,6 +99,17 @@ void MessageOverlay::AddMessage(const std::string& message, Color color) {
 }
 
 void MessageOverlay::Update() {
+	if (!DisplayUi) {
+		return;
+	}
+
+	if (!bitmap) {
+		// Initialisation is delayed because the display is not ready on startup
+		black = Bitmap::Create(DisplayUi->GetWidth(), text_height, Color());
+		bitmap = Bitmap::Create(DisplayUi->GetWidth(), text_height * message_max, true);
+		Graphics::RegisterDrawable(this);
+	}
+
 	if (IsAnyMessageVisible()) {
 		++counter;
 		if (counter > 150) {

--- a/src/message_overlay.h
+++ b/src/message_overlay.h
@@ -73,6 +73,8 @@ private:
 	int message_max;
 
 	std::deque<MessageOverlayItem> messages;
+	/** Last message added to the console before linebreak processing */
+	std::string last_message;
 
 	bool dirty;
 

--- a/src/message_overlay.h
+++ b/src/message_overlay.h
@@ -50,6 +50,8 @@ public:
 
 	bool IsGlobal() const override;
 
+	void Update();
+
 	void AddMessage(const std::string& message, Color color);
 
 	void SetShowAll(bool show_all);

--- a/src/message_overlay.h
+++ b/src/message_overlay.h
@@ -31,6 +31,7 @@ public:
 	std::string text;
 	Color color;
 	bool hidden;
+	int repeat_count;
 };
 
 /**

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -24,6 +24,8 @@
 #include <iostream>
 #include <fstream>
 
+#include "graphics.h"
+
 #ifdef GEKKO
 #  include <unistd.h>
 #  include <gccore.h>
@@ -48,7 +50,7 @@
 namespace {
 	std::ofstream LOG_FILE;
 	bool init = false;
-	
+
 	std::ostream& output_time() {
 		if (!init) {
 			LOG_FILE.open(FileFinder::MakePath(Main_Data::GetSavePath(), OUTPUT_FILENAME).c_str(), std::ios_base::out | std::ios_base::app);
@@ -61,15 +63,6 @@ namespace {
 	}
 
 	bool ignore_pause = false;
-
-	MessageOverlay& message_overlay() {
-		static std::unique_ptr<MessageOverlay> overlay;
-		assert(DisplayUi);
-		if (!overlay) {
-			overlay.reset(new MessageOverlay());
-		}
-		return *overlay;
-	}
 
 	std::string format_string(char const* fmt, va_list args) {
 		char buf[4096];
@@ -151,7 +144,7 @@ static void WriteLog(std::string const& type, std::string const& msg, Color cons
 
 	if (type != "Debug") {
 		if (DisplayUi) {
-			message_overlay().AddMessage(msg, c);
+			Graphics::GetMessageOverlay().AddMessage(msg, c);
 		}
 	}
 }
@@ -249,7 +242,7 @@ bool Output::TakeScreenshot(std::ostream& os) {
 
 void Output::ToggleLog() {
 	static bool show_log = true;
-	message_overlay().SetShowAll(show_log);
+	Graphics::GetMessageOverlay().SetShowAll(show_log);
 	show_log = !show_log;
 }
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -143,9 +143,7 @@ static void WriteLog(std::string const& type, std::string const& msg, Color cons
 #endif
 
 	if (type != "Debug") {
-		if (DisplayUi) {
-			Graphics::GetMessageOverlay().AddMessage(msg, c);
-		}
+		Graphics::GetMessageOverlay().AddMessage(msg, c);
 	}
 }
 
@@ -229,7 +227,7 @@ bool Output::TakeScreenshot(std::string const& file) {
 	std::shared_ptr<std::fstream> ret =
 		FileFinder::openUTF8(file, std::ios_base::binary | std::ios_base::out | std::ios_base::trunc);
 
-	if(ret) {
+	if (ret) {
 		Output::Debug("Saving Screenshot %s", file.c_str());
 		return Output::TakeScreenshot(*ret);
 	}
@@ -307,8 +305,9 @@ void Output::Debug(const char* fmt, ...) {
 	Output::DebugStr(format_string(fmt, args));
 	va_end(args);
 }
+
 void Output::DebugStr(std::string const& msg) {
-	WriteLog("Debug", msg);
+	WriteLog("Debug", msg, Color(128, 128, 128, 255));
 }
 
 #ifdef GEKKO

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -123,6 +123,9 @@ namespace {
 void Player::Init(int argc, char *argv[]) {
 	frames = 0;
 
+	// Must be called before the first call to Output
+	Graphics::Init();
+
 	// Display a nice version string
 	std::stringstream header;
 	std::string addtl_ver(PLAYER_ADDTL);
@@ -188,7 +191,6 @@ void Player::Init(int argc, char *argv[]) {
 			 RUN_ZOOM);
 	}
 
-	Graphics::Init();
 	Input::Init(replay_input_path, record_input_path);
 }
 

--- a/src/sdl_ui.cpp
+++ b/src/sdl_ui.cpp
@@ -162,7 +162,7 @@ SdlUi::SdlUi(long width, long height, bool fs_flag) :
 
 #if (defined(USE_JOYSTICK) && defined(SUPPORT_JOYSTICK)) || (defined(USE_JOYSTICK_AXIS) && defined(SUPPORT_JOYSTICK_AXIS)) || (defined(USE_JOYSTICK_HAT) && defined(SUPPORT_JOYSTICK_HAT))
 	if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) < 0) {
-		Output::Warning("Couldn't initialize joystick.\n%s", SDL_GetError());
+		Output::Warning("Couldn't initialize joystick. %s", SDL_GetError());
 	}
 
 	SDL_JoystickEventState(1);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -42,7 +42,13 @@ std::string Utils::UpperCase(const std::string& str) {
 	return result;
 }
 
-bool Utils::EndsWith(const std::string &str, const std::string &end) {
+
+bool Utils::StartsWith(const std::string& str, const std::string& start) {
+	return str.length() >= start.length() &&
+		   0 == str.compare(0, start.length(), start);
+}
+
+bool Utils::EndsWith(const std::string& str, const std::string& end) {
 	return str.length() >= end.length() &&
 		0 == str.compare(str.length() - end.length(), end.length(), end);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -42,6 +42,15 @@ namespace Utils {
 	std::string UpperCase(const std::string& str);
 
 	/**
+	 * Tests if a string starts with a substring.
+	 *
+	 * @param str String to search in
+	 * @param end Substring to check at the start of str
+	 * @return true when the start matches
+	 */
+	bool StartsWith(const std::string& str, const std::string& end);
+
+	/**
 	 * Tests if a string ends with a substring.
 	 *
 	 * @param str String to search in

--- a/tests/output.cpp
+++ b/tests/output.cpp
@@ -1,7 +1,9 @@
+#include "graphics.h"
 #include "output.h"
 #include "main_data.h"
 
 int main(int, char**) {
+  Graphics::Init();
   Main_Data::Init();
   Output::Debug("Test %s", "debg");
   Output::Warning("Test %s", "test");


### PR DESCRIPTION
![console-0 5 2](https://user-images.githubusercontent.com/1331889/26876545-fdf926f4-4b86-11e7-855e-c6fae1fa7e16.png)

^----- Proposed screenshot for the blogpost

New features:
 - The message overlay can now collect all messages since startup (Graphics::Init was moved to the beginning of Player::Init) and shows them when the Ui is ready (e.g. the NDSP error message on the 3DS)
 - For file-log and on-screen similiar messages increment now a counter [x10] which is appended to the line. For the file-log a message is always written twice: The 1st time it happens and a 2nd time how often it was duplicated (this is to ensure that something is logged in case of crashes), (see screenshot)
- The FileFinder got a new function to strip path components outside of the game path (see screenshot, look at the filenames reported). When the path is outside the game path it does nothing, so RTP paths are not touched.
- Instead of hardcoding "\n" in the messages I use the linebreak function of @rohkea , simplified the code a bit (see screenshot)

Bugfixes:
 - The timeout of the console lines was coupled to the framerate, the timeout is now correctly handled in Update()
 - The linebreak function did not break the last word when the last word exceeded the limit