### PR TITLE
Fix Saving and Loading of panning chunks

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -813,6 +813,9 @@ int Game_Character::GetSpriteX() const {
 			x += GetRemainingStep();
 	} else if (IsJumping())
 		x -= ((GetX() - jump_x) * GetRemainingStep());
+	if (x < 0) {
+		x += Game_Map::GetWidth() * SCREEN_TILE_WIDTH;
+	}
 
 	return x;
 }
@@ -828,6 +831,10 @@ int Game_Character::GetSpriteY() const {
 			y += GetRemainingStep();
 	} else if (IsJumping())
 		y -= (GetY() - jump_y) * GetRemainingStep();
+
+	if (y < 0) {
+		y += Game_Map::GetHeight() * SCREEN_TILE_WIDTH;
+	}
 
 	return y;
 }

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -618,9 +618,12 @@ bool Game_Interpreter_Map::CommandPanScreen(RPG::EventCommand const& com) { // c
 		break;
 	case 3: // Reset
 		speed = com.parameters[3];
-		distance = std::max(std::abs(Game_Map::GetPanX()), std::abs(Game_Map::GetPanY())) / SCREEN_TILE_WIDTH;
 		waiting_pan_screen = com.parameters[4] != 0;
 		Game_Map::ResetPan(speed, waiting_pan_screen);
+		distance = std::max(
+				std::abs(Game_Map::GetPanX() - Game_Map::GetTargetPanX())
+				, std::abs(Game_Map::GetPanY() - Game_Map::GetTargetPanY()));
+		distance /= SCREEN_TILE_WIDTH;
 		break;
 	}
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -47,6 +47,7 @@
 namespace {
 	constexpr int default_pan_x = 9 * SCREEN_TILE_WIDTH;
 	constexpr int default_pan_y = 7 * SCREEN_TILE_WIDTH;
+	constexpr int default_pan_speed = 16;
 
 	RPG::SaveMapInfo& map_info = Main_Data::game_data.map_info;
 	RPG::SavePartyLocation& location = Main_Data::game_data.party_location;
@@ -75,7 +76,6 @@ namespace {
 
 	bool pan_locked;
 	bool pan_wait;
-	int pan_speed;
 
 	int last_map_id;
 
@@ -109,7 +109,7 @@ void Game_Map::Init() {
 
 	pan_locked = false;
 	pan_wait = false;
-	pan_speed = 0;
+	location.pan_speed = default_pan_speed;
 	location.pan_finish_x = default_pan_x;
 	location.pan_finish_y = default_pan_y;
 	location.pan_current_x = default_pan_x;
@@ -153,6 +153,7 @@ void Game_Map::Setup(int _id) {
 		events.emplace_back(location.map_id, ev);
 	}
 
+	location.pan_speed = default_pan_speed;
 	location.pan_finish_x = default_pan_x;
 	location.pan_finish_y = default_pan_y;
 	location.pan_current_x = default_pan_x;
@@ -267,7 +268,6 @@ void Game_Map::SetupCommon(int _id, bool is_load_savegame) {
 		pending.push_back(Main_Data::game_player.get());
 
 	pan_wait = false;
-	pan_speed = 0;
 
 	auto map_save_count = map->save_count;
 	if (Player::IsRPG2k3() && map->save_count_2k3e > 0) {
@@ -1358,14 +1358,14 @@ void Game_Map::StartPan(int direction, int distance, int speed, bool wait) {
 		location.pan_finish_x = new_pan;
 	}
 
-	pan_speed = speed;
+	location.pan_speed = 2 << speed;
 	pan_wait = wait;
 }
 
 void Game_Map::ResetPan(int speed, bool wait) {
 	location.pan_finish_x = default_pan_x;
 	location.pan_finish_y = default_pan_y;
-	pan_speed = speed;
+	location.pan_speed = 2 << speed;
 	pan_wait = wait;
 }
 
@@ -1373,7 +1373,7 @@ void Game_Map::UpdatePan() {
 	if (!IsPanActive())
 		return;
 
-	int step = (SCREEN_TILE_WIDTH/128) << pan_speed;
+	int step = location.pan_speed;
 	int dx = location.pan_finish_x - location.pan_current_x;
 	int dy = location.pan_finish_y - location.pan_current_y;
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -45,6 +45,9 @@
 #include "utils.h"
 
 namespace {
+	constexpr int default_pan_x = 9 * SCREEN_TILE_WIDTH;
+	constexpr int default_pan_y = 7 * SCREEN_TILE_WIDTH;
+
 	RPG::SaveMapInfo& map_info = Main_Data::game_data.map_info;
 	RPG::SavePartyLocation& location = Main_Data::game_data.party_location;
 	RPG::SavePanorama& panorama = Main_Data::game_data.panorama;
@@ -107,10 +110,10 @@ void Game_Map::Init() {
 	pan_locked = false;
 	pan_wait = false;
 	pan_speed = 0;
-	location.pan_finish_x = 0;
-	location.pan_finish_y = 0;
-	location.pan_current_x = 0;
-	location.pan_current_y = 0;
+	location.pan_finish_x = default_pan_x;
+	location.pan_finish_y = default_pan_y;
+	location.pan_current_x = default_pan_x;
+	location.pan_current_y = default_pan_y;
 	last_map_id = -1;
 
 	teleport_delay = false;
@@ -150,10 +153,10 @@ void Game_Map::Setup(int _id) {
 		events.emplace_back(location.map_id, ev);
 	}
 
-	location.pan_finish_x = 0;
-	location.pan_finish_y = 0;
-	location.pan_current_x = 0;
-	location.pan_current_y = 0;
+	location.pan_finish_x = default_pan_x;
+	location.pan_finish_y = default_pan_y;
+	location.pan_current_x = default_pan_x;
+	location.pan_current_y = default_pan_y;
 
 	// Save allowed
 	int current_index = GetMapIndex(location.map_id);
@@ -209,12 +212,6 @@ void Game_Map::SetupFromSave() {
 	SetChipset(map_info.chipset_id);
 
 	SetEncounterSteps(location.encounter_steps);
-
-	// FIXME: Handle Pan correctly
-	location.pan_current_x = 0;
-	location.pan_current_y = 0;
-	location.pan_finish_x = 0;
-	location.pan_finish_y = 0;
 }
 
 
@@ -1348,16 +1345,16 @@ void Game_Map::StartPan(int direction, int distance, int speed, bool wait) {
 	distance *= SCREEN_TILE_WIDTH;
 
 	if (direction == PanUp) {
-		int new_pan = location.pan_finish_y - distance;
-		location.pan_finish_y = new_pan;
-	} else if (direction == PanRight) {
-		int new_pan = location.pan_finish_x + distance;
-		location.pan_finish_x = new_pan;
-	} else if (direction == PanDown) {
 		int new_pan = location.pan_finish_y + distance;
 		location.pan_finish_y = new_pan;
-	} else if (direction == PanLeft) {
+	} else if (direction == PanRight) {
 		int new_pan = location.pan_finish_x - distance;
+		location.pan_finish_x = new_pan;
+	} else if (direction == PanDown) {
+		int new_pan = location.pan_finish_y - distance;
+		location.pan_finish_y = new_pan;
+	} else if (direction == PanLeft) {
+		int new_pan = location.pan_finish_x + distance;
 		location.pan_finish_x = new_pan;
 	}
 
@@ -1366,8 +1363,8 @@ void Game_Map::StartPan(int direction, int distance, int speed, bool wait) {
 }
 
 void Game_Map::ResetPan(int speed, bool wait) {
-	location.pan_finish_x = 0;
-	location.pan_finish_y = 0;
+	location.pan_finish_x = default_pan_x;
+	location.pan_finish_y = default_pan_y;
 	pan_speed = speed;
 	pan_wait = wait;
 }
@@ -1410,19 +1407,19 @@ bool Game_Map::IsPanLocked() {
 }
 
 int Game_Map::GetPanX() {
-	return location.pan_current_x;
+	return -(location.pan_current_x - default_pan_x);
 }
 
 int Game_Map::GetPanY() {
-	return location.pan_current_y;
+	return -(location.pan_current_y - default_pan_y);
 }
 
 int Game_Map::GetTargetPanX() {
-	return location.pan_finish_x;
+	return -(location.pan_finish_x - default_pan_x);
 }
 
 int Game_Map::GetTargetPanY() {
-	return location.pan_finish_y;
+	return -(location.pan_finish_y - default_pan_y);
 }
 
 bool Game_Map::IsTeleportDelayed() {

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -108,14 +108,14 @@ namespace Game_Map {
 	 *
 	 * @param distance scroll amount in sixteenths of a pixel
 	 */
-	void ScrollRight(int distance);
+	void ScrollRight(int distance, bool ignore_pan_lock = false);
 
 	/**
 	 * Scrolls the map view down.
 	 *
 	 * @param distance scroll amount in sixteenths of a pixel
 	 */
-	void ScrollDown(int distance);
+	void ScrollDown(int distance, bool ignore_pan_lock = false);
 
 	/**
 	 * Adds inc, a distance in sixteenths of a pixel, to screen_x, the

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -108,14 +108,14 @@ namespace Game_Map {
 	 *
 	 * @param distance scroll amount in sixteenths of a pixel
 	 */
-	void ScrollRight(int distance, bool ignore_pan_lock = false);
+	void ScrollRight(int distance);
 
 	/**
 	 * Scrolls the map view down.
 	 *
 	 * @param distance scroll amount in sixteenths of a pixel
 	 */
-	void ScrollDown(int distance, bool ignore_pan_lock = false);
+	void ScrollDown(int distance);
 
 	/**
 	 * Adds inc, a distance in sixteenths of a pixel, to screen_x, the

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -119,7 +119,15 @@ void Game_Player::PerformTeleport() {
 
 	SetTransparency(0);
 
+	// When teleporting we always reset the screen position.
+	// After this, the paning stays locked if it was before.
+	const auto is_locked = Game_Map::IsPanLocked();
+	Game_Map::UnlockPan();
 	MoveTo(new_x, new_y);
+	if (is_locked) {
+		Game_Map::LockPan();
+	}
+
 	if (new_direction >= 0) {
 		SetDirection(new_direction);
 		SetSpriteDirection(new_direction);
@@ -238,11 +246,11 @@ void Game_Player::UpdateScroll() {
 
 	// Only move for the pan if we're closer to the target pan than we were before.
 	if (std::abs(actual_pan_x + pan_dx - Game_Map::GetTargetPanX()) < std::abs(actual_pan_x - Game_Map::GetTargetPanX())) {
-		Game_Map::ScrollRight(pan_dx);
+		Game_Map::ScrollRight(pan_dx, true);
 		actual_pan_x += pan_dx;
 	}
 	if (std::abs(actual_pan_y + pan_dy - Game_Map::GetTargetPanY()) < std::abs(actual_pan_y - Game_Map::GetTargetPanY())) {
-		Game_Map::ScrollDown(pan_dy);
+		Game_Map::ScrollDown(pan_dy, true);
 		actual_pan_y += pan_dy;
 	}
 }

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -113,8 +113,6 @@ void Game_Player::PerformTeleport() {
 	if (Game_Map::GetMapId() != new_map_id) {
 		SetAnimFrame(RPG::EventPage::Frame_middle);
 		Game_Map::Setup(new_map_id);
-		last_pan_x = 0;
-		last_pan_y = 0;
 	} else {
 		Game_Map::SetupFromTeleportSelf();
 	}
@@ -166,6 +164,9 @@ void Game_Player::Center() {
 
 	Game_Map::SetPositionX(x);
 	Game_Map::SetPositionY(y);
+
+	last_pan_x = actual_pan_x;
+	last_pan_y = actual_pan_y;
 }
 
 void Game_Player::MoveTo(int x, int y) {

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -101,15 +101,10 @@ private:
 	bool teleporting = false;
 	int new_map_id = 0, new_x = 0, new_y = 0, new_direction = 0;
 
-	int last_pan_x = 0, last_pan_y = 0;
-	int last_remaining_move = 0, last_remaining_jump = 0;
-	// These track how much of the pan has actually occurred, which
-	// may be less than the pan values if the pan went off the map.
-	int actual_pan_x = 0, actual_pan_y = 0;
-
 	RPG::Music walking_bgm;
 
-	void UpdateScroll();
+	void UpdateScroll(int prev_x, int prev_y);
+	void UpdatePan();
 	bool CheckTouchEvent();
 	bool CheckCollisionEvent();
 	bool CheckActionEvent();


### PR DESCRIPTION
**Don't merge until #1502 is merged**

Fixes saving and loading games in the following conditions. Saves were tested to be compatible between `RPG_RT` and `Player` for these behaviors.

* When the screen is panned.
* While the screen is panning.
   * Loading correctly continues the panning. This is broken in `RPG_RT`.
* While screen is locked

I also tested these scenarios
* Screen behavior when event unlocks when screen is in default centered position.
* Screen behavior when event unlocks when screen is panned.
* Teleporting to same map does not change any panning state
    * If pan lock is enabled, the screen will still change position when you teleport to the same map.
* Teleporting to different map resets pan position and speed, but not pan lock.
* Panning move screen event commands still work while screen is locked.
    * Including Loading while pan is occurring.
* Multiple consecutive no wait panning move command overwrite each other. All but the final one become no-ops.
* Verified return to origin panning still works.
    * Including all 4 directions of diagonal panning

This patch uses `RPG_RT` centered panning units inside `Game_Map` and converts to 0 based for use externally. This was done to minimize the amount of change on panning code.