### PR TITLE
Fix vehicle related crash

### DIFF
--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -431,6 +431,10 @@ void Game_Player::Refresh() {
 }
 
 bool Game_Player::GetOnOffVehicle() {
+	if (IsBoardingOrUnboarding()) {
+		return false;
+	}
+
 	if (InVehicle())
 		return GetOffVehicle();
 	return GetOnVehicle();


### PR DESCRIPTION
Start player above boat
Setup parallel event with `GetOnOffVehicle`

The repeated calls will cause the player to board and unboard
while moving, resulting in a null pointer dereference when accessing
the current vehicle.

The fix is to disallow the action if we're currently boarding