### PR TITLE
Battle 2k3: Visual fixes for CogDis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ add_library(${PROJECT_NAME}
 	src/weather.cpp
 	src/window_about.cpp
 	src/window_actorinfo.cpp
+	src/window_actorsp.cpp
 	src/window_actorstatus.cpp
 	src/window_actortarget.cpp
 	src/window_base.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -262,6 +262,8 @@ libeasyrpg_player_la_SOURCES = \
 	src/window_about.h \
 	src/window_actorinfo.cpp \
 	src/window_actorinfo.h \
+	src/window_actorsp.cpp \
+	src/window_actorsp.h \
 	src/window_actorstatus.cpp \
 	src/window_actorstatus.h \
 	src/window_actortarget.cpp \

--- a/src/background.cpp
+++ b/src/background.cpp
@@ -120,8 +120,8 @@ void Background::SetTone(Tone tone) {
 }
 void Background::Update(int& rate, int& value) {
 	int step =
-		(rate > 0) ? 1 << rate :
-		(rate < 0) ? 1 << -rate :
+		(rate > 0) ? 2 << rate :
+		(rate < 0) ? 2 << -rate :
 		0;
 	value += step;
 }

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -91,6 +91,7 @@ void Game_Battle::Quit() {
 
 	Game_Temp::battle_running = false;
 	Game_Temp::battle_background = "";
+	SetTerrainId(0);
 
 	std::vector<Game_Battler*> allies;
 	Main_Data::game_party->GetBattlers(allies);
@@ -411,10 +412,7 @@ void Game_Battle::SetTerrainId(int terrain_id_) {
 }
 
 int Game_Battle::GetTerrainId() {
-	// Fixme: Workaround for battle test
-	// Has options loose/tight formation which hardcodes to specific
-	// x/y values and ignores terrain
-	return terrain_id <= 0 ? 1 : terrain_id;
+	return terrain_id;
 }
 
 void Game_Battle::SetBattleMode(int battle_mode_) {

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -46,6 +46,8 @@ namespace Game_Battle {
 	std::unique_ptr<BattleAnimation> animation;
 
 	int escape_fail_count;
+
+	struct BattleTest battle_test;
 }
 
 namespace {

--- a/src/game_battle.h
+++ b/src/game_battle.h
@@ -19,6 +19,7 @@
 #define EP_GAME_BATTLE_H
 
 #include <functional>
+#include "rpg_system.h"
 #include "rpg_troop.h"
 
 class Game_Battler;
@@ -172,6 +173,17 @@ namespace Game_Battle {
 
 	extern int escape_fail_count;
 	extern std::string background_name;
+
+	struct BattleTest {
+		bool enabled = false;
+		int troop_id = 0;
+		std::string background;
+		int terrain_id = 0;
+		RPG::System::BattleFormation formation;
+		RPG::System::BattleCondition condition;
+	};
+
+	extern struct BattleTest battle_test;
 }
 
 #endif

--- a/src/game_battle.h
+++ b/src/game_battle.h
@@ -179,8 +179,8 @@ namespace Game_Battle {
 		int troop_id = 0;
 		std::string background;
 		int terrain_id = 0;
-		RPG::System::BattleFormation formation;
-		RPG::System::BattleCondition condition;
+		RPG::System::BattleFormation formation = RPG::System::BattleFormation_terrain;
+		RPG::System::BattleCondition condition = RPG::System::BattleCondition_none;
 	};
 
 	extern struct BattleTest battle_test;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1143,8 +1143,6 @@ void Game_Map::SetupBattle() {
 	}
 	if (Data::treemap.maps[current_index].background_type == 2) {
 		Game_Temp::battle_background = Data::treemap.maps[current_index].background_name;
-	} else {
-		Game_Temp::battle_background = Data::terrains[Game_Battle::GetTerrainId() - 1].background_name;
 	}
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -45,6 +45,7 @@
 #include "cache.h"
 #include "filefinder.h"
 #include "game_actors.h"
+#include "game_battle.h"
 #include "game_map.h"
 #include "game_message.h"
 #include "game_enemyparty.h"
@@ -77,8 +78,6 @@ namespace Player {
 	bool hide_title_flag;
 	bool window_flag;
 	bool fps_flag;
-	bool battle_test_flag;
-	int battle_test_troop_id;
 	bool new_game_flag;
 	int load_game_id;
 	int party_x_position;
@@ -382,8 +381,6 @@ void Player::ParseCommandLine(int argc, char *argv[]) {
 	hide_title_flag = false;
 	exit_flag = false;
 	reset_flag = false;
-	battle_test_flag = false;
-	battle_test_troop_id = 0;
 	new_game_flag = false;
 	load_game_id = -1;
 	party_x_position = -1;
@@ -393,6 +390,7 @@ void Player::ParseCommandLine(int argc, char *argv[]) {
 	no_audio_flag = false;
 	mouse_flag = false;
 	touch_flag = false;
+	Game_Battle::battle_test.enabled = false;
 
 	std::vector<std::string> args;
 
@@ -437,11 +435,18 @@ void Player::ParseCommandLine(int argc, char *argv[]) {
 			if (it == args.end()) {
 				return;
 			}
-			battle_test_flag = true;
-			battle_test_troop_id = atoi((*it).c_str());
-			if (battle_test_troop_id == 0) {
+			Game_Battle::battle_test.enabled = true;
+			Game_Battle::battle_test.troop_id = atoi((*it).c_str());
+
+			if (Game_Battle::battle_test.troop_id == 0) {
 				--it;
-				battle_test_troop_id = (argc > 4) ? atoi(argv[4]) : 0;
+				Game_Battle::battle_test.troop_id = (argc > 4) ? atoi(argv[4]) : 0;
+				// 2k3 passes formation, condition and terrain_id as args 5-7
+				if (argc > 7) {
+					Game_Battle::battle_test.formation = (RPG::System::BattleFormation)atoi(argv[5]);
+					Game_Battle::battle_test.condition = (RPG::System::BattleCondition)atoi(argv[6]);
+					Game_Battle::battle_test.terrain_id = (RPG::System::BattleFormation)atoi(argv[7]);
+				}
 			}
 		}
 		else if (*it == "--battle-test") {
@@ -449,8 +454,8 @@ void Player::ParseCommandLine(int argc, char *argv[]) {
 			if (it == args.end()) {
 				return;
 			}
-			battle_test_flag = true;
-			battle_test_troop_id = atoi((*it).c_str());
+			Game_Battle::battle_test.enabled = true;
+			Game_Battle::battle_test.troop_id = atoi((*it).c_str());
 		}
 		else if (*it == "--project-path") {
 			++it;

--- a/src/player.h
+++ b/src/player.h
@@ -239,12 +239,6 @@ namespace Player {
 	/** Touch flag, if true enables finger taps */
 	extern bool touch_flag;
 
-	/** Battle Test flag, if true will run battle test. */
-	extern bool battle_test_flag;
-
-	/** Battle Test Troop ID to fight with if battle test is run. */
-	extern int battle_test_troop_id;
-
 	/** Overwrite party x position */
 	extern int party_x_position;
 

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -195,10 +195,15 @@ void Scene_Battle::InitBattleTest()
 		Game_Temp::battle_background = Data::system.battletest_background;
 		Game_Battle::SetTerrainId(Data::system.battletest_terrain);
 	} else {
-		if (Game_Battle::battle_test.formation == RPG::System::BattleFormation_terrain) {
-			Game_Battle::SetTerrainId(Game_Battle::battle_test.terrain_id);
+		int terrain_id = Game_Battle::battle_test.terrain_id;
+		// Allow fallback to battle background battle when the additional 2k3
+		// command line args are not passed (terrain_id = 0)
+		if (Game_Battle::battle_test.formation == RPG::System::BattleFormation_terrain &&
+			terrain_id > 0) {
+			Game_Battle::SetTerrainId(terrain_id);
 		} else {
 			Game_Temp::battle_background = Data::system.battletest_background;
+			// FIXME: figure out how the terrain is configured
 			Game_Battle::SetTerrainId(1);
 		}
 	}

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -54,15 +54,15 @@ Scene_Battle::~Scene_Battle() {
 }
 
 void Scene_Battle::Start() {
-	if (Player::battle_test_flag) {
-		Game_Temp::battle_troop_id = Player::battle_test_troop_id;
+	if (Game_Battle::battle_test.enabled) {
+		Game_Temp::battle_troop_id = Game_Battle::battle_test.troop_id;
 	}
 
 	const RPG::Troop* troop = ReaderUtil::GetElement(Data::troops, Game_Temp::battle_troop_id);
 
 	if (!troop) {
 		const char* error_msg = "Invalid Monster Party ID %d";
-		if (Player::battle_test_flag) {
+		if (Game_Battle::battle_test.enabled) {
 			Output::Error(error_msg, Game_Temp::battle_troop_id);
 		}
 		else {
@@ -76,7 +76,7 @@ void Scene_Battle::Start() {
 	// Game_Temp::battle_troop_id is valid during the whole battle
 	Output::Debug("Starting battle %d (%s)", Game_Temp::battle_troop_id, troop->name.c_str());
 
-	if (Player::battle_test_flag) {
+	if (Game_Battle::battle_test.enabled) {
 		InitBattleTest();
 	} else {
 		Main_Data::game_enemyparty.reset(new Game_EnemyParty());
@@ -106,7 +106,7 @@ void Scene_Battle::TransitionIn() {
 }
 
 void Scene_Battle::TransitionOut() {
-	if (Player::exit_flag || Player::battle_test_flag || Game_Temp::transition_menu || Scene::instance->type == Scene::Title) {
+	if (Player::exit_flag || Game_Battle::battle_test.enabled || Game_Temp::transition_menu || Scene::instance->type == Scene::Title) {
 		Scene::TransitionOut();
 	}
 	else {
@@ -190,9 +190,18 @@ bool Scene_Battle::IsWindowMoving() {
 
 void Scene_Battle::InitBattleTest()
 {
-	Game_Temp::battle_troop_id = Player::battle_test_troop_id;
-	Game_Temp::battle_background = Data::system.battletest_background;
-	Game_Battle::SetTerrainId(Data::system.battletest_terrain);
+	Game_Temp::battle_troop_id = Game_Battle::battle_test.troop_id;
+	if (Player::IsRPG2k()) {
+		Game_Temp::battle_background = Data::system.battletest_background;
+		Game_Battle::SetTerrainId(Data::system.battletest_terrain);
+	} else {
+		if (Game_Battle::battle_test.formation == RPG::System::BattleFormation_terrain) {
+			Game_Battle::SetTerrainId(Game_Battle::battle_test.terrain_id);
+		} else {
+			Game_Temp::battle_background = Data::system.battletest_background;
+			Game_Battle::SetTerrainId(1);
+		}
+	}
 
 	Main_Data::game_party->SetupBattleTestMembers();
 

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -359,7 +359,7 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 		Scene::Pop();
 		break;
 	case State_Defeat:
-		if (Player::battle_test_flag || Game_Temp::battle_defeat_mode != 0) {
+		if (Game_Battle::battle_test.enabled || Game_Temp::battle_defeat_mode != 0) {
 			Scene::Pop();
 		}
 		else {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -585,7 +585,7 @@ void Scene_Battle_Rpg2k3::ProcessActions() {
 			Scene::Pop();
 			break;
 		case State_Defeat:
-			if (Player::battle_test_flag || Game_Temp::battle_defeat_mode != 0) {
+			if (Game_Battle::battle_test.enabled || Game_Temp::battle_defeat_mode != 0) {
 				Scene::Pop();
 			}
 			else {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -128,6 +128,9 @@ void Scene_Battle_Rpg2k3::CreateUi() {
 
 	enemy_status_window.reset(new Window_BattleStatus(0, 0, SCREEN_TARGET_WIDTH - option_command_mov, 80, true));
 	enemy_status_window->SetVisible(false);
+	sp_window.reset(new Window_ActorSp(SCREEN_TARGET_WIDTH - 60, 136, 60, 32));
+	sp_window->SetVisible(false);
+	sp_window->SetZ(Priority_Window + 1);
 
 	ally_cursor.reset(new Sprite());
 	enemy_cursor.reset(new Sprite());
@@ -171,7 +174,7 @@ void Scene_Battle_Rpg2k3::UpdateCursors() {
 
 		std::vector<Game_Battler*> actors;
 
-		if (ally_index >= 0) {
+		if (ally_index >= 0 && Data::battlecommands.battle_type != RPG::BattleCommands::BattleType_traditional) {
 			ally_cursor->SetVisible(true);
 			Main_Data::game_party->GetBattlers(actors);
 			const Game_Battler* actor = actors[ally_index];
@@ -398,6 +401,7 @@ void Scene_Battle_Rpg2k3::SetState(Scene_Battle::State new_state) {
 	skill_window->SetVisible(false);
 	help_window->SetVisible(false);
 	target_window->SetVisible(false);
+	sp_window->SetVisible(false);
 
 	if (previous_state == State_SelectSkill) {
 		skill_window->SaveActorIndex(actor_index);
@@ -467,6 +471,9 @@ void Scene_Battle_Rpg2k3::SetState(Scene_Battle::State new_state) {
 		skill_window->SetVisible(true);
 		skill_window->SetHelpWindow(help_window.get());
 		help_window->SetVisible(true);
+		if (Data::battlecommands.battle_type == RPG::BattleCommands::BattleType_traditional) {
+			sp_window->SetVisible(true);
+		}
 		break;
 	case State_Victory:
 	case State_Defeat:
@@ -943,6 +950,7 @@ void Scene_Battle_Rpg2k3::CommandSelected() {
 	case RPG::BattleCommand::Type_skill:
 		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 		skill_window->SetSubsetFilter(0);
+		sp_window->SetBattler(*active_actor);
 		SetState(State_SelectSkill);
 		break;
 	case RPG::BattleCommand::Type_special:
@@ -984,6 +992,7 @@ void Scene_Battle_Rpg2k3::SubskillSelected() {
 	// skill subset is 4 (Type_subskill) + counted subsets
 	skill_window->SetSubsetFilter(subskill);
 	SetState(State_SelectSkill);
+	sp_window->SetBattler(*active_actor);
 }
 
 void Scene_Battle_Rpg2k3::SpecialSelected() {

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -21,6 +21,7 @@
 // Headers
 #include "scene_battle.h"
 #include "async_handler.h"
+#include "window_actorsp.h"
 
 /**
  * Scene_Battle class.
@@ -126,6 +127,7 @@ protected:
 	bool play_reflected_anim = false;
 
 	std::unique_ptr<Window_BattleStatus> enemy_status_window;
+	std::unique_ptr<Window_ActorSp> sp_window;
 
 	std::vector<Game_Battler*> targets;
 

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -20,6 +20,7 @@
 #include "async_handler.h"
 #include "bitmap.h"
 #include "filefinder.h"
+#include "game_battle.h"
 #include "input.h"
 #include "player.h"
 #include "scene_map.h"
@@ -35,7 +36,7 @@ Scene_Logo::Scene_Logo() :
 
 void Scene_Logo::Start() {
 	logo.reset(new Sprite());
-	if (!Player::debug_flag) {
+	if (!Player::debug_flag && !Game_Battle::battle_test.enabled) {
 		logo_img = Bitmap::Create(easyrpg_logo, sizeof(easyrpg_logo), false);
 		logo->SetBitmap(logo_img);
 	}
@@ -77,6 +78,7 @@ void Scene_Logo::Update() {
 	++frame_counter;
 
 	if (Player::debug_flag ||
+		Game_Battle::battle_test.enabled ||
 		frame_counter == 60 ||
 		Input::IsTriggered(Input::DECISION) ||
 		Input::IsTriggered(Input::CANCEL)) {

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -22,6 +22,7 @@
 #include "audio.h"
 #include "audio_secache.h"
 #include "cache.h"
+#include "game_battle.h"
 #include "game_screen.h"
 #include "game_system.h"
 #include "game_temp.h"
@@ -42,7 +43,7 @@ Scene_Title::Scene_Title() {
 void Scene_Title::Start() {
 	// Skip background image and music if not used
 	if (Data::system.show_title && !Player::new_game_flag &&
-		!Player::battle_test_flag && !Player::hide_title_flag) {
+		!Game_Battle::battle_test.enabled && !Player::hide_title_flag) {
 		CreateTitleGraphic();
 		PlayTitleMusic();
 	}
@@ -64,7 +65,7 @@ void Scene_Title::Continue() {
 }
 
 void Scene_Title::TransitionIn() {
-	if (Player::battle_test_flag || !Data::system.show_title || Player::new_game_flag)
+	if (Game_Battle::battle_test.enabled || !Data::system.show_title || Player::new_game_flag)
 		return;
 
 	if (command_window->GetVisible()) {
@@ -86,7 +87,7 @@ void Scene_Title::Resume() {
 	}
 }
 void Scene_Title::Update() {
-	if (Player::battle_test_flag) {
+	if (Game_Battle::battle_test.enabled) {
 		PrepareBattleTest();
 		return;
 	}

--- a/src/spriteset_battle.cpp
+++ b/src/spriteset_battle.cpp
@@ -77,6 +77,7 @@ void Spriteset_Battle::Update() {
 		}
 	}
 	background->SetTone(new_tone);
+	background->Update();
 
 	for (auto sprite : sprites) {
 		Game_Battler* battler = sprite->GetBattler();

--- a/src/window_actorsp.cpp
+++ b/src/window_actorsp.cpp
@@ -1,0 +1,49 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Headers
+#include "window_actorsp.h"
+#include "bitmap.h"
+#include "font.h"
+
+Window_ActorSp::Window_ActorSp(int ix, int iy, int iwidth, int iheight) :
+	Window_Base(ix, iy, iwidth, iheight) {
+
+	SetContents(Bitmap::Create(width - 16, height - 16));
+
+	contents->Clear();
+}
+
+void Window_ActorSp::SetBattler(const Game_Battler& battler) {
+	int cx = 0;
+
+	int color = Font::ColorDefault;
+	if (battler.GetMaxSp() != 0 && battler.GetSp() <= battler.GetMaxSp() / 4) {
+		color = Font::ColorCritical;
+	}
+
+	// Draw current Sp
+	contents->TextDraw(cx + 3 * 6, 2, color, std::to_string(battler.GetSp()), Text::AlignRight);
+
+	// Draw /
+	cx += 3 * 6;
+	contents->TextDraw(cx, 2, Font::ColorDefault, "/");
+
+	// Draw Max Sp
+	cx += 6;
+	contents->TextDraw(cx + 3 * 6, 2, Font::ColorDefault, std::to_string(battler.GetMaxSp()), Text::AlignRight);
+}

--- a/src/window_actorsp.h
+++ b/src/window_actorsp.h
@@ -1,0 +1,45 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_WINDOW_ACTOR_SP_H
+#define EP_WINDOW_ACTOR_SP_H
+
+// Headers
+#include "window_base.h"
+#include "text.h"
+
+/**
+ * Window_ActorSp class.
+ * Shows Actor skill points for traditional 2k3 battle system.
+ */
+class Window_ActorSp : public Window_Base {
+
+public:
+	/**
+	 * Constructor.
+	 */
+	Window_ActorSp(int ix, int iy, int iwidth, int iheight);
+
+	/**
+	 * Sets the battler whose SP will be shown.
+	 *
+	 * @param battler battler to use.
+	 */
+	void SetBattler(const Game_Battler& battler);
+};
+
+#endif

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -88,8 +88,12 @@ void Window_BattleStatus::Refresh() {
 
 			DrawActorName(*actor, 4, y);
 			DrawActorState(*actor, 84, y);
-			DrawActorHp(*actor, 126, y, true);
-			DrawActorSp(*actor, 198, y, false);
+			if (Data::battlecommands.battle_type == RPG::BattleCommands::BattleType_traditional) {
+				contents->TextDraw(126 + 42 + 4 * 6, y, Font::ColorDefault, std::to_string(actor->GetHp()), Text::AlignRight);
+			} else {
+				DrawActorHp(*actor, 126, y, true);
+				DrawActorSp(*actor, 198, y, false);
+			}
 		}
 	}
 
@@ -150,7 +154,9 @@ void Window_BattleStatus::RefreshGauge() {
 				int y = 2 + i * 16;
 
 				DrawGauge(*actor, 198 - 10, y - 2);
-				DrawActorSp(*actor, 198, y, false);
+				if (Data::battlecommands.battle_type == RPG::BattleCommands::BattleType_alternative) {
+					DrawActorSp(*actor, 198, y, false);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This needs more testing to determine the correct logic but it seems that the condition for choosing between background and terrain is the terrain ID, not a non-empty background.

CogDis animates the background in a fancy way: the front image is only black + transparent and the background is a moving (downwards) mask image which defines the color. And via that trick they get 3 frames of animated stars on the background.

the lack of ``background->Update()`` completely broke any background scrolling in battles (upps) and the scrolling was too slow.

The rest fixes issues between Traditional vs Alternative style (still not fully matching but gets closer).