### PR TITLE
Allow player input on same frame move route ends

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -145,9 +145,7 @@ void Game_Character::UpdateMovement() {
 	}
 
 	if (!IsMoveRouteOverwritten()) {
-		if (IsStopping() && !IsStopCountActive()) {
-			UpdateSelfMovement();
-		}
+		UpdateSelfMovement();
 	}
 
 	bool moved = false;

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -388,6 +388,9 @@ void Game_Event::UpdateSelfMovement() {
 	if (page == nullptr) {
 		return;
 	}
+	if (IsStopCountActive()) {
+		return;
+	}
 
 	switch (page->move_type) {
 	case RPG::EventPage::MoveType_random:

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -197,7 +197,7 @@ void Game_Player::UpdateScroll(int old_x, int old_y) {
 	}
 }
 
-void Game_Player::UpdatePlayerInput() {
+void Game_Player::UpdateSelfMovement() {
 	if (!Game_Map::GetInterpreter().IsRunning() && !Game_Map::IsAnyEventStarting()) {
 		if (IsMovable()) {
 			const auto old_x = GetX();
@@ -246,7 +246,6 @@ void Game_Player::Update(bool process_movement) {
 	const auto old_sprite_x = GetSpriteX();
 	const auto old_sprite_y = GetSpriteY();
 
-	UpdatePlayerInput();
 	auto was_moving = !IsStopping();
 
 	if (process_movement) {

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -46,6 +46,7 @@ public:
 	void BeginMove() override;
 	void CancelMoveRoute() override;
 	int GetVehicleType() const override;
+	void UpdateSelfMovement() override;
 	/** @} */
 
 	bool IsTeleporting() const;
@@ -106,7 +107,6 @@ private:
 	bool teleporting = false;
 	int new_map_id = 0, new_x = 0, new_y = 0, new_direction = 0;
 
-	void UpdatePlayerInput();
 	void UpdateScroll(int prev_x, int prev_y);
 	void UpdatePan();
 	bool CheckTouchEvent();


### PR DESCRIPTION
Create a parallel event: `SetMoveRoute: Player, Turn Left`

RPG_RT, you can still walk around. Before this fix the player
was stuck.

Fix: #579
Fix: #937