### PR TITLE
Generate quick light red translucid flash when step on damaged terrain.

### DIFF
--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -411,7 +411,7 @@ int Game_Party::GetRunCount() {
 	return data.escapes;
 }
 
-void Game_Party::ApplyDamage(int damage) {
+void Game_Party::ApplyDamage(int damage, bool lethal) {
 	if (damage <= 0) {
 		return;
 	}
@@ -420,7 +420,7 @@ void Game_Party::ApplyDamage(int damage) {
 
 	for (std::vector<Game_Actor*>::iterator i = actors.begin(); i != actors.end(); ++i) {
 		Game_Actor* actor = *i;
-		actor->SetHp(actor->GetHp() - damage);
+		actor->ChangeHp(lethal? -damage : - std::max<int>(0, std::min<int>(damage, actor->GetHp() - 1)));
 	}
 }
 

--- a/src/game_party.h
+++ b/src/game_party.h
@@ -232,8 +232,9 @@ public:
 	 * Used by damage terrain on the map.
 	 *
 	 * @param damage How many damage to apply
+	 * @param lethal If the damage can be lethal (kill a character) or not
 	 */
-	void ApplyDamage(int damage);
+	void ApplyDamage(int damage, bool lethal);
 
 	/**
 	 * Gets average level of the party (for battle)

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -718,7 +718,7 @@ void Game_Player::BeginMove() {
 		}
 		if (terrain->damage > 0) {
 			Main_Data::game_screen->FlashOnce(31, 10, 10, 19, 1);
-			Main_Data::game_party->ApplyDamage(terrain->damage);
+			Main_Data::game_party->ApplyDamage(terrain->damage, false);
 		}
 	} else {
 		Output::Warning("Player BeginMove: Invalid terrain ID %d at (%d, %d)", terrain_id, GetX(), GetY());

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -716,7 +716,10 @@ void Game_Player::BeginMove() {
 		if (!terrain->on_damage_se || (terrain->on_damage_se && (terrain->damage > 0))) {
 			Game_System::SePlay(terrain->footstep);
 		}
-		Main_Data::game_party->ApplyDamage(terrain->damage);
+		if (terrain->damage > 0) {
+			Main_Data::game_screen->FlashOnce(31, 10, 10, 19, 1);
+			Main_Data::game_party->ApplyDamage(terrain->damage);
+		}
 	} else {
 		Output::Warning("Player BeginMove: Invalid terrain ID %d at (%d, %d)", terrain_id, GetX(), GetY());
 	}


### PR DESCRIPTION
Problem: When stepping in damaged terrain and there's more than 0 damage, there's no flash indicating it.

Solution: Put that flash after trial and error getting the exact color, power and time. Also, no need to invoke the damage function to the party when the damage is 0.