### PR TITLE
Fixes of Battle issues ( #1371 )

### DIFF
--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -31,8 +31,8 @@
 #include "player.h"
 #include "game_temp.h"
 
-BattleAnimation::BattleAnimation(const RPG::Animation& anim) :
-	animation(anim), frame(0), frame_update(false)
+BattleAnimation::BattleAnimation(const RPG::Animation& anim, bool only_sound) :
+	animation(anim), frame(0), frame_update(false), should_only_sound(only_sound)
 {
 	SetZ(Priority_BattleAnimation);
 
@@ -139,6 +139,10 @@ void BattleAnimation::DrawAt(int x, int y) {
 	}
 }
 
+bool BattleAnimation::ShouldOnlySound() const {
+	return should_only_sound;
+}
+
 // FIXME: looks okay, but needs to be measured
 static int flash_length = 12;
 
@@ -155,6 +159,8 @@ void BattleAnimation::RunTimedSfx() {
 void BattleAnimation::ProcessAnimationTiming(const RPG::AnimationTiming& timing) {
 	// Play the SE.
 	Game_System::SePlay(timing.se);
+	if (ShouldOnlySound())
+		return;
 
 	// Flash.
 	if (timing.flash_scope == RPG::AnimationTiming::FlashScope_target) {
@@ -214,6 +220,8 @@ BattleAnimationChara::~BattleAnimationChara() {
 	Graphics::RemoveDrawable(this);
 }
 void BattleAnimationChara::Draw() {
+	if (ShouldOnlySound())
+		return;
 	//If animation is targeted on the screen
 	if (animation.scope == RPG::Animation::Scope_screen) {
 		DrawAt(SCREEN_TARGET_WIDTH / 2, SCREEN_TARGET_HEIGHT / 2);
@@ -231,13 +239,13 @@ bool BattleAnimationChara::ShouldScreenFlash() const { return true; }
 
 /////////
 
-BattleAnimationBattlers::BattleAnimationBattlers(const RPG::Animation& anim, Game_Battler& batt, bool flash) :
-	BattleAnimation(anim), battlers(std::vector<Game_Battler*>(1, &batt)), should_flash(flash)
+BattleAnimationBattlers::BattleAnimationBattlers(const RPG::Animation& anim, Game_Battler& batt, bool flash, bool only_sound) :
+	BattleAnimation(anim, only_sound), battlers(std::vector<Game_Battler*>(1, &batt)), should_flash(flash)
 {
 	Graphics::RegisterDrawable(this);
 }
-BattleAnimationBattlers::BattleAnimationBattlers(const RPG::Animation& anim, const std::vector<Game_Battler*>& batts, bool flash) :
-	BattleAnimation(anim), battlers(batts), should_flash(flash)
+BattleAnimationBattlers::BattleAnimationBattlers(const RPG::Animation& anim, const std::vector<Game_Battler*>& batts, bool flash, bool only_sound) :
+	BattleAnimation(anim, only_sound), battlers(batts), should_flash(flash)
 {
 	Graphics::RegisterDrawable(this);
 }
@@ -245,6 +253,8 @@ BattleAnimationBattlers::~BattleAnimationBattlers() {
 	Graphics::RemoveDrawable(this);
 }
 void BattleAnimationBattlers::Draw() {
+	if (ShouldOnlySound())
+		return;
 	if (animation.scope == RPG::Animation::Scope_screen) {
 		DrawAt(SCREEN_TARGET_WIDTH / 2, SCREEN_TARGET_HEIGHT / 3);
 		return;
@@ -282,6 +292,8 @@ BattleAnimationGlobal::~BattleAnimationGlobal() {
 	Graphics::RemoveDrawable(this);
 }
 void BattleAnimationGlobal::Draw() {
+	if (ShouldOnlySound())
+		return;
 	// The animations are played at the vertices of a regular grid,
 	// 20 tiles wide by 10 tiles high, independant of the map.
 	// NOTE: not accurate, but see #574

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -31,8 +31,8 @@
 #include "player.h"
 #include "game_temp.h"
 
-BattleAnimation::BattleAnimation(const RPG::Animation& anim, bool only_sound) :
-	animation(anim), frame(0), frame_update(false), should_only_sound(only_sound)
+BattleAnimation::BattleAnimation(const RPG::Animation& anim, bool only_sound, int cutoff_frame) :
+	animation(anim), frame(0), frame_update(false), should_only_sound(only_sound), cutoff(cutoff_frame)
 {
 	SetZ(Priority_BattleAnimation);
 
@@ -61,7 +61,8 @@ void BattleAnimation::Update() {
 
 	if (frame_update) {
 		frame++;
-		RunTimedSfx();
+		if (cutoff == -1 || frame <= cutoff)
+			RunTimedSfx();
 	}
 	frame_update = !frame_update;
 }
@@ -239,13 +240,13 @@ bool BattleAnimationChara::ShouldScreenFlash() const { return true; }
 
 /////////
 
-BattleAnimationBattlers::BattleAnimationBattlers(const RPG::Animation& anim, Game_Battler& batt, bool flash, bool only_sound) :
-	BattleAnimation(anim, only_sound), battlers(std::vector<Game_Battler*>(1, &batt)), should_flash(flash)
+BattleAnimationBattlers::BattleAnimationBattlers(const RPG::Animation& anim, Game_Battler& batt, bool flash, bool only_sound, int cutoff_frame) :
+	BattleAnimation(anim, only_sound, cutoff_frame), battlers(std::vector<Game_Battler*>(1, &batt)), should_flash(flash)
 {
 	Graphics::RegisterDrawable(this);
 }
-BattleAnimationBattlers::BattleAnimationBattlers(const RPG::Animation& anim, const std::vector<Game_Battler*>& batts, bool flash, bool only_sound) :
-	BattleAnimation(anim, only_sound), battlers(batts), should_flash(flash)
+BattleAnimationBattlers::BattleAnimationBattlers(const RPG::Animation& anim, const std::vector<Game_Battler*>& batts, bool flash, bool only_sound, int cutoff_frame) :
+	BattleAnimation(anim, only_sound, cutoff_frame), battlers(batts), should_flash(flash)
 {
 	Graphics::RegisterDrawable(this);
 }

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -34,7 +34,7 @@ struct FileRequestResult;
 
 class BattleAnimation : public Sprite {
 public:
-	BattleAnimation(const RPG::Animation& anim, bool only_sound = false);
+	BattleAnimation(const RPG::Animation& anim, bool only_sound = false, int cutoff_frame = -1);
 
 	DrawableType GetType() const override;
 
@@ -43,11 +43,11 @@ public:
 	int GetFrames() const;
 	void SetFrame(int);
 	bool IsDone() const;
+	bool ShouldOnlySound() const;
 
 protected:
 	virtual void SetFlash(Color c) = 0;
 	virtual bool ShouldScreenFlash() const = 0;
-	bool ShouldOnlySound() const;
 	void DrawAt(int x, int y);
 	void RunTimedSfx();
 	void ProcessAnimationTiming(const RPG::AnimationTiming& timing);
@@ -58,6 +58,7 @@ protected:
 	const RPG::Animation& animation;
 	int frame;
 	bool frame_update;
+	int cutoff;
 
 	FileRequestBinding request_id;
 };
@@ -77,8 +78,8 @@ protected:
 // For playing animations against a (group of) battlers in battle.
 class BattleAnimationBattlers : public BattleAnimation {
 public:
-	BattleAnimationBattlers(const RPG::Animation& anim, Game_Battler& batt, bool flash = true, bool only_sound = false);
-	BattleAnimationBattlers(const RPG::Animation& anim, const std::vector<Game_Battler*>& batts, bool flash = true, bool only_sound = false);
+	BattleAnimationBattlers(const RPG::Animation& anim, Game_Battler& batt, bool flash = true, bool only_sound = false, int cutoff_frame = -1);
+	BattleAnimationBattlers(const RPG::Animation& anim, const std::vector<Game_Battler*>& batts, bool flash = true, bool only_sound = false, int cutoff_frame = -1);
 	~BattleAnimationBattlers() override;
 	void Draw() override;
 protected:

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -34,7 +34,7 @@ struct FileRequestResult;
 
 class BattleAnimation : public Sprite {
 public:
-	BattleAnimation(const RPG::Animation& anim);
+	BattleAnimation(const RPG::Animation& anim, bool only_sound = false);
 
 	DrawableType GetType() const override;
 
@@ -47,12 +47,14 @@ public:
 protected:
 	virtual void SetFlash(Color c) = 0;
 	virtual bool ShouldScreenFlash() const = 0;
+	bool ShouldOnlySound() const;
 	void DrawAt(int x, int y);
 	void RunTimedSfx();
 	void ProcessAnimationTiming(const RPG::AnimationTiming& timing);
 	void OnBattleSpriteReady(FileRequestResult* result);
 	void OnBattle2SpriteReady(FileRequestResult* result);
 
+	bool should_only_sound;
 	const RPG::Animation& animation;
 	int frame;
 	bool frame_update;
@@ -75,8 +77,8 @@ protected:
 // For playing animations against a (group of) battlers in battle.
 class BattleAnimationBattlers : public BattleAnimation {
 public:
-	BattleAnimationBattlers(const RPG::Animation& anim, Game_Battler& batt, bool flash = true);
-	BattleAnimationBattlers(const RPG::Animation& anim, const std::vector<Game_Battler*>& batts, bool flash = true);
+	BattleAnimationBattlers(const RPG::Animation& anim, Game_Battler& batt, bool flash = true, bool only_sound = false);
+	BattleAnimationBattlers(const RPG::Animation& anim, const std::vector<Game_Battler*>& batts, bool flash = true, bool only_sound = false);
 	~BattleAnimationBattlers() override;
 	void Draw() override;
 protected:

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -35,16 +35,20 @@
 constexpr int max_level_2k = 50;
 constexpr int max_level_2k3 = 99;
 
-static int max_hp_value() {
+static int max_exp_value() {
+	return Player::IsRPG2k() ? 999999 : 9999999;
+}
+
+int Game_Actor::MaxHpValue() const {
 	return Player::IsRPG2k() ? 999 : 9999;
 }
 
-static int max_other_stat_value() {
-	return 999;
+int Game_Actor::MaxStatBattleValue() const {
+	return Player::IsRPG2k() ? 999 : 9999;
 }
 
-static int max_exp_value() {
-	return Player::IsRPG2k() ? 999999 : 9999999;
+int Game_Actor::MaxStatBaseValue() const {
+	return 999;
 }
 
 Game_Actor::Game_Actor(int actor_id) :
@@ -332,7 +336,7 @@ int Game_Actor::GetBaseMaxHp(bool mod) const {
 	if (mod)
 		n += GetData().hp_mod;
 
-	return min(max(n, 1), max_hp_value());
+	return min(max(n, 1), MaxHpValue());
 }
 
 int Game_Actor::GetBaseMaxHp() const {
@@ -350,7 +354,7 @@ int Game_Actor::GetBaseMaxSp(bool mod) const {
 	if (mod)
 		n += GetData().sp_mod;
 
-	return min(max(n, 0), max_other_stat_value());
+	return min(max(n, 0), MaxStatBaseValue());
 }
 
 int Game_Actor::GetBaseMaxSp() const {
@@ -378,7 +382,7 @@ int Game_Actor::GetBaseAtk(bool mod, bool equip) const {
 		}
 	}
 
-	return min(max(n, 1), max_other_stat_value());
+	return min(max(n, 1), MaxStatBaseValue());
 }
 
 int Game_Actor::GetBaseAtk() const {
@@ -406,7 +410,7 @@ int Game_Actor::GetBaseDef(bool mod, bool equip) const {
 		}
 	}
 
-	return min(max(n, 1), max_other_stat_value());
+	return min(max(n, 1), MaxStatBaseValue());
 }
 
 int Game_Actor::GetBaseDef() const {
@@ -434,7 +438,7 @@ int Game_Actor::GetBaseSpi(bool mod, bool equip) const {
 		}
 	}
 
-	return min(max(n, 1), max_other_stat_value());
+	return min(max(n, 1), MaxStatBaseValue());
 }
 
 int Game_Actor::GetBaseSpi() const {
@@ -462,7 +466,7 @@ int Game_Actor::GetBaseAgi(bool mod, bool equip) const {
 		}
 	}
 
-	return min(max(n, 1), max_other_stat_value());
+	return min(max(n, 1), MaxStatBaseValue());
 }
 
 int Game_Actor::GetBaseAgi() const {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -23,6 +23,7 @@
 #include "game_battle.h"
 #include "game_message.h"
 #include "game_party.h"
+#include "game_temp.h"
 #include "main_data.h"
 #include "output.h"
 #include "player.h"
@@ -118,6 +119,9 @@ bool Game_Actor::IsItemUsable(int item_id) const {
 	if (!item) {
 		Output::Warning("IsItemUsable: Invalid item ID %d", item_id);
 		return false;
+	}
+	if (Game_Temp::battle_running && item->type == RPG::Item::Type_medicine && !item->occasion_field1) {
+		return true;
 	}
 
 	// If the actor ID is out of range this is an optimization in the ldb file

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -181,7 +181,7 @@ int Game_Actor::GetSpCostModifier() const {
 }
 
 int Game_Actor::CalculateSkillCost(int skill_id) const {
-	return Game_Battler::CalculateSkillCost(skill_id) / GetSpCostModifier();
+	return std::ceil(Game_Battler::CalculateSkillCost(skill_id) / (float) GetSpCostModifier());
 }
 
 bool Game_Actor::LearnSkill(int skill_id) {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -151,17 +151,13 @@ bool Game_Actor::IsSkillUsable(int skill_id) const {
 	for (size_t i = 0; i < skill->attribute_effects.size(); ++i) {
 		bool required = skill->attribute_effects[i] && Data::attributes[i].type == RPG::Attribute::Type_physical;
 		if (required) {
-			if (item && i < item->attribute_set.size()) {
-				if (!item->attribute_set[i]) {
-					return false;
-				}
-			} else if (item2 && i < item2->attribute_set.size()) {
-				if (!item2->attribute_set[i]) {
-					return false;
-				}
-			} else {
-				return false;
+			if (item && i < item->attribute_set.size() && item->attribute_set[i]) {
+				continue;
 			}
+			if (item2 && i < item2->attribute_set.size() && item2->attribute_set[i]) {
+				continue;
+			}
+			return false;
 		}
 	}
 

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -552,15 +552,25 @@ int Game_Actor::GetNextExp(int level) const {
 }
 
 int Game_Actor::GetStateProbability(int state_id) const {
-	int rate = 2; // C - default
+	int rate = 2, mul = 100; // C - default
 
 	const uint8_t* r = ReaderUtil::GetElement(GetActor().state_ranks, state_id);
 	if (r) {
 		rate = *r;
 	}
 
+	// This takes the armor of the character with the most resistance for that particular state
+	for (const auto equipment : GetWholeEquipment()) {
+		RPG::Item* weapon = ReaderUtil::GetElement(Data::items, equipment);
+		if (weapon != nullptr && (weapon->type == RPG::Item::Type_shield || weapon->type == RPG::Item::Type_armor
+			|| weapon->type == RPG::Item::Type_helmet || weapon->type == RPG::Item::Type_accessory)
+			&& state_id  <= weapon->state_set.size() && weapon->state_set[state_id - 1]) {
+			mul = std::min(mul, 100 - weapon->state_chance);
+		}
+	}
+
 	// GetStateRate verifies the state_id
-	return GetStateRate(state_id, rate);
+	return GetStateRate(state_id, rate) * mul / 100;
 }
 
 int Game_Actor::GetAttributeModifier(int attribute_id) const {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -591,6 +591,16 @@ int Game_Actor::GetAttributeModifier(int attribute_id) const {
 	}
 
 	rate += *shift;
+	for (auto id_object : GetWholeEquipment()) {
+		RPG::Item *object = ReaderUtil::GetElement(Data::items, id_object);
+		if (object != nullptr && (object->type == RPG::Item::Type_shield || object->type == RPG::Item::Type_armor
+			|| object->type == RPG::Item::Type_helmet || object->type == RPG::Item::Type_accessory)
+			&& object->attribute_set.size() >= attribute_id && object->attribute_set[attribute_id - 1]) {
+			rate++;
+			break;
+		}
+	}
+
 	if (rate < 0) {
 		rate = 0;
 	} else if (rate > 4) {

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -46,6 +46,12 @@ public:
 	 */
 	Game_Actor(int actor_id);
 
+	int MaxHpValue() const override;
+
+	int MaxStatBattleValue() const override;
+
+	int MaxStatBaseValue() const override;
+
 	/**
 	 * Sets up the game actor
 	 * This is automatically called in the constructor.

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -145,7 +145,26 @@ bool Game_Battle::CheckWin() {
 }
 
 bool Game_Battle::CheckLose() {
-	return !Main_Data::game_party->IsAnyActive();
+	if (!Main_Data::game_party->IsAnyActive())
+		return true;
+
+	// If there are active characters, but all of them are in a state with Restriction "Do Nothing" and 0% recovery probability, it's game over
+	// Physical recovery doesn't matter in this case
+	int character_number = 0;
+	std::vector<Game_Battler*> actors;
+
+	Main_Data::game_party->GetActiveBattlers(actors);
+	for (auto actor : actors) {
+		for (auto id_state : actor->GetInflictedStates()) {
+			RPG::State *state = ReaderUtil::GetElement(Data::states, id_state);
+			if (state->restriction == RPG::State::Restriction_do_nothing && state->auto_release_prob == 0) {
+				++character_number;
+				break;
+			}
+		}
+	}
+
+	return character_number == actors.size();
 }
 
 Spriteset_Battle& Game_Battle::GetSpriteset() {

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -349,6 +349,7 @@ bool Game_Battle::UpdateEvents() {
 		return false;
 	});
 
+	interpreter->finished_not_updated = false;
 	return true;
 }
 

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -81,6 +81,12 @@ void Game_Battle::Init() {
 		return false;
 	});
 
+	if (Game_Temp::battle_check_surprise_attack) {
+		Game_Temp::battle_first_strike = Utils::GetRandomNumber(1, 100) <=
+			(Main_Data::game_party->GetAverageAgility() > Main_Data::game_enemyparty->GetAverageAgility() ? 5 : 3);
+		//TODO: IMPLEMENT 2k3 DIFFERENT SURPRISE MODES
+	}
+
 	Main_Data::game_party->ResetBattle();
 }
 
@@ -91,6 +97,8 @@ void Game_Battle::Quit() {
 
 	Game_Temp::battle_running = false;
 	Game_Temp::battle_background = "";
+	Game_Temp::battle_first_strike = false;
+	Game_Temp::battle_check_surprise_attack = false;
 
 	std::vector<Game_Battler*> allies;
 	Main_Data::game_party->GetBattlers(allies);

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -152,7 +152,7 @@ Spriteset_Battle& Game_Battle::GetSpriteset() {
 	return *spriteset;
 }
 
-void Game_Battle::ShowBattleAnimation(int animation_id, Game_Battler* target, bool flash, bool only_sound) {
+void Game_Battle::ShowBattleAnimation(int animation_id, Game_Battler* target, bool flash, bool only_sound, int cutoff) {
 	Main_Data::game_data.screen.battleanim_id = animation_id;
 
 	const RPG::Animation* anim = ReaderUtil::GetElement(Data::animations, animation_id);
@@ -161,10 +161,10 @@ void Game_Battle::ShowBattleAnimation(int animation_id, Game_Battler* target, bo
 		return;
 	}
 
-	animation.reset(new BattleAnimationBattlers(*anim, *target, flash, only_sound));
+	animation.reset(new BattleAnimationBattlers(*anim, *target, flash, only_sound, cutoff));
 }
 
-void Game_Battle::ShowBattleAnimation(int animation_id, const std::vector<Game_Battler*>& targets, bool flash, bool only_sound) {
+void Game_Battle::ShowBattleAnimation(int animation_id, const std::vector<Game_Battler*>& targets, bool flash, bool only_sound, int cutoff) {
 	Main_Data::game_data.screen.battleanim_id = animation_id;
 
 	const RPG::Animation* anim = ReaderUtil::GetElement(Data::animations, animation_id);
@@ -173,11 +173,15 @@ void Game_Battle::ShowBattleAnimation(int animation_id, const std::vector<Game_B
 		return;
 	}
 
-	animation.reset(new BattleAnimationBattlers(*anim, targets, flash, only_sound));
+	animation.reset(new BattleAnimationBattlers(*anim, targets, flash, only_sound, cutoff));
 }
 
 bool Game_Battle::IsBattleAnimationWaiting() {
 	return bool(animation);
+}
+
+bool Game_Battle::IsBattleAnimationOnlySound() {
+	return bool(animation) && animation->ShouldOnlySound();
 }
 
 void Game_Battle::NextTurn(Game_Battler* battler) {

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -152,7 +152,7 @@ Spriteset_Battle& Game_Battle::GetSpriteset() {
 	return *spriteset;
 }
 
-void Game_Battle::ShowBattleAnimation(int animation_id, Game_Battler* target, bool flash) {
+void Game_Battle::ShowBattleAnimation(int animation_id, Game_Battler* target, bool flash, bool only_sound) {
 	Main_Data::game_data.screen.battleanim_id = animation_id;
 
 	const RPG::Animation* anim = ReaderUtil::GetElement(Data::animations, animation_id);
@@ -161,10 +161,10 @@ void Game_Battle::ShowBattleAnimation(int animation_id, Game_Battler* target, bo
 		return;
 	}
 
-	animation.reset(new BattleAnimationBattlers(*anim, *target, flash));
+	animation.reset(new BattleAnimationBattlers(*anim, *target, flash, only_sound));
 }
 
-void Game_Battle::ShowBattleAnimation(int animation_id, const std::vector<Game_Battler*>& targets, bool flash) {
+void Game_Battle::ShowBattleAnimation(int animation_id, const std::vector<Game_Battler*>& targets, bool flash, bool only_sound) {
 	Main_Data::game_data.screen.battleanim_id = animation_id;
 
 	const RPG::Animation* anim = ReaderUtil::GetElement(Data::animations, animation_id);
@@ -173,7 +173,7 @@ void Game_Battle::ShowBattleAnimation(int animation_id, const std::vector<Game_B
 		return;
 	}
 
-	animation.reset(new BattleAnimationBattlers(*anim, targets, flash));
+	animation.reset(new BattleAnimationBattlers(*anim, targets, flash, only_sound));
 }
 
 bool Game_Battle::IsBattleAnimationWaiting() {

--- a/src/game_battle.h
+++ b/src/game_battle.h
@@ -69,7 +69,7 @@ namespace Game_Battle {
 	 * @param target pointer to the battler to play against
 	 * @param flash whether or not the screen should flash during the animation
 	 */
-	void ShowBattleAnimation(int animation_id, Game_Battler* target, bool flash = true, bool only_sound = false);
+	void ShowBattleAnimation(int animation_id, Game_Battler* target, bool flash = true, bool only_sound = false, int cutoff = -1);
 
 	/**
 	 * Plays a battle animation against several targets simultaneously.
@@ -78,12 +78,14 @@ namespace Game_Battle {
 	 * @param targets a vector of pointer to the battlers to play against
 	 * @param flash whether or not the screen should flash during the animation
 	 */
-	void ShowBattleAnimation(int animation_id, const std::vector<Game_Battler*>& targets, bool flash = true, bool only_sound = false);
+	void ShowBattleAnimation(int animation_id, const std::vector<Game_Battler*>& targets, bool flash = true, bool only_sound = false, int cutoff = -1);
 
 	/**
 	 * Whether or not a battle animation is currently playing.
 	 */
 	bool IsBattleAnimationWaiting();
+
+	bool IsBattleAnimationOnlySound();
 
 	/**
 	 * Starts a new battle turn.

--- a/src/game_battle.h
+++ b/src/game_battle.h
@@ -69,7 +69,7 @@ namespace Game_Battle {
 	 * @param target pointer to the battler to play against
 	 * @param flash whether or not the screen should flash during the animation
 	 */
-	void ShowBattleAnimation(int animation_id, Game_Battler* target, bool flash = true);
+	void ShowBattleAnimation(int animation_id, Game_Battler* target, bool flash = true, bool only_sound = false);
 
 	/**
 	 * Plays a battle animation against several targets simultaneously.
@@ -78,7 +78,7 @@ namespace Game_Battle {
 	 * @param targets a vector of pointer to the battlers to play against
 	 * @param flash whether or not the screen should flash during the animation
 	 */
-	void ShowBattleAnimation(int animation_id, const std::vector<Game_Battler*>& targets, bool flash = true);
+	void ShowBattleAnimation(int animation_id, const std::vector<Game_Battler*>& targets, bool flash = true, bool only_sound = false);
 
 	/**
 	 * Whether or not a battle animation is currently playing.

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -442,6 +442,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 
 	if (!success) {
 		out.push_back(GetAttackFailureMessage(Data::terms.dodge));
+		return;
 	}
 
 	if (GetAffectedHp() != -1) {
@@ -581,6 +582,9 @@ void Game_BattleAlgorithm::AlgorithmBase::SetTarget(Game_Battler* target) {
 }
 
 void Game_BattleAlgorithm::AlgorithmBase::Apply() {
+	if (!success)
+		return;
+
 	if (GetAffectedHp() != -1) {
 		int hp = GetAffectedHp();
 		int target_hp = GetTarget()->GetHp();
@@ -745,14 +749,13 @@ const RPG::Sound* Game_BattleAlgorithm::AlgorithmBase::GetStartSe() const {
 }
 
 const RPG::Sound* Game_BattleAlgorithm::AlgorithmBase::GetResultSe() const {
-	if (healing || IsAbsorb()) {
-		return NULL;
-	}
-
 	if (!success) {
 		return &Game_System::GetSystemSE(Game_System::SFX_Evasion);
 	}
-	else if (GetAffectedHp() > -1) {
+	if (healing || IsAbsorb()) {
+		return NULL;
+	}
+	if (GetAffectedHp() > -1) {
 		if (current_target != targets.end()) {
 			return (GetTarget()->GetType() == Game_Battler::Type_Ally ?
 				&Game_System::GetSystemSE(Game_System::SFX_AllyDamage) :
@@ -900,7 +903,7 @@ void Game_BattleAlgorithm::Normal::Apply() {
 	AlgorithmBase::Apply();
 
 	source->SetCharged(false);
-	if (source->GetType() == Game_Battler::Type_Ally) {
+	if (source->GetType() == Game_Battler::Type_Ally && success) {
 		Game_Actor* src = static_cast<Game_Actor*>(source);
 		const RPG::Item* weapon = ReaderUtil::GetElement(Data::items, src->GetWeaponId());
 		if (weapon) {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -79,6 +79,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Reset() {
 	reflect = -1;
 	animation = nullptr;
 	conditions.clear();
+	healed_conditions.clear();
 
 	if (!IsFirstAttack()) {
 		switch_on.clear();
@@ -467,6 +468,12 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 				}
 			}
 		}
+
+		// Healed conditions messages
+		std::vector<int16_t>::const_iterator it_healed = healed_conditions.begin();
+		for (; it_healed != healed_conditions.end(); it_healed++) {
+			out.push_back(GetStateMessage(ReaderUtil::GetElement(Data::states, *it_healed)->message_recovery));
+		}
 	}
 
 	if (GetAffectedSp() != -1) {
@@ -502,11 +509,11 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 	std::vector<RPG::State>::const_iterator it = conditions.begin();
 
 	for (; it != conditions.end(); ++it) {
-		if (GetTarget()->HasState(it->ID)) {
+		if (GetTarget()->HasState(it->ID) && std::find(healed_conditions.begin(), healed_conditions.end(), it->ID) == healed_conditions.end()) {
 			if (IsPositive()) {
 				out.push_back(GetStateMessage(it->message_recovery));
 			}
-			if (!it->message_already.empty()) {
+			else if (!it->message_already.empty()) {
 				out.push_back(GetStateMessage(it->message_already));
 			}
 		} else {
@@ -631,8 +638,14 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		Game_Switches[GetAffectedSwitch()] = true;
 	}
 
-	std::vector<RPG::State>::const_iterator it = conditions.begin();
+	// Conditions healed by physical attack:
+	std::vector<int16_t>::const_iterator it_healed = healed_conditions.begin();
+	for (; it_healed != healed_conditions.end(); ++it_healed) {
+		GetTarget()->RemoveState(*it_healed);
+	}
 
+	// Conditions healed/caused:
+	std::vector<RPG::State>::const_iterator it = conditions.begin();
 	for (; it != conditions.end(); ++it) {
 		if (IsPositive()) {
 			if (GetTarget()->IsDead() && it->ID == 1) {
@@ -841,6 +854,11 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 			killed_by_attack_damage = true;
 		}
 		else {
+			// Conditions healed by physical attack:
+			if (!IsPositive())
+				healed_conditions = GetTarget()->BattlePhysicalStateHeal(GetPhysicalDamageRate());
+
+			// Conditions caused:
 			if (source->GetType() == Game_Battler::Type_Ally) {
 				const RPG::Item* weapon = ReaderUtil::GetElement(Data::items, static_cast<Game_Actor*>(source)->GetWeaponId());
 
@@ -1058,6 +1076,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				this->agility = effect;
 		}
 
+		// Conditions:
 		for (int i = 0; i < (int) skill.state_effects.size(); i++) {
 			if (!skill.state_effects[i])
 				continue;
@@ -1564,6 +1583,12 @@ bool Game_BattleAlgorithm::SelfDestruct::Execute() {
 	if (GetTarget()->GetHp() - this->hp <= 0) {
 		// Death state
 		killed_by_attack_damage = true;
+	}
+
+	// Conditions healed by physical attack:
+	std::vector<int16_t>::const_iterator it_healed = healed_conditions.begin();
+	for (; it_healed != healed_conditions.end(); ++it_healed) {
+		GetTarget()->RemoveState(*it_healed);
 	}
 
 	success = true;

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -162,14 +162,14 @@ void Game_BattleAlgorithm::AlgorithmBase::PlayAnimation(bool on_source) {
 	first_attack = old_first_attack;
 }
 
-void Game_BattleAlgorithm::AlgorithmBase::PlaySoundAnimation(bool on_source) {
+void Game_BattleAlgorithm::AlgorithmBase::PlaySoundAnimation(bool on_source, int cutoff) {
 	if (current_target == targets.end() || !GetAnimation()) {
 		return;
 	}
 
 	if (on_source) {
 		std::vector<Game_Battler*> anim_targets = { GetSource() };
-		Game_Battle::ShowBattleAnimation(GetAnimation()->ID, anim_targets, false, true);
+		Game_Battle::ShowBattleAnimation(GetAnimation()->ID, anim_targets, false, true, cutoff);
 		return;
 	}
 
@@ -184,7 +184,7 @@ void Game_BattleAlgorithm::AlgorithmBase::PlaySoundAnimation(bool on_source) {
 
 	Game_Battle::ShowBattleAnimation(
 		GetAnimation()->ID,
-		anim_targets, false, true);
+		anim_targets, false, true, cutoff);
 
 	current_target = old_current_target;
 	first_attack = old_first_attack;

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1403,6 +1403,9 @@ bool Game_BattleAlgorithm::Item::Execute() {
 	this->success = false;
 
 	if (item.type == RPG::Item::Type_medicine) {
+		if (GetTarget()->GetType() == Game_Battler::Type_Ally && !item.actor_set[GetTarget()->GetId() - 1]) {
+			return this->success;
+		}
 		this->healing = true;
 
 		// HP recovery

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1198,12 +1198,19 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 		for (int i = 0; i < (int) skill.state_effects.size(); i++) {
 			if (!skill.state_effects[i])
 				continue;
-			if (!healing && Utils::GetRandomNumber(0, 99) >= skill.hit)
+			if (!healing && GetTarget()->HasState(i + 1)) {
+				this->success = true;
+				conditions.push_back(Data::states[i]);
+				continue;
+			}
+			if (healing && !GetTarget()->HasState(i + 1)) {
+				continue;
+			}
+			if (Utils::GetRandomNumber(0, 99) >= skill.hit)
 				continue;
 
-			this->success = true;
-
 			if (healing || Utils::GetRandomNumber(0, 99) <= GetTarget()->GetStateProbability(Data::states[i].ID)) {
+				this->success = true;
 				conditions.push_back(Data::states[i]);
 			}
 		}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -118,6 +118,10 @@ bool Game_BattleAlgorithm::AlgorithmBase::IsPositive() const {
 	return healing;
 }
 
+bool Game_BattleAlgorithm::AlgorithmBase::IsAbsorb() const {
+	return absorb;
+}
+
 std::string Game_BattleAlgorithm::AlgorithmBase::GetType() const {
 	return "Base";
 }
@@ -455,7 +459,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 				out.push_back(GetUndamagedMessage());
 			}
 			else {
-				if (absorb) {
+				if (IsAbsorb()) {
 					out.push_back(GetHpSpAbsorbedMessage(GetAffectedHp(), Data::terms.health_points));
 				}
 				else {
@@ -470,7 +474,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 			out.push_back(GetHpSpRecoveredMessage(GetAffectedSp(), Data::terms.spirit_points));
 		}
 		else {
-			if (absorb) {
+			if (IsAbsorb()) {
 				out.push_back(GetHpSpAbsorbedMessage(GetAffectedSp(), Data::terms.spirit_points));
 			}
 			else {
@@ -574,7 +578,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		int hp = GetAffectedHp();
 		int target_hp = GetTarget()->GetHp();
 		GetTarget()->ChangeHp(IsPositive() ? hp : -hp);
-		if (absorb) {
+		if (IsAbsorb()) {
 			// Only absorb the hp that were left
 			int src_hp = std::min(target_hp, IsPositive() ? -hp : hp);
 			source->ChangeHp(src_hp);
@@ -585,7 +589,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		int sp = GetAffectedSp();
 		int target_sp = GetTarget()->GetSp();
 		GetTarget()->SetSp(GetTarget()->GetSp() + (IsPositive() ? sp : -sp));
-		if (absorb) {
+		if (IsAbsorb()) {
 			int src_sp = std::min(target_sp, IsPositive() ? -sp : sp);
 			source->ChangeSp(src_sp);
 		}
@@ -594,7 +598,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedAttack() != -1) {
 		int atk = GetAffectedAttack();
 		GetTarget()->SetAtkModifier(IsPositive() ? atk : -atk);
-		if (absorb) {
+		if (IsAbsorb()) {
 			source->SetAtkModifier(IsPositive() ? -atk : atk);
 		}
 	}
@@ -602,7 +606,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedDefense() != -1) {
 		int def = GetAffectedDefense();
 		GetTarget()->SetDefModifier(IsPositive() ? def : -def);
-		if (absorb) {
+		if (IsAbsorb()) {
 			source->SetDefModifier(IsPositive() ? -def : def);
 		}
 	}
@@ -610,7 +614,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedSpirit() != -1) {
 		int spi = GetAffectedSpirit();
 		GetTarget()->SetSpiModifier(IsPositive() ? spi : -spi);
-		if (absorb) {
+		if (IsAbsorb()) {
 			source->SetSpiModifier(IsPositive() ? -spi : spi);
 		}
 	}
@@ -618,7 +622,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedAgility() != -1) {
 		int agi = GetAffectedAgility();
 		GetTarget()->SetAgiModifier(IsPositive() ? agi : -agi);
-		if (absorb) {
+		if (IsAbsorb()) {
 			source->SetAgiModifier(IsPositive() ? -agi : agi);
 		}
 	}
@@ -724,14 +728,14 @@ const RPG::Sound* Game_BattleAlgorithm::AlgorithmBase::GetStartSe() const {
 }
 
 const RPG::Sound* Game_BattleAlgorithm::AlgorithmBase::GetResultSe() const {
-	if (healing) {
+	if (healing || IsAbsorb()) {
 		return NULL;
 	}
 
 	if (!success) {
 		return &Game_System::GetSystemSE(Game_System::SFX_Evasion);
 	}
-	else {
+	else if (GetAffectedHp() > -1) {
 		if (current_target != targets.end()) {
 			return (GetTarget()->GetType() == Game_Battler::Type_Ally ?
 				&Game_System::GetSystemSE(Game_System::SFX_AllyDamage) :
@@ -1076,7 +1080,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 	}
 
 	absorb = skill.absorb_damage;
-	if (absorb && sp != -1) {
+	if (IsAbsorb() && sp != -1) {
 		if (GetTarget()->GetSp() == 0) {
 			this->success = false;
 		}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -641,21 +641,21 @@ Game_Battler* Game_BattleAlgorithm::AlgorithmBase::GetTarget() const {
 }
 
 float Game_BattleAlgorithm::AlgorithmBase::GetAttributeMultiplier(const std::vector<bool>& attributes_set) const {
-	float multiplier = 0;
-	int attributes_applied = 0;
+	float physical = -1001, magical = -1001;
 	for (unsigned int i = 0; i < attributes_set.size(); i++) {
 		if (attributes_set[i]) {
-			multiplier += GetTarget()->GetAttributeModifier(i + 1);
-			attributes_applied++;
+			if (ReaderUtil::GetElement(Data::attributes, i + 1)->type == RPG::Attribute::Type_physical) {
+				physical = std::max<float>(physical, GetTarget()->GetAttributeModifier(i + 1));
+			}
+			else {
+				magical = std::max<float>(magical, GetTarget()->GetAttributeModifier(i + 1));
+			}
 		}
 	}
+	physical = physical < -1000 ? 100 : physical;
+	magical = magical < -1000 ? 100 : magical;
 
-	if (attributes_applied > 0) {
-		multiplier /= (attributes_applied * 100);
-		return multiplier;
-	}
-
-	return 1.0;
+	return physical * magical / 10000;
 }
 
 void Game_BattleAlgorithm::AlgorithmBase::SetTarget(Game_Battler* target) {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -224,7 +224,7 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetDeathMessage() const {
 	}
 
 	bool is_ally = GetTarget()->GetType() == Game_Battler::Type_Ally;
-	const RPG::State* state = GetTarget()->GetSignificantState();
+	const RPG::State* state = ReaderUtil::GetElement(Data::states, 1);
 	const std::string& message = is_ally ? state->message_actor
 										: state->message_enemy;
 
@@ -847,7 +847,7 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 				if (weapon) {
 					for (unsigned int i = 0; i < weapon->state_set.size(); i++) {
 						if (weapon->state_set[i]) {
-							const RPG::State* state = ReaderUtil::GetElement(Data::states, weapon->state_set[i]);
+							RPG::State* state = ReaderUtil::GetElement(Data::states, i + 1);
 							if (!state) {
 								Output::Warning("Algorithm Normal: Weapon %d causes invalid state %d", weapon->ID, weapon->state_set[i]);
 								continue;

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -587,7 +587,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		GetTarget()->ChangeHp(IsPositive() ? hp : -hp);
 		if (IsAbsorb()) {
 			// Only absorb the hp that were left
-			int src_hp = std::min(target_hp, IsPositive() ? -hp : hp);
+			int src_hp = std::min(target_hp, hp);
 			source->ChangeHp(src_hp);
 		}
 	}
@@ -597,40 +597,44 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		int target_sp = GetTarget()->GetSp();
 		GetTarget()->SetSp(GetTarget()->GetSp() + (IsPositive() ? sp : -sp));
 		if (IsAbsorb()) {
-			int src_sp = std::min(target_sp, IsPositive() ? -sp : sp);
+			int src_sp = std::min(target_sp, sp);
 			source->ChangeSp(src_sp);
 		}
 	}
 
 	if (GetAffectedAttack() != -1) {
 		int atk = GetAffectedAttack();
-		GetTarget()->SetAtkModifier(IsPositive() ? atk : -atk);
+		GetTarget()->ChangeAtkModifier(IsPositive() ? atk : -atk);
 		if (IsAbsorb()) {
-			source->SetAtkModifier(IsPositive() ? -atk : atk);
+			atk = std::max<int>(0, std::min<int>(atk, std::min<int>(999, source->GetBaseAtk() * 2) - source->GetAtk()));
+			source->ChangeAtkModifier(atk);
 		}
 	}
 
 	if (GetAffectedDefense() != -1) {
 		int def = GetAffectedDefense();
-		GetTarget()->SetDefModifier(IsPositive() ? def : -def);
+		GetTarget()->ChangeDefModifier(IsPositive() ? def : -def);
 		if (IsAbsorb()) {
-			source->SetDefModifier(IsPositive() ? -def : def);
+			def = std::max<int>(0, std::min<int>(def, std::min<int>(999, source->GetBaseAtk() * 2) - source->GetAtk()));
+			source->ChangeDefModifier(def);
 		}
 	}
 
 	if (GetAffectedSpirit() != -1) {
 		int spi = GetAffectedSpirit();
-		GetTarget()->SetSpiModifier(IsPositive() ? spi : -spi);
+		GetTarget()->ChangeSpiModifier(IsPositive() ? spi : -spi);
 		if (IsAbsorb()) {
-			source->SetSpiModifier(IsPositive() ? -spi : spi);
+			spi = std::max<int>(0, std::min<int>(spi, std::min<int>(999, source->GetBaseAtk() * 2) - source->GetAtk()));
+			source->ChangeSpiModifier(spi);
 		}
 	}
 
 	if (GetAffectedAgility() != -1) {
 		int agi = GetAffectedAgility();
-		GetTarget()->SetAgiModifier(IsPositive() ? agi : -agi);
+		GetTarget()->ChangeAgiModifier(IsPositive() ? agi : -agi);
 		if (IsAbsorb()) {
-			source->SetAgiModifier(IsPositive() ? -agi : agi);
+			agi = std::max<int>(0, std::min<int>(agi, std::min<int>(999, source->GetBaseAtk() * 2) - source->GetAtk()));
+			source->ChangeAgiModifier(agi);
 		}
 	}
 
@@ -998,6 +1002,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 		}
 	}
 
+	absorb = false;
 	this->success = false;
 
 	this->healing =
@@ -1017,22 +1022,24 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 			int effect = (int)(skill.power * mul);
 
 			if (skill.affect_hp)
-				this->hp = effect;
+				this->hp = std::max<int>(0, std::min<int>(effect, GetTarget()->GetMaxHp() - GetTarget()->GetHp()));
 			if (skill.affect_sp)
-				this->sp = effect;
+				this->sp = std::max<int>(0, std::min<int>(effect, GetTarget()->GetMaxSp() - GetTarget()->GetSp()));
 			if (skill.affect_attack)
-				this->attack = effect;
+				this->attack = std::max<int>(0, std::min<int>(effect, std::min<int>(999, GetTarget()->GetBaseAtk() * 2) - GetTarget()->GetAtk()));
 			if (skill.affect_defense)
-				this->defense = effect;
+				this->defense = std::max<int>(0, std::min<int>(effect, std::min<int>(999, GetTarget()->GetBaseDef() * 2) - GetTarget()->GetDef()));
 			if (skill.affect_spirit)
-				this->spirit = effect;
+				this->spirit = std::max<int>(0, std::min<int>(effect, std::min<int>(999, GetTarget()->GetBaseSpi() * 2) - GetTarget()->GetSpi()));
 			if (skill.affect_agility)
-				this->agility = effect;
+				this->agility = std::max<int>(0, std::min<int>(effect, std::min<int>(999, GetTarget()->GetBaseAgi() * 2) - GetTarget()->GetAgi()));
 
 			this->success = GetAffectedHp() != -1 || GetAffectedSp() != -1 || GetAffectedAttack() > 0
 				|| GetAffectedDefense() > 0 || GetAffectedSpirit() > 0 || GetAffectedAgility() > 0;
 		}
 		else if (Utils::GetRandomNumber(0, 99) < skill.hit) {
+			absorb = skill.absorb_damage;
+
 			int effect = skill.power +
 				source->GetAtk() * skill.physical_rate / 20 +
 				source->GetSpi() * skill.magical_rate / 40;
@@ -1055,6 +1062,9 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				this->hp = effect /
 					(GetTarget()->IsDefending() ? GetTarget()->HasStrongDefense() ? 3 : 2 : 1);
 
+				if (IsAbsorb())
+					this->hp = std::min<int>(hp, GetTarget()->GetHp());
+
 				if (GetTarget()->GetHp() - this->hp <= 0) {
 					// Death state
 					killed_by_attack_damage = true;
@@ -1066,13 +1076,13 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 			}
 
 			if (skill.affect_attack)
-				this->attack = effect;
+				this->attack = std::max<int>(0, std::min<int>(effect, GetTarget()->GetAtk() - (GetTarget()->GetBaseAtk() + 1) / 2));
 			if (skill.affect_defense)
-				this->defense = effect;
+				this->defense = std::max<int>(0, std::min<int>(effect, GetTarget()->GetDef() - (GetTarget()->GetBaseDef() + 1) / 2));
 			if (skill.affect_spirit)
-				this->spirit = effect;
+				this->spirit = std::max<int>(0, std::min<int>(effect, GetTarget()->GetSpi() - (GetTarget()->GetBaseSpi() + 1) / 2));
 			if (skill.affect_agility)
-				this->agility = effect;
+				this->agility = std::max<int>(0, std::min<int>(effect, GetTarget()->GetAgi() - (GetTarget()->GetBaseAgi() + 1) / 2));
 
 			this->success = (GetAffectedHp() != -1 && !IsAbsorb()) || (GetAffectedHp() > 0 && IsAbsorb()) || GetAffectedSp() > 0 || GetAffectedAttack() > 0
 				|| GetAffectedDefense() > 0 || GetAffectedSpirit() > 0 || GetAffectedAgility() > 0;
@@ -1100,7 +1110,6 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 		assert(false && "Unsupported skill type");
 	}
 
-	absorb = skill.absorb_damage;
 	if (IsAbsorb() && sp != -1) {
 		if (GetTarget()->GetSp() == 0) {
 			this->success = false;
@@ -1326,12 +1335,12 @@ bool Game_BattleAlgorithm::Item::Execute() {
 
 		// HP recovery
 		if (item.recover_hp != 0 || item.recover_hp_rate != 0) {
-			this->hp = item.recover_hp_rate * GetTarget()->GetMaxHp() / 100 + item.recover_hp;
+			this->hp = std::max<int>(0, std::min<int>(item.recover_hp_rate * GetTarget()->GetMaxHp() / 100 + item.recover_hp, GetTarget()->GetMaxHp() - GetTarget()->GetHp()));
 		}
 
 		// SP recovery
 		if (item.recover_sp != 0 || item.recover_sp_rate != 0) {
-			this->sp = item.recover_sp_rate * GetTarget()->GetMaxSp() / 100 + item.recover_sp;
+			this->sp = std::max<int>(0, std::min<int>(item.recover_sp_rate * GetTarget()->GetMaxSp() / 100 + item.recover_sp, GetTarget()->GetMaxSp() - GetTarget()->GetSp()));
 		}
 
 		for (int i = 0; i < (int)item.state_set.size(); i++) {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -792,7 +792,7 @@ void Game_BattleAlgorithm::AlgorithmBase::TargetFirst() {
 	current_target = targets.begin();
 
 	if (!IsTargetValid()) {
-		TargetNext();
+		AlgorithmBase::TargetNext();
 	}
 
 	first_attack = true;
@@ -1558,31 +1558,31 @@ std::string Game_BattleAlgorithm::Item::GetType() const {
 }
 
 Game_BattleAlgorithm::NormalDual::NormalDual(Game_Battler* source, Game_Battler* target) :
-	AlgorithmBase(source, target) {
+	Normal(source, target), second_attack(false) {
 	// no-op
 }
 
-std::string Game_BattleAlgorithm::NormalDual::GetStartMessage() const {
-	if (Player::IsRPG2k()) {
-		return source->GetName() + " TODO DUAL";
-	}
-	else {
-		return "";
-	}
+Game_BattleAlgorithm::NormalDual::NormalDual(Game_Battler* source, Game_Party_Base* target) :
+	Normal(source, target), second_attack(false) {
+	// no-op
 }
 
-const RPG::Sound* Game_BattleAlgorithm::NormalDual::GetStartSe() const {
-	if (source->GetType() == Game_Battler::Type_Enemy) {
-		return &Game_System::GetSystemSE(Game_System::SFX_EnemyAttacks);
+bool Game_BattleAlgorithm::NormalDual::TargetNext() {
+	if (IsReflected()) {
+		// Only source available, can't target again
+		second_attack = false;
+		return false;
+	}
+	if (!second_attack && !GetTarget()->IsDead()) {
+		first_attack = false;
+		second_attack = true;
+		return true;
 	}
 	else {
-		return NULL;
+		second_attack = false;
 	}
-}
 
-bool Game_BattleAlgorithm::NormalDual::Execute() {
-	Output::Warning("Battle: Enemy Double Attack not implemented");
-	return true;
+	return TargetNextInternal();
 }
 
 std::string Game_BattleAlgorithm::NormalDual::GetType() const {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1142,11 +1142,11 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 void Game_BattleAlgorithm::Skill::Apply() {
 	AlgorithmBase::Apply();
 
-	if (item) {
-		Main_Data::game_party->ConsumeItemUse(item->ID);
-	}
-	else {
-		if (first_attack) {
+	if (IsFirstAttack()) {
+		if (item) {
+			Main_Data::game_party->ConsumeItemUse(item->ID);
+		}
+		else {
 			source->ChangeSp(-source->CalculateSkillCost(skill.ID));
 		}
 	}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -788,6 +788,10 @@ int Game_BattleAlgorithm::AlgorithmBase::GetSourceAnimationState() const {
 	return Sprite_Battler::AnimationState_Idle;
 }
 
+int Game_BattleAlgorithm::AlgorithmBase::GetSourceAnimationStateApply() const {
+	return NULL;
+}
+
 void Game_BattleAlgorithm::AlgorithmBase::TargetFirst() {
 	current_target = targets.begin();
 
@@ -1711,7 +1715,11 @@ std::string Game_BattleAlgorithm::SelfDestruct::GetStartMessage() const {
 }
 
 int Game_BattleAlgorithm::SelfDestruct::GetSourceAnimationState() const {
-	return Sprite_Battler::AnimationState_Dead;
+	return Sprite_Battler::AnimationState_SelfDestruct;
+}
+
+int Game_BattleAlgorithm::SelfDestruct::GetSourceAnimationStateApply() const {
+	return Sprite_Battler::AnimationState_DeadSelfDestruct;
 }
 
 const RPG::Sound* Game_BattleAlgorithm::SelfDestruct::GetStartSe() const {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -170,6 +170,14 @@ bool Game_BattleAlgorithm::AlgorithmBase::IsFirstAttack() const {
 	return first_attack;
 }
 
+bool Game_BattleAlgorithm::AlgorithmBase::IsSecondStartMessage() const {
+	return false;
+}
+
+std::string Game_BattleAlgorithm::AlgorithmBase::GetSecondStartMessage() const {
+	return "";
+}
+
 std::string Game_BattleAlgorithm::AlgorithmBase::GetDeathMessage() const {
 	if (!killed_by_attack_damage) {
 		return "";
@@ -1074,17 +1082,42 @@ std::string Game_BattleAlgorithm::Skill::GetStartMessage() const {
 		}
 		if (Player::IsRPG2kE()) {
 			return Utils::ReplacePlaceholders(
-				skill.using_message1 + '\n' + skill.using_message2,
+				skill.using_message1,
 				{'S', 'O', 'U'},
 				{GetSource()->GetName(), GetTarget()->GetName(), skill.name}
 			);
 		}
 		else {
-			return source->GetName() + skill.using_message1 + '\n' + skill.using_message2;
+			return source->GetName() + skill.using_message1;
 		}
 	}
 	else {
 		return skill.name;
+	}
+}
+
+bool Game_BattleAlgorithm::Skill::IsSecondStartMessage() const {
+	return Player::IsRPG2k() && (!item || item->using_message != 0) && !skill.using_message2.empty();
+}
+
+std::string Game_BattleAlgorithm::Skill::GetSecondStartMessage() const {
+	if (Player::IsRPG2k()) {
+		if (item && item->using_message == 0) {
+			return "";
+		}
+		if (Player::IsRPG2kE()) {
+			return Utils::ReplacePlaceholders(
+				skill.using_message2,
+				{ 'S', 'O', 'U' },
+				{ GetSource()->GetName(), GetTarget()->GetName(), skill.name }
+			);
+		}
+		else {
+			return skill.using_message2;
+		}
+	}
+	else {
+		return "";
 	}
 }
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -156,6 +156,10 @@ bool Game_BattleAlgorithm::AlgorithmBase::IsAbsorb() const {
 	return absorb;
 }
 
+const RPG::Item* Game_BattleAlgorithm::AlgorithmBase::GetItem() const {
+	return nullptr;
+}
+
 std::string Game_BattleAlgorithm::AlgorithmBase::GetType() const {
 	return "Base";
 }
@@ -1424,6 +1428,14 @@ bool Game_BattleAlgorithm::Skill::IsReflected() const {
 	return has_reflect;
 }
 
+int Game_BattleAlgorithm::Skill::GetSpCost() const {
+	return item? -1 : source->CalculateSkillCost(skill.ID);
+}
+
+const RPG::Item* Game_BattleAlgorithm::Skill::GetItem() const {
+	return item;
+}
+
 std::string Game_BattleAlgorithm::Skill::GetType() const {
 	return "Skill";
 }
@@ -1555,6 +1567,10 @@ const RPG::Sound* Game_BattleAlgorithm::Item::GetStartSe() const {
 	else {
 		return NULL;
 	}
+}
+
+const RPG::Item* Game_BattleAlgorithm::Item::GetItem() const {
+	return &item;
 }
 
 std::string Game_BattleAlgorithm::Item::GetType() const {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -995,7 +995,7 @@ void Game_BattleAlgorithm::Normal::Apply() {
 		Game_Actor* src = static_cast<Game_Actor*>(source);
 		const RPG::Item* weapon = ReaderUtil::GetElement(Data::items, src->GetWeaponId());
 		if (weapon) {
-			source->ChangeSp(-weapon->sp_cost / src->GetSpCostModifier());
+			source->ChangeSp(std::ceil(-weapon->sp_cost / (float) src->GetSpCostModifier()));
 		}
 	}
 }

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -480,7 +480,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 		if (IsPositive()) {
 			out.push_back(GetHpSpRecoveredMessage(GetAffectedSp(), Data::terms.spirit_points));
 		}
-		else {
+		else if (GetAffectedSp() > 0) {
 			if (IsAbsorb()) {
 				out.push_back(GetHpSpAbsorbedMessage(GetAffectedSp(), Data::terms.spirit_points));
 			}
@@ -490,19 +490,19 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 		}
 	}
 
-	if (GetAffectedAttack() != -1) {
+	if (GetAffectedAttack() > 0) {
 		out.push_back(GetParameterChangeMessage(IsPositive(), GetAffectedAttack(), Data::terms.attack));
 	}
 
-	if (GetAffectedDefense() != -1) {
+	if (GetAffectedDefense() > 0) {
 		out.push_back(GetParameterChangeMessage(IsPositive(), GetAffectedDefense(), Data::terms.defense));
 	}
 
-	if (GetAffectedSpirit() != -1) {
+	if (GetAffectedSpirit() > 0) {
 		out.push_back(GetParameterChangeMessage(IsPositive(), GetAffectedSpirit(), Data::terms.spirit));
 	}
 
-	if (GetAffectedAgility() != -1) {
+	if (GetAffectedAgility() > 0) {
 		out.push_back(GetParameterChangeMessage(IsPositive(), GetAffectedAgility(), Data::terms.agility));
 	}
 
@@ -1008,8 +1008,6 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 	if (skill.type == RPG::Skill::Type_normal ||
 		skill.type >= RPG::Skill::Type_subskill) {
 		if (this->healing) {
-			this->success = true;
-
 			float mul = GetAttributeMultiplier(skill.attribute_effects);
 			if (mul < 0.5f) {
 				// Determined via testing, the heal is always at least 50%
@@ -1030,10 +1028,11 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				this->spirit = effect;
 			if (skill.affect_agility)
 				this->agility = effect;
+
+			this->success = GetAffectedHp() != -1 || GetAffectedSp() != -1 || GetAffectedAttack() > 0
+				|| GetAffectedDefense() > 0 || GetAffectedSpirit() > 0 || GetAffectedAgility() > 0;
 		}
 		else if (Utils::GetRandomNumber(0, 99) < skill.hit) {
-			this->success = true;
-
 			int effect = skill.power +
 				source->GetAtk() * skill.physical_rate / 20 +
 				source->GetSpi() * skill.magical_rate / 40;
@@ -1074,6 +1073,9 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				this->spirit = effect;
 			if (skill.affect_agility)
 				this->agility = effect;
+
+			this->success = (GetAffectedHp() != -1 && !IsAbsorb()) || (GetAffectedHp() > 0 && IsAbsorb()) || GetAffectedSp() > 0 || GetAffectedAttack() > 0
+				|| GetAffectedDefense() > 0 || GetAffectedSpirit() > 0 || GetAffectedAgility() > 0;
 		}
 
 		// Conditions:

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -836,7 +836,7 @@ bool Game_BattleAlgorithm::AlgorithmBase::IsTargetValid() const {
 		return false;
 	}
 
-	return (!GetTarget()->IsDead());
+	return (!GetTarget()->IsDead() && !GetTarget()->IsHidden());
 }
 
 int Game_BattleAlgorithm::AlgorithmBase::GetSourceAnimationState() const {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1113,8 +1113,10 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 
 			if (skill.affect_hp)
 				this->hp = std::max<int>(0, std::min<int>(effect, GetTarget()->GetMaxHp() - GetTarget()->GetHp()));
-			if (skill.affect_sp)
-				this->sp = std::max<int>(0, std::min<int>(effect, GetTarget()->GetMaxSp() - GetTarget()->GetSp()));
+			if (skill.affect_sp) {
+				int prov_sp = GetSource() == GetTarget() ? source->CalculateSkillCost(skill.ID) : 0;
+				this->sp = std::max<int>(0, std::min<int>(effect, GetTarget()->GetMaxSp() - GetTarget()->GetSp() + prov_sp));
+			}
 			if (skill.affect_attack)
 				this->attack = std::max<int>(0, std::min<int>(effect, std::min<int>(999, GetTarget()->GetBaseAtk() * 2) - GetTarget()->GetAtk()));
 			if (skill.affect_defense)
@@ -1229,8 +1231,6 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 }
 
 void Game_BattleAlgorithm::Skill::Apply() {
-	AlgorithmBase::Apply();
-
 	if (IsFirstAttack()) {
 		if (item) {
 			Main_Data::game_party->ConsumeItemUse(item->ID);
@@ -1239,6 +1239,8 @@ void Game_BattleAlgorithm::Skill::Apply() {
 			source->ChangeSp(-source->CalculateSkillCost(skill.ID));
 		}
 	}
+
+	AlgorithmBase::Apply();
 
 	std::vector<int16_t>::const_iterator it_shift = shift_attributes.begin();
 	for (; it_shift != shift_attributes.end(); ++it_shift) {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -273,7 +273,7 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetHpSpRecoveredMessage(int val
 			particle = particle2 = " ";
 		}
 		ss << particle << points << particle2;
-		ss << GetAffectedHp() << space << Data::terms.hp_recovery;
+		ss << value << space << Data::terms.hp_recovery;
 		return ss.str();
 	}
 }
@@ -344,7 +344,7 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetHpSpAbsorbedMessage(int valu
 		} else {
 			particle = particle2 = " ";
 		}
-		ss << particle << Data::terms.health_points << particle2;
+		ss << particle << points << particle2;
 		ss << value << space << message;
 
 		return ss.str();

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -999,7 +999,7 @@ void Game_BattleAlgorithm::Normal::Apply() {
 	AlgorithmBase::Apply();
 
 	source->SetCharged(false);
-	if (source->GetType() == Game_Battler::Type_Ally && success) {
+	if (source->GetType() == Game_Battler::Type_Ally && IsFirstAttack()) {
 		Game_Actor* src = static_cast<Game_Actor*>(source);
 		const RPG::Item* weapon = ReaderUtil::GetElement(Data::items, src->GetWeaponId());
 		if (weapon) {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -960,6 +960,18 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 
 	to_hit = to_hit_physical(GetSource(), GetTarget(), to_hit);
 
+	// If the target actor has a "Prevent Critic Hits" armor, there's no critic:
+	if (GetTarget()->GetType() == Game_Battler::Type_Ally) {
+		for (auto object_id : static_cast<Game_Actor*>(GetTarget())->GetWholeEquipment()) {
+			RPG::Item *object = ReaderUtil::GetElement(Data::items, object_id);
+			if (object != nullptr && (object->type == RPG::Item::Type_shield || object->type == RPG::Item::Type_armor
+				|| object->type == RPG::Item::Type_helmet || object->type == RPG::Item::Type_accessory) && object->prevent_critical) {
+				crit_chance = 0.0;
+				break;
+			}
+		}
+	}
+
 	// Damage calculation
 	if (Utils::GetRandomNumber(0, 99) < to_hit) {
 		if (!source->IsCharged() && Utils::GetRandomNumber(0, 99) < (int)ceil(crit_chance * 100)) {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1187,7 +1187,9 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				this->success = (GetAffectedHp() != -1 && !IsAbsorb()) || (GetAffectedHp() > 0 && IsAbsorb()) || GetAffectedSp() > 0 || GetAffectedAttack() > 0
 					|| GetAffectedDefense() > 0 || GetAffectedSpirit() > 0 || GetAffectedAgility() > 0;
 
-				if (IsAbsorb() && !success)
+				if (!success &&
+					(IsAbsorb() && ((GetAffectedHp() == 0 && GetAffectedSp() <= 0) || (GetAffectedHp() <= 0 && GetAffectedSp() == 0))) ||
+					(!IsAbsorb() && GetAffectedSp() == 0 && GetAffectedHp() == -1))
 					return this->success;
 			}
 		}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -747,7 +747,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		int atk = GetAffectedAttack();
 		GetTarget()->ChangeAtkModifier(IsPositive() ? atk : -atk);
 		if (IsAbsorb()) {
-			atk = std::max<int>(0, std::min<int>(atk, std::min<int>(999, source->GetBaseAtk() * 2) - source->GetAtk()));
+			atk = std::max<int>(0, std::min<int>(atk, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk()));
 			source->ChangeAtkModifier(atk);
 		}
 	}
@@ -756,7 +756,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		int def = GetAffectedDefense();
 		GetTarget()->ChangeDefModifier(IsPositive() ? def : -def);
 		if (IsAbsorb()) {
-			def = std::max<int>(0, std::min<int>(def, std::min<int>(999, source->GetBaseAtk() * 2) - source->GetAtk()));
+			def = std::max<int>(0, std::min<int>(def, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk()));
 			source->ChangeDefModifier(def);
 		}
 	}
@@ -765,7 +765,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		int spi = GetAffectedSpirit();
 		GetTarget()->ChangeSpiModifier(IsPositive() ? spi : -spi);
 		if (IsAbsorb()) {
-			spi = std::max<int>(0, std::min<int>(spi, std::min<int>(999, source->GetBaseAtk() * 2) - source->GetAtk()));
+			spi = std::max<int>(0, std::min<int>(spi, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk()));
 			source->ChangeSpiModifier(spi);
 		}
 	}
@@ -774,7 +774,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		int agi = GetAffectedAgility();
 		GetTarget()->ChangeAgiModifier(IsPositive() ? agi : -agi);
 		if (IsAbsorb()) {
-			agi = std::max<int>(0, std::min<int>(agi, std::min<int>(999, source->GetBaseAtk() * 2) - source->GetAtk()));
+			agi = std::max<int>(0, std::min<int>(agi, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk()));
 			source->ChangeAgiModifier(agi);
 		}
 	}
@@ -1291,13 +1291,13 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				this->sp = std::max<int>(0, std::min<int>(effect, GetTarget()->GetMaxSp() - GetTarget()->GetSp() + prov_sp));
 			}
 			if (skill.affect_attack)
-				this->attack = std::max<int>(0, std::min<int>(effect, std::min<int>(999, GetTarget()->GetBaseAtk() * 2) - GetTarget()->GetAtk()));
+				this->attack = std::max<int>(0, std::min<int>(effect, std::min<int>(GetTarget()->MaxStatBattleValue(), GetTarget()->GetBaseAtk() * 2) - GetTarget()->GetAtk()));
 			if (skill.affect_defense)
-				this->defense = std::max<int>(0, std::min<int>(effect, std::min<int>(999, GetTarget()->GetBaseDef() * 2) - GetTarget()->GetDef()));
+				this->defense = std::max<int>(0, std::min<int>(effect, std::min<int>(GetTarget()->MaxStatBattleValue(), GetTarget()->GetBaseDef() * 2) - GetTarget()->GetDef()));
 			if (skill.affect_spirit)
-				this->spirit = std::max<int>(0, std::min<int>(effect, std::min<int>(999, GetTarget()->GetBaseSpi() * 2) - GetTarget()->GetSpi()));
+				this->spirit = std::max<int>(0, std::min<int>(effect, std::min<int>(GetTarget()->MaxStatBattleValue(), GetTarget()->GetBaseSpi() * 2) - GetTarget()->GetSpi()));
 			if (skill.affect_agility)
-				this->agility = std::max<int>(0, std::min<int>(effect, std::min<int>(999, GetTarget()->GetBaseAgi() * 2) - GetTarget()->GetAgi()));
+				this->agility = std::max<int>(0, std::min<int>(effect, std::min<int>(GetTarget()->MaxStatBattleValue(), GetTarget()->GetBaseAgi() * 2) - GetTarget()->GetAgi()));
 
 			this->success = GetAffectedHp() != -1 || GetAffectedSp() != -1 || GetAffectedAttack() > 0
 				|| GetAffectedDefense() > 0 || GetAffectedSpirit() > 0 || GetAffectedAgility() > 0;

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1363,16 +1363,11 @@ void Game_BattleAlgorithm::Item::GetResultMessages(std::vector<std::string>& out
 }
 
 const RPG::Sound* Game_BattleAlgorithm::Item::GetStartSe() const {
-	if (item.type == RPG::Item::Type_switch) {
+	if (item.type == RPG::Item::Type_medicine || item.type == RPG::Item::Type_switch) {
 		return &Game_System::GetSystemSE(Game_System::SFX_UseItem);
 	}
 	else {
-		if (source->GetType() == Game_Battler::Type_Enemy) {
-			return &Game_System::GetSystemSE(Game_System::SFX_EnemyAttacks);
-		}
-		else {
-			return NULL;
-		}
+		return NULL;
 	}
 }
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1982,8 +1982,12 @@ int Game_BattleAlgorithm::Escape::GetSourceAnimationState() const {
 		return AlgorithmBase::GetSourceAnimationState();
 	}
 	else {
-		return Sprite_Battler::AnimationState_Dead;
+		return Sprite_Battler::AnimationState_Escape;
 	}
+}
+
+int Game_BattleAlgorithm::Escape::GetSourceAnimationStateApply() const {
+	return Sprite_Battler::AnimationState_Dead;
 }
 
 const RPG::Sound* Game_BattleAlgorithm::Escape::GetStartSe() const {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -470,6 +470,12 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 			}
 		}
 
+		// If enemy is killed, it ends here
+		if (killed_by_attack_damage) {
+			out.push_back(GetDeathMessage());
+			return;
+		}
+
 		// Healed conditions messages
 		std::vector<int16_t>::const_iterator it_healed = healed_conditions.begin();
 		for (; it_healed != healed_conditions.end(); it_healed++) {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -435,12 +435,13 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetStateMessage(const std::stri
 	}
 }
 
-void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::string>& out) const {
+void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::string>& out, std::vector<int>& out_replace) const {
 	if (current_target == targets.end()) {
 		return;
 	}
 
 	if (!success) {
+		out_replace.push_back(0);
 		out.push_back(GetAttackFailureMessage(Data::terms.dodge));
 		return;
 	}
@@ -449,14 +450,17 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 
 		if (IsPositive()) {
 			if (!GetTarget()->IsDead()) {
+				out_replace.push_back(0);
 				out.push_back(GetHpSpRecoveredMessage(GetAffectedHp(), Data::terms.health_points));
 			}
 		}
 		else {
 			if (critical_hit) {
+				out_replace.push_back(0);
 				out.push_back(GetCriticalHitMessage());
 			}
 
+			out_replace.push_back(0);
 			if (GetAffectedHp() == 0) {
 				out.push_back(GetUndamagedMessage());
 			}
@@ -472,6 +476,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 
 		// If enemy is killed, it ends here
 		if (killed_by_attack_damage) {
+			out_replace.push_back(1);
 			out.push_back(GetDeathMessage());
 			return;
 		}
@@ -479,11 +484,13 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 		// Healed conditions messages
 		std::vector<int16_t>::const_iterator it_healed = healed_conditions.begin();
 		for (; it_healed != healed_conditions.end(); it_healed++) {
+			out_replace.push_back(1);
 			out.push_back(GetStateMessage(ReaderUtil::GetElement(Data::states, *it_healed)->message_recovery));
 		}
 	}
 
 	if (GetAffectedSp() != -1) {
+		out_replace.push_back(0);
 		if (IsPositive()) {
 			out.push_back(GetHpSpRecoveredMessage(GetAffectedSp(), Data::terms.spirit_points));
 		}
@@ -498,18 +505,22 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 	}
 
 	if (GetAffectedAttack() > 0) {
+		out_replace.push_back(0);
 		out.push_back(GetParameterChangeMessage(IsPositive(), GetAffectedAttack(), Data::terms.attack));
 	}
 
 	if (GetAffectedDefense() > 0) {
+		out_replace.push_back(0);
 		out.push_back(GetParameterChangeMessage(IsPositive(), GetAffectedDefense(), Data::terms.defense));
 	}
 
 	if (GetAffectedSpirit() > 0) {
+		out_replace.push_back(0);
 		out.push_back(GetParameterChangeMessage(IsPositive(), GetAffectedSpirit(), Data::terms.spirit));
 	}
 
 	if (GetAffectedAgility() > 0) {
+		out_replace.push_back(0);
 		out.push_back(GetParameterChangeMessage(IsPositive(), GetAffectedAgility(), Data::terms.agility));
 	}
 
@@ -518,9 +529,11 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 	for (; it != conditions.end(); ++it) {
 		if (GetTarget()->HasState(it->ID) && std::find(healed_conditions.begin(), healed_conditions.end(), it->ID) == healed_conditions.end()) {
 			if (IsPositive()) {
+				out_replace.push_back(0);
 				out.push_back(GetStateMessage(it->message_recovery));
 			}
 			else if (!it->message_already.empty()) {
+				out_replace.push_back(0);
 				out.push_back(GetStateMessage(it->message_already));
 			}
 		} else {
@@ -530,6 +543,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 			}
 
 			bool is_actor = GetTarget()->GetType() == Game_Battler::Type_Ally;
+			out_replace.push_back(0);
 			out.push_back(GetStateMessage(is_actor ? it->message_actor : it->message_enemy));
 
 			// Reporting ends with death state
@@ -1224,8 +1238,9 @@ const RPG::Sound* Game_BattleAlgorithm::Skill::GetResultSe() const {
 	return !success && skill.failure_message != 3 ? NULL : AlgorithmBase::GetResultSe();
 }
 
-void Game_BattleAlgorithm::Skill::GetResultMessages(std::vector<std::string>& out) const {
+void Game_BattleAlgorithm::Skill::GetResultMessages(std::vector<std::string>& out, std::vector<int>& out_replace) const {
 	if (!success) {
+		out_replace.push_back(0);
 		switch (skill.failure_message) {
 			case 0:
 				out.push_back(AlgorithmBase::GetAttackFailureMessage(Data::terms.skill_failure_a));
@@ -1245,7 +1260,7 @@ void Game_BattleAlgorithm::Skill::GetResultMessages(std::vector<std::string>& ou
 		return;
 	}
 
-	AlgorithmBase::GetResultMessages(out);
+	AlgorithmBase::GetResultMessages(out, out_replace);
 }
 
 int Game_BattleAlgorithm::Skill::GetPhysicalDamageRate() const {
@@ -1402,8 +1417,8 @@ int Game_BattleAlgorithm::Item::GetSourceAnimationState() const {
 	return Sprite_Battler::AnimationState_Item;
 }
 
-void Game_BattleAlgorithm::Item::GetResultMessages(std::vector<std::string>& out) const {
-	AlgorithmBase::GetResultMessages(out);
+void Game_BattleAlgorithm::Item::GetResultMessages(std::vector<std::string>& out, std::vector<int>& out_replace) const {
+	AlgorithmBase::GetResultMessages(out, out_replace);
 }
 
 const RPG::Sound* Game_BattleAlgorithm::Item::GetStartSe() const {
@@ -1707,8 +1722,9 @@ void Game_BattleAlgorithm::Escape::Apply() {
 	}
 }
 
-void Game_BattleAlgorithm::Escape::GetResultMessages(std::vector<std::string>& out) const {
+void Game_BattleAlgorithm::Escape::GetResultMessages(std::vector<std::string>& out, std::vector<int>& out_replace) const {
 	if (source->GetType() == Game_Battler::Type_Ally) {
+		out_replace.push_back(0);
 		if (this->success) {
 			out.push_back(Data::terms.escape_success);
 		}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1468,7 +1468,8 @@ int Game_BattleAlgorithm::Item::GetSourceAnimationState() const {
 }
 
 void Game_BattleAlgorithm::Item::GetResultMessages(std::vector<std::string>& out, std::vector<int>& out_replace) const {
-	AlgorithmBase::GetResultMessages(out, out_replace);
+	if (success)
+		AlgorithmBase::GetResultMessages(out, out_replace);
 }
 
 const RPG::Sound* Game_BattleAlgorithm::Item::GetStartSe() const {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -30,6 +30,7 @@
 #include "game_party_base.h"
 #include "game_switches.h"
 #include "game_system.h"
+#include "game_temp.h"
 #include "main_data.h"
 #include "output.h"
 #include "player.h"
@@ -1814,9 +1815,8 @@ bool Game_BattleAlgorithm::Escape::Execute() {
 	// Monsters always escape
 	this->success = true;
 
-	// TODO: Preemptive attack has 100% escape ratio
-
-	if (source->GetType() == Game_Battler::Type_Ally) {
+	// Preemptive attack has 100% escape ratio
+	if (source->GetType() == Game_Battler::Type_Ally && !(Game_Temp::battle_first_strike && Game_Battle::GetTurn() == 0)) {
 		int ally_agi = Main_Data::game_party->GetAverageAgility();
 		int enemy_agi = Main_Data::game_enemyparty->GetAverageAgility();
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1078,6 +1078,8 @@ bool Game_BattleAlgorithm::Skill::IsTargetValid() const {
 }
 
 bool Game_BattleAlgorithm::Skill::Execute() {
+	int effect;
+
 	if (item && item->skill_id != skill.ID) {
 		assert(false && "Item skill mismatch");
 	}
@@ -1109,7 +1111,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				mul = 0.5f;
 			}
 
-			int effect = (int)(skill.power * mul);
+			effect = (int)(skill.power * mul);
 
 			if (skill.affect_hp)
 				this->hp = std::max<int>(0, std::min<int>(effect, GetTarget()->GetMaxHp() - GetTarget()->GetHp()));
@@ -1140,7 +1142,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 			}
 
 			if (Utils::GetRandomNumber(0, 99) < to_hit) {
-				int effect = skill.power +
+				effect = skill.power +
 					source->GetAtk() * skill.physical_rate / 20 +
 					source->GetSpi() * skill.magical_rate / 40;
 				if (!skill.ignore_defense) {
@@ -1212,6 +1214,17 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 			if (healing || Utils::GetRandomNumber(0, 99) <= GetTarget()->GetStateProbability(Data::states[i].ID)) {
 				this->success = true;
 				conditions.push_back(Data::states[i]);
+			}
+		}
+
+		//If resurrected and no HP selected, the effect value is a percentage:
+		if (healing && GetTarget()->IsDead() && !skill.affect_hp) {
+			for (auto condition : conditions) {
+				if (condition.ID == 1) {
+					hp = GetTarget()->GetMaxHp() * effect / 100;
+					this->success = true;
+					break;
+				}
 			}
 		}
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -118,6 +118,10 @@ bool Game_BattleAlgorithm::AlgorithmBase::IsPositive() const {
 	return healing;
 }
 
+std::string Game_BattleAlgorithm::AlgorithmBase::GetType() const {
+	return "Base";
+}
+
 const std::vector<RPG::State>& Game_BattleAlgorithm::AlgorithmBase::GetAffectedConditions() const {
 	return conditions;
 }
@@ -149,6 +153,34 @@ void Game_BattleAlgorithm::AlgorithmBase::PlayAnimation(bool on_source) {
 	Game_Battle::ShowBattleAnimation(
 		GetAnimation()->ID,
 		anim_targets);
+
+	current_target = old_current_target;
+	first_attack = old_first_attack;
+}
+
+void Game_BattleAlgorithm::AlgorithmBase::PlaySoundAnimation(bool on_source) {
+	if (current_target == targets.end() || !GetAnimation()) {
+		return;
+	}
+
+	if (on_source) {
+		std::vector<Game_Battler*> anim_targets = { GetSource() };
+		Game_Battle::ShowBattleAnimation(GetAnimation()->ID, anim_targets, false, true);
+		return;
+	}
+
+	auto old_current_target = current_target;
+	bool old_first_attack = first_attack;
+
+	std::vector<Game_Battler*> anim_targets;
+
+	do {
+		anim_targets.push_back(*current_target);
+	} while (TargetNextInternal());
+
+	Game_Battle::ShowBattleAnimation(
+		GetAnimation()->ID,
+		anim_targets, false, true);
 
 	current_target = old_current_target;
 	first_attack = old_first_attack;
@@ -888,6 +920,10 @@ int Game_BattleAlgorithm::Normal::GetPhysicalDamageRate() const {
 	return 100;
 }
 
+std::string Game_BattleAlgorithm::Normal::GetType() const {
+	return "Normal";
+}
+
 Game_BattleAlgorithm::Skill::Skill(Game_Battler* source, Game_Battler* target, const RPG::Skill& skill, const RPG::Item* item) :
 	AlgorithmBase(source, target), skill(skill), item(item) {
 	// no-op
@@ -1140,12 +1176,7 @@ const RPG::Sound* Game_BattleAlgorithm::Skill::GetStartSe() const {
 		return &skill.sound_effect;
 	}
 	else {
-		if (source->GetType() == Game_Battler::Type_Enemy) {
-			return &Game_System::GetSystemSE(Game_System::SFX_EnemyAttacks);
-		}
-		else {
-			return NULL;
-		}
+		return NULL;
 	}
 }
 
@@ -1211,6 +1242,10 @@ bool Game_BattleAlgorithm::Skill::IsReflected() const {
 
 	reflect = has_reflect ? 1 : 0;
 	return has_reflect;
+}
+
+std::string Game_BattleAlgorithm::Skill::GetType() const {
+	return "Skill";
 }
 
 Game_BattleAlgorithm::Item::Item(Game_Battler* source, Game_Battler* target, const RPG::Item& item) :
@@ -1341,6 +1376,10 @@ const RPG::Sound* Game_BattleAlgorithm::Item::GetStartSe() const {
 	}
 }
 
+std::string Game_BattleAlgorithm::Item::GetType() const {
+	return "Item";
+}
+
 Game_BattleAlgorithm::NormalDual::NormalDual(Game_Battler* source, Game_Battler* target) :
 	AlgorithmBase(source, target) {
 	// no-op
@@ -1367,6 +1406,10 @@ const RPG::Sound* Game_BattleAlgorithm::NormalDual::GetStartSe() const {
 bool Game_BattleAlgorithm::NormalDual::Execute() {
 	Output::Warning("Battle: Enemy Double Attack not implemented");
 	return true;
+}
+
+std::string Game_BattleAlgorithm::NormalDual::GetType() const {
+	return "NormalDual";
 }
 
 Game_BattleAlgorithm::Defend::Defend(Game_Battler* source) :
@@ -1402,6 +1445,10 @@ void Game_BattleAlgorithm::Defend::Apply() {
 	source->SetDefending(true);
 }
 
+std::string Game_BattleAlgorithm::Defend::GetType() const {
+	return "Defend";
+}
+
 Game_BattleAlgorithm::Observe::Observe(Game_Battler* source) :
 AlgorithmBase(source) {
 	// no-op
@@ -1426,6 +1473,10 @@ std::string Game_BattleAlgorithm::Observe::GetStartMessage() const {
 bool Game_BattleAlgorithm::Observe::Execute() {
 	// Observe only prints the start message
 	return true;
+}
+
+std::string Game_BattleAlgorithm::Observe::GetType() const {
+	return "Observe";
 }
 
 Game_BattleAlgorithm::Charge::Charge(Game_Battler* source) :
@@ -1455,6 +1506,10 @@ bool Game_BattleAlgorithm::Charge::Execute() {
 
 void Game_BattleAlgorithm::Charge::Apply() {
 	source->SetCharged(true);
+}
+
+std::string Game_BattleAlgorithm::Charge::GetType() const {
+	return "Charge";
 }
 
 Game_BattleAlgorithm::SelfDestruct::SelfDestruct(Game_Battler* source, Game_Party_Base* target) :
@@ -1524,6 +1579,10 @@ void Game_BattleAlgorithm::SelfDestruct::Apply() {
 	if (source->GetType() == Game_Battler::Type_Enemy) {
 		static_cast<Game_Enemy*>(source)->SetHidden(true);
 	}
+}
+
+std::string Game_BattleAlgorithm::SelfDestruct::GetType() const {
+	return "SelfDestruct";
 }
 
 Game_BattleAlgorithm::Escape::Escape(Game_Battler* source) :
@@ -1614,6 +1673,10 @@ void Game_BattleAlgorithm::Escape::GetResultMessages(std::vector<std::string>& o
 	}
 }
 
+std::string Game_BattleAlgorithm::Escape::GetType() const {
+	return "Escape";
+}
+
 Game_BattleAlgorithm::Transform::Transform(Game_Battler* source, int new_monster_id) :
 AlgorithmBase(source), new_monster_id(new_monster_id) {
 	// no-op
@@ -1641,6 +1704,10 @@ bool Game_BattleAlgorithm::Transform::Execute() {
 
 void Game_BattleAlgorithm::Transform::Apply() {
 	static_cast<Game_Enemy*>(source)->Transform(new_monster_id);
+}
+
+std::string Game_BattleAlgorithm::Transform::GetType() const {
+	return "Transform";
 }
 
 Game_BattleAlgorithm::NoMove::NoMove(Game_Battler* source) :
@@ -1675,3 +1742,6 @@ void Game_BattleAlgorithm::NoMove::Apply() {
 	// no-op
 }
 
+std::string Game_BattleAlgorithm::NoMove::GetType() const {
+	return "NoMove";
+}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1086,6 +1086,9 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 
 			this->success = (GetAffectedHp() != -1 && !IsAbsorb()) || (GetAffectedHp() > 0 && IsAbsorb()) || GetAffectedSp() > 0 || GetAffectedAttack() > 0
 				|| GetAffectedDefense() > 0 || GetAffectedSpirit() > 0 || GetAffectedAgility() > 0;
+
+			if (IsAbsorb() && !success)
+				return this->success;
 		}
 
 		// Conditions:
@@ -1108,12 +1111,6 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 	}
 	else {
 		assert(false && "Unsupported skill type");
-	}
-
-	if (IsAbsorb() && sp != -1) {
-		if (GetTarget()->GetSp() == 0) {
-			this->success = false;
-		}
 	}
 
 	return this->success;

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -940,7 +940,7 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 			}
 
 			hit_chance = weapon->hit;
-			crit_chance += crit_chance * weapon->critical_hit / 100.0f;
+			crit_chance += (1.0 - crit_chance) * weapon->critical_hit / 100.0f;
 			multiplier = GetAttributeMultiplier(weapon->attribute_set);
 		}
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1214,6 +1214,10 @@ const RPG::Sound* Game_BattleAlgorithm::Skill::GetStartSe() const {
 	}
 }
 
+const RPG::Sound* Game_BattleAlgorithm::Skill::GetResultSe() const {
+	return !success && skill.failure_message != 3 ? NULL : AlgorithmBase::GetResultSe();
+}
+
 void Game_BattleAlgorithm::Skill::GetResultMessages(std::vector<std::string>& out) const {
 	if (!success) {
 		switch (skill.failure_message) {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -773,6 +773,10 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	}
 }
 
+void Game_BattleAlgorithm::AlgorithmBase::ApplyFirst() {
+	// no-op
+}
+
 bool Game_BattleAlgorithm::AlgorithmBase::IsTargetValid() const {
 	if (no_target) {
 		// Selected algorithm does not need a target because it targets
@@ -1671,6 +1675,10 @@ bool Game_BattleAlgorithm::Defend::Execute() {
 }
 
 void Game_BattleAlgorithm::Defend::Apply() {
+	source->SetDefending(true);
+}
+
+void Game_BattleAlgorithm::Defend::ApplyFirst() {
 	source->SetDefending(true);
 }
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -639,7 +639,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (!success)
 		return;
 
-	if (GetAffectedHp() != -1) {
+	if (GetAffectedHp() != -1 && !GetTarget()->IsDead()) {
 		int hp = GetAffectedHp();
 		int target_hp = GetTarget()->GetHp();
 		GetTarget()->ChangeHp(IsPositive() ? hp : -hp);
@@ -712,7 +712,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		if (IsPositive()) {
 			if (GetTarget()->IsDead() && it->ID == 1) {
 				// Was a revive skill with an effect rating of 0
-				GetTarget()->ChangeHp(1);
+				GetTarget()->ChangeHp(std::max<int>(1, GetAffectedHp()));
 			}
 
 			GetTarget()->RemoveState(it->ID);
@@ -1377,14 +1377,6 @@ bool Game_BattleAlgorithm::Item::IsTargetValid() const {
 	if (current_target == targets.end()) {
 		return false;
 	}
-
-	if (GetTarget()->IsDead()) {
-		// Medicine curing death
-		return item.type == RPG::Item::Type_medicine &&
-			!item.state_set.empty() &&
-			item.state_set[0];
-	}
-
 	return item.type == RPG::Item::Type_medicine;
 }
 
@@ -1406,6 +1398,9 @@ bool Game_BattleAlgorithm::Item::Execute() {
 		if (GetTarget()->GetType() == Game_Battler::Type_Ally && !item.actor_set[GetTarget()->GetId() - 1]) {
 			return this->success;
 		}
+		if (item.ko_only && !GetTarget()->IsDead()) {
+			return this->success;
+		}
 		this->healing = true;
 
 		// HP recovery
@@ -1418,13 +1413,20 @@ bool Game_BattleAlgorithm::Item::Execute() {
 			this->sp = std::max<int>(0, std::min<int>(item.recover_sp_rate * GetTarget()->GetMaxSp() / 100 + item.recover_sp, GetTarget()->GetMaxSp() - GetTarget()->GetSp()));
 		}
 
+		bool is_dead_cured = false;
 		for (int i = 0; i < (int)item.state_set.size(); i++) {
 			if (item.state_set[i]) {
-				this->conditions.push_back(Data::states[i]);
+				if (i == 0)
+					is_dead_cured = true;
+				if (GetTarget()->HasState(i + 1))
+					this->conditions.push_back(Data::states[i]);
 			}
 		}
 
-		this->success = true;
+		if (GetTarget()->IsDead() && !is_dead_cured)
+			this->hp = -1;
+
+		this->success = this->hp > -1 || this->sp > -1 || !conditions.empty();
 	}
 	else if (item.type == RPG::Item::Type_switch) {
 		switch_id = item.switch_id;

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -154,6 +154,13 @@ public:
 	bool IsPositive() const;
 
 	/**
+	 * Gets whether the action had absorb component.
+	 *
+	 * @return Whether action was absorb
+	 */
+	bool IsAbsorb() const;
+
+	/**
 	 * Gets the type of algorithm.
 	 *
 	 * @return Whether action was positive

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -154,6 +154,13 @@ public:
 	bool IsPositive() const;
 
 	/**
+	 * Gets the type of algorithm.
+	 *
+	 * @return Whether action was positive
+	 */
+	virtual std::string GetType() const;
+
+	/**
 	 * Gets the Battle Animation that is assigned to the Algorithm
 	 *
 	 * @return Battle Animation or NULL if no animation is assigned
@@ -170,6 +177,8 @@ public:
 	 *                  targets (required for reflect)
 	 */
 	void PlayAnimation(bool on_source = false);
+
+	void PlaySoundAnimation(bool on_source = false);
 
 	/**
 	 * Returns a list of all inflicted/removed conditions.
@@ -383,6 +392,7 @@ public:
 	int GetSourceAnimationState() const override;
 	const RPG::Sound* GetStartSe() const override;
 	int GetPhysicalDamageRate() const override;
+	std::string GetType() const override;
 };
 
 class Skill : public AlgorithmBase {
@@ -403,6 +413,7 @@ public:
 	void GetResultMessages(std::vector<std::string>& out) const override;
 	int GetPhysicalDamageRate() const override;
 	bool IsReflected() const override;
+	std::string GetType() const override;
 
 private:
 	const RPG::Skill& skill;
@@ -423,6 +434,7 @@ public:
 	int GetSourceAnimationState() const override;
 	const RPG::Sound* GetStartSe() const override;
 	void GetResultMessages(std::vector<std::string>& out) const override;
+	std::string GetType() const override;
 
 private:
 	const RPG::Item& item;
@@ -435,6 +447,7 @@ public:
 	std::string GetStartMessage() const override;
 	const RPG::Sound* GetStartSe() const override;
 	bool Execute() override;
+	std::string GetType() const override;
 };
 
 class Defend : public AlgorithmBase {
@@ -445,6 +458,7 @@ public:
 	int GetSourceAnimationState() const override;
 	bool Execute() override;
 	void Apply() override;
+	std::string GetType() const override;
 };
 
 class Observe : public AlgorithmBase {
@@ -453,6 +467,7 @@ public:
 
 	std::string GetStartMessage() const override;
 	bool Execute() override;
+	std::string GetType() const override;
 };
 
 class Charge : public AlgorithmBase {
@@ -462,6 +477,7 @@ public:
 	std::string GetStartMessage() const override;
 	bool Execute() override;
 	void Apply() override;
+	std::string GetType() const override;
 };
 
 class SelfDestruct : public AlgorithmBase {
@@ -473,6 +489,7 @@ public:
 	const RPG::Sound* GetStartSe() const override;
 	bool Execute() override;
 	void Apply() override;
+	std::string GetType() const override;
 };
 
 class Escape : public AlgorithmBase {
@@ -486,6 +503,7 @@ public:
 	void Apply() override;
 
 	void GetResultMessages(std::vector<std::string>& out) const override;
+	std::string GetType() const override;
 };
 
 class Transform : public AlgorithmBase {
@@ -495,6 +513,7 @@ public:
 	std::string GetStartMessage() const override;
 	bool Execute() override;
 	void Apply() override;
+	std::string GetType() const override;
 
 private:
 	int new_monster_id;
@@ -509,6 +528,7 @@ public:
 
 	bool Execute() override;
 	void Apply() override;
+	std::string GetType() const override;
 };
 
 }

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -226,12 +226,27 @@ public:
 	virtual bool IsTargetValid() const;
 
 	/**
-	 * Gets the message that is displayed when the action is invoked.
+	 * Gets the first line message that is displayed when the action is invoked.
 	 * Usually of style "[Name] uses/casts [Weapon/Item/Skill]".
 	 *
 	 * @return message
 	 */
 	virtual std::string GetStartMessage() const = 0;
+
+	/**
+	 * Checks if there is a second line message to display when the action is invoked.
+	 *
+	 * @return check
+	 */
+	virtual bool IsSecondStartMessage() const;
+
+	/**
+	 * Gets the second line message that is displayed when the action is invoked.
+	 * Usually of style "[Name] uses/casts [Weapon/Item/Skill]".
+	 *
+	 * @return message
+	 */
+	virtual std::string GetSecondStartMessage() const;
 
 	/**
 	 * Gets animation state id of the source character.
@@ -381,6 +396,8 @@ public:
 	void Apply() override;
 
 	std::string GetStartMessage() const override;
+	bool IsSecondStartMessage() const override;
+	std::string GetSecondStartMessage() const override;
 	int GetSourceAnimationState() const override;
 	const RPG::Sound* GetStartSe() const override;
 	void GetResultMessages(std::vector<std::string>& out) const override;

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -272,6 +272,13 @@ public:
 	virtual int GetSourceAnimationState() const;
 
 	/**
+	 * Gets animation state id of the source character when applies the action.
+	 *
+	 * @return animation state
+	 */
+	virtual int GetSourceAnimationStateApply() const;
+
+	/**
 	 * Gets the sound effect that is played when the action is starting.
 	 *
 	 * @return start se
@@ -499,6 +506,7 @@ public:
 
 	std::string GetStartMessage() const override;
 	int GetSourceAnimationState() const override;
+	int GetSourceAnimationStateApply() const override;
 	const RPG::Sound* GetStartSe() const override;
 	bool Execute() override;
 	void Apply() override;

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -234,6 +234,11 @@ public:
 	virtual void Apply();
 
 	/**
+	* Applies some results by itself right before the turn comes.
+	*/
+	virtual void ApplyFirst();
+
+	/**
 	 * Tests if it makes sense to apply an action on the target.
 	 * E.g. when it is dead.
 	 *
@@ -496,6 +501,7 @@ public:
 	int GetSourceAnimationState() const override;
 	bool Execute() override;
 	void Apply() override;
+	void ApplyFirst() override;
 	std::string GetType() const override;
 };
 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -418,6 +418,7 @@ public:
 	std::string GetSecondStartMessage() const override;
 	int GetSourceAnimationState() const override;
 	const RPG::Sound* GetStartSe() const override;
+	const RPG::Sound* GetResultSe() const override;
 	void GetResultMessages(std::vector<std::string>& out) const override;
 	int GetPhysicalDamageRate() const override;
 	bool IsReflected() const override;

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -309,7 +309,7 @@ public:
 	 *
 	 * @param out filled with all conditions in text form
 	 */
-	virtual void GetResultMessages(std::vector<std::string>& out) const;
+	virtual void GetResultMessages(std::vector<std::string>& out, std::vector<int>& out_replace) const;
 
 	/**
 	 * Returns the physical rate of the attack.
@@ -419,7 +419,7 @@ public:
 	int GetSourceAnimationState() const override;
 	const RPG::Sound* GetStartSe() const override;
 	const RPG::Sound* GetResultSe() const override;
-	void GetResultMessages(std::vector<std::string>& out) const override;
+	void GetResultMessages(std::vector<std::string>& out, std::vector<int>& out_replace) const override;
 	int GetPhysicalDamageRate() const override;
 	bool IsReflected() const override;
 	std::string GetType() const override;
@@ -442,7 +442,7 @@ public:
 	std::string GetStartMessage() const override;
 	int GetSourceAnimationState() const override;
 	const RPG::Sound* GetStartSe() const override;
-	void GetResultMessages(std::vector<std::string>& out) const override;
+	void GetResultMessages(std::vector<std::string>& out, std::vector<int>& out_replace) const override;
 	std::string GetType() const override;
 
 private:
@@ -511,7 +511,7 @@ public:
 	bool Execute() override;
 	void Apply() override;
 
-	void GetResultMessages(std::vector<std::string>& out) const override;
+	void GetResultMessages(std::vector<std::string>& out, std::vector<int>& out_replace) const override;
 	std::string GetType() const override;
 };
 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -185,7 +185,7 @@ public:
 	 */
 	void PlayAnimation(bool on_source = false);
 
-	void PlaySoundAnimation(bool on_source = false);
+	void PlaySoundAnimation(bool on_source = false, int cutoff = -1);
 
 	/**
 	 * Returns a list of all inflicted/removed conditions.

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -343,6 +343,7 @@ protected:
 	std::string GetDamagedMessage() const;
 	std::string GetParameterChangeMessage(bool is_positive, int value, const std::string& points) const;
 	std::string GetStateMessage(const std::string& message) const;
+	std::string GetShiftAttributeMessage(bool is_positive, const std::string& attribute) const;
 
 	float GetAttributeMultiplier(const std::vector<bool>& attributes_set) const;
 
@@ -384,6 +385,7 @@ protected:
 
 	std::vector<RPG::State> conditions;
 	std::vector<int16_t> healed_conditions;
+	std::vector<int16_t> shift_attributes;
 	std::vector<int> switch_on;
 	std::vector<int> switch_off;
 };

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -344,6 +344,14 @@ public:
 	 */
 	virtual bool IsReflected() const;
 
+	/*
+	 * Returns a copy of the vector with the state ids that remain by being their priority less than 10 of difference than the top one
+	 *
+	 * @param filter_states vector of states to be filtered
+	 * @return vector of states filtered
+	 */
+	virtual std::vector<RPG::State> FilterStatesByPriority(std::vector<RPG::State> filter_states);
+
 protected:
 	AlgorithmBase(Game_Battler* source);
 	AlgorithmBase(Game_Battler* source, Game_Battler* target);

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -556,6 +556,7 @@ public:
 
 	std::string GetStartMessage() const override;
 	int GetSourceAnimationState() const override;
+	int GetSourceAnimationStateApply() const override;
 	const RPG::Sound* GetStartSe() const override;
 	bool Execute() override;
 	void Apply() override;

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -79,7 +79,7 @@ public:
 	 *
 	 * @return true if there was a next target available
 	 */
-	bool TargetNext();
+	virtual bool TargetNext();
 
 	/**
 	 * Defines switches that will be switched on after the action is finished.
@@ -451,14 +451,16 @@ private:
 	const RPG::Item& item;
 };
 
-class NormalDual : public AlgorithmBase {
+class NormalDual : public Normal {
 public:
 	NormalDual(Game_Battler* source, Game_Battler* target);
+	NormalDual(Game_Battler* source, Game_Party_Base* target);
 
-	std::string GetStartMessage() const override;
-	const RPG::Sound* GetStartSe() const override;
-	bool Execute() override;
+	bool TargetNext() override;
 	std::string GetType() const override;
+
+private:
+	bool second_attack;
 };
 
 class Defend : public AlgorithmBase {

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -272,6 +272,13 @@ public:
 	virtual int GetSourceAnimationState() const;
 
 	/**
+	* Gets item associated to the action.
+	*
+	* @return item
+	*/
+	virtual const RPG::Item* GetItem() const;
+
+	/**
 	 * Gets animation state id of the source character when applies the action.
 	 *
 	 * @return animation state
@@ -431,6 +438,8 @@ public:
 	void GetResultMessages(std::vector<std::string>& out, std::vector<int>& out_replace) const override;
 	int GetPhysicalDamageRate() const override;
 	bool IsReflected() const override;
+	int GetSpCost() const;
+	const RPG::Item* GetItem() const override;
 	std::string GetType() const override;
 
 private:
@@ -452,6 +461,7 @@ public:
 	int GetSourceAnimationState() const override;
 	const RPG::Sound* GetStartSe() const override;
 	void GetResultMessages(std::vector<std::string>& out, std::vector<int>& out_replace) const override;
+	const RPG::Item* GetItem() const override;
 	std::string GetType() const override;
 
 private:

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -173,6 +173,15 @@ public:
 	 * @return Battle Animation or NULL if no animation is assigned
 	 */
 	const RPG::Animation* GetAnimation() const;
+	const RPG::Animation* GetSecondAnimation() const;
+
+	/**
+	* Checks if the animation has already played once
+	*
+	* @return Whether the animation played once
+	*/
+	bool HasAnimationPlayed() const;
+	bool HasSecondAnimationPlayed() const;
 
 	/**
 	 * Plays the battle animation on the targets.
@@ -184,6 +193,7 @@ public:
 	 *                  targets (required for reflect)
 	 */
 	void PlayAnimation(bool on_source = false);
+	void PlaySecondAnimation(bool on_source = false);
 
 	void PlaySoundAnimation(bool on_source = false, int cutoff = -1);
 
@@ -409,6 +419,9 @@ protected:
 	mutable int reflect;
 
 	RPG::Animation* animation;
+	RPG::Animation* animation2;
+	bool has_animation_played;
+	bool has_animation2_played;
 
 	std::vector<RPG::State> conditions;
 	std::vector<int16_t> healed_conditions;

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -383,6 +383,7 @@ protected:
 	RPG::Animation* animation;
 
 	std::vector<RPG::State> conditions;
+	std::vector<int16_t> healed_conditions;
 	std::vector<int> switch_on;
 	std::vector<int> switch_off;
 };

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -474,7 +474,7 @@ void Game_Battler::RemoveBattleStates() {
 	}
 
 	for (size_t i = 0; i < states.size(); ++i) {
-		if (non_permanent(i + 1)) {
+		if (i != 0 && (non_permanent(i + 1) || ReaderUtil::GetElement(Data::states, i + 1)->auto_release_prob == 0)) {
 			states[i] = 0;
 		}
 	}

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -378,6 +378,21 @@ void Game_Battler::AddState(int state_id) {
 	}
 
 	states[state_id - 1] = std::max<int> (1, states[state_id - 1]);
+	FilterStatesByPriority();
+}
+
+void Game_Battler::FilterStatesByPriority() {
+	if (!IsDead()) {
+		int new_priority = GetSignificantState() != nullptr? GetSignificantState()->priority : -1;
+		for (auto state_id : GetInflictedStates()) {
+			if (state_id <= 0 || state_id > Data::states.size()) {
+				continue;
+			}
+			if (ReaderUtil::GetElement(Data::states, state_id)->priority < new_priority - 9) {
+				RemoveState(state_id);
+			}
+		}
+	}
 }
 
 void Game_Battler::RemoveState(int state_id) {

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -808,3 +808,11 @@ int Game_Battler::GetShiftAttributeRate(int attribute_id) {
 	}
 	return attribute_shift[attribute_id - 1];
 }
+
+void Game_Battler::SetRandomOrderAgi() {
+	agi_order = GetAgi() + Utils::GetRandomNumber(std::ceil(GetAgi() * -10 / 100.0) - 1, std::ceil(GetAgi() * 10 / 100.0) + 1);
+}
+
+int Game_Battler::GetRandomOrderAgi() {
+	return agi_order;
+}

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -704,7 +704,6 @@ std::vector<int16_t> Game_Battler::BattlePhysicalStateHeal(int physical_rate) {
 
 			if (Utils::ChanceOf(release_chance, 100)) {
 				healed_states.push_back(i + 1);
-				RemoveState(i + 1);
 			}
 		}
 	}

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -801,3 +801,10 @@ void Game_Battler::ShiftAttributeRate(int attribute_id, int shift) {
 		--old_shift;
 	}
 }
+
+int Game_Battler::GetShiftAttributeRate(int attribute_id) {
+	if (attribute_id < 1 || attribute_id >(int)Data::attributes.size()) {
+		assert(false && "invalid attribute_id");
+	}
+	return attribute_shift[attribute_id - 1];
+}

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -377,7 +377,7 @@ void Game_Battler::AddState(int state_id) {
 		states.resize(state_id);
 	}
 
-	states[state_id - 1] = 1;
+	states[state_id - 1] = std::max<int> (1, states[state_id - 1]);
 }
 
 void Game_Battler::RemoveState(int state_id) {
@@ -693,11 +693,13 @@ std::vector<int16_t> Game_Battler::NextBattleTurn() {
 	for (size_t i = 0; i < states.size(); ++i) {
 		if (HasState(i + 1)) {
 			states[i] += 1;
-
-			if (states[i] >= Data::states[i].hold_turn) {
+			if (states[i] > Data::states[i].hold_turn + 1) {
 				if (Utils::ChanceOf(Data::states[i].auto_release_prob, 100)) {
 					healed_states.push_back(i + 1);
 					RemoveState(i + 1);
+				}
+				else {
+					states[i] -= Data::states[i].hold_turn;
 				}
 			}
 		}

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -550,7 +550,7 @@ static int AffectParameter(const int type, const int val) {
 
 int Game_Battler::GetAtk() const {
 	int base_atk = GetBaseAtk();
-	int n = min(max(base_atk, 1), 999);
+	int n = min(max(base_atk, 1), MaxStatBaseValue());
 
 	for (int16_t i : GetInflictedStates()) {
 		// States are guaranteed to be valid
@@ -563,14 +563,14 @@ int Game_Battler::GetAtk() const {
 
 	n += atk_modifier;
 
-	n = min(max(n, 1), 999);
+	n = min(max(n, 1), MaxStatBattleValue());
 
 	return n;
 }
 
 int Game_Battler::GetDef() const {
 	int base_def = GetBaseDef();
-	int n = min(max(base_def, 1), 999);
+	int n = min(max(base_def, 1), MaxStatBaseValue());
 
 	for (int16_t i : GetInflictedStates()) {
 		// States are guaranteed to be valid
@@ -583,14 +583,14 @@ int Game_Battler::GetDef() const {
 
 	n += def_modifier;
 
-	n = min(max(n, 1), 999);
+	n = min(max(n, 1), MaxStatBattleValue());
 
 	return n;
 }
 
 int Game_Battler::GetSpi() const {
 	int base_spi = GetBaseSpi();
-	int n = min(max(base_spi, 1), 999);
+	int n = min(max(base_spi, 1), MaxStatBaseValue());
 
 	for (int16_t i : GetInflictedStates()) {
 		// States are guaranteed to be valid
@@ -603,14 +603,14 @@ int Game_Battler::GetSpi() const {
 
 	n += spi_modifier;
 
-	n = min(max(n, 1), 999);
+	n = min(max(n, 1), MaxStatBattleValue());
 
 	return n;
 }
 
 int Game_Battler::GetAgi() const {
 	int base_agi = GetBaseAgi();
-	int n = min(max(base_agi, 1), 999);
+	int n = min(max(base_agi, 1), MaxStatBaseValue());
 
 	for (int16_t i : GetInflictedStates()) {
 		// States are guaranteed to be valid
@@ -623,7 +623,7 @@ int Game_Battler::GetAgi() const {
 
 	n += agi_modifier;
 
-	n = min(max(n, 1), 999);
+	n = min(max(n, 1), MaxStatBattleValue());
 
 	return n;
 }

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -349,6 +349,22 @@ void Game_Battler::SetAgiModifier(int modifier) {
 	agi_modifier = modifier;
 }
 
+void Game_Battler::ChangeAtkModifier(int modifier) {
+	SetAtkModifier(atk_modifier + modifier);
+}
+
+void Game_Battler::ChangeDefModifier(int modifier) {
+	SetDefModifier(def_modifier + modifier);
+}
+
+void Game_Battler::ChangeSpiModifier(int modifier) {
+	SetSpiModifier(spi_modifier + modifier);
+}
+
+void Game_Battler::ChangeAgiModifier(int modifier) {
+	SetAgiModifier(agi_modifier + modifier);
+}
+
 void Game_Battler::AddState(int state_id) {
 	const RPG::State* state = ReaderUtil::GetElement(Data::states, state_id);
 	if (!state) {

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -379,6 +379,14 @@ public:
 	 */
 	void SetAgiModifier(int modifier);
 
+	void ChangeAtkModifier(int modifier);
+
+	void ChangeDefModifier(int modifier);
+
+	void ChangeSpiModifier(int modifier);
+
+	void ChangeAgiModifier(int modifier);
+
 	/**
 	 * Adds a State.
 	 *

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -600,6 +600,9 @@ public:
 	 */
 	std::vector<int16_t> BattlePhysicalStateHeal(int physical_rate);
 
+	void SetRandomOrderAgi();
+	int GetRandomOrderAgi();
+
 	void SetLastBattleAction(int battle_action);
 
 	int GetLastBattleAction() const;
@@ -631,6 +634,8 @@ protected:
 	int battle_combo_times;
 
 	std::vector<int> attribute_shift;
+
+	int agi_order;
 };
 
 #endif

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -137,6 +137,15 @@ public:
 	void ShiftAttributeRate(int attribute_id, int shift);
 
 	/**
+	 * Gets the current modifier (buff/debuff) to an attribute rate.
+	 * The shift is cleared after the battle ended.
+	 *
+	 * @param attribute_id Attribute modified
+	 * @return shift Shift applied.
+	 */
+	int GetShiftAttributeRate(int attribute_id);
+
+	/**
 	 * Gets probability that a state can be inflicted on this actor.
 	 *
 	 * @param state_id State to test

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -404,6 +404,11 @@ public:
 	virtual void AddState(int state_id);
 
 	/**
+	 * Filters all the states that have 10 or less priority than the top one.
+	 */
+	virtual void FilterStatesByPriority();
+
+	/**
 	 * Removes a State.
 	 *
 	 * @param state_id ID of state to remove.

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -43,6 +43,12 @@ public:
 	 */
 	Game_Battler();
 
+	virtual int MaxHpValue() const = 0;
+
+	virtual int MaxStatBattleValue() const = 0;
+
+	virtual int MaxStatBaseValue() const = 0;
+
 	/**
 	 * Gets if battler has a state.
 	 *

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -337,3 +337,7 @@ const RPG::EnemyAction* Game_Enemy::ChooseRandomAction() {
 
 	return nullptr;
 }
+
+bool Game_Enemy::GetTransparency() const {
+	return enemy->transparent;
+}

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -26,6 +26,7 @@
 #include "reader_util.h"
 #include "output.h"
 #include "utils.h"
+#include "player.h"
 
 namespace {
 	constexpr int levitation_frame_count = 14;
@@ -45,6 +46,18 @@ void Game_Enemy::Setup(int enemy_id) {
 	hidden = false;
 	cycle = Utils::GetRandomNumber(0, levitation_frame_count - 1) * levitation_frame_cycle;
 	flying_offset = 0;
+}
+
+int Game_Enemy::MaxHpValue() const {
+	return Player::IsRPG2k() ? 9999 : 99999;
+}
+
+int Game_Enemy::MaxStatBattleValue() const {
+	return 9999;
+}
+
+int Game_Enemy::MaxStatBaseValue() const {
+	return 999;
 }
 
 const std::vector<int16_t>& Game_Enemy::GetStates() const {

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -33,6 +33,12 @@ public:
 	const std::vector<int16_t>& GetStates() const override;
 	std::vector<int16_t>& GetStates() override;
 
+	int MaxHpValue() const override;
+
+	int MaxStatBattleValue() const override;
+
+	int MaxStatBaseValue() const override;
+
 	/**
 	 * Gets probability that a state can be inflicted on this actor.
 	 *

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -164,6 +164,8 @@ public:
 
 	void UpdateBattle() override;
 
+	bool GetTransparency() const;
+
 	/**
 	 * Get's the ID of the item the enemy drops when defeated.
 	 *

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -526,6 +526,7 @@ bool Game_Interpreter::ExecuteCommand() {
 }
 
 bool Game_Interpreter::CommandEnd() { // code 10
+	finished_not_updated = true;
 	if (main_flag && depth == 0) {
 		Game_Message::SetFaceName("");
 	}

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -67,6 +67,8 @@ public:
 
 	virtual bool ExecuteCommand();
 
+	bool finished_not_updated = false;
+
 protected:
 	friend class Game_Interpreter_Map;
 

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -29,6 +29,7 @@
 #include "player.h"
 #include "game_temp.h"
 #include "game_map.h"
+#include "spriteset_battle.h"
 
 Game_Interpreter_Battle::Game_Interpreter_Battle(int depth, bool main_flag) :
 	Game_Interpreter(depth, main_flag) {
@@ -161,6 +162,9 @@ bool Game_Interpreter_Battle::CommandChangeMonsterHP(RPG::EventCommand const& co
 	bool lose = com.parameters[1] > 0;
 	int hp = enemy.GetHp();
 
+	if (enemy.IsDead())
+		return true;
+
 	int change = 0;
 	switch (com.parameters[2]) {
 	case 0:
@@ -180,6 +184,7 @@ bool Game_Interpreter_Battle::CommandChangeMonsterHP(RPG::EventCommand const& co
 	enemy.ChangeHp(change);
 
 	if (enemy.IsDead()) {
+		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_EnemyKill));
 		Game_Battle::SetNeedRefresh(true);
 	}
 
@@ -218,9 +223,15 @@ bool Game_Interpreter_Battle::CommandChangeMonsterCondition(RPG::EventCommand co
 	int state_id = com.parameters[2];
 	if (remove) {
 		enemy.RemoveState(state_id);
+		if (state_id == 1) {
+			enemy.SetHp(1);
+			Game_Battle::GetSpriteset().FindBattler(&enemy)->SetVisible(true);
+			Game_Battle::SetNeedRefresh(true);
+		}
 	} else {
 		if (state_id == 1) {
 			enemy.ChangeHp(-enemy.GetHp());
+			Game_Battle::GetSpriteset().FindBattler(&enemy)->SetVisible(false);
 			Game_Battle::SetNeedRefresh(true);
 		}
 		enemy.AddState(state_id);

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -250,6 +250,7 @@ bool Game_Interpreter_Map::CommandEnemyEncounter(RPG::EventCommand const& com) {
 	Game_Temp::battle_escape_mode = com.parameters[3]; // 0 disallow, 1 end event processing, 2 victory/escape custom handler
 	Game_Temp::battle_defeat_mode = com.parameters[4]; // 0 game over, 1 victory/defeat custom handler
 	Game_Temp::battle_first_strike = com.parameters[5] != 0;
+	Game_Temp::battle_check_surprise_attack = false;
 
 	if (Player::IsRPG2k())
 		Game_Battle::SetBattleMode(0);

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -982,6 +982,7 @@ bool Game_Map::PrepareEncounter() {
 
 	Game_Temp::battle_troop_id = encounters[Utils::GetRandomNumber(0, encounters.size() - 1)];
 	Game_Temp::battle_calling = true;
+	Game_Temp::battle_check_surprise_attack = true;
 
 	SetupBattle();
 

--- a/src/game_temp.cpp
+++ b/src/game_temp.cpp
@@ -50,6 +50,7 @@ int Game_Temp::battle_formation;
 int Game_Temp::battle_escape_mode;
 int Game_Temp::battle_defeat_mode;
 bool Game_Temp::battle_first_strike;
+bool Game_Temp::battle_check_surprise_attack;
 int Game_Temp::battle_result;
 
 void Game_Temp::Init() {
@@ -81,4 +82,5 @@ void Game_Temp::Init() {
 	battle_escape_mode = -1;
 	battle_defeat_mode = 0;
 	battle_first_strike = false;
+	battle_check_surprise_attack = false;
 }

--- a/src/game_temp.h
+++ b/src/game_temp.h
@@ -72,6 +72,7 @@ public:
 	static int battle_escape_mode;
 	static int battle_defeat_mode;
 	static bool battle_first_strike;
+	static bool battle_check_surprise_attack;
 	static int battle_result;
 
 	enum BattleResult {

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -112,7 +112,7 @@ void Scene_Battle::CreateUi() {
 	commands.push_back(Data::terms.battle_fight);
 	commands.push_back(Data::terms.battle_auto);
 	commands.push_back(Data::terms.battle_escape);
-	options_window.reset(new Window_Command(commands, 76));
+	options_window.reset(new Window_Command(commands, option_command_mov));
 	options_window->SetHeight(80);
 	options_window->SetY(SCREEN_TARGET_HEIGHT - 80);
 
@@ -127,7 +127,7 @@ void Scene_Battle::CreateUi() {
 	skill_window.reset(new Window_Skill(0, (SCREEN_TARGET_HEIGHT-80), SCREEN_TARGET_WIDTH, 80));
 	skill_window->SetHelpWindow(help_window.get());
 
-	status_window.reset(new Window_BattleStatus(0, (SCREEN_TARGET_HEIGHT-80), SCREEN_TARGET_WIDTH - 76, 80));
+	status_window.reset(new Window_BattleStatus(0, (SCREEN_TARGET_HEIGHT-80), SCREEN_TARGET_WIDTH - option_command_mov, 80));
 
 	message_window.reset(new Window_Message(0, (SCREEN_TARGET_HEIGHT - 80), SCREEN_TARGET_WIDTH, 80));
 }
@@ -165,8 +165,10 @@ void Scene_Battle::Update() {
 			skill_window->Update();
 			target_window->Update();
 
-			ProcessActions();
-			ProcessInput();
+			if (!IsWindowMoving()) {
+				ProcessActions();
+				ProcessInput();
+			}
 		}
 	} while (changed_state != state && state == State_SelectOption);
 
@@ -177,6 +179,10 @@ void Scene_Battle::Update() {
 	if (Game_Battle::IsTerminating()) {
 		Scene::Pop();
 	}
+}
+
+bool Scene_Battle::IsWindowMoving() {
+	return options_window->IsMovementActive() || status_window->IsMovementActive() || command_window->IsMovementActive();
 }
 
 void Scene_Battle::InitBattleTest()

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -446,6 +446,7 @@ std::shared_ptr<Scene_Battle> Scene_Battle::Create()
 }
 
 void Scene_Battle::UpdateBattlerAction(Game_Battler* battler) {
+	BattleAlgorithmRef alg = battler->GetBattleAlgorithm();
 	if (!battler->CanAct()) {
 		battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(battler));
 		battler->SetCharged(false);
@@ -466,7 +467,12 @@ void Scene_Battle::UpdateBattlerAction(Game_Battler* battler) {
 		battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::Normal>(battler, target));
 		battler->SetCharged(false);
 	}
-
+	else if (alg->GetType() == "Skill" && alg->GetItem() == nullptr && static_cast<Game_BattleAlgorithm::Skill*>(alg.get())->GetSpCost() > battler->GetSp()) {
+		battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(battler));
+	}
+	else if (alg->GetItem() != nullptr && Main_Data::game_party->GetItemCount(alg->GetItem()->ID, false) == 0) {
+		battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(battler));
+	}
 }
 
 void Scene_Battle::CreateEnemyAction(Game_Enemy* enemy, const RPG::EnemyAction* action) {

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -107,6 +107,10 @@ void Scene_Battle::TransitionOut() {
 	}
 }
 
+void Scene_Battle::DrawBackground() {
+	DisplayUi->CleanDisplay();
+}
+
 void Scene_Battle::CreateUi() {
 	std::vector<std::string> commands;
 	commands.push_back(Data::terms.battle_fight);

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -177,6 +177,7 @@ protected:
 	 */
 	virtual void SetAnimationState(Game_Battler* target, int new_state);
 
+	void UpdateBattlerAction(Game_Battler* battler);
 	void CreateEnemyAction(Game_Enemy* enemy, const RPG::EnemyAction* action);
 	void CreateEnemyActionBasic(Game_Enemy* enemy, const RPG::EnemyAction* action);
 	void CreateEnemyActionSkill(Game_Enemy* enemy, const RPG::EnemyAction* action);

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -46,6 +46,9 @@ class SpriteAction;
 
 class Game_Battler;
 
+constexpr int option_command_mov = 76;
+constexpr int option_command_time = 8;
+
 /**
  * Scene_Battle class.
  * Manages the battles.
@@ -128,6 +131,8 @@ protected:
 	virtual void SetState(Scene_Battle::State new_state) = 0;
 
 	void NextTurn(Game_Battler* battler);
+
+	bool IsWindowMoving();
 
 	virtual void EnemySelected();
 	virtual void AllySelected();

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -65,6 +65,7 @@ public:
 
 	void TransitionIn() override;
 	void TransitionOut() override;
+	void DrawBackground() override;
 
 	enum State {
 		/** Battle has started (Display encounter message) */

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -97,21 +97,38 @@ public:
 
 	enum BattleActionState {
 		/**
-		 * Called once at the beginning of the Action.
-		 * Used to execute the algorithm to play an optional battle animation.
-		 */
-		BattleActionState_Start,
-		/**
+		 * 1st action, called repeatedly.
 		 * Handles healing of conditions that get auto removed after X turns.
 		 */
 		BattleActionState_ConditionHeal,
 		/**
-		 * Used to apply the new conditions that were caused.
-		 * Called once for each condition.
+		 * 2nd action, called once.
+		 * Used to execute the algorithm and print the first start line.
 		 */
-		BattleActionState_Result,
+		BattleActionState_Execute,
 		/**
-		 * Action execution finished (no function is called here)
+		 * 3rd action, called once.
+		 * Used to apply the new conditions, play an optional battle animation and sound, and print the second line of a technique.
+		 */
+		BattleActionState_Apply,
+		/**
+		* 4th action, called repeatedly.
+		* Used for the results, concretely wait a few frames and pop the messages.
+		*/
+		BattleActionState_ResultPop,
+		/**
+		 * 5th action, called repeatedly.
+		 * Used to push the message results, effects and advances the messages. If it finishes, it calls Death. If not, it calls ResultPop
+		 */
+		BattleActionState_ResultPush,
+		/**
+		 * 6th action, called once.
+		 * Action treating whether the enemy died or not.
+		 */
+		BattleActionState_Death,
+		/**
+		 * 7th action, called once.
+		 * It finishes the action and checks whether to repeat it if there is another target to hit.
 		 */
 		BattleActionState_Finished
 	};

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -418,6 +418,13 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 		battle_action_wait = 0;
 		if (action->IsFirstAttack()) {
 			battle_message_window->Clear();
+			source_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetSource());
+			if (source_sprite) {
+				source_sprite->Flash(Color(255, 255, 255, 100), 15);
+				source_sprite->SetAnimationState(
+					action->GetSourceAnimationState(),
+					Sprite_Battler::LoopState_DefaultAnimationAfterFinish);
+			}
 
 			std::vector<int16_t> states_to_heal = action->GetSource()->NextBattleTurn();
 			std::vector<int16_t> states_remaining = action->GetSource()->GetInflictedStates();
@@ -508,14 +515,6 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 						action->PlaySoundAnimation(false, 20);
 					}
 				}
-			}
-
-			source_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetSource());
-			if (source_sprite) {
-				source_sprite->Flash(Color(255, 255, 255, 100), 15);
-				source_sprite->SetAnimationState(
-					action->GetSourceAnimationState(),
-					Sprite_Battler::LoopState_DefaultAnimationAfterFinish);
 			}
 
 			if (action->IsFirstAttack() && action->GetStartSe()) {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -897,7 +897,7 @@ void Scene_Battle_Rpg2k::SelectPreviousActor() {
 
 static bool BattlerSort(Game_Battler* first, Game_Battler* second) {
 	if (first->HasPreemptiveAttack() && second->HasPreemptiveAttack()) {
-		return first->GetAgi() > second->GetAgi();
+		return first->GetRandomOrderAgi() > second->GetRandomOrderAgi();
 	}
 
 	if (first->HasPreemptiveAttack()) {
@@ -908,10 +908,14 @@ static bool BattlerSort(Game_Battler* first, Game_Battler* second) {
 		return false;
 	}
 
-	return first->GetAgi() > second->GetAgi();
+	return first->GetRandomOrderAgi() > second->GetRandomOrderAgi();
 }
 
 void Scene_Battle_Rpg2k::CreateExecutionOrder() {
+	// Define random Agility. Must be done outside of the sort function because of the "strict weak ordering" property, so the sort is consistent
+	for (auto battler : battle_actions) {
+		battler->SetRandomOrderAgi();
+	}
 	std::sort(battle_actions.begin(), battle_actions.end(), BattlerSort);
 }
 

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -155,6 +155,7 @@ void Scene_Battle_Rpg2k::SetState(Scene_Battle::State new_state) {
 			break;
 		case State_SelectItem:
 			item_window->SetActive(true);
+			item_window->SetActor(active_actor);
 			item_window->Refresh();
 			break;
 		case State_SelectSkill:

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -441,10 +441,14 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 				if (battle_message_window->GetLineCount() == 1 && action->IsSecondStartMessage()) {
 					return false;
 				}
-				if (action->GetTarget() &&
-					action->GetTarget()->GetType() == Game_Battler::Type_Enemy) {
-
-					action->PlayAnimation();
+				if (action->GetTarget()) {
+					if (action->GetTarget()->GetType() == Game_Battler::Type_Enemy) {
+						battle_action_wait = GetDelayForLine();
+						action->PlayAnimation();
+					} else if (action->GetTarget()->GetType() == Game_Battler::Type_Ally && action->GetType() == "Skill") {
+						battle_action_wait = GetDelayForLine();
+						action->PlaySoundAnimation();
+					}
 				}
 			}
 
@@ -461,8 +465,6 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 			}
 
 			battle_action_state = BattleActionState_Result;
-
-			battle_action_wait = GetDelayForWindow();
 
 			break;
 		case BattleActionState_ConditionHeal:

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -155,7 +155,8 @@ void Scene_Battle_Rpg2k::SetState(Scene_Battle::State new_state) {
 		case State_SelectSkill:
 			skill_window->SetActive(true);
 			skill_window->SetActor(active_actor->GetId());
-			skill_window->SetIndex(0);
+			if (previous_state == State_SelectCommand)
+				skill_window->SetIndex(0);
 			break;
 		case State_Victory:
 		case State_Defeat:

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -507,11 +507,6 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 		case BattleActionState_Result:
 			battle_action_wait = GetDelayForWindow();
 
-			if (action->GetTarget() && action->IsSuccess()) {
-				// FIXME: Physical damage state heal needs a message
-				action->GetTarget()->BattlePhysicalStateHeal(action->GetPhysicalDamageRate());
-			}
-
 			if (battle_result_messages_it != battle_result_messages.end()) {
 				target_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetTarget());
 				if (battle_result_messages_it == battle_result_messages.begin()) {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -367,10 +367,16 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 }
 
 bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase* action) {
+	/**
+     * Order of execution of BattleActionState:
+	 * ConditionHeal > Execute > Apply > (ResultPop > ResultPush) > Death > Finished.
+	 **/
+
 	if (Game_Battle::IsBattleAnimationWaiting() && !Game_Battle::IsBattleAnimationOnlySound()) {
 		return false;
 	}
 
+	int default_result_lines;
 	Sprite_Battler* source_sprite;
 	Sprite_Battler* target_sprite;
 
@@ -405,9 +411,45 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 		return false;
 	}
 
+	battle_action_wait = action->GetType() == "NoMove" ? 0 : GetDelayForWindow();
+
 	switch (battle_action_state) {
-		case BattleActionState_Start:
-			battle_action_wait = GetDelayForWindow();
+	case BattleActionState_ConditionHeal:
+		battle_action_wait = 0;
+		if (action->IsFirstAttack()) {
+			battle_message_window->Clear();
+
+			std::vector<int16_t> states_to_heal = action->GetSource()->NextBattleTurn();
+			std::vector<int16_t> states_remaining = action->GetSource()->GetInflictedStates();
+			action->GetSource()->ApplyConditions();
+			bool message_to_show = false;
+			if (!states_to_heal.empty() || !states_remaining.empty()) {
+				for (auto state_id : states_to_heal) {
+					// BattleAlgorithm verifies the states
+					const RPG::State* state = ReaderUtil::GetElement(Data::states, state_id);
+					if (!state->message_recovery.empty()) {
+						battle_message_window->PushWithSubject(state->message_recovery, action->GetSource()->GetName());
+						message_to_show = true;
+					}
+				}
+				for (auto state_id : states_remaining) {
+					// BattleAlgorithm verifies the states
+					const RPG::State* state = ReaderUtil::GetElement(Data::states, state_id);
+					if (!state->message_affected.empty()) {
+						battle_message_window->PushWithSubject(state->message_affected, action->GetSource()->GetName());
+						message_to_show = true;
+					}
+				}
+				if (message_to_show) {
+					battle_action_wait = GetDelayForWindow() * 3 / 2;
+				}
+			}
+		}
+
+		battle_action_state = BattleActionState_Execute;
+
+		break;
+		case BattleActionState_Execute:
 			if (action->IsFirstAttack()) {
 				action->TargetFirst();
 			}
@@ -430,26 +472,39 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 
 			action->Execute();
 
-			battle_result_messages.clear();
-			action->GetResultMessages(battle_result_messages);
+			battle_message_window->Clear();
+			battle_message_window->Push(action->GetStartMessage());
 
-			if (battle_message_window->GetLineCount() == 0)
-				battle_message_window->Push(action->GetStartMessage());
-			else if ((battle_message_window->GetLineCount() == 1 && action->IsSecondStartMessage()))
+			battle_result_messages.clear();
+			battle_result_order.clear();
+			action->GetResultMessages(battle_result_messages, battle_result_order);
+			battle_result_messages_it = battle_result_messages.begin();
+			battle_result_order_it = battle_result_order.begin();
+
+			if (!action->IsSecondStartMessage())
+				battle_action_wait = 0;
+
+			battle_action_state = BattleActionState_Apply;
+
+			if (!action->IsFirstAttack()) {
+				battle_action_wait = 0;
+				return ProcessBattleAction(action);
+			}
+
+			break;
+		case BattleActionState_Apply:
+			if (action->IsSecondStartMessage())
 				battle_message_window->Push(action->GetSecondStartMessage());
 
-			action->Apply();
-
-			battle_result_messages_it = battle_result_messages.begin();
-
 			if (action->IsFirstAttack()) {
-				if (battle_message_window->GetLineCount() == 1 && action->IsSecondStartMessage()) {
-					return false;
-				}
-				if (action->GetTarget()) {
+
+				if (action->GetTarget() &&
+					!(action->GetSource()->GetType() == Game_Battler::Type_Enemy)) {
 					if (action->GetTarget()->GetType() == Game_Battler::Type_Enemy) {
 						action->PlayAnimation();
-					} else if (action->GetTarget()->GetType() == Game_Battler::Type_Ally && action->GetType() == "Skill") {
+					}
+					else if (action->GetTarget()->GetType() == Game_Battler::Type_Ally
+						&& action->GetType() == "Skill") {
 						action->PlaySoundAnimation(false, 20);
 					}
 				}
@@ -467,52 +522,31 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 				Game_System::SePlay(*action->GetStartSe());
 			}
 
-			battle_action_state = BattleActionState_Result;
+			action->Apply();
+			battle_action_state = BattleActionState_ResultPop;
 
-			break;
-		case BattleActionState_ConditionHeal:
-			if (action->IsFirstAttack()) {
-				std::vector<int16_t> states_to_heal = action->GetSource()->NextBattleTurn();
-				std::vector<int16_t> states_remaining = action->GetSource()->GetInflictedStates();
-				action->GetSource()->ApplyConditions();
-				bool message_to_show = false;
-				if (!states_to_heal.empty() || !states_remaining.empty()) {
-					battle_message_window->Clear();
-					for (auto state_id : states_to_heal) {
-						// BattleAlgorithm verifies the states
-						const RPG::State* state = ReaderUtil::GetElement(Data::states, state_id);
-						if (!state->message_recovery.empty()) {
-							battle_message_window->PushWithSubject(state->message_recovery, action->GetSource()->GetName());
-							message_to_show = true;
-						}
-					}
-					for (auto state_id : states_remaining) {
-						// BattleAlgorithm verifies the states
-						const RPG::State* state = ReaderUtil::GetElement(Data::states, state_id);
-						if (!state->message_affected.empty()) {
-							battle_message_window->PushWithSubject(state->message_affected, action->GetSource()->GetName());
-							message_to_show = true;
-						}
-					}
-					if (message_to_show) {
-						battle_action_wait = GetDelayForWindow();
-					}
-					else {
-						battle_action_wait = 0;
-					}
-				}
-				else {
-					battle_action_wait = 0;
-				}
+			if (!action->IsFirstAttack()) {
+				battle_action_wait = 0;
+				return ProcessBattleAction(action);
 			}
 
-			battle_action_state = BattleActionState_Start;
-
 			break;
-		case BattleActionState_Result:
-			battle_action_wait = GetDelayForWindow();
+		case BattleActionState_ResultPop:
+			battle_action_wait = std::min<int>(GetDelayForLine() / 2, battle_action_wait);
 
 			if (battle_result_messages_it != battle_result_messages.end()) {
+				default_result_lines = 1 + (action->IsSecondStartMessage() ? 1 : 0);
+				while (battle_message_window->GetLineCount() > (default_result_lines + *battle_result_order_it))
+					battle_message_window->Pop();
+			}
+
+			battle_action_state = BattleActionState_ResultPush;
+
+			return ProcessBattleAction(action);
+		case BattleActionState_ResultPush:
+			if (battle_result_messages_it != battle_result_messages.end()) {
+
+				// Animation and Sound when hurt (only when HP damage):
 				target_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetTarget());
 				if (battle_result_messages_it == battle_result_messages.begin()) {
 					if (action->IsSuccess() && target_sprite && !action->IsPositive() && !action->IsAbsorb() && action->GetAffectedHp() > -1) {
@@ -531,51 +565,49 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 					}
 				}
 
-				if (battle_result_messages_it != battle_result_messages.begin()) {
-					battle_message_window->Clear();
-					battle_message_window->Push(action->GetStartMessage());
-					if (action->IsSecondStartMessage())
-						battle_message_window->Push(action->GetSecondStartMessage());
-				}
+				// Push message, next iteration:
 				battle_message_window->Push(*battle_result_messages_it);
 				++battle_result_messages_it;
-			} else {
-				if (action->IsKilledByAttack()) {
-					battle_message_window->Push(action->GetDeathMessage());
-				}
-				battle_action_state = BattleActionState_Finished;
+				++battle_result_order_it;
 			}
 
+			// When it finishes
 			if (battle_result_messages_it == battle_result_messages.end()) {
-				battle_action_state = BattleActionState_Finished;
+				battle_action_wait = 0;
+				battle_action_state = BattleActionState_Death;
+			}
+			else {
+				battle_action_state = BattleActionState_ResultPop;
 			}
 
 			break;
-		case BattleActionState_Finished:
+		case BattleActionState_Death:
 			if (action->GetTarget()) {
 				target_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetTarget());
-				if (target_sprite && !target_sprite->IsIdling()) {
-					return false;
-				}
-
 				if (action->GetTarget()->IsDead() && action->GetDeathSe()) {
 					Game_System::SePlay(*action->GetDeathSe());
 				}
-
 				if (target_sprite) {
 					target_sprite->DetectStateChange();
 				}
 			}
+			if (battle_result_messages.empty())
+				battle_action_wait = GetDelayForLine();
 
-			if (action->TargetNext()) {
-				battle_action_state = BattleActionState_ConditionHeal;
-				return false;
+			battle_action_state = BattleActionState_Finished;
+
+			break;
+		case BattleActionState_Finished:
+			battle_action_wait = 0;
+			if (action->GetTarget()) {
+				target_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetTarget());
+				if (action->GetTarget() && target_sprite && !target_sprite->IsIdling()) {
+					return false;
+				}
 			}
 
-			// Reset variables
 			battle_action_state = BattleActionState_ConditionHeal;
-
-			return true;
+			return !action->TargetNext();
 	}
 
 	return false;
@@ -723,7 +755,8 @@ void Scene_Battle_Rpg2k::Escape() {
 		escape_alg.Apply();
 
 		battle_result_messages.clear();
-		escape_alg.GetResultMessages(battle_result_messages);
+		battle_result_order.clear();
+		escape_alg.GetResultMessages(battle_result_messages, battle_result_order);
 
 		battle_message_window->Push(battle_result_messages[0]);
 		begin_escape = false;

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -107,7 +107,7 @@ void Scene_Battle_Rpg2k::CreateBattleCommandWindow() {
 
 	command_window.reset(new Window_Command(commands, 76));
 	command_window->SetHeight(80);
-	command_window->SetX(SCREEN_TARGET_WIDTH - 76);
+	command_window->SetX(SCREEN_TARGET_WIDTH - option_command_mov);
 	command_window->SetY(SCREEN_TARGET_HEIGHT-80);
 }
 
@@ -182,10 +182,13 @@ void Scene_Battle_Rpg2k::SetState(Scene_Battle::State new_state) {
 		break;
 	case State_SelectOption:
 		options_window->SetVisible(true);
+		options_window->SetX(0);
 		status_window->SetVisible(true);
-		status_window->SetX(76);
+		status_window->SetX(option_command_mov);
 		status_window->SetIndex(-1);
+		command_window->SetX(SCREEN_TARGET_WIDTH);
 		status_window->Refresh();
+		move_screen = true;
 		break;
 	case State_SelectActor:
 		SelectNextActor();
@@ -194,9 +197,11 @@ void Scene_Battle_Rpg2k::SetState(Scene_Battle::State new_state) {
 		SetState(State_SelectActor);
 		break;
 	case State_SelectCommand:
+		options_window->SetX(-option_command_mov);
 		status_window->SetVisible(true);
-		command_window->SetVisible(true);
 		status_window->SetX(0);
+		command_window->SetVisible(true);
+		command_window->SetX(SCREEN_TARGET_WIDTH - option_command_mov);
 		break;
 	case State_Battle:
 		battle_message_window->SetVisible(true);
@@ -231,6 +236,31 @@ void Scene_Battle_Rpg2k::SetState(Scene_Battle::State new_state) {
 		status_window->SetActive(true);
 		status_window->SetVisible(true);
 		status_window->SetX(0);
+	}
+
+	// If SelectOption <-> SelectCommand => Display Movement:
+	if (state == State_SelectOption && previous_state == State_SelectCommand) {
+		options_window->InitMovement(options_window->GetX() - option_command_mov, options_window->GetY(),
+			options_window->GetX(), options_window->GetY(), option_command_time);
+
+		status_window->InitMovement(status_window->GetX() - option_command_mov, status_window->GetY(),
+			status_window->GetX(), status_window->GetY(), option_command_time);
+
+		command_window->SetVisible(true);
+		command_window->InitMovement(command_window->GetX() - option_command_mov, command_window->GetY(),
+			command_window->GetX(), command_window->GetY(), option_command_time);
+	}
+	else if (state == State_SelectCommand && move_screen) {
+		move_screen = false;
+		options_window->SetVisible(true);
+		options_window->InitMovement(options_window->GetX() + option_command_mov, options_window->GetY(),
+			options_window->GetX(), options_window->GetY(), option_command_time);
+
+		status_window->InitMovement(status_window->GetX() + option_command_mov, status_window->GetY(),
+			status_window->GetX(), status_window->GetY(), option_command_time);
+
+		command_window->InitMovement(command_window->GetX() + option_command_mov, command_window->GetY(),
+			command_window->GetX(), command_window->GetY(), option_command_time);
 	}
 }
 

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -327,6 +327,15 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 		} else {
 			// Everybody acted
 			actor_index = 0;
+			for (auto ally : Main_Data::game_party->GetActors()) {
+				ally->SetDefending(false);
+			}
+			
+			std::vector<Game_Battler*> enemy_battlers;
+			Main_Data::game_enemyparty->GetBattlers(enemy_battlers);
+			for (auto enemy : enemy_battlers) {
+				enemy->SetDefending(false);
+			}
 
 			SetState(State_SelectOption);
 		}
@@ -914,6 +923,9 @@ void Scene_Battle_Rpg2k::CreateExecutionOrder() {
 		battler->SetRandomOrderAgi();
 	}
 	std::sort(battle_actions.begin(), battle_actions.end(), BattlerSort);
+	for (auto battler : battle_actions) {
+		battler->GetBattleAlgorithm()->ApplyFirst();
+	}
 }
 
 void Scene_Battle_Rpg2k::CreateEnemyActions() {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -527,6 +527,13 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 			action->Apply();
 			battle_action_state = BattleActionState_ResultPop;
 
+			if (action->GetSourceAnimationStateApply() != NULL) {
+				source_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetSource());
+				source_sprite->SetAnimationState(
+					action->GetSourceAnimationStateApply(),
+					Sprite_Battler::LoopState_DefaultAnimationAfterFinish);
+			}
+
 			if (!action->IsFirstAttack()) {
 				battle_action_wait = 0;
 				return ProcessBattleAction(action);

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -401,6 +401,10 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 		}
 	}
 
+	if (Input::IsPressed(Input::CANCEL)) {
+		return false;
+	}
+
 	switch (battle_action_state) {
 		case BattleActionState_Start:
 			battle_action_wait = GetDelayForWindow();

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -602,12 +602,12 @@ void Scene_Battle_Rpg2k::ProcessInput() {
 			--actor_index;
 			SelectPreviousActor();
 			break;
-		case State_SelectEnemyTarget:
 		case State_SelectItem:
 		case State_SelectSkill:
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cancel));
 			SetState(State_SelectCommand);
 			break;
+		case State_SelectEnemyTarget:
 		case State_SelectAllyTarget:
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cancel));
 			SetState(previous_state);

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -393,7 +393,11 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 	Sprite_Battler* source_sprite;
 	Sprite_Battler* target_sprite;
 
-	if (battle_action_wait) {
+	if (Input::IsPressed(Input::DECISION)) {
+		--battle_action_wait;
+	}
+
+	if (battle_action_wait > 0) {
 		if (--battle_action_wait) {
 			return false;
 		}
@@ -644,8 +648,7 @@ void Scene_Battle_Rpg2k::ProcessInput() {
 	if (Input::IsTriggered(Input::DECISION)) {
 		switch (state) {
 		case State_Start:
-			// Skip current message
-			encounter_message_sleep_until = Player::GetFrames();
+			// no-op
 			break;
 		case State_SelectOption:
 			// Interpreter message boxes pop up in this state
@@ -789,6 +792,10 @@ void Scene_Battle_Rpg2k::Escape() {
 		begin_escape = false;
 	}
 	else {
+		if (Input::IsPressed(Input::DECISION)) {
+			++escape_counter;
+		}
+
 		++escape_counter;
 
 		if (escape_counter > 60) {
@@ -984,6 +991,10 @@ bool Scene_Battle_Rpg2k::DisplayMonstersInMessageWindow() {
 		Main_Data::game_enemyparty->GetActiveBattlers(visible_enemies);
 		enemy_iterator = visible_enemies.begin();
 		encounter_message_first_monster = false;
+	}
+
+	if (Input::IsPressed(Input::DECISION)) {
+		--encounter_message_sleep_until;
 	}
 
 	if (encounter_message_sleep_until > -1) {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -57,6 +57,11 @@ void Scene_Battle_Rpg2k::Update() {
 	}
 
 	Scene_Battle::Update();
+	
+	// If an event that changed status finishes without displaying a message window,
+	// we need this so it can update automatically the status_window
+	if (Game_Battle::GetInterpreter().finished_not_updated)
+		status_window->Refresh();
 
 	if (Game_Battle::GetInterpreter().IsRunning() && !interpreter_activated && !battle_message_window->GetVisible()) {
 		battle_message_window->SetVisible(true);

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -384,6 +384,10 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 	if (Game_Battle::IsBattleAnimationWaiting() && !Game_Battle::IsBattleAnimationOnlySound()) {
 		return false;
 	}
+	else if (action->HasAnimationPlayed() && action->GetSecondAnimation() != nullptr && !action->HasSecondAnimationPlayed()) {
+		action->PlaySecondAnimation();
+		return false;
+	}
 
 	int critical_hit, default_result_lines;
 	Sprite_Battler* source_sprite;

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -366,7 +366,7 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 }
 
 bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase* action) {
-	if (Game_Battle::IsBattleAnimationWaiting()) {
+	if (Game_Battle::IsBattleAnimationWaiting() && !Game_Battle::IsBattleAnimationOnlySound()) {
 		return false;
 	}
 
@@ -443,11 +443,9 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 				}
 				if (action->GetTarget()) {
 					if (action->GetTarget()->GetType() == Game_Battler::Type_Enemy) {
-						battle_action_wait = GetDelayForLine();
 						action->PlayAnimation();
 					} else if (action->GetTarget()->GetType() == Game_Battler::Type_Ally && action->GetType() == "Skill") {
-						battle_action_wait = GetDelayForLine();
-						action->PlaySoundAnimation();
+						action->PlaySoundAnimation(false, 20);
 					}
 				}
 			}

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -428,13 +428,19 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 			battle_result_messages.clear();
 			action->GetResultMessages(battle_result_messages);
 
-			battle_message_window->Push(action->GetStartMessage());
+			if (battle_message_window->GetLineCount() == 0)
+				battle_message_window->Push(action->GetStartMessage());
+			else if ((battle_message_window->GetLineCount() == 1 && action->IsSecondStartMessage()))
+				battle_message_window->Push(action->GetSecondStartMessage());
 
 			action->Apply();
 
 			battle_result_messages_it = battle_result_messages.begin();
 
 			if (action->IsFirstAttack()) {
+				if (battle_message_window->GetLineCount() == 1 && action->IsSecondStartMessage()) {
+					return false;
+				}
 				if (action->GetTarget() &&
 					action->GetTarget()->GetType() == Game_Battler::Type_Enemy) {
 
@@ -525,6 +531,8 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 				if (battle_result_messages_it != battle_result_messages.begin()) {
 					battle_message_window->Clear();
 					battle_message_window->Push(action->GetStartMessage());
+					if (action->IsSecondStartMessage())
+						battle_message_window->Push(action->GetSecondStartMessage());
 				}
 				battle_message_window->Push(*battle_result_messages_it);
 				++battle_result_messages_it;

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -520,6 +520,9 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 					if (action->IsSuccess() && target_sprite && !action->IsPositive() && !action->IsAbsorb() && action->GetAffectedHp() > -1) {
 						target_sprite->SetAnimationState(Sprite_Battler::AnimationState_Damage);
 					}
+					if (action->IsSuccess() && action->GetTarget()->GetType() == Game_Battler::Type_Ally && !action->IsPositive() && !action->IsAbsorb() && action->GetAffectedHp() > 0) {
+						Main_Data::game_screen->ShakeOnce(2, 16, 1);
+					}
 
 					if (action->GetResultSe()) {
 						Game_System::SePlay(*action->GetResultSe());

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -517,7 +517,7 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 			if (battle_result_messages_it != battle_result_messages.end()) {
 				target_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetTarget());
 				if (battle_result_messages_it == battle_result_messages.begin()) {
-					if (action->IsSuccess() && target_sprite) {
+					if (action->IsSuccess() && target_sprite && !action->IsPositive() && !action->IsAbsorb() && action->GetAffectedHp() > -1) {
 						target_sprite->SetAnimationState(Sprite_Battler::AnimationState_Damage);
 					}
 

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -422,6 +422,7 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 
 			std::vector<int16_t> states_to_heal = action->GetSource()->NextBattleTurn();
 			std::vector<int16_t> states_remaining = action->GetSource()->GetInflictedStates();
+			std::string message_to_print;
 			action->GetSource()->ApplyConditions();
 			bool message_to_show = false;
 			if (!states_to_heal.empty() || !states_remaining.empty()) {
@@ -429,7 +430,7 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 					// BattleAlgorithm verifies the states
 					const RPG::State* state = ReaderUtil::GetElement(Data::states, state_id);
 					if (!state->message_recovery.empty()) {
-						battle_message_window->PushWithSubject(state->message_recovery, action->GetSource()->GetName());
+						message_to_print = state->message_recovery;
 						message_to_show = true;
 					}
 				}
@@ -437,11 +438,12 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 					// BattleAlgorithm verifies the states
 					const RPG::State* state = ReaderUtil::GetElement(Data::states, state_id);
 					if (!state->message_affected.empty()) {
-						battle_message_window->PushWithSubject(state->message_affected, action->GetSource()->GetName());
+						message_to_print = state->message_affected;
 						message_to_show = true;
 					}
 				}
 				if (message_to_show) {
+					battle_message_window->PushWithSubject(message_to_print, action->GetSource()->GetName());
 					battle_action_wait = GetDelayForWindow() * 3 / 2;
 				}
 			}

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -1123,7 +1123,9 @@ bool Scene_Battle_Rpg2k::CheckWin() {
 		Game_Message::texts.push_back(Data::terms.victory + "\\|");
 
 		std::stringstream ss;
-		PushExperienceGainedMessage(exp);
+		if (exp > 0) {
+			PushExperienceGainedMessage(exp);
+		}
 		if (money > 0) {
 			PushGoldReceivedMessage(money);
 		}

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -861,7 +861,7 @@ void Scene_Battle_Rpg2k::CreateExecutionOrder() {
 
 void Scene_Battle_Rpg2k::CreateEnemyActions() {
 	std::vector<Game_Battler*> enemies;
-	Main_Data::game_enemyparty->GetBattlers(enemies);
+	Main_Data::game_enemyparty->GetActiveBattlers(enemies);
 
 	for (Game_Battler* battler : enemies) {
 		if (!battler->CanAct()) {

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -136,6 +136,7 @@ protected:
 	bool interpreter_activated = false;
 
 	bool message_box_got_visible = false;
+	bool move_screen = false;
 
 	int last_turn_check = -1;
 };

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -118,6 +118,8 @@ protected:
 	bool DisplayMonstersInMessageWindow();
 
 	std::unique_ptr<Window_BattleMessage> battle_message_window;
+	std::vector<int> battle_result_order;
+	std::vector<int>::iterator battle_result_order_it;
 	std::vector<std::string> battle_result_messages;
 	std::vector<std::string>::iterator battle_result_messages_it;
 	std::vector<Game_Battler *> visible_enemies;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1022,8 +1022,10 @@ bool Scene_Battle_Rpg2k3::CheckWin() {
 		std::string space = Player::IsRPG2k3E() ? " " : "";
 
 		std::stringstream ss;
-		ss << exp << space << Data::terms.exp_received;
-		Game_Message::texts.push_back(ss.str());
+		if (exp > 0) {
+			ss << exp << space << Data::terms.exp_received;
+			Game_Message::texts.push_back(ss.str());
+		}
 		if (money > 0) {
 			ss.str("");
 			ss << Data::terms.gold_recieved_a << " " << money << Data::terms.gold << Data::terms.gold_recieved_b;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -816,11 +816,11 @@ void Scene_Battle_Rpg2k3::ProcessInput() {
 			active_actor->SetLastBattleAction(-1);
 			SetState(State_SelectOption);
 			break;
-		case State_SelectEnemyTarget:
 		case State_SelectItem:
 		case State_SelectSkill:
 			SetState(State_SelectCommand);
 			break;
+		case State_SelectEnemyTarget:
 		case State_SelectAllyTarget:
 			SetState(previous_state);
 			break;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -37,7 +37,7 @@
 
 Scene_Battle_Rpg2k3::Scene_Battle_Rpg2k3() : Scene_Battle(),
 	battle_action_wait(30),
-	battle_action_state(BattleActionState_Start)
+	battle_action_state(BattleActionState_Execute)
 {
 }
 
@@ -518,7 +518,7 @@ void Scene_Battle_Rpg2k3::ProcessActions() {
 		if (action->IsDead()) {
 			// No zombies allowed ;)
 			RemoveCurrentAction();
-			battle_action_state = BattleActionState_Start;
+			battle_action_state = BattleActionState_Execute;
 		}
 		else if (ProcessBattleAction(action->GetBattleAlgorithm().get())) {
 			RemoveCurrentAction();
@@ -601,7 +601,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 	}
 
 	switch (battle_action_state) {
-	case BattleActionState_Start:
+	case BattleActionState_Execute:
 		if (battle_action_need_event_refresh) {
 			action->GetSource()->NextBattleTurn();
 			NextTurn(action->GetSource());
@@ -676,9 +676,9 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 			}
 		}
 
-		battle_action_state = BattleActionState_Result;
+		battle_action_state = BattleActionState_ResultPush;
 		break;
-	case BattleActionState_Result:
+	case BattleActionState_ResultPush:
 		if (source_sprite) {
 			source_sprite->SetAnimationLoop(Sprite_Battler::LoopState_DefaultAnimationAfterFinish);
 		}
@@ -737,7 +737,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 			battle_action_need_event_refresh = true;
 
 			// Reset variables
-			battle_action_state = BattleActionState_Start;
+			battle_action_state = BattleActionState_Execute;
 			targets.clear();
 			combo_repeat = 1;
 
@@ -776,7 +776,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 			// TODO: Prevent combo when the combo is a skill and needs more SP
 			// then available
 
-			battle_action_state = BattleActionState_Start;
+			battle_action_state = BattleActionState_Execute;
 			// Count how often we have to repeat
 			++combo_repeat;
 			return false;
@@ -975,6 +975,8 @@ void Scene_Battle_Rpg2k3::SpecialSelected() {
 }
 
 void Scene_Battle_Rpg2k3::Escape() {
+	std::vector<int> dummy;
+
 	Game_BattleAlgorithm::Escape escape_alg = Game_BattleAlgorithm::Escape(active_actor);
 	active_actor->SetGauge(0);
 
@@ -983,7 +985,7 @@ void Scene_Battle_Rpg2k3::Escape() {
 
 	if (!escape_success) {
 		std::vector<std::string> battle_result_messages;
-		escape_alg.GetResultMessages(battle_result_messages);
+		escape_alg.GetResultMessages(battle_result_messages, dummy);
 		SetState(State_SelectActor);
 		ShowNotification(battle_result_messages[0]);
 	}

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -49,6 +49,8 @@ void Sprite_Battler::Update() {
 	}
 
 	if (!battler->IsHidden() && old_hidden != battler->IsHidden()) {
+		SetZoomX(1.0);
+		SetZoomY(1.0);
 		SetOpacity(255);
 		SetVisible(true);
 		DoIdleAnimation();
@@ -62,8 +64,9 @@ void Sprite_Battler::Update() {
 
 	if (battler->GetBattleAnimationId() <= 0) {
 		// Animations for monster
-		if (anim_state != AnimationState_Dead) {
+		if (anim_state != AnimationState_Dead && anim_state != AnimationState_DeadSelfDestruct) {
 			fade_out = 255;
+			zoom = 1.0;
 		}
 
 		if (anim_state == AnimationState_Idle) {
@@ -75,6 +78,18 @@ void Sprite_Battler::Update() {
 				fade_out -= 15;
 				SetOpacity(std::max(0, fade_out));
 			} else {
+				idling = true;
+			}
+		}
+		else if (anim_state == AnimationState_DeadSelfDestruct) {
+			if (fade_out > 0) {
+				fade_out -= 15;
+				zoom += 0.07;
+				SetOpacity(std::max(0, fade_out));
+				SetZoomX(zoom);
+				SetZoomY(zoom);
+			}
+			else {
 				idling = true;
 			}
 		}

--- a/src/sprite_battler.h
+++ b/src/sprite_battler.h
@@ -42,7 +42,9 @@ public:
 		AnimationState_WalkingLeft,
 		AnimationState_WalkingRight,
 		AnimationState_Victory,
-		AnimationState_Item
+		AnimationState_Item,
+		AnimationState_SelfDestruct,
+		AnimationState_DeadSelfDestruct
 	};
 
 	enum LoopState {
@@ -115,6 +117,7 @@ protected:
 	std::unique_ptr<BattleAnimation> animation;
 	// false when a newly set animation didn't loop once
 	bool idling = true;
+	float zoom = 1.0;
 
 	FileRequestBinding request_id;
 };

--- a/src/sprite_battler.h
+++ b/src/sprite_battler.h
@@ -43,6 +43,7 @@ public:
 		AnimationState_WalkingRight,
 		AnimationState_Victory,
 		AnimationState_Item,
+		AnimationState_Escape,
 		AnimationState_SelfDestruct,
 		AnimationState_DeadSelfDestruct
 	};

--- a/src/sprite_battler.h
+++ b/src/sprite_battler.h
@@ -102,6 +102,7 @@ protected:
 	void DoIdleAnimation();
 	void OnMonsterSpriteReady(FileRequestResult* result);
 	void OnBattlercharsetReady(FileRequestResult* result, int32_t battler_index);
+	int GetMaxOpacity() const;
 
 	std::string sprite_name;
 	int hue = 0;
@@ -112,6 +113,7 @@ protected:
 	std::string sprite_file;
 	int sprite_frame = -1;
 	int fade_out = 255;
+	int fade_out_incr = 15;
 	int flash_counter = 0;
 	LoopState loop_state = LoopState_DefaultAnimationAfterFinish;
 	bool old_hidden = false;

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -40,6 +40,22 @@ Window_Base::Window_Base(int x, int y, int width, int height) {
 	SetHeight(height);
 	SetStretch(Game_System::GetMessageStretch() == RPG::System::Stretch_stretch);
 	SetZ(Priority_Window);
+
+	current_frame = -1;
+	total_frames = -2;
+}
+
+void Window_Base::InitMovement(int old_x, int old_y, int new_x, int new_y, int duration) {
+	current_frame = 0;
+	total_frames = duration;
+	old_position[0] = old_x;
+	old_position[1] = old_y;
+	new_position[0] = new_x;
+	new_position[1] = new_y;
+}
+
+bool Window_Base::IsMovementActive() {
+	return current_frame <= total_frames;
 }
 
 void Window_Base::Update() {
@@ -49,6 +65,26 @@ void Window_Base::Update() {
 		SetWindowskin(Cache::System(windowskin_name));
 	}
 	SetStretch(Game_System::GetMessageStretch() == RPG::System::Stretch_stretch);
+	UpdateMovement();
+}
+
+void Window_Base::UpdateMovement() {
+	if (!IsMovementActive()) {
+		return;
+	}
+	current_frame++;
+	if (!IsMovementActive()) {
+		SetX(new_position[0]);
+		SetY(new_position[1]);
+	}
+}
+
+void Window_Base::Draw() {
+	if (IsMovementActive()) {
+		SetX(old_position[0] + (new_position[0] - old_position[0]) * current_frame / total_frames);
+		SetY(old_position[1] + (new_position[1] - old_position[1]) * current_frame / total_frames);
+	}
+	Window::Draw();
 }
 
 void Window_Base::OnFaceReady(FileRequestResult* result, int face_index, int cx, int cy, bool flip) {

--- a/src/window_base.h
+++ b/src/window_base.h
@@ -19,6 +19,7 @@
 #define EP_WINDOW_BASE_H
 
 // Headers
+#include <array>
 #include <string>
 #include "window.h"
 #include "game_actor.h"
@@ -74,12 +75,24 @@ public:
 	 */
 	void CancelFace();
 
+	void InitMovement(int old_x, int old_y, int new_x, int new_y, int duration);
+	bool IsMovementActive();
+	void UpdateMovement();
+
+	void Draw() override;
+
 protected:
 	void OnFaceReady(FileRequestResult* result, int face_index, int cx, int cy, bool flip);
 
 	std::string windowskin_name;
 
 	std::vector<FileRequestBinding> face_request_ids;
+
+	int current_frame;
+	int total_frames;
+	std::array<int, 2> old_position;
+	std::array<int, 2> new_position;
+
 };
 
 #endif

--- a/src/window_item.cpp
+++ b/src/window_item.cpp
@@ -84,9 +84,7 @@ void Window_Item::Refresh() {
 
 	CreateContents();
 
-	if (index > 0 && index >= item_max) {
-		--index;
-	}
+	SetIndex(index);
 
 	contents->Clear();
 

--- a/src/window_item.cpp
+++ b/src/window_item.cpp
@@ -48,7 +48,7 @@ bool Window_Item::CheckInclude(int item_id) {
 }
 
 bool Window_Item::CheckEnable(int item_id) {
-	return Main_Data::game_party->IsItemUsable(item_id);
+	return Main_Data::game_party->IsItemUsable(item_id, actor);
 }
 
 void Window_Item::Refresh() {


### PR DESCRIPTION
I will be posting one fix for one issue per commit.

"1.2: RM2000: Animations executed in a battle event should not wait until the animation is over when the option "wait to end" is selected."

Solution: Eliminate in Game_Interpreter_Battle::ExecuteCommand and "if" that checks whether the animation is finished no matter if the option "wait to finish" is clicked or not. This difference is already treated and differentiated by itself, and this condition is just a left-over code from previous function structure that isn't needed anymore.