### PR TITLE
Show arrow in equipment scene

### DIFF
--- a/src/window_equipstatus.cpp
+++ b/src/window_equipstatus.cpp
@@ -116,13 +116,16 @@ void Window_EquipStatus::DrawParameter(int cx, int cy, int type) {
 	contents->TextDraw(cx, cy, 1, name);
 
 	// Draw Value
-	cx += 60;
-	contents->TextDraw(cx + 10, cy, Font::ColorDefault, std::to_string(value), Text::AlignRight);
+	cx += 10 * 6 + 6 * 3;
+	contents->TextDraw(cx, cy, Font::ColorDefault, std::to_string(value), Text::AlignRight);
 
 	if (draw_params) {
+		// Draw arrow (+3 for center between the two numbers)
+		contents->TextDraw(cx + 3, cy, 1, ">");
+
 		// Draw New Value
-		cx += 38;
+		cx += 6 * 2 + 6 * 3;
 		int color = GetNewParameterColor(value, new_value);
-		contents->TextDraw(cx + 10, cy, color, std::to_string(new_value), Text::AlignRight);
+		contents->TextDraw(cx, cy, color, std::to_string(new_value), Text::AlignRight);
 	}
 }


### PR DESCRIPTION
Related #1443

What I propose, centered ">":

![screenshot_5-fs8](https://user-images.githubusercontent.com/1331889/53687545-2a606700-3d36-11e9-8964-8bb39973cbc5.png)

Alternatives (imo -> what jp uses is ugly and I bet → starts to become problematic when we ever add freetype font support)

![montage2](https://user-images.githubusercontent.com/1331889/53687544-27fe0d00-3d36-11e9-84c6-901c0df74c37.png)
