### PR TITLE
Small fixes for the emscripten port

### DIFF
--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -176,9 +176,11 @@ void FileRequestAsync::Start() {
 		request_path += path;
 	}
 
-	// URL encode % and #
+	// URL encode %, #, [ and ] (RFC 2396)
 	request_path = std::regex_replace(request_path, std::regex("%"), "%25");
 	request_path = std::regex_replace(request_path, std::regex("#"), "%23");
+	request_path = std::regex_replace(request_path, std::regex("\\["), "%5B");
+	request_path = std::regex_replace(request_path, std::regex("\\]"), "%5D");
 
 	emscripten_async_wget2(
 		request_path.c_str(),

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -164,7 +164,7 @@ void Player::Init(int argc, char *argv[]) {
 
 	// Create initial directory structure in our private area
 	// Retrieve save directory from persistent storage
-	EM_ASM(
+	EM_ASM((
 
 		FS.mkdir("easyrpg");
 		FS.chdir("easyrpg");
@@ -176,7 +176,7 @@ void Player::Init(int argc, char *argv[]) {
 
 		FS.syncfs(true, function(err) {
 		});
-	);
+	));
 #endif
 
 	Main_Data::Init();


### PR DESCRIPTION
The braces change is only to support @rohkea's game... 😀

It seems, that currently the emscripten port is broken, as it fails inside SDL2 for me.
Note: buildscript needs now: ` -s 'EXPORTED_RUNTIME_METHODS=["Pointer_stringify"]' ` for SDL2.