### PR TITLE
Support proper rendering of Sprites at map borders of looping maps

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -106,38 +106,32 @@ void Game_Character::MoveTo(int x, int y) {
 	SetRemainingStep(0);
 }
 
-int Game_Character::GetScreenX() const {
+int Game_Character::GetScreenX(bool apply_shift) const {
 	int x = GetSpriteX() / TILE_SIZE - Game_Map::GetDisplayX() / TILE_SIZE + (TILE_SIZE / 2);
 
-	if (Game_Map::LoopHorizontal() && (x <= -TILE_SIZE / 2 || x > 0 || Game_Map::GetWidth() == 20)) {
-		int map_width = Game_Map::GetWidth() * TILE_SIZE;
-		x = (x + map_width) % map_width;
+	if (apply_shift) {
+		x += Game_Map::GetWidth() * TILE_SIZE;
 	}
 
 	return x;
 }
 
-int Game_Character::GetScreenY() const {
+int Game_Character::GetScreenY(bool apply_shift) const {
 	int y = GetSpriteY() / TILE_SIZE - Game_Map::GetDisplayY() / TILE_SIZE + TILE_SIZE;
-
-	if (Game_Map::LoopVertical()) {
-		int map_height = Game_Map::GetHeight() * TILE_SIZE;
-		y = (y + map_height) % map_height;
-
-		if (y == 0) {
-			y += map_height;
-		}
-	}
 
 	if (IsJumping()) {
 		int jump_height = (GetRemainingStep() > SCREEN_TILE_SIZE / 2 ? SCREEN_TILE_SIZE - GetRemainingStep() : GetRemainingStep()) / 8;
 		y -= (jump_height < 5 ? jump_height * 2 : jump_height < 13 ? jump_height + 4 : 16);
 	}
 
+	if (apply_shift) {
+		y += Game_Map::GetHeight() * TILE_SIZE;
+	}
+
 	return y;
 }
 
-int Game_Character::GetScreenZ() const {
+int Game_Character::GetScreenZ(bool apply_shift) const {
 	int z = 0;
 
 	if (IsFlying()) {
@@ -151,7 +145,7 @@ int Game_Character::GetScreenZ() const {
 	}
 
 	// For events on the screen, this should be inside a 0-40 range
-	z += GetScreenY() >> 3;
+	z += GetScreenY(apply_shift) >> 3;
 
 	return z;
 }

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -632,23 +632,26 @@ public:
 	/**
 	 * Gets sprite x coordinate transformed to screen coordinate in pixels.
 	 *
+	 * @param apply_shift When true the coordinate is shifted by the map width (for looping maps)
 	 * @return screen x coordinate in pixels.
 	 */
-	virtual int GetScreenX() const;
+	virtual int GetScreenX(bool apply_shift = false) const;
 
 	/**
 	 * Gets sprite y coordinate transformed to screen coordinate in pixels.
 	 *
+	 * @param apply_shift When true the coordinate is shifted by the map height (for looping maps)
 	 * @return screen y coordinate in pixels.
 	 */
-	virtual int GetScreenY() const;
+	virtual int GetScreenY(bool apply_shift = false) const;
 
 	/**
 	 * Gets screen z coordinate in pixels.
 	 *
+	 * @param apply_shift Forwarded to GetScreenY
 	 * @return screen z coordinate in pixels.
 	 */
-	virtual int GetScreenZ() const;
+	virtual int GetScreenZ(bool apply_shift = false) const;
 
 	/**
 	 * Gets tile graphic ID.

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -44,10 +44,10 @@ Game_Player::Game_Player():
 	SetAnimationType(RPG::EventPage::AnimType_non_continuous);
 }
 
-int Game_Player::GetScreenZ() const {
+int Game_Player::GetScreenZ(bool apply_shift) const {
 	// Player is always slightly above events
 	// (and always on "same layer as hero" obviously)
-	return Game_Character::GetScreenZ() + 1;
+	return Game_Character::GetScreenZ(apply_shift) + 1;
 }
 
 int Game_Player::GetOriginalMoveRouteIndex() const {

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -40,7 +40,7 @@ public:
 	 * Implementation of abstract methods
 	 */
 	/** @{ */
-	int GetScreenZ() const override;
+	int GetScreenZ(bool apply_shift = false) const override;
 	int GetOriginalMoveRouteIndex() const override;
 	void SetOriginalMoveRouteIndex(int new_index) override;
 	bool GetVisible() const override;

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -252,8 +252,8 @@ int Game_Vehicle::GetAltitude() const {
 		return SCREEN_TILE_SIZE / (SCREEN_TILE_SIZE / TILE_SIZE);
 }
 
-int Game_Vehicle::GetScreenY() const {
-	return Game_Character::GetScreenY() - GetAltitude();
+int Game_Vehicle::GetScreenY(bool apply_shift) const {
+	return Game_Character::GetScreenY(apply_shift) - GetAltitude();
 }
 
 bool Game_Vehicle::IsMovable() {

--- a/src/game_vehicle.h
+++ b/src/game_vehicle.h
@@ -69,7 +69,7 @@ public:
 	void GetOff();
 	bool IsInUse() const;
 	void SyncWithPlayer();
-	int GetScreenY() const override;
+	int GetScreenY(bool apply_shift = false) const override;
 	bool IsMovable();
 	bool CanLand() const;
 	void Update() override;

--- a/src/sprite_airshipshadow.cpp
+++ b/src/sprite_airshipshadow.cpp
@@ -25,13 +25,16 @@
 #include "sprite_airshipshadow.h"
 #include <string>
 
-Sprite_AirshipShadow::Sprite_AirshipShadow() {
+Sprite_AirshipShadow::Sprite_AirshipShadow(CloneType type) {
 	SetBitmap(Bitmap::Create(16,16));
 
 	SetOx(TILE_SIZE/2);
 	SetOy(TILE_SIZE);
 
 	RecreateShadow();
+
+	x_shift = ((type & XClone) == XClone);
+	y_shift = ((type & YClone) == YClone);
 }
 
 // Draws the two shadow sprites to a single intermediate bitmap to be blit to the map
@@ -68,8 +71,8 @@ void Sprite_AirshipShadow::Update() {
 	const double opacity = (double)altitude / max_altitude;
 	SetOpacity(opacity * 255);
 
-	SetX(Main_Data::game_player->GetScreenX());
-	SetY(Main_Data::game_player->GetScreenY());
+	SetX(Main_Data::game_player->GetScreenX(x_shift));
+	SetY(Main_Data::game_player->GetScreenY(y_shift));
 	// Synchronized with airship priority
-	SetZ(airship->GetScreenZ());
+	SetZ(airship->GetScreenZ(y_shift));
 }

--- a/src/sprite_airshipshadow.h
+++ b/src/sprite_airshipshadow.h
@@ -31,9 +31,19 @@
  */
 class Sprite_AirshipShadow : public Sprite {
 public:
-	Sprite_AirshipShadow();
+	enum CloneType {
+		Original = 1,
+		XClone = 2,
+		YClone = 4
+	};
+
+	Sprite_AirshipShadow(CloneType type = CloneType::Original);
 	void Update();
 	void RecreateShadow();
+
+private:
+	bool x_shift = false;
+	bool y_shift = false;
 };
 
 #endif

--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -21,12 +21,16 @@
 #include "game_map.h"
 #include "bitmap.h"
 
-Sprite_Character::Sprite_Character(Game_Character* character) :
+Sprite_Character::Sprite_Character(Game_Character* character, CloneType type) :
 	character(character),
 	tile_id(-1),
 	character_index(0),
 	chara_width(0),
 	chara_height(0) {
+
+	x_shift = ((type & XClone) == XClone);
+	y_shift = ((type & YClone) == YClone);
+
 	Update();
 }
 
@@ -71,11 +75,11 @@ void Sprite_Character::Update() {
 		SetOpacity(character->GetOpacity());
 	}
 
-	SetX(character->GetScreenX());
-	SetY(character->GetScreenY());
-	SetZ(character->GetScreenZ());
+	SetX(character->GetScreenX(x_shift));
+	SetY(character->GetScreenY(y_shift));
+	// y_shift because Z is calculated via the screen Y position
+	SetZ(character->GetScreenZ(y_shift));
 
-	//SetBlendType(character->GetBlendType());
 	int bush_split = 4 - character->GetBushDepth();
 	SetBushDepth(bush_split > 3 ? 0 : GetHeight() / bush_split);
 }

--- a/src/sprite_character.h
+++ b/src/sprite_character.h
@@ -32,12 +32,19 @@ struct FileRequestResult;
  */
 class Sprite_Character : public Sprite {
 public:
+	enum CloneType {
+		Original = 1,
+		XClone = 2,
+		YClone = 4
+	};
+
 	/**
 	 * Constructor.
 	 *
 	 * @param character game character to display
+	 * @param type Type of the sprite for multiple renderings on looping maps
 	 */
-	Sprite_Character(Game_Character* character);
+	Sprite_Character(Game_Character* character, CloneType type = CloneType::Original);
 
 	/**
 	 * Updates sprite state.
@@ -70,6 +77,9 @@ private:
 
 	/** Returns true for charset sprites; false for tiles. */
 	bool UsesCharset() const;
+
+	bool x_shift = false;
+	bool y_shift = false;
 
 	void OnTileSpriteReady(FileRequestResult*);
 	void OnCharSpriteReady(FileRequestResult*);

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -39,14 +39,16 @@ Spriteset_Map::Spriteset_Map() {
 
 	ChipsetUpdated();
 
+	need_x_clone = Game_Map::LoopHorizontal();
+	need_y_clone = Game_Map::LoopVertical();
+
 	for (Game_Event& ev : Game_Map::GetEvents()) {
-		character_sprites.push_back(std::make_shared<Sprite_Character>(&ev));
+		CreateSprite(&ev, need_x_clone, need_y_clone);
 	}
 
 	airship_shadow.reset(new Sprite_AirshipShadow());
 
-	character_sprites.push_back
-		(std::make_shared<Sprite_Character>(Main_Data::game_player.get()));
+	CreateSprite(Main_Data::game_player.get(), need_x_clone, need_y_clone);
 
 	timer1.reset(new Sprite_Timer(0));
 	timer2.reset(new Sprite_Timer(1));
@@ -95,7 +97,7 @@ void Spriteset_Map::Update() {
 
 		if (!vehicle_loaded[i - 1] && vehicle->GetMapId() == map_id) {
 			vehicle_loaded[i - 1] = true;
-			character_sprites.push_back(std::make_shared<Sprite_Character>(vehicle));
+			CreateSprite(vehicle, need_x_clone, need_y_clone);
 		}
 	}
 
@@ -184,6 +186,20 @@ bool Spriteset_Map::RequireBackground(const Graphics::DrawableList& drawable_lis
 
 	// shouldn't happen
 	return false;
+}
+
+void Spriteset_Map::CreateSprite(Game_Character* character, bool create_x_clone, bool create_y_clone) {
+	character_sprites.push_back(std::make_shared<Sprite_Character>(character));
+	if (create_x_clone) {
+		character_sprites.push_back(std::make_shared<Sprite_Character>(character, Sprite_Character::XClone));
+	}
+	if (create_y_clone) {
+		character_sprites.push_back(std::make_shared<Sprite_Character>(character, Sprite_Character::YClone));
+	}
+	if (create_x_clone && create_y_clone) {
+		character_sprites.push_back(std::make_shared<Sprite_Character>(character,
+			(Sprite_Character::CloneType)(Sprite_Character::XClone | Sprite_Character::YClone)));
+	}
 }
 
 void Spriteset_Map::OnTilemapSpriteReady(FileRequestResult*) {

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -46,7 +46,7 @@ Spriteset_Map::Spriteset_Map() {
 		CreateSprite(&ev, need_x_clone, need_y_clone);
 	}
 
-	airship_shadow.reset(new Sprite_AirshipShadow());
+	CreateAirshipShadowSprite(need_x_clone, need_y_clone);
 
 	CreateSprite(Main_Data::game_player.get(), need_x_clone, need_y_clone);
 
@@ -101,8 +101,10 @@ void Spriteset_Map::Update() {
 		}
 	}
 
-	airship_shadow->SetTone(new_tone);
-	airship_shadow->Update();
+	for (auto& shadow : airship_shadows) {
+		shadow->SetTone(new_tone);
+		shadow->Update();
+	}
 
 	timer1->Update();
 	timer2->Update();
@@ -135,7 +137,9 @@ void Spriteset_Map::ChipsetUpdated() {
 }
 
 void Spriteset_Map::SystemGraphicUpdated() {
-	airship_shadow->RecreateShadow();
+	for (auto& shadow : airship_shadows) {
+		shadow->RecreateShadow();
+	}
 }
 
 void Spriteset_Map::SubstituteDown(int old_id, int new_id) {
@@ -189,16 +193,34 @@ bool Spriteset_Map::RequireBackground(const Graphics::DrawableList& drawable_lis
 }
 
 void Spriteset_Map::CreateSprite(Game_Character* character, bool create_x_clone, bool create_y_clone) {
+	using CloneType = Sprite_Character::CloneType;
+
 	character_sprites.push_back(std::make_shared<Sprite_Character>(character));
 	if (create_x_clone) {
-		character_sprites.push_back(std::make_shared<Sprite_Character>(character, Sprite_Character::XClone));
+		character_sprites.push_back(std::make_shared<Sprite_Character>(character, CloneType::XClone));
 	}
 	if (create_y_clone) {
-		character_sprites.push_back(std::make_shared<Sprite_Character>(character, Sprite_Character::YClone));
+		character_sprites.push_back(std::make_shared<Sprite_Character>(character, CloneType::YClone));
 	}
 	if (create_x_clone && create_y_clone) {
 		character_sprites.push_back(std::make_shared<Sprite_Character>(character,
-			(Sprite_Character::CloneType)(Sprite_Character::XClone | Sprite_Character::YClone)));
+			(CloneType)(CloneType::XClone | CloneType::YClone)));
+	}
+}
+
+void Spriteset_Map::CreateAirshipShadowSprite(bool create_x_clone, bool create_y_clone) {
+	using CloneType = Sprite_AirshipShadow::CloneType;
+
+	airship_shadows.push_back(std::make_shared<Sprite_AirshipShadow>());
+	if (create_x_clone) {
+		airship_shadows.push_back(std::make_shared<Sprite_AirshipShadow>(CloneType::XClone));
+	}
+	if (create_y_clone) {
+		airship_shadows.push_back(std::make_shared<Sprite_AirshipShadow>(CloneType::YClone));
+	}
+	if (create_x_clone && create_y_clone) {
+		airship_shadows.push_back(std::make_shared<Sprite_AirshipShadow>(
+			(CloneType)(CloneType::XClone | CloneType::YClone)));
 	}
 }
 

--- a/src/spriteset_map.h
+++ b/src/spriteset_map.h
@@ -76,8 +76,8 @@ protected:
 	std::unique_ptr<Tilemap> tilemap;
 	std::unique_ptr<Plane> panorama;
 	std::string panorama_name;
-	std::vector<std::shared_ptr<Sprite_Character> > character_sprites;
-	std::unique_ptr<Sprite_AirshipShadow> airship_shadow;
+	std::vector<std::shared_ptr<Sprite_Character>> character_sprites;
+	std::vector<std::shared_ptr<Sprite_AirshipShadow>> airship_shadows;
 	std::unique_ptr<Sprite_Timer> timer1;
 	std::unique_ptr<Sprite_Timer> timer2;
 	std::unique_ptr<Screen> screen;
@@ -85,6 +85,7 @@ protected:
 	std::unique_ptr<Frame> frame;
 
 	void CreateSprite(Game_Character* character, bool create_x_clone, bool create_y_clone);
+	void CreateAirshipShadowSprite(bool create_x_clone, bool create_y_clone);
 
 	void OnTilemapSpriteReady(FileRequestResult*);
 	void OnPanoramaSpriteReady(FileRequestResult* result);

--- a/src/spriteset_map.h
+++ b/src/spriteset_map.h
@@ -84,11 +84,16 @@ protected:
 	std::unique_ptr<Weather> weather;
 	std::unique_ptr<Frame> frame;
 
+	void CreateSprite(Game_Character* character, bool create_x_clone, bool create_y_clone);
+
 	void OnTilemapSpriteReady(FileRequestResult*);
 	void OnPanoramaSpriteReady(FileRequestResult* result);
 
 	FileRequestBinding panorama_request_id;
 	FileRequestBinding tilemap_request_id;
+
+	bool need_x_clone = false;
+	bool need_y_clone = false;
 
 	bool vehicle_loaded[3] = {};
 


### PR DESCRIPTION
Alternative to https://github.com/EasyRPG/Player/pull/1401/commits/d11a906a196ecda412a7adf8fc731eba9746fe56  as you can see my solution is a bit simpler ;).

This depends on #1498 because the Screen scroll changes/fixes made it much easier to implement this.

Test case: https://easyrpg.org/play/pr1541/?start-map-id=44
