### PR TITLE
Battle 2k3: Bugfixes

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1359,12 +1359,23 @@ void Game_Actor::RemoveInvalidData() {
 		RPG::Item::Type_accessory
 	};
 
-	for (int i = 1; i <= 5; ++i) {
-		const RPG::Item* item = GetEquipment(i);
-		if (item && item->type != eq_types[i - 1]) {
-			Output::Debug("Actor %d: Removing invalid item %d (of type %d) from equipment slot %d (needs type %d)",
-			GetId(), item->ID, item->type, i, eq_types[i - 1]);
-			SetEquipment(i, 0);
+	auto& equipment = GetWholeEquipment();
+	for (size_t i = 0; i < equipment.size(); ++i) {
+		int eq_id = equipment[i];
+		RPG::Item* item = ReaderUtil::GetElement(Data::items, eq_id);
+
+		if (!item && eq_id != 0) {
+			Output::Debug("Actor %d: Removing invalid item %d from equipment slot %d",
+			GetId(), eq_id, eq_types[i]);
+			SetEquipment(i + 1, 0);
+		} else if (item && item->type != eq_types[i]) {
+			Output::Debug("Actor %d: Removing item %d (of type %d) from equipment slot %d (needs type %d)",
+			GetId(), item->ID, item->type, i + 1, eq_types[i]);
+			SetEquipment(i + 1, 0);
+		} else if (item && !IsItemUsable(item->ID)) {
+			Output::Debug("Actor %d: Removing item %d from equipment slot %d (Not equippable by this actor)",
+			GetId(), item->ID, i + 1);
+			SetEquipment(i + 1, 0);
 		}
 	}
 

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -247,8 +247,8 @@ void Game_Battle::NextTurn(Game_Battler* battler) {
 
 void Game_Battle::UpdateGauges() {
 	std::vector<Game_Battler*> battlers;
-	Main_Data::game_enemyparty->GetBattlers(battlers);
-	Main_Data::game_party->GetBattlers(battlers);
+	Main_Data::game_enemyparty->GetActiveBattlers(battlers);
+	Main_Data::game_party->GetActiveBattlers(battlers);
 
 	int max_agi = 1;
 
@@ -256,6 +256,9 @@ void Game_Battle::UpdateGauges() {
 		it != battlers.end(); ++it) {
 		max_agi = std::max(max_agi, (*it)->GetAgi());
 	}
+
+	// Only affects how fast the gauges move, can be safely clamped
+	max_agi = Utils::Clamp(max_agi, 1, 1000);
 
 	for (std::vector<Game_Battler*>::const_iterator it = battlers.begin();
 		it != battlers.end(); ++it) {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -206,8 +206,8 @@ void Scene_Battle_Rpg2k3::UpdateCursors() {
 				auto states = actor->GetInflictedStates();
 
 				help_window->SetVisible(!states.empty());
+				help_window->Clear();
 				BitmapRef contents = help_window->GetContents();
-				contents->Clear();
 
 				int text_width = 0;
 				for (auto state_id : states) {

--- a/src/window_help.cpp
+++ b/src/window_help.cpp
@@ -52,3 +52,8 @@ void Window_Help::SetText(std::string text,	Text::Alignment align) {
 		}
 	}
 }
+
+void Window_Help::Clear() {
+	this->text = "";
+	contents->Clear();
+}

--- a/src/window_help.h
+++ b/src/window_help.h
@@ -42,6 +42,11 @@ public:
 	 */
 	void SetText(std::string text, Text::Alignment align = Text::AlignLeft);
 
+	/**
+	 * Clears the window
+	 */
+	void Clear();
+
 private:
 	/** Text to draw. */
 	std::string text;


### PR DESCRIPTION
~~Don't merge yet, the heal/inflict logic still has some bug. I know where it is but touching battle at this time of the day is a bad idea~~ Decided to not fix this for skills, battlealgortihm needs a refactor first

and in #821 it ticks one more option:
- Items (Other): The 2nd option (heal instead of inflict) for states

This isn't really a battle thing, this just means that the item causes a permanent state that can't be removed except by unequipping.

Also improved the equip sanity check, handles now more corner cases.