### PR TITLE
Regression fix

### DIFF
--- a/builds/cmake/Modules/FindSDL2.cmake
+++ b/builds/cmake/Modules/FindSDL2.cmake
@@ -236,7 +236,7 @@ if(SDL2_FOUND)
 		set_target_properties(SDL2::SDL2main
 			PROPERTIES
 			INTERFACE_LINK_LIBRARIES "${SDL2MAIN_LIBRARIES}")
-		
+
 		if(WIN32)
 			set_property(TARGET SDL2::SDL2 APPEND_STRING PROPERTY
 				INTERFACE_LINK_LIBRARIES "winmm;imm32;version")
@@ -248,11 +248,12 @@ if(SDL2_FOUND)
 			find_library(CARBON_LIBRARY Carbon)
 			find_library(COREAUDIO CoreAudio)
 			find_library(AUDIOTOOLBOX AudioToolbox)
+			find_library(AUDIOUNIT AudioUnit)
 			find_library(ICONV_LIBRARY iconv)
 			set_property(TARGET SDL2::SDL2 APPEND_STRING PROPERTY
 				INTERFACE_LINK_LIBRARIES ${COREVIDEO} ${COCOA_LIBRARY}
 					${IOKIT} ${FORCEFEEDBACK} ${CARBON_LIBRARY}
-					${COREAUDIO} ${AUDIOTOOLBOX} ${ICONV_LIBRARY})
+					${COREAUDIO} ${AUDIOTOOLBOX} ${AUDIOUNIT} ${ICONV_LIBRARY})
 		else()
 			# Remove -lSDL2 -lSDL2main from the pkg-config linker line,
 			# to prevent linking against the system library

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2327,6 +2327,12 @@ bool Game_Interpreter::CommandMoveEvent(RPG::EventCommand const& com) { // code 
 
 		RPG::MoveRoute route;
 		int move_freq = com.parameters[1];
+
+		if (move_freq <= 0 || move_freq > 8) {
+			// Invalid values
+			move_freq = 6;
+		}
+
 		route.repeat = com.parameters[2] != 0;
 		route.skippable = com.parameters[3] != 0;
 

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -154,10 +154,10 @@ TilemapLayer::TilemapLayer(int ilayer) :
 
 	// SubLayer for the tiles with Wall or Above passability
 	// Its z-value should be between the z of the events in the upper layer and the hero
-	sublayers.push_back(std::make_shared<TilemapSubLayer>(this, Priority_TilesetAbove));
+	sublayers.push_back(std::make_shared<TilemapSubLayer>(this, Priority_TilesetAbove + layer));
 	// SubLayer for the tiles without Wall or Above passability
 	// Its z-value should be under z of the events in the lower layer
-	sublayers.push_back(std::make_shared<TilemapSubLayer>(this, Priority_TilesetBelow));
+	sublayers.push_back(std::make_shared<TilemapSubLayer>(this, Priority_TilesetBelow + layer));
 }
 
 void TilemapLayer::DrawTile(Bitmap& screen, int x, int y, int row, int col) {
@@ -363,9 +363,9 @@ void TilemapLayer::CreateTileCache(const std::vector<short>& nmap_data) {
 			if (!passable.empty()) {
 				if (tile.ID >= BLOCK_F) { // Upper layer
 					if ((passable[substitutions[tile.ID - BLOCK_F]] & Passable::Above) != 0)
-						tile.z = Priority_TilesetAbove; // Upper sublayer
+						tile.z = Priority_TilesetAbove + 1; // Upper sublayer
 					else
-						tile.z = Priority_TilesetBelow; // Lower sublayer
+						tile.z = Priority_TilesetBelow + 1; // Lower sublayer
 
 				} else { // Lower layer
 					int chip_index =


### PR DESCRIPTION
The Drawable std::list -> std::vector change actually broke something because the stable sort of std::list.sort shadowed another bug introduced by the 2k3E z-layering code :/
The "+1" added matches what was there before (See e.g. 0.5.0).
