### PR TITLE
Allow item usage again instead of crashing

### DIFF
--- a/src/scene_item.cpp
+++ b/src/scene_item.cpp
@@ -82,11 +82,11 @@ void Scene_Item::Update() {
 					Scene::PopUntil(Scene::Map);
 					Game_Map::SetNeedRefresh(Game_Map::Refresh_All);
 				} else {
-					Scene::Push(std::make_shared<Scene_ActorTarget>(item_id, item_window->GetIndex()));
+					Scene::Push(std::make_shared<Scene_ActorTarget>(item_id));
 					item_index = item_window->GetIndex();
 				}
 			} else {
-				Scene::Push(std::make_shared<Scene_ActorTarget>(item_id, item_window->GetIndex()));
+				Scene::Push(std::make_shared<Scene_ActorTarget>(item_id));
 				item_index = item_window->GetIndex();
 			}
 		} else {


### PR DESCRIPTION
Fixes a bug introduced in 0c7cbac3cf13.
The wrong constructor of `Scene_ActorTarget` was used which lead to `actor_index` being the `item_index` instead, which lead to items used as skills with out-of-bounds IDs.