### PR TITLE
[Regression fix] Stop sounds (OFF) / (...) only when CommandPlaySound is called.

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1488,7 +1488,7 @@ bool Game_Interpreter::CommandPlaySound(RPG::EventCommand const& com) { // code 
 	sound.volume = com.parameters[0];
 	sound.tempo = com.parameters[1];
 	sound.balance = com.parameters[2];
-	Game_System::SePlay(sound);
+	Game_System::SePlay(sound, true);
 	return true;
 }
 

--- a/src/game_system.h
+++ b/src/game_system.h
@@ -117,8 +117,9 @@ namespace Game_System {
 	 * Plays a Sound.
 	 *
 	 * @param se sound data.
+	 * @param stop_sounds If true stops all SEs when playing (OFF)/(...). Only used by the interpreter.
 	 */
-	void SePlay(RPG::Sound const& se);
+	void SePlay(RPG::Sound const& se, bool stop_sounds = false);
 
 	/**
 	 * Gets system graphic name.
@@ -244,7 +245,7 @@ namespace Game_System {
 	void PlayMemorizedBGM();
 
 	void OnBgmReady(FileRequestResult* result);
-	void OnSeReady(FileRequestResult* result, int volume, int tempo);
+	void OnSeReady(FileRequestResult* result, int volume, int tempo, bool stop_sounds);
 }
 
 #endif


### PR DESCRIPTION
Problem: An option where, if an (OFF), Empty or filename in parenthesis is called, makes all the sound effects stop (SE_Stop). This also happened in instances outside "CommandPlaySound" (where the creator puts it intentionally), for example in Battle sound animations for effects that include anything but a flash, and generated sound cuts everywhere.

Solution: Add in SePlay and OnSeReady an optional input bool "stop_sounds" (by default "false") that only stop all sounds if it's true, with the OnSeReady input being dependent of the SePlay input. We also put SePlay in CommandPlaySound with stop_sounds = true, the only case where we want it to.