### PR TITLE
ChangeHP, AddState and RemoveState changes.

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1204,26 +1204,6 @@ void Game_Actor::SetHp(int hp) {
 	GetData().current_hp = min(max(hp, 0), GetMaxHp());
 }
 
-void Game_Actor::ChangeHp(int hp) {
-	Game_Battler::ChangeHp(hp);
-
-	if (GetData().current_hp == 0) {
-		// Death
-		SetGauge(0);
-		RemoveAllStates();
-		SetDefending(false);
-		SetCharged(false);
-		AddState(1);
-	} else {
-		// Back to life
-		RemoveState(1);
-		if (GetHp() <= 0) {
-			// Reviving gives at least 1 Hp
-			SetHp(1);
-		}
-	}
-}
-
 void Game_Actor::SetSp(int sp) {
 	GetData().current_sp = min(max(sp, 0), GetMaxSp());
 }

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -805,16 +805,16 @@ void Game_Actor::ChangeLevel(int new_level, bool level_up_message) {
 		// At least level minimum
 		SetExp(max(GetBaseExp(), GetExp()));
 	} else if (new_level < old_level) {
-		// Set HP and SP to maximum possible value
-		SetHp(GetHp());
-		SetSp(GetSp());
-
 		// Experience adjustment:
 		// Level minimum if higher then Level maximum
 		if (GetExp() >= GetNextExp()) {
 			SetExp(GetBaseExp());
 		}
 	}
+
+	// Set HP and SP to maximum possible value
+	SetHp(GetHp());
+	SetSp(GetSp());
 }
 
 bool Game_Actor::IsEquippable(int item_id) const {

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -492,7 +492,6 @@ public:
 
 	int GetHp() const override;
 	void SetHp(int _hp) override;
-	void ChangeHp(int hp) override;
 
 	int GetSp() const override;
 	void SetSp(int _sp) override;

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -796,6 +796,7 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 		}
 		this->hp = (effect * (critical_hit ? 3 : 1) * (source->IsCharged() ? 2 : 1)) /
 			(GetTarget()->IsDefending() ? GetTarget()->HasStrongDefense() ? 3 : 2 : 1);
+		this->hp = std::min(this->hp, source->MaxDamageValue());
 
 		if (GetTarget()->GetHp() - this->hp <= 0) {
 			// Death state
@@ -955,6 +956,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 			}
 
 			int effect = (int)(skill.power * mul);
+			effect = std::min(effect, source->MaxDamageValue());
 
 			if (skill.affect_hp)
 				this->hp = std::max<int>(0, std::min<int>(effect, GetTarget()->GetMaxHp() - GetTarget()->GetHp()));
