### PR TITLE
Make RTP warnings more noticeable

### DIFF
--- a/resources/easyrpg-player.6.adoc
+++ b/resources/easyrpg-player.6.adoc
@@ -28,7 +28,8 @@ for some additional binary patches.
   Disable audio (in case you prefer your own music).
 
 *--disable-rtp*::
-  Disable support for the Runtime Package (RTP).
+  Disable support for the Runtime Package (RTP). Will lead to checkerboard
+  graphics and silent music/sound effects in games depending on the RTP.
 
 *--encoding* 'ENCODING'::
   Instead of auto detecting the encoding or using the one in RPG_RT.ini, the

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -225,12 +225,8 @@ namespace {
 			std::string msg = "Cannot find: %s/%s. " + std::string(search_paths.empty() ?
 				"Install RTP %d to resolve this warning." : "RTP %d was probably not installed correctly.");
 
-			Output::Warning(msg.c_str(),
-				dir.c_str(), name.c_str(), Player::IsRPG2k() ? 2000 : 2003);
+			Output::Warning(msg.c_str(), dir.c_str(), rtp_name.c_str(), Player::EngineVersion());
 		}
-
-		Output::Debug("Cannot find: %s/%s (%s)", dir.c_str(), name.c_str(),
-						name == rtp_name ? "!" : rtp_name.c_str());
 
 		return std::string();
 	}
@@ -476,11 +472,7 @@ void FileFinder::InitRtpPaths(bool no_rtp) {
 		return;
 	}
 
