### PR TITLE
EXE ExFont extraction.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(${PROJECT_NAME}
 	src/decoder_wildmidi.cpp
 	src/decoder_xmp.cpp
 	src/drawable.cpp
+	src/exe_reader.cpp
 	src/filefinder.cpp
 	src/font.cpp
 	src/fps_overlay.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -59,6 +59,8 @@ libeasyrpg_player_la_SOURCES = \
 	src/docmain.h \
 	src/drawable.cpp \
 	src/drawable.h \
+	src/exe_reader.cpp \
+	src/exe_reader.h \
 	src/exfont.h \
 	src/filefinder.cpp \
 	src/filefinder.h \

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -257,6 +257,8 @@ namespace {
 	}
 }
 
+std::vector<uint8_t> Cache::exfont_custom;
+
 #define cache(elem) \
 	BitmapRef Cache::elem(const std::string& f) { \
 		bool trans = spec[Material::elem].transparent; \
@@ -292,18 +294,11 @@ BitmapRef Cache::Exfont() {
 	cache_type::iterator const it = cache.find(hash);
 
 	if (it == cache.end() || !it->second.bitmap) {
-		std::string exfont_file = FileFinder::FindImage(".", "ExFont");
-		if (exfont_file.empty()) {
-			// Check for automatically extracted ExFont in the save directory
-			std::shared_ptr<FileFinder::DirectoryTree> save_tree = FileFinder::CreateSaveDirectoryTree();
-			// Due to API limitations only check for ExFont.bmp
-			exfont_file = FileFinder::FindImage(*save_tree, "ExFont.bmp");
-		}
-		BitmapRef exfont_img;
 		// Allow overwriting of built-in exfont with a custom ExFont image file
-		// Probe before using LoadBitmap because this generates a warning when the file is missing
-		if (!exfont_file.empty()) {
-			exfont_img = Bitmap::Create(exfont_file, true);
+		// exfont_custom is filled by Player::CreateGameObjects
+		BitmapRef exfont_img;
+		if (!exfont_custom.empty()) {
+			exfont_img = Bitmap::Create(exfont_custom.data(), exfont_custom.size(), true);
 		} else {
 			exfont_img = Bitmap::Create(exfont_h, sizeof(exfont_h), true);
 		}

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -294,10 +294,10 @@ BitmapRef Cache::Exfont() {
 	if (it == cache.end() || !it->second.bitmap) {
 		std::string exfont_file = FileFinder::FindImage(".", "ExFont");
 		if (exfont_file.empty()) {
-			// Extracted EXFONTs have a specific name and are only in the save directory tree.
-            // To clarify - CreateSaveDirectoryTree *must* be called to ensure the resulting directory tree is up to date.
-            std::shared_ptr<FileFinder::DirectoryTree> save_tree = FileFinder::CreateSaveDirectoryTree();
-			exfont_file = FileFinder::FindDefault(*save_tree, "ExFont.bmp");
+			// Check for automatically extracted ExFont in the save directory
+			std::shared_ptr<FileFinder::DirectoryTree> save_tree = FileFinder::CreateSaveDirectoryTree();
+			// Due to API limitations only check for ExFont.bmp
+			exfont_file = FileFinder::FindImage(*save_tree, "ExFont.bmp");
 		}
 		BitmapRef exfont_img;
 		// Allow overwriting of built-in exfont with a custom ExFont image file

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -295,7 +295,9 @@ BitmapRef Cache::Exfont() {
 		std::string exfont_file = FileFinder::FindImage(".", "ExFont");
 		if (exfont_file.empty()) {
 			// Extracted EXFONTs have a specific name and are only in the save directory tree.
-			exfont_file = FileFinder::FindDefault(*FileFinder::CreateSaveDirectoryTree(), "ExFont.bmp");
+            // To clarify - CreateSaveDirectoryTree *must* be called to ensure the resulting directory tree is up to date.
+            std::shared_ptr<FileFinder::DirectoryTree> save_tree = FileFinder::CreateSaveDirectoryTree();
+			exfont_file = FileFinder::FindDefault(*save_tree, "ExFont.bmp");
 		}
 		BitmapRef exfont_img;
 		// Allow overwriting of built-in exfont with a custom ExFont image file
@@ -356,12 +358,6 @@ void Cache::Clear() {
 	}
 
 	cache_tiles.clear();
-}
-
-void Cache::ForceLoadExfont() {
-	string_pair const hash("ExFont","ExFont");
-	// FileFinder won't believe it.
-	cache.erase(hash);
 }
 
 void Cache::SetSystemName(std::string const& filename) {

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -293,6 +293,10 @@ BitmapRef Cache::Exfont() {
 
 	if (it == cache.end() || !it->second.bitmap) {
 		std::string exfont_file = FileFinder::FindImage(".", "ExFont");
+		if (exfont_file.empty()) {
+			// Extracted EXFONTs have a specific name and are only in the save directory tree.
+			exfont_file = FileFinder::FindDefault(*FileFinder::CreateSaveDirectoryTree(), "ExFont.bmp");
+		}
 		BitmapRef exfont_img;
 		// Allow overwriting of built-in exfont with a custom ExFont image file
 		// Probe before using LoadBitmap because this generates a warning when the file is missing
@@ -352,6 +356,12 @@ void Cache::Clear() {
 	}
 
 	cache_tiles.clear();
+}
+
+void Cache::ForceLoadExfont() {
+	string_pair const hash("ExFont","ExFont");
+	// FileFinder won't believe it.
+	cache.erase(hash);
 }
 
 void Cache::SetSystemName(std::string const& filename) {

--- a/src/cache.h
+++ b/src/cache.h
@@ -52,6 +52,9 @@ namespace Cache {
 
 	void Clear();
 
+	// If you are sure the Exfont should be loadable, use this.
+	void ForceLoadExfont();
+
 	BitmapRef System();
 	void SetSystemName(std::string const& filename);
 }

--- a/src/cache.h
+++ b/src/cache.h
@@ -20,6 +20,7 @@
 
 // Headers
 #include <string>
+#include <vector>
 
 #include "system.h"
 #include "color.h"
@@ -54,6 +55,8 @@ namespace Cache {
 
 	BitmapRef System();
 	void SetSystemName(std::string const& filename);
+
+	extern std::vector<uint8_t> exfont_custom;
 }
 
 #endif

--- a/src/cache.h
+++ b/src/cache.h
@@ -52,9 +52,6 @@ namespace Cache {
 
 	void Clear();
 
-	// If you are sure the Exfont should be loadable, use this.
-	void ForceLoadExfont();
-
 	BitmapRef System();
 	void SetSystemName(std::string const& filename);
 }

--- a/src/exe_reader.cpp
+++ b/src/exe_reader.cpp
@@ -15,6 +15,9 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
+// All of this code is unused on EMSCRIPTEN. *Do not use it*!
+#ifndef EMSCRIPTEN
+
 #include "exe_reader.h"
 #include "filefinder.h"
 #include "bitmap.h"
@@ -197,3 +200,5 @@ bool EXEReader::ResNameCheck(uint32_t i, const char * p) {
 	}
 	return true;
 }
+
+#endif

--- a/src/exe_reader.cpp
+++ b/src/exe_reader.cpp
@@ -63,6 +63,14 @@ EXEReader::EXEReader(std::istream& core) : corefile(core) {
 EXEReader::~EXEReader() {
 }
 
+static uint32_t djb2_hash(char* str, size_t length) {
+    uint32_t hash = 5381;
+	for (size_t i = 0; i < length; ++i) {
+        hash = ((hash << 5) + hash) + str[i];
+	}
+    return hash;
+}
+
 static std::vector<uint8_t> exe_reader_perform_exfont_save(std::istream& corefile, uint32_t position, uint32_t len) {
 	std::vector<uint8_t> exfont;
 	constexpr int header_size = 14;
@@ -111,6 +119,11 @@ static std::vector<uint8_t> exe_reader_perform_exfont_save(std::istream& corefil
 			break;
 		exfont[pos++] = v;
 		len--;
+	}
+
+	// Check if the ExFont is the original through a fast hash function
+	if (djb2_hash((char*)exfont.data() + header_size, exfont.size() - header_size) != 0xf90c5cde) {
+		Output::Debug("EXEReader: Custom ExFont found");
 	}
 
 	return exfont;

--- a/src/exe_reader.cpp
+++ b/src/exe_reader.cpp
@@ -1,0 +1,189 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "exe_reader.h"
+#include "bitmap.h"
+#include "output.h"
+#include <iostream>
+#include <fstream>
+
+EXEReader::EXEReader(std::istream & core) : corefile(core) {
+	// The Incredibly Dumb Resource Grabber (tm)
+	// The idea is that this code will eventually be moved to happen earlier or broken down as-needed.
+	// Since EXFONT is the only thing that matters right now, it's the only thing handled.
+	uint32_t ofs = GetU32(0x3C);
+	uint16_t sections = GetU16(ofs + 6);
+	uint32_t sectionsOfs = ofs + 0x18 + GetU16(ofs + 0x14);
+	resource_rva = GetU32(ofs + 0x88);
+	if (!resource_rva)
+		return;
+	while (sections) {
+		uint32_t sectVs = GetU32(sectionsOfs + 0x08);
+		uint32_t sectRs = GetU32(sectionsOfs + 0x10);
+		if (sectRs > sectVs) {
+			// Actually a problem in some files.
+			sectVs = sectRs;
+		}
+		uint32_t sectRva = GetU32(sectionsOfs + 0x0C);
+		uint32_t sectRdptr = GetU32(sectionsOfs + 0x14);
+		if ((sectRva <= resource_rva) && ((sectRva + sectVs) > resource_rva)) {
+			// Resources located.
+			resource_ofs = sectRdptr + (resource_rva - sectRva);
+			break;
+		}
+		sections--;
+		sectionsOfs += 0x28;
+	}
+	if (sections == 0)
+		resource_rva = 0;
+}
+
+EXEReader::~EXEReader() {
+}
+
+static void exe_reader_perform_exfont_save(std::string f, std::istream & corefile, uint32_t pos, uint32_t len) {
+	corefile.seekg(pos, std::ios_base::beg);
+	// Solely for calculating position of actual data
+	uint32_t hdrL = corefile.get();
+	hdrL |= ((uint32_t) corefile.get()) << 8;
+	hdrL |= ((uint32_t) corefile.get()) << 16;
+	hdrL |= ((uint32_t) corefile.get()) << 24;
+	// As it turns out, EXFONTs appear to operate on all the same restrictions as an ordinary BMP.
+	// Given this particular resource is loaded by the RPG Maker half of the engine, this makes the usual amount of sense.
+	// This means 256 palette entries. Without fail. Even though only two are used, the first and last.
+	// Since this is a packed bitmap, there's nothing else to worry about.
+	hdrL += 256 * 4;
+	// And the header that's going to be prepended.
+	hdrL += 14;
+
+	std::ofstream exfile(f, std::ios::binary);
+
+	// 0 (these are in decimal)
+	exfile.put('B');
+	exfile.put('M');
+	// 2
+	uint32_t totallen = len + 14;
+	exfile.put((totallen) & 0xFF);
+	exfile.put((totallen >> 8) & 0xFF);
+	exfile.put((totallen >> 16) & 0xFF);
+	exfile.put((totallen >> 24) & 0xFF);
+	// 6
+	exfile.put('E');
+	exfile.put('x');
+	exfile.put('F');
+	exfile.put('n');
+	// 10
+	exfile.put((hdrL) & 0xFF);
+	exfile.put((hdrL >> 8) & 0xFF);
+	exfile.put((hdrL >> 16) & 0xFF);
+	exfile.put((hdrL >> 24) & 0xFF);
+
+	corefile.seekg(pos, std::ios_base::beg);
+	while (len > 0) {
+		int v = corefile.get();
+		if (v == -1)
+			break;
+		exfile.put(v);
+		len--;
+	}
+	
+	exfile.close();
+}
+
+static uint32_t exe_reader_roffset(uint32_t bas, uint32_t ofs) {
+	return bas + (ofs ^ 0x80000000);
+}
+
+void EXEReader::GetExfont(std::string file) {
+	// Part 2 of the resource grabber.
+	if (!resource_ofs) {
+		Output::Debug("EXEReader::GetExfont : No resource section.");
+		return;
+	}
+	// For each ID/Name entry in the outer...
+	uint32_t resourcesIDEs = GetU16(resource_ofs + 0x0C) + (uint32_t) GetU16(resource_ofs + 0x0E);
+	uint32_t resourcesIDEbase = resource_ofs + 0x10;
+	while (resourcesIDEs) {
+		// This can only be 2 if valid. Don't worry about it.
+		if (GetU32(resourcesIDEbase) == 2) {
+			uint32_t bitmapDBase = exe_reader_roffset(resource_ofs, GetU32(resourcesIDEbase + 4));
+			// Looking for a named entry.
+			uint16_t resourcesNDEs = GetU16(bitmapDBase + 0x0C) + (uint32_t) GetU16(bitmapDBase + 0x0E);
+			uint32_t resourcesNDEbase = bitmapDBase + 0x10;
+			while (resourcesNDEs) {
+				uint32_t name = GetU32(resourcesNDEbase);
+				// Actually a name?
+				if (name & 0x80000000) {
+					name = exe_reader_roffset(resource_ofs, name);
+					// Output::Debug("EXEReader::GetExfont : Name at %x.", name);
+					if (ResNameCheck(name, "EXFONT")) {
+						uint32_t dataent = GetU32(resourcesNDEbase + 4);
+						if (dataent & 0x80000000) {
+							dataent = exe_reader_roffset(resource_ofs, dataent);
+							dataent = resource_ofs + GetU32(dataent + 0x14);
+						}
+						uint32_t filebase = (GetU32(dataent) - resource_rva) + resource_ofs;
+						uint32_t filesize = GetU32(dataent + 0x04);
+						Output::Debug("EXEReader::GetExfont : EXFONT found (DE %x ; %x ; len %x), committing to extraction.", dataent, filebase, filesize);
+						exe_reader_perform_exfont_save(file, corefile, filebase, filesize);
+						return;
+					}
+				}
+				resourcesNDEbase += 8;
+				resourcesNDEs--;
+			}
+			Output::Debug("EXEReader::GetExfont : EXFONT not found in dbase at %x.", bitmapDBase);
+			return;
+		}
+		resourcesIDEbase += 8;
+		resourcesIDEs--;
+	}
+	Output::Debug("EXEReader::GetExfont : BITMAP not found.");
+	return;
+}
+
+uint8_t EXEReader::GetU8(uint32_t i) {
+	corefile.seekg(i, std::ios_base::beg);
+	int ch = corefile.get();
+	if (ch == -1)
+		ch = 0;
+	return (uint8_t) ch;
+}
+
+uint16_t EXEReader::GetU16(uint32_t i) {
+	uint16_t v = GetU8(i);
+	v |= ((uint32_t) GetU8(i + 1)) << 8;
+	return v;
+}
+
+uint32_t EXEReader::GetU32(uint32_t i) {
+	uint32_t v = GetU16(i);
+	v |= ((uint32_t) GetU16(i + 2)) << 16;
+	return v;
+}
+
+bool EXEReader::ResNameCheck(uint32_t i, const char * p) {
+	if (GetU16(i) != strlen(p))
+		return false;
+	while (*p) {
+		i += 2;
+		if (GetU16(i) != *p)
+			return false;
+		p++;
+	}
+	return true;
+}

--- a/src/exe_reader.h
+++ b/src/exe_reader.h
@@ -1,0 +1,59 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_EXE_READER_H
+#define EP_EXE_READER_H
+
+#include <string>
+#include <istream>
+#include "bitmap.h"
+
+/**
+ * Extracts resources from an EXE.
+ * The istream given is still owned by the parent,
+ *  but it is in use by the reader.
+ */
+class EXEReader {
+public:
+	// uint32_t is used here as:
+	// 1. everywhere else uses "unsigned", which is equally as odd...
+	// 2. max offset value is this size
+
+	EXEReader(std::istream & core);
+	~EXEReader();
+
+	// Extracts an EXFONT resource with BMP header if present,
+	//  and saves it in the appropriate place.
+	void GetExfont(std::string filename);
+private:
+	// Bounds-checked unaligned reader primitives.
+	// In case of out-of-bounds, returns 0 - this will usually result in a harmless error at some other level,
+	//  or a partial correct interpretation.
+	uint8_t GetU8(uint32_t point);
+	uint16_t GetU16(uint32_t point);
+	uint32_t GetU32(uint32_t point);
+
+	bool ResNameCheck(uint32_t namepoint, const char * name);
+
+	// 0 if resource section was unfindable.
+	uint32_t resource_ofs;
+	uint32_t resource_rva;
+
+	std::istream & corefile;
+};
+
+#endif

--- a/src/exe_reader.h
+++ b/src/exe_reader.h
@@ -18,8 +18,10 @@
 #ifndef EP_EXE_READER_H
 #define EP_EXE_READER_H
 
+#include <cstdint>
 #include <string>
 #include <istream>
+#include <vector>
 #include "bitmap.h"
 
 /**
@@ -33,13 +35,12 @@ public:
 	// 1. everywhere else uses "unsigned", which is equally as odd...
 	// 2. max offset value is this size
 
-	EXEReader(std::istream & core);
+	EXEReader(std::istream& core);
 	~EXEReader();
 
-	// Extracts an EXFONT resource with BMP header if present,
-	//  and saves it in the given place.
-	// Returns true on success.
-	bool GetExfont(std::string filename);
+	// Extracts an EXFONT resource with BMP header if present
+	// and returns exfont buffer on success.
+	std::vector<uint8_t> GetExFont();
 private:
 	// Bounds-checked unaligned reader primitives.
 	// In case of out-of-bounds, returns 0 - this will usually result in a harmless error at some other level,
@@ -48,13 +49,13 @@ private:
 	uint16_t GetU16(uint32_t point);
 	uint32_t GetU32(uint32_t point);
 
-	bool ResNameCheck(uint32_t namepoint, const char * name);
+	bool ResNameCheck(uint32_t namepoint, const char* name);
 
 	// 0 if resource section was unfindable.
 	uint32_t resource_ofs;
 	uint32_t resource_rva;
 
-	std::istream & corefile;
+	std::istream& corefile;
 };
 
 #endif

--- a/src/exe_reader.h
+++ b/src/exe_reader.h
@@ -37,8 +37,9 @@ public:
 	~EXEReader();
 
 	// Extracts an EXFONT resource with BMP header if present,
-	//  and saves it in the appropriate place.
-	void GetExfont(std::string filename);
+	//  and saves it in the given place.
+	// Returns true on success.
+	bool GetExfont(std::string filename);
 private:
 	// Bounds-checked unaligned reader primitives.
 	// In case of out-of-bounds, returns 0 - this will usually result in a harmless error at some other level,

--- a/src/options.h
+++ b/src/options.h
@@ -57,6 +57,21 @@
 /** INI configuration filename. */
 #define INI_NAME "RPG_RT.ini"
 
+/**
+ * EXE filename.
+ * Note that this is only used for EXFONT, and downloading RPG_RT.exe individually would probably cause complaints.
+ * So in case of Emscripten, instead the filename used is "exfont.dll",
+ *  which makes it clear the file is only being downloaded for the EXFONT resource.
+ * The best way to handle this is of course to just have people extracting the resource themselves,
+ *  but we can't really go around expecting people to do that.
+ * However much protection that gives... debate in PR comments.
+ */
+#ifndef EMSCRIPTEN
+#define EXE_NAME "RPG_RT.exe"
+#else
+#define EXE_NAME "exfont.dll"
+#endif
+
 /** Database filename. */
 #define DATABASE_NAME "RPG_RT.ldb"
 #define DATABASE_NAME_EASYRPG "EASY_RT.edb"

--- a/src/options.h
+++ b/src/options.h
@@ -57,21 +57,6 @@
 /** INI configuration filename. */
 #define INI_NAME "RPG_RT.ini"
 
-/**
- * EXE filename.
- * Note that this is only used for EXFONT, and downloading RPG_RT.exe individually would probably cause complaints.
- * So in case of Emscripten, instead the filename used is "exfont.dll",
- *  which makes it clear the file is only being downloaded for the EXFONT resource.
- * The best way to handle this is of course to just have people extracting the resource themselves,
- *  but we can't really go around expecting people to do that.
- * However much protection that gives... debate in PR comments.
- */
-#ifndef EMSCRIPTEN
-#define EXE_NAME "RPG_RT.exe"
-#else
-#define EXE_NAME "exfont.dll"
-#endif
-
 /** Database filename. */
 #define DATABASE_NAME "RPG_RT.ldb"
 #define DATABASE_NAME_EASYRPG "EASY_RT.edb"
@@ -79,6 +64,12 @@
 /** Map tree filename. */
 #define TREEMAP_NAME "RPG_RT.lmt"
 #define TREEMAP_NAME_EASYRPG "EASY_RT.emt"
+
+/**
+ * RPG_RT.exe (official engine) filename.
+ * Not used by emscripten.
+ */
+#define EXE_NAME "RPG_RT.exe"
 
 /** Default fps rate. */
 #define DEFAULT_FPS 60

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -692,26 +692,29 @@ void Player::CreateGameObjects() {
 
 	std::string exfont_file = FileFinder::FindImage(".", "ExFont");
 	if (exfont_file.empty()) {
-		Output::Debug("No EXFONT.");
 		std::shared_ptr<FileFinder::DirectoryTree> save_tree = FileFinder::CreateSaveDirectoryTree();
 		std::string filename = FileFinder::MakePath(save_tree->directory_path, "ExFont.bmp");
-		Output::Debug("No evidence of attempted EXFONT replacement, will try to extract from EXE.");
+		Output::Debug("No EXFONT - trying EXE");
 		// User does not apparently have a custom EXFONT, so be helpful and extract it for them.
 		std::string exep = FileFinder::FindDefault(EXE_NAME);
 		std::ifstream exe(exep, std::ios::binary);
-		EXEReader exe_reader = EXEReader(exe);
-		exe_reader.GetExfont(filename);
-		exe.close();
+		if (exe.fail()) {
+			Output::Debug("No access to EXE");
+		} else {
+			EXEReader exe_reader = EXEReader(exe);
+			exe_reader.GetExfont(filename);
+			exe.close();
 #ifdef EMSCRIPTEN
-		// From scene_save : Save changed file system
-		EM_ASM(
-			FS.syncfs(function(err) {
-			});
-		);
+			// From scene_save : Save changed file system
+			EM_ASM(
+				FS.syncfs(function(err) {
+				});
+			);
 #endif
-		// Supposedly having to do this is fixed in the VFS branch?
-		// Let's not bother with sanity
-		Cache::ForceLoadExfont();
+			// Supposedly having to do this is fixed in the VFS branch?
+			// Let's not bother with sanity
+			Cache::ForceLoadExfont();
+		}
 	}
 
 	ResetGameObjects();

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -120,14 +120,11 @@ void Scene_Logo::OnIndexReady(FileRequestResult*) {
 	tree->SetImportantFile(true);
 	FileRequestAsync* ini = AsyncHandler::RequestFile(INI_NAME);
 	ini->SetImportantFile(true);
-	FileRequestAsync* exe = AsyncHandler::RequestFile(EXE_NAME);
-	exe->SetImportantFile(true);
 	FileRequestAsync* exfont = AsyncHandler::RequestFile("ExFont");
 	exfont->SetImportantFile(true);
 
 	db->Start();
 	tree->Start();
 	ini->Start();
-	exe->Start();
 	exfont->Start();
 }

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -120,11 +120,14 @@ void Scene_Logo::OnIndexReady(FileRequestResult*) {
 	tree->SetImportantFile(true);
 	FileRequestAsync* ini = AsyncHandler::RequestFile(INI_NAME);
 	ini->SetImportantFile(true);
+	FileRequestAsync* exe = AsyncHandler::RequestFile(EXE_NAME);
+	exe->SetImportantFile(true);
 	FileRequestAsync* exfont = AsyncHandler::RequestFile("ExFont");
 	exfont->SetImportantFile(true);
 
 	db->Start();
 	tree->Start();
 	ini->Start();
+	exe->Start();
 	exfont->Start();
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -460,6 +460,20 @@ std::vector<std::string> Utils::Tokenize(const std::string &str_to_tokenize, con
 	return tokens;
 }
 
+std::vector<uint8_t> Utils::ReadStream(std::istream& stream) {
+	constexpr int buffer_incr = 8192;
+	std::vector<uint8_t> outbuf;
+
+	do {
+		outbuf.resize(outbuf.size() + buffer_incr);
+		stream.read(reinterpret_cast<char*>(outbuf.data() + outbuf.size() - buffer_incr), buffer_incr);
+	} while (stream.gcount() == buffer_incr);
+
+	outbuf.resize(outbuf.size() - buffer_incr + stream.gcount());
+
+	return outbuf;
+}
+
 std::string Utils::ReplacePlaceholders(const std::string& text_template, std::vector<char> types, std::vector<std::string> values) {
 	std::string str = text_template;
 	size_t index = str.find("%");

--- a/src/utils.h
+++ b/src/utils.h
@@ -231,6 +231,15 @@ namespace Utils {
 	template <typename F>
 	void ForEachLine(const std::string& line, F&& f);
 
+
+	/**
+	 * Reads a stream until EOF and returns the read bytes.
+	 *
+	 * @param stream input stream to read
+	 * @return content read from stream
+	 */
+	std::vector<uint8_t> ReadStream(std::istream& stream);
+
 	/**
 	 * Replaces placeholders (like %S, %O, %V, %U) in strings.
 	 *


### PR DESCRIPTION
While this code probably isn't perfect, it's hopefully simple and hopefully works (It seems to so far).
If no ExFont file is present as a known image, one will be written to the save directory.
NOTE: This occurs even if one is already in the save directory that is not recognized as a game directory image.
This quirk is so Emscripten-based game updates work properly.
Also, adds support for loading ExFont.bmp from the save directory.

So far, only tested with "Mother: Cognitive Dissonance", but EXFONT format does not appear to vary.