### PR TITLE
Witch's Heart: Fix broom landing

### DIFF
--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -451,17 +451,8 @@ void Game_Player::Update() {
 	if (last_moving && location.unboarding) {
 		// Unboarding completed
 		location.unboarding = false;
-		location.vehicle = Game_Vehicle::None;
 		CheckTouchEvent();
 		return;
-	}
-
-	if (InAirship() && !GetVehicle()->IsInUse()) {
-		// Airship has landed
-		Unboard();
-		location.vehicle = Game_Vehicle::None;
-		SetDirection(RPG::EventPage::Direction_down);
-
 	}
 
 	if (last_moving && CheckTouchEvent()) return;
@@ -660,18 +651,6 @@ bool Game_Player::GetOffVehicle() {
 	}
 
 	GetVehicle()->GetOff();
-	if (!InAirship()) {
-		location.unboarding = true;
-		Unboard();
-		if (!GetThrough()) {
-			SetThrough(true);
-			MoveForward();
-			SetThrough(false);
-		} else {
-			MoveForward();
-		}
-	}
-
 	return true;
 }
 
@@ -781,4 +760,21 @@ void Game_Player::Unboard() {
 
 bool Game_Player::IsBoardingOrUnboarding() const {
 	return location.boarding || location.unboarding;
+}
+
+void Game_Player::UnboardingFinished() {
+	Unboard();
+	if (InAirship()) {
+		SetDirection(RPG::EventPage::Direction_down);
+	} else {
+		location.unboarding = true;
+		if (!GetThrough()) {
+			SetThrough(true);
+			MoveForward();
+			SetThrough(false);
+		} else {
+			MoveForward();
+		}
+	}
+	location.vehicle = Game_Vehicle::None;
 }

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -123,8 +123,13 @@ public:
 	Game_Vehicle* GetVehicle() const;
 	bool CanWalk(int x, int y);
 
-	/* Workaround used to avoid blocking the player with move routes that are completeable in a single frame */
+	/** Workaround used to avoid blocking the player with move routes that are completeable in a single frame */
 	bool IsBlockedByMoveRoute() const;
+
+	/**
+	 * Callback function invoked by the Vehicle to notify that the unboarding has finished
+	 */
+	void UnboardingFinished();
 
 private:
 	RPG::SavePartyLocation& location;

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -347,6 +347,7 @@ void Game_Vehicle::GetOff() {
 		data.remaining_descent = SCREEN_TILE_WIDTH;
 	} else {
 		driving = false;
+		Main_Data::game_player->UnboardingFinished();
 	}
 	SetDirection(Left);
 	SetSpriteDirection(Left);
@@ -421,6 +422,7 @@ void Game_Vehicle::Update() {
 				if (CanLand()) {
 					SetLayer(RPG::EventPage::Layers_same);
 					driving = false;
+					Main_Data::game_player->UnboardingFinished();
 					data.flying = false;
 					walk_animation = false;
 					pattern = 1;


### PR DESCRIPTION
tl;dr Added a callback function which allows the Vehicle to notify the Player, keeps the data on sync.

Before the information was incorrect for one frame which caused an issue with Event command "Conditional Branch -> Is Driven" in combination with "Set Vehicle Position" because the Player was moved together with the vehicle even though it was reported as not being driven.

Fixes landing with the broom in Witch's Heart. Thanks to vgperson for figuring this out.