### PR TITLE
Fix missing background on battle test quit in emscripten

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -348,9 +348,9 @@ void Player::Exit() {
 	emscripten_cancel_main_loop();
 
 	BitmapRef surface = DisplayUi->GetDisplaySurface();
-	std::string error = "You can turn off your browser now.";
+	std::string message = "It's now safe to turn off\n      your browser.";
 
-	Text::Draw(*surface, 55, DisplayUi->GetHeight() / 2 - 6, Color(255, 255, 255, 255), Font::Default(), error);
+	Text::Draw(*surface, 84, DisplayUi->GetHeight() / 2 - 30, Color(221, 123, 64, 255), Font::Default(), message);
 	DisplayUi->UpdateDisplay();
 #endif
 

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -99,7 +99,7 @@ void Scene_Battle::TransitionIn() {
 }
 
 void Scene_Battle::TransitionOut() {
-	if (Player::exit_flag) {
+	if (Player::exit_flag || Player::battle_test_flag) {
 		Scene::TransitionOut();
 	}
 	else {


### PR DESCRIPTION
also, improve Win9x emulation with a proper message ;)

The proposed fix adds a black background before displaying the browser quit message by allowing transition out on battle quit when the battle test flag is set. Better approaches are welcome.