### PR TITLE
More battle states fixes + Defend

### DIFF
--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1097,6 +1097,8 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 						}
 					}
 				}
+
+				GetTarget()->FilterInapplicableStates(conditions);
 			}
 		}
 	}
@@ -1336,9 +1338,12 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				continue;
 
 			if (healing || Utils::PercentChance(GetTarget()->GetStateProbability(state_id))) {
-				this->success = true;
 				conditions.push_back(state_id);
 			}
+		}
+		GetTarget()->FilterInapplicableStates(conditions);
+		if (!conditions.empty()) {
+			this->success = true;
 		}
 
 		// Attribute resistance / weakness + an attribute selected + can be modified

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1350,7 +1350,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 		if (!success && skill.affect_attr_defence) {
 			for (int i = 0; i < skill.attribute_effects.size(); i++) {
 				if (skill.attribute_effects[i] && GetTarget()->CanShiftAttributeRate(i + 1, IsPositive() ? 1 : -1)) {
-					if (Utils::GetRandomNumber(0, 99) >= skill.hit)
+					if (!Utils::PercentChance(skill.hit))
 						continue;
 					shift_attributes.push_back(i + 1);
 					this->success = true;
@@ -1907,7 +1907,7 @@ bool Game_BattleAlgorithm::Escape::Execute() {
 		to_hit += Game_Battle::escape_fail_count * 0.1f;
 
 		to_hit *= 100;
-		this->success = Utils::GetRandomNumber(0, 99) < (int)to_hit;
+		this->success = Utils::PercentChance((int)to_hit);
 	}
 
 	return this->success;

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -786,7 +786,6 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		}
 	}
 
-	source->SetDefending(false);
 	ApplyActionSwitches();
 }
 
@@ -1712,7 +1711,6 @@ bool Game_BattleAlgorithm::Defend::Execute() {
 }
 
 void Game_BattleAlgorithm::Defend::Apply() {
-	source->SetDefending(true);
 	ApplyActionSwitches();
 }
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1323,12 +1323,19 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 			if (!skill.state_effects[i])
 				continue;
 
-			if (!healing && !Utils::PercentChance(to_hit))
+			if (!healing && GetTarget()->HasState(i + 1)) {
+				this->success = true;
+				conditions.push_back(Data::states[i]);
+				continue;
+			}
+			if (healing && !GetTarget()->HasState(i + 1)) {
+				continue;
+			}
+			if (!Utils::PercentChance(to_hit))
 				continue;
 
-			this->success = true;
-
 			if (healing || Utils::PercentChance(GetTarget()->GetStateProbability(Data::states[i].ID))) {
+				this->success = true;
 				conditions.push_back(Data::states[i]);
 			}
 		}

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -215,7 +215,7 @@ public:
 	 *
 	 * @return List of all inflicted/removed conditions
 	 */
