### PR TITLE
"2.28: RM2000 + RM2003: If a battler is thrown a state again, the tur…

### DIFF
--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -380,7 +380,7 @@ void Game_Battler::AddState(int state_id) {
 		states.resize(state_id);
 	}
 
-	states[state_id - 1] = 1;
+	states[state_id - 1] = std::max<int> (1, states[state_id - 1]);
 }
 
 void Game_Battler::RemoveState(int state_id) {
@@ -696,11 +696,13 @@ std::vector<int16_t> Game_Battler::NextBattleTurn() {
 	for (size_t i = 0; i < states.size(); ++i) {
 		if (HasState(i + 1)) {
 			states[i] += 1;
-
-			if (states[i] >= Data::states[i].hold_turn) {
+			if (states[i] > Data::states[i].hold_turn + 1) {
 				if (Utils::ChanceOf(Data::states[i].auto_release_prob, 100)) {
 					healed_states.push_back(i + 1);
 					RemoveState(i + 1);
+				}
+				else {
+					states[i] -= Data::states[i].hold_turn;
 				}
 			}
 		}


### PR DESCRIPTION
…n count for recovery probability should be the same with no changes, it shouldn't "reset". Probability of state recovery probability should also be only each X turns, not each turn after it surpasses X turn. When the battler is first thrown into a state, if it has 1 turn recovery or more, there should be an extra turn where they do nothing (afterwards it's always a multiple. With 0 turn it happens even in the first turn)."

Solution:
1. To avoid "resetting" each time a state is readded, when the state is set, the turn count doesn't start on 1 but clamps it at 1 at minimum.
2. To make sure the turn where it tries to recover each probability is each X turns, multiples, we put that, if the recovery fails, the turn is decreased X, so in the next X turns it will try again.
3. Turn ">=" in ">" and adding +1 makes sure the turn appears two later. Before, a Turn 0, Turn 1 and Turn 2 were executed right after the battler had the state.

>  2.28: RM2000 + RM2003: If a battler is thrown a state again, the tur

>Because the code before is
>states[i] += 1; 
>if (states[i] > Data::states[i].hold_turn + 1) {
>
>isn't this the same as states[i] = 1?

>I don't think so.

>(s > ht + 1) is equivalent to (s - ht) > 1. So s >= 2 when that write happens.


>I have no idea if RPG2000 does this different but for RPG2003 I question the whole code except >states[state_id - 1] = std::max<int> (1, states[state_id - 1]); (which prevents turn count reduction when the >same state is applied again). I used a Poison with 10 turns & 20% setting and I got it healt after turn 16... >(according to this commit it should be again at 20?)


