### PR TITLE
Random Encounters fixes

### DIFF
--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -137,7 +137,7 @@ void Game_Map::Quit() {
 void Game_Map::Setup(int _id) {
 	SetupCommon(_id, false);
 	map_info.encounter_rate = GetMapInfo().encounter_steps;
-	ResetEncounterSteps();
+	SetEncounterSteps(0);
 
 	Parallax::ClearChangedBG();
 
@@ -206,7 +206,7 @@ void Game_Map::SetupFromSave() {
 	map_info.Fixup(GetMapInfo());
 	SetChipset(map_info.chipset_id);
 
-	ResetEncounterSteps();
+	SetEncounterSteps(location.encounter_steps);
 
 	// FIXME: Handle Pan correctly
 	location.pan_current_x = 0;
@@ -217,7 +217,7 @@ void Game_Map::SetupFromSave() {
 
 
 void Game_Map::SetupFromTeleportSelf() {
-	ResetEncounterSteps();
+	SetEncounterSteps(0);
 }
 
 void Game_Map::SetupCommon(int _id, bool is_load_savegame) {
@@ -983,14 +983,14 @@ void Game_Map::UpdateEncounterSteps() {
 	auto draw = std::uniform_real_distribution<float>()(Utils::GetRNG());
 
 	if (draw < p) {
-		ResetEncounterSteps();
+		SetEncounterSteps(0);
 		PrepareEncounter();
 	}
 }
 
-void Game_Map::ResetEncounterSteps() {
+void Game_Map::SetEncounterSteps(int steps) {
 	last_encounter_idx = 0;
-	location.encounter_steps = 0;
+	location.encounter_steps = steps;
 }
 
 std::vector<int> Game_Map::GetEncountersAt(int x, int y) {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1008,6 +1008,10 @@ bool Game_Map::PrepareEncounter() {
 	Game_Temp::battle_troop_id = encounters[Utils::GetRandomNumber(0, encounters.size() - 1)];
 	Game_Temp::battle_calling = true;
 
+	if (Utils::GetRandomNumber(1, 32) == 1) {
+		Game_Temp::battle_first_strike = true;
+	}
+
 	SetupBattle();
 
 	return true;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -212,6 +212,11 @@ void Game_Map::SetupFromSave() {
 	location.pan_finish_y = 0;
 }
 
+
+void Game_Map::SetupFromTeleportSelf() {
+	ResetEncounterSteps();
+}
+
 void Game_Map::SetupCommon(int _id, bool is_load_savegame) {
 	Dispose();
 

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -306,10 +306,9 @@ namespace Game_Map {
 	void UpdateEncounterSteps();
 
 	/**
-	 * Resets encounter step counter based on the encounter rate using
-	 * Gaussian distribution.
+	 * Sets encounter_steps to steps.
 	 */
-	void ResetEncounterSteps();
+	void SetEncounterSteps(int steps);
 
 	/**
 	 * Gets possible encounters at a location.

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -74,6 +74,13 @@ namespace Game_Map {
 	void SetupFromSave();
 
 	/**
+	 * Performs Setup on a map when teleport to self.
+	 *
+	 * @param map_id map ID.
+	 */
+	void SetupFromTeleportSelf();
+
+	/**
 	 * Shared code of the Setup methods.
 	 *
 	 * @param _id map ID.

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -268,6 +268,8 @@ void Game_Player::PerformTeleport() {
 		Game_Map::Setup(new_map_id);
 		last_pan_x = 0;
 		last_pan_y = 0;
+	} else {
+		Game_Map::SetupFromTeleportSelf();
 	}
 
 	SetOpacity(255);


### PR DESCRIPTION
Depends on:  #1441

Info from here: https://github.com/EasyRPG/liblcf/issues/261

* Correctly load encounter_rate from saved game
* Compute first strike chance on random encounter.