### PR TITLE
Crash Bugfix: Pictures not cleaned up

### DIFF
--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -50,6 +50,9 @@ void Game_Screen::CreatePicturesFromSave() {
 }
 
 void Game_Screen::Reset(bool is_load_savegame) {
+	if (Main_Data::game_data.pictures.size() < pictures.size()) {
+		pictures.resize(Main_Data::game_data.pictures.size());
+	}
 	for (auto& p : pictures) {
 		if (p) {
 			p->Erase(false);


### PR DESCRIPTION
If you load a save game which has fewer pictures than exist
currently, Game_Screen::Reset() will try to Erase() pictures
which don't exist and this causes a segfault.


No idea when this was introduced or how long it has existed.