### PR TITLE
Fix state recovery turns logic

### DIFF
--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -730,13 +730,12 @@ std::vector<int16_t> Game_Battler::NextBattleTurn() {
 
 	for (size_t i = 0; i < states.size(); ++i) {
 		if (HasState(i + 1)) {
-			states[i] += 1;
-
-			if (states[i] >= Data::states[i].hold_turn) {
-				if (Utils::ChanceOf(Data::states[i].auto_release_prob, 100)) {
-					healed_states.push_back(i + 1);
-					RemoveState(i + 1);
-				}
+			if (states[i] > Data::states[i].hold_turn
+					&& Utils::ChanceOf(Data::states[i].auto_release_prob, 100)) {
+				healed_states.push_back(i + 1);
+				RemoveState(i + 1);
+			} else {
+				++states[i];
 			}
 		}
 	}


### PR DESCRIPTION
Logic was incorrect. Can be tested with a state that lasts
1 turn, 0 turns, N turns, etc...

I've pulled this out of #1508 as this is an obvious bug fix that can be merged to solve #1504 and #1506. The other states PR needs more work.


Fix #1504