### PR TITLE
Fix uninitialized Transition::screen_erase

### DIFF
--- a/src/transition.h
+++ b/src/transition.h
@@ -114,7 +114,7 @@ private:
 	Scene *scene;
 	int current_frame;
 	int total_frames;
-	bool screen_erased;
+	bool screen_erased = false;
 
 	Color flash_color;
 	int flash_duration;


### PR DESCRIPTION
This is used uininitialized on transition.cpp:74 the first
time it is called.