### PR TITLE
Refactor Event Update Ordering

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -58,7 +58,7 @@ bool Game_Character::MakeWay(int x, int y, int d) const {
 		return MakeWayDiagonal(x, y, d);
 	}
 
-	return Game_Map::MakeWay(x, y, d, *this, false);
+	return Game_Map::MakeWay(x, y, d, *this);
 }
 
 bool Game_Character::IsLandable(int x, int y) const

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -980,3 +980,9 @@ bool Game_Character::IsMoveRouteActive() const {
 int Game_Character::GetVehicleType() const {
 	return 0;
 }
+
+void Game_Character::SetActive(bool active) {
+	data()->active = active;
+	SetVisible(active);
+}
+

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -782,6 +782,7 @@ int Game_Character::DistanceYfromPlayer() const {
 
 void Game_Character::ForceMoveRoute(const RPG::MoveRoute& new_route,
 									int frequency) {
+	const auto prev_max_sc = GetMaxStopCount();
 	if (IsMoveRouteActive()) {
 		CancelMoveRoute();
 	}
@@ -805,7 +806,12 @@ void Game_Character::ForceMoveRoute(const RPG::MoveRoute& new_route,
 
 	SetMoveRouteOverwritten(true);
 	SetMoveFrequency(frequency);
-	SetMaxStopCountForStep();
+
+	if (frequency != original_move_frequency) {
+		SetMaxStopCountForStep();
+	} else {
+		SetMaxStopCount(prev_max_sc);
+	}
 }
 
 void Game_Character::CancelMoveRoute() {

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -31,11 +31,12 @@
 #include <cmath>
 #include <cassert>
 
-Game_Character::Game_Character(RPG::SaveMapEventBase* d) :
+Game_Character::Game_Character(Type type, RPG::SaveMapEventBase* d) :
 	move_failed(false),
 	jump_plus_x(0),
 	jump_plus_y(0),
 	visible(true),
+	_type(type),
 	_data(d)
 {
 }

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -159,7 +159,8 @@ void Game_Character::UpdateMovement() {
 		SetRemainingStep(GetRemainingStep() - min(1 << (1 + GetMoveSpeed()), GetRemainingStep()));
 		moved = true;
 	} else {
-		if (IsMoveRouteOverwritten() || (!Game_Map::GetInterpreter().IsRunning() && !Game_Map::IsAnyEventStarting())) {
+		if (GetStopCount() == 0 || IsMoveRouteOverwritten() ||
+					(Game_Message::GetContinueEvents() || !Game_Map::GetInterpreter().IsRunning())) {
 			SetStopCount(GetStopCount() + 1);
 		}
 	}

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -160,7 +160,7 @@ void Game_Character::UpdateMovement() {
 		moved = true;
 	} else {
 		if (GetStopCount() == 0 || IsMoveRouteOverwritten() ||
-					(Game_Message::GetContinueEvents() || !Game_Map::GetInterpreter().IsRunning())) {
+					((Game_Message::GetContinueEvents() || !Game_Map::GetInterpreter().IsRunning()) && !IsPaused())) {
 			SetStopCount(GetStopCount() + 1);
 		}
 	}
@@ -785,6 +785,7 @@ void Game_Character::ForceMoveRoute(const RPG::MoveRoute& new_route,
 		CancelMoveRoute();
 	}
 
+	SetPaused(false);
 	SetStopCount(0xFFFF);
 	SetMoveRouteIndex(0);
 	SetMoveRouteRepeated(false);

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -480,6 +480,20 @@ public:
 	void SetPaused(bool val);
 
 	/**
+	 * Activates or deactivates the event.
+	 *
+	 * @param active enables or disables the event.
+	 */
+	void SetActive(bool active);
+
+	/**
+	 * Gets if the event is active.
+	 *
+	 * @return if the event is active (or inactive via EraseEvent-EventCommand).
+	 */
+	bool IsActive() const;
+
+	/**
 	 * Checks if the character is stopping.
 	 *
 	 * @return whether the character is stopping.
@@ -1165,6 +1179,10 @@ inline bool Game_Character::IsPaused() const {
 
 inline void Game_Character::SetPaused(bool val) {
 	data()->pause = val;
+}
+
+inline bool Game_Character::IsActive() const {
+	return data()->active;
 }
 
 

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -863,7 +863,6 @@ protected:
 
 	bool visible;
 
-	int frame_count_at_last_update_parallel = -1;
 	RPG::SaveMapEventBase* _data = nullptr;
 };
 

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -37,6 +37,12 @@ class Game_Character {
 public:
 	using AnimType = RPG::EventPage::AnimType;
 
+	enum Type {
+		Event,
+		Player,
+		Vehicle
+	};
+
 	/**
 	 * Destructor.
 	 */
@@ -46,6 +52,9 @@ public:
 	virtual
 #endif
 	~Game_Character();
+
+	/** @return the type of character this is */
+	Type GetType() const;
 
 	/**
 	 * Gets x position in tiles.
@@ -851,7 +860,7 @@ public:
 	static Game_Character* GetCharacter(int character_id, int event_id);
 
 protected:
-	explicit Game_Character(RPG::SaveMapEventBase* d);
+	explicit Game_Character(Type type, RPG::SaveMapEventBase* d);
 	bool MakeWayDiagonal(int x, int y, int d) const;
 	virtual void UpdateSelfMovement() {}
 	void UpdateJump();
@@ -877,9 +886,9 @@ protected:
 
 	bool visible;
 
+	Type _type;
 	RPG::SaveMapEventBase* _data = nullptr;
 };
-
 
 inline RPG::SaveMapEventBase* Game_Character::data() {
 	return _data;
@@ -887,6 +896,10 @@ inline RPG::SaveMapEventBase* Game_Character::data() {
 
 inline const RPG::SaveMapEventBase* Game_Character::data() const {
 	return _data;
+}
+
+inline Game_Character::Type Game_Character::GetType() const {
+	return _type;
 }
 
 inline int Game_Character::GetX() const {

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -470,6 +470,16 @@ public:
 	void SetProcessed(bool val);
 
 	/**
+	 * @return whether the event is paused.
+	 */
+	bool IsPaused() const;
+
+	/**
+	 * Set the paused flag
+	 */
+	void SetPaused(bool val);
+
+	/**
 	 * Checks if the character is stopping.
 	 *
 	 * @return whether the character is stopping.
@@ -1149,5 +1159,14 @@ inline bool Game_Character::IsProcessed() const {
 inline void Game_Character::SetProcessed(bool val) {
 	data()->processed = val;
 }
+
+inline bool Game_Character::IsPaused() const {
+	return data()->pause;
+}
+
+inline void Game_Character::SetPaused(bool val) {
+	data()->pause = val;
+}
+
 
 #endif

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -38,19 +38,14 @@ void Game_CommonEvent::SetSaveData(const RPG::SaveEventData& data) {
 
 void Game_CommonEvent::Refresh() {
 	if (GetTrigger() == RPG::EventPage::Trigger_parallel) {
-		if (GetSwitchFlag() ? Game_Switches.Get(GetSwitchId()) : true) {
-			if (!interpreter) {
-				interpreter.reset(new Game_Interpreter_Map());
-			}
-			parallel_running = true;
-		} else {
-			parallel_running = false;
+		if (!interpreter) {
+			interpreter.reset(new Game_Interpreter_Map());
 		}
 	}
 }
 
-void Game_CommonEvent::UpdateParallel() {
-	if (interpreter && parallel_running) {
+void Game_CommonEvent::Update() {
+	if (interpreter && IsWaitingBackgroundExecution()) {
 		if (!interpreter->IsRunning()) {
 			interpreter->Setup(this, 0);
 		}
@@ -97,6 +92,13 @@ RPG::SaveEventData Game_CommonEvent::GetSaveData() {
 bool Game_CommonEvent::IsWaitingForegroundExecution() const {
 	auto* ce = ReaderUtil::GetElement(Data::commonevents, common_event_id);
 	return ce->trigger == RPG::EventPage::Trigger_auto_start &&
+		(!ce->switch_flag || Game_Switches.Get(ce->switch_id))
+		&& !ce->event_commands.empty();
+}
+
+bool Game_CommonEvent::IsWaitingBackgroundExecution() const {
+	auto* ce = ReaderUtil::GetElement(Data::commonevents, common_event_id);
+	return ce->trigger == RPG::EventPage::Trigger_parallel &&
 		(!ce->switch_flag || Game_Switches.Get(ce->switch_id))
 		&& !ce->event_commands.empty();
 }

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -49,22 +49,6 @@ void Game_CommonEvent::Refresh() {
 	}
 }
 
-void Game_CommonEvent::Update() {
-	if (GetTrigger() != RPG::EventPage::Trigger_auto_start)
-		return;
-
-	for (int i = 0; i < 500; ++i) {
-		if (GetSwitchFlag() ? Game_Switches.Get(GetSwitchId()) : true) {
-			if (!Game_Map::GetInterpreter().IsRunning()) {
-				Game_Map::GetInterpreter().Setup(this, 0);
-				Game_Map::GetInterpreter().Update();
-				continue;
-			}
-		}
-		return;
-	}
-}
-
 void Game_CommonEvent::UpdateParallel() {
 	if (interpreter && parallel_running) {
 		if (!interpreter->IsRunning()) {
@@ -108,4 +92,11 @@ RPG::SaveEventData Game_CommonEvent::GetSaveData() {
 	}
 
 	return event_data;
+}
+
+bool Game_CommonEvent::IsWaitingForegroundExecution() const {
+	auto* ce = ReaderUtil::GetElement(Data::commonevents, common_event_id);
+	return ce->trigger == RPG::EventPage::Trigger_auto_start &&
+		(!ce->switch_flag || Game_Switches.Get(ce->switch_id))
+		&& !ce->event_commands.empty();
 }

--- a/src/game_commonevent.h
+++ b/src/game_commonevent.h
@@ -52,7 +52,7 @@ public:
 	/**
 	 * Updates common event parallel interpreter.
 	 */
-	void UpdateParallel();
+	void Update();
 
 	/**
 	 * Gets common event index.
@@ -101,13 +101,11 @@ public:
 	/** @return true if waiting for foreground execution */
 	bool IsWaitingForegroundExecution() const;
 
+	/** @return true if waiting for background execution */
+	bool IsWaitingBackgroundExecution() const;
+
 private:
 	int common_event_id;
-	/**
-	 * If parallel interpreter is running (true) or suspended (false).
-	 * When switched to running it continues where it was suspended.
-	 */
-	bool parallel_running = false;
 
 	/** Interpreter for parallel common events. */
 	std::unique_ptr<Game_Interpreter_Map> interpreter;

--- a/src/game_commonevent.h
+++ b/src/game_commonevent.h
@@ -50,11 +50,6 @@ public:
 	void Refresh();
 
 	/**
-	 * Updates common event.
-	 */
-	void Update();
-
-	/**
 	 * Updates common event parallel interpreter.
 	 */
 	void UpdateParallel();
@@ -102,6 +97,9 @@ public:
 	std::vector<RPG::EventCommand>& GetList();
 
 	RPG::SaveEventData GetSaveData();
+
+	/** @return true if waiting for foreground execution */
+	bool IsWaitingForegroundExecution() const;
 
 private:
 	int common_event_id;

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -101,6 +101,8 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 		interpreter.reset();
 	}
 
+	SetPaused(false);
+
 	if (page == nullptr) {
 		SetSpriteName("");
 		SetSpriteIndex(0);
@@ -322,6 +324,7 @@ void Game_Event::Start(bool by_decision_key) {
 
 	starting = true;
 	data()->triggered_by_decision_key = by_decision_key;
+	SetPaused(true);
 }
 
 const std::vector<RPG::EventCommand>& Game_Event::GetList() const {
@@ -334,11 +337,12 @@ void Game_Event::StartTalkToHero() {
 	}
 }
 
-void Game_Event::StopTalkToHero() {
+void Game_Event::OnFinishForegroundEvent() {
 	if (!(IsDirectionFixed() || IsFacingLocked() || IsSpinning())) {
 		SetSpriteDirection(GetDirection());
 	}
 
+	SetPaused(false);
 	halting = true;
 }
 
@@ -378,7 +382,7 @@ bool Game_Event::CheckEventTriggerTouch(int x, int y) {
 }
 
 void Game_Event::UpdateSelfMovement() {
-	if (running)
+	if (IsPaused())
 		return;
 	if (!Game_Message::GetContinueEvents() && Game_Map::GetInterpreter().IsRunning())
 		return;

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -33,7 +33,7 @@
 #include <cmath>
 
 Game_Event::Game_Event(int map_id, const RPG::Event& event) :
-	Game_Character(new RPG::SaveMapEvent()),
+	Game_Character(Event, new RPG::SaveMapEvent()),
 	_data_copy(this->data()),
 	event(event),
 	from_save(false)
@@ -45,7 +45,7 @@ Game_Event::Game_Event(int map_id, const RPG::Event& event) :
 }
 
 Game_Event::Game_Event(int map_id, const RPG::Event& event, const RPG::SaveMapEvent& orig_data) :
-	Game_Character(new RPG::SaveMapEvent(orig_data)),
+	Game_Character(Event, new RPG::SaveMapEvent(orig_data)),
 	_data_copy(this->data()),
 	event(event),
 	from_save(true)

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -306,14 +306,6 @@ RPG::EventPage::Trigger Game_Event::GetTrigger() const {
 	return static_cast<RPG::EventPage::Trigger>(trigger);
 }
 
-void Game_Event::SetActive(bool active) {
-	data()->active = active;
-	SetVisible(active);
-}
-
-bool Game_Event::GetActive() const {
-	return data()->active;
-}
 
 bool Game_Event::SetAsWaitingForegroundExecution(bool face_hero, bool by_decision_key) {
 	// RGSS scripts consider list empty if size <= 1. Why?

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -39,7 +39,6 @@ Game_Event::Game_Event(int map_id, const RPG::Event& event) :
 	from_save(false)
 {
 	SetMapId(map_id);
-	SetProcessed(true); // RPG_RT compatibility
 	SetMoveSpeed(3);
 	MoveTo(event.x, event.y);
 	Refresh();
@@ -53,7 +52,6 @@ Game_Event::Game_Event(int map_id, const RPG::Event& event, const RPG::SaveMapEv
 {
 	// Savegames have 0 for the mapid for compatibility with RPG_RT.
 	SetMapId(map_id);
-	SetProcessed(true); // RPG_RT compatibility
 
 	this->event.ID = data()->ID;
 
@@ -549,6 +547,11 @@ void Game_Event::Update() {
 	if (!data()->active || page == NULL) {
 		return;
 	}
+
+	if (IsProcessed()) {
+		return;
+	}
+	SetProcessed(true);
 
 	auto was_moving = !IsStopping();
 	Game_Character::UpdateMovement();

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -83,7 +83,6 @@ void Game_Event::SetThrough(bool through) {
 
 void Game_Event::ClearStarting() {
 	starting = false;
-	started_by_decision_key = false;
 }
 
 void Game_Event::Setup(const RPG::EventPage* new_page) {
@@ -300,7 +299,7 @@ bool Game_Event::GetStarting() const {
 }
 
 bool Game_Event::WasStartedByDecisionKey() const {
-	return started_by_decision_key;
+	return data()->triggered_by_decision_key;
 }
 
 RPG::EventPage::Trigger Game_Event::GetTrigger() const {
@@ -322,7 +321,7 @@ void Game_Event::Start(bool by_decision_key) {
 		return;
 
 	starting = true;
-	started_by_decision_key = by_decision_key;
+	data()->triggered_by_decision_key = by_decision_key;
 }
 
 const std::vector<RPG::EventCommand>& Game_Event::GetList() const {

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -303,8 +303,8 @@ bool Game_Event::WasStartedByDecisionKey() const {
 	return started_by_decision_key;
 }
 
-int Game_Event::GetTrigger() const {
-	return trigger;
+RPG::EventPage::Trigger Game_Event::GetTrigger() const {
+	return static_cast<RPG::EventPage::Trigger>(trigger);
 }
 
 void Game_Event::SetActive(bool active) {

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -52,11 +52,6 @@ public:
 	/** @} */
 
 	/**
-	 * Clears starting flag.
-	 */
-	void ClearStarting();
-
-	/**
 	 * Does refresh.
 	 */
 	void Refresh();
@@ -78,12 +73,11 @@ public:
 	 */
 	std::string GetName() const;
 
-	/**
-	 * Gets starting flag.
-	 *
-	 * @return starting flag.
-	 */
-	bool GetStarting() const;
+	/** Clears waiting_execution flag */
+	void ClearWaitingForegroundExecution();
+
+	/** @return waiting_execution flag.  */
+	bool IsWaitingForegroundExecution() const;
 
 	/**
 	 * If the event is starting, whether or not it was started
@@ -108,21 +102,18 @@ public:
 	const std::vector<RPG::EventCommand>& GetList() const;
 
 	/**
-	 * Event's sprite looks towards the hero but its original direction is remembered.
-	 */
-	void StartTalkToHero();
-
-	/**
 	 * Event returns to its original direction before talking to the hero.
 	 */
 	void OnFinishForegroundEvent();
+
+	/** Mark the event as waiting for execution */
+	bool SetAsWaitingForegroundExecution(bool face_hero, bool triggered_by_decision_key);
 
 	/** Update this for the current frame */
 	void Update();
 
 	void CheckEventTriggers();
 	bool CheckEventTriggerTouch(int x, int y) override;
-	void Start(bool triggered_by_decision_key = false);
 	void UpdateParallel();
 	bool AreConditionsMet(const RPG::EventPage& page);
 
@@ -216,16 +207,12 @@ private:
 	// reference.
 	std::unique_ptr<RPG::SaveMapEvent> _data_copy;
 
-	bool starting = false, running = false, halting = false;
 	int trigger = -1;
 	RPG::Event event;
 	const RPG::EventPage* page = nullptr;
 	std::vector<RPG::EventCommand> list;
 	std::shared_ptr<Game_Interpreter> interpreter;
 	bool from_save;
-	bool updating = false;
-
-	int frame_count_at_last_auto_start_check = -1;
 };
 
 inline RPG::SaveMapEvent* Game_Event::data() {

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -115,7 +115,7 @@ public:
 	/**
 	 * Event returns to its original direction before talking to the hero.
 	 */
-	void StopTalkToHero();
+	void OnFinishForegroundEvent();
 
 	/** Update this for the current frame */
 	void Update();

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -118,20 +118,6 @@ public:
 	bool AreConditionsMet(const RPG::EventPage& page);
 
 	/**
-	 * Activates or deactivates the event.
-	 *
-	 * @param active enables or disables the event.
-	 */
-	void SetActive(bool active);
-
-	/**
-	 * Gets if the event is active.
-	 *
-	 * @return if the event is active (or inactive via EraseEvent-EventCommand).
-	 */
-	bool GetActive() const;
-
-	/**
 	 * Returns current index of a "Movement Type Custom" move route.
 	 *
 	 * @return current original move route index

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -217,7 +217,6 @@ private:
 	std::unique_ptr<RPG::SaveMapEvent> _data_copy;
 
 	bool starting = false, running = false, halting = false;
-	bool started_by_decision_key = false;
 	int trigger = -1;
 	RPG::Event event;
 	const RPG::EventPage* page = nullptr;

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -98,7 +98,7 @@ public:
 	 *
 	 * @return trigger condition.
 	 */
-	int GetTrigger() const;
+	RPG::EventPage::Trigger GetTrigger() const;
 
 	/**
 	 * Gets event commands list.

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -548,7 +548,7 @@ bool Game_Interpreter::CommandEnd() { // code 10
 	if (main_flag && depth == 0 && event_id > 0) {
 		Game_Event* evnt = Game_Map::GetEvent(event_id);
 		if (evnt)
-			evnt->StopTalkToHero();
+			evnt->OnFinishForegroundEvent();
 	}
 
 	Scene::instance->onCommandEnd();

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -260,6 +260,10 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 	}
 
 	updating = false;
+
+	if (Game_Map::GetNeedRefresh()) {
+		Game_Map::Refresh();
+	}
 }
 
 // Setup Starting Event

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -142,11 +142,18 @@ void Game_Interpreter::SetContinuation(Game_Interpreter::ContinuationFunction fu
 	continuation = func;
 }
 
+bool Game_Interpreter::ReachedLoopLimit() const {
+	return loop_count >= 10000;
+}
+
 // Update
-void Game_Interpreter::Update() {
+void Game_Interpreter::Update(bool reset_loop_count) {
 	updating = true;
 	// 10000 based on: https://gist.github.com/4406621
-	for (loop_count = 0; loop_count < 10000; ++loop_count) {
+	if (reset_loop_count) {
+		loop_count = 0;
+	}
+	for (; loop_count < 10000; ++loop_count) {
 		/* If map is different than event startup time
 		set event_id to 0 */
 		if (Game_Map::GetMapId() != map_id) {
@@ -261,7 +268,6 @@ void Game_Interpreter::Setup(Game_Event* ev) {
 	event_info.x = ev->GetX();
 	event_info.y = ev->GetY();
 	event_info.page = ev->GetActivePage();
-	ev->ClearStarting();
 }
 
 void Game_Interpreter::Setup(Game_CommonEvent* ev, int caller_id) {

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -53,6 +53,7 @@ public:
 	void Clear();
 
 	bool IsRunning() const;
+	int GetLoopCount() const;
 	bool ReachedLoopLimit() const;
 	void Update(bool reset_loop_count=true);
 
@@ -252,6 +253,10 @@ protected:
 
 	static Scene::SceneType scene_call;
 };
+
+inline int Game_Interpreter::GetLoopCount() const {
+	return loop_count;
+}
 
 inline Scene::SceneType Game_Interpreter::GetSceneCalling() {
 	return scene_call;

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -53,7 +53,8 @@ public:
 	void Clear();
 
 	bool IsRunning() const;
-	void Update();
+	bool ReachedLoopLimit() const;
+	void Update(bool reset_loop_count=true);
 
 	void Setup(
 			const std::vector<RPG::EventCommand>& _list,

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -84,10 +84,6 @@ namespace {
 
 	int last_encounter_idx = 0;
 
-	// RPG_RT doesn't update player or vehicle movement or animation on the first frame
-	// of a new map. We use this flag to emulate that behavior.
-	bool first_frame = false;
-
 	//FIXME: Find a better way to do this.
 	bool reset_panorama_x_on_next_init = true;
 	bool reset_panorama_y_on_next_init = true;
@@ -149,7 +145,6 @@ void Game_Map::Quit() {
 
 void Game_Map::Setup(int _id) {
 	Dispose();
-	first_frame = true;
 	SetupCommon(_id, false);
 	map_info.encounter_rate = GetMapInfo().encounter_steps;
 	SetEncounterSteps(0);
@@ -617,7 +612,7 @@ bool Game_Map::MakeWay(int x, int y, int d, const Game_Character& self, bool for
 			&& !Main_Data::game_player->GetThrough()
 			&& self.GetLayer() == RPG::EventPage::Layers_same) {
 		// Update the Player to see if they'll move and recheck.
-		Main_Data::game_player->Update(!first_frame);
+		Main_Data::game_player->Update();
 		if (Main_Data::game_player->IsInPosition(new_x, new_y)) {
 			return false;
 		}
@@ -909,7 +904,7 @@ int Game_Map::CheckEvent(int x, int y) {
 	return 0;
 }
 
-void Game_Map::Update(bool only_parallel) {
+void Game_Map::Update(bool is_preupdate) {
 	if (GetNeedRefresh() != Refresh_None) Refresh();
 	Parallax::Update();
 	if (animation) {
@@ -937,15 +932,16 @@ void Game_Map::Update(bool only_parallel) {
 		ev.Update();
 	}
 
-	if (only_parallel)
+	if (is_preupdate) {
 		return;
+	}
 
-	Main_Data::game_player->Update(!first_frame);
+	Main_Data::game_player->Update();
 	UpdatePan();
 
 	for (auto& vehicle: vehicles) {
 		if (vehicle->GetMapId() == location.map_id) {
-			vehicle->Update(!first_frame);
+			vehicle->Update();
 		}
 	}
 
@@ -997,8 +993,6 @@ void Game_Map::Update(bool only_parallel) {
 	}
 
 	free_interpreters.clear();
-
-	first_frame = false;
 }
 
 RPG::MapInfo const& Game_Map::GetMapInfo() {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -934,17 +934,17 @@ void Game_Map::Update(bool only_parallel) {
 		ev.CheckEventTriggers();
 	}
 
-	Main_Data::game_player->Update(!first_frame);
-	UpdatePan();
-	GetInterpreter().Update();
+	for (Game_CommonEvent& ev : common_events) {
+		ev.Update();
+	}
 
 	for (Game_Event& ev : events) {
 		ev.Update();
 	}
 
-	for (Game_CommonEvent& ev : common_events) {
-		ev.Update();
-	}
+	Main_Data::game_player->Update(!first_frame);
+	UpdatePan();
+	GetInterpreter().Update();
 
 	for (auto& vehicle: vehicles) {
 		if (vehicle->GetMapId() == location.map_id) {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -981,9 +981,13 @@ void Game_Map::Update(bool is_preupdate) {
 			}
 		}
 		if (run_ev) {
-			interp.Setup(run_ev);
+			if (run_ev->IsActive()) {
+				interp.Setup(run_ev);
+			}
 			run_ev->ClearWaitingForegroundExecution();
-			interp.Update(false);
+			if (run_ev->IsActive()) {
+				interp.Update(false);
+			}
 			if (interp.IsRunning()) {
 				break;
 			}

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -930,7 +930,7 @@ void Game_Map::Update(bool only_parallel) {
 	}
 
 	for (Game_CommonEvent& ev : common_events) {
-		ev.UpdateParallel();
+		ev.Update();
 	}
 
 	for (Game_Event& ev : events) {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -919,6 +919,16 @@ void Game_Map::Update(bool only_parallel) {
 		}
 	}
 
+	for (Game_Event& ev : events) {
+		ev.SetProcessed(false);
+	}
+	Main_Data::game_player->SetProcessed(false);
+	for (auto& vehicle: vehicles) {
+		if (vehicle->GetMapId() == location.map_id) {
+			vehicle->SetProcessed(false);
+		}
+	}
+
 	for (Game_CommonEvent& ev : common_events) {
 		ev.UpdateParallel();
 	}

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -571,14 +571,14 @@ static CollisionResult TestCollisionDuringMove(
 	return NoCollision;
 }
 
-bool Game_Map::MakeWay(int x, int y, int d, const Game_Character& self, bool force_through) {
+bool Game_Map::MakeWay(int x, int y, int d, const Game_Character& self) {
 	int new_x = RoundX(x + (d == Game_Character::Right ? 1 : d == Game_Character::Left ? -1 : 0));
 	int new_y = RoundY(y + (d == Game_Character::Down ? 1 : d == Game_Character::Up ? -1 : 0));
 
 	if (!Game_Map::IsValid(new_x, new_y))
 		return false;
 
-	if (self.GetThrough() || force_through) return true;
+	if (self.GetThrough()) return true;
 
 	// A character can move to a position with an impassable tile by
 	// standing on top of an event below it. These flags track whether

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -954,6 +954,12 @@ void Game_Map::Update(bool only_parallel) {
 	// Run any event loaded from last frame.
 	interp.Update(true);
 	while (!interp.IsRunning() && !interp.ReachedLoopLimit()) {
+		// This logic is probably one big loop in RPG_RT. We have to replicate
+		// it here because once we stop executing from this we should not
+		// clear anymore waiting flags.
+		if (interp.IsImmediateCall() && interp.GetLoopCount() > 0) {
+			break;
+		}
 		Game_CommonEvent* run_ce = nullptr;
 
 		for (auto& ce: common_events) {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -527,7 +527,7 @@ static CollisionResult TestCollisionDuringMove(
 	const Game_Character& self,
 	const Game_Event& other
 ) {
-	if (!other.GetActive()) {
+	if (!other.IsActive()) {
 		return NoCollision;
 	}
 
@@ -856,7 +856,7 @@ bool Game_Map::AirshipLandOk(int const x, int const y) {
 
 void Game_Map::GetEventsXY(std::vector<Game_Event*>& events, int x, int y) {
 	for (Game_Event& ev : GetEvents()) {
-		if (ev.IsInPosition(x, y) && ev.GetActive()) {
+		if (ev.IsInPosition(x, y) && ev.IsActive()) {
 			events.push_back(&ev);
 		}
 	}
@@ -1398,7 +1398,7 @@ Game_Vehicle* Game_Map::GetVehicle(Game_Vehicle::Type which) {
 
 bool Game_Map::IsAnyEventStarting() {
 	for (Game_Event& ev : events)
-		if (ev.IsWaitingForegroundExecution() && !ev.GetList().empty() && ev.GetActive())
+		if (ev.IsWaitingForegroundExecution() && !ev.GetList().empty() && ev.IsActive())
 			return true;
 
 	for (Game_CommonEvent& ev : common_events)

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -233,9 +233,9 @@ namespace Game_Map {
 	/**
 	 * Updates the map state.
 	 *
-	 * @param only_parallel Update only parallel interpreters
+	 * @param is_preupdate Update only common events and map events
 	 */
-	void Update(bool only_parallel = false);
+	void Update(bool is_preupdate = false);
 
 	/**
 	 * Gets current map_info.

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -148,10 +148,9 @@ namespace Game_Map {
 	 * @param y tile y.
 	 * @param d direction
 	 * @param self Character to move.
-	 * @param force_through act as if self.SetThrough() == true
 	 * @return whether is passable.
 	 */
-	bool MakeWay(int x, int y, int d, const Game_Character& self, bool force_through);
+	bool MakeWay(int x, int y, int d, const Game_Character& self);
 
 	/**
 	 * Gets if a tile coordinate is passable in a direction.

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -36,7 +36,7 @@
 #include <cmath>
 
 Game_Player::Game_Player():
-	Game_Character(&Main_Data::game_data.party_location)
+	Game_Character(Player, &Main_Data::game_data.party_location)
 {
 	SetDirection(RPG::EventPage::Direction_down);
 	SetMoveSpeed(4);

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -229,7 +229,7 @@ void Game_Player::UpdateSelfMovement() {
 
 }
 
-void Game_Player::Update(bool process_movement) {
+void Game_Player::Update() {
 	if (IsProcessed()) {
 		return;
 	}
@@ -245,40 +245,36 @@ void Game_Player::Update(bool process_movement) {
 
 	auto was_moving = !IsStopping();
 
-	if (process_movement) {
-		Game_Character::UpdateMovement();
-		Game_Character::UpdateAnimation(was_moving);
-	}
+	Game_Character::UpdateMovement();
+	Game_Character::UpdateAnimation(was_moving);
 
 	UpdateScroll(old_sprite_x, old_sprite_y);
 
 	if (IsMoving()) return;
 
-	if (process_movement) {
-		if (data()->boarding) {
-			// Boarding completed
-			data()->aboard = true;
-			data()->boarding = false;
-			auto* vehicle = GetVehicle();
-			if (vehicle->IsMoveRouteOverwritten()) {
-				vehicle->CancelMoveRoute();
-			}
-			SetMoveSpeed(vehicle->GetMoveSpeed());
-			vehicle->SetDirection(GetDirection());
-			vehicle->SetSpriteDirection(Left);
-			// Note: RPG_RT ignores the lock_facing flag here!
-			SetSpriteDirection(Left);
-			vehicle->SetX(GetX());
-			vehicle->SetY(GetY());
-			return;
+	if (data()->boarding) {
+		// Boarding completed
+		data()->aboard = true;
+		data()->boarding = false;
+		auto* vehicle = GetVehicle();
+		if (vehicle->IsMoveRouteOverwritten()) {
+			vehicle->CancelMoveRoute();
 		}
+		SetMoveSpeed(vehicle->GetMoveSpeed());
+		vehicle->SetDirection(GetDirection());
+		vehicle->SetSpriteDirection(Left);
+		// Note: RPG_RT ignores the lock_facing flag here!
+		SetSpriteDirection(Left);
+		vehicle->SetX(GetX());
+		vehicle->SetY(GetY());
+		return;
+	}
 
-		if (data()->unboarding) {
-			// Unboarding completed
-			data()->unboarding = false;
-			CheckTouchEvent();
-			return;
-		}
+	if (data()->unboarding) {
+		// Unboarding completed
+		data()->unboarding = false;
+		CheckTouchEvent();
+		return;
 	}
 
 	if (was_blocked) return;

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -39,7 +39,6 @@ Game_Player::Game_Player():
 	Game_Character(&Main_Data::game_data.party_location)
 {
 	SetDirection(RPG::EventPage::Direction_down);
-	SetProcessed(true); // RPG_RT compatibility
 	SetMoveSpeed(4);
 	SetAnimationType(RPG::EventPage::AnimType_non_continuous);
 }
@@ -231,12 +230,10 @@ void Game_Player::UpdateSelfMovement() {
 }
 
 void Game_Player::Update(bool process_movement) {
-	int cur_frame_count = Player::GetFrames();
-	// Only update the event once per frame
-	if (cur_frame_count == frame_count_at_last_update_parallel) {
+	if (IsProcessed()) {
 		return;
 	}
-	frame_count_at_last_update_parallel = cur_frame_count;
+	SetProcessed(true);
 
 	const bool last_moving = IsMoving() || IsJumping();
 

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -325,24 +325,22 @@ bool Game_Player::CheckCollisionEvent() {
 	return CheckEventTriggerHere({RPG::EventPage::Trigger_collision});
 }
 
-bool Game_Player::CheckEventTriggerHere(const std::vector<int>& triggers, bool triggered_by_decision_key) {
+bool Game_Player::CheckEventTriggerHere(TriggerSet triggers, bool triggered_by_decision_key) {
 	bool result = false;
 
 	std::vector<Game_Event*> events;
 	Game_Map::GetEventsXY(events, GetX(), GetY());
 
-	std::vector<Game_Event*>::iterator i;
-	for (i = events.begin(); i != events.end(); ++i) {
-		if (((*i)->GetLayer() != RPG::EventPage::Layers_same)
-			&& std::find(triggers.begin(), triggers.end(), (*i)->GetTrigger() ) != triggers.end() ) {
-			(*i)->Start(triggered_by_decision_key);
-			result = (*i)->GetStarting();
+	for (auto* ev: events) {
+		if (ev->GetLayer() != RPG::EventPage::Layers_same && triggers[ev->GetTrigger()]) {
+			ev->Start(triggered_by_decision_key);
+			result = ev->GetStarting();
 		}
 	}
 	return result;
 }
 
-bool Game_Player::CheckEventTriggerThere(const std::vector<int>& triggers, bool triggered_by_decision_key) {
+bool Game_Player::CheckEventTriggerThere(TriggerSet triggers, bool triggered_by_decision_key) {
 	if ( Game_Map::GetInterpreter().IsRunning() ) return false;
 
 	bool result = false;
@@ -354,10 +352,7 @@ bool Game_Player::CheckEventTriggerThere(const std::vector<int>& triggers, bool 
 	Game_Map::GetEventsXY(events, front_x, front_y);
 
 	for (const auto& ev : events) {
-		if ( ev->GetLayer() == RPG::EventPage::Layers_same &&
-			std::find(triggers.begin(), triggers.end(), ev->GetTrigger() ) != triggers.end()
-		)
-		{
+		if ( ev->GetLayer() == RPG::EventPage::Layers_same && triggers[ev->GetTrigger()]) {
 			if (!ev->GetList().empty()) {
 				ev->StartTalkToHero();
 			}
@@ -373,10 +368,7 @@ bool Game_Player::CheckEventTriggerThere(const std::vector<int>& triggers, bool 
 		Game_Map::GetEventsXY(events, front_x, front_y);
 
 		for (const auto& ev : events) {
-			if ( ev->GetLayer() == 1 &&
-				std::find(triggers.begin(), triggers.end(), ev->GetTrigger() ) != triggers.end()
-			)
-			{
+			if ( ev->GetLayer() == RPG::EventPage::Layers_same && triggers[ev->GetTrigger()]) {
 				if (!ev->GetList().empty()) {
 					ev->StartTalkToHero();
 				}

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -330,8 +330,7 @@ bool Game_Player::CheckEventTriggerHere(TriggerSet triggers, bool triggered_by_d
 
 	for (auto* ev: events) {
 		if (ev->GetLayer() != RPG::EventPage::Layers_same && triggers[ev->GetTrigger()]) {
-			ev->Start(triggered_by_decision_key);
-			result = ev->GetStarting();
+			result |= ev->SetAsWaitingForegroundExecution(true, triggered_by_decision_key);
 		}
 	}
 	return result;
@@ -350,11 +349,7 @@ bool Game_Player::CheckEventTriggerThere(TriggerSet triggers, bool triggered_by_
 
 	for (const auto& ev : events) {
 		if ( ev->GetLayer() == RPG::EventPage::Layers_same && triggers[ev->GetTrigger()]) {
-			if (!ev->GetList().empty()) {
-				ev->StartTalkToHero();
-			}
-			ev->Start(triggered_by_decision_key);
-			result = true;
+			result |= ev->SetAsWaitingForegroundExecution(true, triggered_by_decision_key);
 		}
 	}
 
@@ -366,11 +361,7 @@ bool Game_Player::CheckEventTriggerThere(TriggerSet triggers, bool triggered_by_
 
 		for (const auto& ev : events) {
 			if ( ev->GetLayer() == RPG::EventPage::Layers_same && triggers[ev->GetTrigger()]) {
-				if (!ev->GetList().empty()) {
-					ev->StartTalkToHero();
-				}
-				ev->Start(triggered_by_decision_key);
-				result = true;
+				result |= ev->SetAsWaitingForegroundExecution(true, triggered_by_decision_key);
 			}
 		}
 	}
@@ -389,11 +380,7 @@ bool Game_Player::CheckEventTriggerTouch(int x, int y) {
 		if (ev->GetLayer() == RPG::EventPage::Layers_same &&
 			(ev->GetTrigger() == RPG::EventPage::Trigger_touched ||
 			ev->GetTrigger() == RPG::EventPage::Trigger_collision) ) {
-			if (!ev->GetList().empty()) {
-				ev->StartTalkToHero();
-			}
-			ev->Start();
-			result = true;
+			result |= ev->SetAsWaitingForegroundExecution(true, false);
 
 		}
 	}

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -22,6 +22,7 @@
 #include "rpg_music.h"
 #include "rpg_savepartylocation.h"
 #include "game_character.h"
+#include "flag_set.h"
 #include <vector>
 
 class Game_Vehicle;
@@ -103,6 +104,7 @@ protected:
 	RPG::SavePartyLocation* data();
 	const RPG::SavePartyLocation* data() const;
 private:
+	using TriggerSet = FlagSet<RPG::EventPage::Trigger>;
 
 	bool teleporting = false;
 	int new_map_id = 0, new_x = 0, new_y = 0, new_direction = 0;
@@ -112,8 +114,8 @@ private:
 	bool CheckTouchEvent();
 	bool CheckCollisionEvent();
 	bool CheckActionEvent();
-	bool CheckEventTriggerHere(const std::vector<int>& triggers, bool triggered_by_decision_key = false);
-	bool CheckEventTriggerThere(const std::vector<int>& triggers, bool triggered_by_decision_key = false);
+	bool CheckEventTriggerHere(TriggerSet triggers, bool triggered_by_decision_key = false);
+	bool CheckEventTriggerThere(TriggerSet triggers, bool triggered_by_decision_key = false);
 	bool GetOnVehicle();
 	bool GetOffVehicle();
 	void Unboard();

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -88,9 +88,6 @@ public:
 	Game_Vehicle* GetVehicle() const;
 	bool CanWalk(int x, int y);
 
-	/** Workaround used to avoid blocking the player with move routes that are completeable in a single frame */
-	bool IsBlockedByMoveRoute() const;
-
 	/**
 	 * Callback function invoked by the Vehicle to notify that the unboarding has finished
 	 */

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -66,12 +66,8 @@ public:
 	void PerformTeleport();
 	void MoveTo(int x, int y) override;
 
-	/** 
-	 * Update this for the current frame
-	 *
-	 * @param process_movement if false, we will not process movement or animations
-	 * */
-	void Update(bool process_movement);
+	/** Update this for the current frame */
+	void Update();
 
 	void Refresh();
 

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -284,10 +284,7 @@ void Game_Vehicle::UpdateAnimationShip() {
 	}
 }
 
-void Game_Vehicle::Update(bool process_movement) {
-	if (!process_movement) {
-		return;
-	}
+void Game_Vehicle::Update() {
 	if (IsProcessed()) {
 		return;
 	}

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -48,7 +48,7 @@ static RPG::SaveVehicleLocation* getDataFromType(Game_Vehicle::Type ty) {
 }
 
 Game_Vehicle::Game_Vehicle(Type _type) :
-	Game_Character(getDataFromType(_type))
+	Game_Character(Vehicle, getDataFromType(_type))
 {
 	type = _type;
 	SetDirection(Left);

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -127,7 +127,6 @@ void Game_Vehicle::Refresh() {
 	if (IsInUse()) {
 		SetMapId(Game_Map::GetMapId());
 	} else if (IsInCurrentMap()) {
-		SetProcessed(true); // RPG_RT compatibility
 		MoveTo(GetX(), GetY());
 	}
 
@@ -286,10 +285,13 @@ void Game_Vehicle::UpdateAnimationShip() {
 }
 
 void Game_Vehicle::Update(bool process_movement) {
-
 	if (!process_movement) {
 		return;
 	}
+	if (IsProcessed()) {
+		return;
+	}
+	SetProcessed(true);
 
 	if (IsAboard()) {
 		SyncWithPlayer();

--- a/src/game_vehicle.h
+++ b/src/game_vehicle.h
@@ -48,12 +48,8 @@ public:
 	int GetVehicleType() const override;
 	/** @} */
 
-	/** 
-	 * Update this for the current frame
-	 *
-	 * @param process_movement if false, we will not process movement or animations
-	 * */
-	void Update(bool process_movement);
+	/** Update this for the current frame */
+	void Update();
 
 	void LoadSystemSettings();
 	RPG::Music& GetBGM();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -306,7 +306,11 @@ void Player::Update(bool update_scene) {
 	int speed_modifier = GetSpeedModifier();
 
 	for (int i = 0; i < speed_modifier; ++i) {
+		bool was_transition_pending = Graphics::IsTransitionPending();
 		Graphics::Update();
+		if (was_transition_pending && !Graphics::IsTransitionPending() && Scene::instance->IsInitialized()) {
+			Scene::instance->OnTransitionFinish();
+		}
 		if (update_scene) {
 			Scene::instance->Update();
 			++frames;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -308,6 +308,8 @@ void Player::Update(bool update_scene) {
 	for (int i = 0; i < speed_modifier; ++i) {
 		bool was_transition_pending = Graphics::IsTransitionPending();
 		Graphics::Update();
+		// This is used to provide a hook for Scene_Map to finish
+		// it's PreUpdate() logic after transition.
 		if (was_transition_pending && !Graphics::IsTransitionPending() && Scene::instance->IsInitialized()) {
 			Scene::instance->OnTransitionFinish();
 		}

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -144,6 +144,9 @@ void Scene::TransitionOut() {
 	Graphics::GetTransition().Init(Transition::TransitionFadeOut, this, 6, true);
 }
 
+void Scene::OnTransitionFinish() {
+}
+
 void Scene::Update() {
 }
 

--- a/src/scene.h
+++ b/src/scene.h
@@ -117,6 +117,11 @@ public:
 	virtual void TransitionOut();
 
 	/**
+	 * Called when a transition is finished and scene has been initialized
+	 */
+	virtual void OnTransitionFinish();
+
+	/**
 	 * Called every frame.
 	 * The scene should redraw all elements.
 	 */
@@ -175,6 +180,9 @@ public:
 	/** Called by the interpreter when an event finishes processing */
 	virtual void onCommandEnd() {}
 
+	/** @return true if the Scene has been initialized */
+	bool IsInitialized() const;
+
 private:
 	/** Scene stack. */
 	static std::vector<std::shared_ptr<Scene> > instances;
@@ -195,5 +203,9 @@ private:
 
 	static void DebugValidate(const char* caller);
 };
+
+inline bool Scene::IsInitialized() const {
+	return initialized;
+}
 
 #endif

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -62,7 +62,7 @@ void Scene_Map::Start() {
 
 	Player::FrameReset();
 
-	Game_Map::Update(true);
+	PreUpdate();
 	spriteset->Update();
 }
 
@@ -109,10 +109,23 @@ void Scene_Map::TransitionOut() {
 	}
 }
 
+void Scene_Map::OnTransitionFinish() {
+	if (do_preupdate) {
+		UpdateSceneCalling();
+		do_preupdate = false;
+	}
+}
+
 void Scene_Map::DrawBackground() {
 	if (spriteset->RequireBackground(GetGraphicsState().drawable_list)) {
 		DisplayUi->CleanDisplay();
 	}
+}
+
+void Scene_Map::PreUpdate() {
+	Game_Map::Update(true);
+	// Tells the next OnTransitionFinish() to allow scene changes.
+	do_preupdate = true;
 }
 
 void Scene_Map::Update() {
@@ -153,7 +166,10 @@ void Scene_Map::Update() {
 	message_window->Update();
 
 	StartTeleportPlayer();
+	UpdateSceneCalling();
+}
 
+void Scene_Map::UpdateSceneCalling() {
 	if (Game_Temp::gameover) {
 		Game_Temp::gameover = false;
 		Scene::Push(std::make_shared<Scene_Gameover>());

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -42,6 +42,7 @@ public:
 	void Resume() override;
 	void TransitionIn() override;
 	void TransitionOut() override;
+	void OnTransitionFinish() override;
 	void DrawBackground() override;
 
 	void CallBattle();
@@ -57,12 +58,15 @@ public:
 private:
 	void StartTeleportPlayer();
 	void FinishTeleportPlayer();
+	void PreUpdate();
+	void UpdateSceneCalling();
 
 	std::unique_ptr<Window_Message> message_window;
 
 	bool from_save;
 	bool auto_transition = false;
 	bool auto_transition_erase = false;
+	bool do_preupdate = false;
 	int debug_menuoverwrite_counter = 0;
 };
 


### PR DESCRIPTION
The PR refactors a number of interpreter and event related items

* Adds support for `triggered_by_decision_key` chunk
* Adds support for `pause` chunk
* Adds support for `waiting_execution` chunk
* Adds support for `processed` chunk
* Fixes the execution order of event update routines to match RPG_RT.
* Correctly handles "PreUpdate" which is the partial update routine done at startup which only updates events but not player or vehicles. This also happens when you teleport or use escape/teleport from the menu. *I haven't addressed the teleport PreUpdate() cases yet and may not do so in this PR*.

Fix: #1623 
Fix: #1247
Fix: #1595 
Fix: #663
Fix: #1664

Breaks: #937