### PR TITLE
Redirect Teleport and Escape skills that target areas to the owning map

### DIFF
--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -920,7 +920,7 @@ std::vector<int> Game_Map::GetEncountersAt(int x, int y) {
 					out.push_back(enc.troop_id);
 				}
 			}
-		} else if (map.parent_map == location.map_id && map.type == 2) {
+		} else if (map.parent_map == location.map_id && map.type == RPG::TreeMap::MapType_area) {
 			// Area
 			Rect area_rect(map.area_rect.l, map.area_rect.t, map.area_rect.r - map.area_rect.l, map.area_rect.b - map.area_rect.t);
 			Rect player_rect(x, y, 1, 1);
@@ -1111,6 +1111,24 @@ std::string Game_Map::GetMapName(int id) {
 	}
 	// nothing found
 	return "";
+}
+
+int Game_Map::GetMapType(int map_id) {
+	int index = Game_Map::GetMapIndex(map_id);
+	if (index == -1) {
+		return 0;
+	}
+
+	return Data::treemap.maps[index].type;
+}
+
+int Game_Map::GetParentId(int map_id) {
+	int index = Game_Map::GetMapIndex(map_id);
+	if (index == -1) {
+		return 0;
+	}
+
+	return Data::treemap.maps[index].parent_map;
 }
 
 void Game_Map::SetChipset(int id) {

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -531,6 +531,23 @@ namespace Game_Map {
 	std::string GetMapName(int id);
 
 	/**
+	 * Gets the type (1 = normal, 2 = area) of the map.
+	 *
+	 * @parem map_id map id
+	 * @return type of the map
+	 */
+	int GetMapType(int map_id);
+
+	/**
+	 * Gets the ID of the parent map.
+	 * The root of the tree has ID 0.
+	 *
+	 * @param map_id map id
+	 * @return parent map id
+	 */
+	int GetParentId(int map_id);
+
+	/**
 	 * Sets the chipset.
 	 *
 	 * @param id new chipset ID.

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -223,7 +223,14 @@ void Game_Player::ReserveTeleport(int map_id, int x, int y, int direction) {
 }
 
 void Game_Player::ReserveTeleport(const RPG::SaveTarget& target) {
-	ReserveTeleport(target.map_id, target.map_x, target.map_y, Down);
+	int map_id = target.map_id;
+
+	if (Game_Map::GetMapType(target.map_id) == RPG::TreeMap::MapType_area) {
+		// Area: Obtain the map the area belongs to
+		map_id = Game_Map::GetParentId(target.map_id);
+	}
+
+	ReserveTeleport(map_id, target.map_x, target.map_y, Down);
 
 	if (target.switch_on) {
 		Game_Switches[target.switch_id] = true;


### PR DESCRIPTION
The only games affected by this are the two japanese Dragon Quest fangames DQ列伝 and DQ2悪霊の勇者・製品版

Fix #1253

The two new functions in Game_Map could be used in some other places, too but I'm too afraid to break something...