### PR TITLE
Fixes for skills and attributes

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -84,7 +84,7 @@ int Game_Actor::GetId() const {
 	return actor_id;
 }
 
-bool Game_Actor::UseItem(int item_id) {
+bool Game_Actor::UseItem(int item_id, const Game_Battler* source) {
 	const RPG::Item* item = ReaderUtil::GetElement(Data::items, item_id);
 	if (!item) {
 		Output::Warning("UseItem: Can't use invalid item %d", item_id);
@@ -110,7 +110,7 @@ bool Game_Actor::UseItem(int item_id) {
 		return true;
 	}
 
-	return Game_Battler::UseItem(item_id);
+	return Game_Battler::UseItem(item_id, source);
 }
 
 bool Game_Actor::IsItemUsable(int item_id) const {

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -73,7 +73,7 @@ public:
 	 * @param item_id ID if item to use
 	 * @return true if item affected anything
 	 */
-	bool UseItem(int item_id) override;
+	bool UseItem(int item_id, const Game_Battler* source) override;
 
 	/**
 	 * Checks if the actor is permitted to use the item at all.

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1087,10 +1087,6 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 
 		if (this->healing) {
 			float mul = GetTarget()->GetAttributeMultiplier(skill.attribute_effects);
-			if (mul < 0.5f) {
-				// Determined via testing, the heal is always at least 50%
-				mul = 0.5f;
-			}
 
 			effect +=
 				source->GetAtk() * skill.physical_rate / 20 +

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -625,24 +625,6 @@ Game_Battler* Game_BattleAlgorithm::AlgorithmBase::GetTarget() const {
 	return *current_target;
 }
 
-float Game_BattleAlgorithm::AlgorithmBase::GetAttributeMultiplier(const std::vector<bool>& attributes_set) const {
-	float multiplier = 0;
-	int attributes_applied = 0;
-	for (unsigned int i = 0; i < attributes_set.size(); i++) {
-		if (attributes_set[i]) {
-			multiplier += GetTarget()->GetAttributeModifier(i + 1);
-			attributes_applied++;
-		}
-	}
-
-	if (attributes_applied > 0) {
-		multiplier /= (attributes_applied * 100);
-		return multiplier;
-	}
-
-	return 1.0;
-}
-
 void Game_BattleAlgorithm::AlgorithmBase::SetTarget(Game_Battler* target) {
 	targets.clear();
 
@@ -891,7 +873,7 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 				Output::Warning("Algorithm Normal: Invalid weapon animation ID %d", weapon->animation_id);
 			}
 
-			multiplier = GetAttributeMultiplier(weapon->attribute_set);
+			multiplier = GetTarget()->GetAttributeMultiplier(weapon->attribute_set);
 		}
 
 	} else {
@@ -1104,7 +1086,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 		}
 
 		if (this->healing) {
-			float mul = GetAttributeMultiplier(skill.attribute_effects);
+			float mul = GetTarget()->GetAttributeMultiplier(skill.attribute_effects);
 			if (mul < 0.5f) {
 				// Determined via testing, the heal is always at least 50%
 				mul = 0.5f;
@@ -1148,7 +1130,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				effect -= GetTarget()->GetDef() * skill.physical_rate / 40;
 				effect -= GetTarget()->GetSpi() * skill.magical_rate / 80;
 			}
-			effect *= GetAttributeMultiplier(skill.attribute_effects);
+			effect *= GetTarget()->GetAttributeMultiplier(skill.attribute_effects);
 
 			if (effect < 0) {
 				effect = 0;

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -371,7 +371,6 @@ protected:
 	std::string GetAttributeShiftMessage(const std::string& attribute) const;
 
 	void ApplyActionSwitches();
-	float GetAttributeMultiplier(const std::vector<bool>& attributes_set) const;
 
 	void Reset();
 

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -282,15 +282,25 @@ bool Game_Battler::UseItem(int item_id) {
 		return true;
 	}
 
-	switch (item->type) {
-		case RPG::Item::Type_weapon:
-		case RPG::Item::Type_shield:
-		case RPG::Item::Type_armor:
-		case RPG::Item::Type_helmet:
-		case RPG::Item::Type_accessory:
-			return item->use_skill && UseSkill(item->skill_id, Main_Data::game_party->GetHighestLeveledActor());
-		case RPG::Item::Type_special:
-			return UseSkill(item->skill_id, Main_Data::game_party->GetHighestLeveledActor());
+	bool do_skill = RPG::Item::Type_special
+		|| (item->use_skill && (
+				item->type == RPG::Item::Type_weapon
+				|| item->type == RPG::Item::Type_shield
+				|| item->type == RPG::Item::Type_armor
+				|| item->type == RPG::Item::Type_helmet
+				|| item->type == RPG::Item::Type_accessory
+				)
+				);
+
+	if (do_skill) {
+		auto* skill = ReaderUtil::GetElement(Data::skills, item->skill_id);
+		if (skill != nullptr) {
+			Game_Battler* source = this;
+			if (skill->scope != RPG::Skill::Scope_self) {
+				source = Main_Data::game_party->GetHighestLeveledActor();
+			}
+			UseSkill(item->skill_id, source);
+		}
 	}
 
 	return false;

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -326,10 +326,6 @@ bool Game_Battler::UseSkill(int skill_id, const Game_Battler* source) {
 
 		// Calculate effect:
 		float mul = GetAttributeMultiplier(skill->attribute_effects);
-		if (mul < 0.5f) {
-			// Determined via testing, the heal is always at least 50%
-			mul = 0.5f;
-		}
 
 		int effect = skill->power;
 		if (source != nullptr) {

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -288,21 +288,22 @@ bool Game_Battler::UseItem(int item_id) {
 		case RPG::Item::Type_armor:
 		case RPG::Item::Type_helmet:
 		case RPG::Item::Type_accessory:
-			return item->use_skill && UseSkill(item->skill_id);
+			return item->use_skill && UseSkill(item->skill_id, Main_Data::game_party->GetHighestLeveledActor());
 		case RPG::Item::Type_special:
-			return UseSkill(item->skill_id);
+			return UseSkill(item->skill_id, Main_Data::game_party->GetHighestLeveledActor());
 	}
 
 	return false;
 }
 
-bool Game_Battler::UseSkill(int skill_id) {
+bool Game_Battler::UseSkill(int skill_id, Game_Battler* source) {
 	const RPG::Skill* skill = ReaderUtil::GetElement(Data::skills, skill_id);
 	if (!skill) {
 		Output::Warning("UseSkill: Can't use skill with invalid ID %d", skill_id);
 		return false;
 	}
 
+	bool cure_hp_percentage = false;
 	bool was_used = false;
 
 	if (skill->type == RPG::Skill::Type_normal || skill->type >= RPG::Skill::Type_subskill) {
@@ -315,6 +316,26 @@ bool Game_Battler::UseSkill(int skill_id) {
 			return false;
 		}
 
+		// Calculate effect:
+		float mul = GetAttributeMultiplier(skill->attribute_effects);
+		if (mul < 0.5f) {
+			// Determined via testing, the heal is always at least 50%
+			mul = 0.5f;
+		}
+
+		int effect = skill->power;
+		if (source != nullptr) {
+			effect += source->GetAtk() * skill->physical_rate / 20 +
+				source->GetSpi() * skill->magical_rate / 40;
+		}
+		effect *= mul;
+
+		effect += (effect * Utils::GetRandomNumber(-skill->variance * 10, skill->variance * 10) / 100);
+
+		if (effect < 0)
+			effect = 0;
+
+		// Cure states
 		for (int i = 0; i < (int)skill->state_effects.size(); i++) {
 			if (skill->state_effects[i]) {
 				if (skill->state_effect) {
@@ -324,19 +345,28 @@ bool Game_Battler::UseSkill(int skill_id) {
 				else {
 					was_used |= HasState(Data::states[i].ID);
 					RemoveState(Data::states[i].ID);
+
+					// If Death is cured and HP is not selected, we set a bool so it later heals HP percentage
+					if (i == 0 && !skill->affect_hp) {
+						cure_hp_percentage = true;
+					}
 				}
 			}
 		}
 
 		// Skills only increase hp and sp outside of battle
-		if (skill->power > 0 && skill->affect_hp && !HasFullHp() && !IsDead()) {
+		if (effect > 0 && skill->affect_hp && !HasFullHp() && !IsDead()) {
 			was_used = true;
-			ChangeHp(skill->power);
+			ChangeHp(effect);
+		}
+		else if (effect > 0 && cure_hp_percentage) {
+			was_used = true;
+			ChangeHp(GetMaxHp() * effect / 100);
 		}
 
-		if (skill->power > 0 && skill->affect_sp && !HasFullSp() && !IsDead()) {
+		if (effect > 0 && skill->affect_sp && !HasFullSp() && !IsDead()) {
 			was_used = true;
-			ChangeSp(skill->power);
+			ChangeSp(effect);
 		}
 
 	} else if (skill->type == RPG::Skill::Type_teleport || skill->type == RPG::Skill::Type_escape) {

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -163,24 +163,34 @@ int Game_Battler::GetAttributeRate(int attribute_id, int rate) const {
 }
 
 float Game_Battler::GetAttributeMultiplier(const std::vector<bool>& attributes_set) const {
+	constexpr auto min_mod = std::numeric_limits<int>::min();
+	int physical = min_mod;
+	int magical = min_mod;
+
 	float multiplier = 0;
 	int attributes_applied = 0;
 	for (unsigned int i = 0; i < attributes_set.size(); i++) {
 		if (attributes_set[i]) {
-			multiplier += GetAttributeModifier(i + 1);
-			attributes_applied++;
+			auto* attr = ReaderUtil::GetElement(Data::attributes, i + 1);
+			if (attr) {
+				if (attr->type == RPG::Attribute::Type_physical) {
+					physical = std::max(physical, GetAttributeModifier(i + 1));
+				} else {
+					magical = std::max(magical, GetAttributeModifier(i + 1));
+				}
+			}
 		}
 	}
 
-	if (attributes_applied > 0) {
-		multiplier /= (attributes_applied * 100);
-		return multiplier;
+	if (physical == min_mod) {
+		physical = 100;
+	}
+	if (magical == min_mod) {
+		magical = 100;
 	}
 
-	return 1.0;
+	return float(physical * magical) / 10000.0;
 }
-
-
 
 bool Game_Battler::IsSkillUsable(int skill_id) const {
 	const RPG::Skill* skill = ReaderUtil::GetElement(Data::skills, skill_id);

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -233,7 +233,7 @@ bool Game_Battler::IsSkillUsable(int skill_id) const {
 	return true;
 }
 
-bool Game_Battler::UseItem(int item_id) {
+bool Game_Battler::UseItem(int item_id, const Game_Battler* source) {
 	const RPG::Item* item = ReaderUtil::GetElement(Data::items, item_id);
 	if (!item) {
 		Output::Warning("UseItem: Can't use item with invalid ID %d", item_id);
@@ -282,7 +282,7 @@ bool Game_Battler::UseItem(int item_id) {
 		return true;
 	}
 
-	bool do_skill = RPG::Item::Type_special
+	bool do_skill = (item->type == RPG::Item::Type_special)
 		|| (item->use_skill && (
 				item->type == RPG::Item::Type_weapon
 				|| item->type == RPG::Item::Type_shield
@@ -294,19 +294,17 @@ bool Game_Battler::UseItem(int item_id) {
 
 	if (do_skill) {
 		auto* skill = ReaderUtil::GetElement(Data::skills, item->skill_id);
-		if (skill != nullptr) {
-			Game_Battler* source = this;
-			if (skill->scope != RPG::Skill::Scope_self) {
-				source = Main_Data::game_party->GetHighestLeveledActorWhoCanAct();
-			}
-			UseSkill(item->skill_id, source);
+		if (skill == nullptr) {
+			Output::Warning("UseItem: Can't use item %d skill with invalid ID %d", item->ID, item->skill_id);
+			return false;
 		}
+		UseSkill(item->skill_id, source);
 	}
 
 	return false;
 }
 
-bool Game_Battler::UseSkill(int skill_id, Game_Battler* source) {
+bool Game_Battler::UseSkill(int skill_id, const Game_Battler* source) {
 	const RPG::Skill* skill = ReaderUtil::GetElement(Data::skills, skill_id);
 	if (!skill) {
 		Output::Warning("UseSkill: Can't use skill with invalid ID %d", skill_id);

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -162,6 +162,26 @@ int Game_Battler::GetAttributeRate(int attribute_id, int rate) const {
 	return 0;
 }
 
+float Game_Battler::GetAttributeMultiplier(const std::vector<bool>& attributes_set) const {
+	float multiplier = 0;
+	int attributes_applied = 0;
+	for (unsigned int i = 0; i < attributes_set.size(); i++) {
+		if (attributes_set[i]) {
+			multiplier += GetAttributeModifier(i + 1);
+			attributes_applied++;
+		}
+	}
+
+	if (attributes_applied > 0) {
+		multiplier /= (attributes_applied * 100);
+		return multiplier;
+	}
+
+	return 1.0;
+}
+
+
+
 bool Game_Battler::IsSkillUsable(int skill_id) const {
 	const RPG::Skill* skill = ReaderUtil::GetElement(Data::skills, skill_id);
 

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -297,7 +297,7 @@ bool Game_Battler::UseItem(int item_id) {
 		if (skill != nullptr) {
 			Game_Battler* source = this;
 			if (skill->scope != RPG::Skill::Scope_self) {
-				source = Main_Data::game_party->GetHighestLeveledActor();
+				source = Main_Data::game_party->GetHighestLeveledActorWhoCanAct();
 			}
 			UseSkill(item->skill_id, source);
 		}

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -167,6 +167,14 @@ public:
 	virtual int GetAttributeModifier(int attribute_id) const = 0;
 
 	/**
+	 * Gets the final effect multiplier when a skill/attack is targeting this battler.
+	 *
+	 * @param attributes set for the incoming action
+	 * @return effect multiplier
+	 */
+	float GetAttributeMultiplier(const std::vector<bool>& attributes_set) const;
+
+	/**
 	 * Gets the characters name
 	 *
 	 * @return Character name

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -361,9 +361,10 @@ public:
 	 * Does not reduce the MP, use Game_Party->UseSkill for this.
 	 *
 	 * @param skill_id ID of skill to use
+	 * @param source battler who threw the skill
 	 * @return true if skill affected anything
 	 */
-	virtual bool UseSkill(int skill_id);
+	virtual bool UseSkill(int skill_id, Game_Battler* source);
 
 	/**
 	 * Calculates the Skill costs including all modifiers.

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -352,7 +352,7 @@ public:
 	 * @param item_id ID if item to use
 	 * @return true if item affected anything
 	 */
-	virtual bool UseItem(int item_id);
+	virtual bool UseItem(int item_id, const Game_Battler* source);
 
 	/**
 	 * Applies the effects of a skill.
@@ -364,7 +364,7 @@ public:
 	 * @param source battler who threw the skill
 	 * @return true if skill affected anything
 	 */
-	virtual bool UseSkill(int skill_id, Game_Battler* source);
+	virtual bool UseSkill(int skill_id, const Game_Battler* source);
 
 	/**
 	 * Calculates the Skill costs including all modifiers.

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -339,13 +339,13 @@ bool Game_Party::UseSkill(int skill_id, Game_Actor* source, Game_Actor* target) 
 	bool was_used = false;
 
 	if (target) {
-		was_used = target->UseSkill(skill_id);
+		was_used = target->UseSkill(skill_id, source);
 	}
 	else {
 		std::vector<Game_Actor*> actors = GetActors();
 		std::vector<Game_Actor*>::iterator it;
 		for (it = actors.begin(); it != actors.end(); ++it) {
-			was_used |= (*it)->UseSkill(skill_id);
+			was_used |= (*it)->UseSkill(skill_id, source);
 		}
 	}
 
@@ -632,3 +632,13 @@ bool Game_Party::IsAnyControllable() {
 	return false;
 }
 
+Game_Actor* Game_Party::GetHighestLeveledActor() const {
+	Game_Actor* best = nullptr;
+
+	for (auto* actor : GetActors()) {
+		if (best == nullptr || best->GetLevel() < actor->GetLevel()) {
+			best = actor;
+		}
+	}
+	return best;
+}

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -632,11 +632,11 @@ bool Game_Party::IsAnyControllable() {
 	return false;
 }
 
-Game_Actor* Game_Party::GetHighestLeveledActor() const {
+Game_Actor* Game_Party::GetHighestLeveledActorWhoCanAct() const {
 	Game_Actor* best = nullptr;
 
 	for (auto* actor : GetActors()) {
-		if (best == nullptr || best->GetLevel() < actor->GetLevel()) {
+		if (actor->CanAct() && (best == nullptr || best->GetLevel() < actor->GetLevel())) {
 			best = actor;
 		}
 	}

--- a/src/game_party.h
+++ b/src/game_party.h
@@ -341,6 +341,13 @@ public:
 	 */
 	bool IsAnyControllable();
 
+	/**
+	 * Gets the actor with the highest level. If there are many, choose the one with the earliest position in the group.
+	 *
+	 * @return The first Highest leveled actor.
+	 */
+	Game_Actor* GetHighestLeveledActor() const;
+
 private:
 	const RPG::SaveInventory& data() const;
 	RPG::SaveInventory& data();

--- a/src/game_party.h
+++ b/src/game_party.h
@@ -342,11 +342,11 @@ public:
 	bool IsAnyControllable();
 
 	/**
-	 * Gets the actor with the highest level. If there are many, choose the one with the earliest position in the group.
+	 * Gets the actor with the highest level who can act. If there are many, choose the one with the earliest position in the group.
 	 *
-	 * @return The first Highest leveled actor.
+	 * @return The first Highest leveled actor who can act.
 	 */
-	Game_Actor* GetHighestLeveledActor() const;
+	Game_Actor* GetHighestLeveledActorWhoCanAct() const;
 
 private:
 	const RPG::SaveInventory& data() const;

--- a/src/game_party.h
+++ b/src/game_party.h
@@ -342,11 +342,13 @@ public:
 	bool IsAnyControllable();
 
 	/**
-	 * Gets the actor with the highest level who can act. If there are many, choose the one with the earliest position in the group.
+	 * Gets the actor with the highest level who can act and use the given item. If there are many, choose the one with the earliest position in the group.
+	 *
+	 * @param the item to check
 	 *
 	 * @return The first Highest leveled actor who can act.
 	 */
-	Game_Actor* GetHighestLeveledActorWhoCanAct() const;
+	Game_Actor* GetHighestLeveledActorWhoCanUse(const RPG::Item*) const;
 
 private:
 	const RPG::SaveInventory& data() const;

--- a/src/scene_actortarget.cpp
+++ b/src/scene_actortarget.cpp
@@ -52,18 +52,33 @@ void Scene_ActorTarget::Start() {
 		if (!item) {
 			Output::Warning("Scene ActorTarget: Invalid item ID %d", id);
 			Scene::Pop();
+			return;
 		}
-
-		if (item->entire_party) {
-			target_window->SetIndex(-100);
+		const RPG::Skill* skill = nullptr;
+		if (item->type == RPG::Item::Type_special) {
+			skill = ReaderUtil::GetElement(Data::skills, item->skill_id);
+			if (!skill) {
+				Output::Warning("Scene ActorTarget: Item %d has invalid skill ID %d", id, item->skill_id);
+				Scene::Pop();
+				return;
+			}
+			if (skill->scope == RPG::Skill::Scope_party) {
+				target_window->SetIndex(-100);
+			}
+		} else {
+			if (item->entire_party) {
+				target_window->SetIndex(-100);
+			}
 		}
 		status_window->SetData(id, true, 0);
 		help_window->SetText(item->name);
+		return;
 	} else {
 		const RPG::Skill* skill = ReaderUtil::GetElement(Data::skills, id);
 		if (!skill) {
 			Output::Warning("Scene ActorTarget: Invalid skill ID %d", id);
 			Scene::Pop();
+			return;
 		}
 
 		if (skill->scope == RPG::Skill::Scope_self) {


### PR DESCRIPTION
Contains a commit from #1394. Also Sormat battle commit 3.16, which somehow got lost in the rebasing.

Sormat's observation that items that trigger skills always set the source battler as the highest level member of the party. If there are multiple members of the party with the highest level, the first is selected. From testing I found his observations to be correct, with the additional caveat that the source also has to be able to act (not dead or has a nomove state).

In `RPG_RT`, this logic is applied a bit too heavy handedly and has a bug. Skills with usage of "Self" also get their source set to the highest level member of the party. Since the target is self, that means the target also gets forced to the highest level member! When you use such an item the first actor is highlighted, you can't select another actor, and the effect is always on the highest leveled party member regardless.

I opted to break compatibility for self skills here. Instead I let you use them on anyone, with the source being that same actor instead of the highest level member.

I tested all of this by changing the levels of party members and hacking their SPI stats really high or low to determine which character was being used as the source.

The idea behind the highest level actor logic makes sense but its not very good. For example, if your highest level actor is a fighter type with low SPI and then you use an item which cases a healing spell that has SPI effect, it'll be wasted as your high level fighter's SPI gets used.