### PR TITLE
Fix the windowed mode fallback for SDL1.2

### DIFF
--- a/src/sdl_ui.cpp
+++ b/src/sdl_ui.cpp
@@ -179,11 +179,10 @@ bool SdlUi::RequestVideoMode(int width, int height, bool fullscreen) {
 		toggle_fs_available = true;
 		// FIXME: this for may work, but is really confusing. Calling a method
 		// that does this with the desired flags would be nicer.
+		if (fullscreen) {
+			flags |= SDL_FULLSCREEN;
+		}
 		for (;;) {
-			if (fullscreen) {
-				flags |= SDL_FULLSCREEN;
-			}
-
 			modes = SDL_ListModes(NULL, flags);
 			if (modes != NULL) {
 				// Set up...


### PR DESCRIPTION
The SdlUi::RequestVideoMode function is supposed to have a fallback to windowed mode when neither 320x240 nor 640x480 are available. Due to an oversight the loop always sets the SDL_FULLSCREEN flag at the beginning, so the windowed mode list is never checked, and it gets stuck in and endless loop. I moved the SDL_FULLSCREEN flag setting out of the loop to fix this. I noticed it on AROS, where the VESA driver only has one fixed resolution available after booting. 