### PR TITLE
Fix to_hit calculation - Previously Albeleon 2.34 + Weapon sp cost fix

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1284,6 +1284,15 @@ int Game_Actor::GetBattleAnimationId() const {
 }
 
 int Game_Actor::GetHitChance() const {
+	auto* weapon1 = GetWeapon();
+	auto* weapon2 = Get2ndWeapon();
+	if (weapon1 && weapon2) {
+		return std::max(weapon1->hit, weapon2->hit);
+	} else if(weapon1) {
+		return weapon1->hit;
+	} else if(weapon2) {
+		return weapon2->hit;
+	}
 	return 90;
 }
 

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1451,6 +1451,13 @@ const RPG::Item* Game_Actor::GetAccessory() const {
 	return nullptr;
 }
 
+bool Game_Actor::AttackIgnoresEvasion() const {
+	auto checkEquip = [](const RPG::Item* item) {
+		return item && item->ignore_evasion;
+	};
+	return checkEquip(GetWeapon()) || checkEquip(Get2ndWeapon());
+}
+
 bool Game_Actor::PreventsCritical() const {
 	auto checkEquip = [](const RPG::Item* item) {
 		return item && item->prevent_critical;

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1305,16 +1305,6 @@ float Game_Actor::GetCriticalHitChance() const {
 	return crit_chance + (weapon_bonus / 100.0f);
 }
 
-bool Game_Actor::PreventsCritical() const {
-	auto checkEquip = [](const RPG::Item* item) {
-		return item && item->prevent_critical;
-	};
-	return checkEquip(GetShield())
-		|| checkEquip(GetArmor())
-		|| checkEquip(GetHelmet())
-		|| checkEquip(GetAccessory());
-}
-
 Game_Battler::BattlerType Game_Actor::GetType() const {
 	return Game_Battler::Type_Ally;
 }
@@ -1401,19 +1391,6 @@ void Game_Actor::RemoveInvalidData() {
 	}
 }
 
-bool Game_Actor::PreventsTerrainDamage() {
-	for (auto object_id : GetWholeEquipment()) {
-		RPG::Item *object = ReaderUtil::GetElement(Data::items, object_id);
-		if (object != nullptr && (object->type == RPG::Item::Type_shield || object->type == RPG::Item::Type_armor
-			|| object->type == RPG::Item::Type_helmet || object->type == RPG::Item::Type_accessory) && object->no_terrain_damage) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
-
 const RPG::Item* Game_Actor::GetWeapon() const {
 	auto* weapon = GetEquipment(RPG::Item::Type_weapon);
 	if (weapon && weapon->type == RPG::Item::Type_weapon) {
@@ -1463,6 +1440,46 @@ const RPG::Item* Game_Actor::GetAccessory() const {
 		return accessory;
 	}
 	return nullptr;
+}
+
+bool Game_Actor::PreventsCritical() const {
+	auto checkEquip = [](const RPG::Item* item) {
+		return item && item->prevent_critical;
+	};
+	return checkEquip(GetShield())
+		|| checkEquip(GetArmor())
+		|| checkEquip(GetHelmet())
+		|| checkEquip(GetAccessory());
+}
+
+bool Game_Actor::PreventsTerrainDamage() const {
+	auto checkEquip = [](const RPG::Item* item) {
+		return item && item->no_terrain_damage;
+	};
+	return checkEquip(GetShield())
+		|| checkEquip(GetArmor())
+		|| checkEquip(GetHelmet())
+		|| checkEquip(GetAccessory());
+}
+
+bool Game_Actor::HasPhysicalEvasionUp() const {
+	auto checkEquip = [](const RPG::Item* item) {
+		return item && item->raise_evasion;
+	};
+	return checkEquip(GetShield())
+		|| checkEquip(GetArmor())
+		|| checkEquip(GetHelmet())
+		|| checkEquip(GetAccessory());
+}
+
+bool Game_Actor::HasHalfSpCost() const {
+	auto checkEquip = [](const RPG::Item* item) {
+		return item && item->half_sp_cost;
+	};
+	return checkEquip(GetShield())
+		|| checkEquip(GetArmor())
+		|| checkEquip(GetHelmet())
+		|| checkEquip(GetAccessory());
 }
 
 

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -169,24 +169,30 @@ bool Game_Actor::IsSkillUsable(int skill_id) const {
 	return Game_Battler::IsSkillUsable(skill_id);
 }
 
-int Game_Actor::GetSpCostModifier() const {
-	// Only non-weapons have this modifier
-	int start = HasTwoWeapons() ? RPG::Item::Type_armor : RPG::Item::Type_shield;
-	int sp_mod = 1;
-
-	for (int i = start; i <= 5; ++i) {
-		const RPG::Item* item = GetEquipment(i);
-		if (item && item->half_sp_cost) {
-			sp_mod = 2;
-			break;
-		}
+int Game_Actor::CalculateSkillCost(int skill_id) const {
+	int cost = Game_Battler::CalculateSkillCost(skill_id);
+	if (HasHalfSpCost()) {
+		cost = (cost + 1) / 2;
 	}
-
-	return sp_mod;
+	return cost;
 }
 
-int Game_Actor::CalculateSkillCost(int skill_id) const {
-	return std::ceil(Game_Battler::CalculateSkillCost(skill_id) / (float) GetSpCostModifier());
+int Game_Actor::CalculateWeaponSpCost() const {
+	int cost = 0;
+	auto* w1 = GetWeapon();
+	if (w1) {
+		cost += w1->sp_cost;
+	}
+	auto* w2 = Get2ndWeapon();
+	if (w2) {
+		cost += w2->sp_cost;
+	}
+
+	if (HasHalfSpCost()) {
+		cost = (cost + 1) / 2;
+	}
+
+	return cost;
 }
 
 bool Game_Actor::LearnSkill(int skill_id) {

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -122,19 +122,17 @@ public:
 	bool IsSkillUsable(int skill_id) const override;
 
 	/**
-	 * Returns the modifier by which skill costs are divided.
-	 *
-	 * @return modifier
-	 */
-	int GetSpCostModifier() const;
-
-	/**
 	 * Calculates the Skill costs including all modifiers.
 	 *
 	 * @param skill_id ID of skill to calculate.
 	 * @return needed skill cost.
 	 */
 	int CalculateSkillCost(int skill_id) const override;
+
+	/**
+	 * @return sp cost for attacking with weapon.
+	 */
+	int CalculateWeaponSpCost() const;
 
 	/**
 	 * Gets the actor ID.

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -772,6 +772,11 @@ public:
 	void SetBattleRow(RowType battle_row);
 
 	/**
+	 * @return If the actor has weapon that ignores evasion
+	 */
+	bool AttackIgnoresEvasion() const;
+
+	/**
 	 * @return If the actor has equipment that protects against terrain damage.
 	 */
 	bool PreventsTerrainDamage() const;

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -772,16 +772,24 @@ public:
 	void SetBattleRow(RowType battle_row);
 
 	/**
-	 * Checks if the actor has an equipment that protects against terrain damage.
-	 *
-	 * @return Whether the actor avoid terrain damage.
+	 * @return If the actor has equipment that protects against terrain damage.
 	 */
-	bool PreventsTerrainDamage();
+	bool PreventsTerrainDamage() const;
 
 	/**
 	 * @return If the actor has an equipment that protects against critical hits.
 	 */
 	bool PreventsCritical() const;
+
+	/**
+	 * @return If the actor has an equipment that with physical evasion up.
+	 */
+	bool HasPhysicalEvasionUp() const;
+
+	/**
+	 * @return If the actor has an equipment with half sp cost.
+	 */
+	bool HasHalfSpCost() const;
 
 	int GetBattleAnimationId() const override;
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -41,6 +41,33 @@
 #include "sprite_battler.h"
 #include "utils.h"
 
+static inline int ToHitPhysical(Game_Battler *source, Game_Battler *target, int to_hit) {
+	// If target has Restriction "do_nothing", the attack always hits
+	if (target->GetSignificantRestriction() == RPG::State::Restriction_do_nothing) {
+		return 100;
+	}
+
+	// Modify hit chance for each state the source has
+	to_hit = (to_hit * source->GetHitChanceModifierFromStates()) / 100;
+
+	// Stop here if attacker ignores evasion.
+	if (source->GetType() == Game_Battler::Type_Ally
+		&& static_cast<Game_Actor*>(source)->AttackIgnoresEvasion()) {
+		return to_hit;
+	}
+
+	// AGI adjustment.
+	to_hit = 100 - (100 - to_hit) * (1.5f * (float(target->GetAgi()) / float(source->GetAgi()) - 1.0f));
+
+	// If target has physical dodge evasion:
+	if (target->GetType() == Game_Battler::Type_Ally
+			&& static_cast<Game_Actor*>(target)->HasPhysicalEvasionUp()) {
+		to_hit -= 25;
+	}
+
+	return to_hit;
+}
+
 Game_BattleAlgorithm::AlgorithmBase::AlgorithmBase(Type ty, Game_Battler* source) :
 	type(ty), source(source), no_target(true), first_attack(true) {
 	Reset();
@@ -791,7 +818,6 @@ Game_BattleAlgorithm::Normal::Normal(Game_Battler* source, Game_Party_Base* targ
 bool Game_BattleAlgorithm::Normal::Execute() {
 	Reset();
 
-	int to_hit;
 	float multiplier = 1;
 
 	// Criticals cannot occur when ally attacks ally or enemy attacks enemy (e.g. confusion)
@@ -804,8 +830,7 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 
 	if (source->GetType() == Game_Battler::Type_Ally) {
 		Game_Actor* ally = static_cast<Game_Actor*>(source);
-		int hit_chance = ally->GetHitChance();
-		const RPG::Item* weapon = ReaderUtil::GetElement(Data::items, ally->GetWeaponId());
+		const RPG::Item* weapon = ally->GetWeapon();
 
 		if (!weapon) {
 			// No Weapon
@@ -824,22 +849,18 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 			multiplier = GetAttributeMultiplier(weapon->attribute_set);
 		}
 
-		if (weapon && !weapon->ignore_evasion) {
-			to_hit = (int)(100 - (100 - hit_chance) * (1 + (1.0 * GetTarget()->GetAgi() / ally->GetAgi() - 1) / 2));
-		} else {
-			to_hit = (int)(100 - (100 - hit_chance));
-		}
 	} else {
 		// Source is Enemy
-		int hit = source->GetHitChance();
-		to_hit = (int)(100 - (100 - hit) * (1 + (1.0 * GetTarget()->GetAgi() / source->GetAgi() - 1) / 2));
 		if (!Data::animations.empty()) {
 			animation = &Data::animations[0];
 		}
 	}
 
+	auto to_hit = source->GetHitChance();
+	to_hit = ToHitPhysical(GetSource(), GetTarget(), to_hit);
+
 	// Damage calculation
-	if (Utils::GetRandomNumber(0, 99) < to_hit) {
+	if (Utils::PercentChance(to_hit)) {
 		if (Utils::PercentChance(crit_chance)) {
 			critical_hit = true;
 		}
@@ -1027,6 +1048,14 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 
 	if (skill.type == RPG::Skill::Type_normal ||
 		skill.type >= RPG::Skill::Type_subskill) {
+
+		int to_hit = skill.hit;
+
+		//If Physical technique, apply physical restrictions
+		if (skill.failure_message == 3) {
+			to_hit = ToHitPhysical(GetSource(), GetTarget(), to_hit);
+		}
+
 		if (this->healing) {
 			float mul = GetAttributeMultiplier(skill.attribute_effects);
 			if (mul < 0.5f) {
@@ -1052,7 +1081,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 			this->success = GetAffectedHp() != -1 || GetAffectedSp() != -1 || GetAffectedAttack() > 0
 				|| GetAffectedDefense() > 0 || GetAffectedSpirit() > 0 || GetAffectedAgility() > 0;
 		}
-		else if (Utils::GetRandomNumber(0, 99) < skill.hit) {
+		else if (Utils::PercentChance(to_hit)) {
 			absorb = skill.absorb_damage;
 
 			int effect = skill.power +
@@ -1064,7 +1093,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 			}
 			effect *= GetAttributeMultiplier(skill.attribute_effects);
 
-			if(effect < 0) {
+			if (effect < 0) {
 				effect = 0;
 			}
 
@@ -1110,7 +1139,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 		for (int i = 0; i < (int) skill.state_effects.size(); i++) {
 			if (!skill.state_effects[i])
 				continue;
-			if (!healing && Utils::GetRandomNumber(0, 99) >= skill.hit)
+			if (!healing && Utils::PercentChance(to_hit))
 				continue;
 
 			this->success = true;

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -804,7 +804,7 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 
 	if (source->GetType() == Game_Battler::Type_Ally) {
 		Game_Actor* ally = static_cast<Game_Actor*>(source);
-		int hit_chance = source->GetHitChance();
+		int hit_chance = ally->GetHitChance();
 		const RPG::Item* weapon = ReaderUtil::GetElement(Data::items, ally->GetWeaponId());
 
 		if (!weapon) {
@@ -821,7 +821,6 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 				Output::Warning("Algorithm Normal: Invalid weapon animation ID %d", weapon->animation_id);
 			}
 
-			hit_chance = weapon->hit;
 			multiplier = GetAttributeMultiplier(weapon->attribute_set);
 		}
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -941,11 +941,7 @@ void Game_BattleAlgorithm::Normal::Apply() {
 
 	source->SetCharged(false);
 	if (source->GetType() == Game_Battler::Type_Ally) {
-		Game_Actor* src = static_cast<Game_Actor*>(source);
-		const RPG::Item* weapon = ReaderUtil::GetElement(Data::items, src->GetWeaponId());
-		if (weapon) {
-			source->ChangeSp(std::ceil(-weapon->sp_cost / (float) src->GetSpCostModifier()));
-		}
+		source->ChangeSp(-static_cast<Game_Actor*>(source)->CalculateWeaponSpCost());
 	}
 }
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -940,7 +940,7 @@ void Game_BattleAlgorithm::Normal::Apply() {
 	AlgorithmBase::Apply();
 
 	source->SetCharged(false);
-	if (source->GetType() == Game_Battler::Type_Ally) {
+	if (source->GetType() == Game_Battler::Type_Ally && IsFirstAttack()) {
 		source->ChangeSp(-static_cast<Game_Actor*>(source)->CalculateWeaponSpCost());
 	}
 }

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -844,3 +844,15 @@ void Game_Battler::SetBattleOrderAgi(int val) {
 int Game_Battler::GetBattleOrderAgi() {
 	return battle_order;
 }
+
+int Game_Battler::GetHitChanceModifierFromStates() const {
+	int modifier = 100;
+	// Modify hit chance for each state the source has
+	for (const auto id : GetInflictedStates()) {
+		auto* state = ReaderUtil::GetElement(Data::states, id);
+		if (state) {
+			modifier = std::min(modifier, state->reduce_hit_ratio);
+		}
+	}
+	return modifier;
+}

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -606,6 +606,11 @@ public:
 	 */
 	virtual void ResetBattle();
 
+	/**
+	 * @return Effective physical hit rate modifier from inflicted states.
+	 */
+	int GetHitChanceModifierFromStates() const;
+
 protected:
 	/** Gauge for RPG2k3 Battle */
 	int gauge;


### PR DESCRIPTION
From Cherry:

>if target is not able to move, success probability = 100, otherwise: success probability = (skill success probability * (min(100, all the attacker's state accuracy rates)/100) and then only if weapon doesn't have "ignore enemy dodge rate" option is enabled: final success probability = 100 - (100 - success probability) * (1 + 0.5 * (target agility / attacker agility - 1)) and then only if target has an equipment with "increase dodge rate against physical attacks": final success probability -= 25 "this condition": only if the failure_message is 3 >and the target is an (or all) enemy not sure why the enemy thing though. that means that if an enemy casts >a spell, the agilities never matter...? I think the failure_message 3 classifies it as a physical attack in a way so you can dodge it actually it is illogical that this applies only to skills with enemies as target, yet it checks if the target has equipment with the "increase dodge rate" option since enemies can't wear equipment but I guess it's just copied from normal attack logic...
But this is for skills. Now, for physical attack, most of this is the same. But instead of the skill success probability, you have:
>
>if attacker is actor: max(weapon1's Item.hit, weapon2's Item.hit) or 90 if no weapons equipped else: if Enemy.miss then 70, otherwise 90