### PR TITLE
Refactor move type random

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -474,15 +474,15 @@ void Game_Character::Turn(int dir) {
 }
 
 void Game_Character::Turn90DegreeLeft() {
-	Turn((GetSpriteDirection() + 3) % 4);
+	Turn(GetDirection90DegreeLeft(GetSpriteDirection()));
 }
 
 void Game_Character::Turn90DegreeRight() {
-	Turn((GetSpriteDirection() + 1) % 4);
+	Turn(GetDirection90DegreeRight(GetSpriteDirection()));
 }
 
 void Game_Character::Turn180Degree() {
-	Turn((GetSpriteDirection() + 2) % 4);
+	Turn(GetDirection180Degree(GetSpriteDirection()));
 }
 
 void Game_Character::Turn90DegreeLeftOrRight() {
@@ -876,18 +876,15 @@ int Game_Character::ReverseDir(int dir) {
 }
 
 void Game_Character::SetMaxStopCountForStep() {
-	const auto freq = GetMoveFrequency();
-	SetMaxStopCount(freq >= 8 ? 0 : 1 << (9 - freq));
+	SetMaxStopCount(GetMaxStopCountForStep(GetMoveFrequency()));
 }
 
 void Game_Character::SetMaxStopCountForTurn() {
-	const auto freq = GetMoveFrequency();
-	SetMaxStopCount(freq >= 8 ? 0 : 1 << (8 - freq));
+	SetMaxStopCount(GetMaxStopCountForTurn(GetMoveFrequency()));
 }
 
 void Game_Character::SetMaxStopCountForWait() {
-	const auto freq = GetMoveFrequency();
-	SetMaxStopCount(20 + (freq >= 8 ? 0 : 1 << (8 - freq)));
+	SetMaxStopCount(GetMaxStopCountForWait(GetMoveFrequency()));
 }
 
 bool Game_Character::IsMoveRouteActive() const {

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -374,6 +374,24 @@ public:
 	int GetMaxStopCount() const;
 
 	/**
+	 * @return stepping max_stop_count for the given frequency
+	 * @param freq input movement frequency
+	 */
+	static constexpr int GetMaxStopCountForStep(int freq);
+
+	/**
+	 * @return turning max_stop_count for the given frequency
+	 * @param freq input movement frequency
+	 */
+	constexpr int GetMaxStopCountForTurn(int freq);
+
+	/**
+	 * @return waiting max_stop_count for the given frequency
+	 * @param freq input movement frequency
+	 */
+	constexpr int GetMaxStopCountForWait(int freq);
+
+	/**
 	 * Sets the max_stop_count
 	 *
 	 * @param sc the new max stop count
@@ -584,6 +602,26 @@ public:
 	/** @return the direction we would need to face away from hero. */
 	int GetDirectionAwayHero();
 
+	/**
+	 * @param dir input direction
+	 *
+	 * @return the direction 90 degrees to the left of dir
+	 */
+	static constexpr int GetDirection90DegreeLeft(int dir);
+
+	/**
+	 * @param dir input direction
+	 *
+	 * @return the direction 90 degrees to the right of dir
+	 */
+	static constexpr int GetDirection90DegreeRight(int dir);
+
+	/**
+	 * @param dir input direction
+	 *
+	 * @return the direction 180 degrees to the of dir
+	 */
+	static constexpr int GetDirection180Degree(int dir);
 
 	/**
 	 * Character looks in a random direction
@@ -1160,6 +1198,30 @@ inline bool Game_Character::HasTileSprite() const {
 
 inline void Game_Character::SetVisible(bool visible) {
 	this->visible = visible;
+}
+
+constexpr int Game_Character::GetDirection90DegreeLeft(int dir) {
+	return (dir + 3) % 4;
+}
+
+constexpr int Game_Character::GetDirection90DegreeRight(int dir) {
+	return (dir + 1) % 4;
+}
+
+constexpr int Game_Character::GetDirection180Degree(int dir) {
+	return (dir + 2) % 4;
+}
+
+constexpr int Game_Character::GetMaxStopCountForStep(int freq) {
+	return freq >= 8 ? 0 : 1 << (9 - freq);
+}
+
+constexpr int Game_Character::GetMaxStopCountForTurn(int freq) {
+	return freq >= 8 ? 0 : 1 << (8 - freq);
+}
+
+constexpr int Game_Character::GetMaxStopCountForWait(int freq) {
+	return 20 + GetMaxStopCountForTurn(freq);
 }
 
 #endif

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -409,26 +409,28 @@ void Game_Event::UpdateSelfMovement() {
 }
 
 void Game_Event::MoveTypeRandom() {
-	int last_direction = GetDirection();
-	switch (Utils::GetRandomNumber(0, 5)) {
-	case 0:
-		SetStopCount(GetStopCount() - Utils::GetRandomNumber(0, GetStopCount()));
-		if (GetStopCount() < 0) {
-			SetStopCount(0);
-		}
-		return;
-	case 1:
-		MoveForward();
-		break;
-	default:
-		MoveRandom();
-	}
-	if (move_failed) {
-		SetDirection(last_direction);
-		if (!(IsDirectionFixed() || IsFacingLocked()))
-			SetSpriteDirection(last_direction);
+	auto st = GetMaxStopCountForStep(GetMoveFrequency());
+	st *= (Utils::GetRandomNumber(0, 3) + 3) / 5;
+	SetMaxStopCount(st);
+
+	int draw = Utils::GetRandomNumber(0, 9);
+
+	const auto opt = MoveOption::IgnoreIfCantMove;
+
+	if (draw < 3) {
+		auto dir = GetDirection();
+		Move(dir, opt);
+	} else if (draw < 5) {
+		auto dir = GetDirection90DegreeLeft(GetDirection());
+		Move(dir, opt);
+	} else if (draw < 7) {
+		auto dir = GetDirection90DegreeRight(GetDirection());
+		Move(dir, opt);
+	} else if (draw < 8) {
+		auto dir = GetDirection180Degree(GetDirection());
+		Move(dir, opt);
 	} else {
-		SetMaxStopCount(GetMaxStopCount() / 5 * Utils::GetRandomNumber(3, 6));
+		SetStopCount(Utils::GetRandomNumber(0, GetMaxStopCount()));
 	}
 }
 


### PR DESCRIPTION
Fix #1638 

~~This is derived from what I've seen empirically, but the random algo may not be right.~~

The MV Algo of [0:1] Random, [2:4] Forward, [5] Reset is definately wrong.

~~I know for a fact we never reset stop count, but we do sometimes wait an extra frame.~~ The MV algo moves forward too much. This can be observed simply by watching an event walk around.