### PR TITLE
Handle saving and loading of tile substitutions

### DIFF
--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1330,20 +1330,23 @@ void Game_Map::RemoveAllPendingMoves() {
 	pending.clear();
 }
 
-void Game_Map::SubstituteDown(int old_id, int new_id) {
-	for (size_t i = 0; i < map_info.lower_tiles.size(); ++i) {
-		if (map_info.lower_tiles[i] == old_id) {
-			map_info.lower_tiles[i] = (uint8_t) new_id;
+static int DoSubstitute(std::vector<uint8_t>& tiles, int old_id, int new_id) {
+	int num_subst = 0;
+	for (size_t i = 0; i < tiles.size(); ++i) {
+		if (tiles[i] == old_id) {
+			tiles[i] = (uint8_t) new_id;
+			++num_subst;
 		}
 	}
+	return num_subst;
 }
 
-void Game_Map::SubstituteUp(int old_id, int new_id) {
-	for (size_t i = 0; i < map_info.upper_tiles.size(); ++i) {
-		if (map_info.upper_tiles[i] == old_id) {
-			map_info.upper_tiles[i] = (uint8_t) new_id;
-		}
-	}
+int Game_Map::SubstituteDown(int old_id, int new_id) {
+	return DoSubstitute(map_info.lower_tiles, old_id, new_id);
+}
+
+int Game_Map::SubstituteUp(int old_id, int new_id) {
+	return DoSubstitute(map_info.upper_tiles, old_id, new_id);
 }
 
 void Game_Map::LockPan() {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -147,6 +147,13 @@ void Game_Map::Setup(int _id) {
 
 	SetChipset(map->chipset_id);
 
+	for (size_t i = 0; i < map_info.lower_tiles.size(); i++) {
+		map_info.lower_tiles[i] = i;
+	}
+	for (size_t i = 0; i < map_info.upper_tiles.size(); i++) {
+		map_info.upper_tiles[i] = i;
+	}
+
 	events.reserve(map->events.size());
 	for (const RPG::Event& ev : map->events) {
 		events.emplace_back(location.map_id, ev);
@@ -1272,10 +1279,6 @@ void Game_Map::SetChipset(int id) {
 		passages_down.resize(162, (unsigned char) 0x0F);
 	if (passages_up.size() < 144)
 		passages_up.resize(144, (unsigned char) 0x0F);
-	for (uint8_t i = 0; i < 144; i++) {
-		map_info.lower_tiles[i] = i;
-		map_info.upper_tiles[i] = i;
-	}
 }
 
 Game_Vehicle* Game_Map::GetVehicle(Game_Vehicle::Type which) {

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -564,8 +564,8 @@ namespace Game_Map {
 	void SetChipset(int id);
 
 	Game_Vehicle* GetVehicle(Game_Vehicle::Type which);
-	void SubstituteDown(int old_id, int new_id);
-	void SubstituteUp(int old_id, int new_id);
+	int SubstituteDown(int old_id, int new_id);
+	int SubstituteUp(int old_id, int new_id);
 
 	bool IsPassableTile(int bit, int tile_index);
 

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -137,13 +137,17 @@ void Spriteset_Map::SystemGraphicUpdated() {
 }
 
 void Spriteset_Map::SubstituteDown(int old_id, int new_id) {
-	Game_Map::SubstituteDown(old_id, new_id);
-	tilemap->SubstituteDown(old_id, new_id);
+	int num_subst = Game_Map::SubstituteDown(old_id, new_id);
+	if (num_subst) {
+		tilemap->OnSubstituteDown();
+	}
 }
 
 void Spriteset_Map::SubstituteUp(int old_id, int new_id) {
-	Game_Map::SubstituteUp(old_id, new_id);
-	tilemap->SubstituteUp(old_id, new_id);
+	int num_subst = Game_Map::SubstituteUp(old_id, new_id);
+	if (num_subst) {
+		tilemap->OnSubstituteUp();
+	}
 }
 
 bool Spriteset_Map::RequireBackground(const Graphics::DrawableList& drawable_list) {

--- a/src/tilemap.cpp
+++ b/src/tilemap.cpp
@@ -109,11 +109,11 @@ int Tilemap::GetAnimationType() const {
 void Tilemap::SetAnimationType(int type) {
 	layer_down.SetAnimationType(type);
 }
-void Tilemap::SubstituteDown(int old_id, int new_id) {
-	layer_down.Substitute(old_id, new_id);
+void Tilemap::OnSubstituteDown() {
+	layer_down.OnSubstitute();
 }
-void Tilemap::SubstituteUp(int old_id, int new_id) {
-	layer_up.Substitute(old_id, new_id);
+void Tilemap::OnSubstituteUp() {
+	layer_up.OnSubstitute();
 }
 
 void Tilemap::SetFastBlitDown(bool fast) {

--- a/src/tilemap.h
+++ b/src/tilemap.h
@@ -57,8 +57,8 @@ public:
 	void SetAnimationSpeed(int speed);
 	int GetAnimationType() const;
 	void SetAnimationType(int type);
-	void SubstituteDown(int old_id, int new_id);
-	void SubstituteUp(int old_id, int new_id);
+	void OnSubstituteDown();
+	void OnSubstituteUp();
 	void SetFastBlitDown(bool fast);
 	void SetTone(Tone tone);
 

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -25,6 +25,7 @@
 #include "map_data.h"
 #include "bitmap.h"
 #include "game_map.h"
+#include "main_data.h"
 
 // Blocks subtiles IDs
 // Mess with this code and you will die in 3 days...
@@ -137,6 +138,9 @@ static const uint8_t BlockD_Subtiles_IDS[50][2][2][2] = {
 };
 
 TilemapLayer::TilemapLayer(int ilayer) :
+	substitutions(ilayer >= 1
+			? Main_Data::game_data.map_info.upper_tiles
+			: Main_Data::game_data.map_info.lower_tiles),
 	visible(true),
 	ox(0),
 	oy(0),
@@ -681,13 +685,6 @@ std::vector<unsigned char> TilemapLayer::GetPassable() const {
 void TilemapLayer::SetPassable(const std::vector<unsigned char>& npassable) {
 	passable = npassable;
 
-	if (substitutions.size() < passable.size())
-	{
-		substitutions.resize(passable.size());
-		for (uint8_t i = 0; i < substitutions.size(); i++)
-			substitutions[i] = i;
-	}
-
 	// Recalculate z values of all tiles
 	CreateTileCache(map_data);
 }
@@ -748,20 +745,9 @@ void TilemapLayer::SetAnimationType(int type) {
 	animation_type = type;
 }
 
-void TilemapLayer::Substitute(int old_id, int new_id) {
-	int subst_count = 0;
-
-	for (size_t i = 0; i < substitutions.size(); ++i) {
-		if (substitutions[i] == old_id) {
-			++subst_count;
-			substitutions[i] = (uint8_t) new_id;
-		}
-	}
-
-	if (subst_count > 0) {
-		// Recalculate z values of all tiles
-		CreateTileCache(map_data);
-	}
+void TilemapLayer::OnSubstitute() {
+	// Recalculate z values of all tiles
+	CreateTileCache(map_data);
 }
 
 void TilemapLayer::SetFastBlit(bool fast) {

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -80,7 +80,7 @@ public:
 	void SetAnimationSpeed(int speed);
 	int GetAnimationType() const;
 	void SetAnimationType(int type);
-	void Substitute(int old_id, int new_id);
+	void OnSubstitute();
 	/**
 	 * Influences how tiles of the tilemap are blitted.
 	 * When enabled the opacity information of the tile is ignored and a opaque
@@ -99,7 +99,8 @@ private:
 
 	std::vector<short> map_data;
 	std::vector<uint8_t> passable;
-	std::vector<uint8_t> substitutions;
+	// FIXME Should be span<uint8_t>
+	const std::vector<uint8_t>& substitutions;
 	bool visible;
 	int ox;
 	int oy;


### PR DESCRIPTION
Tested:
* Loading tile substitutions from save game
* Change chipset event command after doing tile substitution
* Loading changed chipset

---

Fixes #1266.