### PR TITLE
Implement SaveScreen::pan_x and SaveScreen::pan_y

### DIFF
--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -366,6 +366,10 @@ void Game_Map::ScrollRight(int distance) {
 	AddScreenX(x, distance);
 	map_info.position_x = x;
 	Parallax::Scroll(distance, 0);
+	// Unused, except compatibility with RPG_RT
+	auto& pan_x = Main_Data::game_data.screen.pan_x;
+	const auto pan_limit_x = 20 * SCREEN_TILE_WIDTH;
+	pan_x = (pan_x - distance + pan_limit_x) % pan_limit_x;
 }
 
 void Game_Map::ScrollDown(int distance) {
@@ -373,6 +377,10 @@ void Game_Map::ScrollDown(int distance) {
 	AddScreenY(y, distance);
 	map_info.position_y = y;
 	Parallax::Scroll(0, distance);
+	// Unused, except compatibility with RPG_RT
+	auto& pan_y = Main_Data::game_data.screen.pan_y;
+	const auto pan_limit_y = 10 * SCREEN_TILE_WIDTH;
+	pan_y = (pan_y + distance + pan_limit_y) % pan_limit_y;
 }
 
 // Add inc to acc, clamping the result into the range [low, high].


### PR DESCRIPTION
Fix #1521 

* Units of 1/16th pixel
* Starts at (0,0) for new game
* Changes when the screen scrolls due to player movement
  or panning commands.
* Doesn't change when you teleport.
* X is always modulo 20 * 256
* Y is always modulo 10 * 256 (Why not 15??)
* And thats it...?

Teleporting to different maps doesn't change the pan_x/pan_y. It just starts at (0,0) and increments/decrements forever as you walk around. 

I have no clue what this is supposed to be for but thats the behavior I've observed with RPG_RT.
