### PR TITLE
Add Russian name input

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1034,6 +1034,11 @@ bool Player::IsCJK() {
 			IsBig5() || IsCP936());
 }
 
+bool Player::IsCP1251() {
+	return (encoding == "ibm-5347_P100-1998" ||
+			encoding == "windows-1251" || encoding == "1251");
+}
+
 #if (defined(_WIN32) && defined(NDEBUG) && defined(WINVER) && WINVER >= 0x0600)
 // Minidump code for Windows
 // Original Author: Oleg Starodumov (www.debuginfo.com)

--- a/src/player.h
+++ b/src/player.h
@@ -199,6 +199,12 @@ namespace Player {
 	bool IsCJK();
 
 	/**
+	 * @return true if encoding is CP1251 (used for languages written in
+	 * Cyrillic script) or false if not
+	 */
+	bool IsCP1251();
+
+	/**
 	 * @return Returns how fast EasyRPG currently runs (1: Normal speed, 2: double speed, 5: 5x speed, ...)
 	 */
 	int GetSpeedModifier();

--- a/src/scene_name.cpp
+++ b/src/scene_name.cpp
@@ -49,6 +49,9 @@ void Scene_Name::Start() {
 	// Simp. Chinese pages
 	} else if (Player::IsCP936()) {
 		kbd_window->SetMode(Window_Keyboard::Mode(Game_Temp::hero_name_charset + Window_Keyboard::ZhCn1));
+	// Cyrillic page (we assume it’s Russian since we have no way to detect Serbian etc.)
+	} else if (Player::IsCP1251()) {
+		kbd_window->SetMode(Window_Keyboard::Mode(Game_Temp::hero_name_charset + Window_Keyboard::RuCyrl));
 	// ASCII pages
 	} else {
 		kbd_window->SetMode(Window_Keyboard::Mode(Game_Temp::hero_name_charset + Window_Keyboard::Letter));
@@ -76,7 +79,8 @@ void Scene_Name::Update() {
 
 		if (s == Window_Keyboard::DONE || s == Window_Keyboard::DONE_JP
 			|| s == Window_Keyboard::DONE_KO
-			|| s == Window_Keyboard::DONE_ZH_CN ) {
+			|| s == Window_Keyboard::DONE_ZH_CN
+			|| s == Window_Keyboard::DONE_RU ) {
 			Game_Temp::hero_name = name_window->Get();
 			Game_Actor* actor = Game_Actors::GetActor(Game_Temp::hero_name_id);
 			if (actor != NULL) {
@@ -104,6 +108,10 @@ void Scene_Name::Update() {
 			kbd_window->SetMode(Window_Keyboard::ZhCn1);
 		} else if (s == Window_Keyboard::TO_ZH_CN_2) {
 			kbd_window->SetMode(Window_Keyboard::ZhCn2);
+		} else if (s == Window_Keyboard::TO_CYRILLIC_RU) {
+			kbd_window->SetMode(Window_Keyboard::RuCyrl);
+		} else if (s == Window_Keyboard::TO_LATIN_RU) {
+			kbd_window->SetMode(Window_Keyboard::RuLatn);
 		} else if (s == Window_Keyboard::SPACE) {
 			name_window->Append(" ");
 		} else {

--- a/src/window_keyboard.cpp
+++ b/src/window_keyboard.cpp
@@ -32,6 +32,10 @@ const char* const Window_Keyboard::TO_KATAKANA = "<カナ>";
 const char* const Window_Keyboard::TO_HIRAGANA = "<かな>";
 const char* const Window_Keyboard::DONE_JP = "<決定>";
 
+const char* const Window_Keyboard::TO_CYRILLIC_RU = "<Абвг>";
+const char* const Window_Keyboard::TO_LATIN_RU = "<Abcd>";
+const char* const Window_Keyboard::DONE_RU = "<OK>";
+
 const char* const Window_Keyboard::TO_HANGUL_1 = "<앞P>";
 const char* const Window_Keyboard::TO_HANGUL_2 = "<뒤P>";
 const char* const Window_Keyboard::DONE_KO = "<결정>";
@@ -41,7 +45,8 @@ const char* const Window_Keyboard::TO_ZH_CN_2 = "<前页>";
 const char* const Window_Keyboard::DONE_ZH_CN = "<确定>";
 
 /*
- * Hiragana <-> Katakana; Hangul 1 <-> Hangul 2; Simp. Chinese 1 <-> Simp. Chinese 2; letter <-> symbol
+ * Hiragana <-> Katakana; Hangul 1 <-> Hangul 2; Simp. Chinese 1 <-> Simp. Chinese 2;
+ * Rus.Cyrillic <-> Rus.Latin; letter <-> symbol
  */
 
 std::string Window_Keyboard::items[Window_Keyboard::MODE_END][9][10] = {
@@ -115,6 +120,30 @@ std::string Window_Keyboard::items[Window_Keyboard::MODE_END][9][10] = {
 		{"威", "维", "韦", "卫", "温", "沃", "乌", "西", "希", "夏"},
 		{"辛", "修", "休", "雅", "亚", "林", "琳", "留", "隆", "鲁"},
 		{"伊", "英", "尤", "则", "扎", "", Window_Keyboard::TO_ZH_CN_1, "", Window_Keyboard::DONE_ZH_CN}
+	},
+
+	{ // Cp1251 Russian Cyrillic (+ Bel. and Ukr. letters in the last row)
+		{"А", "Б", "В", "Г", "Д", "а", "б", "в", "г", "д"},
+		{"Е", "Ё", "Ж", "З", "И", "е", "ё", "ж", "з", "и"},
+		{"Й", "К", "Л", "М", "Н", "й", "к", "л", "м", "н"},
+		{"О", "П", "Р", "С", "Т", "о", "п", "р", "с", "т"},
+		{"У", "Ф", "Х", "Ц", "Ч", "у", "ф", "х", "ц", "ч"},
+		{"Щ", "Ъ", "Ы", "Ь", "Э", "щ", "ъ", "ы", "ь", "э"},
+		{"Ю", "Я",  "",  "",  "", "ю", "я",  "",  "",  ""},
+		{"Ґ", "Є", "І", "Ї", "Ў", "ґ", "є", "і", "ї", "ў"},
+		{"ʼ",  "",  "",  "",  "",  "", Window_Keyboard::TO_LATIN_RU, "", Window_Keyboard::DONE_RU},
+	},
+
+	{ // Cp1251 Latin (should ideally be merged with Letter)
+		{"A", "B", "C", "D", "E", "a", "b", "c", "d", "e"},
+		{"F", "G", "H", "I", "J", "f", "g", "h", "i", "j"},
+		{"K", "L", "M", "N", "O", "k", "l", "m", "n", "o"},
+		{"P", "Q", "R", "S", "T", "p", "q", "r", "s", "t"},
+		{"U", "V", "W", "X", "Y", "u", "v", "w", "x", "y"},
+		{"Z", "" ,"" ,"" ,"" ,"z",},
+		{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},
+		{Window_Keyboard::SPACE},
+		{"" ,  "" ,  "" ,  "" ,  "" ,  "" , Window_Keyboard::TO_CYRILLIC_RU, "", Window_Keyboard::DONE_RU},
 	},
 
 	{ // Letter

--- a/src/window_keyboard.h
+++ b/src/window_keyboard.h
@@ -43,6 +43,8 @@ public:
 		Hangul2,
 		ZhCn1,
 		ZhCn2,
+		RuCyrl,
+		RuLatn,
 		Letter,
 		Symbol,
 		MODE_END
@@ -71,6 +73,10 @@ public:
 	static const char* const TO_ZH_CN_1;
 	static const char* const TO_ZH_CN_2;
 	static const char* const DONE_ZH_CN;
+
+	static const char* const TO_CYRILLIC_RU;
+	static const char* const TO_LATIN_RU;
+	static const char* const DONE_RU;
 
 protected:
 	static const int border_x = 8;


### PR DESCRIPTION
Not very elegant (RuLatn and Letter are almost identical), but useful for many games.

![screenshot_0](https://user-images.githubusercontent.com/3201243/31356062-3ed48298-ad45-11e7-8c34-157f6ce6ffc8.png)

Can also be used for the following languages with no known games: Belarusian, Bulgarian, Crimean Tatar, Ukrainian (although those will feel second-class citizens as the extra letters are below Russian and not in their alphabetic places).

**NOT** useful for Serbian and Macedonian (too many extra letters). There are no known games in Serbian and Macedonian, but we’d eventually need to devise an encoding-independent way of specifying a language for such things. (Also needed for UTF-8 support.)