### PR TITLE
Fix 1574, 1576 and improve title reload

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -21,6 +21,7 @@
 #endif
 
 #include <map>
+#include <tuple>
 
 #include "async_handler.h"
 #include "cache.h"
@@ -33,7 +34,7 @@
 #include "data.h"
 
 namespace {
-	typedef std::pair<std::string,std::string> string_pair;
+	using KeyType = std::tuple<std::string,std::string,bool>;
 
 	struct CacheItem {
 		BitmapRef bitmap;
@@ -70,7 +71,7 @@ namespace {
 
 	BitmapRef LoadBitmap(std::string const& folder_name, const std::string& filename,
 						 bool transparent, uint32_t const flags) {
-		string_pair const key(folder_name, filename);
+		KeyType const key(folder_name, filename, transparent);
 
 		cache_type::iterator const it = cache.find(key);
 
@@ -197,7 +198,7 @@ namespace {
 
 		Spec const& s = spec[T];
 
-		string_pair const key(folder_name, filename);
+		KeyType const key(folder_name, filename, false);
 
 		BitmapRef bitmap = s.dummy_renderer();
 
@@ -286,7 +287,7 @@ BitmapRef Cache::Picture(const std::string& f, bool trans) {
 }
 
 BitmapRef Cache::Exfont() {
-	string_pair const hash("ExFont","ExFont");
+	KeyType const hash("ExFont", "ExFont", false);
 
 	cache_type::iterator const it = cache.find(hash);
 

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -41,12 +41,12 @@ namespace {
 		uint32_t last_access;
 	};
 
-	typedef std::pair<std::string, int> tile_pair;
+	using tile_pair = std::pair<std::string, int>;
 
-	typedef std::map<string_pair, CacheItem> cache_type;
+	using cache_type = std::map<KeyType, CacheItem>;
 	cache_type cache;
 
-	typedef std::map<tile_pair, std::weak_ptr<Bitmap> > cache_tiles_type;
+	using cache_tiles_type = std::map<tile_pair, std::weak_ptr<Bitmap>>;
 	cache_tiles_type cache_tiles;
 
 	std::string system_name;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -57,6 +57,8 @@ namespace {
 	static Game_Interpreter* transition_owner = nullptr;
 }
 
+Game_Interpreter::EventCalling Game_Interpreter::event_calling = {};
+
 Game_Interpreter::Game_Interpreter(int _depth, bool _main_flag) {
 	depth = _depth;
 	main_flag = _main_flag;
@@ -91,7 +93,6 @@ void Game_Interpreter::Clear() {
 			child_interpreter.reset();
 	}
 	list.clear();
-	ResetEventCalling();
 }
 
 // Is interpreter running.
@@ -3081,8 +3082,7 @@ void Game_Interpreter::ResetEventCalling() {
 	Game_Temp::battle_calling = false;
 }
 
-
-bool Game_Interpreter::IsImmediateCall() const {
+bool Game_Interpreter::IsImmediateCall() {
 	return event_calling.load
 		|| event_calling.save
 		|| event_calling.name

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -70,37 +70,37 @@ public:
 	/**
 	 * @return true if an immediate call is requested
 	 */
-	bool IsImmediateCall() const;
+	static bool IsImmediateCall();
 
 	/**
 	 * Reset the event calling flags
 	 */
-	void ResetEventCalling();
+	static void ResetEventCalling();
 
 	/**
 	 * @return true if interpreter wants to immediately call the main menu
 	 */
-	bool IsMenuCalling() const;
+	static bool IsMenuCalling();
 
 	/**
 	 * @return true if interpreter wants to immediately call the save menu
 	 */
-	bool IsSaveCalling() const;
+	static bool IsSaveCalling();
 
 	/**
 	 * @return true if interpreter wants to immediately call the load menu
 	 */
-	bool IsLoadCalling() const;
+	static bool IsLoadCalling();
 
 	/**
 	 * @return true if interpreter wants to immediately call the name actor menu
 	 */
-	bool IsNameCalling() const;
+	static bool IsNameCalling();
 
 	/**
 	 * @return true if interpreter wants to immediately call the shop menu
 	 */
-	bool IsShopCalling() const;
+	static bool IsShopCalling();
 
 protected:
 	friend class Game_Interpreter_Map;
@@ -278,27 +278,27 @@ protected:
 		bool save = false;
 		bool load = false;
 	};
-	EventCalling event_calling = {};
+	static EventCalling event_calling;
 };
 
 
-inline bool Game_Interpreter::IsMenuCalling() const {
+inline bool Game_Interpreter::IsMenuCalling() {
 	return event_calling.menu;
 }
 
-inline bool Game_Interpreter::IsSaveCalling() const {
+inline bool Game_Interpreter::IsSaveCalling() {
 	return event_calling.save;
 }
 
-inline bool Game_Interpreter::IsLoadCalling() const {
+inline bool Game_Interpreter::IsLoadCalling() {
 	return event_calling.load;
 }
 
-inline bool Game_Interpreter::IsNameCalling() const {
+inline bool Game_Interpreter::IsNameCalling() {
 	return event_calling.name;
 }
 
-inline bool Game_Interpreter::IsShopCalling() const {
+inline bool Game_Interpreter::IsShopCalling() {
 	return event_calling.shop;
 }
 

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -393,6 +393,7 @@ void Game_Player::Refresh() {
 
 	if (Main_Data::game_party->GetActors().empty()) {
 		SetSpriteName("");
+		SetSpriteIndex(0);
 		return;
 	}
 

--- a/src/game_temp.cpp
+++ b/src/game_temp.cpp
@@ -46,7 +46,6 @@ int Game_Temp::battle_escape_mode;
 int Game_Temp::battle_defeat_mode;
 bool Game_Temp::battle_first_strike;
 int Game_Temp::battle_result;
-bool Game_Temp::restart_title_cache;
 
 void Game_Temp::Init() {
 	battle_calling = false;
@@ -76,5 +75,4 @@ void Game_Temp::Init() {
 	battle_defeat_mode = 0;
 	battle_first_strike = false;
 	battle_result = BattleAbort;
-	restart_title_cache = false;
 }

--- a/src/game_temp.h
+++ b/src/game_temp.h
@@ -58,7 +58,7 @@ public:
 	static std::string hero_name;
 	static int hero_name_id;
 	static int hero_name_charset;
-	
+
 	static bool battle_running;
 	static int battle_troop_id;
 	static std::string battle_background;
@@ -67,8 +67,6 @@ public:
 	static int battle_defeat_mode;
 	static bool battle_first_strike;
 	static int battle_result;
-
-	static bool restart_title_cache;
 
 	enum BattleResult {
 		BattleVictory,

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -286,7 +286,6 @@ void Player::Update(bool update_scene) {
 	} else if (reset_flag) {
 		reset_flag = false;
 		if (Scene::Find(Scene::Title) && Scene::instance->type != Scene::Title) {
-			Game_Temp::restart_title_cache = true;
 			Scene::PopUntil(Scene::Title);
 			// Fade out music and stop sound effects before returning
 			Game_System::BgmFade(800);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -634,7 +634,7 @@ void Player::CreateGameObjects() {
 		Output::Debug("Loading game %s", game_title.c_str());
 		title << game_title << " - ";
 	} else {
-		Output::Warning("Could not read game title.");
+		Output::Debug("Could not read game title.");
 	}
 	title << GAME_TITLE;
 	DisplayUi->SetTitle(title.str());

--- a/src/scene_load.cpp
+++ b/src/scene_load.cpp
@@ -24,6 +24,7 @@
 #include "scene_load.h"
 #include "scene_file.h"
 #include "scene_map.h"
+#include "scene_title.h"
 
 Scene_Load::Scene_Load() :
 	Scene_File(Data::terms.load_game_message) {
@@ -39,7 +40,11 @@ void Scene_Load::Action(int index) {
 	std::string save_name = FileFinder::FindDefault(*tree, ss.str());
 
 	Player::LoadSavegame(save_name);
-	Game_Temp::restart_title_cache = true;
+
+	auto title_scene = Scene::Find(Scene::Title);
+	if (title_scene) {
+		static_cast<Scene_Title*>(title_scene.get())->OnGameLoad();
+	}
 
 	Scene::Push(std::make_shared<Scene_Map>(true));
 }

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -190,41 +190,39 @@ void Scene_Map::Update() {
 		}
 	}
 
-	auto& interp = Game_Map::GetInterpreter();
-
-	if (!Main_Data::game_player->IsMoving() || interp.IsImmediateCall() || force_menu_calling) {
-		if (Main_Data::game_data.party_location.menu_calling || interp.IsMenuCalling() || force_menu_calling) {
-			interp.ResetEventCalling();
+	if (!Main_Data::game_player->IsMoving() || Game_Interpreter::IsImmediateCall() || force_menu_calling) {
+		if (Main_Data::game_data.party_location.menu_calling || Game_Interpreter::IsMenuCalling() || force_menu_calling) {
+			Game_Interpreter::ResetEventCalling();
 			CallMenu();
 			return;
 		}
 
-		if (interp.IsNameCalling()) {
-			interp.ResetEventCalling();
+		if (Game_Interpreter::IsNameCalling()) {
+			Game_Interpreter::ResetEventCalling();
 			CallName();
 			return;
 		}
 
-		if (interp.IsShopCalling()) {
-			interp.ResetEventCalling();
+		if (Game_Interpreter::IsShopCalling()) {
+			Game_Interpreter::ResetEventCalling();
 			CallShop();
 			return;
 		}
 
-		if (interp.IsSaveCalling()) {
-			interp.ResetEventCalling();
+		if (Game_Interpreter::IsSaveCalling()) {
+			Game_Interpreter::ResetEventCalling();
 			CallSave();
 			return;
 		}
 
-		if (interp.IsLoadCalling()) {
-			interp.ResetEventCalling();
+		if (Game_Interpreter::IsLoadCalling()) {
+			Game_Interpreter::ResetEventCalling();
 			CallLoad();
 			return;
 		}
 
 		if (Game_Temp::battle_calling) {
-			interp.ResetEventCalling();
+			Game_Interpreter::ResetEventCalling();
 			CallBattle();
 			return;
 		}

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -51,9 +51,9 @@ void Scene_Title::Start() {
 }
 
 void Scene_Title::Continue() {
-	if (Game_Temp::restart_title_cache) {
-		// Clear the cache when the game returns to the
-		// title screen e.g. by pressing F12, except the Title Load menu
+	if (restart_title_cache) {
+		// Clear the cache when the game returns to the title screen
+		// e.g. by pressing F12, except the Title Load menu
 		Cache::Clear();
 		AudioSeCache::Clear();
 
@@ -181,7 +181,6 @@ void Scene_Title::CommandNewGame() {
 	if (!CheckValidPlayerLocation()) {
 		Output::Warning("The game has no start location set.");
 	} else {
-		Game_Temp::restart_title_cache = true;
 		Output::Debug("Starting new game");
 		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 		Game_System::BgmStop();
@@ -200,6 +199,7 @@ void Scene_Title::CommandContinue() {
 		return;
 	}
 
+	restart_title_cache = false;
 	Scene::Push(std::make_shared<Scene_Load>());
 }
 
@@ -211,4 +211,8 @@ void Scene_Title::CommandShutdown() {
 
 void Scene_Title::OnTitleSpriteReady(FileRequestResult* result) {
 	title->SetBitmap(Cache::Title(result->file));
+}
+
+void Scene_Title::OnGameLoad() {
+	restart_title_cache = true;
 }

--- a/src/scene_title.h
+++ b/src/scene_title.h
@@ -90,6 +90,11 @@ public:
 	 */
 	void CommandShutdown();
 
+	/**
+	 * Invoked by the load scene to notify that a game was loaded.
+	 */
+	void OnGameLoad();
+
 private:
 	void OnTitleSpriteReady(FileRequestResult* result);
 
@@ -101,6 +106,8 @@ private:
 
 	/** Contains the state of continue button. */
 	bool continue_enabled;
+
+	bool restart_title_cache = true;
 
 	FileRequestBinding request_id;
 };


### PR DESCRIPTION
The title cache change removes one Game_Temp variable and should unbreak "Return To Title" event command.