### PR TITLE
Bugfix: MakeCanonical didn't skip empty path components

### DIFF
--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -292,7 +292,7 @@ std::string FileFinder::MakeCanonical(const std::string& path, int initial_deepn
 			} else {
 				Output::Debug("Path traversal out of game directory: %s", path.c_str());
 			}
-		} else if (path_comp == ".") {
+		} else if (path_comp.empty() || path_comp == ".") {
 			// ignore
 		} else {
 			path_can.push_back(path_comp);


### PR DESCRIPTION
e.g. //a/./ was transformed to //a/, not /a/

Fixes this fancy game I found on twitter 20 min ago: 

[viptmp1440.zip](https://github.com/EasyRPG/Player/files/2659794/viptmp1440.zip)

![montage-fs8](https://user-images.githubusercontent.com/1331889/49687509-2e4c6680-fb04-11e8-8ca3-327d3708e8c2.png)

