### PR TITLE
Allow re-using name-input layouts for different languages

### DIFF
--- a/src/scene_name.h
+++ b/src/scene_name.h
@@ -37,6 +37,10 @@ public:
 	void Start() override;
 	void Update() override;
 
+protected:
+	std::vector<Window_Keyboard::Mode> layouts;
+	size_t layout_index;
+
 private:
 	std::unique_ptr<Window_Keyboard> kbd_window;
 	std::unique_ptr<Window_Name> name_window;

--- a/src/window_keyboard.cpp
+++ b/src/window_keyboard.cpp
@@ -23,25 +23,12 @@
 #include "bitmap.h"
 #include "font.h"
 
-const char* const Window_Keyboard::TO_SYMBOL = "Symbol";
-const char* const Window_Keyboard::TO_LETTER = "Letter";
-const char* const Window_Keyboard::DONE = "Done";
+const char* const Window_Keyboard::DONE = "<Done>";
 const char* const Window_Keyboard::SPACE = "SPACE";
-
-const char* const Window_Keyboard::TO_KATAKANA = "<カナ>";
-const char* const Window_Keyboard::TO_HIRAGANA = "<かな>";
+const char* const Window_Keyboard::NEXT_PAGE = "<Page>";
 const char* const Window_Keyboard::DONE_JP = "<決定>";
-
-const char* const Window_Keyboard::TO_CYRILLIC_RU = "<Абвг>";
-const char* const Window_Keyboard::TO_LATIN_RU = "<Abcd>";
 const char* const Window_Keyboard::DONE_RU = "<OK>";
-
-const char* const Window_Keyboard::TO_HANGUL_1 = "<앞P>";
-const char* const Window_Keyboard::TO_HANGUL_2 = "<뒤P>";
 const char* const Window_Keyboard::DONE_KO = "<결정>";
-
-const char* const Window_Keyboard::TO_ZH_CN_1 = "<翻页>";
-const char* const Window_Keyboard::TO_ZH_CN_2 = "<前页>";
 const char* const Window_Keyboard::DONE_ZH_CN = "<确定>";
 
 /*
@@ -49,130 +36,139 @@ const char* const Window_Keyboard::DONE_ZH_CN = "<确定>";
  * Rus.Cyrillic <-> Rus.Latin; letter <-> symbol
  */
 
