### PR TITLE
Vehicle bgm fix

### DIFF
--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -371,7 +371,7 @@ void Game_Map::PlayBgm() {
 		current_index = GetMapIndex(Data::treemap.maps[current_index].parent_map);
 	}
 
-	if ((current_index > -1) && !Data::treemap.maps[current_index].music.name.empty()) {
+	if ((current_index > 0) && !Data::treemap.maps[current_index].music.name.empty()) {
 		if (Data::treemap.maps[current_index].music_type == 1) {
 			return;
 		}

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -375,7 +375,12 @@ void Game_Map::PlayBgm() {
 		if (Data::treemap.maps[current_index].music_type == 1) {
 			return;
 		}
-		Game_System::BgmPlay(Data::treemap.maps[current_index].music);
+		auto& music = Data::treemap.maps[current_index].music;
+		if (!Main_Data::game_player->IsAboard()) {
+			Game_System::BgmPlay(music);
+		} else {
+			Main_Data::game_data.system.before_vehicle_music = music;
+		}
 	}
 }
 

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -606,6 +606,10 @@ void Game_Player::Unboard() {
 	Game_System::BgmPlay(walking_bgm);
 }
 
+bool Game_Player::IsAboard() const {
+	return data()->aboard;
+}
+
 bool Game_Player::IsBoardingOrUnboarding() const {
 	return data()->boarding || data()->unboarding;
 }

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -466,7 +466,7 @@ bool Game_Player::GetOnVehicle() {
 		SetDirection(RPG::EventPage::Direction_left);
 	}
 
-	walking_bgm = Game_System::GetCurrentBGM();
+	Main_Data::game_data.system.before_vehicle_music = Game_System::GetCurrentBGM();
 	GetVehicle()->GetOn();
 	return true;
 }
@@ -603,7 +603,7 @@ void Game_Player::Unboard() {
 	data()->aboard = false;
 	SetMoveSpeed(data()->preboard_move_speed);
 
-	Game_System::BgmPlay(walking_bgm);
+	Game_System::BgmPlay(Main_Data::game_data.system.before_vehicle_music);
 }
 
 bool Game_Player::IsAboard() const {

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -101,8 +101,6 @@ private:
 	bool teleporting = false;
 	int new_map_id = 0, new_x = 0, new_y = 0, new_direction = 0;
 
-	RPG::Music walking_bgm;
-
 	void UpdateScroll(int prev_x, int prev_y);
 	void UpdatePan();
 	bool CheckTouchEvent();

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -80,6 +80,7 @@ public:
 	bool IsMovable() const;
 	bool InVehicle() const;
 	bool InAirship() const;
+	bool IsAboard() const;
 	bool IsBoardingOrUnboarding() const;
 	Game_Vehicle* GetVehicle() const;
 	bool CanWalk(int x, int y);


### PR DESCRIPTION
Fixes #1619 

Note: I use the aboard flag here because that's what tells us the player is actually inside the vehicle. You could have an event that teleports you while boarding and then the bgm effect would not happen.

I tested this parallel event:
```
GetOnOffVehicle
Wait 0.0s (x3)
Teleport other map
```

The player teleports to the other map, the other map music plays, and then the player boards the ship on that map and the vehicle bgm never plays.

I'll fix that behavior in #1601 