-	std::string const version_str =
-		Player::IsRPG2k() ? "2000" :
-		Player::IsRPG2k3() ? "2003" :
-		"";
-
+	std::string const version_str =	Player::GetEngineVersion();
 	assert(!version_str.empty());
 
 #ifdef GEKKO

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -42,9 +42,9 @@ namespace FileFinder {
 	/**
 	 * Adds RTP paths to the file finder
 	 *
-	 * @param warn_no_rtp_found Emits a warning on screen when no RTP was found.
+	 * @param disable_rtp When true disables RTP handling in the FileFinder
 	 */
-	void InitRtpPaths(bool warn_no_rtp_found = true);
+	void InitRtpPaths(bool disable_rtp = false);
 
 	/**
 	 * Quits FileFinder.

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -43,8 +43,9 @@ namespace FileFinder {
 	 * Adds RTP paths to the file finder
 	 *
 	 * @param disable_rtp When true disables RTP handling in the FileFinder
+	 * @param disable_warnings When true disables warnings about missing RTP files
 	 */
-	void InitRtpPaths(bool disable_rtp = false);
+	void InitRtpPaths(bool disable_rtp = false, bool disable_warnings = false);
 
 	/**
 	 * Quits FileFinder.

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -685,9 +685,7 @@ void Player::CreateGameObjects() {
 	}
 	Output::Debug("Engine configured as: 2k=%d 2k3=%d 2k3Legacy=%d MajorUpdated=%d Eng=%d", Player::IsRPG2k(), Player::IsRPG2k3(), Player::IsRPG2k3Legacy(), Player::IsMajorUpdatedVersion(), Player::IsEnglish());
 
-	if (!no_rtp_flag) {
-		FileFinder::InitRtpPaths();
-	}
+	FileFinder::InitRtpPaths(no_rtp_flag);
 
 	ResetGameObjects();
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1012,13 +1012,11 @@ bool Player::IsMajorUpdatedVersion() {
 }
 
 bool Player::IsRPG2k3E() {
-	return ((engine & EngineRpg2k3) == EngineRpg2k3)
-		&& ((engine & EngineEnglish) == EngineEnglish);
+	return (IsRPG2k3() && IsEnglish());
 }
 
 bool Player::IsRPG2kE() {
-	return ((engine & EngineRpg2k) == EngineRpg2k)
-		&& ((engine & EngineEnglish) == EngineEnglish);
+	return (IsRPG2k() && IsEnglish());
 }
 
 bool Player::IsEnglish() {
@@ -1044,11 +1042,21 @@ bool Player::IsCP936() {
 }
 
 bool Player::IsCJK() {
-	return (IsCP932() || IsCP949() ||
-			IsBig5() || IsCP936());
+	return (IsCP932() || IsCP949() || IsBig5() || IsCP936());
 }
 
 bool Player::IsCP1251() {
 	return (encoding == "ibm-5347_P100-1998" ||
 			encoding == "windows-1251" || encoding == "1251");
+}
+
+int Player::EngineVersion() {
+	if (IsRPG2k3()) return 2003;
+	if (IsRPG2k()) return 2000;
+	return 0;
+}
+
+std::string Player::GetEngineVersion() {
+	if (EngineVersion() > 0) return std::to_string(EngineVersion());
+	return std::string();
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -625,13 +625,14 @@ void Player::CreateGameObjects() {
 
 	LoadDatabase();
 
+	bool no_rtp_warning_flag = false;
 	std::string ini_file = FileFinder::FindDefault(INI_NAME);
 
 	INIReader ini(ini_file);
 	if (ini.ParseError() != -1) {
-		std::string title = ini.Get("RPG_RT", "GameTitle", GAME_TITLE);
+		std::string title = ini.GetString("RPG_RT", "GameTitle", "");
 		game_title = ReaderUtil::Recode(title, encoding);
-		no_rtp_flag = ini.Get("RPG_RT", "FullPackageFlag", "0") == "1"? true : no_rtp_flag;
+		no_rtp_warning_flag = ini.GetBoolean("RPG_RT", "FullPackageFlag", false);
 	}
 
 	std::stringstream title;
@@ -643,6 +644,10 @@ void Player::CreateGameObjects() {
 	}
 	title << GAME_TITLE;
 	DisplayUi->SetTitle(title.str());
+
+	if (no_rtp_warning_flag) {
+		Output::Debug("Game does not need RTP (FullPackageFlag=1)");
+	}
 
 	if (engine == EngineNone) {
 		if (Data::system.ldb_id == 2003) {
@@ -685,7 +690,7 @@ void Player::CreateGameObjects() {
 	}
 	Output::Debug("Engine configured as: 2k=%d 2k3=%d 2k3Legacy=%d MajorUpdated=%d Eng=%d", Player::IsRPG2k(), Player::IsRPG2k3(), Player::IsRPG2k3Legacy(), Player::IsMajorUpdatedVersion(), Player::IsEnglish());
 
-	FileFinder::InitRtpPaths(no_rtp_flag);
+	FileFinder::InitRtpPaths(no_rtp_flag, no_rtp_warning_flag);
 
 	ResetGameObjects();
 }

--- a/src/player.h
+++ b/src/player.h
@@ -205,6 +205,12 @@ namespace Player {
 	bool IsCP1251();
 
 	/**
+	 * @return Running engine version. 2000 for RPG2k and 2003 for RPG2k3
+	 */
+	int EngineVersion();
+	std::string GetEngineVersion();
+
+	/**
 	 * @return Returns how fast EasyRPG currently runs (1: Normal speed, 2: double speed, 5: 5x speed, ...)
 	 */
 	int GetSpeedModifier();


### PR DESCRIPTION
By telling the user everytime a RTP asset is missing. Sound and Music is also a visual warning, because we got already many reports that our Player fails to play sound...
Additionally when the RTP is not installed and the game never uses the RTP (but has no fullpackageflag=1) the user won't receive this annoying warning on startup.

Is kinda-RFC, maybe you have a better idea.

Also pretty sure I fixed a bug because search_paths.clear(); was not called when the game loaded has FullPackageFlag=1

![a-fs8](https://user-images.githubusercontent.com/1331889/52535342-7dee1f00-2d4d-11e9-998a-29276ff0d8e1.png)

Fixes #1274.