@@ -996,6 +998,8 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 			if (skill.affect_hp) {
 				this->hp = effect /
 					(GetTarget()->IsDefending() ? GetTarget()->HasStrongDefense() ? 3 : 2 : 1);
+
+				effect = std::min(effect, source->MaxDamageValue());
 
 				if (IsAbsorb())
 					this->hp = std::min<int>(hp, GetTarget()->GetHp());
@@ -1483,6 +1487,7 @@ bool Game_BattleAlgorithm::SelfDestruct::Execute() {
 
 	this->hp = effect / (
 		GetTarget()->IsDefending() ? GetTarget()->HasStrongDefense() ? 3 : 2 : 1);
+	this->hp = std::min(this->hp, source->MaxDamageValue());
 
 	if (GetTarget()->GetHp() - this->hp <= 0) {
 		// Death state

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -38,7 +38,7 @@ Game_Battler::Game_Battler() {
 }
 
 int Game_Battler::MaxDamageValue() const {
-	return Player::IsRPG2k ? 999 : 9999;
+	return Player::IsRPG2k() ? 999 : 9999;
 }
 
 bool Game_Battler::HasState(int state_id) const {
@@ -256,15 +256,16 @@ bool Game_Battler::UseItem(int item_id) {
 		return true;
 	}
 
+	// FIXME: For items with skills the user of the skill depends on the scope
 	switch (item->type) {
 		case RPG::Item::Type_weapon:
 		case RPG::Item::Type_shield:
 		case RPG::Item::Type_armor:
 		case RPG::Item::Type_helmet:
 		case RPG::Item::Type_accessory:
-			return item->use_skill && UseSkill(item->skill_id, Main_Data::game_party->GetHighestLeveledActor());
+			return item->use_skill && UseSkill(item->skill_id, this);
 		case RPG::Item::Type_special:
-			return UseSkill(item->skill_id, Main_Data::game_party->GetHighestLeveledActor());
+			return UseSkill(item->skill_id, this);
 	}
 
 	return false;

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -37,6 +37,10 @@ Game_Battler::Game_Battler() {
 	ResetBattle();
 }
 
+int Game_Battler::MaxDamageValue() const {
+	return Player::IsRPG2k ? 999 : 9999;
+}
+
 bool Game_Battler::HasState(int state_id) const {
 	const std::vector<int16_t> states = GetInflictedStates();
 
@@ -303,6 +307,7 @@ bool Game_Battler::UseSkill(int skill_id, Game_Battler* source) {
 
 		if (effect < 0)
 			effect = 0;
+		effect = std::min(effect, MaxDamageValue());
 
 		// Cure states
 		for (int i = 0; i < (int)skill->state_effects.size(); i++) {

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -43,6 +43,8 @@ public:
 	 */
 	Game_Battler();
 
+	int MaxDamageValue() const;
+
 	/**
 	 * Gets if battler has a state.
 	 *

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -339,9 +339,10 @@ public:
 	 * Does not reduce the MP, use Game_Party->UseSkill for this.
 	 *
 	 * @param skill_id ID of skill to use
+	 * @param source battler who threw the skill
 	 * @return true if skill affected anything
 	 */
-	virtual bool UseSkill(int skill_id);
+	virtual bool UseSkill(int skill_id, Game_Battler* source);
 
 	/**
 	 * Calculates the Skill costs including all modifiers.
@@ -602,6 +603,14 @@ public:
 	 * Initializes battle related data to there default values.
 	 */
 	virtual void ResetBattle();
+
+	/**
+	 * Gets the attribute multiplier percentage for this battler.
+	 *
+	 * @param attributes_set the attack's attribute set
+	 * @return the multiplier percentage
+	 */
+	float GetAttributeMultiplier(const std::vector<bool>& attributes_set) const;
 
 protected:
 	/** Gauge for RPG2k3 Battle */

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -131,22 +131,6 @@ void Game_Enemy::SetHp(int _hp) {
 	hp = std::min(std::max(_hp, 0), GetMaxHp());
 }
 
-void Game_Enemy::ChangeHp(int hp) {
-	SetHp(GetHp() + hp);
-
-	if (this->hp == 0) {
-		// Death
-		SetGauge(0);
-		SetDefending(false);
-		SetCharged(false);
-		RemoveAllStates();
-		AddState(1);
-	} else {
-		// Back to life
-		RemoveState(1);
-	}
-}
-
 void Game_Enemy::SetSp(int _sp) {
 	sp = std::min(std::max(_sp, 0), GetMaxSp());
 }

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -143,7 +143,6 @@ public:
 
 	int GetHp() const override;
 	void SetHp(int _hp) override;
-	void ChangeHp(int hp) override;
 
 	int GetSp() const override;
 	void SetSp(int _sp) override;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1438,9 +1438,9 @@ bool Game_Interpreter::CommandChangeCondition(RPG::EventCommand const& com) { //
 
 bool Game_Interpreter::CommandFullHeal(RPG::EventCommand const& com) { // Code 10490
 	for (const auto& actor : GetActors(com.parameters[0], com.parameters[1])) {
+		actor->RemoveAllStates();
 		actor->ChangeHp(actor->GetMaxHp());
 		actor->SetSp(actor->GetMaxSp());
-		actor->RemoveAllStates();
 	}
 
 	Game_Battle::SetNeedRefresh(true);

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -487,9 +487,9 @@ bool Game_Interpreter_Map::ContinuationShowInnStart(RPG::EventCommand const& /* 
 		// Full heal
 		std::vector<Game_Actor*> actors = Main_Data::game_party->GetActors();
 		for (Game_Actor* actor : actors) {
+			actor->RemoveAllStates();
 			actor->ChangeHp(actor->GetMaxHp());
 			actor->SetSp(actor->GetMaxSp());
-			actor->RemoveAllStates();
 		}
 		Graphics::GetTransition().Init(Transition::TransitionFadeOut, Scene::instance.get(), 36, true);
 		Game_System::BgmFade(800);

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -339,13 +339,13 @@ bool Game_Party::UseSkill(int skill_id, Game_Actor* source, Game_Actor* target) 
 	bool was_used = false;
 
 	if (target) {
-		was_used = target->UseSkill(skill_id);
+		was_used = target->UseSkill(skill_id, source);
 	}
 	else {
 		std::vector<Game_Actor*> actors = GetActors();
 		std::vector<Game_Actor*>::iterator it;
 		for (it = actors.begin(); it != actors.end(); ++it) {
-			was_used |= (*it)->UseSkill(skill_id);
+			was_used |= (*it)->UseSkill(skill_id, source);
 		}
 	}
 
@@ -621,4 +621,19 @@ bool Game_Party::ApplyStateDamage() {
 	}
 
 	return damage;
+}
+
+Game_Actor* Game_Party::GetHighestLeveledActor() const {
+	int max_level = -1;
+
+	for (auto actor : GetActors()) {
+		max_level = std::max(max_level, actor->GetLevel());
+	}
+	for (auto actor : GetActors()) {
+		if (actor->GetLevel() == max_level) {
+			return actor;
+		}
+	}
+
+	return nullptr;
 }

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -622,18 +622,3 @@ bool Game_Party::ApplyStateDamage() {
 
 	return damage;
 }
-
-Game_Actor* Game_Party::GetHighestLeveledActor() const {
-	int max_level = -1;
-
-	for (auto actor : GetActors()) {
-		max_level = std::max(max_level, actor->GetLevel());
-	}
-	for (auto actor : GetActors()) {
-		if (actor->GetLevel() == max_level) {
-			return actor;
-		}
-	}
-
-	return nullptr;
-}

--- a/src/game_party.h
+++ b/src/game_party.h
@@ -336,13 +336,6 @@ public:
 	 */
 	bool ApplyStateDamage();
 
-	/**
-	 * Gets the actor with the highest level. If there are many, choose the one with the earliest position in the group.
-	 *
-	 * @return The first Highest leveled actor.
-	 */
-	Game_Actor* GetHighestLeveledActor() const;
-
 private:
 	const RPG::SaveInventory& data() const;
 	RPG::SaveInventory& data();

--- a/src/game_party.h
+++ b/src/game_party.h
@@ -336,6 +336,13 @@ public:
 	 */
 	bool ApplyStateDamage();
 
+	/**
+	 * Gets the actor with the highest level. If there are many, choose the one with the earliest position in the group.
+	 *
+	 * @return The first Highest leveled actor.
+	 */
+	Game_Actor* GetHighestLeveledActor() const;
+
 private:
 	const RPG::SaveInventory& data() const;
 	RPG::SaveInventory& data();


### PR DESCRIPTION
The way RPG_RT works:
 - You cannot change a battler's HP when they're dead.
 - If ChangeHP kills a character, it adds the Death state to that battler.
 - When Death state is cured, even if alone, it always sets the HP to 1, instead of other functions.
 - When a character is caused Death, all the other states are erased; the defense, charge, gauge and stat modifiers are reset, and the current attribute shifts erased.

We implement all of this, with these particular changes:
 - Now there is no difference between Game_Actor::ChangeHP and Game_Enemy::ChangeHP, so we delete this function from both and add the ChangeHP characteristics to the superclass Game_Battler.
 - In Game_Battler::UseItem, the function now doesn't have to set the HP. However, it needs to have an int "revived" that checks if the character was revived, so in case the function heals HP too after dead, it substracts 1 since that value is automatically put after the Death state is removed. We also move the state cure before the HP change, so the Death State is cured before ChangeHP is executed (if this function was executed before Death state was cured, due to our new conditions, it wouldn't do anything).

---

Fixes #1128.