### PR TITLE
Implement Get MIDI Ticks for non-MIDI formats by returning position in sec

### DIFF
--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -20,6 +20,7 @@
 #include "system.h"
 #include "baseui.h"
 #include "player.h"
+#include "graphics.h"
 
 AudioInterface& Audio() {
 	static EmptyAudio default_;
@@ -32,12 +33,23 @@ AudioInterface& Audio() {
 
 void EmptyAudio::BGM_Play(std::string const&, int, int, int) {
 	bgm_starttick = Player::GetFrames();
+	playing = true;
+}
+
+void EmptyAudio::BGM_Stop() {
+	playing = false;
 }
 
 unsigned EmptyAudio::BGM_GetTicks() const {
-	return (Player::GetFrames() - bgm_starttick) * 500; // Arbitrary
+	if (!playing) {
+		return 0;
+	}
+
+	// Time since BGM_Play was called, works for everything except MIDI
+	return (Player::GetFrames() - bgm_starttick + 1) / Graphics::GetDefaultFps();
 }
 
 bool EmptyAudio::BGM_PlayedOnce() const {
-	return BGM_GetTicks() > 5000; // Arbitrary
+	// 5 seconds, arbitrary
+	return BGM_GetTicks() > (Graphics::GetDefaultFps() * 5);
 }

--- a/src/audio.h
+++ b/src/audio.h
@@ -51,10 +51,10 @@ struct AudioInterface {
 	 * Returns whether the background music has played at least once.
 	 */
 	virtual bool BGM_PlayedOnce() const = 0;
-	
+
 	/**
 	 * Reports if a music file is currently being played.
-	 * 
+	 *
 	 * @return true when BGM is playing
 	 */
 	virtual bool BGM_IsPlaying() const = 0;
@@ -112,10 +112,11 @@ struct AudioInterface {
 };
 
 struct EmptyAudio : public AudioInterface {
+public:
 	void BGM_Play(std::string const&, int, int, int) override;
 	void BGM_Pause() override {}
 	void BGM_Resume() override {}
-	void BGM_Stop() override {}
+	void BGM_Stop() override;
 	bool BGM_PlayedOnce() const override;
 	bool BGM_IsPlaying() const override { return false; }
 	unsigned BGM_GetTicks() const override;
@@ -126,7 +127,10 @@ struct EmptyAudio : public AudioInterface {
 	void SE_Stop() override {}
 	void Update() override {}
 
+private:
 	unsigned bgm_starttick = 0;
+
+	bool playing = false;
 };
 
 AudioInterface& Audio();

--- a/src/audio_decoder.h
+++ b/src/audio_decoder.h
@@ -249,7 +249,7 @@ public:
 	 * 200 = double speed and so on
 	 * Not all audio decoders support this. Using the audio hardware is
 	 * recommended.
-	 * 
+	 *
 	 * @param pitch Pitch multiplier to use
 	 * @return true if pitch was set, false otherwise
 	 */
@@ -275,9 +275,11 @@ public:
 	virtual size_t Tell() const;
 
 	/**
-	 * Returns amount of executed ticks. Only useful for MIDI format.
+	 * Returns a value suitable for the GetMidiTicks command.
+	 * For MIDI this is the amount of MIDI ticks, for other
+	 * formats usually the playback position in seconds.
 	 *
-	 * @return Amount of MIDI ticks.
+	 * @return Amount of MIDI ticks or position in seconds
 	 */
 	virtual int GetTicks() const;
 

--- a/src/audio_generic.cpp
+++ b/src/audio_generic.cpp
@@ -113,6 +113,7 @@ unsigned GenericAudio::BGM_GetTicks() const {
 	for (unsigned i = 0; i < nr_of_bgm_channels; i++) {
 		if (BGM_Channels[i].decoder) {
 			ticks = BGM_Channels[i].decoder->GetTicks();
+			break;
 		}
 	}
 	UnlockMutex();

--- a/src/audio_sdl_mixer.cpp
+++ b/src/audio_sdl_mixer.cpp
@@ -455,12 +455,16 @@ bool SdlMixerAudio::BGM_IsPlaying() const {
 }
 
 unsigned SdlMixerAudio::BGM_GetTicks() const {
+	if (!BGM_IsPlaying()) {
+		return 0;
+	}
+
 	if (audio_decoder) {
 		return audio_decoder->GetTicks();
 	}
 
-	// TODO: Implement properly. This is an approximation.
-	return SDL_GetTicks() - bgm_starttick;
+	// Should work for everything except MIDI
+	return SDL_GetTicks() + 1 - bgm_starttick;
 }
 
 void SdlMixerAudio::BGM_Volume(int volume) {

--- a/src/decoder_mpg123.cpp
+++ b/src/decoder_mpg123.cpp
@@ -94,6 +94,11 @@ bool Mpg123Decoder::Open(FILE* file) {
 		return false;
 	}
 
+	// Samplerate cached, regularly needed for Ticks function
+	int ch;
+	int fmt;
+	mpg123_getformat(handle.get(), &samplerate, &ch, &fmt);
+
 	return true;
 }
 
@@ -185,6 +190,15 @@ bool Mpg123Decoder::SetFormat(int freq, AudioDecoder::Format fmt, int channels) 
 	return err == MPG123_OK;
 }
 
+int Mpg123Decoder::GetTicks() const {
+	if (samplerate == 0) {
+		return 0;
+	}
+
+	off_t pos = mpg123_tell(handle.get());
+	return pos / samplerate;
+}
+
 bool Mpg123Decoder::IsMp3(FILE* stream) {
 	Mpg123Decoder decoder;
 	// Prevent stream handle destruction
@@ -199,7 +213,7 @@ bool Mpg123Decoder::IsMp3(FILE* stream) {
 	int err = 0;
 	size_t done = 0;
 	int err_count = 0;
-	
+
 	// Read beginning of assumed MP3 file and count errors as an heuristic to detect MP3
 	for (int i = 0; i < 10; ++i) {
 		err = mpg123_read(decoder.handle.get(), buffer, 1024, &done);

--- a/src/decoder_mpg123.h
+++ b/src/decoder_mpg123.h
@@ -47,6 +47,8 @@ public:
 
 	bool SetFormat(int frequency, AudioDecoder::Format format, int channels) override;
 
+	int GetTicks() const override;
+
 	static bool IsMp3(FILE* stream);
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
@@ -56,6 +58,8 @@ private:
 #endif
 	int err = 0;
 	bool finished = false;
+
+	long samplerate = 0;
 };
 
 #endif

--- a/src/decoder_oggvorbis.cpp
+++ b/src/decoder_oggvorbis.cpp
@@ -68,7 +68,6 @@ bool OggVorbisDecoder::Open(FILE* file) {
 		return false;
 	}
 
-	// (long)ov_pcm_total(ovf, -1)) -> decoded length in samples, maybe useful for ticks later?
 	frequency = vi->rate;
 	channels = vi->channels;
 
@@ -105,6 +104,14 @@ bool OggVorbisDecoder::SetFormat(int freq, AudioDecoder::Format format, int chan
 		return false;
 
 	return true;
+}
+
+int OggVorbisDecoder::GetTicks() const {
+	if (!ovf) {
+		return 0;
+	}
+
+	return (int)ov_time_tell(ovf);
 }
 
 int OggVorbisDecoder::FillBuffer(uint8_t* buffer, int length) {

--- a/src/decoder_oggvorbis.h
+++ b/src/decoder_oggvorbis.h
@@ -49,6 +49,8 @@ public:
 	void GetFormat(int& frequency, AudioDecoder::Format& format, int& channels) const override;
 
 	bool SetFormat(int frequency, AudioDecoder::Format format, int channels) override;
+
+	int GetTicks() const override;
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 

--- a/src/decoder_opus.cpp
+++ b/src/decoder_opus.cpp
@@ -103,6 +103,15 @@ bool OpusDecoder::SetFormat(int freq, AudioDecoder::Format format, int chans) {
 	return true;
 }
 
+int OpusDecoder::GetTicks() const {
+	if (!oof) {
+		return 0;
+	}
+
+	// According to the docs it is number of samples at 48 kHz
+	return op_pcm_tell(oof) / 48000;
+}
+
 int OpusDecoder::FillBuffer(uint8_t* buffer, int length) {
 	if (!oof)
 		return -1;

--- a/src/decoder_opus.h
+++ b/src/decoder_opus.h
@@ -42,6 +42,8 @@ public:
 	void GetFormat(int& frequency, AudioDecoder::Format& format, int& channels) const override;
 
 	bool SetFormat(int frequency, AudioDecoder::Format format, int channels) override;
+
+	int GetTicks() const override;
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 


### PR DESCRIPTION
Implemented for mpg123, libvorbisfile and libopusfile.
Works for EmptyAudio and SDLAudio by approximating it through the frame count.

When no BGM is playing the returned value is 0.

Fix #1517