### PR TITLE
ZIP file support for standalone mode on Android.

### DIFF
--- a/builds/android/app/src/main/java/org/easyrpg/player/MainActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/MainActivity.java
@@ -70,7 +70,20 @@ public class MainActivity extends Activity {
             if (!(new File(dataDir + "/game").exists())) {
                 AssetUtils.copyFolder(assetManager, "game", dataDir + "/game");
             }
+        }
 
+        // Standalone mode: Unzip game.zip
+        if (AssetUtils.fileExists(assetManager, "game.zip")) {
+            Log.i("EasyRPG", "Standalone mode : a \"game.zip\" file is present inside the asset folder");
+            standaloneMode = true;
+
+            // Unzip game to internal memory
+            if (!(new File(dataDir + "/game").exists())) {
+                AssetUtils.unzipFile(assetManager, "game.zip", dataDir + "/game");
+            }
+        }
+
+        if (standaloneMode) {
             // Launch the game
             GameInformation project = new GameInformation(dataDir + "/game");
             GameBrowserHelper.launchGame(this, project);


### PR DESCRIPTION
Add support for reading the game from a ZIP file (game.zip) in standa…lone mode instead of a plain directory.

This addresses issues with filenames containing umlauts or other special characters not being allowed into AssetManager's asset bundle.
Also allows for compression to save space.