### PR TITLE
Additional features for DebugMenu

### DIFF
--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -288,7 +288,7 @@ void Scene_Debug::UpdateRangeListWindow() {
 				addItem(i++, "Load", true);
 				addItem(i++, "Switches", true);
 				addItem(i++, "Variables", true);
-				addItem(i++, "Gold", true);
+				addItem(i++, Data::terms.gold.c_str(), true);
 				addItem(i++, "Items", true);
 				while (i < 10) {
 					addItem(i++, "", true);
@@ -330,7 +330,7 @@ void Scene_Debug::UpdateRangeListWindow() {
 			}
 			break;
 		case eGold:
-			range_window->SetItemText(0, "Gold");
+			range_window->SetItemText(0, Data::terms.gold);
 			for (int i = 1; i < 10; i++){
 				range_window->SetItemText(i, "");
 			}

--- a/src/scene_debug.h
+++ b/src/scene_debug.h
@@ -66,7 +66,8 @@ private:
 		eSwitch,
 		eVariable,
 		eGold,
-		eItem
+		eItem,
+		eBattle
 	};
 	/** Current variables being displayed (Switches or Integers). */
 	Mode mode = eMain;
@@ -86,6 +87,10 @@ private:
 	int prev_item_range_index = 0;
 	/** Last range page used for item */
 	int prev_item_range_page = 0;
+	/** Last range index used for troop */
+	int prev_troop_range_index = 0;
+	/** Last range page used for troop */
+	int prev_troop_range_page = 0;
 
 	/** Creates Range window. */
 	void CreateRangeWindow();

--- a/src/scene_debug.h
+++ b/src/scene_debug.h
@@ -74,6 +74,14 @@ private:
 	int range_page;
 	/** Current range being displayed. */
 	int range_index;
+	/** Last range_index used for switch */
+	int prev_switch_range_index = 0;
+	/** Last range page used for switch */
+	int prev_switch_range_page = 0;
+	/** Last range index used for variable */
+	int prev_variable_range_index = 0;
+	/** Last range page used for variable */
+	int prev_variable_range_page = 0;
 
 	/** Creates Range window. */
 	void CreateRangeWindow();

--- a/src/scene_debug.h
+++ b/src/scene_debug.h
@@ -64,7 +64,8 @@ private:
 	enum Mode {
 		eMain,
 		eSwitch,
-		eVariable
+		eVariable,
+		eGold
 	};
 	/** Current variables being displayed (Switches or Integers). */
 	Mode mode = eMain;

--- a/src/scene_debug.h
+++ b/src/scene_debug.h
@@ -60,20 +60,18 @@ public:
 	 */
 	int GetIndex();
 
-	enum VarType {
-		TypeInt,
-		TypeSwitch,
-		TypeGeneral,
-		TypeEnd
-	};
-
 private:
+	enum Mode {
+		eMain,
+		eSwitch,
+		eVariable
+	};
 	/** Current variables being displayed (Switches or Integers). */
-	int current_var_type;
+	Mode mode = eMain;
 	/** Current Page being displayed */
-	int range_page;
+	int range_page = 0;
 	/** Current range being displayed. */
-	int range_index;
+	int range_index = 0;
 	/** Last range_index used for switch */
 	int prev_switch_range_index = 0;
 	/** Last range page used for switch */
@@ -92,7 +90,10 @@ private:
 	/** Creates number input window. */
 	void CreateNumberInputWindow();
 
-	/** Displays a range selection for current var type. */
+	/** Get the last page for the current mode */
+	int GetLastPage();
+
+	/** Displays a range selection for mode. */
 	std::unique_ptr<Window_Command> range_window;
 	/** Displays the vars inside the current range. */
 	std::unique_ptr<Window_VarList> var_window;

--- a/src/scene_debug.h
+++ b/src/scene_debug.h
@@ -65,7 +65,8 @@ private:
 		eMain,
 		eSwitch,
 		eVariable,
-		eGold
+		eGold,
+		eItem
 	};
 	/** Current variables being displayed (Switches or Integers). */
 	Mode mode = eMain;
