### PR TITLE
Fix #1308

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -774,8 +774,13 @@ int Game_Character::DistanceYfromPlayer() const {
 
 void Game_Character::ForceMoveRoute(const RPG::MoveRoute& new_route,
 									int frequency) {
-
 	Game_Map::RemovePendingMove(this);
+
+	if (new_route.move_commands.empty()) {
+		CancelMoveRoute();
+		return;
+	}
+
 	Game_Map::AddPendingMove(this);
 
 	original_move_frequency = GetMoveFrequency();

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -171,6 +171,7 @@ void Graphics::DrawFrame() {
 
 	if (screen_erased) {
 		DisplayUi->CleanDisplay();
+		DisplayUi->UpdateDisplay();
 		return;
 	}
 


### PR DESCRIPTION
Using CommandMoveEvent with an empty move route only removes the previous move route without adding a new move route that introduces a one frame wait until the new (empty) move route executes.

Confirmed this with the event tracer: (F is the frame counter)
```
F	71
E	1	1	0 <- SetMoveRoute (empty route)
E	1	1	1 <- Proceed With Movement
E	1	1	2 <- Message "Done"
F	134
```
vs
```
F	72
E	1	1	0 <- SetMoveRoute (Turn up)
E	1	1	1 <- Proceed With Movement
F	73
M	8	0         <- Move: Turn up
E	1	1	2 <- Message "Done"
```

The 2nd commit fixes a problem I encoutered during the hang in VH: The erased screen is never redrawn.