### PR TITLE
Correct battle turn order in rpg2k battle - previously Albeleon 2.42

### DIFF
--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -41,22 +41,22 @@
 #include "sprite_battler.h"
 #include "utils.h"
 
-Game_BattleAlgorithm::AlgorithmBase::AlgorithmBase(Game_Battler* source) :
-	source(source), no_target(true), first_attack(true) {
+Game_BattleAlgorithm::AlgorithmBase::AlgorithmBase(Type ty, Game_Battler* source) :
+	type(ty), source(source), no_target(true), first_attack(true) {
 	Reset();
 
 	current_target = targets.end();
 }
 
-Game_BattleAlgorithm::AlgorithmBase::AlgorithmBase(Game_Battler* source, Game_Battler* target) :
-	source(source), no_target(false), first_attack(true) {
+Game_BattleAlgorithm::AlgorithmBase::AlgorithmBase(Type ty, Game_Battler* source, Game_Battler* target) :
+	type(ty), source(source), no_target(false), first_attack(true) {
 	Reset();
 
 	SetTarget(target);
 }
 
-Game_BattleAlgorithm::AlgorithmBase::AlgorithmBase(Game_Battler* source, Game_Party_Base* target) :
-	source(source), no_target(false), first_attack(true) {
+Game_BattleAlgorithm::AlgorithmBase::AlgorithmBase(Type ty, Game_Battler* source, Game_Party_Base* target) :
+	type(ty), source(source), no_target(false), first_attack(true) {
 	Reset();
 
 	target->GetBattlers(targets);
@@ -778,17 +778,13 @@ bool Game_BattleAlgorithm::AlgorithmBase::IsReflected() const {
 	return false;
 }
 
-bool Game_BattleAlgorithm::AlgorithmBase::IsSoundAnimationOnAlly() const {
-	return false;
-}
-
 Game_BattleAlgorithm::Normal::Normal(Game_Battler* source, Game_Battler* target) :
-	AlgorithmBase(source, target) {
+	AlgorithmBase(Type::Normal, source, target) {
 	// no-op
 }
 
 Game_BattleAlgorithm::Normal::Normal(Game_Battler* source, Game_Party_Base* target) :
-	AlgorithmBase(source, target) {
+	AlgorithmBase(Type::Normal, source, target) {
 	// no-op
 }
 
@@ -971,17 +967,17 @@ int Game_BattleAlgorithm::Normal::GetPhysicalDamageRate() const {
 }
 
 Game_BattleAlgorithm::Skill::Skill(Game_Battler* source, Game_Battler* target, const RPG::Skill& skill, const RPG::Item* item) :
-	AlgorithmBase(source, target), skill(skill), item(item) {
+	AlgorithmBase(Type::Skill, source, target), skill(skill), item(item) {
 	// no-op
 }
 
 Game_BattleAlgorithm::Skill::Skill(Game_Battler* source, Game_Party_Base* target, const RPG::Skill& skill, const RPG::Item* item) :
-	AlgorithmBase(source, target), skill(skill), item(item) {
+	AlgorithmBase(Type::Skill, source, target), skill(skill), item(item) {
 	// no-op
 }
 
 Game_BattleAlgorithm::Skill::Skill(Game_Battler* source, const RPG::Skill& skill, const RPG::Item* item) :
-	AlgorithmBase(source), skill(skill), item(item) {
+	AlgorithmBase(Type::Skill, source), skill(skill), item(item) {
 	// no-op
 }
 
@@ -1301,22 +1297,18 @@ bool Game_BattleAlgorithm::Skill::IsReflected() const {
 	return has_reflect;
 }
 
-bool Game_BattleAlgorithm::Skill::IsSoundAnimationOnAlly() const {
-	return true;
-}
-
 Game_BattleAlgorithm::Item::Item(Game_Battler* source, Game_Battler* target, const RPG::Item& item) :
-	AlgorithmBase(source, target), item(item) {
+	AlgorithmBase(Type::Item, source, target), item(item) {
 		// no-op
 }
 
 Game_BattleAlgorithm::Item::Item(Game_Battler* source, Game_Party_Base* target, const RPG::Item& item) :
-	AlgorithmBase(source, target), item(item) {
+	AlgorithmBase(Type::Item, source, target), item(item) {
 		// no-op
 }
 
 Game_BattleAlgorithm::Item::Item(Game_Battler* source, const RPG::Item& item) :
-AlgorithmBase(source), item(item) {
+AlgorithmBase(Type::Item, source), item(item) {
 	// no-op
 }
 
@@ -1436,7 +1428,7 @@ const RPG::Sound* Game_BattleAlgorithm::Item::GetStartSe() const {
 }
 
 Game_BattleAlgorithm::NormalDual::NormalDual(Game_Battler* source, Game_Battler* target) :
-	AlgorithmBase(source, target) {
+	AlgorithmBase(Type::NormalDual, source, target) {
 	// no-op
 }
 
@@ -1464,7 +1456,7 @@ bool Game_BattleAlgorithm::NormalDual::Execute() {
 }
 
 Game_BattleAlgorithm::Defend::Defend(Game_Battler* source) :
-	AlgorithmBase(source) {
+	AlgorithmBase(Type::Defend, source) {
 	// no-op
 }
 
@@ -1498,7 +1490,7 @@ void Game_BattleAlgorithm::Defend::Apply() {
 }
 
 Game_BattleAlgorithm::Observe::Observe(Game_Battler* source) :
-AlgorithmBase(source) {
+AlgorithmBase(Type::Observe, source) {
 	// no-op
 }
 
@@ -1524,7 +1516,7 @@ bool Game_BattleAlgorithm::Observe::Execute() {
 }
 
 Game_BattleAlgorithm::Charge::Charge(Game_Battler* source) :
-AlgorithmBase(source) {
+AlgorithmBase(Type::Charge, source) {
 	// no-op
 }
 
@@ -1554,7 +1546,7 @@ void Game_BattleAlgorithm::Charge::Apply() {
 }
 
 Game_BattleAlgorithm::SelfDestruct::SelfDestruct(Game_Battler* source, Game_Party_Base* target) :
-AlgorithmBase(source, target) {
+AlgorithmBase(Type::SelfDestruct, source, target) {
 	// no-op
 }
 
@@ -1629,7 +1621,7 @@ void Game_BattleAlgorithm::SelfDestruct::Apply() {
 }
 
 Game_BattleAlgorithm::Escape::Escape(Game_Battler* source) :
-	AlgorithmBase(source) {
+	AlgorithmBase(Type::Escape, source) {
 	// no-op
 }
 
@@ -1718,7 +1710,7 @@ void Game_BattleAlgorithm::Escape::GetResultMessages(std::vector<std::string>& o
 }
 
 Game_BattleAlgorithm::Transform::Transform(Game_Battler* source, int new_monster_id) :
-AlgorithmBase(source), new_monster_id(new_monster_id) {
+AlgorithmBase(Type::Transform, source), new_monster_id(new_monster_id) {
 	// no-op
 }
 
@@ -1748,7 +1740,7 @@ void Game_BattleAlgorithm::Transform::Apply() {
 }
 
 Game_BattleAlgorithm::NoMove::NoMove(Game_Battler* source) :
-AlgorithmBase(source) {
+AlgorithmBase(Type::NoMove, source) {
 	// no-op
 }
 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -41,6 +41,21 @@ namespace RPG {
  */
 namespace Game_BattleAlgorithm {
 
+enum class Type {
+	Null,
+	Normal,
+	Skill,
+	Item,
+	NormalDual,
+	Defend,
+	Observe,
+	Charge,
+	SelfDestruct,
+	Escape,
+	Transform,
+	NoMove,
+};
+
 class AlgorithmBase {
 public:
 	/**
@@ -324,14 +339,14 @@ public:
 	virtual bool IsReflected() const;
 
 	/**
-	 * @return true if this action uses PlaySoundAnimation() on allies
+	 * Returns the algorithm type of this object.
 	 */
-	virtual bool IsSoundAnimationOnAlly() const;
+	Type GetType() const;
 
 protected:
-	AlgorithmBase(Game_Battler* source);
-	AlgorithmBase(Game_Battler* source, Game_Battler* target);
-	AlgorithmBase(Game_Battler* source, Game_Party_Base* target);
+	AlgorithmBase(Type t, Game_Battler* source);
+	AlgorithmBase(Type t, Game_Battler* source, Game_Battler* target);
+	AlgorithmBase(Type t, Game_Battler* source, Game_Party_Base* target);
 
 	std::string GetAttackFailureMessage(const std::string& points) const;
 	std::string GetHpSpRecoveredMessage(int value, const std::string& points) const;
@@ -357,6 +372,7 @@ protected:
 	 */
 	bool TargetNextInternal() const;
 
+	Type type = Type::Null;
 	Game_Battler* source;
 	std::vector<Game_Battler*> targets;
 	mutable std::vector<Game_Battler*>::iterator current_target;
@@ -420,7 +436,6 @@ public:
 	void GetResultMessages(std::vector<std::string>& out) const override;
 	int GetPhysicalDamageRate() const override;
 	bool IsReflected() const override;
-	bool IsSoundAnimationOnAlly() const override;
 
 private:
 	const RPG::Skill& skill;
@@ -529,6 +544,11 @@ public:
 	void Apply() override;
 };
 
+
+inline Type AlgorithmBase::GetType() const {
+	return type;
 }
+
+} //namespace Game_BattleAlgorithm
 
 #endif

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -836,3 +836,11 @@ void Game_Battler::ShiftAttributeRate(int attribute_id, int shift) {
 		--old_shift;
 	}
 }
+
+void Game_Battler::SetBattleOrderAgi(int val) {
+	battle_order = val;
+}
+
+int Game_Battler::GetBattleOrderAgi() {
+	return battle_order;
+}

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -591,6 +591,9 @@ public:
 	 */
 	std::vector<int16_t> BattlePhysicalStateHeal(int physical_rate);
 
+	void SetBattleOrderAgi(int val);
+	int GetBattleOrderAgi();
+
 	void SetLastBattleAction(int battle_action);
 
 	int GetLastBattleAction() const;
@@ -622,6 +625,8 @@ protected:
 	int battle_combo_times;
 
 	std::vector<int> attribute_shift;
+
+	int battle_order = 0;
 };
 
 #endif

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -449,7 +449,7 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 				if (action->GetTarget()) {
 					if (action->GetTarget()->GetType() == Game_Battler::Type_Enemy) {
 						action->PlayAnimation();
-					} else if (action->GetTarget()->GetType() == Game_Battler::Type_Ally && action->IsSoundAnimationOnAlly()) {
+					} else if (action->GetTarget()->GetType() == Game_Battler::Type_Ally && action->GetType() == Game_BattleAlgorithm::Type::Skill) {
 						action->PlaySoundAnimation(false, 20);
 					}
 				}

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -849,24 +849,20 @@ void Scene_Battle_Rpg2k::SelectPreviousActor() {
 	SetState(State_SelectActor);
 }
 
-static bool BattlerSort(Game_Battler* first, Game_Battler* second) {
-	if (first->HasPreemptiveAttack() && second->HasPreemptiveAttack()) {
-		return first->GetAgi() > second->GetAgi();
-	}
-
-	if (first->HasPreemptiveAttack()) {
-		return true;
-	}
-
-	if (second->HasPreemptiveAttack()) {
-		return false;
-	}
-
-	return first->GetAgi() > second->GetAgi();
-}
-
 void Scene_Battle_Rpg2k::CreateExecutionOrder() {
-	std::sort(battle_actions.begin(), battle_actions.end(), BattlerSort);
+	// Define random Agility. Must be done outside of the sort function because of the "strict weak ordering" property, so the sort is consistent
+	for (auto battler : battle_actions) {
+		int battle_order = battler->GetAgi() + Utils::GetRandomNumber(0, battler->GetAgi() / 4 + 3);
+		if (battler->GetBattleAlgorithm()->GetType() == Game_BattleAlgorithm::Type::Normal && battler->HasPreemptiveAttack()) {
+			// This is an arbitrarily large number to separate preemptive vs non-preemptive battlers
+			battle_order += 100000;
+		}
+		battler->SetBattleOrderAgi(battle_order);
+	}
+	std::sort(battle_actions.begin(), battle_actions.end(),
+			[](Game_Battler* l, Game_Battler* r) {
+			return l->GetBattleOrderAgi() > r->GetBattleOrderAgi();
+			});
 }
 
 void Scene_Battle_Rpg2k::CreateEnemyActions() {


### PR DESCRIPTION
From Cherry:
> RPG_RT defines something like a "battle agility" for each turn which is AGI+X. X is a random number below (AGI/4 + 3). However, if the attack is a basic attack with a weapon that has the "Start with Initiative" checkbox, this puts it into a class of its own which follows the same rules but can rival only other attacks with such weapons (I think this is done by simply adding a huge number like 100000 to the value in such a case). The turn order is then decided by this "battle agility", high to low.