### PR TITLE
Windows_Message::ApplyTextInsertingCommands fix

### DIFF
--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -112,21 +112,20 @@ void Window_Message::ApplyTextInsertingCommands() {
 				}
 
 				if (!success || std::find(replaced_actors.begin(), replaced_actors.end(), parsed_num) != replaced_actors.end()) {
-					text_index = start_code - 2;
+					text_index = start_code;
 					continue;
 				}
 
 				if (ch == 'n') {
 					replaced_actors.push_back(parsed_num);
-					if (text.begin() + actor_replacement_start >= text_index - 1) {
-						actor_replacement_start = std::distance(text.begin(), text_index - 1);
-					}
+					actor_replacement_start = std::min<int>(std::distance(text.begin(), start_code), actor_replacement_start);
 				}
 
 				text.replace(start_code, text_index + 1, command_result);
 				// Start from the beginning, the inserted text might add new commands
 				text_index = text.end();
 				end = text.end();
+				actor_replacement_start = std::min<int> (std::distance(text.begin(), end), actor_replacement_start);
 
 				// Move on first valid char
 				--text_index;


### PR DESCRIPTION
Problems:
1. If you put in a message "\n[x]" whose name is also "\n[x]" it generates a loop problem.
2. If "\n[x]" or "\v[x]" result in smaller characters (i.e. a/0) and they are the last characters in the message, it will generate an out-of-range error because the actor_replacement_start will be bigger than the replaced message.

Solutions:
1. The actor_replacement_start should not be the end of the number, but code_start.
2. actor_replacement_start should clamp with the size of the string after being replaced to avoid these problems.
3. "start_code - 2", the -2 while it doesn't really bother it's pointless and the function is clearer without it (not a function that needs efficiency over simplicity).