-std::string Window_Keyboard::items[Window_Keyboard::MODE_END][9][10] = {
-	{ // Hiragana
-		{"あ", "い", "う", "え", "お", "が", "ぎ", "ぐ", "げ", "ご"},
-		{"か", "き", "く", "け", "こ", "ざ", "じ", "ず", "ぜ", "ぞ"},
-		{"さ", "し", "す", "せ", "そ", "だ", "ぢ", "づ", "で", "ど"},
-		{"た", "ち", "つ", "て", "と", "ば", "び", "ぶ", "べ", "ぼ"},
-		{"な", "に", "ぬ", "ね", "の", "ぱ", "ぴ", "ぷ", "ぺ", "ぽ"},
-		{"は", "ひ", "ふ", "へ", "ほ", "ぁ", "ぃ", "ぅ", "ぇ", "ぉ"},
-		{"ま", "み", "む", "め", "も", "っ", "ゃ", "ゅ", "ょ", "ゎ"},
-		{"や", "ゆ", "よ", "わ", "ん", "ー", "～", "・", "＝", "☆"},
-		{"ら", "り", "る", "れ", "ろ", "ヴ", Window_Keyboard::TO_KATAKANA, "", Window_Keyboard::DONE_JP}
+Keyboard_Layout Window_Keyboard::layouts[Window_Keyboard::MODE_END] = {
+	{
+		"<かな>",
+		{ // Hiragana
+			{"あ", "い", "う", "え", "お", "が", "ぎ", "ぐ", "げ", "ご"},
+			{"か", "き", "く", "け", "こ", "ざ", "じ", "ず", "ぜ", "ぞ"},
+			{"さ", "し", "す", "せ", "そ", "だ", "ぢ", "づ", "で", "ど"},
+			{"た", "ち", "つ", "て", "と", "ば", "び", "ぶ", "べ", "ぼ"},
+			{"な", "に", "ぬ", "ね", "の", "ぱ", "ぴ", "ぷ", "ぺ", "ぽ"},
+			{"は", "ひ", "ふ", "へ", "ほ", "ぁ", "ぃ", "ぅ", "ぇ", "ぉ"},
+			{"ま", "み", "む", "め", "も", "っ", "ゃ", "ゅ", "ょ", "ゎ"},
+			{"や", "ゆ", "よ", "わ", "ん", "ー", "～", "・", "＝", "☆"},
+			{"ら", "り", "る", "れ", "ろ", "ヴ", Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE}
+		}
 	},
+	{
+		"<カナ>",
+		{ // Katakana
+			{"ア", "イ", "ウ", "エ", "オ", "ガ", "ギ", "グ", "ゲ", "ゴ"},
+			{"カ", "キ", "ク", "ケ", "コ", "ザ", "ジ", "ズ", "ゼ", "ゾ"},
+			{"サ", "シ", "ス", "セ", "ソ", "ダ", "ヂ", "ヅ", "デ", "ド"},
+			{"タ", "チ", "ツ", "テ", "ト", "バ", "ビ", "ブ", "ベ", "ボ"},
+			{"ナ", "ニ", "ヌ", "ネ", "ノ", "パ", "ピ", "プ", "ペ", "ポ"},
+			{"ハ", "ヒ", "フ", "ヘ", "ホ", "ァ", "ィ", "ゥ", "ェ", "ォ"},
+			{"マ", "ミ", "ム", "メ", "モ", "ッ", "ャ", "ュ", "ョ", "ヮ"},
+			{"ヤ", "ユ", "ヨ", "ワ", "ン", "ー", "～", "・", "＝", "☆"},
+			{"ラ", "リ", "ル", "レ", "ロ", "ヴ", Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE}
+		}
+	},
+	{
+		"<앞P>",
+		{ // Hangul 1
+			{"가", "갸", "거", "겨", "고", "교", "구", "계", "그", "기"},
+			{"나", "냐", "너", "녀", "노", "뇨", "누", "뉴", "느", "녹"},
+			{"다", "댜", "더", "뎌", "도", "됴", "두", "듀", "드", "디"},
+			{"라", "랴", "러", "려", "로", "료", "루", "류", "르", "리"},
+			{"마", "먀", "머", "며", "모", "묘", "무", "물", "므", "미"},
+			{"바", "뱌", "버", "벼", "보", "뵤", "부", "뷰", "비", "밤"},
+			{"사", "색", "서", "세", "소", "쇼", "수", "슈", "신", "심"},
+			{"아", "야", "어", "여", "오", "요", "우", "유", "으", "이"},
+			{"〜", "·", ".", "☆", Window_Keyboard::SPACE, "", Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE}
+		}
 
-	{ // Katakana
-		{"ア", "イ", "ウ", "エ", "オ", "ガ", "ギ", "グ", "ゲ", "ゴ"},
-		{"カ", "キ", "ク", "ケ", "コ", "ザ", "ジ", "ズ", "ゼ", "ゾ"},
-		{"サ", "シ", "ス", "セ", "ソ", "ダ", "ヂ", "ヅ", "デ", "ド"},
-		{"タ", "チ", "ツ", "テ", "ト", "バ", "ビ", "ブ", "ベ", "ボ"},
-		{"ナ", "ニ", "ヌ", "ネ", "ノ", "パ", "ピ", "プ", "ペ", "ポ"},
-		{"ハ", "ヒ", "フ", "ヘ", "ホ", "ァ", "ィ", "ゥ", "ェ", "ォ"},
-		{"マ", "ミ", "ム", "メ", "モ", "ッ", "ャ", "ュ", "ョ", "ヮ"},
-		{"ヤ", "ユ", "ヨ", "ワ", "ン", "ー", "～", "・", "＝", "☆"},
-		{"ラ", "リ", "ル", "レ", "ロ", "ヴ", Window_Keyboard::TO_HIRAGANA, "", Window_Keyboard::DONE_JP}
 	},
-
-	{ // Hangul 1
-		{"가", "갸", "거", "겨", "고", "교", "구", "계", "그", "기"},
-		{"나", "냐", "너", "녀", "노", "뇨", "누", "뉴", "느", "녹"},
-		{"다", "댜", "더", "뎌", "도", "됴", "두", "듀", "드", "디"},
-		{"라", "랴", "러", "려", "로", "료", "루", "류", "르", "리"},
-		{"마", "먀", "머", "며", "모", "묘", "무", "물", "므", "미"},
-		{"바", "뱌", "버", "벼", "보", "뵤", "부", "뷰", "비", "밤"},
-		{"사", "색", "서", "세", "소", "쇼", "수", "슈", "신", "심"},
-		{"아", "야", "어", "여", "오", "요", "우", "유", "으", "이"},
-		{"〜", "·", ".", "☆", Window_Keyboard::SPACE, "", Window_Keyboard::TO_HANGUL_2, "", Window_Keyboard::DONE_KO}
+	{
+		"<뒤P>",
+		{ // Hangul 2
+			{"자", "쟈", "저", "져", "조", "죠", "주", "쥬", "즈", "지"},
+			{"차", "챠", "처", "쳐", "초", "쵸", "추", "츄", "츠", "치"},
+			{"카", "캬", "커", "켜", "코", "쿄", "쿠", "큐", "크", "키"},
+			{"타", "탸", "터", "텨", "토", "툐", "투", "튜", "트", "티"},
+			{"파", "퍄", "퍼", "펴", "포", "표", "푸", "퓨", "프", "피"},
+			{"하", "햐", "허", "혀", "호", "효", "후", "휴", "흐", "해"},
+			{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0"},
+			{"진", "녘", "의", "민", "예", "건", "현", "운", "걔", "임"},
+			{"영", "은", "성", "준", Window_Keyboard::SPACE, "", Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE}
+		},
 	},
-
-	{ // Hangul 2
-		{"자", "쟈", "저", "져", "조", "죠", "주", "쥬", "즈", "지"},
-		{"차", "챠", "처", "쳐", "초", "쵸", "추", "츄", "츠", "치"},
-		{"카", "캬", "커", "켜", "코", "쿄", "쿠", "큐", "크", "키"},
-		{"타", "탸", "터", "텨", "토", "툐", "투", "튜", "트", "티"},
-		{"파", "퍄", "퍼", "펴", "포", "표", "푸", "퓨", "프", "피"},
-		{"하", "햐", "허", "혀", "호", "효", "후", "휴", "흐", "해"},
-		{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0"},
-		{"진", "녘", "의", "민", "예", "건", "현", "운", "걔", "임"},
-		{"영", "은", "성", "준", Window_Keyboard::SPACE, "", Window_Keyboard::TO_HANGUL_1, "", Window_Keyboard::DONE_KO}
+	{
+		"<翻页>",
+		{ // Simp. Chinese 1
+			{"阿", "艾", "安", "奥", "巴", "拜", "班", "邦", "贝", "本"},
+			{"比", "宾", "波", "伯", "布", "查", "达", "丹", "当", "道"},
+			{"德", "登", "迪", "蒂", "丁", "度", "杜", "顿", "多", "厄"},
+			{"尔", "恩", "法", "凡", "菲", "费", "芬", "佛", "弗", "夫"},
+			{"盖", "格", "戈", "冈", "古", "哈", "海", "汉", "豪", "赫"},
+			{"华", "霍", "基", "吉", "加", "杰", "捷", "金", "卡", "凯"},
+			{"科", "克", "肯", "拉", "莱", "兰", "朗", "劳", "勒", "雷"},
+			{"里", "利", "立", "丽", "莉", "林", "琳", "留", "隆", "鲁"},
+			{"路", "伦", "罗", "洛", "律", "", Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE}
+		}
 	},
-
-	{ // Simp. Chinese 1
-		{"阿", "艾", "安", "奥", "巴", "拜", "班", "邦", "贝", "本"},
-		{"比", "宾", "波", "伯", "布", "查", "达", "丹", "当", "道"},
-		{"德", "登", "迪", "蒂", "丁", "度", "杜", "顿", "多", "厄"},
-		{"尔", "恩", "法", "凡", "菲", "费", "芬", "佛", "弗", "夫"},
-		{"盖", "格", "戈", "冈", "古", "哈", "海", "汉", "豪", "赫"},
-		{"华", "霍", "基", "吉", "加", "杰", "捷", "金", "卡", "凯"},
-		{"科", "克", "肯", "拉", "莱", "兰", "朗", "劳", "勒", "雷"},
-		{"里", "利", "立", "丽", "莉", "林", "琳", "留", "隆", "鲁"},
-		{"路", "伦", "罗", "洛", "律", "", Window_Keyboard::TO_ZH_CN_2, "", Window_Keyboard::DONE_ZH_CN}
+	{
+		"<前页>",
+		{ // Simp. Chinese 2
+			{"玛", "迈", "曼", "梅", "美", "门", "米", "密", "明", "缪"},
+			{"摩", "莫", "姆", "穆", "那", "娜", "纳", "奈", "南", "尼"},
+			{"宁", "纽", "奴", "诺", "欧", "帕", "派", "佩", "皮", "普"},
+			{"奇", "琪", "琼", "丘", "萨", "撒", "赛", "桑", "瑟", "森"},
+			{"沙", "山", "珊", "史", "世", "斯", "丝", "司", "苏", "所"},
+			{"索", "塔", "泰", "坦", "汤", "特", "提", "汀", "统", "瓦"},
+			{"威", "维", "韦", "卫", "温", "沃", "乌", "西", "希", "夏"},
+			{"辛", "修", "休", "雅", "亚", "林", "琳", "留", "隆", "鲁"},
+			{"伊", "英", "尤", "则", "扎", "", Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE}
+		}
 	},
-
-	{ // Simp. Chinese 2
-		{"玛", "迈", "曼", "梅", "美", "门", "米", "密", "明", "缪"},
-		{"摩", "莫", "姆", "穆", "那", "娜", "纳", "奈", "南", "尼"},
-		{"宁", "纽", "奴", "诺", "欧", "帕", "派", "佩", "皮", "普"},
-		{"奇", "琪", "琼", "丘", "萨", "撒", "赛", "桑", "瑟", "森"},
-		{"沙", "山", "珊", "史", "世", "斯", "丝", "司", "苏", "所"},
-		{"索", "塔", "泰", "坦", "汤", "特", "提", "汀", "统", "瓦"},
-		{"威", "维", "韦", "卫", "温", "沃", "乌", "西", "希", "夏"},
-		{"辛", "修", "休", "雅", "亚", "林", "琳", "留", "隆", "鲁"},
-		{"伊", "英", "尤", "则", "扎", "", Window_Keyboard::TO_ZH_CN_1, "", Window_Keyboard::DONE_ZH_CN}
+	{
+		"<Абвг>",
+		{ // Cp1251 Russian Cyrillic (+ Bel. and Ukr. letters in the last row)
+			{"А", "Б", "В", "Г", "Д", "а", "б", "в", "г", "д"},
+			{"Е", "Ё", "Ж", "З", "И", "е", "ё", "ж", "з", "и"},
+			{"Й", "К", "Л", "М", "Н", "й", "к", "л", "м", "н"},
+			{"О", "П", "Р", "С", "Т", "о", "п", "р", "с", "т"},
+			{"У", "Ф", "Х", "Ц", "Ч", "у", "ф", "х", "ц", "ч"},
+			{"Ш", "Щ", "Ъ", "Ы", "Ь", "ш", "щ", "ъ", "ы", "ь"},
+			{"Э", "Ю", "Я",  "",  "", "э", "ю", "я",  "",  ""},
+			{"Ґ", "Є", "І", "Ї", "Ў", "ґ", "є", "і", "ї", "ў"},
+			{"ʼ",  "",  "",  "",  "",  "", Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE},
+		}
 	},
-
-	{ // Cp1251 Russian Cyrillic (+ Bel. and Ukr. letters in the last row)
-		{"А", "Б", "В", "Г", "Д", "а", "б", "в", "г", "д"},
-		{"Е", "Ё", "Ж", "З", "И", "е", "ё", "ж", "з", "и"},
-		{"Й", "К", "Л", "М", "Н", "й", "к", "л", "м", "н"},
-		{"О", "П", "Р", "С", "Т", "о", "п", "р", "с", "т"},
-		{"У", "Ф", "Х", "Ц", "Ч", "у", "ф", "х", "ц", "ч"},
-		{"Ш", "Щ", "Ъ", "Ы", "Ь", "ш", "щ", "ъ", "ы", "ь"},
-		{"Э", "Ю", "Я",  "",  "", "э", "ю", "я",  "",  ""},
-		{"Ґ", "Є", "І", "Ї", "Ў", "ґ", "є", "і", "ї", "ў"},
-		{"ʼ",  "",  "",  "",  "",  "", Window_Keyboard::TO_LATIN_RU, "", Window_Keyboard::DONE_RU},
+	{
+		"<Abcd>",
+		{ // Letter
+			{"A", "B", "C", "D", "E", "a", "b", "c", "d", "e"},
+			{"F", "G", "H", "I", "J", "f", "g", "h", "i", "j"},
+			{"K", "L", "M", "N", "O", "k", "l", "m", "n", "o"},
+			{"P", "Q", "R", "S", "T", "p", "q", "r", "s", "t"},
+			{"U", "V", "W", "X", "Y", "u", "v", "w", "x", "y"},
+			{"Z", "" ,"" ,"" ,"" ,"z",},
+			{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},
+			{Window_Keyboard::SPACE},
+			{"" ,  "" ,  "" ,  "" ,  "" ,  "" , Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE},
+		}
 	},
-
-	{ // Cp1251 Latin (should ideally be merged with Letter)
-		{"A", "B", "C", "D", "E", "a", "b", "c", "d", "e"},
-		{"F", "G", "H", "I", "J", "f", "g", "h", "i", "j"},
-		{"K", "L", "M", "N", "O", "k", "l", "m", "n", "o"},
-		{"P", "Q", "R", "S", "T", "p", "q", "r", "s", "t"},
-		{"U", "V", "W", "X", "Y", "u", "v", "w", "x", "y"},
-		{"Z", "" ,"" ,"" ,"" ,"z",},
-		{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},
-		{Window_Keyboard::SPACE},
-		{"" ,  "" ,  "" ,  "" ,  "" ,  "" , Window_Keyboard::TO_CYRILLIC_RU, "", Window_Keyboard::DONE_RU},
-	},
-
-	{ // Letter
-		{"A", "B", "C", "D", "E", "a", "b", "c", "d", "e"},
-		{"F", "G", "H", "I", "J", "f", "g", "h", "i", "j"},
-		{"K", "L", "M", "N", "O", "k", "l", "m", "n", "o"},
-		{"P", "Q", "R", "S", "T", "p", "q", "r", "s", "t"},
-		{"U", "V", "W", "X", "Y", "u", "v", "w", "x", "y"},
-		{"Z", "" ,"" ,"" ,"" ,"z",},
-		{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},
-		{Window_Keyboard::SPACE},
-		{"" ,  "" ,  "" ,  "" ,  "" ,  "" , Window_Keyboard::TO_SYMBOL, "", Window_Keyboard::DONE},
-	},
-
-	{ // Symbol
-		{"$A", "$B", "$C", "$D", "$E", "$a", "$b", "$c", "$d", "$e"},
-		{"$F", "$G", "$H", "$I", "$J", "$f", "$g", "$h", "$i", "$j"},
-		{"$K", "$L", "$M", "$N", "$O", "$k", "$l", "$m", "$n", "$o"},
-		{"$P", "$Q", "$R", "$S", "$T", "$p", "$q", "$r", "$s", "$t"},
-		{"$U", "$V", "$W", "$X", "$Y", "$u", "$v", "$w", "$x", "$y"},
-		{"$Z",  "" ,  "" ,  "" ,  "" , "$z"},
-		{},
-		{},
-		{ "" ,  "" ,  "" ,  "" ,  "" ,  "" , Window_Keyboard::TO_LETTER, "", Window_Keyboard::DONE},
-	},
+	{
+		"<$A$B>",
+		{ // Symbol
+			{"$A", "$B", "$C", "$D", "$E", "$a", "$b", "$c", "$d", "$e"},
+			{"$F", "$G", "$H", "$I", "$J", "$f", "$g", "$h", "$i", "$j"},
+			{"$K", "$L", "$M", "$N", "$O", "$k", "$l", "$m", "$n", "$o"},
+			{"$P", "$Q", "$R", "$S", "$T", "$p", "$q", "$r", "$s", "$t"},
+			{"$U", "$V", "$W", "$X", "$Y", "$u", "$v", "$w", "$x", "$y"},
+			{"$Z",  "" ,  "" ,  "" ,  "" , "$z"},
+			{},
+			{},
+			{ "" ,  "" ,  "" ,  "" ,  "" ,  "" , Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE},
+		}
+	}
 };
 
-Window_Keyboard::Window_Keyboard(int ix, int iy, int iwidth, int iheight)
+Window_Keyboard::Window_Keyboard(int ix, int iy, int iwidth, int iheight, const char* ndone_text)
 		: Window_Base(ix, iy, iwidth, iheight)
+		, done_text(ndone_text)
 		, play_cursor(false)
 {
 	row = 0;
@@ -184,26 +180,40 @@ Window_Keyboard::Window_Keyboard(int ix, int iy, int iwidth, int iheight)
 	col_spacing = (contents->GetWidth() - 2 * border_x) / col_max;
 
 	mode = Letter;
+	next_mode = Symbol;
 
 	Refresh();
 	UpdateCursorRect();
 }
 
-void Window_Keyboard::SetMode(Window_Keyboard::Mode nmode) {
+void Window_Keyboard::SetMode(Window_Keyboard::Mode nmode, Window_Keyboard::Mode nnext_mode) {
 	mode = nmode;
+	next_mode = nnext_mode;
 	Refresh();
 	UpdateCursorRect();
+}
+
+std::string const& Window_Keyboard::GetKey(int row, int col) const {
+	std::string const& str = layouts[mode].items[row][col];
+	if (str == NEXT_PAGE) {
+		return layouts[next_mode].key_text;
+	}
+	else if (str == DONE) {
+		return done_text;
+	}
+	else {
+		return str;
+	}
 }
 
 std::string const& Window_Keyboard::GetSelected() const {
-	return items[mode][row][col];
+	return layouts[mode].items[row][col];
 }
 
 Rect Window_Keyboard::GetItemRect(int row, int col) const {
-	std::string const& str = items[mode][row][col];
 	return Rect(col * col_spacing + border_x,
 				row * row_spacing + border_y,
-				Font::Default()->GetSize(str).width + 8,
+				Font::Default()->GetSize(GetKey(row, col)).width + 8,
 				row_spacing);
 }
 
@@ -219,7 +229,7 @@ void Window_Keyboard::Refresh() {
 	for (int j = 0; j < row_max; j++) {
 		for (int i = 0; i < col_max; i++) {
 			Rect r = GetItemRect(j, i);
-			contents->TextDraw(r.x + 4, r.y, Font::ColorDefault, items[mode][j][i]);
+			contents->TextDraw(r.x + 4, r.y, Font::ColorDefault, GetKey(j, i));
 		}
 	}
 }
@@ -232,7 +242,7 @@ void Window_Keyboard::Update() {
 			play_cursor = true;
 			row = (row + 1) % row_max;
 
-			if (col > 0 && GetSelected().empty() && !items[mode][row][col - 1].empty()) {
+			if (col > 0 && GetSelected().empty() && !GetKey(row, col - 1).empty()) {
 				col--;
 			}
 		}
@@ -240,7 +250,7 @@ void Window_Keyboard::Update() {
 			play_cursor = true;
 			row = (row + row_max - 1) % row_max;
 
-			if (col > 0 && GetSelected().empty() && !items[mode][row][col - 1].empty()) {
+			if (col > 0 && GetSelected().empty() && !GetKey(row, col - 1).empty()) {
 				col--;
 			}
 		}

--- a/src/window_keyboard.cpp
+++ b/src/window_keyboard.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <string>
+#include <algorithm>
 
 #include "window_keyboard.h"
 #include "game_system.h"
@@ -48,7 +49,7 @@ Keyboard_Layout Window_Keyboard::layouts[Window_Keyboard::MODE_END] = {
 			{"は", "ひ", "ふ", "へ", "ほ", "ぁ", "ぃ", "ぅ", "ぇ", "ぉ"},
 			{"ま", "み", "む", "め", "も", "っ", "ゃ", "ゅ", "ょ", "ゎ"},
 			{"や", "ゆ", "よ", "わ", "ん", "ー", "～", "・", "＝", "☆"},
-			{"ら", "り", "る", "れ", "ろ", "ヴ", Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE}
+			{"ら", "り", "る", "れ", "ろ", "ヴ", NEXT_PAGE, "", DONE}
 		}
 	},
 	{
@@ -62,7 +63,7 @@ Keyboard_Layout Window_Keyboard::layouts[Window_Keyboard::MODE_END] = {
 			{"ハ", "ヒ", "フ", "ヘ", "ホ", "ァ", "ィ", "ゥ", "ェ", "ォ"},
 			{"マ", "ミ", "ム", "メ", "モ", "ッ", "ャ", "ュ", "ョ", "ヮ"},
 			{"ヤ", "ユ", "ヨ", "ワ", "ン", "ー", "～", "・", "＝", "☆"},
-			{"ラ", "リ", "ル", "レ", "ロ", "ヴ", Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE}
+			{"ラ", "リ", "ル", "レ", "ロ", "ヴ", NEXT_PAGE, "", DONE}
 		}
 	},
 	{
@@ -76,7 +77,7 @@ Keyboard_Layout Window_Keyboard::layouts[Window_Keyboard::MODE_END] = {
 			{"바", "뱌", "버", "벼", "보", "뵤", "부", "뷰", "비", "밤"},
 			{"사", "색", "서", "세", "소", "쇼", "수", "슈", "신", "심"},
 			{"아", "야", "어", "여", "오", "요", "우", "유", "으", "이"},
-			{"〜", "·", ".", "☆", Window_Keyboard::SPACE, "", Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE}
+			{"〜", "·", ".", "☆", SPACE, "", NEXT_PAGE, "", DONE}
 		}
 
 	},
@@ -91,7 +92,7 @@ Keyboard_Layout Window_Keyboard::layouts[Window_Keyboard::MODE_END] = {
 			{"하", "햐", "허", "혀", "호", "효", "후", "휴", "흐", "해"},
 			{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0"},
 			{"진", "녘", "의", "민", "예", "건", "현", "운", "걔", "임"},
-			{"영", "은", "성", "준", Window_Keyboard::SPACE, "", Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE}
+			{"영", "은", "성", "준", SPACE, "", NEXT_PAGE, "", DONE}
 		},
 	},
 	{
@@ -105,7 +106,7 @@ Keyboard_Layout Window_Keyboard::layouts[Window_Keyboard::MODE_END] = {
 			{"华", "霍", "基", "吉", "加", "杰", "捷", "金", "卡", "凯"},
 			{"科", "克", "肯", "拉", "莱", "兰", "朗", "劳", "勒", "雷"},
 			{"里", "利", "立", "丽", "莉", "林", "琳", "留", "隆", "鲁"},
-			{"路", "伦", "罗", "洛", "律", "", Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE}
+			{"路", "伦", "罗", "洛", "律", "", NEXT_PAGE, "", DONE}
 		}
 	},
 	{
@@ -119,7 +120,7 @@ Keyboard_Layout Window_Keyboard::layouts[Window_Keyboard::MODE_END] = {
 			{"索", "塔", "泰", "坦", "汤", "特", "提", "汀", "统", "瓦"},
 			{"威", "维", "韦", "卫", "温", "沃", "乌", "西", "希", "夏"},
 			{"辛", "修", "休", "雅", "亚", "林", "琳", "留", "隆", "鲁"},
-			{"伊", "英", "尤", "则", "扎", "", Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE}
+			{"伊", "英", "尤", "则", "扎", "", NEXT_PAGE, "", DONE}
 		}
 	},
 	{
@@ -133,7 +134,7 @@ Keyboard_Layout Window_Keyboard::layouts[Window_Keyboard::MODE_END] = {
 			{"Ш", "Щ", "Ъ", "Ы", "Ь", "ш", "щ", "ъ", "ы", "ь"},
 			{"Э", "Ю", "Я",  "",  "", "э", "ю", "я",  "",  ""},
 			{"Ґ", "Є", "І", "Ї", "Ў", "ґ", "є", "і", "ї", "ў"},
-			{"ʼ",  "",  "",  "",  "",  "", Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE},
+			{"ʼ",  "",  "",  "",  "",  "", NEXT_PAGE, "", DONE}
 		}
 	},
 	{
@@ -144,10 +145,10 @@ Keyboard_Layout Window_Keyboard::layouts[Window_Keyboard::MODE_END] = {
 			{"K", "L", "M", "N", "O", "k", "l", "m", "n", "o"},
 			{"P", "Q", "R", "S", "T", "p", "q", "r", "s", "t"},
 			{"U", "V", "W", "X", "Y", "u", "v", "w", "x", "y"},
-			{"Z", "" ,"" ,"" ,"" ,"z",},
+			{"Z", "" , "" , "" , "" , "z"},
 			{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"},
-			{Window_Keyboard::SPACE},
-			{"" ,  "" ,  "" ,  "" ,  "" ,  "" , Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE},
+			{SPACE},
+			{"" , "" , "" , "" , "" , "" , NEXT_PAGE, "", DONE}
 		}
 	},
 	{
@@ -161,7 +162,7 @@ Keyboard_Layout Window_Keyboard::layouts[Window_Keyboard::MODE_END] = {
 			{"$Z",  "" ,  "" ,  "" ,  "" , "$z"},
 			{},
 			{},
-			{ "" ,  "" ,  "" ,  "" ,  "" ,  "" , Window_Keyboard::NEXT_PAGE, "", Window_Keyboard::DONE},
+			{ "" ,  "" ,  "" ,  "" ,  "" ,  "" , NEXT_PAGE, "", DONE}
 		}
 	}
 };
@@ -237,42 +238,38 @@ void Window_Keyboard::Refresh() {
 void Window_Keyboard::Update() {
 	Window_Base::Update();
 
+	// move left on wide fields
+	int skip_dir = -1;
+
 	if (active) {
 		if (Input::IsRepeated(Input::DOWN)) {
 			play_cursor = true;
 			row = (row + 1) % row_max;
-
-			if (col > 0 && GetSelected().empty() && !GetKey(row, col - 1).empty()) {
-				col--;
-			}
 		}
 		if (Input::IsRepeated(Input::UP)) {
 			play_cursor = true;
 			row = (row + row_max - 1) % row_max;
-
-			if (col > 0 && GetSelected().empty() && !GetKey(row, col - 1).empty()) {
-				col--;
-			}
 		}
 		if (Input::IsRepeated(Input::RIGHT)) {
 			play_cursor = true;
-			col += 1;
-			if (col >= col_max) {
-				col = 0;
-				if (mode == Letter) { row = (row + 1) % row_max; }
-			}
+			col = (col + 1) % col_max;
+			skip_dir = 1;
 		}
 		if (Input::IsRepeated(Input::LEFT)) {
 			play_cursor = true;
-			col -= 1;
-			if (col < 0) {
-				col = col_max - 1;
-				if (mode == Letter) { row = (row + row_max - 1) % row_max; }
-			}
+			col = (col + col_max - 1) % col_max;
 		}
-
 	}
 
+	// Special handling for wide fields
+	if (col > 0) {
+		// page switch and done are always in the bottom right corner
+		if ((row == row_max - 1 && (col == col_max - 3 || col == col_max - 1))
+			|| GetKey(row, col - 1) == SPACE)
+			col = std::min(col + skip_dir, col_max - 1);
+	}
+
+	// Skip empty cells
 	if (GetSelected().empty()) {
 		Update();
 		return;

--- a/src/window_keyboard.h
+++ b/src/window_keyboard.h
@@ -20,7 +20,6 @@
 
 #include "window_base.h"
 
-
 struct Keyboard_Layout;
 
 /**
@@ -77,6 +76,7 @@ protected:
 	static const int border_x = 8;
 	static const int border_y = 4;
 	static const int min_width = 2;
+
 	std::string done_text;
 	int row_spacing;
 	int col_spacing;

--- a/src/window_keyboard.h
+++ b/src/window_keyboard.h
@@ -20,6 +20,9 @@
 
 #include "window_base.h"
 
+
+struct Keyboard_Layout;
+
 /**
  * Window Input Number Class.
  * The number input window.
@@ -33,8 +36,9 @@ public:
 	 * @param iy window y position.
 	 * @param iwidth window width.
 	 * @param iheight window height.
+	 * @param ndone_text text for the "Done" button.
 	 */
-	Window_Keyboard(int ix, int iy, int iwidth = 320, int iheight = 80);
+	Window_Keyboard(int ix, int iy, int iwidth = 320, int iheight = 80, const char* ndone_text = DONE);
 
 	enum Mode {
 		Hiragana,
@@ -44,7 +48,6 @@ public:
 		ZhCn1,
 		ZhCn2,
 		RuCyrl,
-		RuLatn,
 		Letter,
 		Symbol,
 		MODE_END
@@ -54,44 +57,45 @@ public:
 	Rect GetItemRect(int row, int col) const;
 	void Update() override;
 	void Refresh();
-	void SetMode(Mode nmode);
+	void SetMode(Mode nmode, Mode nnext_mode);
+	std::string const& GetKey(int row, int col) const;
 	std::string const& GetSelected() const;
 
-	static const char* const TO_SYMBOL;
-	static const char* const TO_LETTER;
 	static const char* const DONE;
 	static const char* const SPACE;
-
-	static const char* const TO_KATAKANA;
-	static const char* const TO_HIRAGANA;
+	static const char* const NEXT_PAGE;
 	static const char* const DONE_JP;
-
-	static const char* const TO_HANGUL_1;
-	static const char* const TO_HANGUL_2;
 	static const char* const DONE_KO;
-
-	static const char* const TO_ZH_CN_1;
-	static const char* const TO_ZH_CN_2;
 	static const char* const DONE_ZH_CN;
-
-	static const char* const TO_CYRILLIC_RU;
-	static const char* const TO_LATIN_RU;
 	static const char* const DONE_RU;
+
+	static const int row_max = 9;
+	static const int col_max = 10;
+	static Keyboard_Layout layouts[MODE_END];
 
 protected:
 	static const int border_x = 8;
 	static const int border_y = 4;
-	static const int row_max = 9;
-	static const int col_max = 10;
 	static const int min_width = 2;
-	static std::string items[MODE_END][row_max][col_max];
+	std::string done_text;
 	int row_spacing;
 	int col_spacing;
 	Mode mode;
+	Mode next_mode;
 	int row;
 	int col;
 
 	bool play_cursor;
+};
+
+
+/**
+ * Keyboard layout struct.
+ * Defines which keys are available and how the key to switch here is named
+ */
+struct Keyboard_Layout {
+	const std::string key_text;
+	const std::string items[Window_Keyboard::row_max][Window_Keyboard::col_max];
 };
 
 #endif


### PR DESCRIPTION
Seems to work for me, please test.

Feedback is welcome. I’m particularly not happy with the forward declaration of ``struct Keyboard_Layout;``.

---
EDIT by @carstene1ns: Fixes #1272.