@@ -81,6 +82,10 @@ private:
 	int prev_variable_range_index = 0;
 	/** Last range page used for variable */
 	int prev_variable_range_page = 0;
+	/** Last range index used for item */
+	int prev_item_range_index = 0;
+	/** Last range page used for item */
+	int prev_item_range_page = 0;
 
 	/** Creates Range window. */
 	void CreateRangeWindow();

--- a/src/window_varlist.cpp
+++ b/src/window_varlist.cpp
@@ -22,6 +22,9 @@
 #include "game_switches.h"
 #include "game_variables.h"
 #include "bitmap.h"
+#include "data.h"
+#include "reader_util.h"
+#include "game_party.h"
 
 Window_VarList::Window_VarList(std::vector<std::string> commands) :
 Window_Command(commands, 224, 10) {
@@ -48,12 +51,28 @@ void Window_VarList::DrawItemValue(int index){
 	}
 	switch (mode) {
 		case eSwitch:
-			DrawItem(index, Font::ColorDefault);
-			contents->TextDraw(GetWidth() - 16, 16 * index + 2, (!Game_Switches[first_var+index]) ? Font::ColorCritical : Font::ColorDefault, Game_Switches[first_var+index] ? "[ON]" : "[OFF]", Text::AlignRight);
+			{
+				auto value = Game_Switches[first_var + index];
+				auto font = (!value) ? Font::ColorCritical : Font::ColorDefault;
+				DrawItem(index, Font::ColorDefault);
+				contents->TextDraw(GetWidth() - 16, 16 * index + 2, font, value ? "[ON]" : "[OFF]", Text::AlignRight);
+			}
 			break;
 		case eVariable:
-			DrawItem(index, Font::ColorDefault);
-			contents->TextDraw(GetWidth() - 16, 16 * index + 2, (Game_Variables[first_var+index] < 0) ? Font::ColorCritical : Font::ColorDefault, std::to_string(Game_Variables[first_var+index]), Text::AlignRight);
+			{
+				auto value = Game_Variables[first_var + index];
+				auto font = (value < 0) ? Font::ColorCritical : Font::ColorDefault;
+				DrawItem(index, Font::ColorDefault);
+				contents->TextDraw(GetWidth() - 16, 16 * index + 2, font, std::to_string(value), Text::AlignRight);
+			}
+			break;
+		case eItem:
+			{
+				auto value = Main_Data::game_party->GetItemCount(first_var + index);
+				auto font = (value == 0) ? Font::ColorCritical : Font::ColorDefault;
+				DrawItem(index, Font::ColorDefault);
+				contents->TextDraw(GetWidth() - 16, 16 * index + 2, font, std::to_string(value), Text::AlignRight);
+			}
 			break;
 	}
 }
@@ -73,6 +92,9 @@ void Window_VarList::UpdateList(int first_value){
 				break;
 			case eVariable:
 				ss << Game_Variables.GetName(first_value + i);
+				break;
+			case eItem:
+				ss << ReaderUtil::GetElement(Data::items, first_value+i)->name;
 				break;
 			default:
 				break;
@@ -109,6 +131,8 @@ bool Window_VarList::DataIsValid(int range_index) {
 			return Game_Switches.IsValid(range_index);
 		case eVariable:
 			return Game_Variables.IsValid(range_index);
+		case eItem:
+			return range_index > 0 && range_index <= Data::items.size();
 		default:
 			break;
 	}

--- a/src/window_varlist.cpp
+++ b/src/window_varlist.cpp
@@ -74,6 +74,12 @@ void Window_VarList::DrawItemValue(int index){
 				contents->TextDraw(GetWidth() - 16, 16 * index + 2, font, std::to_string(value), Text::AlignRight);
 			}
 			break;
+		case eTroop:
+			{
+				DrawItem(index, Font::ColorDefault);
+				contents->TextDraw(GetWidth() - 16, 16 * index + 2, Font::ColorDefault, "", Text::AlignRight);
+			}
+			break;
 	}
 }
 
