### PR TITLE
Update map spriteset before a transition.

### DIFF
--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -57,7 +57,9 @@ void Scene_Map::Start() {
 	}
 
 	Player::FrameReset();
+
 	Game_Map::Update(true);
+	spriteset->Update();
 }
 
 void Scene_Map::Continue() {
@@ -232,6 +234,7 @@ void Scene_Map::FinishTeleportPlayer() {
 	spriteset.reset(new Spriteset_Map());
 
 	Game_Map::Update(true);
+	spriteset->Update();
 
 	if (autotransition) {
 		auto_transition = true;


### PR DESCRIPTION
Otherwise parallel events are running for one frame but their visual changes are not visible until the transition is finished.

Won't work properly in emscripten.

Fix #1358