### PR TITLE
Move Route refactors

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -86,6 +86,8 @@ bool Game_Character::IsLandable(int x, int y) const
 
 	if (GetThrough()) return true;
 
+	if (IsFlying()) return true;
+
 	if (!Game_Map::IsLandable(x, y, this))
 		return false;
 

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -707,27 +707,33 @@ void Game_Character::BeginJump(int32_t& current_index, const RPG::MoveRoute& cur
 		}
 	}
 
-	if (jump_plus_x != 0 || jump_plus_y != 0) {
-		if (std::abs(jump_plus_y) >= std::abs(jump_plus_x)) {
-			SetDirection(jump_plus_y > 0 ? Down : Up);
-			if (!IsDirectionFixed() && !IsFacingLocked()) {
-				SetSpriteDirection(GetDirection());
-			}
-		} else {
-			SetDirection(jump_plus_x > 0 ? Right : Left);
-			if (!IsDirectionFixed() && !IsFacingLocked()) {
-				SetSpriteDirection(GetDirection());
-			}
-		}
-	}
-
 	if (
 		// A character can always land on a tile they were already standing on
 		!(jump_plus_x == 0 && jump_plus_y == 0) &&
 		!IsLandable(new_x, new_y)
 	) {
-		// Reset to begin jump command and try again...
 		move_failed = true;
+	}
+
+
+	if (!move_failed || !current_route.skippable) {
+		if (jump_plus_x != 0 || jump_plus_y != 0) {
+			if (std::abs(jump_plus_y) >= std::abs(jump_plus_x)) {
+				SetDirection(jump_plus_y > 0 ? Down : Up);
+				if (!IsDirectionFixed() && !IsFacingLocked()) {
+					SetSpriteDirection(GetDirection());
+				}
+			} else {
+				SetDirection(jump_plus_x > 0 ? Right : Left);
+				if (!IsDirectionFixed() && !IsFacingLocked()) {
+					SetSpriteDirection(GetDirection());
+				}
+			}
+		}
+	}
+
+	if (move_failed) {
+		// Reset to begin jump command and try again...
 		SetJumping(false);
 
 		if (current_route.skippable) {

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -32,9 +32,7 @@
 #include <cassert>
 
 Game_Character::Game_Character(RPG::SaveMapEventBase* d) :
-	move_type(RPG::EventPage::MoveType_stationary),
 	move_failed(false),
-	move_count(0),
 	jump_plus_x(0),
 	jump_plus_y(0),
 	visible(true),

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -140,8 +140,6 @@ int Game_Character::GetScreenZ(bool apply_shift) const {
 }
 
 void Game_Character::UpdateMovement() {
-	bool was_move_route_overriden = IsMoveRouteOverwritten();
-
 	if (IsMoveRouteOverwritten()) {
 		UpdateMoveRoute(data()->move_route_index, data()->move_route);
 	}

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -963,3 +963,7 @@ bool Game_Character::IsMoveRouteActive() const {
 	return IsMoveRouteOverwritten();
 }
 
+
+int Game_Character::GetVehicleType() const {
+	return 0;
+}

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -32,7 +32,6 @@
 #include <cassert>
 
 Game_Character::Game_Character(RPG::SaveMapEventBase* d) :
-	original_move_frequency(-1),
 	move_type(RPG::EventPage::MoveType_stationary),
 	move_failed(false),
 	move_count(0),

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -191,8 +191,12 @@ void Game_Character::UpdateMovement() {
 
 void Game_Character::UpdateAnimation(bool was_moving) {
 	const auto anim_type = GetAnimationType();
-	if (!IsAnimated()) {
+	if (IsAnimPaused()) {
 		ResetAnimation();
+		return;
+	}
+
+	if (!IsAnimated()) {
 		return;
 	}
 

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -562,26 +562,34 @@ void Game_Character::BeginMove() {
 	// no-op
 }
 
-void Game_Character::TurnTowardHero() {
+int Game_Character::GetDirectionToHero() {
 	int sx = DistanceXfromPlayer();
 	int sy = DistanceYfromPlayer();
 
 	if ( std::abs(sx) > std::abs(sy) ) {
-		Turn((sx > 0) ? Left : Right);
+		return (sx > 0) ? Left : Right;
 	} else {
-		Turn((sy > 0) ? Up : Down);
+		return (sy > 0) ? Up : Down;
 	}
 }
 
-void Game_Character::TurnAwayFromHero() {
+int Game_Character::GetDirectionAwayHero() {
 	int sx = DistanceXfromPlayer();
 	int sy = DistanceYfromPlayer();
 
 	if ( std::abs(sx) > std::abs(sy) ) {
-		Turn((sx > 0) ? Right : Left);
+		return (sx > 0) ? Right : Left;
 	} else {
-		Turn((sy > 0) ? Down : Up);
+		return (sy > 0) ? Down : Up;
 	}
+}
+
+void Game_Character::TurnTowardHero() {
+	Turn(GetDirectionToHero());
+}
+
+void Game_Character::TurnAwayFromHero() {
+	Turn(GetDirectionAwayHero());
 }
 
 void Game_Character::FaceRandomDirection() {

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -308,10 +308,10 @@ void Game_Character::UpdateMoveRoute(int32_t& current_index, const RPG::MoveRout
 				MoveRandom(option);
 				break;
 			case RPG::MoveCommand::Code::move_towards_hero:
-				MoveTowardsPlayer();
+				Move(GetDirectionToHero());
 				break;
 			case RPG::MoveCommand::Code::move_away_from_hero:
-				MoveAwayFromPlayer();
+				Move(GetDirectionAwayHero());
 				break;
 			case RPG::MoveCommand::Code::move_forward:
 				MoveForward(option);
@@ -621,10 +621,10 @@ void Game_Character::BeginJump(int32_t& current_index, const RPG::MoveRoute& cur
 				MoveRandom();
 				break;
 			case RPG::MoveCommand::Code::move_towards_hero:
-				MoveTowardsPlayer();
+				Move(GetDirectionToHero());
 				break;
 			case RPG::MoveCommand::Code::move_away_from_hero:
-				MoveAwayFromPlayer();
+				Move(GetDirectionAwayHero());
 				break;
 			case RPG::MoveCommand::Code::move_forward:
 				MoveForward();

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -227,7 +227,7 @@ void Game_Character::UpdateAnimation(bool was_moving) {
 
 	if (IsContinuous()
 			|| was_moving
-			|| data()->anim_frame == 0 || data()->anim_frame == 2
+			|| data()->anim_frame == RPG::EventPage::Frame_left || data()->anim_frame == RPG::EventPage::Frame_right
 			|| GetAnimCount() < stationary_limit) {
 		IncAnimCount();
 	}

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -88,6 +88,9 @@ void Game_Character::MoveTo(int x, int y) {
 	SetX(Game_Map::RoundX(x));
 	SetY(Game_Map::RoundY(y));
 	SetRemainingStep(0);
+	// This Fixes an RPG_RT bug where the jumping flag doesn't get reset
+	// if you change maps during a jump
+	SetJumping(false);
 }
 
 int Game_Character::GetJumpHeight() const {

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -205,11 +205,11 @@ void Game_Character::UpdateAnimation(bool was_moving) {
 	if (IsSpinning()) {
 		const auto limit = spin_limits[step_idx];
 
-		if (GetAnimCount() >= limit) {
+		IncAnimCount();
+
+		if (GetAnimCount() > limit) {
 			SetSpriteDirection((GetSpriteDirection() + 1) % 4);
 			SetAnimCount(0);
-		} else {
-			IncAnimCount();
 		}
 		return;
 	}
@@ -224,21 +224,18 @@ void Game_Character::UpdateAnimation(bool was_moving) {
 	const auto stationary_limit = stationary_limits[step_idx];
 	const auto continuous_limit = continuous_limits[step_idx];
 
-	if (GetAnimCount() >= continuous_limit) {
+	if (IsContinuous()
+			|| was_moving
+			|| data()->anim_frame == 0 || data()->anim_frame == 2
+			|| GetAnimCount() < stationary_limit) {
+		IncAnimCount();
+	}
+
+	if (GetAnimCount() > continuous_limit
+			|| (was_moving && GetAnimCount() > stationary_limit)) {
 		IncAnimFrame();
 		return;
 	}
-
-	if (GetAnimCount() >= stationary_limit) {
-		if (was_moving) {
-			IncAnimFrame();
-			return;
-		} else if (!IsContinuous() && (data()->anim_frame == 1 || data()->anim_frame == 3)) {
-			return;
-		}
-	}
-
-	IncAnimCount();
 }
 
 void Game_Character::UpdateJump() {

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -192,6 +192,7 @@ void Game_Character::UpdateMovement() {
 void Game_Character::UpdateAnimation(bool was_moving) {
 	const auto anim_type = GetAnimationType();
 	if (!IsAnimated()) {
+		ResetAnimation();
 		return;
 	}
 

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -106,6 +106,14 @@ void Game_Character::MoveTo(int x, int y) {
 	SetRemainingStep(0);
 }
 
+int Game_Character::GetJumpHeight() const {
+	if (IsJumping()) {
+		int jump_height = (GetRemainingStep() > SCREEN_TILE_SIZE / 2 ? SCREEN_TILE_SIZE - GetRemainingStep() : GetRemainingStep()) / 8;
+		return (jump_height < 5 ? jump_height * 2 : jump_height < 13 ? jump_height + 4 : 16);
+	}
+	return 0;
+}
+
 int Game_Character::GetScreenX(bool apply_shift) const {
 	int x = GetSpriteX() / TILE_SIZE - Game_Map::GetDisplayX() / TILE_SIZE + (TILE_SIZE / 2);
 
@@ -119,10 +127,7 @@ int Game_Character::GetScreenX(bool apply_shift) const {
 int Game_Character::GetScreenY(bool apply_shift) const {
 	int y = GetSpriteY() / TILE_SIZE - Game_Map::GetDisplayY() / TILE_SIZE + TILE_SIZE;
 
-	if (IsJumping()) {
-		int jump_height = (GetRemainingStep() > SCREEN_TILE_SIZE / 2 ? SCREEN_TILE_SIZE - GetRemainingStep() : GetRemainingStep()) / 8;
-		y -= (jump_height < 5 ? jump_height * 2 : jump_height < 13 ? jump_height + 4 : 16);
-	}
+	y -= GetJumpHeight();
 
 	if (apply_shift) {
 		y += Game_Map::GetHeight() * TILE_SIZE;

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -419,7 +419,7 @@ void Game_Character::MoveTypeCustom() {
 				CancelMoveRoute();
 				Game_Map::RemovePendingMove(this);
 				SetStopCount(0);
-				SetMaxStopCount((GetMoveFrequency() > 7) ? 0 : (int) pow(2.0, 8 - GetMoveFrequency()));
+				SetMaxStopCountForStep();
 			}
 		}
 	}
@@ -477,7 +477,7 @@ void Game_Character::Move(int dir, MoveOption option) {
 	}
 
 	SetStopCount(0);
-	SetMaxStopCount((GetMoveFrequency() > 7) ? 0 : pow(2.0, 9 - GetMoveFrequency()));
+	SetMaxStopCountForStep();
 }
 
 void Game_Character::MoveForward(MoveOption option) {
@@ -535,7 +535,7 @@ void Game_Character::Turn(int dir) {
 	SetSpriteDirection(dir);
 	move_failed = false;
 	SetStopCount(0);
-	SetMaxStopCount((GetMoveFrequency() > 7) ? 0 : pow(2.0, 8 - GetMoveFrequency()));
+	SetMaxStopCountForTurn();
 }
 
 void Game_Character::Turn90DegreeLeft() {
@@ -735,7 +735,7 @@ void Game_Character::BeginJump(const RPG::MoveRoute* current_route, int* current
 
 	SetRemainingStep(SCREEN_TILE_SIZE);
 	SetStopCount(0);
-	SetMaxStopCount((GetMoveFrequency() > 7) ? 0 : pow(2.0, 9 - GetMoveFrequency()));
+	SetMaxStopCountForStep();
 	move_failed = false;
 
 	if (IsContinuous()) {
@@ -940,3 +940,19 @@ bool Game_Character::MakeWayDiagonal(int x, int y, int d) const {
 	return ((MakeWay(x, y, dy + 1) && MakeWay(x, y + dy, -dx + 2)) ||
 			(MakeWay(x, y, -dx + 2) && MakeWay(x + dx, y, dy + 1)));
 }
+
+void Game_Character::SetMaxStopCountForStep() {
+	const auto freq = GetMoveFrequency();
+	SetMaxStopCount(freq >= 8 ? 0 : 1 << (9 - freq));
+}
+
+void Game_Character::SetMaxStopCountForTurn() {
+	const auto freq = GetMoveFrequency();
+	SetMaxStopCount(freq >= 8 ? 0 : 1 << (8 - freq));
+}
+
+void Game_Character::SetMaxStopCountForWait() {
+	const auto freq = GetMoveFrequency();
+	SetMaxStopCount(20 + (freq >= 8 ? 0 : 1 << (8 - freq)));
+}
+

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -842,11 +842,9 @@ protected:
 	const RPG::SaveMapEventBase* data() const;
 
 	int original_move_frequency = 2;
-	int move_type;
 	bool move_failed;
 	// contains if any movement (<= step_forward) of a forced move route was successful
 	bool any_move_successful;
-	int move_count;
 
 	int jump_plus_x;
 	int jump_plus_y;

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -166,14 +166,14 @@ public:
 	 *
 	 * @return character movement speed
 	 */
-	virtual int GetMoveSpeed() const;
+	int GetMoveSpeed() const;
 
 	/**
 	 * Sets character movement speed.
 	 *
 	 * @param speed new movement speed
 	 */
-	virtual void SetMoveSpeed(int speed);
+	void SetMoveSpeed(int speed);
 
 	/**
 	 * Gets character movement frequency.

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -577,6 +577,13 @@ public:
 	 */
 	virtual void BeginMove();
 
+	/** @return the direction we would need to face the hero. */
+	int GetDirectionToHero();
+
+	/** @return the direction we would need to face away from hero. */
+	int GetDirectionAwayHero();
+
+
 	/**
 	 * Character looks in a random direction
 	 */
@@ -588,7 +595,7 @@ public:
 	void TurnTowardHero();
 
 	/**
-	 * Character looks away from the the hero.
+	 * Character looks away from the hero.
 	 */
 	void TurnAwayFromHero();
 

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -831,6 +831,9 @@ protected:
 	bool MakeWayDiagonal(int x, int y, int d) const;
 	virtual void UpdateSelfMovement();
 	void UpdateJump();
+	void SetMaxStopCountForStep();
+	void SetMaxStopCountForTurn();
+	void SetMaxStopCountForWait();
 
 	RPG::SaveMapEventBase* data();
 	const RPG::SaveMapEventBase* data() const;

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -1090,7 +1090,7 @@ inline void Game_Character::IncAnimFrame() {
 inline void Game_Character::ResetAnimation() {
 	SetAnimCount(0);
 	if (GetAnimationType() != RPG::EventPage::AnimType_fixed_graphic) {
-		SetAnimFrame(1);
+		SetAnimFrame(RPG::EventPage::Frame_middle);
 	}
 }
 

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -401,6 +401,9 @@ public:
 	 */
 	void SetAnimCount(int ac);
 
+	/** Resets the stepping animation */
+	void ResetAnimation();
+
 	/**
 	 * Gets if character is moving.
 	 *
@@ -774,14 +777,14 @@ public:
 	 *
 	 * @return Wheter animations are enabled.
 	 */
-	virtual bool IsAnimated() const;
+	bool IsAnimated() const;
 
 	/**
 	 * Tests if animation type is any continuous state.
 	 *
 	 * @return Whether animation is continuous
 	 */
-	virtual bool IsContinuous() const;
+	bool IsContinuous() const;
 
 	/**
 	 * Tests if animation is of the type spin.
@@ -1083,6 +1086,14 @@ inline void Game_Character::IncAnimCount() {
 
 inline void Game_Character::IncAnimFrame() {
 	data()->anim_frame = (data()->anim_frame + 1) % 4;
+	SetAnimCount(0);
+}
+
+inline void Game_Character::ResetAnimation() {
+	SetAnimCount(0);
+	if (GetAnimationType() != RPG::EventPage::AnimType_fixed_graphic) {
+		SetAnimFrame(1);
+	}
 }
 
 inline int Game_Character::GetRemainingStep() const {

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -622,6 +622,9 @@ public:
 	 */
 	virtual void CancelMoveRoute();
 
+	/** @return height of active jump in pixels */
+	int GetJumpHeight() const;
+
 	/**
 	 * Gets sprite x coordinate transformed to screen coordinate in pixels.
 	 *

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -36,7 +36,6 @@
 class Game_Character {
 public:
 	using AnimType = RPG::EventPage::AnimType;
-	using AnimFrame = RPG::EventPage::Frame;
 
 	/**
 	 * Destructor.
@@ -152,14 +151,6 @@ public:
 	 * @return whether event overlap is forbidden.
 	 */
 	virtual bool IsOverlapForbidden() const;
-
-	/**
-	 * Gets character stepping speed: the number of frames between each change
-	 * of the left-middle-right-middle walking animation or the spinning animation
-	 *
-	 * @return stepping speed (the same units as movement speed)
-	 */
-	virtual int GetSteppingSpeed() const;
 
 	/**
 	 * Gets character movement speed.
@@ -283,14 +274,14 @@ public:
 	 *
 	 * @return anim_frame
 	 */
-	AnimFrame GetAnimFrame() const;
+	int GetAnimFrame() const;
 
 	/**
 	 * Sets animation frame of character.
 	 *
 	 * @param frame new anim_frame
 	 */
-	void SetAnimFrame(AnimFrame frame);
+	void SetAnimFrame(int frame);
 
 	/**
 	 * @return true if animation is paused.
@@ -516,9 +507,16 @@ public:
 	virtual void Update() = 0;
 
 	/**
-	 * Updates character animation and movement.
+	 * Updates character and movement.
 	 */
 	void UpdateMovement();
+
+	/**
+	 * Updates character animation
+	 *
+	 * @param was_moving if the event moved or jumped this frame
+	 */
+	void UpdateAnimation(bool was_moving);
 
 	/**
 	 * Walks around on a custom move route.
@@ -832,11 +830,11 @@ protected:
 	void SetMaxStopCountForTurn();
 	void SetMaxStopCountForWait();
 	void UpdateMoveRoute(int32_t& current_index, const RPG::MoveRoute& current_route);
+	void IncAnimCount();
+	void IncAnimFrame();
 
 	RPG::SaveMapEventBase* data();
 	const RPG::SaveMapEventBase* data() const;
-
-	int last_pattern;
 
 	int original_move_frequency;
 	int move_type;
@@ -989,12 +987,12 @@ inline void Game_Character::SetSpriteIndex(int index) {
 	data()->sprite_id = index;
 }
 
-inline Game_Character::AnimFrame Game_Character::GetAnimFrame() const {
-	return AnimFrame(data()->anim_frame);
+inline int Game_Character::GetAnimFrame() const {
+	return data()->anim_frame;
 }
 
-inline void Game_Character::SetAnimFrame(AnimFrame frame) {
-	data()->anim_frame = AnimFrame(frame);
+inline void Game_Character::SetAnimFrame(int frame) {
+	data()->anim_frame = frame;
 }
 
 inline bool Game_Character::IsAnimPaused() const {
@@ -1075,6 +1073,14 @@ inline int Game_Character::GetAnimCount() const {
 
 inline void Game_Character::SetAnimCount(int ac) {
 	data()->anim_count = ac;
+}
+
+inline void Game_Character::IncAnimCount() {
+	++data()->anim_count;
+}
+
+inline void Game_Character::IncAnimFrame() {
+	data()->anim_frame = (data()->anim_frame + 1) % 4;
 }
 
 inline int Game_Character::GetRemainingStep() const {

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -171,14 +171,14 @@ public:
 	 *
 	 * @return character movement frequency
 	 */
-	virtual int GetMoveFrequency() const;
+	int GetMoveFrequency() const;
 
 	/**
 	 * Sets character movement frequency.
 	 *
 	 * @param frequency new character movement frequency
 	 */
-	virtual void SetMoveFrequency(int frequency);
+	void SetMoveFrequency(int frequency);
 
 	/**
 	 * Returns the custom move route assigned via a MoveEvent.
@@ -841,7 +841,7 @@ protected:
 	RPG::SaveMapEventBase* data();
 	const RPG::SaveMapEventBase* data() const;
 
-	int original_move_frequency;
+	int original_move_frequency = 2;
 	int move_type;
 	bool move_failed;
 	// contains if any movement (<= step_forward) of a forced move route was successful

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -204,18 +204,9 @@ public:
 	void SetMoveRoute(const RPG::MoveRoute& move_route);
 
 	/**
-	 * Returns current index of a "Movement Type Custom" move route.
-	 *
-	 * @return current original move route index
+	 * @return true if this character is currently following a move route.
 	 */
-	virtual int GetOriginalMoveRouteIndex() const = 0;
-
-	/**
-	 * Sets current index of a "Movement Type Custom" move route.
-	 *
-	 * @param new_index New move route index
-	 */
-	virtual void SetOriginalMoveRouteIndex(int new_index) = 0;
+	virtual bool IsMoveRouteActive() const;
 
 	/**
 	 * Returns current index of the route assigned via a MoveEvent.
@@ -401,6 +392,9 @@ public:
 	 */
 	void SetMaxStopCount(int sc);
 
+	/** @return true if waiting for stop count in movement to complete */
+	bool IsStopCountActive() const;
+
 	/**
 	 * @return anim_count
 	 */
@@ -516,17 +510,16 @@ public:
 	/**
 	 * Updates character state and actions.
 	 */
-	virtual void Update();
+	virtual void Update() = 0;
 
 	/**
 	 * Updates character animation and movement.
 	 */
-	void UpdateSprite();
+	void UpdateMovement();
 
 	/**
 	 * Walks around on a custom move route.
 	 */
-	void MoveTypeCustom();
 
 	void Turn(int dir);
 
@@ -606,10 +599,10 @@ public:
 	/**
 	 * Jump action begins. Ends the movement when EndJump is missing.
 	 *
-	 * @param current_route Current move route
 	 * @param current_index Index in the current route
+	 * @param current_route Current move route
 	 */
-	void BeginJump(const RPG::MoveRoute* current_route, int* current_index);
+	void BeginJump(int32_t& current_index, const RPG::MoveRoute& current_route);
 
 	/**
 	 * Jump action ends.
@@ -826,25 +819,22 @@ public:
 
 protected:
 	explicit Game_Character(RPG::SaveMapEventBase* d);
-
-protected:
 	bool MakeWayDiagonal(int x, int y, int d) const;
-	virtual void UpdateSelfMovement();
+	virtual void UpdateSelfMovement() {}
 	void UpdateJump();
 	void SetMaxStopCountForStep();
 	void SetMaxStopCountForTurn();
 	void SetMaxStopCountForWait();
+	void UpdateMoveRoute(int32_t& current_index, const RPG::MoveRoute& current_route);
 
 	RPG::SaveMapEventBase* data();
 	const RPG::SaveMapEventBase* data() const;
 
 	int last_pattern;
 
-	RPG::MoveRoute original_move_route;
 	int original_move_frequency;
 	int move_type;
 	bool move_failed;
-	bool last_move_failed;
 	// contains if any movement (<= step_forward) of a forced move route was successful
 	bool any_move_successful;
 	int move_count;
@@ -1067,6 +1057,10 @@ inline int Game_Character::GetMaxStopCount() const {
 
 inline void Game_Character::SetMaxStopCount(int sc) {
 	data()->max_stop_count = sc;
+}
+
+inline bool Game_Character::IsStopCountActive() const {
+	return GetStopCount() < GetMaxStopCount();
 }
 
 inline int Game_Character::GetAnimCount() const {

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -297,6 +297,9 @@ public:
 	 */
 	bool IsAnimPaused() const;
 
+	/** @return the type of vehicle this event itself is, or is boarded */
+	virtual int GetVehicleType() const;
+
 	/**
 	 * Sets whether animation is paused.
 	 *

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -848,7 +848,6 @@ protected:
 	// contains if any movement (<= step_forward) of a forced move route was successful
 	bool any_move_successful;
 	int move_count;
-	int wait_count;
 
 	int jump_plus_x;
 	int jump_plus_y;

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -502,11 +502,6 @@ public:
 	virtual void MoveTo(int x, int y);
 
 	/**
-	 * Updates character state and actions.
-	 */
-	virtual void Update() = 0;
-
-	/**
 	 * Updates character and movement.
 	 */
 	void UpdateMovement();

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -126,7 +126,7 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 	SetSpriteName(page->character_name);
 	SetSpriteIndex(page->character_index);
 
-	SetAnimFrame(AnimFrame(page->character_pattern));
+	SetAnimFrame(page->character_pattern);
 
 	move_type = page->move_type;
 	SetMoveSpeed(page->move_speed);
@@ -556,7 +556,10 @@ void Game_Event::Update() {
 		return;
 	}
 
+	auto was_moving = !IsStopping();
 	Game_Character::UpdateMovement();
+	Game_Character::UpdateAnimation(was_moving);
+
 
 	if (starting && !Game_Map::GetInterpreter().IsRunning()) {
 		Game_Map::GetInterpreter().Setup(this);

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -65,17 +65,6 @@ Game_Event::Game_Event(int map_id, const RPG::Event& event, const RPG::SaveMapEv
 	Refresh();
 }
 
-int Game_Event::GetMoveFrequency() const {
-	return data()->move_frequency;
-}
-
-void Game_Event::SetMoveFrequency(int frequency) {
-	data()->move_frequency = frequency;
-	if (original_move_frequency == -1) {
-		original_move_frequency = frequency;
-	}
-}
-
 int Game_Event::GetOriginalMoveRouteIndex() const {
 	return data()->original_move_route_index;
 }
@@ -177,6 +166,7 @@ void Game_Event::SetupFromSave(const RPG::EventPage* new_page) {
 	}
 
 	move_type = page->move_type;
+	original_move_frequency = page->move_frequency;
 	trigger = page->trigger;
 	list = page->event_commands;
 

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -343,15 +343,13 @@ const std::vector<RPG::EventCommand>& Game_Event::GetList() const {
 }
 
 void Game_Event::StartTalkToHero() {
-	if (!(IsDirectionFixed() || IsFacingLocked())) {
-		int prelock_dir = GetDirection();
-		TurnTowardHero();
-		SetDirection(prelock_dir);
+	if (!(IsDirectionFixed() || IsFacingLocked() || IsSpinning())) {
+		SetSpriteDirection(GetDirectionToHero());
 	}
 }
 
 void Game_Event::StopTalkToHero() {
-	if (!(IsDirectionFixed() || IsFacingLocked())) {
+	if (!(IsDirectionFixed() || IsFacingLocked() || IsSpinning())) {
 		SetSpriteDirection(GetDirection());
 	}
 

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -132,10 +132,13 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 	SetMoveSpeed(page->move_speed);
 	SetMoveFrequency(page->move_frequency);
 	if (!IsMoveRouteOverwritten()) {
-		SetMaxStopCountForTurn();
+		if (move_type == RPG::EventPage::MoveType_custom) {
+			SetMaxStopCountForTurn();
+		} else {
+			SetMaxStopCountForStep();
+		}
 	}
 	original_move_frequency = page->move_frequency;
-	original_move_route = page->move_route;
 	SetOriginalMoveRouteIndex(0);
 
 	bool same_direction_as_on_old_page = old_page && old_page->character_direction == new_page->character_direction;
@@ -172,7 +175,6 @@ void Game_Event::SetupFromSave(const RPG::EventPage* new_page) {
 	}
 
 	move_type = page->move_type;
-	original_move_route = page->move_route;
 	trigger = page->trigger;
 	list = page->event_commands;
 
@@ -416,7 +418,7 @@ void Game_Event::UpdateSelfMovement() {
 		MoveTypeAwayFromPlayer();
 		break;
 	case RPG::EventPage::MoveType_custom:
-		MoveTypeCustom();
+		UpdateMoveRoute(data()->original_move_route_index, page->move_route);
 		break;
 	}
 }
@@ -554,7 +556,7 @@ void Game_Event::Update() {
 		return;
 	}
 
-	Game_Character::UpdateSprite();
+	Game_Character::UpdateMovement();
 
 	if (starting && !Game_Map::GetInterpreter().IsRunning()) {
 		Game_Map::GetInterpreter().Setup(this);
@@ -602,7 +604,6 @@ void Game_Event::UpdateParallel() {
 	}
 	frame_count_at_last_update_parallel = cur_frame_count;
 
-	Game_Character::Update();
 	updating = false;
 }
 
@@ -624,4 +625,8 @@ const RPG::SaveMapEvent& Game_Event::GetSaveData() {
 	data()->ID = event.ID;
 
 	return *data();
+}
+
+bool Game_Event::IsMoveRouteActive() const {
+	return true;
 }

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -126,8 +126,6 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 	SetSpriteName(page->character_name);
 	SetSpriteIndex(page->character_index);
 
-	SetAnimFrame(page->character_pattern);
-
 	move_type = page->move_type;
 	SetMoveSpeed(page->move_speed);
 	SetMoveFrequency(page->move_frequency);
@@ -143,6 +141,10 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 
 	bool same_direction_as_on_old_page = old_page && old_page->character_direction == new_page->character_direction;
 	SetAnimationType(RPG::EventPage::AnimType(page->animation_type));
+
+	if (GetAnimationType() == RPG::EventPage::AnimType_fixed_graphic) {
+		SetAnimFrame(page->character_pattern);
+	}
 
 	if (from_null || !(same_direction_as_on_old_page || IsMoving())) {
 		SetSpriteDirection(page->character_direction);

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -106,7 +106,6 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 		SetSpriteName("");
 		SetSpriteIndex(0);
 		SetDirection(RPG::EventPage::Direction_down);
-		//move_type = 0;
 		trigger = -1;
 		list.clear();
 		return;
@@ -115,11 +114,10 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 	SetSpriteName(page->character_name);
 	SetSpriteIndex(page->character_index);
 
-	move_type = page->move_type;
 	SetMoveSpeed(page->move_speed);
 	SetMoveFrequency(page->move_frequency);
 	if (!IsMoveRouteOverwritten()) {
-		if (move_type == RPG::EventPage::MoveType_custom) {
+		if (page->move_type == RPG::EventPage::MoveType_custom) {
 			SetMaxStopCountForTurn();
 		} else {
 			SetMaxStopCountForStep();
@@ -165,7 +163,6 @@ void Game_Event::SetupFromSave(const RPG::EventPage* new_page) {
 		return;
 	}
 
-	move_type = page->move_type;
 	original_move_frequency = page->move_frequency;
 	trigger = page->trigger;
 	list = page->event_commands;
@@ -390,8 +387,11 @@ void Game_Event::UpdateSelfMovement() {
 		return;
 	if (!IsStopping())
 		return;
+	if (page == nullptr) {
+		return;
+	}
 
-	switch (move_type) {
+	switch (page->move_type) {
 	case RPG::EventPage::MoveType_random:
 		MoveTypeRandom();
 		break;

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -116,12 +116,10 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 
 	SetMoveSpeed(page->move_speed);
 	SetMoveFrequency(page->move_frequency);
-	if (!IsMoveRouteOverwritten()) {
-		if (page->move_type == RPG::EventPage::MoveType_custom) {
-			SetMaxStopCountForTurn();
-		} else {
-			SetMaxStopCountForStep();
-		}
+	if (page->move_type == RPG::EventPage::MoveType_custom) {
+		SetMaxStopCountForTurn();
+	} else {
+		SetMaxStopCountForStep();
 	}
 	original_move_frequency = page->move_frequency;
 	SetOriginalMoveRouteIndex(0);

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -132,7 +132,7 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 	SetMoveSpeed(page->move_speed);
 	SetMoveFrequency(page->move_frequency);
 	if (!IsMoveRouteOverwritten()) {
-		SetMaxStopCount((GetMoveFrequency() > 7) ? 0 : (int) pow(2.0, 8 - GetMoveFrequency()));
+		SetMaxStopCountForTurn();
 	}
 	original_move_frequency = page->move_frequency;
 	original_move_route = page->move_route;
@@ -446,7 +446,7 @@ void Game_Event::MoveTypeRandom() {
 }
 
 void Game_Event::MoveTypeCycle(int default_dir) {
-	SetMaxStopCount((GetMoveFrequency() > 7) ? 0 : (1 << (9 - GetMoveFrequency())));
+	SetMaxStopCountForStep();
 	if (GetStopCount() < GetMaxStopCount()) return;
 
 	const int reverse_dir = ReverseDir(default_dir);

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -46,8 +46,6 @@ public:
 	 * Implementation of abstract methods
 	 */
 	/** @{ */
-	int GetMoveFrequency() const override;
-	void SetMoveFrequency(int frequency) override;
 	bool GetThrough() const override;
 	void SetThrough(bool through) override;
 	bool IsMoveRouteActive() const override;

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -48,10 +48,9 @@ public:
 	/** @{ */
 	int GetMoveFrequency() const override;
 	void SetMoveFrequency(int frequency) override;
-	int GetOriginalMoveRouteIndex() const override;
-	void SetOriginalMoveRouteIndex(int new_index) override;
 	bool GetThrough() const override;
 	void SetThrough(bool through) override;
+	bool IsMoveRouteActive() const override;
 	/** @} */
 
 	/**
@@ -140,6 +139,20 @@ public:
 	 * @return if the event is active (or inactive via EraseEvent-EventCommand).
 	 */
 	bool GetActive() const;
+
+	/**
+	 * Returns current index of a "Movement Type Custom" move route.
+	 *
+	 * @return current original move route index
+	 */
+	int GetOriginalMoveRouteIndex() const;
+
+	/**
+	 * Sets current index of a "Movement Type Custom" move route.
+	 *
+	 * @param new_index New move route index
+	 */
+	void SetOriginalMoveRouteIndex(int new_index);
 
 	/**
 	 * Returns the event page or nullptr is page does not exist.

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -119,10 +119,12 @@ public:
 	 */
 	void StopTalkToHero();
 
+	/** Update this for the current frame */
+	void Update();
+
 	void CheckEventTriggers();
 	bool CheckEventTriggerTouch(int x, int y) override;
 	void Start(bool triggered_by_decision_key = false);
-	void Update() override;
 	void UpdateParallel();
 	bool AreConditionsMet(const RPG::EventPage& page);
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -750,6 +750,9 @@ bool Game_Map::IsLandable(int x, int y, const Game_Character *self_event) {
 				}
 			}
 		}
+		if (self_event->GetVehicleType() > 0) {
+			return Game_Map::IsPassableVehicle(x, y, (Game_Vehicle::Type) self_event->GetVehicleType());
+		}
 	}
 
 	return IsPassableTile(bit, x + y * GetWidth());

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1395,11 +1395,9 @@ void Game_Map::RemovePendingMove(Game_Character* character) {
 }
 
 void Game_Map::RemoveAllPendingMoves() {
-	std::vector<Game_Character*>::iterator it;
-	for (it = pending.begin(); it != pending.end(); ++it)
-		(*it)->CancelMoveRoute();
-
-	pending.clear();
+	while (!pending.empty()) {
+		pending.back()->CancelMoveRoute();
+	}
 }
 
 static int DoSubstitute(std::vector<uint8_t>& tiles, int old_id, int new_id) {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -84,10 +84,13 @@ namespace {
 
 	int last_encounter_idx = 0;
 
+	// RPG_RT doesn't update player or vehicle movement or animation on the first frame
+	// of a new map. We use this flag to emulate that behavior.
+	bool first_frame = false;
+
 	//FIXME: Find a better way to do this.
 	bool reset_panorama_x_on_next_init = true;
 	bool reset_panorama_y_on_next_init = true;
-	bool first_frame = false;
 }
 
 static Game_Map::Parallax::Params GetParallaxParams();
@@ -614,7 +617,7 @@ bool Game_Map::MakeWay(int x, int y, int d, const Game_Character& self, bool for
 			&& !Main_Data::game_player->GetThrough()
 			&& self.GetLayer() == RPG::EventPage::Layers_same) {
 		// Update the Player to see if they'll move and recheck.
-		Main_Data::game_player->Update();
+		Main_Data::game_player->Update(!first_frame);
 		if (Main_Data::game_player->IsInPosition(new_x, new_y)) {
 			return false;
 		}
@@ -931,7 +934,7 @@ void Game_Map::Update(bool only_parallel) {
 		ev.CheckEventTriggers();
 	}
 
-	Main_Data::game_player->Update();
+	Main_Data::game_player->Update(!first_frame);
 	UpdatePan();
 	GetInterpreter().Update();
 
@@ -945,11 +948,13 @@ void Game_Map::Update(bool only_parallel) {
 
 	for (auto& vehicle: vehicles) {
 		if (vehicle->GetMapId() == location.map_id) {
-			vehicle->Update();
+			vehicle->Update(!first_frame);
 		}
 	}
 
 	free_interpreters.clear();
+
+	first_frame = false;
 }
 
 RPG::MapInfo const& Game_Map::GetMapInfo() {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -87,6 +87,7 @@ namespace {
 	//FIXME: Find a better way to do this.
 	bool reset_panorama_x_on_next_init = true;
 	bool reset_panorama_y_on_next_init = true;
+	bool first_frame = false;
 }
 
 static Game_Map::Parallax::Params GetParallaxParams();
@@ -145,6 +146,7 @@ void Game_Map::Quit() {
 
 void Game_Map::Setup(int _id) {
 	Dispose();
+	first_frame = true;
 	SetupCommon(_id, false);
 	map_info.encounter_rate = GetMapInfo().encounter_steps;
 	SetEncounterSteps(0);

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -640,6 +640,7 @@ void Game_Player::UnboardingFinished() {
 	Unboard();
 	if (InAirship()) {
 		SetDirection(RPG::EventPage::Direction_down);
+		SetSpriteDirection(RPG::EventPage::Direction_down);
 	} else {
 		data()->unboarding = true;
 		if (!GetThrough()) {

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -269,7 +269,9 @@ void Game_Player::Update(bool process_movement) {
 			}
 			SetMoveSpeed(vehicle->GetMoveSpeed());
 			vehicle->SetDirection(GetDirection());
-			vehicle->SetSpriteDirection(GetSpriteDirection());
+			vehicle->SetSpriteDirection(Left);
+			// Note: RPG_RT ignores the lock_facing flag here!
+			SetSpriteDirection(Left);
 			vehicle->SetX(GetX());
 			vehicle->SetY(GetY());
 			return;
@@ -478,6 +480,7 @@ bool Game_Player::GetOnVehicle() {
 		}
 		SetMoveSpeed(vehicle->GetMoveSpeed());
 		SetDirection(RPG::EventPage::Direction_left);
+		// Note: RPG_RT ignores the lock_facing flag here!
 		SetSpriteDirection(RPG::EventPage::Direction_left);
 		vehicle->SetX(GetX());
 		vehicle->SetY(GetY());
@@ -640,6 +643,7 @@ void Game_Player::UnboardingFinished() {
 	Unboard();
 	if (InAirship()) {
 		SetDirection(RPG::EventPage::Direction_down);
+		// Note: RPG_RT ignores the lock_facing flag here!
 		SetSpriteDirection(RPG::EventPage::Direction_down);
 	} else {
 		data()->unboarding = true;

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -431,9 +431,6 @@ void Game_Player::Refresh() {
 }
 
 bool Game_Player::GetOnOffVehicle() {
-	if (!IsMovable())
-		return false;
-
 	if (InVehicle())
 		return GetOffVehicle();
 	return GetOnVehicle();
@@ -453,6 +450,16 @@ bool Game_Player::GetOnVehicle() {
 	else
 		return false;
 
+	auto* vehicle = Game_Map::GetVehicle(type);
+
+	if (vehicle->IsAscendingOrDescending()) {
+		return false;
+	}
+
+	if (type == Game_Vehicle::Airship && (IsMoving() || IsJumping())) {
+		return false;
+	}
+
 	data()->vehicle = type;
 	data()->preboard_move_speed = GetMoveSpeed();
 	if (type != Game_Vehicle::Airship) {
@@ -466,7 +473,6 @@ bool Game_Player::GetOnVehicle() {
 		}
 	} else {
 		data()->aboard = true;
-		auto* vehicle = GetVehicle();
 		if (vehicle->IsMoveRouteOverwritten()) {
 			vehicle->CancelMoveRoute();
 		}
@@ -491,8 +497,13 @@ bool Game_Player::GetOffVehicle() {
 			&& !Game_Map::GetVehicle(Game_Vehicle::Ship)->IsInPosition(front_x, front_y))
 			return false;
 	}
+	auto* vehicle = GetVehicle();
 
-	GetVehicle()->GetOff();
+	if (vehicle->IsAscendingOrDescending()) {
+		return false;
+	}
+
+	vehicle->GetOff();
 	return true;
 }
 

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -653,3 +653,7 @@ void Game_Player::UnboardingFinished() {
 	}
 	data()->vehicle = Game_Vehicle::None;
 }
+
+int Game_Player::GetVehicleType() const {
+	return data()->vehicle;
+}

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -260,15 +260,21 @@ void Game_Player::Update() {
 
 	UpdateScroll(old_sprite_x, old_sprite_y);
 
-	if (IsMoving() || was_blocked) return;
+	if (IsMoving()) return;
 
 	if (last_moving && data()->boarding) {
 		// Boarding completed
 		data()->aboard = true;
 		data()->boarding = false;
-		SetMoveSpeed(GetVehicle()->GetMoveSpeed());
-		GetVehicle()->SetDirection(GetDirection());
-		GetVehicle()->SetSpriteDirection(GetSpriteDirection());
+		auto* vehicle = GetVehicle();
+		if (vehicle->IsMoveRouteOverwritten()) {
+			vehicle->CancelMoveRoute();
+		}
+		SetMoveSpeed(vehicle->GetMoveSpeed());
+		vehicle->SetDirection(GetDirection());
+		vehicle->SetSpriteDirection(GetSpriteDirection());
+		vehicle->SetX(GetX());
+		vehicle->SetY(GetY());
 		return;
 	}
 
@@ -278,6 +284,8 @@ void Game_Player::Update() {
 		CheckTouchEvent();
 		return;
 	}
+
+	if (was_blocked) return;
 
 	if (last_moving && CheckTouchEvent()) return;
 
@@ -458,8 +466,15 @@ bool Game_Player::GetOnVehicle() {
 		}
 	} else {
 		data()->aboard = true;
-		SetMoveSpeed(GetVehicle()->GetMoveSpeed());
+		auto* vehicle = GetVehicle();
+		if (vehicle->IsMoveRouteOverwritten()) {
+			vehicle->CancelMoveRoute();
+		}
+		SetMoveSpeed(vehicle->GetMoveSpeed());
 		SetDirection(RPG::EventPage::Direction_left);
+		SetSpriteDirection(RPG::EventPage::Direction_left);
+		vehicle->SetX(GetX());
+		vehicle->SetY(GetY());
 	}
 
 	Main_Data::game_data.system.before_vehicle_music = Game_System::GetCurrentBGM();

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -256,7 +256,9 @@ void Game_Player::Update() {
 	const auto old_sprite_y = GetSpriteY();
 
 	UpdatePlayerInput();
+	auto was_moving = !IsStopping();
 	Game_Character::UpdateMovement();
+	Game_Character::UpdateAnimation(was_moving);
 
 	UpdateScroll(old_sprite_x, old_sprite_y);
 
@@ -628,10 +630,6 @@ void Game_Player::Unboard() {
 	SetMoveSpeed(data()->preboard_move_speed);
 
 	Game_System::BgmPlay(Main_Data::game_data.system.before_vehicle_music);
-}
-
-bool Game_Player::IsAboard() const {
-	return data()->aboard;
 }
 
 bool Game_Player::IsAboard() const {

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -90,15 +90,6 @@ void Game_Player::PerformTeleport() {
 
 	teleporting = false;
 
-	// Finish (un)boarding process
-	if (data()->boarding) {
-		data()->boarding = false;
-		data()->aboard = true;
-	} else if (data()->unboarding) {
-		data()->unboarding = false;
-		data()->aboard = false;
-	}
-
 	// Reset sprite if it was changed by a move
 	// Even when target is the same map
 	Refresh();
@@ -267,27 +258,29 @@ void Game_Player::Update(bool process_movement) {
 
 	if (IsMoving()) return;
 
-	if (last_moving && data()->boarding) {
-		// Boarding completed
-		data()->aboard = true;
-		data()->boarding = false;
-		auto* vehicle = GetVehicle();
-		if (vehicle->IsMoveRouteOverwritten()) {
-			vehicle->CancelMoveRoute();
+	if (process_movement) {
+		if (data()->boarding) {
+			// Boarding completed
+			data()->aboard = true;
+			data()->boarding = false;
+			auto* vehicle = GetVehicle();
+			if (vehicle->IsMoveRouteOverwritten()) {
+				vehicle->CancelMoveRoute();
+			}
+			SetMoveSpeed(vehicle->GetMoveSpeed());
+			vehicle->SetDirection(GetDirection());
+			vehicle->SetSpriteDirection(GetSpriteDirection());
+			vehicle->SetX(GetX());
+			vehicle->SetY(GetY());
+			return;
 		}
-		SetMoveSpeed(vehicle->GetMoveSpeed());
-		vehicle->SetDirection(GetDirection());
-		vehicle->SetSpriteDirection(GetSpriteDirection());
-		vehicle->SetX(GetX());
-		vehicle->SetY(GetY());
-		return;
-	}
 
-	if (last_moving && data()->unboarding) {
-		// Unboarding completed
-		data()->unboarding = false;
-		CheckTouchEvent();
-		return;
+		if (data()->unboarding) {
+			// Unboarding completed
+			data()->unboarding = false;
+			CheckTouchEvent();
+			return;
+		}
 	}
 
 	if (was_blocked) return;

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -239,7 +239,7 @@ void Game_Player::UpdatePlayerInput() {
 
 }
 
-void Game_Player::Update() {
+void Game_Player::Update(bool process_movement) {
 	int cur_frame_count = Player::GetFrames();
 	// Only update the event once per frame
 	if (cur_frame_count == frame_count_at_last_update_parallel) {
@@ -257,8 +257,11 @@ void Game_Player::Update() {
 
 	UpdatePlayerInput();
 	auto was_moving = !IsStopping();
-	Game_Character::UpdateMovement();
-	Game_Character::UpdateAnimation(was_moving);
+
+	if (process_movement) {
+		Game_Character::UpdateMovement();
+		Game_Character::UpdateAnimation(was_moving);
+	}
 
 	UpdateScroll(old_sprite_x, old_sprite_y);
 

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -103,8 +103,8 @@ void Game_Player::PerformTeleport() {
 	// Even when target is the same map
 	Refresh();
 
+	ResetAnimation();
 	if (Game_Map::GetMapId() != new_map_id) {
-		SetAnimFrame(RPG::EventPage::Frame_middle);
 		Game_Map::Setup(new_map_id);
 	} else {
 		Game_Map::SetupFromTeleportSelf();

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -464,12 +464,14 @@ bool Game_Player::GetOnVehicle() {
 	data()->preboard_move_speed = GetMoveSpeed();
 	if (type != Game_Vehicle::Airship) {
 		data()->boarding = true;
-		if (!GetThrough()) {
-			SetThrough(true);
-			MoveForward();
-			SetThrough(false);
-		} else {
-			MoveForward();
+		if (!IsMoving() && !IsJumping()) {
+			if (!GetThrough()) {
+				SetThrough(true);
+				MoveForward();
+				SetThrough(false);
+			} else {
+				MoveForward();
+			}
 		}
 	} else {
 		data()->aboard = true;
@@ -632,6 +634,10 @@ bool Game_Player::IsAboard() const {
 	return data()->aboard;
 }
 
+bool Game_Player::IsAboard() const {
+	return data()->aboard;
+}
+
 bool Game_Player::IsBoardingOrUnboarding() const {
 	return data()->boarding || data()->unboarding;
 }
@@ -643,12 +649,14 @@ void Game_Player::UnboardingFinished() {
 		SetSpriteDirection(RPG::EventPage::Direction_down);
 	} else {
 		data()->unboarding = true;
-		if (!GetThrough()) {
-			SetThrough(true);
-			MoveForward();
-			SetThrough(false);
-		} else {
-			MoveForward();
+		if (!IsMoving() && !IsJumping()) {
+			if (!GetThrough()) {
+				SetThrough(true);
+				MoveForward();
+				SetThrough(false);
+			} else {
+				MoveForward();
+			}
 		}
 	}
 	data()->vehicle = Game_Vehicle::None;

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -45,6 +45,7 @@ public:
 	bool MakeWay(int x, int y, int d) const override;
 	void BeginMove() override;
 	void CancelMoveRoute() override;
+	int GetVehicleType() const override;
 	/** @} */
 
 	bool IsTeleporting() const;

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -41,8 +41,6 @@ public:
 	 */
 	/** @{ */
 	int GetScreenZ(bool apply_shift = false) const override;
-	int GetOriginalMoveRouteIndex() const override;
-	void SetOriginalMoveRouteIndex(int new_index) override;
 	bool GetVisible() const override;
 	bool MakeWay(int x, int y, int d) const override;
 	void BeginMove() override;
@@ -101,6 +99,7 @@ private:
 	bool teleporting = false;
 	int new_map_id = 0, new_x = 0, new_y = 0, new_direction = 0;
 
+	void UpdatePlayerInput();
 	void UpdateScroll(int prev_x, int prev_y);
 	void UpdatePan();
 	bool CheckTouchEvent();

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -63,7 +63,13 @@ public:
 	void StartTeleport();
 	void PerformTeleport();
 	void MoveTo(int x, int y) override;
-	void Update() override;
+
+	/** 
+	 * Update this for the current frame
+	 *
+	 * @param process_movement if false, we will not process movement or animations
+	 * */
+	void Update(bool process_movement);
 
 	void Refresh();
 

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -307,3 +307,7 @@ void Game_Vehicle::Update() {
 bool Game_Vehicle::CheckEventTriggerTouch(int /* x */, int /* y */) {
 	return false;
 }
+
+int Game_Vehicle::GetVehicleType() const {
+	return data()->vehicle;
+}

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -221,6 +221,9 @@ void Game_Vehicle::SyncWithPlayer() {
 	SetX(Main_Data::game_player->GetX());
 	SetY(Main_Data::game_player->GetY());
 	SetRemainingStep(Main_Data::game_player->GetRemainingStep());
+	SetJumping(Main_Data::game_player->IsJumping());
+	SetBeginJumpX(Main_Data::game_player->GetBeginJumpX());
+	SetBeginJumpY(Main_Data::game_player->GetBeginJumpY());
 	if (!IsAscendingOrDescending()) {
 		SetDirection(Main_Data::game_player->GetDirection());
 		SetSpriteDirection(Main_Data::game_player->GetSpriteDirection());

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -215,9 +215,6 @@ bool Game_Vehicle::IsInUse() const {
 }
 
 void Game_Vehicle::SyncWithPlayer() {
-	if (!IsInUse()) {
-		return;
-	}
 	SetX(Main_Data::game_player->GetX());
 	SetY(Main_Data::game_player->GetY());
 	SetRemainingStep(Main_Data::game_player->GetRemainingStep());
@@ -277,7 +274,7 @@ bool Game_Vehicle::CanLand() const {
 void Game_Vehicle::Update() {
 	Game_Character::UpdateMovement();
 
-	if (!Main_Data::game_player->IsBoardingOrUnboarding()) {
+	if (IsInUse() && Main_Data::game_player->IsAboard()) {
 		SyncWithPlayer();
 	}
 

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -265,10 +265,10 @@ void Game_Vehicle::UpdateAnimationAirship() {
 	if (IsAboard()) {
 		const auto limit = 11;
 
-		if (GetAnimCount() >= limit) {
+		IncAnimCount();
+
+		if (GetAnimCount() > limit) {
 			IncAnimFrame();
-		} else {
-			IncAnimCount();
 		}
 	} else {
 		ResetAnimation();
@@ -278,10 +278,10 @@ void Game_Vehicle::UpdateAnimationAirship() {
 void Game_Vehicle::UpdateAnimationShip() {
 	const auto limit = 15;
 
-	if (GetAnimCount() >= limit) {
+	IncAnimCount();
+
+	if (GetAnimCount() > limit) {
 		IncAnimFrame();
-	} else {
-		IncAnimCount();
 	}
 }
 

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -297,7 +297,12 @@ void Game_Vehicle::UpdateAnimationShip() {
 	}
 }
 
-void Game_Vehicle::Update() {
+void Game_Vehicle::Update(bool process_movement) {
+
+	if (!process_movement) {
+		return;
+	}
+
 	if (IsAboard()) {
 		SyncWithPlayer();
 	} else {

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -78,14 +78,6 @@ bool Game_Vehicle::MakeWay(int x, int y, int d) const {
 }
 
 
-bool Game_Vehicle::IsAnimated() const {
-	return IsContinuous();
-}
-
-bool Game_Vehicle::IsContinuous() const {
-	return type != Airship || (IsFlying() && !IsAscendingOrDescending());
-}
-
 void Game_Vehicle::LoadSystemSettings() {
 	switch (type) {
 		case None:
@@ -274,14 +266,12 @@ void Game_Vehicle::UpdateAnimationAirship() {
 		const auto limit = 11;
 
 		if (GetAnimCount() >= limit) {
-			SetAnimCount(0);
 			IncAnimFrame();
 		} else {
 			IncAnimCount();
 		}
 	} else {
-		SetAnimCount(0);
-		SetAnimFrame(1);
+		ResetAnimation();
 	}
 }
 
@@ -289,7 +279,6 @@ void Game_Vehicle::UpdateAnimationShip() {
 	const auto limit = 15;
 
 	if (GetAnimCount() >= limit) {
-		SetAnimCount(0);
 		IncAnimFrame();
 	} else {
 		IncAnimCount();

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -154,8 +154,7 @@ void Game_Vehicle::Refresh() {
 
 void Game_Vehicle::SetPosition(int _map_id, int _x, int _y) {
 	SetMapId(_map_id);
-	SetX(_x);
-	SetY(_y);
+	MoveTo(_x, _y);
 }
 
 bool Game_Vehicle::IsInCurrentMap() const {

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -74,15 +74,6 @@ void Game_Vehicle::SetMoveSpeed(int speed) {
 	}
 }
 
-int Game_Vehicle::GetOriginalMoveRouteIndex() const {
-	return data()->original_move_route_index;
-}
-
-void Game_Vehicle::SetOriginalMoveRouteIndex(int new_index) {
-	data()->original_move_route_index = new_index;
-}
-
-
 bool Game_Vehicle::MakeWay(int x, int y, int d) const {
 	if (d > 3) {
 		return MakeWayDiagonal(x, y, d);
@@ -281,8 +272,7 @@ bool Game_Vehicle::CanLand() const {
 }
 
 void Game_Vehicle::Update() {
-	Game_Character::Update();
-	Game_Character::UpdateSprite();
+	Game_Character::UpdateMovement();
 
 	if (!Main_Data::game_player->IsBoardingOrUnboarding()) {
 		SyncWithPlayer();

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -62,18 +62,6 @@ int Game_Vehicle::GetSteppingSpeed() const {
 	return 16;
 }
 
-int Game_Vehicle::GetMoveSpeed() const {
-	return data()->move_speed;
-}
-
-void Game_Vehicle::SetMoveSpeed(int speed) {
-	if (IsInUse()) {
-		Main_Data::game_player->SetMoveSpeed(speed);
-	} else {
-		Game_Character::SetMoveSpeed(speed);
-	}
-}
-
 bool Game_Vehicle::MakeWay(int x, int y, int d) const {
 	if (d > 3) {
 		return MakeWayDiagonal(x, y, d);

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -298,13 +298,14 @@ void Game_Vehicle::UpdateAnimationShip() {
 }
 
 void Game_Vehicle::Update() {
-	Game_Character::UpdateMovement();
 	if (IsAboard()) {
 		SyncWithPlayer();
+	} else {
+		Game_Character::UpdateMovement();
 	}
 
 	if (type == Airship) {
-		if (!IsMoving() && !IsJumping()) {
+		if (IsStopping()) {
 			if (IsAscending()) {
 				data()->remaining_ascent = data()->remaining_ascent - 8;
 			} else if (IsDescending()) {

--- a/src/game_vehicle.h
+++ b/src/game_vehicle.h
@@ -45,8 +45,6 @@ public:
 	 */
 	/** @{ */
 	int GetSteppingSpeed() const override;
-	int GetMoveSpeed() const override;
-	void SetMoveSpeed(int speed) override;
 	bool IsAnimated() const override;
 	bool IsContinuous() const override;
 	bool MakeWay(int x, int y, int d) const override;

--- a/src/game_vehicle.h
+++ b/src/game_vehicle.h
@@ -48,6 +48,7 @@ public:
 	bool IsAnimated() const override;
 	bool IsContinuous() const override;
 	bool MakeWay(int x, int y, int d) const override;
+	int GetVehicleType() const override;
 	/** @} */
 
 	void LoadSystemSettings();

--- a/src/game_vehicle.h
+++ b/src/game_vehicle.h
@@ -47,8 +47,6 @@ public:
 	int GetSteppingSpeed() const override;
 	int GetMoveSpeed() const override;
 	void SetMoveSpeed(int speed) override;
-	int GetOriginalMoveRouteIndex() const override;
-	void SetOriginalMoveRouteIndex(int new_index) override;
 	bool IsAnimated() const override;
 	bool IsContinuous() const override;
 	bool MakeWay(int x, int y, int d) const override;

--- a/src/game_vehicle.h
+++ b/src/game_vehicle.h
@@ -44,7 +44,6 @@ public:
 	 * Implementation of abstract methods
 	 */
 	/** @{ */
-	int GetSteppingSpeed() const override;
 	bool IsAnimated() const override;
 	bool IsContinuous() const override;
 	bool MakeWay(int x, int y, int d) const override;
@@ -65,12 +64,15 @@ public:
 	void GetOn();
 	void GetOff();
 	bool IsInUse() const;
+	bool IsAboard() const;
 	void SyncWithPlayer();
 	int GetScreenY(bool apply_shift = false) const override;
 	bool IsMovable();
 	bool CanLand() const;
 	void Update() override;
 	bool CheckEventTriggerTouch(int x, int y) override;
+	void UpdateAnimationShip();
+	void UpdateAnimationAirship();
 
 protected:
 	RPG::SaveVehicleLocation* data();

--- a/src/game_vehicle.h
+++ b/src/game_vehicle.h
@@ -50,6 +50,13 @@ public:
 	int GetVehicleType() const override;
 	/** @} */
 
+	/** 
+	 * Update this for the current frame
+	 *
+	 * @param process_movement if false, we will not process movement or animations
+	 * */
+	void Update(bool process_movement);
+
 	void LoadSystemSettings();
 	RPG::Music& GetBGM();
 	void Refresh();
@@ -69,7 +76,6 @@ public:
 	int GetScreenY(bool apply_shift = false) const override;
 	bool IsMovable();
 	bool CanLand() const;
-	void Update() override;
 	bool CheckEventTriggerTouch(int x, int y) override;
 	void UpdateAnimationShip();
 	void UpdateAnimationAirship();

--- a/src/game_vehicle.h
+++ b/src/game_vehicle.h
@@ -44,8 +44,6 @@ public:
 	 * Implementation of abstract methods
 	 */
 	/** @{ */
-	bool IsAnimated() const override;
-	bool IsContinuous() const override;
 	bool MakeWay(int x, int y, int d) const override;
 	int GetVehicleType() const override;
 	/** @} */

--- a/src/sprite_airshipshadow.cpp
+++ b/src/sprite_airshipshadow.cpp
@@ -72,7 +72,7 @@ void Sprite_AirshipShadow::Update() {
 	SetOpacity(opacity * 255);
 
 	SetX(Main_Data::game_player->GetScreenX(x_shift));
-	SetY(Main_Data::game_player->GetScreenY(y_shift));
+	SetY(Main_Data::game_player->GetScreenY(y_shift) + Main_Data::game_player->GetJumpHeight());
 	// Synchronized with airship priority
 	SetZ(airship->GetScreenZ(y_shift));
 }

--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -58,7 +58,9 @@ void Sprite_Character::Update() {
 
 	if (UsesCharset()) {
 		int row = character->GetSpriteDirection();
-		r.Set(character->GetAnimFrame() * chara_width, row * chara_height, chara_width, chara_height);
+		auto frame = character->GetAnimFrame();
+		if (frame >= 3) frame = 1;
+		r.Set(frame * chara_width, row * chara_height, chara_width, chara_height);
 		SetSrcRect(r);
 	}
 

--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -59,7 +59,7 @@ void Sprite_Character::Update() {
 	if (UsesCharset()) {
 		int row = character->GetSpriteDirection();
 		auto frame = character->GetAnimFrame();
-		if (frame >= 3) frame = 1;
+		if (frame >= RPG::EventPage::Frame_middle2) frame = RPG::EventPage::Frame_middle;
 		r.Set(frame * chara_width, row * chara_height, chara_width, chara_height);
 		SetSrcRect(r);
 	}


### PR DESCRIPTION
This PR is refactor `SaveMapEventBase` move route related chunks to behave more like `RPG_RT` and improve support loading save games correctly on any frame of movement.

This still needs a lot more testing and probably more changes to be correct. 

Detailed test cases and research can be found in #1567

Fix #1267 
Fix #1293
Fix #1346
Fix #1429
Fix #1585
Fix #1587
Fix #1593
Fix #1604
Fix #1654
Fix #1671

Breaks #579
Breaks #937

Behaviors of `stop_count`
- [x] Continues ticking through the end of the last move route command into infinity, does not reset
- [x] Resets every time the player takes a step from the keyboard
- [x] Initialized to 0 on the first frame of a new game
- [x] Does not reset when we change maps
- [x] Move route advances *after* `stop_count == max_stop_count`
- [x] Initialized to `65535` when a `SetMoveRoute` command is processed.
- [x] Initialized to `0` when the next move command is processed, and then advances to `1` on the same frame.
- [x] Move routes are not processed on the first frame of a new map, and so `stop_count` will not tick for the first frame. This means it'll be `0` if on the first frame you do have a parallel event do `OpenSaveMenu` or `65535` if you do `SetMoveRoute, OpenSaveMenu`. The behavior affects the Player and Vehicles but not map events! :question: 
- [x] `stop_count` ticks while any (player, event, or vehicle) is idle and has no move route, unless an event is active in the foreground (autostart, talk).
- [x] Does not tick for vehicles not on the current map. Stays frozen to whatever the previous value was when you teleport away from a map that had the vehicle.
- [x] Does not tick for events which don't have any active page.
- [x] If the last move command is a step, we ignore `max_stop_count` and cancel the move route as soon as the move finishes, reseting back to idle state.
- [x] If the last move command is a jump, we ignore `max_stop_count` and cancel the move route as soon as the move finishes, reseting back to idle state.
- [x] When player `vehicle > 0` and `aboard = 1`, that vehicle `stop_count` is frozen.
- [x] Does not change when you talk to an event and that event changes direction (or doesn't change)
- [x] SetEventLocation and SetVehicleLocation do not reset `stop_count`
- [x] Teleport does not reset `stop_count`

Behaviors of `max_stop_count`
- [x] Player and vehicle initialized to 0 on new game.
- [x] Map event initialized to stepping value of event's `move_frequency`.
- [x] Step: `move_frequency == 8 ? 0 : (2 ^ (9 - move_frequency))`
- [x] Turn: `move_frequency == 8 ? 0 : (2 ^ (8 - move_frequency))`
- [x] Wait: `20 + (move_frequency == 8 ? 0 : (2 ^ (8 - move_frequency)))`
- [x] When a `SetMoveRoute` command is processed, initialized to stepping value for the `move_frequency` of the move route.
- [x] After move route finishes, resets to stepping value of the `original_move_frequency`
- [x] Does not change when the player steps from player controls (remains 0 when walking around after new game, or 128 when walking around after the Player has had 1 move route since the game started).

Behaviors of `move_frequency`
- [x] Player defaults to 2 (empty chunk) and resets to 2 after move route finishes
- [x] Vehicle defaults to 2 (empty chunk) and resets to 2 after move route finishes
- [x] Event defaults to active page move_frequency and resets to it after move route finishes 
- [x] Event defaults to 2 (empty chunk) if no active page
- [x] When loading a save during an active move route, Player `move_frequency` resets to 0 after the move route finishes. (RPG_RT bug)
    - [x] Fixed in Player
- [x] When loading a save during an active move route, Vehicle `move_frequency` resets to 0 after the move route finishes. (RPG_RT bug)
    - [x] Fixed in Player
- [x] Increase/decrease frequency commands don't last after move route finishes

Behaviors of `move_commands`
- [x] Populated with array of commands when move route starts
- [x] Not cleared after move route finishes. Remains forever until next move route.

Behaviors of `move_route_index`
- [x] Starts at 0
- [x] Resets to 0 when new move route starts
- [x] When move command is being processed, points to the next move command, or `move_commands.size()` if this is the last move command.
- [x] If the last move command is a step, resets to 0 when move route finishes
- [x] If the last move command is not a step, remains unchanged when move route finishes

Behaviors of `move_route_overwrite`
- [x] Set 1 when move route starts
- [x] Set to 0 on the frame after move route finishes

Behaviors of `jumping`
- [x] Set to 1 on the frame the jump starts
- [x] Set to 0 on the last frame of the jump (when remaining_step = 0). This is different than most things which trigger on the frame after the movement.
- [x] SetEventLocation and SetVehicleLocation do not reset `jumping` (RPG_RT bug :exclamation: )
    - [x] Fixed in Player
- [x] Teleport does not reset `jumping` (RPG_RT bug :exclamation: )
    - [x] Fixed in Player


Behaviors of `remaining_step`
- [x] SetEventLocation and SetVehicleLocation reset `remaining_step`
- [x] Teleport resets `remaining_step`

Behaviors of `anim_count`
- [x] When `animation_type` is `fixed_graphic` or `step_frame_fix`, `anim_count` is always 0.
- [x] limit non-continuous = [11, 9, 7, 5, 4, 3] (based on `move_speed`)
- [x] limit continuous = [15, 11, 9, 7, 6, 5] (based on `move_speed`)
- [x] limit spin = [23, 14, 11, 7, 5, 3] (based on `move_speed`)
- [x] When anim_count reaches appropriate limit, either freezes there or increments `anim_frame` and goes back to 0. (see cases below)
- [x] when event `animation_type` is non_continous, `remaining_step=0`, and `anim_frame=1 or 3`, `anim_count` counts up to the non_continuous limit and then freezes there.
- [x]  when event `animation_type` is non_continous, `remaining_step=0`, and `anim_frame=0 or 2`, `anim_count` counts up to the continuous limit and then `anim_frame` cycles to the next value (1 or 3)
- [x]  when event `animation_type` is continous, `remaining_step=0`, `anim_count` counts up to the continuous limit and then `anim_frame` cycles to the next value
- [x] When `remaining_step > 0`, `anim_count` counts up to the non_continuous limit and then `anim_frame` cycles to the next value. Note that `remaining_step` decrements first, so this rule relies on the `remaining_step` value at the beginning of this frame.
- [x] Decreasing `move_speed` will cause `anim_count` to increment further as the limit increases.
- [x] Increasing `move_speed` will reduce the limit but `anim_count` will not change.
- [x] If you increase the `move_speed` enough that your current `anim_count` is now above the continuous limit for the new speed, the `anim_frame` will increment. #663 
- [x] Setting a tile graphic doesn't change anything.
- [x] Change graphic move command has no effect on animations.
- [x] When `jumping=1`, then we force `anim_count=0` and `anim_frame=1`. This means when a jump is started, the animation resets.
- [x] On the last frame of the jump, `jumping=0` and `anim_count=1`. That is, the `anim_count` starts ticking on the last frame of the jump, instead of waiting for the next frame to start.
- [x] When no event page is active, `anim_count=0` and `anim_frame=1`
- [x] SetEventLocation and SetVehicleLocation do not reset `anim_count`
- [x] Teleport resets `anim_count`
- [x] Is reset when `anim_paused=1`



Behaviors of `anim_frame`:
- [x] 0 = Left
- [x] 1 = Middle
- [x] 2 = Right
- [x] 3 = Middle
- [x] Defaults to 1, and then cycles 1, 2, 3, 0, 1, 2, 3, 0, ... as mentioned above in `anim_count` cases.
- [x] SetEventLocation and SetVehicleLocation do not reset `anim_frame`
- [x] Teleport resets `anim_frame`
- [x] Is reset when `anim_paused=1`

Animation of Vehicles:
- [x] Boat and Ship limit is always 15 regardless of `move_speed` and always continuously animating `anim_frame` to this.
- [x] Airship `anim_count=0` and `anim_frame=1` while `aboard=0`. This includes getting reset when landing
- [x] Airship limit is 11 and continuously animates while boarded
- [x] No change when player boards a vehicle, except the move speed of the vehicle (airship) can change how the animation continues as described above.
- [ ] If you put any move route on the airship, it's `anim_count` limit changes to 15 instead of 11 and seems to stay there forever. If you quit and load and saved game it goes back to 11 until you make a new move route. RPG_RT bug?? :exclamation: 

Behaviors of spinning events:
- [x] Spinning animation only changes `sprite_direction`.
- [x] A Turn move command changes both `direction` and `sprite_direction`
- [x] If a Turn move command is started on the same frame as animation, the `direction` will be of the turn, and `sprite_direction = (direction + 1) % 4`
- [x] A Move move command changes only `direction`
- [x] Triggering a spinning event via Action, Player Touch, or Event Touch does not affect `direction` or `sprite_direction`
- [x] When a jump is started, both `direction` and `sprite_direction` are set in the direction of the jump
- [x] When a jump is in progress, the spin will still continue to animate.
- [x] If a jump is started on the same frame as animation, the `direction` will be of the jump, and `sprite_direction = (direction + 1) % 4`

Player Controls:
- [x] Player controls don't respond until movement and `stop_count` of last move command finishes.

Vehicle Move Route interactions:
- [x] Airship move route gets canceled 1 frame after player boards
- [x] An active Boat, Ship move route gets canceled when player finishes boarding and `aboard` is set to 1.
- [x] Boat, Ship position fixed to player position when boarding finishes. This can be seen by moving the ship with a move route while the player is boarding.
- [x] If `Player::vehicle > 0`, SetMoveRoute against that vehicle gets applied to the player instead
- [x] If a move route gets set on the player while boarding, it will wait until the player finishes boarding and then execute on the player in the vehicle.

TBD:
- [x] How overwritten move route interacts with Event original move_route
- [x] Behavior of counters when move fails
- [x] Devirtualize GetOriginalMoveRouteIndex()
- [x] Don't store copy of original_move_route
- [x] When active move route is interrupted by another move route
- [x] How move route interacts with teleport
- [x] How move route interacts with get on/off vehicle  #1429
- [x] Investigate `through` and `route_through` behavior when getting on/off vehicles
- [x] Effect of Erase Event and disabling all active pages. What happens when you do this mid move, `stop_count`, `anim_count`, etc...?
- [x] Effect of changing the active event page in the middle of a move or wait? Animations?
- [x] Effect of Animation Off move command during different animation frames.
- [x] Effect of failed jump on animation
- [x] Effect of wait for all movement
- [x] Effect of stop all movement
- [x] Effect of `move_type=random`

Please post more test cases if you can think of any not here.