### PR TITLE
ChangeHP, AddState and RemoveState changes - single commit

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1200,26 +1200,6 @@ void Game_Actor::SetHp(int hp) {
 	GetData().current_hp = min(max(hp, 0), GetMaxHp());
 }
 
-void Game_Actor::ChangeHp(int hp) {
-	Game_Battler::ChangeHp(hp);
-
-	if (GetData().current_hp == 0) {
-		// Death
-		SetGauge(0);
-		RemoveAllStates();
-		SetDefending(false);
-		SetCharged(false);
-		AddState(1);
-	} else {
-		// Back to life
-		RemoveState(1);
-		if (GetHp() <= 0) {
-			// Reviving gives at least 1 Hp
-			SetHp(1);
-		}
-	}
-}
-
 void Game_Actor::SetSp(int sp) {
 	GetData().current_sp = min(max(sp, 0), GetMaxSp());
 }

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -492,7 +492,6 @@ public:
 
 	int GetHp() const override;
 	void SetHp(int _hp) override;
-	void ChangeHp(int hp) override;
 
 	int GetSp() const override;
 	void SetSp(int _sp) override;

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -131,22 +131,6 @@ void Game_Enemy::SetHp(int _hp) {
 	hp = std::min(std::max(_hp, 0), GetMaxHp());
 }
 
-void Game_Enemy::ChangeHp(int hp) {
-	SetHp(GetHp() + hp);
-
-	if (this->hp == 0) {
-		// Death
-		SetGauge(0);
-		SetDefending(false);
-		SetCharged(false);
-		RemoveAllStates();
-		AddState(1);
-	} else {
-		// Back to life
-		RemoveState(1);
-	}
-}
-
 void Game_Enemy::SetSp(int _sp) {
 	sp = std::min(std::max(_sp, 0), GetMaxSp());
 }

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -143,7 +143,6 @@ public:
 
 	int GetHp() const override;
 	void SetHp(int _hp) override;
-	void ChangeHp(int hp) override;
 
 	int GetSp() const override;
 	void SetSp(int _sp) override;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1424,9 +1424,9 @@ bool Game_Interpreter::CommandChangeCondition(RPG::EventCommand const& com) { //
 
 bool Game_Interpreter::CommandFullHeal(RPG::EventCommand const& com) { // Code 10490
 	for (const auto& actor : GetActors(com.parameters[0], com.parameters[1])) {
+		actor->RemoveAllStates();
 		actor->ChangeHp(actor->GetMaxHp());
 		actor->SetSp(actor->GetMaxSp());
-		actor->RemoveAllStates();
 	}
 
 	Game_Battle::SetNeedRefresh(true);

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -487,9 +487,9 @@ bool Game_Interpreter_Map::ContinuationShowInnStart(RPG::EventCommand const& /* 
 		// Full heal
 		std::vector<Game_Actor*> actors = Main_Data::game_party->GetActors();
 		for (Game_Actor* actor : actors) {
+			actor->RemoveAllStates();
 			actor->ChangeHp(actor->GetMaxHp());
 			actor->SetSp(actor->GetMaxSp());
-			actor->RemoveAllStates();
 		}
 		Graphics::GetTransition().Init(Transition::TransitionFadeOut, Scene::instance.get(), 36, true);
 		Game_System::BgmFade(800);


### PR DESCRIPTION
The way RPG_RT works:
 - You cannot change a battler's HP when they're dead.
 - If ChangeHP kills a character, it adds the Death state to that battler.
 - When Death state is cured, even if alone, it always sets the HP to 1, instead of other functions.
 - When a character is caused Death, all the other states are erased; the defense, charge, gauge and stat modifiers are reset, and the current attribute shifts erased.

We implement all of this, with these particular changes:
 - Now there is no difference between Game_Actor::ChangeHP and Game_Enemy::ChangeHP, so we delete this function from both and add the ChangeHP characteristics to the superclass Game_Battler.
 - In Game_Battler::UseItem, the function now doesn't have to set the HP. However, it needs to have an int "revived" that checks if the character was revived, so in case the function heals HP too after dead, it substracts 1 since that value is automatically put after the Death state is removed. We also move the state cure before the HP change, so the Death State is cured before ChangeHP is executed (if this function was executed before Death state was cured, due to our new conditions, it wouldn't do anything).
 - When you rest on an inn and when the command FullHeal, we move the RemoveAllStates function before the ChangeHP too.
 - We move in UseSkill the state before the ChangeHP too. We also add that, if the character is still dead, then the HP and SP changes can't happen (you can't throw a Cure spell to a dead character).