### PR TITLE
Allow loading of custom ExFont file if available in the game directory

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -279,7 +279,17 @@ BitmapRef Cache::Exfont() {
 	cache_type::iterator const it = cache.find(hash);
 
 	if (it == cache.end() || !it->second.bitmap) {
-		return(cache[hash] = {Bitmap::Create(exfont_h, sizeof(exfont_h), true), DisplayUi->GetTicks()}).bitmap;
+		std::string exfont_file = FileFinder::FindImage(".", "ExFont");
+		BitmapRef exfont_img;
+		// Allow overwriting of built-in exfont with a custom ExFont image file
+		// Probe before using LoadBitmap because this generates a warning when the file is missing
+		if (!exfont_file.empty()) {
+			exfont_img = Bitmap::Create(exfont_file, true);
+		} else {
+			exfont_img = Bitmap::Create(exfont_h, sizeof(exfont_h), true);
+		}
+
+		return(cache[hash] = {exfont_img, DisplayUi->GetTicks()}).bitmap;
 	} else {
 		it->second.last_access = DisplayUi->GetTicks();
 		return it->second.bitmap;

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -118,7 +118,10 @@ namespace {
 			// Very few games (e.g. Yume2kki) use path traversal (..) in the filenames to point
 			// to files outside of the actual directory.
 			// Fix the path and search the file again with the correct root directory set.
-			Output::Debug("Path adjusted: %s -> %s", combined_path.c_str(), canon.c_str());
+			if (dir != ".") {
+				// Prevent "path adjusted" debug log when searching for ExFont
+				Output::Debug("Path adjusted: %s -> %s", combined_path.c_str(), canon.c_str());
+			}
 			for (char const** c = exts; *c != NULL; ++c) {
 				std::string res = FileFinder::FindDefault(tree, canon + *c);
 				if (!res.empty()) {

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -118,8 +118,11 @@ void Scene_Logo::OnIndexReady(FileRequestResult*) {
 	tree->SetImportantFile(true);
 	FileRequestAsync* ini = AsyncHandler::RequestFile(INI_NAME);
 	ini->SetImportantFile(true);
+	FileRequestAsync* exfont = AsyncHandler::RequestFile("ExFont");
+	exfont->SetImportantFile(true);
 
 	db->Start();
 	tree->Start();
 	ini->Start();
+	exfont->Start();
 }


### PR DESCRIPTION
Sorry for using FindImage(".", "ExFont") instead of adding a new FindImage("ExFont") and that strange check in FileFinder for the root directory, but I'm currently heavily modifying filefinder.cpp and don't want to reapply gigantic changes ^^.

Related: #1349