### PR TITLE
Albeleons's Battle fixes 1 of N

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1031,7 +1031,8 @@ int Game_Actor::GetBattleY() const {
 }
 
 const std::string& Game_Actor::GetSkillName() const {
-	return GetActor().skill_name;
+	auto& a = GetActor();
+	return a.rename_skill ? a.skill_name : Data::terms.command_skill;
 }
 
 void Game_Actor::SetName(const std::string &new_name) {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1293,16 +1293,11 @@ void Game_BattleAlgorithm::Item::GetResultMessages(std::vector<std::string>& out
 }
 
 const RPG::Sound* Game_BattleAlgorithm::Item::GetStartSe() const {
-	if (item.type == RPG::Item::Type_switch) {
+	if (item.type == RPG::Item::Type_medicine || item.type == RPG::Item::Type_switch) {
 		return &Game_System::GetSystemSE(Game_System::SFX_UseItem);
 	}
 	else {
-		if (source->GetType() == Game_Battler::Type_Enemy) {
-			return &Game_System::GetSystemSE(Game_System::SFX_EnemyAttacks);
-		}
-		else {
-			return NULL;
-		}
+		return NULL;
 	}
 }
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -184,7 +184,7 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetDeathMessage() const {
 	}
 
 	bool is_ally = GetTarget()->GetType() == Game_Battler::Type_Ally;
-	const RPG::State* state = GetTarget()->GetSignificantState();
+	const RPG::State* state = ReaderUtil::GetElement(Data::states, 1);
 	const std::string& message = is_ally ? state->message_actor
 										: state->message_enemy;
 
@@ -804,7 +804,7 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 				if (weapon) {
 					for (unsigned int i = 0; i < weapon->state_set.size(); i++) {
 						if (weapon->state_set[i]) {
-							const RPG::State* state = ReaderUtil::GetElement(Data::states, weapon->state_set[i]);
+							const RPG::State* state = ReaderUtil::GetElement(Data::states, i + 1);
 							if (!state) {
 								Output::Warning("Algorithm Normal: Weapon %d causes invalid state %d", weapon->ID, weapon->state_set[i]);
 								continue;

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -231,7 +231,7 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetHpSpRecoveredMessage(int val
 			particle = particle2 = " ";
 		}
 		ss << particle << points << particle2;
-		ss << GetAffectedHp() << space << Data::terms.hp_recovery;
+		ss << value << space << Data::terms.hp_recovery;
 		return ss.str();
 	}
 }
@@ -301,7 +301,7 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetHpSpAbsorbedMessage(int valu
 		} else {
 			particle = particle2 = " ";
 		}
-		ss << particle << Data::terms.health_points << particle2;
+		ss << particle << points << particle2;
 		ss << value << space << message;
 
 		return ss.str();

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -427,7 +427,7 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 		if (IsPositive()) {
 			out.push_back(GetHpSpRecoveredMessage(GetAffectedSp(), Data::terms.spirit_points));
 		}
-		else {
+		else if (GetAffectedSp() > 0) {
 			if (IsAbsorb()) {
 				out.push_back(GetHpSpAbsorbedMessage(GetAffectedSp(), Data::terms.spirit_points));
 			}
@@ -437,19 +437,19 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 		}
 	}
 
-	if (GetAffectedAttack() != -1) {
+	if (GetAffectedAttack() > 0) {
 		out.push_back(GetParameterChangeMessage(IsPositive(), GetAffectedAttack(), Data::terms.attack));
 	}
 
-	if (GetAffectedDefense() != -1) {
+	if (GetAffectedDefense() > 0) {
 		out.push_back(GetParameterChangeMessage(IsPositive(), GetAffectedDefense(), Data::terms.defense));
 	}
 
-	if (GetAffectedSpirit() != -1) {
+	if (GetAffectedSpirit() > 0) {
 		out.push_back(GetParameterChangeMessage(IsPositive(), GetAffectedSpirit(), Data::terms.spirit));
 	}
 
-	if (GetAffectedAgility() != -1) {
+	if (GetAffectedAgility() > 0) {
 		out.push_back(GetParameterChangeMessage(IsPositive(), GetAffectedAgility(), Data::terms.agility));
 	}
 
@@ -943,8 +943,6 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 	if (skill.type == RPG::Skill::Type_normal ||
 		skill.type >= RPG::Skill::Type_subskill) {
 		if (this->healing) {
-			this->success = true;
-
 			float mul = GetAttributeMultiplier(skill.attribute_effects);
 			if (mul < 0.5f) {
 				// Determined via testing, the heal is always at least 50%
@@ -965,10 +963,11 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				this->spirit = effect;
 			if (skill.affect_agility)
 				this->agility = effect;
+
+			this->success = GetAffectedHp() != -1 || GetAffectedSp() != -1 || GetAffectedAttack() > 0
+				|| GetAffectedDefense() > 0 || GetAffectedSpirit() > 0 || GetAffectedAgility() > 0;
 		}
 		else if (Utils::GetRandomNumber(0, 99) < skill.hit) {
-			this->success = true;
-
 			int effect = skill.power +
 				source->GetAtk() * skill.physical_rate / 20 +
 				source->GetSpi() * skill.magical_rate / 40;
@@ -1009,6 +1008,9 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				this->spirit = effect;
 			if (skill.affect_agility)
 				this->agility = effect;
+
+			this->success = (GetAffectedHp() != -1 && !IsAbsorb()) || (GetAffectedHp() > 0 && IsAbsorb()) || GetAffectedSp() > 0 || GetAffectedAttack() > 0
+				|| GetAffectedDefense() > 0 || GetAffectedSpirit() > 0 || GetAffectedAgility() > 0;
 		}
 
 		for (int i = 0; i < (int) skill.state_effects.size(); i++) {

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -154,6 +154,13 @@ public:
 	bool IsPositive() const;
 
 	/**
+	 * Gets whether the action had absorb component.
+	 *
+	 * @return Whether action was absorb
+	 */
+	bool IsAbsorb() const;
+
+	/**
 	 * Gets the Battle Animation that is assigned to the Algorithm
 	 *
 	 * @return Battle Animation or NULL if no animation is assigned

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -352,6 +352,22 @@ void Game_Battler::SetAgiModifier(int modifier) {
 	agi_modifier = modifier;
 }
 
+void Game_Battler::ChangeAtkModifier(int modifier) {
+	SetAtkModifier(atk_modifier + modifier);
+}
+
+void Game_Battler::ChangeDefModifier(int modifier) {
+	SetDefModifier(def_modifier + modifier);
+}
+
+void Game_Battler::ChangeSpiModifier(int modifier) {
+	SetSpiModifier(spi_modifier + modifier);
+}
+
+void Game_Battler::ChangeAgiModifier(int modifier) {
+	SetAgiModifier(agi_modifier + modifier);
+}
+
 void Game_Battler::AddState(int state_id) {
 	const RPG::State* state = ReaderUtil::GetElement(Data::states, state_id);
 	if (!state) {

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -379,6 +379,14 @@ public:
 	 */
 	void SetAgiModifier(int modifier);
 
+	void ChangeAtkModifier(int modifier);
+
+	void ChangeDefModifier(int modifier);
+
+	void ChangeSpiModifier(int modifier);
+
+	void ChangeAgiModifier(int modifier);
+
 	/**
 	 * Adds a State.
 	 *

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -29,6 +29,7 @@
 #include "player.h"
 #include "game_temp.h"
 #include "game_map.h"
+#include "spriteset_battle.h"
 
 Game_Interpreter_Battle::Game_Interpreter_Battle(int depth, bool main_flag) :
 	Game_Interpreter(depth, main_flag) {
@@ -161,6 +162,9 @@ bool Game_Interpreter_Battle::CommandChangeMonsterHP(RPG::EventCommand const& co
 	bool lose = com.parameters[1] > 0;
 	int hp = enemy.GetHp();
 
+	if (enemy.IsDead())
+		return true;
+
 	int change = 0;
 	switch (com.parameters[2]) {
 	case 0:
@@ -219,9 +223,15 @@ bool Game_Interpreter_Battle::CommandChangeMonsterCondition(RPG::EventCommand co
 	int state_id = com.parameters[2];
 	if (remove) {
 		enemy.RemoveState(state_id);
+		if (state_id == 1) {
+			enemy.SetHp(1);
+			Game_Battle::GetSpriteset().FindBattler(&enemy)->SetVisible(true);
+			Game_Battle::SetNeedRefresh(true);
+		}
 	} else {
 		if (state_id == 1) {
 			enemy.ChangeHp(-enemy.GetHp());
+			Game_Battle::GetSpriteset().FindBattler(&enemy)->SetVisible(false);
 			Game_Battle::SetNeedRefresh(true);
 		}
 		enemy.AddState(state_id);

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -40,10 +40,6 @@ bool Game_Interpreter_Battle::ExecuteCommand() {
 		return CommandEnd();
 	}
 
-	if (Game_Battle::IsBattleAnimationWaiting()) {
-		return false;
-	}
-
 	RPG::EventCommand const& com = list[index];
 
 	switch (com.code) {

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -235,6 +235,7 @@ void Scene_Battle::EnemySelected() {
 		}
 	}
 
+	Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 	ActionSelectedCallback(active_actor);
 }
 
@@ -258,6 +259,7 @@ void Scene_Battle::AllySelected() {
 		assert("Invalid previous state for ally selection" && false);
 	}
 
+	Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 	ActionSelectedCallback(active_actor);
 }
 

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -106,7 +106,7 @@ void Scene_Battle::TransitionIn() {
 }
 
 void Scene_Battle::TransitionOut() {
-	if (Player::exit_flag || Player::battle_test_flag || Game_Temp::transition_menu) {
+	if (Player::exit_flag || Player::battle_test_flag || Game_Temp::transition_menu || Scene::instance->type == Scene::Title) {
 		Scene::TransitionOut();
 	}
 	else {

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -89,9 +89,9 @@ void Scene_Battle::Start() {
 	auto_battle = false;
 	enemy_action = NULL;
 
-	CreateUi();
-
 	Game_System::BgmPlay(Game_System::GetSystemBGM(Game_System::BGM_Battle));
+
+	CreateUi();
 
 	SetState(State_Start);
 }

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -593,12 +593,12 @@ void Scene_Battle_Rpg2k::ProcessInput() {
 			--actor_index;
 			SelectPreviousActor();
 			break;
-		case State_SelectEnemyTarget:
 		case State_SelectItem:
 		case State_SelectSkill:
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cancel));
 			SetState(State_SelectCommand);
 			break;
+		case State_SelectEnemyTarget:
 		case State_SelectAllyTarget:
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cancel));
 			SetState(previous_state);

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -102,9 +102,7 @@ void Scene_Battle_Rpg2k::CreateBattleCommandWindow() {
 }
 
 void Scene_Battle_Rpg2k::RefreshCommandWindow() {
-	std::string skill_name = active_actor->GetSkillName();
-	command_window->SetItemText(1,
-		skill_name.empty() ? Data::terms.command_skill : skill_name);
+	command_window->SetItemText(1, active_actor->GetSkillName());
 }
 
 void Scene_Battle_Rpg2k::SetState(Scene_Battle::State new_state) {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -678,9 +678,6 @@ void Scene_Battle_Rpg2k::Escape() {
 		escape_success = escape_alg.Execute();
 		escape_alg.Apply();
 
-		if (escape_success)
-			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Escape));
-
 		battle_result_messages.clear();
 		escape_alg.GetResultMessages(battle_result_messages);
 
@@ -695,6 +692,8 @@ void Scene_Battle_Rpg2k::Escape() {
 			escape_counter = 0;
 
 			if (escape_success) {
+				Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Escape));
+
 				Game_Temp::battle_result = Game_Temp::BattleEscape;
 
 				Scene::Pop();

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -822,7 +822,7 @@ void Scene_Battle_Rpg2k::CreateExecutionOrder() {
 
 void Scene_Battle_Rpg2k::CreateEnemyActions() {
 	std::vector<Game_Battler*> enemies;
-	Main_Data::game_enemyparty->GetBattlers(enemies);
+	Main_Data::game_enemyparty->GetActiveBattlers(enemies);
 
 	for (Game_Battler* battler : enemies) {
 		if (!battler->CanAct()) {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -646,19 +646,21 @@ void Scene_Battle_Rpg2k::OptionSelected() {
 }
 
 void Scene_Battle_Rpg2k::CommandSelected() {
-	Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 
 	switch (command_window->GetIndex()) {
 		case 0: // Attack
 			AttackSelected();
 			break;
 		case 1: // Skill
+			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 			SetState(State_SelectSkill);
 			break;
 		case 2: // Defense
+			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 			DefendSelected();
 			break;
 		case 3: // Item
+			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 			SetState(State_SelectItem);
 			break;
 		default:

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -149,7 +149,8 @@ void Scene_Battle_Rpg2k::SetState(Scene_Battle::State new_state) {
 	case State_SelectSkill:
 		skill_window->SetActive(true);
 		skill_window->SetActor(active_actor->GetId());
-		skill_window->SetIndex(0);
+		if (previous_state == State_SelectCommand)
+			skill_window->SetIndex(0);
 		break;
 	case State_Victory:
 	case State_Defeat:

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -925,11 +925,11 @@ void Scene_Battle_Rpg2k::PushExperienceGainedMessage(int exp) {
 				Data::terms.exp_received,
 				{'V', 'U'},
 				{ss.str(), Data::terms.exp_short}
-			)
+			) + Player::escape_symbol + "."
 		);
 	}
 	else {
-		ss << exp << Data::terms.exp_received;
+		ss << exp << Data::terms.exp_received << Player::escape_symbol << ".";
 		Game_Message::texts.push_back(ss.str());
 	}
 }
@@ -944,11 +944,11 @@ void Scene_Battle_Rpg2k::PushGoldReceivedMessage(int money) {
 				Data::terms.gold_recieved_a,
 				{'V', 'U'},
 				{ss.str(), Data::terms.gold}
-			)
+			) + Player::escape_symbol + "."
 		);
 	}
 	else {
-		ss << Data::terms.gold_recieved_a << " " << money << Data::terms.gold << Data::terms.gold_recieved_b;
+		ss << Data::terms.gold_recieved_a << " " << money << Data::terms.gold << Data::terms.gold_recieved_b << Player::escape_symbol << ".";
 		Game_Message::texts.push_back(ss.str());
 	}
 }
@@ -970,12 +970,12 @@ void Scene_Battle_Rpg2k::PushItemRecievedMessages(std::vector<int> drops) {
 					Data::terms.item_recieved,
 					{'S'},
 					{item_name}
-				)
+				) + Player::escape_symbol + "."
 			);
 		}
 		else {
 			ss.str("");
-			ss << item_name << Data::terms.item_recieved;
+			ss << item_name << Data::terms.item_recieved << Player::escape_symbol << ".";
 			Game_Message::texts.push_back(ss.str());
 		}
 	}
@@ -992,7 +992,7 @@ bool Scene_Battle_Rpg2k::CheckWin() {
 		Main_Data::game_enemyparty->GenerateDrops(drops);
 
 		Game_Message::is_word_wrapped = Player::IsRPG2kE();
-		Game_Message::texts.push_back(Data::terms.victory);
+		Game_Message::texts.push_back(Data::terms.victory + Player::escape_symbol + "|");
 
 		std::stringstream ss;
 		PushExperienceGainedMessage(exp);

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -470,7 +470,7 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 			if (battle_result_messages_it != battle_result_messages.end()) {
 				target_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetTarget());
 				if (battle_result_messages_it == battle_result_messages.begin()) {
-					if (action->IsSuccess() && target_sprite) {
+					if (action->IsSuccess() && target_sprite && !action->IsPositive() && !action->IsAbsorb() && action->GetAffectedHp() > -1) {
 						target_sprite->SetAnimationState(Sprite_Battler::AnimationState_Damage);
 					}
 

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -654,7 +654,6 @@ void Scene_Battle_Rpg2k::CommandSelected() {
 			SetState(State_SelectSkill);
 			break;
 		case 2: // Defense
-			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 			DefendSelected();
 			break;
 		case 3: // Item

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -473,6 +473,9 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 					if (action->IsSuccess() && target_sprite && !action->IsPositive() && !action->IsAbsorb() && action->GetAffectedHp() > -1) {
 						target_sprite->SetAnimationState(Sprite_Battler::AnimationState_Damage);
 					}
+					if (action->IsSuccess() && action->GetTarget()->GetType() == Game_Battler::Type_Ally && !action->IsPositive() && !action->IsAbsorb() && action->GetAffectedHp() > 0) {
+						Main_Data::game_screen->ShakeOnce(2, 16, 1);
+					}
 
 					if (action->GetResultSe()) {
 						Game_System::SePlay(*action->GetResultSe());

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -580,7 +580,6 @@ void Scene_Battle_Rpg2k::ProcessInput() {
 	}
 
 	if (Input::IsTriggered(Input::CANCEL)) {
-		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cancel));
 		switch (state) {
 		case State_Start:
 		case State_SelectOption:
@@ -588,18 +587,22 @@ void Scene_Battle_Rpg2k::ProcessInput() {
 			break;
 		case State_SelectActor:
 		case State_AutoBattle:
+			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cancel));
 			SetState(State_SelectOption);
 			break;
 		case State_SelectCommand:
+			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cancel));
 			--actor_index;
 			SelectPreviousActor();
 			break;
 		case State_SelectEnemyTarget:
 		case State_SelectItem:
 		case State_SelectSkill:
+			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cancel));
 			SetState(State_SelectCommand);
 			break;
 		case State_SelectAllyTarget:
+			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cancel));
 			SetState(previous_state);
 			break;
 		case State_Battle:

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -980,7 +980,7 @@ bool Scene_Battle_Rpg2k3::CheckWin() {
 		std::vector<int> drops;
 		Main_Data::game_enemyparty->GenerateDrops(drops);
 
-		Game_Message::texts.push_back(Data::terms.victory);
+		Game_Message::texts.push_back(Data::terms.victory + Player::escape_symbol + "|");
 
 		std::string space = Player::IsRPG2k3E() ? " " : "";
 

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -865,7 +865,6 @@ void Scene_Battle_Rpg2k3::CommandSelected() {
 
 	switch (command->type) {
 	case RPG::BattleCommand::Type_attack:
-		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 		AttackSelected();
 		break;
 	case RPG::BattleCommand::Type_defense:

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -816,11 +816,11 @@ void Scene_Battle_Rpg2k3::ProcessInput() {
 			active_actor->SetLastBattleAction(-1);
 			SetState(State_SelectOption);
 			break;
-		case State_SelectEnemyTarget:
 		case State_SelectItem:
 		case State_SelectSkill:
 			SetState(State_SelectCommand);
 			break;
+		case State_SelectEnemyTarget:
 		case State_SelectAllyTarget:
 			SetState(previous_state);
 			break;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -868,7 +868,6 @@ void Scene_Battle_Rpg2k3::CommandSelected() {
 		AttackSelected();
 		break;
 	case RPG::BattleCommand::Type_defense:
-		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 		DefendSelected();
 		break;
 	case RPG::BattleCommand::Type_escape:

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -254,6 +254,7 @@ void Scene_Map::FinishTeleportPlayer() {
 void Scene_Map::CallBattle() {
 	Main_Data::game_data.system.before_battle_music = Game_System::GetCurrentBGM();
 	Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_BeginBattle));
+	Game_System::BgmPlay(Game_System::GetSystemBGM(Game_System::BGM_Battle));
 
 	Scene::Push(Scene_Battle::Create());
 }

--- a/src/window_item.cpp
+++ b/src/window_item.cpp
@@ -84,9 +84,7 @@ void Window_Item::Refresh() {
 
 	CreateContents();
 
-	if (index > 0 && index >= item_max) {
-		--index;
-	}
+	SetIndex(index);
 
 	contents->Clear();
 


### PR DESCRIPTION
Here is the first batch of rebased fixes from #1373

All of these are pretty simple changes so I'm making a first PR with these. They are not all in the same order as originally presented. I'm trying to pull out the ones that are simple and don't require a lot of merging so they can be quickly reviewed and merged into master.

Changes made:
 * 2.7 - Using `Player::escape_char` instead of `"\\"`
 * ~~4.1 - `Battle_BGM` was moved earlier so don't play it twice.~~
 * 2.15 - Added back `const`
 * 2.4 - Enhanced `Game_Actor::GetSkillName()` with skill selection logic.

These alone fix some issues from #1418 and #985