### PR TITLE
Battle action and states fixes - Previous Albeleon 2.21 / 2.41 from battle 7

### DIFF
--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -162,6 +162,10 @@ bool Game_BattleAlgorithm::AlgorithmBase::IsRevived() const {
 	return revived;
 }
 
+bool Game_BattleAlgorithm::AlgorithmBase::ActionIsPossible() const {
+	return true;
+}
+
 const std::vector<RPG::State>& Game_BattleAlgorithm::AlgorithmBase::GetAffectedConditions() const {
 	return conditions;
 }
@@ -1405,6 +1409,13 @@ bool Game_BattleAlgorithm::Skill::IsReflected() const {
 	return has_reflect;
 }
 
+bool Game_BattleAlgorithm::Skill::ActionIsPossible() const {
+	if (item) {
+		return Main_Data::game_party->GetItemCount(item->ID, false) > 0;
+	}
+	return source->GetSp() >= source->CalculateSkillCost(skill.ID);
+}
+
 Game_BattleAlgorithm::Item::Item(Game_Battler* source, Game_Battler* target, const RPG::Item& item) :
 	AlgorithmBase(Type::Item, source, target), item(item) {
 		// no-op
@@ -1540,6 +1551,10 @@ const RPG::Sound* Game_BattleAlgorithm::Item::GetStartSe() const {
 	else {
 		return NULL;
 	}
+}
+
+bool Game_BattleAlgorithm::Item::ActionIsPossible() const {
+	return Main_Data::game_party->GetItemCount(item.ID, false) > 0;
 }
 
 Game_BattleAlgorithm::NormalDual::NormalDual(Game_Battler* source, Game_Battler* target) :

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -69,21 +69,27 @@ static inline int ToHitPhysical(Game_Battler *source, Game_Battler *target, int 
 }
 
 Game_BattleAlgorithm::AlgorithmBase::AlgorithmBase(Type ty, Game_Battler* source) :
-	type(ty), source(source), no_target(true), first_attack(true) {
+	type(ty), source(source), no_target(true), first_attack(true),
+	source_restriction(RPG::State::Restriction(source->GetSignificantRestriction()))
+{
 	Reset();
 
 	current_target = targets.end();
 }
 
 Game_BattleAlgorithm::AlgorithmBase::AlgorithmBase(Type ty, Game_Battler* source, Game_Battler* target) :
-	type(ty), source(source), no_target(false), first_attack(true) {
+	type(ty), source(source), no_target(false), first_attack(true),
+	source_restriction(RPG::State::Restriction(source->GetSignificantRestriction()))
+{
 	Reset();
 
 	SetTarget(target);
 }
 
 Game_BattleAlgorithm::AlgorithmBase::AlgorithmBase(Type ty, Game_Battler* source, Game_Party_Base* target) :
-	type(ty), source(source), no_target(false), first_attack(true) {
+	type(ty), source(source), no_target(false), first_attack(true),
+	source_restriction(RPG::State::Restriction(source->GetSignificantRestriction()))
+{
 	Reset();
 
 	target->GetBattlers(targets);
@@ -268,6 +274,10 @@ std::string Game_BattleAlgorithm::AlgorithmBase::GetDeathMessage() const {
 	else {
 		return GetTarget()->GetName() + message;
 	}
+}
+
+RPG::State::Restriction Game_BattleAlgorithm::AlgorithmBase::GetSourceRestrictionWhenStarted() const {
+	return source_restriction;
 }
 
 std::string Game_BattleAlgorithm::AlgorithmBase::GetAttackFailureMessage(const std::string& message) const {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1206,12 +1206,13 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 		for (int i = 0; i < (int) skill.state_effects.size(); i++) {
 			if (!skill.state_effects[i])
 				continue;
-			if (!healing && Utils::PercentChance(to_hit))
+
+			if (!healing && !Utils::PercentChance(to_hit))
 				continue;
 
 			this->success = true;
 
-			if (healing || Utils::GetRandomNumber(0, 99) <= GetTarget()->GetStateProbability(Data::states[i].ID)) {
+			if (healing || Utils::PercentChance(GetTarget()->GetStateProbability(Data::states[i].ID))) {
 				conditions.push_back(Data::states[i]);
 			}
 		}

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -20,6 +20,7 @@
 
 #include <string>
 #include <vector>
+#include "rpg_state.h"
 
 class Game_Battler;
 class Game_Party_Base;
@@ -355,6 +356,12 @@ public:
 	 */
 	Type GetType() const;
 
+	/**
+	 * @return The significant restriction of the source when this
+	 *      algorithm was created.
+	 */
+	RPG::State::Restriction GetSourceRestrictionWhenStarted() const;
+
 protected:
 	AlgorithmBase(Type t, Game_Battler* source);
 	AlgorithmBase(Type t, Game_Battler* source, Game_Battler* target);
@@ -408,6 +415,7 @@ protected:
 	bool absorb;
 	bool revived = false;
 	mutable int reflect;
+	RPG::State::Restriction source_restriction = RPG::State::Restriction_normal;
 
 	RPG::Animation* animation;
 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -293,6 +293,11 @@ public:
 	virtual int GetSourceAnimationState() const;
 
 	/**
+	* @return true if it is still possible to perform this action now.
+	*/
+	virtual bool ActionIsPossible() const;
+
+	/**
 	 * Gets the sound effect that is played when the action is starting.
 	 *
 	 * @return start se
@@ -459,6 +464,7 @@ public:
 	void GetResultMessages(std::vector<std::string>& out, std::vector<int>& out_replace) const override;
 	int GetPhysicalDamageRate() const override;
 	bool IsReflected() const override;
+	bool ActionIsPossible() const override;
 
 private:
 	const RPG::Skill& skill;
@@ -479,6 +485,7 @@ public:
 	int GetSourceAnimationState() const override;
 	const RPG::Sound* GetStartSe() const override;
 	void GetResultMessages(std::vector<std::string>& out, std::vector<int>& out_replace) const override;
+	bool ActionIsPossible() const override;
 
 private:
 	const RPG::Item& item;

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -81,7 +81,7 @@ public:
 	 *
 	 * @return First non-normal restriction or normal if not restricted
 	 */
-	int GetSignificantRestriction() const;
+	RPG::State::Restriction GetSignificantRestriction() const;
 
 	/**
 	 * Gets the Battler ID.

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -462,13 +462,19 @@ void Scene_Battle::UpdateBattlerActions() {
 		return;
 	}
 
+	// If we can no longer perform the action (no more items, ran out of SP, etc..)
+	if (!battler->GetBattleAlgorithm()->ActionIsPossible()) {
+		battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(battler));
+		battler->SetCharged(false);
+		return;
+	}
+
 	// If we had a state restriction previously but were recovered, we do nothing for this round.
 	if (battler->GetBattleAlgorithm()->GetSourceRestrictionWhenStarted() != RPG::State::Restriction_normal) {
 		battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(battler));
 		battler->SetCharged(false);
 		return;
 	}
-
 }
 
 void Scene_Battle::CreateEnemyAction(Game_Enemy* enemy, const RPG::EnemyAction* action) {

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -467,6 +467,13 @@ void Scene_Battle::UpdateBattlerActions() {
 		return;
 	}
 
+	// If we had a state restriction previously but were recovered, we do nothing for this round.
+	if (battler->GetBattleAlgorithm()->GetSourceRestrictionWhenStarted() != RPG::State::Restriction_normal) {
+		battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(battler));
+		battler->SetCharged(false);
+		return;
+	}
+
 }
 
 void Scene_Battle::CreateEnemyAction(Game_Enemy* enemy, const RPG::EnemyAction* action) {

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -441,6 +441,7 @@ void Scene_Battle::UpdateBattlerActions() {
 		UpdateBattlerActions();
 		return;
 	}
+
 	if (!battler->CanAct()) {
 		battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(battler));
 		battler->SetCharged(false);

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -436,12 +436,6 @@ void Scene_Battle::UpdateBattlerActions() {
 	}
 
 	auto* battler = battle_actions.front();
-	if (battler->IsDead()) {
-		RemoveCurrentAction();
-		UpdateBattlerActions();
-		return;
-	}
-
 	if (!battler->CanAct()) {
 		battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(battler));
 		battler->SetCharged(false);

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -178,6 +178,7 @@ protected:
 	 */
 	virtual void SetAnimationState(Game_Battler* target, int new_state);
 
+	void UpdateBattlerActions();
 	void CreateEnemyAction(Game_Enemy* enemy, const RPG::EnemyAction* action);
 	void CreateEnemyActionBasic(Game_Enemy* enemy, const RPG::EnemyAction* action);
 	void CreateEnemyActionSkill(Game_Enemy* enemy, const RPG::EnemyAction* action);

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -519,10 +519,10 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 
 			if (action->IsFirstAttack()) {
 				if (action->GetTarget() &&
-					!(action->GetSource()->GetType() == Game_Battler::Type_Enemy)) {
+					action->GetSource()->GetType() == Game_Battler::Type_Ally) {
 					if (action->GetTarget()->GetType() == Game_Battler::Type_Enemy) {
 						action->PlayAnimation();
-					} else if (action->GetTarget()->GetType() == Game_Battler::Type_Ally && action->GetType() == Game_BattleAlgorithm::Type::Skill) {
+					} else {
 						action->PlaySoundAnimation(false, 20);
 					}
 				}

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -304,13 +304,12 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 		if (!battle_action_pending && CheckResultConditions()) {
 			return;
 		}
+		if (!battle_action_pending) {
+			// If we will start a new battle action, first check for state changes
+			// such as death, paralyze, confuse, etc..
+			UpdateBattlerActions();
+		}
 		if (!battle_actions.empty()) {
-			if (battle_actions.front()->IsDead()) {
-				// No zombies allowed ;)
-				RemoveCurrentAction();
-				return;
-			}
-
 			Game_BattleAlgorithm::AlgorithmBase* alg = battle_actions.front()->GetBattleAlgorithm().get();
 
 			battle_action_pending = true;
@@ -374,7 +373,6 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase* action) {
 	// Order of execution of BattleActionState:
 	// ConditionHeal > Execute > Apply > (ResultPop > ResultPush) > Death > Finished.
-
 	if (Game_Battle::IsBattleAnimationWaiting() && !Game_Battle::IsBattleAnimationOnlySound()) {
 		return false;
 	}

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -520,14 +520,17 @@ void Scene_Battle_Rpg2k3::ProcessActions() {
 		Scene::Pop();
 	}
 
+	if (!battle_action_pending) {
+		// If we will start a new battle action, first check for state changes
+		// such as death, paralyze, confuse, etc..
+		UpdateBattlerActions();
+	}
+
 	if (!battle_actions.empty()) {
 		Game_Battler* action = battle_actions.front();
-		if (action->IsDead()) {
-			// No zombies allowed ;)
-			RemoveCurrentAction();
-			battle_action_state = BattleActionState_Execute;
-		}
-		else if (ProcessBattleAction(action->GetBattleAlgorithm().get())) {
+		battle_action_pending = true;
+		if (ProcessBattleAction(action->GetBattleAlgorithm().get())) {
+			battle_action_pending = false;
 			RemoveCurrentAction();
 			if (CheckResultConditions()) {
 				return;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -593,6 +593,11 @@ void Scene_Battle_Rpg2k3::ProcessActions() {
 }
 
 bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase* action) {
+	// Immediately quit for dead actors no move. Prevents any animations or delays.
+	if (action->GetType() == Game_BattleAlgorithm::Type::NoMove && action->GetSource()->IsDead()) {
+		return true;
+	}
+
 	if (Game_Battle::IsBattleAnimationWaiting()) {
 		return false;
 	}

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -92,6 +92,7 @@ protected:
 	int select_target_flash_count = 0;
 
 	FileRequestBinding request_id;
+	bool battle_action_pending = false;
 };
 
 #endif


### PR DESCRIPTION
A simpler reimplementation of Albeleon 2.21.

To test these, create a 1x 1+ turn battle event which does:

```
Cure provoke, berserk, death, shock
Show Choice:
  Death: Add dead
  Provoke: Add provoke
  Confuse: Add confuse
  Shock: Add shock
  Else:
```

To test the effects of multiple states, do the show choice twice.

To test state recovery, you can use the above event. You can also inflict states, and the have a very fast actor use a recovery item.

