### PR TITLE
Support debug menu in battles

### DIFF
--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -38,6 +38,7 @@
 #include "scene_battle_rpg2k.h"
 #include "scene_battle_rpg2k3.h"
 #include "scene_gameover.h"
+#include "scene_debug.h"
 
 Scene_Battle::Scene_Battle() :
 	actor_index(0),
@@ -538,5 +539,11 @@ void Scene_Battle::ActionSelectedCallback(Game_Battler* for_battler) {
 
 	if (for_battler->GetType() == Game_Battler::Type_Ally) {
 		SetState(State_SelectActor);
+	}
+}
+
+void Scene_Battle::CallDebug() {
+	if (Player::debug_flag) {
+		Scene::Push(std::make_shared<Scene_Debug>());
 	}
 }

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -160,6 +160,9 @@ protected:
 	void CreateEnemyActionSkill(Game_Enemy* enemy, const RPG::EnemyAction* action);
 
 	void RemoveCurrentAction();
+
+	void CallDebug();
+
 	// Variables
 	State state;
 	State previous_state;

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -612,6 +612,9 @@ void Scene_Battle_Rpg2k::ProcessInput() {
 			break;
 		}
 	}
+	if (Input::IsTriggered(Input::DEBUG_MENU)) {
+		this->CallDebug();
+	}
 }
 
 void Scene_Battle_Rpg2k::OptionSelected() {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -834,6 +834,10 @@ void Scene_Battle_Rpg2k3::ProcessInput() {
 			break;
 		}
 	}
+
+	if (Input::IsTriggered(Input::DEBUG_MENU)) {
+		this->CallDebug();
+	}
 }
 
 void Scene_Battle_Rpg2k3::OptionSelected() {

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -34,6 +34,7 @@
 #include "window_varlist.h"
 #include "window_numberinput.h"
 #include "bitmap.h"
+#include "game_temp.h"
 
 Scene_Debug::Scene_Debug() {
 	Scene::type = Scene::Debug;
@@ -83,8 +84,12 @@ void Scene_Debug::Update() {
 			if (current_var_type == TypeGeneral) {
 				switch (range_window->GetIndex()) {
 					case 0:
-						Scene::PopUntil(Scene::Map);
-						Scene::Push(std::make_shared<Scene_Save>());
+						if (Game_Temp::battle_running) {
+							Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Buzzer));
+						} else {
+							Scene::PopUntil(Scene::Map);
+							Scene::Push(std::make_shared<Scene_Save>());
+						}
 						break;
 					case 1:
 						Scene::Push(std::make_shared<Scene_Load>());
@@ -183,6 +188,9 @@ void Scene_Debug::UpdateRangeListWindow() {
 	if (current_var_type != TypeSwitch &&
 			current_var_type != TypeInt) {
 		range_window->SetItemText(0, "Save");
+		if (Game_Temp::battle_running) {
+			range_window->DisableItem(0);
+		}
 		range_window->SetItemText(1, "Load");
 		for (int i = 2; i < 10; i++){
 			range_window->SetItemText(i, "");


### PR DESCRIPTION
Depends on: #1436 

This enables the F9 Debug menu during battles. Save is greyed out and disabled but Load is usable.

Testing this exposed a bug in `Scene_Load`, where the scene stack was not properly properly cleared. Any use of load from the debug menu in Player would keep pushing more stuff onto the stack.

In my case, because the `Scene_Battle` was never popped off the stack, the game loaded with `Game_Temp::battle_running == true` when on the map, which caused lots of errors to display on the screen.

The fix is to always unwind up to the title screen.

This was tested against a liblcf built from https://github.com/EasyRPG/liblcf/pull/242