### PR TITLE
Only apply bush_depth when sprite layer is SameAsCharacters

### DIFF
--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -76,8 +76,12 @@ void Sprite_Character::Update() {
 	SetZ(character->GetScreenZ());
 
 	//SetBlendType(character->GetBlendType());
-	int bush_split = 4 - character->GetBushDepth();
-	SetBushDepth(bush_split > 3 ? 0 : GetHeight() / bush_split);
+	if (character->GetLayer() != RPG::EventPage::Layers_same) {
+		SetBushDepth(0);
+	} else {
+		int bush_split = 4 - character->GetBushDepth();
+		SetBushDepth(bush_split > 3 ? 0 : GetHeight() / bush_split);
+	}
 }
 
 Game_Character* Sprite_Character::GetCharacter() {


### PR DESCRIPTION
Resolves: #1465

Test against `RPG_RT.exe` behavior of Lower, Same, and Upper layer sprites on terrain with bush depths using a test game.

I also tested these behaviors and the Player is already correct:
* When the event graphic is a chipset tile instead of a charset bush depth is not applied.
* When the player steps on the above event, the player still has bush depth applied.