### PR TITLE
Fixes for GCW0 port

### DIFF
--- a/builds/opendingux/Makefile
+++ b/builds/opendingux/Makefile
@@ -34,9 +34,9 @@ ifeq ($(BUILD_TARGET), gcwzero)
 	TOOLCHAINDIR ?= /opt/gcw0-toolchain
 	SYSROOT = $(TOOLCHAINDIR)/usr/mipsel-gcw0-linux-uclibc/sysroot
 	BINDIR = $(TOOLCHAINDIR)/usr/bin
-	CFLAGS = -Ofast -fomit-frame-pointer -fdata-sections -ffunction-sections -mips32r2 -mmxu -std=gnu++11 -DLCF_SUPPORT_ICU 
+	CFLAGS = -Ofast -fomit-frame-pointer -fdata-sections -ffunction-sections -mips32r2 -std=gnu++11 -DLCF_SUPPORT_ICU 
 	CFLAGS += -DGCW_ZERO -DWANT_FMMIDI=2 -DHAVE_MPG123 -DHAVE_LIBSNDFILE -DWANT_FASTWAV
-	LDFLAGS = -Wl,--as-needed,--gc-sections -flto
+	LDFLAGS = -Wl,--no-as-needed,--gc-sections -flto
 	PKG_CONFIG := $(BINDIR)/pkg-config
 	PNG_LIBS := $(shell $(PKG_CONFIG) --libs libpng)
 	PIXMAN_CFLAGS := $(shell $(PKG_CONFIG) --static --cflags pixman-1)
@@ -67,7 +67,7 @@ BINFILES = $(foreach dir, $(DATA), $(wildcard $(dir)/*.*))
 OBJS = $(addsuffix .o, $(BINFILES)) $(CPPFILES:.cpp=.o)
 
 # Compiler flags
-CFLAGS += -Wall -DUSE_SDL -DHAVE_SDL_MIXER -DSUPPORT_AUDIO `$(SDL_CONFIG) --cflags` $(PIXMAN_CFLAGS) $(FREETYPE_CFLAGS) $(ICU_CFLAGS) $(LIBMPG123_CFLAGS) $(LIBSNDFILE_CFLAGS)
+CFLAGS += -Wall -DNDEBUG -DUSE_SDL -DHAVE_SDL_MIXER -DSUPPORT_AUDIO `$(SDL_CONFIG) --cflags` $(PIXMAN_CFLAGS) $(FREETYPE_CFLAGS) $(ICU_CFLAGS) $(LIBMPG123_CFLAGS) $(LIBSNDFILE_CFLAGS)
 CXXFLAGS += $(CFLAGS) -fno-rtti -fno-exceptions
 LDFLAGS += -lstdc++ -lexpat -lz -lfreetype -lvorbisidec -lgcc -lm -lc -lpthread \
            -ldl `$(SDL_CONFIG) --libs` $(LIBSDLMIXER_LIBS) $(PIXMAN_LIBS) $(ICU_LIBS) $(PNG_LIBS) $(LIBMPG123_LIBS) $(LIBSNDFILE_LIBS)

--- a/builds/opendingux/gcw-zero/readme.txt
+++ b/builds/opendingux/gcw-zero/readme.txt
@@ -4,8 +4,8 @@ Installation Instructions
 RTP
 ---
 * Install the RTP files on your computer
-* RPG2K games: Copy the RTP files, not the RTP folder iteself, to /media/data/local/share/easyrpg/rtp2k
-* RPG2K3 games: Copy the RTP files, not the RTP folder itself, to /media/data/local/share/easyrpg/rtp2k3
+* RPG2K games: Copy the RTP files, not the RTP folder iteself, to /usr/local/home/.easyrpg/rtp2k
+* RPG2K3 games: Copy the RTP files, not the RTP folder itself, to /usr/local/home/.easyrpg/rtp2k3
 
 Games
 -----

--- a/src/decoder_fmmidi.cpp
+++ b/src/decoder_fmmidi.cpp
@@ -20,6 +20,7 @@
 #ifdef WANT_FMMIDI
 
 // Headers
+#include <cstdio>
 #include <cassert>
 #include "audio_decoder.h"
 #include "output.h"

--- a/src/system.h
+++ b/src/system.h
@@ -58,6 +58,10 @@
 #  define WORDS_BIGENDIAN
 #endif
 
+#ifdef OPENDINGUX
+#  include <sys/types.h>
+#endif
+
 #define SUPPORT_BMP
 #define SUPPORT_PNG
 #define SUPPORT_XYZ


### PR DESCRIPTION
This fixes the GCW0 port, again.
I switched back to using SDL 1.2 because it runs faster on the GCW0 than the SDL2 version.
(etnaviv, the 3D driver, still sucks on it and will probably stay that way. SDL2 version works fine tho)
Let me know if that's an issue.

I also added some headers to some files (i think they got removed ? not sure) because these are required for compiling. 

Switching to using -Wl,--no-as-needed because it does not compile with -as-needed.

I tried it on my GCW0 and it works okay. It seems smoother too.

Btw, it also requires this pull request too : [here](https://github.com/EasyRPG/liblcf/pull/220).