### PR TITLE
ToneBlit performance and Method Implementation, Sprite Flashes, other fixes

### DIFF
--- a/src/background.cpp
+++ b/src/background.cpp
@@ -29,7 +29,7 @@
 #include "output.h"
 
 Background::Background(const std::string& name) :
-	visible(true),
+	visible(true), tone_effect(Tone()),
 	bg_hscroll(0), bg_vscroll(0), bg_x(0), bg_y(0),
 	fg_hscroll(0), fg_vscroll(0), fg_x(0), fg_y(0) {
 
@@ -43,7 +43,7 @@ Background::Background(const std::string& name) :
 }
 
 Background::Background(int terrain_id) :
-	visible(true),
+	visible(true), tone_effect(Tone()),
 	bg_hscroll(0), bg_vscroll(0), bg_x(0), bg_y(0),
 	fg_hscroll(0), fg_vscroll(0), fg_x(0), fg_y(0) {
 
@@ -109,6 +109,15 @@ DrawableType Background::GetType() const {
 	return type;
 }
 
+Tone Background::GetTone() const {
+	return tone_effect;
+}
+
+void Background::SetTone(Tone tone) {
+	if (tone_effect != tone) {
+		tone_effect = tone;
+	}
+}
 void Background::Update(int& rate, int& value) {
 	int step =
 		(rate > 0) ? 1 << rate :
@@ -143,4 +152,8 @@ void Background::Draw() {
 
 	if (fg_bitmap)
 		dst->TiledBlit(-Scale(fg_x), -Scale(fg_y), fg_bitmap->GetRect(), *fg_bitmap, dst_rect, 255);
+
+	if (tone_effect != Tone()) {
+		dst->ToneBlit(0, 0, *dst, dst->GetRect(), tone_effect, Opacity::opaque);
+	}
 }

--- a/src/background.h
+++ b/src/background.h
@@ -23,6 +23,7 @@
 #include "system.h"
 #include "drawable.h"
 #include "async_handler.h"
+#include "tone.h"
 
 class Background : public Drawable {
 public:
@@ -32,6 +33,8 @@ public:
 
 	void Draw() override;
 	void Update();
+	Tone GetTone() const;
+	void SetTone(Tone tone);
 
 	int GetZ() const override;
 	DrawableType GetType() const override;
@@ -48,6 +51,8 @@ private:
 
 	bool visible;
 
+	Tone tone_effect;
+	Tone current_tone;
 	BitmapRef bg_bitmap;
 	int bg_hscroll;
 	int bg_vscroll;

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -140,7 +140,7 @@ void BattleAnimation::DrawAt(int x, int y) {
 }
 
 // FIXME: looks okay, but needs to be measured
-static int flash_length = 5;
+static int flash_length = 12;
 
 void BattleAnimation::RunTimedSfx() {
 	// Lookup any timed SFX (SE/flash/shake) data for this frame
@@ -158,10 +158,10 @@ void BattleAnimation::ProcessAnimationTiming(const RPG::AnimationTiming& timing)
 
 	// Flash.
 	if (timing.flash_scope == RPG::AnimationTiming::FlashScope_target) {
-		SetFlash(Color(timing.flash_red << 3,
-			timing.flash_green << 3,
-			timing.flash_blue << 3,
-			timing.flash_power << 3));
+		SetFlash(Color(timing.flash_red * 255 / 31,
+			timing.flash_green * 255 / 31,
+			timing.flash_blue * 255 / 31,
+			timing.flash_power * 255 / 31));
 	} else if (timing.flash_scope == RPG::AnimationTiming::FlashScope_screen && ShouldScreenFlash()) {
 		Main_Data::game_screen->FlashOnce(
 			timing.flash_red,

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -867,7 +867,7 @@ static inline void color_tone(uint32_t &src_pixel, Tone tone, uint8_t hard_light
 		| ((uint32_t)((src_pixel >> as) & 0xFF) << as);
 }
 
-void Bitmap::ToneBlit(int x, int y, Bitmap const& src, Rect const& src_rect, const Tone &tone, Opacity const& opacity) {
+void Bitmap::ToneBlit(int x, int y, Bitmap const& src, Rect const& src_rect, const Tone &tone, Opacity const& opacity, bool check_alpha) {
 	if (tone == Tone(128,128,128,128)) {
 		if (&src != this) {
 			Blit(x, y, src, src_rect, opacity);
@@ -910,7 +910,7 @@ void Bitmap::ToneBlit(int x, int y, Bitmap const& src, Rect const& src_rect, con
 	if (tone.gray != 128 && (tone.red != 128 || tone.green != 128 || tone.blue != 128)) {
 		int sat = tone.gray > 128 ? 1024 + (tone.gray - 128) * 16 : tone.gray * 8;
 
-		if (&src != this) {
+		if (&src != this || check_alpha) {
 			for (uint16_t i = 0; i < limit_height; ++i) {
 				pixels += next_row;
 				for (uint16_t j = 0; j < limit_width; ++j) {
@@ -937,7 +937,7 @@ void Bitmap::ToneBlit(int x, int y, Bitmap const& src, Rect const& src_rect, con
 	else if (tone.gray != 128) {
 		int sat = tone.gray > 128 ? 1024 + (tone.gray - 128) * 16 : tone.gray * 8;
 
-		if (&src != this) {
+		if (&src != this || check_alpha) {
 			for (uint16_t i = 0; i < limit_height; ++i) {
 				pixels += next_row;
 				for (uint16_t j = 0; j < limit_width; ++j) {
@@ -960,7 +960,7 @@ void Bitmap::ToneBlit(int x, int y, Bitmap const& src, Rect const& src_rect, con
 
 	// If Only Color:
 	else if (tone.red != 128 || tone.green != 128 || tone.blue != 128) {
-		if (&src != this) {
+		if (&src != this || check_alpha) {
 			for (uint16_t i = 0; i < limit_height; ++i) {
 				pixels += next_row;
 				for (uint16_t j = 0; j < limit_width; ++j) {

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -431,7 +431,7 @@ public:
 	 * @param tone tone to apply.
 	 * @param opacity opacity to apply.
 	 */
-	void ToneBlit(int x, int y, Bitmap const& src, Rect const& src_rect, const Tone &tone, Opacity const& opacity);
+	void ToneBlit(int x, int y, Bitmap const& src, Rect const& src_rect, const Tone &tone, Opacity const& opacity, bool check_alpha = false);
 
 	/**
 	 * Blends bitmap with color.

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -721,6 +721,7 @@ protected:
 	int stop_count;
 	int max_stop_count;
 	bool walk_animation;
+	uint8_t flash_alpha;
 
 	int opacity;
 	bool visible;

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -195,13 +195,14 @@ void Game_Event::SetSpriteIndex(int index) {
 }
 
 Color Game_Event::GetFlashColor() const {
-	return Color(data.flash_red, data.flash_green, data.flash_blue, 128);
+	return Color(data.flash_red, data.flash_green, data.flash_blue, flash_alpha);
 }
 
 void Game_Event::SetFlashColor(const Color& flash_color) {
 	data.flash_red = flash_color.red;
 	data.flash_blue = flash_color.blue;
 	data.flash_green = flash_color.green;
+	flash_alpha = flash_color.alpha;
 }
 
 double Game_Event::GetFlashLevel() const {

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -655,10 +655,11 @@ bool Game_Interpreter_Map::CommandShowBattleAnimation(RPG::EventCommand const& c
 
 bool Game_Interpreter_Map::CommandFlashSprite(RPG::EventCommand const& com) { // code 11320
 	int event_id = com.parameters[0];
-	Color color(com.parameters[1] << 3,
-				com.parameters[2] << 3,
-				com.parameters[3] << 3,
-				com.parameters[4] << 3);
+	Color color(com.parameters[1] * 255 / 31,
+		com.parameters[2] * 255 / 31,
+		com.parameters[3] * 255 / 31,
+		com.parameters[4] * 255 / 31);
+
 	int tenths = com.parameters[5];
 	bool wait = com.parameters[6] > 0;
 	Game_Character* event = GetCharacter(event_id);

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -180,13 +180,14 @@ bool Game_Player::GetVisible() const {
 }
 
 Color Game_Player::GetFlashColor() const {
-	return Color(location.flash_red, location.flash_green, location.flash_blue, 128);
+	return Color(location.flash_red, location.flash_green, location.flash_blue, flash_alpha);
 }
 
 void Game_Player::SetFlashColor(const Color& flash_color) {
 	location.flash_red = flash_color.red;
 	location.flash_blue = flash_color.blue;
 	location.flash_green = flash_color.green;
+	flash_alpha = flash_color.alpha;
 }
 
 double Game_Player::GetFlashLevel() const {

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -181,13 +181,14 @@ void Game_Vehicle::SetSpriteIndex(int index) {
 }
 
 Color Game_Vehicle::GetFlashColor() const {
-	return Color(data.flash_red, data.flash_green, data.flash_blue, 128);
+	return Color(data.flash_red, data.flash_green, data.flash_blue, flash_alpha);
 }
 
 void Game_Vehicle::SetFlashColor(const Color& flash_color) {
 	data.flash_red = flash_color.red;
 	data.flash_blue = flash_color.blue;
 	data.flash_green = flash_color.green;
+	flash_alpha = flash_color.alpha;
 }
 
 double Game_Vehicle::GetFlashLevel() const {

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -47,10 +47,6 @@ void Screen::Update() {
 void Screen::Draw() {
 	BitmapRef disp = DisplayUi->GetDisplaySurface();
 
-	if (tone_effect != Tone()) {
-		disp->ToneBlit(0, 0, *disp, Rect(0, 0, SCREEN_TARGET_WIDTH, SCREEN_TARGET_HEIGHT), tone_effect, Opacity::opaque);
-	}
-
 	int flash_time_left;
 	int flash_current_level;
 	Color flash_color = Main_Data::game_screen->GetFlash(flash_current_level, flash_time_left);
@@ -63,12 +59,4 @@ void Screen::Draw() {
 		}
 		disp->Blit(0, 0, *flash, flash->GetRect(), flash_current_level);
 	}
-}
-
-Tone Screen::GetTone() const {
-	return tone_effect;
-}
-
-void Screen::SetTone(Tone tone) {
-	tone_effect = tone;
 }

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -172,12 +172,12 @@ BitmapRef Sprite::Refresh(Rect& rect) {
 			bitmap_effects->Flip(rect, flipx_effect, flipy_effect);
 		}
 		else if (no_flip) {
-			bitmap_effects->BlendBlit(rect.x, rect.y, *bitmap, rect, flash_effect, Opacity::opaque);
-			bitmap_effects->ToneBlit(rect.x, rect.y, *bitmap_effects, rect, tone_effect, Opacity::opaque);
+			bitmap_effects->ToneBlit(rect.x, rect.y, *bitmap, rect, tone_effect, Opacity::opaque);
+			bitmap_effects->BlendBlit(rect.x, rect.y, *bitmap_effects, rect, flash_effect, Opacity::opaque);
 		}
 		else {
-			bitmap_effects->BlendBlit(rect.x, rect.y, *bitmap, rect, flash_effect, Opacity::opaque);
-			bitmap_effects->ToneBlit(rect.x, rect.y, *bitmap_effects, rect, tone_effect, Opacity::opaque);
+			bitmap_effects->ToneBlit(rect.x, rect.y, *bitmap, rect, tone_effect, Opacity::opaque);
+			bitmap_effects->BlendBlit(rect.x, rect.y, *bitmap_effects, rect, flash_effect, Opacity::opaque);
 			bitmap_effects->Flip(rect, flipx_effect, flipy_effect);
 		}
 

--- a/src/spriteset_battle.cpp
+++ b/src/spriteset_battle.cpp
@@ -65,8 +65,7 @@ Spriteset_Battle::Spriteset_Battle() {
 }
 
 void Spriteset_Battle::Update() {
-	// Battle is not as resource heavy as map, always use screen tone
-	screen->SetTone(Main_Data::game_screen->GetTone());
+	Tone new_tone = Main_Data::game_screen->GetTone();
 
 	// Handle background change
 	if (background_name != Game_Battle::background_name) {
@@ -77,6 +76,7 @@ void Spriteset_Battle::Update() {
 			background.reset();
 		}
 	}
+	background->SetTone(new_tone);
 
 	for (auto sprite : sprites) {
 		Game_Battler* battler = sprite->GetBattler();
@@ -85,6 +85,7 @@ void Spriteset_Battle::Update() {
 		}
 
 		sprite->Update();
+		sprite->SetTone(new_tone);
 	}
 
 	timer1->Update();

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -62,19 +62,6 @@ Spriteset_Map::Spriteset_Map() {
 void Spriteset_Map::Update() {
 	Tone new_tone = Main_Data::game_screen->GetTone();
 
-	if (new_tone != last_tone) {
-		// Could be a gradient change, just updating the display is faster
-		screen->SetTone(new_tone);
-		last_tone = new_tone;
-
-		// Normal tone for all graphics
-		new_tone = Tone();
-	} else {
-		// Not a gradient change, use the cached Tone graphics instead of
-		// recalculating the screen tone
-		screen->SetTone(Tone());
-	}
-
 	tilemap->SetOx(Game_Map::GetDisplayX() / (SCREEN_TILE_WIDTH / TILE_SIZE));
 	tilemap->SetOy(Game_Map::GetDisplayY() / (SCREEN_TILE_WIDTH / TILE_SIZE));
 	tilemap->SetTone(new_tone);

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -123,7 +123,7 @@ void Weather::DrawRain() {
 	if (!rain_bitmap) {
 		rain_bitmap = Bitmap::Create(rain_image, sizeof(rain_image));
 		if (tone_effect != Tone()) {
-			rain_bitmap->ToneBlit(0, 0, *rain_bitmap, rain_bitmap->GetRect(), tone_effect, Opacity::opaque);
+			rain_bitmap->ToneBlit(0, 0, *rain_bitmap, rain_bitmap->GetRect(), tone_effect, Opacity::opaque, true);
 		}
 	}
 
@@ -146,7 +146,7 @@ void Weather::DrawSnow() {
 	if (!snow_bitmap) {
 		snow_bitmap = Bitmap::Create(snow_image, sizeof(snow_image));
 		if (tone_effect != Tone()) {
-			snow_bitmap->ToneBlit(0, 0, *snow_bitmap, snow_bitmap->GetRect(), tone_effect, Opacity::opaque);
+			snow_bitmap->ToneBlit(0, 0, *snow_bitmap, snow_bitmap->GetRect(), tone_effect, Opacity::opaque, true);
 		}
 	}
 


### PR DESCRIPTION
The issues: ToneBlit is not very efficient, Battle tones and Gradual TintScreen are tinted differently, and Sprite flashes.

ToneBlit is very heavy performance-wise, which forces us to use two different ways to implement tintscreen in our screen:
1. We use ToneBlit for any individual tile, background and sprite when they're drawn.
2. After all the drawables are drawn, we use ToneBlit to the screen.

 - The 1st method, with a little modification, allows us to generate Sprite flashes that ignore the tintscreen (for example, a white flash with a dark-red tintscreen, it should appear completely white instead of red-ish). The 2nd doesn't allow that.
 - The 1st method is more efficient when the tintscreen remains static, but slower when the tone screen is gradually changing.
 - The 2nd is used for Gradual Tintscreen and Battle scenes. The 1st one is used anywhere else.

The ideal solution would be using the first to fix the flash bug. For that, we try to make the ToneBlit function more efficient. It sacrifices legibility in order to gain a little more of performance. These changes (cache variables, combining checks, etc.) improve the performance so there's not much difference for the 1st and 2nd method when a gradual tone screen happens, and therefore the 1st method is viable for everything.

To implement this:
 - Bitmap: We modify the ToneBlit to make it more efficient.
 - Sprite: We invert the positions of ToneBlit and BlendBlit. This way the flash color will have priority and not be tinted.
 - Spriteset_Map: Now in all the cases it uses the 1st method, so the code that allows the 2nd method is deleted.
 - Spriteset_Battle: We change from the 2nd method to the 1st one. We set the tone for the background and the battler sprites.
 - Background: We include the option of setting and getting a tone, and then draw it.
 - Screen: We eliminate the tone functions since no other class uses them.

Also, another fixes:
 - Game_Character flashes were limited to 128 no matter what the actual value was. An attribute flash_alpha has been added to account for this, and when the flash is set and invoked in its subclasses (Event, Vehicle, Player) we use that attribute.
 - Battle_Animation "flash_length" has been changed from 5 to 12, because the way it was before it was almost unnoticeable in comparison with RPG_RT.
 - Battle_Animation and Game_Interpreter_Map: The value of the flashes before with the << 3 operation meant the flash value for each part would be [0, 248]. With "x * 255 / 31", the values is really [0, 255].

Fix #1225