@@ -95,6 +101,9 @@ void Window_VarList::UpdateList(int first_value){
 				break;
 			case eItem:
 				ss << ReaderUtil::GetElement(Data::items, first_value+i)->name;
+				break;
+			case eTroop:
+				ss << ReaderUtil::GetElement(Data::troops, first_value+i)->name;
 				break;
 			default:
 				break;
@@ -133,6 +142,8 @@ bool Window_VarList::DataIsValid(int range_index) {
 			return Game_Variables.IsValid(range_index);
 		case eItem:
 			return range_index > 0 && range_index <= Data::items.size();
+		case eTroop:
+			return range_index > 0 && range_index <= Data::troops.size();
 		default:
 			break;
 	}

--- a/src/window_varlist.h
+++ b/src/window_varlist.h
@@ -24,6 +24,11 @@
 class Window_VarList : public Window_Command
 {
 public:
+	enum Mode {
+		eNone,
+		eSwitch,
+		eVariable,
+	};
 	/**
 	 * Constructor.
 	 *
@@ -45,11 +50,11 @@ public:
 	void  Refresh();
 
 	/**
-	 * Indicate if item value displayed on the window correspond to switches or variables.
+	 * Indicate what to display.
 	 *
-	 * @param _switch true to display switches, false to display variables.
+	 * @param mode the mode to set.
 	 */
-	void SetShowSwitch(bool _switch);
+	void SetMode(Mode mode);
 
 	/**
 	 * Overwrite SetActive to hide/show selection rect when window is disabled.
@@ -72,9 +77,11 @@ private:
 	 */
 	void DrawItemValue(int index);
 
-	bool show_switch;
-	int first_var;
-	int hidden_index;
+	Mode mode = eNone;
+	int first_var = 0;
+	int hidden_index = 0;
+
+	bool DataIsValid(int range_index);
 
 };
 

--- a/src/window_varlist.h
+++ b/src/window_varlist.h
@@ -29,6 +29,7 @@ public:
 		eSwitch,
 		eVariable,
 	};
+
 	/**
 	 * Constructor.
 	 *
@@ -68,6 +69,11 @@ public:
 	 */
 	int GetIndex();
 
+	/**
+	 * Returns the current mode.
+	 */
+	Mode GetMode() const;
+
 private:
 
 	/**
@@ -84,5 +90,9 @@ private:
 	bool DataIsValid(int range_index);
 
 };
+
+inline Window_VarList::Mode Window_VarList::GetMode() const {
+	return mode;
+}
 
 #endif

--- a/src/window_varlist.h
+++ b/src/window_varlist.h
@@ -28,6 +28,7 @@ public:
 		eNone,
 		eSwitch,
 		eVariable,
+		eItem,
 	};
 
 	/**

--- a/src/window_varlist.h
+++ b/src/window_varlist.h
@@ -29,6 +29,7 @@ public:
 		eSwitch,
 		eVariable,
 		eItem,
+		eTroop,
 	};
 
 	/**


### PR DESCRIPTION
This adds new features to the debug menu. This makes it less compatible with the original debug menu in rm2/3, but I don't think that's important compared to the benefit here.

* Uses a 2 level menu system instead of left - right scrolling through everything. Makes it faster to go through variables and switches.
* Add support for changing party gold
* Add support for changing party items
* Add support for starting battles
* Use instant transition, just like with call menu for faster response

![debug](https://user-images.githubusercontent.com/1198466/46647369-9eb72580-cb5d-11e8-998b-96189234ae76.png)
![items](https://user-images.githubusercontent.com/1198466/46647376-a1197f80-cb5d-11e8-8bc0-ad1e3b4a75e7.png)
