### PR TITLE
Various fixes (#1268, #1198, two undocumented GetActors uses, Bitmap::Create(w, h, col). Split from other PR)

### DIFF
--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -41,7 +41,7 @@
 const Opacity Opacity::opaque;
 
 BitmapRef Bitmap::Create(int width, int height, const Color& color) {
-    BitmapRef surface = Bitmap::Create(width, height, false);
+	BitmapRef surface = Bitmap::Create(width, height, true);
 	surface->Fill(color);
 	return surface;
 }

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -34,7 +34,6 @@
 Game_Character::Game_Character() :
 	tile_id(0),
 	pattern(RPG::EventPage::Frame_middle),
-	original_pattern(RPG::EventPage::Frame_middle),
 	last_pattern(0),
 	animation_id(0),
 	animation_type(RPG::EventPage::AnimType_non_continuous),
@@ -202,7 +201,7 @@ void Game_Character::UpdateSprite() {
 			anime_count++;
 	} else {
 		stop_count++;
-		if ((walk_animation && (IsSpinning() || IsContinuous())) || pattern != original_pattern)
+		if ((walk_animation && (IsSpinning() || IsContinuous())) || pattern != RPG::EventPage::Frame_middle)
 			anime_count++;
 	}
 
@@ -210,7 +209,7 @@ void Game_Character::UpdateSprite() {
 		if (IsSpinning()) {
 			SetSpriteDirection((GetSpriteDirection() + 1) % 4);
 		} else if (!IsContinuous() && IsStopping()) {
-			pattern = original_pattern;
+			pattern = RPG::EventPage::Frame_middle;
 			last_pattern = last_pattern == RPG::EventPage::Frame_left ? RPG::EventPage::Frame_right : RPG::EventPage::Frame_left;
 		} else {
 			if (last_pattern == RPG::EventPage::Frame_left) {

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -687,7 +687,6 @@ protected:
 
 	int tile_id;
 	int pattern;
-	int original_pattern;
 	int last_pattern;
 	int animation_id;
 	int animation_type;

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -265,7 +265,6 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 	tile_id = page->character_name.empty() ? page->character_index : 0;
 
 	pattern = page->character_pattern;
-	original_pattern = pattern;
 
 	move_type = page->move_type;
 	SetMoveSpeed(page->move_speed);
@@ -310,7 +309,6 @@ void Game_Event::SetupFromSave(const RPG::EventPage* new_page) {
 	tile_id = page->character_name.empty() ? page->character_index : 0;
 
 	pattern = page->character_pattern;
-	original_pattern = pattern;
 
 	move_type = page->move_type;
 	original_move_route = page->move_route;

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -673,6 +673,13 @@ bool Game_Player::GetOffVehicle() {
 	return true;
 }
 
+bool Game_Player::IsStopping() const {
+	// Prevent MoveRoute execution while the airship is ascending/descending (Issue #1268)
+	if (InAirship() && !GetVehicle()->IsMovable())
+		return false;
+	return Game_Character::IsStopping();
+}
+
 bool Game_Player::IsMovable() const {
 	if (IsMoving() || IsJumping())
 		return false;

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -109,6 +109,12 @@ public:
 
 	bool CheckEventTriggerTouch(int x, int y) override;
 
+	/*
+	 * Overridden to convince Game_Character we aren't stopped if boarding/unboarding.
+	 * Consider calling this 'IsReadyToMove' or something, and 'IsMovable' -> 'IsPlayerMovable'
+	 */
+	bool IsStopping() const override;
+
 	bool GetOnOffVehicle();
 	bool IsMovable() const;
 	bool InVehicle() const;

--- a/src/message_overlay.cpp
+++ b/src/message_overlay.cpp
@@ -124,7 +124,7 @@ void MessageOverlay::Update() {
 
 	if (!bitmap) {
 		// Initialisation is delayed because the display is not ready on startup
-		black = Bitmap::Create(DisplayUi->GetWidth(), text_height, Color());
+		black = Bitmap::Create(DisplayUi->GetWidth(), text_height, Color(0, 0, 0, 255));
 		bitmap = Bitmap::Create(DisplayUi->GetWidth(), text_height * message_max, true);
 		Graphics::RegisterDrawable(this);
 	}


### PR DESCRIPTION
This includes a fix for #1268, a fix for #1198, and adds support for two undocumented(?) GetActors uses.
This was split from #1287, so the testcase for this (which proves said GetActors calls exist) is there.

The future suggestion-aka-nitpick referring to this part is:
"`IsStopping` in Player ought to be something like `IsReadyToMove`?"
