### PR TITLE
Refresh status window when battle events affect actors - Previously Albeleon 1.4

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -551,6 +551,8 @@ bool Game_Interpreter::CommandEnd() { // code 10
 			evnt->StopTalkToHero();
 	}
 
+	Scene::instance->onCommandEnd();
+
 	return true;
 }
 

--- a/src/scene.h
+++ b/src/scene.h
@@ -172,6 +172,9 @@ public:
 
 	Graphics::State& GetGraphicsState();
 
+	/** Called by the interpreter when an event finishes processing */
+	virtual void onCommandEnd() {}
+
 private:
 	/** Scene stack. */
 	static std::vector<std::shared_ptr<Scene> > instances;

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -556,3 +556,9 @@ void Scene_Battle::CallDebug() {
 		Scene::Push(std::make_shared<Scene_Debug>());
 	}
 }
+
+void Scene_Battle::onCommandEnd() {
+	// If an event that changed status finishes without displaying a message window,
+	// we need this so it can update automatically the status_window
+	status_window->Refresh();
+}

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -160,6 +160,7 @@ protected:
 	void CreateEnemyActionSkill(Game_Enemy* enemy, const RPG::EnemyAction* action);
 
 	void RemoveCurrentAction();
+	virtual void onCommandEnd() override;
 
 	void CallDebug();
 

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -1051,3 +1051,4 @@ bool Scene_Battle_Rpg2k::CheckLose() {
 bool Scene_Battle_Rpg2k::CheckResultConditions() {
 	return CheckLose() || CheckWin();
 }
+


### PR DESCRIPTION
~~…sage display window is needed to display, the status window should be able to refresh inmediately without skipping a frame (for example, if "Event page: (Turn 0x + 0); DecreaseHP(Player1, 999, Dead)"."~~

~~Solution: Game_Battle only knows when the event ends when using UpdateEvents in the next frame, which mean we can't depend on that, if we refresh the status window then, for a frame we would see the previous state. That's why, to solve that frame of space while UpdateEvents is not updated:~~

~~1. We add to Game_Interpreter a "finished_not_updated" bool, initialized to false.
2. In CommandEnd, we set the variable to "true". In Game_Battle::UpdateEvents, we set it to "false". This means this variable will be active while the interpreted is finished but the events aren't active.
3. Right after the Scene_Battle::Update, we check if the variable is true. If that's the case, Refresh the status window. This way it's been updated before the status window is drawn when it has the previous data.~~

* When a battle event finishes it may have changes character HP/SP/State etc.. Therefore we need to refresh the status window `onCommandEnd()`.