### PR TITLE
More panorama fixes

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -130,7 +130,7 @@ int Game_Character::GetScreenY() const {
 	}
 
 	if (IsJumping()) {
-		int jump_height = (GetRemainingStep() > SCREEN_TILE_WIDTH / 2 ? SCREEN_TILE_WIDTH - GetRemainingStep() : GetRemainingStep()) / 8;
+		int jump_height = (GetRemainingStep() > SCREEN_TILE_SIZE / 2 ? SCREEN_TILE_SIZE - GetRemainingStep() : GetRemainingStep()) / 8;
 		y -= (jump_height < 5 ? jump_height * 2 : jump_height < 13 ? jump_height + 4 : 16);
 	}
 
@@ -478,7 +478,7 @@ void Game_Character::Move(int dir, MoveOption option) {
 	} else {
 		SetX(Game_Map::RoundX(GetX() + dx));
 		SetY(Game_Map::RoundY(GetY() + dy));
-		SetRemainingStep(SCREEN_TILE_WIDTH);
+		SetRemainingStep(SCREEN_TILE_SIZE);
 		BeginMove();
 	}
 
@@ -739,7 +739,7 @@ void Game_Character::BeginJump(const RPG::MoveRoute* current_route, int* current
 	SetY(new_y);
 	*current_index = i;
 
-	SetRemainingStep(SCREEN_TILE_WIDTH);
+	SetRemainingStep(SCREEN_TILE_SIZE);
 	SetStopCount(0);
 	SetMaxStopCount((GetMoveFrequency() > 7) ? 0 : pow(2.0, 9 - GetMoveFrequency()));
 	move_failed = false;
@@ -813,7 +813,7 @@ int Game_Character::GetTileId() const {
 }
 
 int Game_Character::GetSpriteX() const {
-	int x = GetX() * SCREEN_TILE_WIDTH;
+	int x = GetX() * SCREEN_TILE_SIZE;
 
 	if (IsMoving()) {
 		int d = GetDirection();
@@ -824,14 +824,14 @@ int Game_Character::GetSpriteX() const {
 	} else if (IsJumping())
 		x -= ((GetX() - GetBeginJumpX()) * GetRemainingStep());
 	if (x < 0) {
-		x += Game_Map::GetWidth() * SCREEN_TILE_WIDTH;
+		x += Game_Map::GetWidth() * SCREEN_TILE_SIZE;
 	}
 
 	return x;
 }
 
 int Game_Character::GetSpriteY() const {
-	int y = GetY() * SCREEN_TILE_WIDTH;
+	int y = GetY() * SCREEN_TILE_SIZE;
 
 	if (IsMoving()) {
 		int d = GetDirection();
@@ -843,7 +843,7 @@ int Game_Character::GetSpriteY() const {
 		y -= (GetY() - GetBeginJumpY()) * GetRemainingStep();
 
 	if (y < 0) {
-		y += Game_Map::GetHeight() * SCREEN_TILE_WIDTH;
+		y += Game_Map::GetHeight() * SCREEN_TILE_SIZE;
 	}
 
 	return y;

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -624,7 +624,7 @@ bool Game_Interpreter_Map::CommandPanScreen(RPG::EventCommand const& com) { // c
 		distance = std::max(
 				std::abs(Game_Map::GetPanX() - Game_Map::GetTargetPanX())
 				, std::abs(Game_Map::GetPanY() - Game_Map::GetTargetPanY()));
-		distance /= SCREEN_TILE_WIDTH;
+		distance /= SCREEN_TILE_SIZE;
 		break;
 	}
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1192,6 +1192,7 @@ void Game_Map::SetPositionX(int x) {
 		x = std::max(0, std::min(map_width - SCREEN_WIDTH, x));
 	}
 	map_info.position_x = x;
+	Parallax::ResetPositionX();
 }
 
 int Game_Map::GetPositionY() {
@@ -1210,6 +1211,7 @@ void Game_Map::SetPositionY(int y) {
 		y = std::max(0, std::min(map_height - SCREEN_HEIGHT, y));
 	}
 	map_info.position_y = y;
+	Parallax::ResetPositionY();
 }
 
 Game_Map::RefreshMode Game_Map::GetNeedRefresh() {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -45,8 +45,8 @@
 #include "utils.h"
 
 namespace {
-	constexpr int default_pan_x = 9 * SCREEN_TILE_WIDTH;
-	constexpr int default_pan_y = 7 * SCREEN_TILE_WIDTH;
+	constexpr int default_pan_x = 9 * SCREEN_TILE_SIZE;
+	constexpr int default_pan_y = 7 * SCREEN_TILE_SIZE;
 	constexpr int default_pan_speed = 16;
 
 	RPG::SaveMapInfo& map_info = Main_Data::game_data.map_info;
@@ -387,7 +387,7 @@ void Game_Map::ScrollRight(int distance) {
 	}
 	// Unused, except compatibility with RPG_RT
 	auto& pan_x = Main_Data::game_data.screen.pan_x;
-	const auto pan_limit_x = 20 * SCREEN_TILE_WIDTH;
+	const auto pan_limit_x = 20 * SCREEN_TILE_SIZE;
 	pan_x = (pan_x - distance + pan_limit_x) % pan_limit_x;
 
 	Game_Map::Parallax::ScrollRight(distance);
@@ -402,7 +402,7 @@ void Game_Map::ScrollDown(int distance) {
 	}
 	// Unused, except compatibility with RPG_RT
 	auto& pan_y = Main_Data::game_data.screen.pan_y;
-	const auto pan_limit_y = 10 * SCREEN_TILE_WIDTH;
+	const auto pan_limit_y = 10 * SCREEN_TILE_SIZE;
 	pan_y = (pan_y - distance + pan_limit_y) % pan_limit_y;
 
 	Game_Map::Parallax::ScrollDown(distance);
@@ -418,7 +418,7 @@ static void ClampingAdd(int low, int high, int& acc, int& inc) {
 }
 
 void Game_Map::AddScreenX(int& screen_x, int& inc) {
-	int map_width = GetWidth() * SCREEN_TILE_WIDTH;
+	int map_width = GetWidth() * SCREEN_TILE_SIZE;
 	if (LoopHorizontal()) {
 		screen_x = Utils::PositiveModulo(screen_x + inc, map_width);
 	} else {
@@ -427,7 +427,7 @@ void Game_Map::AddScreenX(int& screen_x, int& inc) {
 }
 
 void Game_Map::AddScreenY(int& screen_y, int& inc) {
-	int map_height = GetHeight() * SCREEN_TILE_WIDTH;
+	int map_height = GetHeight() * SCREEN_TILE_SIZE;
 	if (LoopVertical()) {
 		screen_y = Utils::PositiveModulo(screen_y + inc, map_height);
 	} else {
@@ -1185,7 +1185,7 @@ int Game_Map::GetDisplayX() {
 }
 
 void Game_Map::SetPositionX(int x) {
-	const int map_width = GetWidth() * SCREEN_TILE_WIDTH;
+	const int map_width = GetWidth() * SCREEN_TILE_SIZE;
 	if (LoopHorizontal()) {
 		x = Utils::PositiveModulo(x, map_width);
 	} else {
@@ -1204,7 +1204,7 @@ int Game_Map::GetDisplayY() {
 }
 
 void Game_Map::SetPositionY(int y) {
-	const int map_height = GetHeight() * SCREEN_TILE_WIDTH;
+	const int map_height = GetHeight() * SCREEN_TILE_SIZE;
 	if (LoopVertical()) {
 		y = Utils::PositiveModulo(y, map_height);
 	} else {
@@ -1387,7 +1387,7 @@ void Game_Map::UnlockPan() {
 }
 
 void Game_Map::StartPan(int direction, int distance, int speed, bool wait) {
-	distance *= SCREEN_TILE_WIDTH;
+	distance *= SCREEN_TILE_SIZE;
 
 	if (direction == PanUp) {
 		int new_pan = location.pan_finish_y + distance;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1566,6 +1566,9 @@ void Game_Map::Parallax::ResetPositionX() {
 	Params params = GetParallaxParams();
 
 	panorama.pan_x = 0;
+	if (params.name.empty()) {
+		return;
+	}
 	if (params.scroll_horz || LoopHorizontal()) {
 		panorama.pan_x = map_info.position_x;
 	} else if (GetWidth() > 20 && parallax_width > SCREEN_TARGET_WIDTH) {
@@ -1577,6 +1580,9 @@ void Game_Map::Parallax::ResetPositionY() {
 	Params params = GetParallaxParams();
 
 	panorama.pan_y = 0;
+	if (params.name.empty()) {
+		return;
+	}
 	if (params.scroll_vert || Game_Map::LoopVertical()) {
 		panorama.pan_y = map_info.position_y;
 	} else if (GetHeight() > 15 && parallax_height > SCREEN_TARGET_HEIGHT) {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1566,22 +1566,22 @@ void Game_Map::Parallax::ResetPositionX() {
 	Params params = GetParallaxParams();
 
 	panorama.pan_x = 0;
-	if (params.scroll_horz || LoopHorizontal())
+	if (params.scroll_horz || LoopHorizontal()) {
 		panorama.pan_x = map_info.position_x;
-	else if (GetWidth() > 20 && parallax_width > SCREEN_TARGET_WIDTH)
-		panorama.pan_x = std::min(map_info.position_x,
-				(map_info.position_x / (SCREEN_TILE_WIDTH / TILE_SIZE)) * (parallax_width - SCREEN_TARGET_WIDTH) / (GetWidth() - 20)) * 2;
+	} else if (GetWidth() > 20 && parallax_width > SCREEN_TARGET_WIDTH) {
+		panorama.pan_x = map_info.position_x * (parallax_width - SCREEN_TARGET_WIDTH) * 2 / ((GetWidth() - 20) * TILE_SIZE);
+	}
 }
 
 void Game_Map::Parallax::ResetPositionY() {
 	Params params = GetParallaxParams();
 
 	panorama.pan_y = 0;
-	if (params.scroll_vert || Game_Map::LoopVertical())
+	if (params.scroll_vert || Game_Map::LoopVertical()) {
 		panorama.pan_y = map_info.position_y;
-	else if (GetHeight() > 15 && parallax_height > SCREEN_TARGET_HEIGHT)
-		panorama.pan_y = std::min(map_info.position_y,
-				(map_info.position_y / (SCREEN_TILE_WIDTH / TILE_SIZE)) * (parallax_height - SCREEN_TARGET_HEIGHT) / (GetHeight() - 15)) * 2;
+	} else if (GetHeight() > 15 && parallax_height > SCREEN_TARGET_HEIGHT) {
+		panorama.pan_y = map_info.position_y * (parallax_height - SCREEN_TARGET_HEIGHT) * 2 / ((GetHeight() - 15) * TILE_SIZE);
+	}
 }
 
 void Game_Map::Parallax::ScrollRight(int distance) {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -393,7 +393,7 @@ void Game_Map::ScrollDown(int distance) {
 	// Unused, except compatibility with RPG_RT
 	auto& pan_y = Main_Data::game_data.screen.pan_y;
 	const auto pan_limit_y = 10 * SCREEN_TILE_WIDTH;
-	pan_y = (pan_y + distance + pan_limit_y) % pan_limit_y;
+	pan_y = (pan_y - distance + pan_limit_y) % pan_limit_y;
 
 	Game_Map::Parallax::ScrollDown(distance);
 }

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1574,7 +1574,8 @@ void Game_Map::Parallax::ResetPositionX() {
 	if (params.scroll_horz || LoopHorizontal()) {
 		panorama.pan_x = map_info.position_x;
 	} else if (GetWidth() > 20 && parallax_width > SCREEN_TARGET_WIDTH) {
-		panorama.pan_x = map_info.position_x * (parallax_width - SCREEN_TARGET_WIDTH) * 2 / ((GetWidth() - 20) * TILE_SIZE);
+		panorama.pan_x = std::min(map_info.position_x * (parallax_width - SCREEN_TARGET_WIDTH) * 2 / ((GetWidth() - 20) * TILE_SIZE)
+				, map_info.position_x * 2);
 	}
 }
 
@@ -1588,7 +1589,8 @@ void Game_Map::Parallax::ResetPositionY() {
 	if (params.scroll_vert || Game_Map::LoopVertical()) {
 		panorama.pan_y = map_info.position_y;
 	} else if (GetHeight() > 15 && parallax_height > SCREEN_TARGET_HEIGHT) {
-		panorama.pan_y = map_info.position_y * (parallax_height - SCREEN_TARGET_HEIGHT) * 2 / ((GetHeight() - 15) * TILE_SIZE);
+		panorama.pan_y = std::min(map_info.position_y * (parallax_height - SCREEN_TARGET_HEIGHT) * 2 / ((GetHeight() - 15) * TILE_SIZE)
+				, map_info.position_y * 2);
 	}
 }
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1606,6 +1606,10 @@ void Game_Map::Parallax::ScrollRight(int distance) {
 		return;
 	}
 
+	if (Game_Map::LoopHorizontal()) {
+		return;
+	}
+
 	ResetPositionX();
 }
 
@@ -1618,6 +1622,10 @@ void Game_Map::Parallax::ScrollDown(int distance) {
 	if (params.scroll_vert) {
 		const auto h = parallax_height * TILE_SIZE * 2;
 		panorama.pan_y = (panorama.pan_y + distance + h) % h;
+		return;
+	}
+
+	if (Game_Map::LoopVertical()) {
 		return;
 	}
 

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -32,9 +32,9 @@
 class FileRequestAsync;
 
 // These are in sixteenths of a pixel.
-constexpr int SCREEN_TILE_WIDTH = 256;
-constexpr int SCREEN_WIDTH = 20 * SCREEN_TILE_WIDTH;
-constexpr int SCREEN_HEIGHT = 15 * SCREEN_TILE_WIDTH;
+constexpr int SCREEN_TILE_SIZE = 256;
+constexpr int SCREEN_WIDTH = 20 * SCREEN_TILE_SIZE;
+constexpr int SCREEN_HEIGHT = 15 * SCREEN_TILE_SIZE;
 
 /**
  * Game_Map namespace

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -656,7 +656,11 @@ namespace Game_Map {
 		 *
 		 * @param init if true will always reset position, even on looping maps
 		 */
-		void UpdatePosition(bool init = false);
+		void ResetPositionX();
+		void ResetPositionY();
+
+		void ScrollRight(int distance);
+		void ScrollDown(int distance);
 
 		/** Update autoscrolling BG (call every frame). */
 		void Update();

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -651,15 +651,24 @@ namespace Game_Map {
 		/** Call this when you find out the width and height of the BG. */
 		void Initialize(int width, int height);
 
-		/**
-		 * Reset the x- and y- position of the BG.
-		 *
-		 * @param init if true will always reset position, even on looping maps
-		 */
+		/** Reset the x position of the BG. */
 		void ResetPositionX();
+
+		/** Reset the y position of the BG. */
 		void ResetPositionY();
 
+		/**
+		 * To be called when the map scrolls right.
+		 *
+		 * @param distance Amount of scroll in 1/16th pixels.
+		 */
 		void ScrollRight(int distance);
+
+		/**
+		 * To be called when the map scrolls down.
+		 *
+		 * @param distance Amount of scroll in 1/16th pixels.
+		 */
 		void ScrollDown(int distance);
 
 		/** Update autoscrolling BG (call every frame). */

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -181,6 +181,30 @@ void Game_Player::UpdateScroll(int old_x, int old_y) {
 	int new_panx = new_x - screen_x;
 	int new_pany = new_y - screen_y;
 
+	// Detect whether we crossed map boundary.
+	// We need to scale down dx/dy to a single step
+	// to not message up further calculations.
+	// FIXME: This logic will break if something moves so fast
+	// as to cross half the map in 1 frame.
+	if (Game_Map::LoopHorizontal()) {
+		auto w = Game_Map::GetWidth() * SCREEN_TILE_WIDTH;
+		if (std::abs(dx) > w / 2) {
+			dx = (w - std::abs(dx)) % w;
+			if (new_x > old_x) {
+				dx = -dx;
+			}
+		}
+	}
+	if (Game_Map::LoopVertical()) {
+		auto h = Game_Map::GetHeight() * SCREEN_TILE_WIDTH;
+		if (std::abs(dy) > h / 2) {
+			dy = (h - std::abs(dy)) % h;
+			if (new_y > old_y) {
+				dy = -dy;
+			}
+		}
+	}
+
 	if (Game_Map::LoopHorizontal() ||
 			std::abs(data()->pan_current_x - new_panx) >=
 			std::abs(data()->pan_current_x - old_panx)) {

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -148,17 +148,13 @@ bool Game_Player::IsTeleporting() const {
 	return teleporting;
 }
 
-void Game_Player::Center() {
-	Game_Map::SetPositionX(GetSpriteX() - data()->pan_current_x);
-	Game_Map::SetPositionY(GetSpriteY() - data()->pan_current_y);
-}
-
 void Game_Player::MoveTo(int x, int y) {
 	x = max(0, min(x, Game_Map::GetWidth() - 1));
 	y = max(0, min(y, Game_Map::GetHeight() - 1));
 
 	Game_Character::MoveTo(x, y);
-	Center();
+	Game_Map::SetPositionX(GetSpriteX() - data()->pan_current_x);
+	Game_Map::SetPositionY(GetSpriteY() - data()->pan_current_y);
 }
 
 void Game_Player::UpdateScroll(int old_x, int old_y) {

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -183,7 +183,7 @@ void Game_Player::UpdateScroll(int old_x, int old_y) {
 	// FIXME: This logic will break if something moves so fast
 	// as to cross half the map in 1 frame.
 	if (Game_Map::LoopHorizontal()) {
-		auto w = Game_Map::GetWidth() * SCREEN_TILE_WIDTH;
+		auto w = Game_Map::GetWidth() * SCREEN_TILE_SIZE;
 		if (std::abs(dx) > w / 2) {
 			dx = (w - std::abs(dx)) % w;
 			if (new_x > old_x) {
@@ -192,7 +192,7 @@ void Game_Player::UpdateScroll(int old_x, int old_y) {
 		}
 	}
 	if (Game_Map::LoopVertical()) {
-		auto h = Game_Map::GetHeight() * SCREEN_TILE_WIDTH;
+		auto h = Game_Map::GetHeight() * SCREEN_TILE_SIZE;
 		if (std::abs(dy) > h / 2) {
 			dy = (h - std::abs(dy)) % h;
 			if (new_y > old_y) {

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -63,7 +63,6 @@ public:
 	void ReserveTeleport(const RPG::SaveTarget& target);
 	void StartTeleport();
 	void PerformTeleport();
-	void Center();
 	void MoveTo(int x, int y) override;
 	void Update() override;
 

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -209,7 +209,7 @@ bool Game_Vehicle::GetVisible() const {
 
 void Game_Vehicle::GetOn() {
 	if (type == Airship) {
-		data()->remaining_ascent = SCREEN_TILE_WIDTH;
+		data()->remaining_ascent = SCREEN_TILE_SIZE;
 		SetFlying(true);
 		Main_Data::game_player->SetFlying(true);
 		SetAnimFrame(AnimFrame::Frame_middle);
@@ -219,7 +219,7 @@ void Game_Vehicle::GetOn() {
 
 void Game_Vehicle::GetOff() {
 	if (type == Airship) {
-		data()->remaining_descent = SCREEN_TILE_WIDTH;
+		data()->remaining_descent = SCREEN_TILE_SIZE;
 	} else {
 		Main_Data::game_player->UnboardingFinished();
 	}
@@ -245,11 +245,11 @@ int Game_Vehicle::GetAltitude() const {
 	if (!IsFlying())
 		return 0;
 	else if (IsAscending())
-		return (SCREEN_TILE_WIDTH - data()->remaining_ascent) / (SCREEN_TILE_WIDTH / TILE_SIZE);
+		return (SCREEN_TILE_SIZE - data()->remaining_ascent) / (SCREEN_TILE_SIZE / TILE_SIZE);
 	else if (IsDescending())
-		return data()->remaining_descent / (SCREEN_TILE_WIDTH / TILE_SIZE);
+		return data()->remaining_descent / (SCREEN_TILE_SIZE / TILE_SIZE);
 	else
-		return SCREEN_TILE_WIDTH / (SCREEN_TILE_WIDTH / TILE_SIZE);
+		return SCREEN_TILE_SIZE / (SCREEN_TILE_SIZE / TILE_SIZE);
 }
 
 int Game_Vehicle::GetScreenY() const {
@@ -302,7 +302,7 @@ void Game_Vehicle::Update() {
 					Main_Data::game_player->SetFlying(false);
 				} else {
 					// Can't land here, ascend again
-					data()->remaining_ascent = SCREEN_TILE_WIDTH;
+					data()->remaining_ascent = SCREEN_TILE_SIZE;
 				}
 			}
 		}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -772,7 +772,6 @@ static void OnMapSaveFileReady(FileRequestResult*) {
 	Game_Map::GetVehicle(Game_Vehicle::Ship)->SetAnimationType(Game_Character::AnimType::AnimType_non_continuous);
 	Game_Map::GetVehicle(Game_Vehicle::Airship)->SetAnimationType(Game_Character::AnimType::AnimType_non_continuous);
 
-	Main_Data::game_player->Center();
 	Main_Data::game_player->Refresh();
 
 	RPG::Music current_music = Main_Data::game_data.system.current_music;

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -62,8 +62,8 @@ Spriteset_Map::Spriteset_Map() {
 void Spriteset_Map::Update() {
 	Tone new_tone = Main_Data::game_screen->GetTone();
 
-	tilemap->SetOx(Game_Map::GetDisplayX() / (SCREEN_TILE_WIDTH / TILE_SIZE));
-	tilemap->SetOy(Game_Map::GetDisplayY() / (SCREEN_TILE_WIDTH / TILE_SIZE));
+	tilemap->SetOx(Game_Map::GetDisplayX() / (SCREEN_TILE_SIZE / TILE_SIZE));
+	tilemap->SetOy(Game_Map::GetDisplayY() / (SCREEN_TILE_SIZE / TILE_SIZE));
 	tilemap->SetTone(new_tone);
 	tilemap->Update();
 


### PR DESCRIPTION
I found more issues with panorama.

- [x] Our panorama pan_x / pan_y were not compatible with rm2k3e. The means saving and loading games between them will be wrong. We were treating them as scrolling offsets, but they are actually the entire panorama image offset.
- [x] We weren't handling Looping and scrolling maps right
- [x] `SaveScreen::pan_y` was inverted (not used in panorama but similar code so added here)
- [x] Save data not loaded correctly in all cases
- [x] Scroll jumps when you move slowly and is sometimes 1 pixel off in frames.
- [x] Retest #1550 with this PR.
- [x] Fixes: #1534 

So I've had to refactor this yet again!

I've retested this by trying different combinations of maps, saving the game in various spots, and comparing the pan_x and pan_y of Player vs RPG_RT.

Testing performed:
* Map with no looping, no scroll - Panorama is 2x size and moves with relative position on map 
* Map with looping, no scroll - Panorama is screen size and doesn't move
* Map with looping, scroll - Panorama is screen size and moves with player
* Map with no loop, scroll - Panorama is screen size and moves with player
* Map with loop, scroll, auto scroll - moves with player and moves by itself

I'm going to need to ask you guys to help test this one. Try some different size maps and panorama pictures. I don't want to keep finding bugs and refactoring this over and over again.