### PR TITLE
Initial Enemy appearance message: Only visible enemies.

### DIFF
--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -849,7 +849,7 @@ int Scene_Battle_Rpg2k::GetDelayForLine() {
 }
 
 void Scene_Battle_Rpg2k::SetWaitForEnemyAppearanceMessages() {
-	if ((enemy_iterator == Main_Data::game_enemyparty->GetEnemies().end() &&
+	if ((enemy_iterator == visible_enemies.end() &&
 			!battle_message_window->GetHiddenLineCount()) ||
 			battle_message_window->IsPageFilled()) {
 		encounter_message_sleep_until = Player::GetFrames() + GetDelayForWindow();
@@ -861,7 +861,8 @@ void Scene_Battle_Rpg2k::SetWaitForEnemyAppearanceMessages() {
 
 bool Scene_Battle_Rpg2k::DisplayMonstersInMessageWindow() {
 	if (encounter_message_first_monster) {
-		enemy_iterator = Main_Data::game_enemyparty->GetEnemies().begin();
+		Main_Data::game_enemyparty->GetActiveBattlers(visible_enemies);
+		enemy_iterator = visible_enemies.begin();
 		encounter_message_first_monster = false;
 	}
 
@@ -885,7 +886,7 @@ bool Scene_Battle_Rpg2k::DisplayMonstersInMessageWindow() {
 		return false;
 	}
 
-	if (enemy_iterator == Main_Data::game_enemyparty->GetEnemies().end()) {
+	if (enemy_iterator == visible_enemies.end()) {
 		battle_message_window->Clear();
 		if (Game_Temp::battle_first_strike && !encounter_message_first_strike) {
 			battle_message_window->Push(Data::terms.special_combat);

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -120,7 +120,8 @@ protected:
 	std::unique_ptr<Window_BattleMessage> battle_message_window;
 	std::vector<std::string> battle_result_messages;
 	std::vector<std::string>::iterator battle_result_messages_it;
-	std::vector<std::shared_ptr<Game_Enemy> >::const_iterator enemy_iterator;
+	std::vector<Game_Battler *> visible_enemies;
+	std::vector<Game_Battler *>::const_iterator enemy_iterator;
 	int battle_action_wait;
 	int battle_action_state;
 


### PR DESCRIPTION
This PR intends for, in the initial messages about enemy appearances, not including the ones that are hidden just like RM2000. For this:

        - A "Game_EnemyParty::GetVisibleEnemies" function is created.
        - A variable with the visible enemies is initialized right after "enemies" and saved in .cpp. Here I'm not sure whether it should be a private attribute in the header instead, please tell me which one is better.
        - Change in Scene_Battle_Rpg2k the references to GetEnemies for GetVisibleEnemies.