### PR TITLE
Fix a regression introduced in b7f307e which resulted in a glitchy airship sprite

### DIFF
--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -435,9 +435,6 @@ void Game_Player::Update() {
 	Game_Character::UpdateSprite();
 	UpdateScroll();
 
-	if (location.aboard)
-		GetVehicle()->SyncWithPlayer();
-
 	if (IsMoving() || was_blocked) return;
 
 	if (last_moving && location.boarding) {

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -413,6 +413,10 @@ void Game_Vehicle::Update() {
 	Game_Character::Update();
 	Game_Character::UpdateSprite();
 
+	if (!Main_Data::game_player->IsBoardingOrUnboarding()) {
+		SyncWithPlayer();
+	}
+
 	if (type == Airship) {
 		if (IsAscending()) {
 			data.remaining_ascent = data.remaining_ascent - 8;


### PR DESCRIPTION
The observation by Sormat was correct that one of the two SyncWithPlayer calls is redundant.

This change keeps his bugfix (Ship "jumps" to the player while entering) and resolves the flickering.

@fmatthew5876 please test.