### PR TITLE
Support ThisEvent in CommonEvents

### DIFF
--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -55,7 +55,7 @@ void Game_CommonEvent::Update() {
 	for (int i = 0; i < 500; ++i) {
 		if (GetSwitchFlag() ? Game_Switches[GetSwitchId()] : true) {
 			if (!Game_Map::GetInterpreter().IsRunning()) {
-				Game_Map::GetInterpreter().SetupStartingEvent(this);
+				Game_Map::GetInterpreter().Setup(this);
 				Game_Map::GetInterpreter().Update();
 				continue;
 			}
@@ -67,7 +67,7 @@ void Game_CommonEvent::Update() {
 void Game_CommonEvent::UpdateParallel() {
 	if (interpreter && parallel_running) {
 		if (!interpreter->IsRunning()) {
-			interpreter->Setup(GetList(), 0, false, -common_event_id, -2);
+			interpreter->Setup(this);
 		}
 		interpreter->Update();
 	}

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -55,7 +55,7 @@ void Game_CommonEvent::Update() {
 	for (int i = 0; i < 500; ++i) {
 		if (GetSwitchFlag() ? Game_Switches[GetSwitchId()] : true) {
 			if (!Game_Map::GetInterpreter().IsRunning()) {
-				Game_Map::GetInterpreter().Setup(this);
+				Game_Map::GetInterpreter().Setup(this, 0);
 				Game_Map::GetInterpreter().Update();
 				continue;
 			}
@@ -67,7 +67,7 @@ void Game_CommonEvent::Update() {
 void Game_CommonEvent::UpdateParallel() {
 	if (interpreter && parallel_running) {
 		if (!interpreter->IsRunning()) {
-			interpreter->Setup(this);
+			interpreter->Setup(this, 0);
 		}
 		interpreter->Update();
 	}

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -233,10 +233,10 @@ void Game_Event::ClearStarting() {
 	started_by_decision_key = false;
 }
 
-void Game_Event::Setup(RPG::EventPage* new_page) {
-	bool from_null = page == NULL;
+void Game_Event::Setup(const RPG::EventPage* new_page) {
+	bool from_null = page == nullptr;
 
-	RPG::EventPage* old_page = page;
+	const RPG::EventPage* old_page = page;
 	page = new_page;
 
 	// Free resources if needed
@@ -249,7 +249,7 @@ void Game_Event::Setup(RPG::EventPage* new_page) {
 		interpreter.reset();
 	}
 
-	if (page == NULL) {
+	if (page == nullptr) {
 		tile_id = 0;
 		SetSpriteName("");
 		SetSpriteIndex(0);
@@ -294,10 +294,10 @@ void Game_Event::Setup(RPG::EventPage* new_page) {
 	}
 }
 
-void Game_Event::SetupFromSave(RPG::EventPage* new_page) {
+void Game_Event::SetupFromSave(const RPG::EventPage* new_page) {
 	page = new_page;
 
-	if (page == NULL) {
+	if (page == nullptr) {
 		tile_id = 0;
 		trigger = -1;
 		list.clear();
@@ -337,7 +337,7 @@ void Game_Event::Refresh() {
 		return;
 	}
 
-	RPG::EventPage* new_page = NULL;
+	RPG::EventPage* new_page = nullptr;
 	std::vector<RPG::EventPage>::reverse_iterator i;
 	for (i = event.pages.rbegin(); i != event.pages.rend(); ++i) {
 		// Loop in reverse order to see whether any page meets conditions...
@@ -481,7 +481,7 @@ void Game_Event::Start(bool by_decision_key) {
 	started_by_decision_key = by_decision_key;
 }
 
-std::vector<RPG::EventCommand>& Game_Event::GetList() {
+const std::vector<RPG::EventCommand>& Game_Event::GetList() const {
 	return list;
 }
 
@@ -690,7 +690,7 @@ void Game_Event::Update() {
 	Game_Character::UpdateSprite();
 
 	if (starting && !Game_Map::GetInterpreter().IsRunning()) {
-		Game_Map::GetInterpreter().SetupStartingEvent(this);
+		Game_Map::GetInterpreter().Setup(this);
 		Game_Map::GetInterpreter().Update();
 		running = true;
 	}
@@ -720,7 +720,7 @@ void Game_Event::UpdateParallel() {
 
 	if (interpreter) {
 		if (!interpreter->IsRunning()) {
-			interpreter->Setup(list, event.ID, started_by_decision_key, -event.x, event.y);
+			interpreter->Setup(this);
 		}
 		interpreter->Update();
 	}
@@ -744,6 +744,10 @@ const RPG::EventPage* Game_Event::GetPage(int page) const {
 		return nullptr;
 	}
 	return &event.pages[page - 1];
+}
+
+const RPG::EventPage *Game_Event::GetActivePage() const {
+	return page;
 }
 
 const RPG::SaveMapEvent& Game_Event::GetSaveData() {

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -99,8 +99,8 @@ public:
 	 */
 	void Refresh();
 
-	void Setup(RPG::EventPage* new_page);
-	void SetupFromSave(RPG::EventPage* new_page);
+	void Setup(const RPG::EventPage* new_page);
+	void SetupFromSave(const RPG::EventPage* new_page);
 
 	/**
 	 * Gets event ID.
@@ -143,7 +143,7 @@ public:
 	 *
 	 * @return event commands list.
 	 */
-	std::vector<RPG::EventCommand>& GetList();
+	const std::vector<RPG::EventCommand>& GetList() const;
 
 	/**
 	 * Event's sprite looks towards the hero but its original direction is remembered.
@@ -184,6 +184,13 @@ public:
 	 * @return page or nullptr
 	 */
 	const RPG::EventPage* GetPage(int page) const;
+
+	/**
+	 * Returns the active event page or nullptr if no page is active.
+	 *
+	 * @return active page or nullptr
+	 */
+	const RPG::EventPage* GetActivePage() const;
 
 	const RPG::SaveMapEvent& GetSaveData();
 private:
@@ -231,7 +238,7 @@ private:
 	bool started_by_decision_key = false;
 	int trigger = -1;
 	RPG::Event event;
-	RPG::EventPage* page = nullptr;
+	const RPG::EventPage* page = nullptr;
 	std::vector<RPG::EventCommand> list;
 	std::shared_ptr<Game_Interpreter> interpreter;
 	bool from_save;

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -60,7 +60,7 @@ public:
 			bool started_by_decision_key = false
 	);
 	void Setup(Game_Event* ev);
-	void Setup(Game_CommonEvent* ev);
+	void Setup(Game_CommonEvent* ev, int caller_id);
 
 	void InputButton();
 	void SetupChoices(const std::vector<std::string>& choices);

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -31,6 +31,10 @@
 class Game_Event;
 class Game_CommonEvent;
 
+namespace RPG {
+	class EventPage;
+}
+
 /**
  * Game_Interpreter class
  */
@@ -46,18 +50,18 @@ public:
 	~Game_Interpreter();
 
 	void Clear();
-	void Setup(
-		const std::vector<RPG::EventCommand>& _list,
-		int _event_id,
-		bool started_by_decision_key = false,
-		int dbg_x = -1, int dbg_y = -1
-	);
 
 	bool IsRunning() const;
 	void Update();
 
-	void SetupStartingEvent(Game_Event* ev);
-	void SetupStartingEvent(Game_CommonEvent* ev);
+	void Setup(
+			const std::vector<RPG::EventCommand>& _list,
+			int _event_id,
+			bool started_by_decision_key = false
+	);
+	void Setup(Game_Event* ev);
+	void Setup(Game_CommonEvent* ev);
+
 	void InputButton();
 	void SetupChoices(const std::vector<std::string>& choices);
 
@@ -220,8 +224,12 @@ protected:
 
 	void OnChangeSystemGraphicReady(FileRequestResult* result);
 
-	int debug_x;
-	int debug_y;
+	struct {
+		int x = 0;
+		int y = 0;
+		// nullptr when common event
+		const RPG::EventPage* page = nullptr;
+	} event_info;
 
 	FileRequestBinding request_id;
 };

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -86,7 +86,7 @@ bool Game_Interpreter_Battle::CommandCallCommonEvent(RPG::EventCommand const& co
 	int event_id = com.parameters[0];
 
 	child_interpreter.reset(new Game_Interpreter_Battle(depth + 1));
-	child_interpreter->Setup(&Game_Map::GetCommonEvents()[event_id - 1]);
+	child_interpreter->Setup(&Game_Map::GetCommonEvents()[event_id - 1], 0);
 
 	return true;
 }

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -27,6 +27,7 @@
 #include "output.h"
 #include "player.h"
 #include "game_temp.h"
+#include "game_map.h"
 
 Game_Interpreter_Battle::Game_Interpreter_Battle(int depth, bool main_flag) :
 	Game_Interpreter(depth, main_flag) {
@@ -84,10 +85,8 @@ bool Game_Interpreter_Battle::CommandCallCommonEvent(RPG::EventCommand const& co
 
 	int event_id = com.parameters[0];
 
-	const RPG::CommonEvent& event = Data::commonevents[event_id - 1];
-
 	child_interpreter.reset(new Game_Interpreter_Battle(depth + 1));
-	child_interpreter->Setup(event.event_commands, 0, false, event.ID, -2);
+	child_interpreter->Setup(&Game_Map::GetCommonEvents()[event_id - 1]);
 
 	return true;
 }


### PR DESCRIPTION
Works across all engines - EraseEvent is handled in a special way to prevent regressions.

I decided to make these commits independend of my RPG2k3 1.12 PR because this makes the reviewing easier and doesn't depend on any new liblcf chunks.

Fix #1201