### PR TITLE
Increment SaveInventory::steps and fix state damage algo

### DIFF
--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -389,14 +389,6 @@ int Game_Party::GetActorPositionInParty(int actor_id) {
 	return it != data().party.end() ? std::distance(data().party.begin(), it) : -1;
 }
 
-int Game_Party::GetGold() {
-	return data().gold;
-}
-
-int Game_Party::GetSteps() {
-	return data().steps;
-}
-
 std::vector<Game_Actor*> Game_Party::GetActors() const {
 	std::vector<Game_Actor*> actors;
 	std::vector<int16_t>::const_iterator it;
@@ -596,18 +588,17 @@ bool Game_Party::ApplyStateDamage() {
 	bool damage = false;
 	std::vector<int16_t> states = GetInflictedStates();
 
-	for (auto state_id : states) {
-		if (static_cast<int>(state_steps_hp.size()) < state_id) {
-			state_steps_hp.resize(state_id);
-		}
-		if (static_cast<int>(state_steps_sp.size()) < state_id) {
-			state_steps_sp.resize(state_id);
-		}
+	const auto steps = GetSteps();
 
+	for (auto state_id : states) {
 		RPG::State *state = ReaderUtil::GetElement(Data::states, state_id);
 
-		if (state->hp_change_map_val > 0 && (++state_steps_hp[state_id - 1]) >= state->hp_change_map_steps) {
-			state_steps_hp[state_id - 1] = 0;
+		//NOTE: We do steps + 1 here because this gets called before steps are incremented.
+
+		if (state->hp_change_map_steps > 0
+				&& state->hp_change_map_val > 0
+				&& (((steps + 1) % state->hp_change_map_steps) == 0)
+				) {
 			for (auto actor : GetActors()) {
 				if (actor->HasState(state_id)) {
 					actor->ChangeHp(-std::max<int>(0, std::min<int>(state->hp_change_map_val, actor->GetHp() - 1)));
@@ -616,8 +607,10 @@ bool Game_Party::ApplyStateDamage() {
 			}
 		}
 
-		if (state->sp_change_map_val > 0 && (++state_steps_sp[state_id - 1]) >= state->sp_change_map_steps) {
-			state_steps_sp[state_id - 1] = 0;
+		if (state->sp_change_map_steps > 0
+				&& state->sp_change_map_val > 0
+				&& (((steps + 1) % state->sp_change_map_steps) == 0)
+		   ){
 			for (auto actor : GetActors()) {
 				if (actor->HasState(state_id)) {
 					actor->ChangeSp(-state->sp_change_map_val);

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -593,7 +593,7 @@ bool Game_Party::ApplyStateDamage() {
 	for (auto state_id : states) {
 		RPG::State *state = ReaderUtil::GetElement(Data::states, state_id);
 
-		//NOTE: We do steps + 1 here because this gets called before steps are incremented.
+		// NOTE: We do steps + 1 here because this gets called before steps are incremented.
 
 		if (state->hp_change_map_steps > 0
 				&& state->hp_change_map_val > 0

--- a/src/game_party.h
+++ b/src/game_party.h
@@ -178,14 +178,19 @@ public:
 	 *
 	 * @return gold possessed.
 	 */
-	int GetGold();
+	int GetGold() const;
 
 	/**
 	 * Gets steps walked.
 	 *
 	 * @return steps walked.
 	 */
-	int GetSteps();
+	int GetSteps() const;
+
+	/**
+	 * Increment the number of steps walked by 1.
+	 */
+	void IncSteps();
 
 	/**
 	 * Gets actors in party list.
@@ -334,10 +339,6 @@ public:
 private:
 	const RPG::SaveInventory& data() const;
 	RPG::SaveInventory& data();
-
-private:
-	std::vector<int> state_steps_hp;
-	std::vector<int> state_steps_sp;
 };
 
 // ------ INLINES --------
@@ -380,6 +381,18 @@ inline int Game_Party::GetRunCount() const {
 
 inline void Game_Party::IncRunCount() {
 	++data().escapes;
+}
+
+inline int Game_Party::GetGold() const {
+	return data().gold;
+}
+
+inline int Game_Party::GetSteps() const {
+	return data().steps;
+}
+
+inline void Game_Party::IncSteps() {
+	++data().steps;
 }
 
 

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -430,7 +430,7 @@ void Game_Player::Update() {
 					Move(Up);
 			}
 			if (GetX() != old_x || GetY() != old_y) {
-				++Main_Data::game_data.inventory.steps;
+				Main_Data::game_party->IncSteps();
 			}
 		}
 

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -414,6 +414,8 @@ void Game_Player::Update() {
 
 	if (!Game_Map::GetInterpreter().IsRunning() && !Game_Map::IsAnyEventStarting()) {
 		if (IsMovable()) {
+			auto old_x = GetX();
+			auto old_y = GetY();
 			switch (Input::dir4) {
 				case 2:
 					Move(Down);
@@ -426,6 +428,9 @@ void Game_Player::Update() {
 					break;
 				case 8:
 					Move(Up);
+			}
+			if (GetX() != old_x || GetY() != old_y) {
+				++Main_Data::game_data.inventory.steps;
 			}
 		}
 


### PR DESCRIPTION
* Ticks when player moves with keyboard
* Ticks when plyaer moves with keyboard in a vehicle
* Does not tick for events forcing player movement
* Does not tick for moving once space to embark/disembark
* Tested and matches RPG_RT behavior

This counter ticks in RPG_RT and is stored in the save data, but outside of that it appears completely unused.

@CherryDT Is there anything we should be doing in the interpreter that depends on this?