### PR TITLE
Fix Item usability in battle - Previously Albeleon 2.30

### DIFF
--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1243,6 +1243,12 @@ bool Game_BattleAlgorithm::Item::Execute() {
 
 	if (item.type == RPG::Item::Type_medicine) {
 		this->healing = true;
+		// RM2k3 BUG: In rm2k3 battle system, this IsItemUsable() check is only applied when equipment_setting == actor, not for class.
+		if (GetTarget()->GetType() == Game_Battler::Type_Ally && !static_cast<Game_Actor*>(GetTarget())->IsItemUsable(item.ID)) {
+			// No effect, but doesn't behave like a dodge or damage to set healing and success to true.
+			this->success = true;
+			return this->success;
+		}
 
 		// HP recovery
 		if (item.recover_hp != 0 || item.recover_hp_rate != 0) {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -144,6 +144,7 @@ void Scene_Battle_Rpg2k::SetState(Scene_Battle::State new_state) {
 		break;
 	case State_SelectItem:
 		item_window->SetActive(true);
+		item_window->SetActor(active_actor);
 		item_window->Refresh();
 		break;
 	case State_SelectSkill:

--- a/src/window_item.cpp
+++ b/src/window_item.cpp
@@ -48,7 +48,14 @@ bool Window_Item::CheckInclude(int item_id) {
 }
 
 bool Window_Item::CheckEnable(int item_id) {
-	return Main_Data::game_party->IsItemUsable(item_id);
+	auto* item = ReaderUtil::GetElement(Data::items, item_id);
+	if (!item) {
+		return false;
+	}
+	if (item->type == RPG::Item::Type_medicine) {
+		return true;
+	}
+	return Main_Data::game_party->IsItemUsable(item_id, actor);
 }
 
 void Window_Item::Refresh() {


### PR DESCRIPTION

>    2.30: RM2000 + RM2003: Mark as "unusable" the objects of type "speci
>
>If I understand this correctly the purpose of the new line in ÌsitemUsable is to ensure that the items are always selectable semi-ot: occasion_field1 is btw confusing, maybe we should think about a better name
>
>I see multiple flaws here:
>item.actor_set could be also item.class_set, therefore we should fine a way to get this handled by IsItemUsable imo. (maybe move the check from IsItemUsable to CheckEnable, then the codepath is free)
>
> Also actor_set could be smaller than the ID, resulting in an out-of-bounds read.
