### PR TITLE
Fix Kanga Punch (1413), Shitigadianzu (1412) and minor stuff

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1345,9 +1345,12 @@ void Game_Actor::RemoveInvalidData() {
 	// through database editing. Hopefully no game uses negative levels.
 	if (GetLevel() == 0) {
 		Output::Debug("Actor %d: Special handling for level 0", GetId());
-	} else if (GetLevel() < 0 || GetLevel() > GetMaxLevel()) {
-		Output::Warning("Actor %d: Invalid level %d", GetId(), GetLevel());
+	} else if (GetLevel() < 0) {
+		Output::Warning("Actor %d: Invalid level %d, changed to 1", GetId(), GetLevel());
 		SetLevel(1);
+	} else if (GetLevel() > GetMaxLevel()) {
+		Output::Warning("Actor %d: Invalid level %d, changed to %d", GetId(), GetLevel(), GetMaxLevel());
+		SetLevel(GetMaxLevel());
 	}
 }
 

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -128,7 +128,7 @@ void Game_Character::MoveTo(int x, int y) {
 }
 
 int Game_Character::GetScreenX() const {
-	int x = GetRealX() / TILE_SIZE - Game_Map::GetDisplayX() / TILE_SIZE + (TILE_SIZE / 2);
+	int x = GetSpriteX() / TILE_SIZE - Game_Map::GetDisplayX() / TILE_SIZE + (TILE_SIZE / 2);
 
 	if (Game_Map::LoopHorizontal() && (x <= -TILE_SIZE / 2 || x > 0 || Game_Map::GetWidth() == 20)) {
 		int map_width = Game_Map::GetWidth() * TILE_SIZE;
@@ -139,7 +139,7 @@ int Game_Character::GetScreenX() const {
 }
 
 int Game_Character::GetScreenY() const {
-	int y = GetRealY() / TILE_SIZE - Game_Map::GetDisplayY() / TILE_SIZE + TILE_SIZE;
+	int y = GetSpriteY() / TILE_SIZE - Game_Map::GetDisplayY() / TILE_SIZE + TILE_SIZE;
 
 	if (Game_Map::LoopVertical()) {
 		int map_height = Game_Map::GetHeight() * TILE_SIZE;
@@ -818,7 +818,7 @@ int Game_Character::GetTileId() const {
 	return tile_id;
 }
 
-int Game_Character::GetRealX() const {
+int Game_Character::GetSpriteX() const {
 	int x = GetX() * SCREEN_TILE_WIDTH;
 
 	if (IsMoving()) {
@@ -833,7 +833,7 @@ int Game_Character::GetRealX() const {
 	return x;
 }
 
-int Game_Character::GetRealY() const {
+int Game_Character::GetSpriteY() const {
 	int y = GetY() * SCREEN_TILE_WIDTH;
 
 	if (IsMoving()) {

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -44,28 +44,28 @@ public:
 	~Game_Character();
 
 	/**
-	 * Gets x position.
+	 * Gets x position in tiles.
 	 *
 	 * @return x position.
 	 */
 	virtual int GetX() const = 0;
 
 	/**
-	 * Sets x position.
+	 * Sets x position in tiles.
 	 *
 	 * @param new_x new x position.
 	 */
 	virtual void SetX(int new_x) = 0;
 
 	/**
-	 * Gets y position.
+	 * Gets y position in tiles.
 	 *
 	 * @return y position.
 	 */
 	virtual int GetY() const = 0;
 
 	/**
-	 * Sets y position.
+	 * Sets y position in tiles.
 	 *
 	 * @param new_y new y position.
 	 */
@@ -512,14 +512,14 @@ public:
 	virtual void CancelMoveRoute();
 
 	/**
-	 * Gets screen x coordinate in pixels.
+	 * Gets sprite x coordinate transformed to screen coordinate in pixels.
 	 *
 	 * @return screen x coordinate in pixels.
 	 */
 	virtual int GetScreenX() const;
 
 	/**
-	 * Gets screen y coordinate in pixels.
+	 * Gets sprite y coordinate transformed to screen coordinate in pixels.
 	 *
 	 * @return screen y coordinate in pixels.
 	 */
@@ -540,18 +540,18 @@ public:
 	int GetTileId() const;
 
 	/**
-	 * Gets real x.
+	 * Gets sprite x position in pixels.
 	 *
 	 * @return real x.
 	 */
-	int GetRealX() const;
+	int GetSpriteX() const;
 
 	/**
-	 * Gets real y.
+	 * Gets sprite y position in pixels.
 	 *
 	 * @return real y.
 	 */
-	int GetRealY() const;
+	int GetSpriteY() const;
 
 	/**
 	 * Gets remaining step
@@ -584,6 +584,14 @@ public:
 	int DistanceXfromPlayer() const;
 	int DistanceYfromPlayer() const;
 
+	/**
+	 * Tests if the character is currently on the tile at x/y or moving
+	 * towards it.
+	 *
+	 * @param x X tile position
+	 * @param y Y tile position
+	 * @return If on tile or moving towards
+	 */
 	virtual bool IsInPosition(int x, int y) const;
 
 	virtual bool CheckEventTriggerTouch(int x, int y) = 0;

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -528,7 +528,7 @@ bool Game_Event::CheckEventTriggerTouch(int x, int y) {
 			return false;
 		}
 
-		if (Main_Data::game_player->IsInPosition(x, y) && !Main_Data::game_player->IsBlockedByMoveRoute()) {
+		if (Main_Data::game_player->IsInPosition(x, y)) {
 			if (Main_Data::game_player->InAirship() && GetLayer() == RPG::EventPage::Layers_same) {
 				return false;
 			}

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -523,7 +523,7 @@ bool Game_Event::CheckEventTriggerTouch(int x, int y) {
 	if (Game_Map::GetInterpreter().IsRunning())
 		return false;
 
-	if (trigger == RPG::EventPage::Trigger_collision && !IsJumping()) {
+	if (trigger == RPG::EventPage::Trigger_collision) {
 		if (Main_Data::game_player->IsInPosition(GetX(), GetY()) && GetLayer() == RPG::EventPage::Layers_same) {
 			return false;
 		}

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -280,9 +280,13 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 	bool same_direction_as_on_old_page = old_page && old_page->character_direction == new_page->character_direction;
 	animation_type = page->animation_type;
 
-	if (from_null || !(same_direction_as_on_old_page || IsMoving()) || IsDirectionFixed()) {
+	if (from_null || !(same_direction_as_on_old_page || IsMoving())) {
 		SetSpriteDirection(page->character_direction);
 		SetDirection(page->character_direction);
+	}
+
+	if (IsDirectionFixed()) {
+		SetSpriteDirection(page->character_direction);
 	}
 
 	SetOpacity(page->translucent ? 160 : 255);

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -297,8 +297,8 @@ bool Game_Player::IsTeleporting() const {
 }
 
 void Game_Player::Center() {
-	int x = GetRealX() + SCREEN_TILE_WIDTH;
-	int y = GetRealY() + SCREEN_TILE_WIDTH / 2;
+	int x = GetSpriteX() + SCREEN_TILE_WIDTH;
+	int y = GetSpriteY() + SCREEN_TILE_WIDTH / 2;
 
 	int dist_to_screen_left = -SCREEN_WIDTH / 2;
 	int dist_to_screen_top = -SCREEN_HEIGHT / 2;


### PR DESCRIPTION
I discovered the bogus level sanity check when loading one of the savegames bundled with Shitigadianzu (they are > max_level).

The GetReal -> GetSprite change is the first step for my fix of the collision tests in #886 but the function renaming alone doesn't hurt imo.