### PR TITLE
Battle 2k: Always allow escape escaping from random encounters

### DIFF
--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -362,12 +362,7 @@ void Game_Battle::RefreshEvents(std::function<bool(const RPG::TroopPage&)> predi
 }
 
 bool Game_Battle::IsEscapeAllowed() {
-	if (Game_Temp::battle_escape_mode == -1) {
-		return Game_System::GetAllowEscape();
-	}
-	else {
-		return !!Game_Temp::battle_escape_mode;
-	}
+	return Game_Temp::battle_escape_mode != 0;
 }
 
 bool Game_Battle::IsTerminating() {


### PR DESCRIPTION
Finally something simple to review ;)

Due to an oversight GetAllowEscape was used to check if random encouter escapes are allowed but this flag is only for escape spells, Escaping is always possible in random encouters >.>

Iirc this was reported via mail as a bug in Vampires Dawn, but can't find it anymore.