### PR TITLE
Regression Fix: RTP table mapping japanese <-> other

### DIFF
--- a/src/rtp_table.h
+++ b/src/rtp_table.h
@@ -20,9 +20,16 @@
 
 #include <map>
 #include <string>
+#include <cstring>
 
 namespace RTP {
-	using rtp_table_type = std::map<const char*, std::map<const char*, const char*>>;
+	struct rtp_table_cmp {
+		bool operator()(char const* a, char const* b) const {
+			return std::strcmp(a, b) < 0;
+		}
+	};
+
+	using rtp_table_type = std::map<const char*, std::map<const char*, const char*, rtp_table_cmp>, rtp_table_cmp>;
 
 	void Init();
 


### PR DESCRIPTION
Maybe you remember how I fixed the 3DS crash by replacing std::string with const char* in the std::map of the rtp-table. The result of this change was that the function size was significantly reduced (which was probably the crash reason, function section too large???).

Turns out std::map doesn't implement a proper operator < for char* which means our table didn't work anymore :-1: .