-	const std::vector<RPG::State>& GetAffectedConditions() const;
+	const std::vector<int16_t>& GetAffectedConditions() const;
 
 	/**
 	 * Returns whether the action hit the target.
@@ -442,7 +442,7 @@ protected:
 	bool has_animation_played;
 	bool has_animation2_played;
 
-	std::vector<RPG::State> conditions;
+	std::vector<int16_t> conditions;
 	std::vector<int16_t> healed_conditions;
 	std::vector<int16_t> shift_attributes;
 	std::vector<int> switch_on;

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -32,6 +32,7 @@
 #include "utils.h"
 #include "output.h"
 #include "reader_util.h"
+#include "game_battlealgorithm.h"
 
 Game_Battler::Game_Battler() {
 	ResetBattle();
@@ -461,7 +462,6 @@ void Game_Battler::AddState(int state_id) {
 	if (state_id == 1) {
 		SetGauge(0);
 		RemoveAllStates();
-		SetDefending(false);
 		SetCharged(false);
 		SetHp(0);
 		SetAtkModifier(0);
@@ -620,7 +620,10 @@ void Game_Battler::SetCharged(bool charge) {
 }
 
 bool Game_Battler::IsDefending() const {
-	return defending;
+	auto* algo = GetBattleAlgorithm().get();
+	return algo
+		&& algo->GetType() == Game_BattleAlgorithm::Type::Defend
+		&& GetSignificantRestriction() == RPG::State::Restriction_normal;
 }
 
 bool Game_Battler::HasStrongDefense() const {
@@ -629,10 +632,6 @@ bool Game_Battler::HasStrongDefense() const {
 
 bool Game_Battler::HasPreemptiveAttack() const {
 	return false;
-}
-
-void Game_Battler::SetDefending(bool defend) {
-	defending = defend;
 }
 
 bool Game_Battler::IsHidden() const {
@@ -891,7 +890,6 @@ void Game_Battler::ResetBattle() {
 		gauge /= 2;
 	}
 	charged = false;
-	defending = false;
 	battle_turn = 0;
 	last_battle_action = -1;
 	atk_modifier = 0;

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -424,6 +424,16 @@ public:
 	virtual void AddState(int state_id);
 
 	/**
+	 * Filters out all states that can't be applied due to their priority being
+	 * < 10 of the most significant state.
+	 *
+	 * @param states in-out parameter of states.
+	 *
+	 * @return The number of states removed.
+	 */
+	int FilterInapplicableStates(std::vector<int16_t>& states) const;
+
+	/**
 	 * Removes a State.
 	 *
 	 * @param state_id ID of state to remove.

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -522,13 +522,6 @@ public:
 	 */
 	virtual bool HasPreemptiveAttack() const;
 
-	/**
-	 * Sets defence state (next turn, defense is doubled)
-	 *
-	 * @param defend new defence state
-	 */
-	void SetDefending(bool defend);
-
 	enum BattlerType {
 		Type_Ally,
 		Type_Enemy
@@ -658,7 +651,6 @@ protected:
 	BattleAlgorithmRef battle_algorithm;
 
 	bool charged;
-	bool defending;
 	int atk_modifier;
 	int def_modifier;
 	int spi_modifier;

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -430,49 +430,47 @@ std::shared_ptr<Scene_Battle> Scene_Battle::Create()
 }
 
 void Scene_Battle::UpdateBattlerActions() {
-	if (battle_actions.empty()) {
-		return;
-	}
+	for (auto* battler: battle_actions) {
+		if (!battler->CanAct()) {
+			if (battler->GetBattleAlgorithm()->GetType() != Game_BattleAlgorithm::Type::NoMove) {
+				battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(battler));
+				battler->SetCharged(false);
+			}
+			continue;
+		}
 
-	auto* battler = battle_actions.front();
-	if (!battler->CanAct()) {
-		battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(battler));
-		battler->SetCharged(false);
-		return;
-	}
+		if (battler->GetSignificantRestriction() == RPG::State::Restriction_attack_ally) {
+			if (battler->GetBattleAlgorithm()->GetSourceRestrictionWhenStarted() != RPG::State::Restriction_attack_ally) {
+				Game_Battler *target = battler->GetType() == Game_Battler::Type_Enemy ?
+					Main_Data::game_enemyparty->GetRandomActiveBattler() :
+					Main_Data::game_party->GetRandomActiveBattler();
 
-	if (battler->GetSignificantRestriction() == RPG::State::Restriction_attack_ally) {
-		Game_Battler *target = battler->GetType() == Game_Battler::Type_Enemy ?
-			Main_Data::game_enemyparty->GetRandomActiveBattler() :
-			Main_Data::game_party->GetRandomActiveBattler();
+				battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::Normal>(battler, target));
+				battler->SetCharged(false);
+			}
+			continue;
+		}
 
