### PR TITLE
Fix emscripten & OSX build

### DIFF
--- a/builds/cmake/Modules/FindSDL2.cmake
+++ b/builds/cmake/Modules/FindSDL2.cmake
@@ -249,11 +249,13 @@ if(SDL2_FOUND)
 			find_library(COREAUDIO CoreAudio)
 			find_library(AUDIOTOOLBOX AudioToolbox)
 			find_library(AUDIOUNIT AudioUnit)
+			find_library(METAL Metal)
 			find_library(ICONV_LIBRARY iconv)
 			set_property(TARGET SDL2::SDL2 APPEND_STRING PROPERTY
 				INTERFACE_LINK_LIBRARIES ${COREVIDEO} ${COCOA_LIBRARY}
 					${IOKIT} ${FORCEFEEDBACK} ${CARBON_LIBRARY}
-					${COREAUDIO} ${AUDIOTOOLBOX} ${AUDIOUNIT} ${ICONV_LIBRARY})
+					${COREAUDIO} ${AUDIOTOOLBOX} ${AUDIOUNIT} ${METAL}
+					${ICONV_LIBRARY})
 		else()
 			# Remove -lSDL2 -lSDL2main from the pkg-config linker line,
 			# to prevent linking against the system library

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -159,7 +159,7 @@ void Player::Init(int argc, char *argv[]) {
 
 	// Create initial directory structure in our private area
 	// Retrieve save directory from persistent storage
-	EM_ASM(
+	EM_ASM(({
 
 		FS.mkdir("easyrpg");
 		FS.chdir("easyrpg");
@@ -171,7 +171,7 @@ void Player::Init(int argc, char *argv[]) {
 
 		FS.syncfs(true, function(err) {
 		});
-	);
+	}));
 #endif
 
 	Main_Data::Init();

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -109,10 +109,10 @@ void Scene_Save::Action(int index) {
 
 #ifdef EMSCRIPTEN
 	// Save changed file system
-	EM_ASM(
+	EM_ASM({
 		FS.syncfs(function(err) {
 		});
-	);
+	});
 #endif
 
 	Scene::Pop();


### PR DESCRIPTION
Have no idea if the Metal.framework dep breaks running on OSX < 10.11 but this is a SDL problem then and I have no way to test this. (ObjC does lazy binding... should work in theory)