### PR TITLE
Battle fixes - replaces some Albeleon battle 3 commits + new fixes

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1295,6 +1295,11 @@ Game_Battler::BattlerType Game_Actor::GetType() const {
 	return Game_Battler::Type_Ally;
 }
 
+int Game_Actor::IsControllable() const {
+	return GetSignificantRestriction() == RPG::State::Restriction_normal;
+}
+
+
 const RPG::Actor& Game_Actor::GetActor() const {
 	// Always valid
 	return *ReaderUtil::GetElement(Data::actors, actor_id);

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1296,7 +1296,7 @@ Game_Battler::BattlerType Game_Actor::GetType() const {
 }
 
 int Game_Actor::IsControllable() const {
-	return GetSignificantRestriction() == RPG::State::Restriction_normal;
+	return GetSignificantRestriction() == RPG::State::Restriction_normal && !GetAutoBattle();
 }
 
 

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -756,6 +756,12 @@ public:
 	std::string GetLearningMessage(const RPG::Learning& learn) const;
 
 	BattlerType GetType() const override;
+
+	/**
+	 * @return true if the actor is controllable in battle.
+	 */
+	int IsControllable() const;
+
 private:
 	/**
 	 * @return Reference to the Actor data of the LDB

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -53,7 +53,7 @@ std::vector<int16_t> Game_Battler::GetInflictedStates() const {
 	return states;
 }
 
-int Game_Battler::GetSignificantRestriction() {
+int Game_Battler::GetSignificantRestriction() const {
 	const std::vector<int16_t> states = GetInflictedStates();
 	for (int i = 0; i < (int)states.size(); i++) {
 		// States are guaranteed to be valid

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -81,7 +81,7 @@ public:
 	 *
 	 * @return First non-normal restriction or normal if not restricted
 	 */
-	int GetSignificantRestriction();
+	int GetSignificantRestriction() const;
 
 	/**
 	 * Gets the Battler ID.

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -622,3 +622,13 @@ bool Game_Party::ApplyStateDamage() {
 
 	return damage;
 }
+
+bool Game_Party::IsAnyControllable() {
+	for (auto& actor: GetActors()) {
+		if (actor->IsControllable()) {
+			return true;
+		}
+	}
+	return false;
+}
+

--- a/src/game_party.h
+++ b/src/game_party.h
@@ -336,6 +336,11 @@ public:
 	 */
 	bool ApplyStateDamage();
 
+	/**
+	 * @return Whether any party member accepts custom battle commands.
+	 */
+	bool IsAnyControllable();
+
 private:
 	const RPG::SaveInventory& data() const;
 	RPG::SaveInventory& data();

--- a/src/game_party_base.cpp
+++ b/src/game_party_base.cpp
@@ -118,21 +118,6 @@ int Game_Party_Base::GetAverageAgility() {
 	return agi /= battlers.size();
 }
 
-bool Game_Party_Base::IsAnyControllable() {
-	std::vector<Game_Battler*> battlers;
-	GetBattlers(battlers);
-
-	std::vector<Game_Battler*>::const_iterator it;
-
-	for (it = battlers.begin(); it != battlers.end(); ++it) {
-		if ((*it)->GetSignificantRestriction() == RPG::State::Restriction_normal) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
 void Game_Party_Base::ResetBattle() {
 	std::vector<Game_Battler*> battlers;
 	GetBattlers(battlers);

--- a/src/game_party_base.h
+++ b/src/game_party_base.h
@@ -102,13 +102,6 @@ public:
 	virtual int GetAverageAgility();
 
 	/**
-	 * Tests if any party member has no state restriction.
-	 *
-	 * @return Whether any party member accepts custom battle commands.
-	 */
-	bool IsAnyControllable();
-
-	/**
 	 * Resets battle modifiers of all members (gauge, defense and charge).
 	 */
 	void ResetBattle();

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -166,8 +166,8 @@ protected:
 	void CallDebug();
 
 	// Variables
-	State state;
-	State previous_state;
+	State state = State_Start;
+	State previous_state = State_Start;
 	bool auto_battle;
 	int cycle;
 	int attack_state;

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -238,8 +238,7 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 	case State_Start:
 		if (DisplayMonstersInMessageWindow()) {
 			Game_Battle::RefreshEvents();
-			SetState(State_SelectOption);
-			CheckResultConditions();
+			SetState(State_Battle);
 		}
 		break;
 	case State_SelectOption:
@@ -290,7 +289,12 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 			// Everybody acted
 			actor_index = 0;
 
-			SetState(State_SelectOption);
+			// Go right into next turn if no actors controllable.
+			if (!Main_Data::game_party->IsAnyControllable()) {
+				SelectNextActor();
+			} else {
+				SetState(State_SelectOption);
+			}
 		}
 		break;
 	case State_SelectEnemyTarget: {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -808,7 +808,7 @@ void Scene_Battle_Rpg2k::SelectPreviousActor() {
 	battle_actions.back()->SetBattleAlgorithm(std::shared_ptr<Game_BattleAlgorithm::AlgorithmBase>());
 	battle_actions.pop_back();
 
-	if (active_actor->GetAutoBattle()) {
+	if (active_actor->GetAutoBattle() || !active_actor->IsControllable()) {
 		SelectPreviousActor();
 		return;
 	}

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -886,11 +886,11 @@ bool Scene_Battle_Rpg2k::DisplayMonstersInMessageWindow() {
 		encounter_message_first_monster = false;
 	}
 
-	if (Input::IsPressed(Input::DECISION)) {
-		--encounter_message_sleep_until;
-	}
-
 	if (encounter_message_sleep_until > -1) {
+		if (Input::IsPressed(Input::DECISION)) {
+			--encounter_message_sleep_until;
+		}
+
 		if (Player::GetFrames() >= encounter_message_sleep_until) {
 			// Sleep over
 			encounter_message_sleep_until = -1;

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -162,14 +162,16 @@ void Scene_Battle_Rpg2k::SetState(Scene_Battle::State new_state) {
 		break;
 	}
 
-	options_window->SetVisible(false);
-	status_window->SetVisible(false);
-	command_window->SetVisible(false);
-	item_window->SetVisible(false);
-	skill_window->SetVisible(false);
-	help_window->SetVisible(false);
-	target_window->SetVisible(false);
-	battle_message_window->SetVisible(false);
+	if (state != State_SelectEnemyTarget && state != State_SelectAllyTarget) {
+		options_window->SetVisible(false);
+		status_window->SetVisible(false);
+		command_window->SetVisible(false);
+		target_window->SetVisible(false);
+		battle_message_window->SetVisible(false);
+		item_window->SetVisible(false);
+		skill_window->SetVisible(false);
+		help_window->SetVisible(false);
+	}
 
 	switch (state) {
 	case State_Start:
@@ -194,15 +196,14 @@ void Scene_Battle_Rpg2k::SetState(Scene_Battle::State new_state) {
 		status_window->SetX(0);
 		break;
 	case State_SelectEnemyTarget:
-		status_window->SetVisible(true);
-		command_window->SetVisible(true);
 		target_window->SetActive(true);
 		target_window->SetVisible(true);
+		target_window->SetIndex(0);
 		break;
 	case State_SelectAllyTarget:
 		status_window->SetVisible(true);
 		status_window->SetX(0);
-		command_window->SetVisible(true);
+		status_window->SetIndex(0);
 		break;
 	case State_Battle:
 		battle_message_window->SetVisible(true);

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -808,7 +808,7 @@ void Scene_Battle_Rpg2k::SelectPreviousActor() {
 	battle_actions.back()->SetBattleAlgorithm(std::shared_ptr<Game_BattleAlgorithm::AlgorithmBase>());
 	battle_actions.pop_back();
 
-	if (active_actor->GetAutoBattle() || !active_actor->IsControllable()) {
+	if (!active_actor->IsControllable()) {
 		SelectPreviousActor();
 		return;
 	}

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -130,6 +130,7 @@ protected:
 	int encounter_message_sleep_until = -1;
 	bool encounter_message_first_strike = false;
 
+	bool battle_action_pending = false;
 	bool begin_escape = true;
 	bool escape_success = false;
 	int escape_counter = 0;


### PR DESCRIPTION
Fixes all of the following scenarios from #1449. In master you see the battle menu flicker on the screen when these things happen.

1. Party starts the battle unable to move (recoverable) -> skip menu and start battle sequence
2. Party starts the battle unable to move (not recoverable) -> skip menu and start defeat sequence
3. Turn 0 event kills the party or immobilizes (not recoverable) the party -> skip menu and start defeat sequence
4. Turn 0 event immobilizes (recoverable) party -> skip menu and start battle sequence
5. Turn 0 event which creates a message window -> display message
6. Turn 0 event which waits -> battle window is empty while waiting


Also includes some minor cleanups