### PR TITLE
Reset Game_Temp globals when loading saved game.

### DIFF
--- a/src/game_temp.cpp
+++ b/src/game_temp.cpp
@@ -57,6 +57,7 @@ void Game_Temp::Init() {
 	menu_calling = false;
 	battle_calling = false;
 	shop_calling = false;
+	inn_calling = false;
 	name_calling = false;
 	save_calling = false;
 	load_calling = false;
@@ -70,6 +71,8 @@ void Game_Temp::Init() {
 	shop_sells = true;
 	shop_type = 0;
 	shop_handlers = false;
+	shop_goods = {};
+	shop_transaction = false;
 	inn_price = 0;
 	inn_handlers = false;
 	hero_name = "";
@@ -77,10 +80,11 @@ void Game_Temp::Init() {
 	hero_name_charset = 0;
 	battle_running = false;
 	battle_troop_id = 0;
-	battle_background = "";
+	battle_background = {};
 	battle_formation = 0;
 	battle_escape_mode = -1;
 	battle_defeat_mode = 0;
 	battle_first_strike = false;
+	battle_result = 0;
 	restart_title_cache = false;
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -786,6 +786,7 @@ void Player::LoadSavegame(const std::string& save_name) {
 		Output::Error("%s", LcfReader::GetError().c_str());
 	}
 
+	Scene::PopUntil(Scene::Title);
 	Game_Temp::Init();
 
 	Main_Data::game_data = *save.get();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -786,6 +786,8 @@ void Player::LoadSavegame(const std::string& save_name) {
 		Output::Error("%s", LcfReader::GetError().c_str());
 	}
 
+	Game_Temp::Init();
+
 	Main_Data::game_data = *save.get();
 	Main_Data::game_data.system.Fixup();
 

--- a/src/scene_load.cpp
+++ b/src/scene_load.cpp
@@ -41,7 +41,6 @@ void Scene_Load::Action(int index) {
 	Player::LoadSavegame(save_name);
 	Game_Temp::restart_title_cache = true;
 
-	Scene::PopUntil(Scene::Title);
 	Scene::Push(std::make_shared<Scene_Map>(true));
 }
 


### PR DESCRIPTION
When a game is loaded from the title screen, all of the Game_Temp statics are set to their default values.

This patch resets them any time a saved game is loaded. This provides consistently and rules out classes of bugs that could occur when loading games from different contexts.