### PR TITLE
Emterpretify to support frameskip in the web player

### DIFF
--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -59,13 +59,18 @@ namespace {
 	void download_success(unsigned, void* userData, const char*) {
 		FileRequestAsync* req = static_cast<FileRequestAsync*>(userData);
 		//Output::Debug("DL Success: %s", req->GetPath().c_str());
+
 		req->DownloadDone(true);
+
+		emscripten_sleep_with_yield(1);
 	}
 
 	void download_failure(unsigned, void* userData, int) {
 		FileRequestAsync* req = static_cast<FileRequestAsync*>(userData);
 		Output::Debug("DL Failure: %s", req->GetPath().c_str());
 		req->DownloadDone(false);
+
+		emscripten_sleep_with_yield(1);
 	}
 #endif
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -254,6 +254,11 @@ void Player::Update(bool update_scene) {
 		if (cur_time < next_frame) {
 			DisplayUi->Sleep((uint32_t)(next_frame - cur_time));
 		}
+#ifdef EMSCRIPTEN
+		else {
+			DisplayUi->Sleep(1);
+		}
+#endif
 	} else {
 		Graphics::Update(false);
 	}
@@ -294,6 +299,10 @@ void Player::Update(bool update_scene) {
 
 	Audio().Update();
 	Input::Update();
+// BAD
+	//if (AsyncHandler::IsImportantFilePending()) {
+		DisplayUi->Sleep(1);
+	//}
 
 	if (update_scene) {
 		std::shared_ptr<Scene> old_instance = Scene::instance;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -205,9 +205,7 @@ void Player::Run() {
 	FrameReset();
 
 	// Main loop
-#ifdef EMSCRIPTEN
-	emscripten_set_main_loop(Player::MainLoop, 0, 0);
-#elif defined(_3DS)
+#if defined(_3DS)
 	while (aptMainLoop() && (Graphics::IsTransitionPending() || Scene::instance->type != Scene::Null))
 	{
 		hidScanInput();
@@ -246,12 +244,6 @@ void Player::Update(bool update_scene) {
 	static const double framerate_interval = 1000.0 / Graphics::GetDefaultFps();
 	next_frame = start_time + framerate_interval;
 
-#ifdef EMSCRIPTEN
-	// Ticks in emscripten are unreliable due to how the main loop works:
-	// This function is only called 60 times per second instead of theoretical
-	// 1000s of times.
-	Graphics::Update(true);
-#else
 	// Time left before next frame? Let's render the current frame.
 	double cur_time = (double)DisplayUi->GetTicks();
 	if (cur_time < next_frame) {
@@ -265,7 +257,6 @@ void Player::Update(bool update_scene) {
 	} else {
 		Graphics::Update(false);
 	}
-#endif
 
 	// Normal logic update
 	if (Input::IsTriggered(Input::TOGGLE_FPS)) {

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -66,6 +66,8 @@ Scene::Scene() {
 }
 
 void Scene::MainFunction() {
+	Scene* old_instance = instance.get();
+
 	static bool init = false;
 
 	if (AsyncHandler::IsImportantFilePending() || Graphics::IsTransitionPending()) {
@@ -74,15 +76,15 @@ void Scene::MainFunction() {
 		// Initialization after scene switch
 		switch (push_pop_operation) {
 		case ScenePushed:
-			Start();
-			initialized = true;
+			instance->Start();
+			instance->initialized = true;
 			break;
 		case ScenePopped:
-			if (!initialized) {
-				Start();
-				initialized = true;
+			if (!instance->initialized) {
+				instance->Start();
+				instance->initialized = true;
 			} else {
-				Continue();
+				instance->Continue();
 			}
 			break;
 		default:;
@@ -90,8 +92,8 @@ void Scene::MainFunction() {
 
 		push_pop_operation = 0;
 
-		TransitionIn();
-		Resume();
+		instance->TransitionIn();
+		instance->Resume();
 
 		init = true;
 
@@ -100,15 +102,15 @@ void Scene::MainFunction() {
 		Player::Update();
 	}
 
-	if (Scene::instance.get() != this) {
+	if (Scene::instance.get() != old_instance) {
 		// Shutdown after scene switch
 		assert(Scene::instance == instances.back() &&
 			"Don't set Scene::instance directly, use Push instead!");
 
 		Graphics::Update(true);
 
-		Suspend();
-		TransitionOut();
+		instance->Suspend();
+		instance->TransitionOut();
 
 		switch (push_pop_operation) {
 		case ScenePushed:

--- a/src/scene.h
+++ b/src/scene.h
@@ -70,7 +70,7 @@ public:
 	 * executes the scene that is currently on the top of
 	 * the stack.
 	 */
-	virtual void MainFunction();
+	static void MainFunction();
 
 	/**
 	 * Start processing.
@@ -176,7 +176,7 @@ private:
 	static int push_pop_operation;
 
 	/**
-	 * true if Start() was called. For handling the special case that two 
+	 * true if Start() was called. For handling the special case that two
 	 * or more scenes are pushed. In that case only the last calls start, the
 	 * other Continue(). This enforces calling Start().
 	 */

--- a/src/sdl_ui.cpp
+++ b/src/sdl_ui.cpp
@@ -208,6 +208,8 @@ uint32_t SdlUi::GetTicks() const {
 void SdlUi::Sleep(uint32_t time) {
 #ifndef EMSCRIPTEN
 	SDL_Delay(time);
+#else
+	emscripten_sleep(time);
 #endif
 }
 

--- a/src/sdl_ui.cpp
+++ b/src/sdl_ui.cpp
@@ -209,7 +209,7 @@ void SdlUi::Sleep(uint32_t time) {
 #ifndef EMSCRIPTEN
 	SDL_Delay(time);
 #else
-	emscripten_sleep(time);
+	emscripten_sleep_with_yield(time);
 #endif
 }
 


### PR DESCRIPTION
(already updated the jenkins PR job)

To allow sleep the following functions must run through the emterpreter (slow!):
main -> Player::Run -> Player::MainLoop -> Scene::MainFunction -> Player::Update -> SDLUi::Sleep

The only "complex" function here is Player::Update but even this function contains mostly only function calls which execute through asm.js (except SDLUi::Sleep) so the performance penalty is probably not noticable (and if it really runs slower this is frameskipped now :P)