### PR TITLE
Pop all scenes when loading game

### DIFF
--- a/src/scene_load.cpp
+++ b/src/scene_load.cpp
@@ -41,7 +41,8 @@ void Scene_Load::Action(int index) {
 	Player::LoadSavegame(save_name);
 	Game_Temp::restart_title_cache = true;
 
-	Scene::Push(std::make_shared<Scene_Map>(true), true);
+	Scene::PopUntil(Scene::Title);
+	Scene::Push(std::make_shared<Scene_Map>(true));
 }
 
 bool Scene_Load::IsSlotValid(int index) {


### PR DESCRIPTION
Fixes bugs when loading game debug menu. The stack would keep the old
maps and game state. This breaks when you try to load from battle.