### PR TITLE
Support SavePanorama data

### DIFF
--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1582,6 +1582,7 @@ void Game_Map::Parallax::ChangeBG(const Params& params) {
 	map_info.parallax_vert = params.scroll_vert;
 	map_info.parallax_vert_auto = params.scroll_vert_auto;
 	map_info.parallax_vert_speed = params.scroll_vert_speed;
+	panorama = {};
 }
 
 void Game_Map::Parallax::ClearChangedBG() {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -283,6 +283,7 @@ void Game_Map::SetupCommon(int _id, bool is_load_savegame) {
 			Main_Data::game_data.common_events = {};
 			Main_Data::game_data.events = {};
 			Main_Data::game_data.map_info.events = {};
+			Main_Data::game_data.panorama = {};
 		} else if (location.database_save_count != Data::system.save_count) {
 			Main_Data::game_data.common_events = {};
 		}

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -47,6 +47,7 @@
 namespace {
 	RPG::SaveMapInfo& map_info = Main_Data::game_data.map_info;
 	RPG::SavePartyLocation& location = Main_Data::game_data.party_location;
+	RPG::SavePanorama& panorama = Main_Data::game_data.panorama;
 
 	std::string chipset_name;
 	std::string battleback_name;
@@ -138,6 +139,7 @@ void Game_Map::Setup(int _id) {
 	SetupCommon(_id, false);
 	map_info.encounter_rate = GetMapInfo().encounter_steps;
 	SetEncounterSteps(0);
+	panorama = {};
 
 	Parallax::ClearChangedBG();
 
@@ -1475,11 +1477,11 @@ std::string Game_Map::Parallax::GetName() {
 }
 
 int Game_Map::Parallax::GetX() {
-	return parallax_x / TILE_SIZE;
+	return (parallax_x - panorama.pan_x / 2) / TILE_SIZE;
 }
 
 int Game_Map::Parallax::GetY() {
-	return parallax_y / TILE_SIZE;
+	return (parallax_y - panorama.pan_y / 2) / TILE_SIZE;
 }
 
 void Game_Map::Parallax::Initialize(int width, int height) {
@@ -1521,11 +1523,16 @@ void Game_Map::Parallax::Update() {
 		return 0;
 	};
 
+
 	if (params.scroll_horz && params.scroll_horz_auto) {
-		parallax_x += scroll_amt(params.scroll_horz_speed);
+		const auto w = parallax_width * TILE_SIZE * 2;
+		panorama.pan_x -= scroll_amt(params.scroll_horz_speed) * 2;
+		panorama.pan_x = (panorama.pan_x + w) % w;
 	}
 	if (params.scroll_vert && params.scroll_vert_auto) {
-		parallax_y += scroll_amt(params.scroll_vert_speed);
+		const auto h = parallax_height * TILE_SIZE * 2;
+		panorama.pan_y -= scroll_amt(params.scroll_vert_speed) * 2;
+		panorama.pan_y = (panorama.pan_y + h) % h;
 	}
 }
 


### PR DESCRIPTION
* saves and loads scrolling panorama x and y position.
* Only supported by rm2k3e, but we enable for all modes.

I've tested and the numbers match rm2k3e. You can save and load a game between RPG_RT and Player and the panorama will have the same starting position.

One thing I don't understand is that the range of pan_x/pan_y are 2 times the size of the panorama picture. In order to make the numbers match rm2k3e I had to scale them by 2 in places.

This feature has a bug in rm2k3. If you edit the map, say to change the panorama or turn off scrolling and the load the game the offsets still get loaded. So you could have a non-scrolling panorama which is stuck at a weird offset. I reset the panorama data when `save_count` does not match.