-		battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::Normal>(battler, target));
-		battler->SetCharged(false);
-		return;
-	}
+		if (battler->GetSignificantRestriction() == RPG::State::Restriction_attack_enemy) {
+			if (battler->GetBattleAlgorithm()->GetSourceRestrictionWhenStarted() != RPG::State::Restriction_attack_enemy) {
+				Game_Battler *target = battler->GetType() == Game_Battler::Type_Ally ?
+					Main_Data::game_enemyparty->GetRandomActiveBattler() :
+					Main_Data::game_party->GetRandomActiveBattler();
 
-	if (battler->GetSignificantRestriction() == RPG::State::Restriction_attack_enemy) {
-		Game_Battler *target = battler->GetType() == Game_Battler::Type_Ally ?
-			Main_Data::game_enemyparty->GetRandomActiveBattler() :
-			Main_Data::game_party->GetRandomActiveBattler();
+				battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::Normal>(battler, target));
+				battler->SetCharged(false);
+			}
+			continue;
+		}
 
-		battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::Normal>(battler, target));
-		battler->SetCharged(false);
-		return;
-	}
-
-	// If we can no longer perform the action (no more items, ran out of SP, etc..)
-	if (!battler->GetBattleAlgorithm()->ActionIsPossible()) {
-		battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(battler));
-		battler->SetCharged(false);
-		return;
-	}
-
-	// If we had a state restriction previously but were recovered, we do nothing for this round.
-	if (battler->GetBattleAlgorithm()->GetSourceRestrictionWhenStarted() != RPG::State::Restriction_normal) {
-		battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(battler));
-		battler->SetCharged(false);
-		return;
+		// If we had a state restriction previously but were recovered, we do nothing for this round.
+		if (battler->GetBattleAlgorithm()->GetSourceRestrictionWhenStarted() != RPG::State::Restriction_normal) {
+			if (battler->GetBattleAlgorithm()->GetType() != Game_BattleAlgorithm::Type::NoMove) {
+				battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(battler));
+				battler->SetCharged(false);
+			}
+			continue;
+		}
 	}
 }
 

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -310,7 +310,15 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 			UpdateBattlerActions();
 		}
 		if (!battle_actions.empty()) {
-			Game_BattleAlgorithm::AlgorithmBase* alg = battle_actions.front()->GetBattleAlgorithm().get();
+			auto* battler = battle_actions.front();
+			if (!battle_action_pending) {
+				// If we can no longer perform the action (no more items, ran out of SP, etc..)
+				if (!battler->GetBattleAlgorithm()->ActionIsPossible()) {
+					battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(battler));
+					battler->SetCharged(false);
+				}
+			}
+			auto* alg = battler->GetBattleAlgorithm().get();
 
 			battle_action_pending = true;
 			if (ProcessBattleAction(alg)) {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -527,9 +527,17 @@ void Scene_Battle_Rpg2k3::ProcessActions() {
 	}
 
 	if (!battle_actions.empty()) {
-		Game_Battler* action = battle_actions.front();
+		auto* battler = battle_actions.front();
+		if (!battle_action_pending) {
+			// If we can no longer perform the action (no more items, ran out of SP, etc..)
+			if (!battler->GetBattleAlgorithm()->ActionIsPossible()) {
+				battler->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(battler));
+				battler->SetCharged(false);
+			}
+		}
+		auto* alg = battler->GetBattleAlgorithm().get();
 		battle_action_pending = true;
-		if (ProcessBattleAction(action->GetBattleAlgorithm().get())) {
+		if (ProcessBattleAction(alg)) {
 			battle_action_pending = false;
 			RemoveCurrentAction();
 			if (CheckResultConditions()) {


### PR DESCRIPTION
I've tested 2.36. It looks good with no changes:

* State inflicted when you already have the state - success, already has msg
* State inflicted when you aready have the state, even when your state rate is E (0%) - success, already has msg
* State infliced when you don't have the state - sucess, state inflicted
* State inflict attempt missed - failure
* Heal state when you have state - success, was healed
* Heal state failure when you have state - failure
* Heal state you don't have - failure