### PR TITLE
Scene_Debug: Support debug menu in battles & use instant transition 

### DIFF
--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -96,11 +96,16 @@ void Scene_Battle::Start() {
 }
 
 void Scene_Battle::TransitionIn() {
-	Graphics::GetTransition().Init((Transition::TransitionType)Game_System::GetTransition(Game_System::Transition_BeginBattleShow), this, 32);
+	if (Game_Temp::transition_menu) {
+		Game_Temp::transition_menu = false;
+		Scene::TransitionIn();
+	} else {
+		Graphics::GetTransition().Init((Transition::TransitionType)Game_System::GetTransition(Game_System::Transition_BeginBattleShow), this, 32);
+	}
 }
 
 void Scene_Battle::TransitionOut() {
-	if (Player::exit_flag || Player::battle_test_flag) {
+	if (Player::exit_flag || Player::battle_test_flag || Game_Temp::transition_menu) {
 		Scene::TransitionOut();
 	}
 	else {
@@ -544,6 +549,7 @@ void Scene_Battle::ActionSelectedCallback(Game_Battler* for_battler) {
 
 void Scene_Battle::CallDebug() {
 	if (Player::debug_flag) {
+		Game_Temp::transition_menu = true;
 		Scene::Push(std::make_shared<Scene_Debug>());
 	}
 }

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -38,6 +38,7 @@
 #include "scene_battle_rpg2k.h"
 #include "scene_battle_rpg2k3.h"
 #include "scene_gameover.h"
+#include "scene_debug.h"
 
 Scene_Battle::Scene_Battle() :
 	actor_index(0),
@@ -538,5 +539,11 @@ void Scene_Battle::ActionSelectedCallback(Game_Battler* for_battler) {
 
 	if (for_battler->GetType() == Game_Battler::Type_Ally) {
 		SetState(State_SelectActor);
+	}
+}
+
+void Scene_Battle::CallDebug() {
+	if (Player::debug_flag) {
+		Scene::Push(std::make_shared<Scene_Debug>());
 	}
 }

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -160,6 +160,9 @@ protected:
 	void CreateEnemyActionSkill(Game_Enemy* enemy, const RPG::EnemyAction* action);
 
 	void RemoveCurrentAction();
+
+	void CallDebug();
+
 	// Variables
 	State state;
 	State previous_state;

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -612,6 +612,9 @@ void Scene_Battle_Rpg2k::ProcessInput() {
 			break;
 		}
 	}
+	if (Input::IsTriggered(Input::DEBUG_MENU)) {
+		this->CallDebug();
+	}
 }
 
 void Scene_Battle_Rpg2k::OptionSelected() {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -834,6 +834,10 @@ void Scene_Battle_Rpg2k3::ProcessInput() {
 			break;
 		}
 	}
+
+	if (Input::IsTriggered(Input::DEBUG_MENU)) {
+		this->CallDebug();
+	}
 }
 
 void Scene_Battle_Rpg2k3::OptionSelected() {

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -34,6 +34,7 @@
 #include "window_varlist.h"
 #include "window_numberinput.h"
 #include "bitmap.h"
+#include "game_temp.h"
 
 Scene_Debug::Scene_Debug() {
 	Scene::type = Scene::Debug;
@@ -83,8 +84,12 @@ void Scene_Debug::Update() {
 			if (current_var_type == TypeGeneral) {
 				switch (range_window->GetIndex()) {
 					case 0:
-						Scene::PopUntil(Scene::Map);
-						Scene::Push(std::make_shared<Scene_Save>());
+						if (Game_Temp::battle_running) {
+							Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Buzzer));
+						} else {
+							Scene::PopUntil(Scene::Map);
+							Scene::Push(std::make_shared<Scene_Save>());
+						}
 						break;
 					case 1:
 						Scene::Push(std::make_shared<Scene_Load>());
@@ -183,6 +188,9 @@ void Scene_Debug::UpdateRangeListWindow() {
 	if (current_var_type != TypeSwitch &&
 			current_var_type != TypeInt) {
 		range_window->SetItemText(0, "Save");
+		if (Game_Temp::battle_running) {
+			range_window->DisableItem(0);
+		}
 		range_window->SetItemText(1, "Load");
 		for (int i = 2; i < 10; i++){
 			range_window->SetItemText(i, "");

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -46,6 +46,10 @@ Scene_Map::Scene_Map(bool from_save) :
 	type = Scene::Map;
 }
 
+Scene_Map::~Scene_Map() {
+	Game_Temp::transition_menu = false;
+}
+
 void Scene_Map::Start() {
 	spriteset.reset(new Spriteset_Map());
 	message_window.reset(new Window_Message(0, SCREEN_TARGET_HEIGHT - 80, SCREEN_TARGET_WIDTH, 80));
@@ -303,6 +307,7 @@ void Scene_Map::CallLoad() {
 
 void Scene_Map::CallDebug() {
 	if (Player::debug_flag) {
+		Game_Temp::transition_menu = true;
 		Scene::Push(std::make_shared<Scene_Debug>());
 	}
 }

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -34,6 +34,8 @@ public:
 	 */
 	Scene_Map(bool from_save = false);
 
+	~Scene_Map();
+
 	void Start() override;
 	void Continue() override;
 	void Update() override;


### PR DESCRIPTION
Depends on #1430

This change treats the debug menu similar to the main menu. The screen transitions are made to be fast.

Currently in master normal transitions are used to and from debug menu which is jarring and slow. It makes it painful to use and it's not how `RPG_RT.exe` does it.