### PR TITLE
Remove SaveMapEvent::Fixup call

### DIFF
--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -311,8 +311,6 @@ void Game_Event::SetupFromSave(const RPG::EventPage* new_page) {
 		return;
 	}
 
-	data.Fixup(*new_page);
-
 	tile_id = page->character_name.empty() ? page->character_index : 0;
 
 	pattern = page->character_pattern;


### PR DESCRIPTION
I've added this PR as an easy way to allow `Player` to compile when https://github.com/EasyRPG/liblcf/pull/282 is merged.

This Fixup() call doesn't do anything useful, so this PR can be merged anytime.