### PR TITLE
Fix screen shake algo

### DIFF
--- a/src/game_picture.cpp
+++ b/src/game_picture.cpp
@@ -80,8 +80,15 @@ void Game_Picture::UpdateSprite() {
 		sprite->SetBitmap(sheet_bitmap);
 	}
 
-	sprite->SetX((int)data.current_x);
-	sprite->SetY((int)data.current_y);
+	int x = data.current_x;
+	int y = data.current_y;
+	if (data.flags.affected_by_shake) {
+		x -= Main_Data::game_data.screen.shake_position;
+		y += Main_Data::game_data.screen.shake_position_y;
+	}
+
+	sprite->SetX(x);
+	sprite->SetY(y);
 	if (Player::IsMajorUpdatedVersion()) {
 		// Battle Animations are above pictures
 		int priority = Drawable::GetPriorityForMapLayer(data.map_layer);

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -16,6 +16,7 @@
  */
 
 // Headers
+#define _USE_MATH_DEFINES
 #include "bitmap.h"
 #include "data.h"
 #include "game_battle.h"
@@ -26,6 +27,9 @@
 #include "main_data.h"
 #include "output.h"
 #include "utils.h"
+#include <cmath>
+
+static constexpr int kShakeContinuousTimeStart = 65535;
 
 Game_Screen::Game_Screen() :
 	data(Main_Data::game_data.screen)
@@ -72,12 +76,13 @@ void Game_Screen::Reset(bool is_load_savegame) {
 		data.tint_current_sat = 100;
 	}
 
-	data.shake_strength = 0;
-	data.shake_speed = 0;
-	data.shake_time_left = 0;
-	data.shake_position = 0;
-	data.shake_continuous = false;
-	shake_direction = 1;
+	if (!is_load_savegame) {
+		data.shake_strength = 0;
+		data.shake_speed = 0;
+		data.shake_time_left = 0;
+		data.shake_position = 0;
+		data.shake_continuous = false;
+	}
 
 	movie_filename = "";
 	movie_pos_x = 0;
@@ -163,12 +168,13 @@ void Game_Screen::ShakeOnce(int power, int speed, int tenths) {
 void Game_Screen::ShakeBegin(int power, int speed) {
 	data.shake_strength = power;
 	data.shake_speed = speed;
-	data.shake_time_left = 0;
+	data.shake_time_left = kShakeContinuousTimeStart;
 	data.shake_position = 0;
 	data.shake_continuous = true;
 }
 
 void Game_Screen::ShakeEnd() {
+	data.shake_position = 0;
 	data.shake_time_left = 0;
 	data.shake_continuous = false;
 }
@@ -251,19 +257,21 @@ void Game_Screen::Update() {
 		}
 	}
 
-	if (data.shake_continuous || data.shake_time_left > 0 || data.shake_position != 0) {
-		double delta = (data.shake_strength * data.shake_speed * shake_direction) / 10.0;
-		if (data.shake_time_left <= 1 && data.shake_position * (data.shake_position + delta) < 0)
-			data.shake_position = 0;
-		else
-			data.shake_position = data.shake_position + (int)delta;
-		if (data.shake_position > data.shake_strength * 2)
-			shake_direction = -1;
-		if (data.shake_position < -data.shake_strength * 2)
-			shake_direction = 1;
+	if (data.shake_continuous || data.shake_time_left > 0) {
+		--data.shake_time_left;
+		if (data.shake_continuous || data.shake_time_left > 0) {
+			if (data.shake_time_left < 0 && data.shake_continuous) {
+				data.shake_time_left = kShakeContinuousTimeStart;
+			}
+			int amplitude = 1 + 2 * data.shake_strength;
+			int newpos = amplitude * sin((data.shake_time_left * 4 * (data.shake_speed + 2)) % 256 * M_PI / 128);
+			int cutoff = (data.shake_speed * amplitude / 8) + 1;
 
-		if (data.shake_time_left > 0)
-			data.shake_time_left = data.shake_time_left - 1;
+			data.shake_position = Utils::Clamp(newpos, data.shake_position - cutoff, data.shake_position + cutoff);
+		} else {
+			data.shake_position = 0;
+			data.shake_time_left = 0;
+		}
 	}
 
 	for (const auto& picture : pictures) {

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -76,14 +76,6 @@ void Game_Screen::Reset(bool is_load_savegame) {
 		data.tint_current_sat = 100;
 	}
 
-	if (!is_load_savegame) {
-		data.shake_strength = 0;
-		data.shake_speed = 0;
-		data.shake_time_left = 0;
-		data.shake_position = 0;
-		data.shake_continuous = false;
-	}
-
 	movie_filename = "";
 	movie_pos_x = 0;
 	movie_pos_y = 0;

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -153,16 +153,18 @@ void Game_Screen::ShakeOnce(int power, int speed, int tenths) {
 	data.shake_strength = power;
 	data.shake_speed = speed;
 	data.shake_time_left = tenths;
-	data.shake_position = 0;
 	data.shake_continuous = false;
+	// Shake position is not reset in RPG_RT, so that multiple shakes
+	// which interrupt each other flow smoothly.
 }
 
 void Game_Screen::ShakeBegin(int power, int speed) {
 	data.shake_strength = power;
 	data.shake_speed = speed;
 	data.shake_time_left = kShakeContinuousTimeStart;
-	data.shake_position = 0;
 	data.shake_continuous = true;
+	// Shake position is not reset in RPG_RT, so that multiple shakes
+	// which interrupt each other flow smoothly.
 }
 
 void Game_Screen::ShakeEnd() {

--- a/src/game_screen.h
+++ b/src/game_screen.h
@@ -100,7 +100,6 @@ private:
 	RPG::SaveScreen& data;
 	int flash_sat;		// RPGMaker bug: this isn't saved
 	int flash_period;	// RPGMaker bug: this isn't saved
-	int shake_direction;
 
 	std::string movie_filename;
 	int movie_pos_x;

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -147,8 +147,8 @@ void Scene_Map::Update() {
 
 	Main_Data::game_party->UpdateTimers();
 
-	Game_Map::Update();
 	Main_Data::game_screen->Update();
+	Game_Map::Update();
 	spriteset->Update();
 	message_window->Update();
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -234,6 +234,16 @@ namespace Utils {
 	 */
 	std::string ReplacePlaceholders(const std::string& text_template, std::vector<char> types, std::vector<std::string> values);
 
+	/**
+	 * @return value clamped between min and max
+	 */
+	template <typename T> T Clamp(T value, const T& minv, const T& maxv);
+
 } // namespace Utils
+
+template <typename T>
+inline T Utils::Clamp(T value, const T& minv, const T& maxv) {
+	return (value < minv) ? (minv) : ((value > maxv) ? maxv : value);
+}
 
 #endif


### PR DESCRIPTION
Fixes: #1547 

From Cherry:
```
and the Shake X comes from something like this:

ConvertedPower = 1 + 2*Power
Val = ConvertedPower * Sin((FrameCount * 4*(Speed + 2)) % 256) * pi / 128)
Cutoff = Speed * ConvertedPower/8

newX = min(prevX + Cutoff, max(prevX - cutoff, Val))

I'm not sure this is right because I don't understand why it's so complicated and includes the old value

and when frame count is zero (I guess it's also set to zero when shake is turned off?) it just resets shake X and Y to 0
```

I've tested the following cases so far and they are frame accurate with RPG_RT:

| Strength | Speed | Wait |
| --- | --- | --- |
| 1 | 1 | 2.0s |
| 1 | 9 | 2.0s |
| 9 | 1 | 2.0s |
| 9 | 9 | 2.0s |

Some data here:
[RPG_RT-shake_9_1_20.pdf](https://github.com/EasyRPG/Player/files/2660859/RPG_RT-shake_9_1_20.pdf)
 