### PR TITLE
Class / BattleCommands -related fixes

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -45,11 +45,6 @@ Game_Actor::Game_Actor(int actor_id) :
 	Game_Battler(),
 	actor_id(actor_id) {
 	GetData().Setup(actor_id);
-	// - LSD readout is showing this happens.
-	GetData().class_id = -1;
-	GetData().battle_commands.clear();
-	GetData().battle_commands.resize(7, -1);
-
 	Setup();
 }
 
@@ -946,9 +941,9 @@ void Game_Actor::ChangeBattleCommands(bool add, int id) {
 	// stands for the Row command
 	if (add) {
 		if (std::find(cmds.begin(), cmds.end(), id)	== cmds.end()) {
-			std::vector<uint32_t> new_cmds;
+			std::vector<int32_t> new_cmds;
 			std::copy_if(cmds.begin(), cmds.end(),
-						 std::back_inserter(new_cmds), [](uint32_t i) { return i != 0 && i != -1; });
+						 std::back_inserter(new_cmds), [](int32_t i) { return i != 0 && i != -1; });
 			// Needs space for at least 2 more commands (new command and row)
 			if (new_cmds.size() >= 6) {
 				return;
@@ -962,7 +957,7 @@ void Game_Actor::ChangeBattleCommands(bool add, int id) {
 		cmds.clear();
 		cmds.push_back(0);
 	} else {
-		std::vector<uint32_t>::iterator it;
+		std::vector<int32_t>::iterator it;
 		it = std::find(cmds.begin(), cmds.end(), id);
 		if (it != cmds.end())
 			cmds.erase(it);
@@ -973,7 +968,7 @@ void Game_Actor::ChangeBattleCommands(bool add, int id) {
 
 const std::vector<const RPG::BattleCommand*> Game_Actor::GetBattleCommands() const {
 	std::vector<const RPG::BattleCommand*> commands;
-	std::vector<uint32_t> obc = GetData().battle_commands;
+	std::vector<int32_t> obc = GetData().battle_commands;
 	if (!GetData().changed_class) {
 		// In this case, get it straight from the LDB.
 		obc = Data::actors[actor_id - 1].battle_commands;

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -932,9 +932,9 @@ void Game_Actor::ChangeBattleCommands(bool add, int id) {
 
 	// If changing battle commands, that is when RPG_RT will replace the -1 list with a 'true' list.
 	// Fetch original command array.
-	if (!GetData().changed_class) {
+	if (!GetData().changed_battle_commands) {
 		cmds = Data::actors[GetId() - 1].battle_commands;
-		GetData().changed_class = true;
+		GetData().changed_battle_commands = true;
 	}
 
 	// The battle commands array always has a size of 7 padded with -1. The last element before the padding is 0 which
@@ -969,7 +969,7 @@ void Game_Actor::ChangeBattleCommands(bool add, int id) {
 const std::vector<const RPG::BattleCommand*> Game_Actor::GetBattleCommands() const {
 	std::vector<const RPG::BattleCommand*> commands;
 	std::vector<int32_t> obc = GetData().battle_commands;
-	if (!GetData().changed_class) {
+	if (!GetData().changed_battle_commands) {
 		// In this case, get it straight from the LDB.
 		obc = Data::actors[actor_id - 1].battle_commands;
 	}
@@ -1010,7 +1010,7 @@ const RPG::Class* Game_Actor::GetClass() const {
 
 void Game_Actor::SetClass(int _class_id) {
 	GetData().class_id = _class_id;
-	GetData().changed_class = true; // Any change counts as a battle commands change.
+	GetData().changed_battle_commands = true; // Any change counts as a battle commands change.
 
 	// The class settings are not applied when the actor has a class on startup
 	// but only when the "Change Class" event command is used.

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -18,6 +18,7 @@
 // Headers
 #include <algorithm>
 #include <sstream>
+#include <iterator>
 #include "game_actor.h"
 #include "game_battle.h"
 #include "game_message.h"

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -754,6 +754,12 @@ private:
 	 */
 	void RemoveInvalidEquipment();
 
+	/**
+	 * Either pads GetData().battle_commands to 7 entries including the 0 and -1 used by RPG_RT,
+	 * or cuts them off for use while adjusting the array.
+	 */
+	void PadBattleCommandsArray(bool include7);
+
 	int actor_id;
 	std::vector<int> exp_list;
 };

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -754,12 +754,6 @@ private:
 	 */
 	void RemoveInvalidEquipment();
 
-	/**
-	 * Either pads GetData().battle_commands to 7 entries including the 0 and -1 used by RPG_RT,
-	 * or cuts them off for use while adjusting the array.
-	 */
-	void PadBattleCommandsArray(bool include7);
-
 	int actor_id;
 	std::vector<int> exp_list;
 };

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2918,6 +2918,20 @@ bool Game_Interpreter::CommandChangeClass(RPG::EventCommand const& com) { // cod
 				}
 			}
 		}
+		else {
+			for (const RPG::Learning& learn : Data::actors[actor_id - 1].skills) {
+				if (level >= learn.level) {
+					actor->LearnSkill(learn.skill_id);
+					if (show) {
+						std::stringstream ss;
+						ss << Data::skills[learn.skill_id - 1].name;
+						ss << (Player::IsRPG2k3E() ? " " : "") << Data::terms.skill_learned;
+						Game_Message::texts.push_back(ss.str());
+						level_up = true;
+					}
+				}
+			}
+		}
 
 		if (level_up) {
 			Game_Message::texts.back().append("\f");


### PR DESCRIPTION
This hopefully fixes Class BattleCommands issues.

A potential further improvement would be to research what happens when battle commands space is exhausted, but as this should almost never come up, I believe my current solution (sacrifice the Row command first, then just give up and become non-compliant with the 7 length bound) works.

Test cases to be used with Ib English Translation's RPG_RT v1.1.0 for comparison against Player, along with documentation on more or less what they do:
https://20kdc.duckdns.org/PR1TestCase.zip

Recommended further steps (maybe nitpicky, but still):

In Player:

ChangeClass logic to SetClass: that's for if/when SetClass gets an `std::vector<uint32_t>` return value or something, necessary because the skill list needs to be preserved.

In liblcf:

`changed_class` ought to be `battle_commands_changed` - it only indicates if the battle commands array is initialized.

`class_id` is as it says, but starts at -1, and `battle_commands` is initialized to `[-1, -1, -1, -1, -1, -1, -1]`. If this was it's default I would be unsurprised. Setup is doing the wrong thing with these two.
