### PR TITLE
Fix compilation with GCC 4.7

### DIFF
--- a/src/input_source.cpp
+++ b/src/input_source.cpp
@@ -21,6 +21,8 @@
 #include "input_source.h"
 #include "player.h"
 
+Input::Source::~Source() = default;
+
 void Input::UiSource::Update() {
 	BaseUi::KeyStatus& keystates = DisplayUi->GetKeyStates();
 

--- a/src/input_source.h
+++ b/src/input_source.h
@@ -31,7 +31,7 @@ namespace Input {
 	public:
 		Source() = default;
 
-		virtual ~Source() = default;
+		virtual ~Source();
 
 		/**
 		 * Called once each frame to update pressed_buttons.

--- a/src/output.h
+++ b/src/output.h
@@ -26,6 +26,12 @@
 #undef Debug
 #endif
 
+#if defined __GNUC__ && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC__ < 8))
+#define EASYRPG_NORETURN __attribute__((noreturn))
+#else
+#define EASYRPG_NORETURN [[noreturn]]
+#endif
+
 /**
  * Output Namespace.
  */
@@ -111,7 +117,7 @@ namespace Output {
 	 *
 	 * @param fmt formatted error to display.
 	 */
-	[[noreturn]] void Error(const char* fmt, ...);
+	EASYRPG_NORETURN void Error(const char* fmt, ...);
 
 	/**
 	 * Display an error message and closes the player
@@ -119,7 +125,7 @@ namespace Output {
 	 *
 	 * @param err error to display.
 	 */
-	[[noreturn]] void ErrorStr(std::string const& err);
+	EASYRPG_NORETURN void ErrorStr(std::string const& err);
 
 	/**
 	 * Prints a debug message to the console.


### PR DESCRIPTION
~~Building with GCC 4.7 also produces the following errors:~~
>In file included from ../../src/input.h:26:0,
>                 from ../../src/scene_shop.cpp:22:
>../../src/input_source.h:57:3: error: looser throw specifier for 'virtual Input::UiSource::~UiSource()'
>../../src/input_source.h:34:11: error:   overriding 'virtual Input::Source::~Source() noexcept (true)'
>../../src/input_source.h:71:3: error: looser throw specifier for 'virtual Input::LogSource::~LogSource()'
>../../src/input_source.h:34:11: error:   overriding 'virtual Input::Source::~Source() noexcept (true)'

~~I've tried fixing this locally, but I'm not convinced that what I'm doing is correct.~~ Fixed now.