### PR TITLE
RFC: Synchronous Transitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,7 @@ add_library(${PROJECT_NAME}
 	src/switch_ui.cpp
 	src/switch_ui.h
 	src/system.h
+	src/teleport_target.h
 	src/text.cpp
 	src/text.h
 	src/tilemap.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -241,6 +241,7 @@ libeasyrpg_player_a_SOURCES = \
 	src/spriteset_map.cpp \
 	src/spriteset_map.h \
 	src/system.h \
+	src/teleport_target.h \
 	src/text.cpp \
 	src/text.h \
 	src/tilemap.cpp \

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -395,11 +395,6 @@ void Game_Character::UpdateMoveRoute(int32_t& current_index, const RPG::MoveRout
 				break;
 		}
 
-		//FIXME: DO we need this?
-		if (move_command.command_id <= RPG::MoveCommand::Code::move_forward) {
-			any_move_successful |= !move_failed;
-		}
-
 		if (move_failed && !current_route.skippable) {
 			break;
 		}
@@ -762,7 +757,6 @@ void Game_Character::ForceMoveRoute(const RPG::MoveRoute& new_route,
 	SetMoveRouteIndex(0);
 	SetMoveRouteRepeated(false);
 	SetMoveRoute(new_route);
-	any_move_successful = false;
 
 	if (GetMoveRoute().move_commands.empty()) {
 		// Matches RPG_RT behavior

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -437,7 +437,7 @@ void Game_Character::Move(int dir, MoveOption option) {
 	}
 
 	if (move_failed) {
-		CheckEventTriggerTouch(Game_Map::RoundX(GetX() + dx), Game_Map::RoundY(GetY() + dy));
+		OnMoveFailed(Game_Map::RoundX(GetX() + dx), Game_Map::RoundY(GetY() + dy));
 		return;
 	}
 

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -58,7 +58,7 @@ bool Game_Character::MakeWay(int x, int y, int d) const {
 		return MakeWayDiagonal(x, y, d);
 	}
 
-	return Game_Map::MakeWay(x, y, d, *this, false);
+	return Game_Map::MakeWay(x, y, d, *this);
 }
 
 bool Game_Character::IsLandable(int x, int y) const

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -53,12 +53,8 @@ bool Game_Character::IsStopping() const {
 	return !(IsMoving() || IsJumping());
 }
 
-bool Game_Character::MakeWay(int x, int y, int d) const {
-	if (d > 3) {
-		return MakeWayDiagonal(x, y, d);
-	}
-
-	return Game_Map::MakeWay(x, y, d, *this);
+bool Game_Character::MakeWay(int x, int y) const {
+	return Game_Map::MakeWay(*this, x, y);
 }
 
 bool Game_Character::IsLandable(int x, int y) const
@@ -447,7 +443,7 @@ void Game_Character::Move(int dir, MoveOption option) {
 		return;
 	}
 
-	move_failed = !MakeWay(GetX(), GetY(), dir);
+	move_failed = !MakeWay(GetX() + dx, GetY() + dy);
 
 	if (!move_failed || option == MoveOption::Normal) {
 		SetDirection(dir);
@@ -703,11 +699,7 @@ void Game_Character::BeginJump(int32_t& current_index, const RPG::MoveRoute& cur
 		}
 	}
 
-	if (
-		// A character can always land on a tile they were already standing on
-		!(jump_plus_x == 0 && jump_plus_y == 0) &&
-		!IsLandable(new_x, new_y)
-	) {
+	if (!MakeWay(new_x, new_y)) {
 		move_failed = true;
 	}
 
@@ -948,14 +940,6 @@ int Game_Character::ReverseDir(int dir) {
 	constexpr static char reversed[] =
 		{ Down, Left, Up, Right, DownLeft, UpLeft, UpRight, DownRight };
 	return reversed[dir];
-}
-
-
-bool Game_Character::MakeWayDiagonal(int x, int y, int d) const {
-	int dx = (d == UpRight || d == DownRight) - (d == DownLeft || d == UpLeft);
-	int dy = (d == DownRight || d == DownLeft) - (d == UpRight || d == UpLeft);
-	return ((MakeWay(x, y, dy + 1) && MakeWay(x, y + dy, -dx + 2)) ||
-			(MakeWay(x, y, -dx + 2) && MakeWay(x + dx, y, dy + 1)));
 }
 
 void Game_Character::SetMaxStopCountForStep() {

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -980,3 +980,9 @@ bool Game_Character::IsMoveRouteActive() const {
 int Game_Character::GetVehicleType() const {
 	return 0;
 }
+
+void Game_Character::SetActive(bool active) {
+	data()->active = active;
+	SetVisible(active);
+}
+

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -45,14 +45,6 @@ Game_Character::~Game_Character() {
 	Game_Map::RemovePendingMove(this);
 }
 
-bool Game_Character::IsMoving() const {
-	return !IsJumping() && GetRemainingStep() > 0;
-}
-
-bool Game_Character::IsStopping() const {
-	return !(IsMoving() || IsJumping());
-}
-
 bool Game_Character::MakeWay(int x, int y) const {
 	return Game_Map::MakeWay(*this, x, y);
 }

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -57,27 +57,6 @@ bool Game_Character::MakeWay(int x, int y) const {
 	return Game_Map::MakeWay(*this, x, y);
 }
 
-bool Game_Character::IsLandable(int x, int y) const
-{
-	if (!Game_Map::IsValid(x, y))
-		return false;
-
-	if (GetThrough()) return true;
-
-	if (IsFlying()) return true;
-
-	if (!Game_Map::IsLandable(x, y, this))
-		return false;
-
-	if (GetLayer() == RPG::EventPage::Layers_same && Main_Data::game_player->IsInPosition(x, y)) {
-		if (!Main_Data::game_player->GetThrough() && !GetSpriteName().empty() && (this != Main_Data::game_player.get())) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 void Game_Character::MoveTo(int x, int y) {
 	SetX(Game_Map::RoundX(x));
 	SetY(Game_Map::RoundY(y));

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -31,11 +31,12 @@
 #include <cmath>
 #include <cassert>
 
-Game_Character::Game_Character(RPG::SaveMapEventBase* d) :
+Game_Character::Game_Character(Type type, RPG::SaveMapEventBase* d) :
 	move_failed(false),
 	jump_plus_x(0),
 	jump_plus_y(0),
 	visible(true),
+	_type(type),
 	_data(d)
 {
 }

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -159,7 +159,8 @@ void Game_Character::UpdateMovement() {
 		SetRemainingStep(GetRemainingStep() - min(1 << (1 + GetMoveSpeed()), GetRemainingStep()));
 		moved = true;
 	} else {
-		if (IsMoveRouteOverwritten() || (!Game_Map::GetInterpreter().IsRunning() && !Game_Map::IsAnyEventStarting())) {
+		if (GetStopCount() == 0 || IsMoveRouteOverwritten() ||
+					(Game_Message::GetContinueEvents() || !Game_Map::GetInterpreter().IsRunning())) {
 			SetStopCount(GetStopCount() + 1);
 		}
 	}

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -160,7 +160,7 @@ void Game_Character::UpdateMovement() {
 		moved = true;
 	} else {
 		if (GetStopCount() == 0 || IsMoveRouteOverwritten() ||
-					(Game_Message::GetContinueEvents() || !Game_Map::GetInterpreter().IsRunning())) {
+					((Game_Message::GetContinueEvents() || !Game_Map::GetInterpreter().IsRunning()) && !IsPaused())) {
 			SetStopCount(GetStopCount() + 1);
 		}
 	}
@@ -785,6 +785,7 @@ void Game_Character::ForceMoveRoute(const RPG::MoveRoute& new_route,
 		CancelMoveRoute();
 	}
 
+	SetPaused(false);
 	SetStopCount(0xFFFF);
 	SetMoveRouteIndex(0);
 	SetMoveRouteRepeated(false);

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -524,15 +524,6 @@ public:
 	virtual bool MakeWay(int x, int y) const;
 
 	/**
-	 * Gets if the character can jump to a tile.
-	 *
-	 * @param x tile x.
-	 * @param y tile y.
-	 * @return whether the character can jump to.
-	 */
-	virtual bool IsLandable(int x, int y) const;
-
-	/**
 	 * Moves the character to a new tile.
 	 *
 	 * @param x tile x.

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -480,6 +480,20 @@ public:
 	void SetPaused(bool val);
 
 	/**
+	 * Activates or deactivates the event.
+	 *
+	 * @param active enables or disables the event.
+	 */
+	void SetActive(bool active);
+
+	/**
+	 * Gets if the event is active.
+	 *
+	 * @return if the event is active (or inactive via EraseEvent-EventCommand).
+	 */
+	bool IsActive() const;
+
+	/**
 	 * Checks if the character is stopping.
 	 *
 	 * @return whether the character is stopping.
@@ -1165,6 +1179,10 @@ inline bool Game_Character::IsPaused() const {
 
 inline void Game_Character::SetPaused(bool val) {
 	data()->pause = val;
+}
+
+inline bool Game_Character::IsActive() const {
+	return data()->active;
 }
 
 

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -653,7 +653,7 @@ public:
 	/**
 	 * Cancels a previous forced move route.
 	 */
-	virtual void CancelMoveRoute();
+	void CancelMoveRoute();
 
 	/** @return height of active jump in pixels */
 	int GetJumpHeight() const;

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -744,8 +744,6 @@ public:
 	 */
 	virtual bool IsInPosition(int x, int y) const;
 
-	virtual bool CheckEventTriggerTouch(int x, int y) = 0;
-
 	/**
 	 * Gets current opacity of character.
 	 *
@@ -856,6 +854,7 @@ public:
 protected:
 	explicit Game_Character(Type type, RPG::SaveMapEventBase* d);
 	virtual void UpdateSelfMovement() {}
+	virtual void OnMoveFailed(int x, int y) {}
 	void UpdateJump();
 	void SetMaxStopCountForStep();
 	void SetMaxStopCountForTurn();

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -257,6 +257,9 @@ public:
 	 */
 	const std::string& GetSpriteName() const;
 
+	/** @return true if this has a tile sprite */
+	bool HasTileSprite() const;
+
 	/**
 	 * Sets sprite name. Usually the name of the graphic file.
 	 *
@@ -509,16 +512,16 @@ public:
 	 */
 	virtual bool IsStopping() const;
 
+
 	/**
-	 * Makes way for the character to move from (x,y) in the direction d. Returns
+	 * Makes way for the character to move to (x,y). Returns
 	 * true if the move can be completed.
 	 *
-	 * @param x tile x.
-	 * @param y tile y.
-	 * @param d character direction.
+	 * @param x new x position.
+	 * @param y new y position.
 	 * @return whether the character can walk through.
 	 */
-	virtual bool MakeWay(int x, int y, int d) const;
+	virtual bool MakeWay(int x, int y) const;
 
 	/**
 	 * Gets if the character can jump to a tile.
@@ -861,7 +864,6 @@ public:
 
 protected:
 	explicit Game_Character(Type type, RPG::SaveMapEventBase* d);
-	bool MakeWayDiagonal(int x, int y, int d) const;
 	virtual void UpdateSelfMovement() {}
 	void UpdateJump();
 	void SetMaxStopCountForStep();
@@ -1198,5 +1200,8 @@ inline bool Game_Character::IsActive() const {
 	return data()->active;
 }
 
+inline bool Game_Character::HasTileSprite() const {
+	return GetSpriteName().empty();
+}
 
 #endif

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -863,7 +863,6 @@ protected:
 
 	bool visible;
 
-	int frame_count_at_last_update_parallel = -1;
 	RPG::SaveMapEventBase* _data = nullptr;
 };
 

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -37,6 +37,12 @@ class Game_Character {
 public:
 	using AnimType = RPG::EventPage::AnimType;
 
+	enum Type {
+		Event,
+		Player,
+		Vehicle
+	};
+
 	/**
 	 * Destructor.
 	 */
@@ -46,6 +52,9 @@ public:
 	virtual
 #endif
 	~Game_Character();
+
+	/** @return the type of character this is */
+	Type GetType() const;
 
 	/**
 	 * Gets x position in tiles.
@@ -851,7 +860,7 @@ public:
 	static Game_Character* GetCharacter(int character_id, int event_id);
 
 protected:
-	explicit Game_Character(RPG::SaveMapEventBase* d);
+	explicit Game_Character(Type type, RPG::SaveMapEventBase* d);
 	bool MakeWayDiagonal(int x, int y, int d) const;
 	virtual void UpdateSelfMovement() {}
 	void UpdateJump();
@@ -877,9 +886,9 @@ protected:
 
 	bool visible;
 
+	Type _type;
 	RPG::SaveMapEventBase* _data = nullptr;
 };
-
 
 inline RPG::SaveMapEventBase* Game_Character::data() {
 	return _data;
@@ -887,6 +896,10 @@ inline RPG::SaveMapEventBase* Game_Character::data() {
 
 inline const RPG::SaveMapEventBase* Game_Character::data() const {
 	return _data;
+}
+
+inline Game_Character::Type Game_Character::GetType() const {
+	return _type;
 }
 
 inline int Game_Character::GetX() const {

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -510,8 +510,7 @@ public:
 	 *
 	 * @return whether the character is stopping.
 	 */
-	virtual bool IsStopping() const;
-
+	bool IsStopping() const;
 
 	/**
 	 * Makes way for the character to move to (x,y). Returns
@@ -859,7 +858,7 @@ protected:
 	void SetMaxStopCountForStep();
 	void SetMaxStopCountForTurn();
 	void SetMaxStopCountForWait();
-	void UpdateMoveRoute(int32_t& current_index, const RPG::MoveRoute& current_route);
+	virtual void UpdateMoveRoute(int32_t& current_index, const RPG::MoveRoute& current_route);
 	void IncAnimCount();
 	void IncAnimFrame();
 
@@ -1137,6 +1136,15 @@ inline bool Game_Character::IsJumping() const {
 inline void Game_Character::SetJumping(bool val) {
 	data()->jumping = val;
 }
+
+inline bool Game_Character::IsMoving() const {
+	return !IsJumping() && GetRemainingStep() > 0;
+}
+
+inline bool Game_Character::IsStopping() const {
+	return !(IsMoving() || IsJumping());
+}
+
 
 inline int Game_Character::GetBeginJumpX() const {
 	return data()->begin_jump_x;

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -470,6 +470,16 @@ public:
 	void SetProcessed(bool val);
 
 	/**
+	 * @return whether the event is paused.
+	 */
+	bool IsPaused() const;
+
+	/**
+	 * Set the paused flag
+	 */
+	void SetPaused(bool val);
+
+	/**
 	 * Checks if the character is stopping.
 	 *
 	 * @return whether the character is stopping.
@@ -1149,5 +1159,14 @@ inline bool Game_Character::IsProcessed() const {
 inline void Game_Character::SetProcessed(bool val) {
 	data()->processed = val;
 }
+
+inline bool Game_Character::IsPaused() const {
+	return data()->pause;
+}
+
+inline void Game_Character::SetPaused(bool val) {
+	data()->pause = val;
+}
+
 
 #endif

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -38,19 +38,14 @@ void Game_CommonEvent::SetSaveData(const RPG::SaveEventData& data) {
 
 void Game_CommonEvent::Refresh() {
 	if (GetTrigger() == RPG::EventPage::Trigger_parallel) {
-		if (GetSwitchFlag() ? Game_Switches.Get(GetSwitchId()) : true) {
-			if (!interpreter) {
-				interpreter.reset(new Game_Interpreter_Map());
-			}
-			parallel_running = true;
-		} else {
-			parallel_running = false;
+		if (!interpreter) {
+			interpreter.reset(new Game_Interpreter_Map());
 		}
 	}
 }
 
-void Game_CommonEvent::UpdateParallel() {
-	if (interpreter && parallel_running) {
+void Game_CommonEvent::Update() {
+	if (interpreter && IsWaitingBackgroundExecution()) {
 		if (!interpreter->IsRunning()) {
 			interpreter->Setup(this, 0);
 		}
@@ -97,6 +92,13 @@ RPG::SaveEventData Game_CommonEvent::GetSaveData() {
 bool Game_CommonEvent::IsWaitingForegroundExecution() const {
 	auto* ce = ReaderUtil::GetElement(Data::commonevents, common_event_id);
 	return ce->trigger == RPG::EventPage::Trigger_auto_start &&
+		(!ce->switch_flag || Game_Switches.Get(ce->switch_id))
+		&& !ce->event_commands.empty();
+}
+
+bool Game_CommonEvent::IsWaitingBackgroundExecution() const {
+	auto* ce = ReaderUtil::GetElement(Data::commonevents, common_event_id);
+	return ce->trigger == RPG::EventPage::Trigger_parallel &&
 		(!ce->switch_flag || Game_Switches.Get(ce->switch_id))
 		&& !ce->event_commands.empty();
 }

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -49,22 +49,6 @@ void Game_CommonEvent::Refresh() {
 	}
 }
 
-void Game_CommonEvent::Update() {
-	if (GetTrigger() != RPG::EventPage::Trigger_auto_start)
-		return;
-
-	for (int i = 0; i < 500; ++i) {
-		if (GetSwitchFlag() ? Game_Switches.Get(GetSwitchId()) : true) {
-			if (!Game_Map::GetInterpreter().IsRunning()) {
-				Game_Map::GetInterpreter().Setup(this, 0);
-				Game_Map::GetInterpreter().Update();
-				continue;
-			}
-		}
-		return;
-	}
-}
-
 void Game_CommonEvent::UpdateParallel() {
 	if (interpreter && parallel_running) {
 		if (!interpreter->IsRunning()) {
@@ -108,4 +92,11 @@ RPG::SaveEventData Game_CommonEvent::GetSaveData() {
 	}
 
 	return event_data;
+}
+
+bool Game_CommonEvent::IsWaitingForegroundExecution() const {
+	auto* ce = ReaderUtil::GetElement(Data::commonevents, common_event_id);
+	return ce->trigger == RPG::EventPage::Trigger_auto_start &&
+		(!ce->switch_flag || Game_Switches.Get(ce->switch_id))
+		&& !ce->event_commands.empty();
 }

--- a/src/game_commonevent.h
+++ b/src/game_commonevent.h
@@ -52,7 +52,7 @@ public:
 	/**
 	 * Updates common event parallel interpreter.
 	 */
-	void UpdateParallel();
+	void Update();
 
 	/**
 	 * Gets common event index.
@@ -101,13 +101,11 @@ public:
 	/** @return true if waiting for foreground execution */
 	bool IsWaitingForegroundExecution() const;
 
+	/** @return true if waiting for background execution */
+	bool IsWaitingBackgroundExecution() const;
+
 private:
 	int common_event_id;
-	/**
-	 * If parallel interpreter is running (true) or suspended (false).
-	 * When switched to running it continues where it was suspended.
-	 */
-	bool parallel_running = false;
 
 	/** Interpreter for parallel common events. */
 	std::unique_ptr<Game_Interpreter_Map> interpreter;

--- a/src/game_commonevent.h
+++ b/src/game_commonevent.h
@@ -50,11 +50,6 @@ public:
 	void Refresh();
 
 	/**
-	 * Updates common event.
-	 */
-	void Update();
-
-	/**
 	 * Updates common event parallel interpreter.
 	 */
 	void UpdateParallel();
@@ -102,6 +97,9 @@ public:
 	std::vector<RPG::EventCommand>& GetList();
 
 	RPG::SaveEventData GetSaveData();
+
+	/** @return true if waiting for foreground execution */
+	bool IsWaitingForegroundExecution() const;
 
 private:
 	int common_event_id;

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -364,6 +364,9 @@ void Game_Event::OnMoveFailed(int x, int y) {
 
 	if (Main_Data::game_player->IsInPosition(x, y)) {
 		SetAsWaitingForegroundExecution(false, false);
+		// Events with trigger collision and layer same always reset their
+		// stop_count when they fail movement to a tile that the player inhabits.
+		SetStopCount(0);
 		return;
 	}
 }
@@ -441,16 +444,6 @@ void Game_Event::MoveTypeCycle(int default_dir) {
 	Move(move_dir, MoveOption::IgnoreIfCantMove);
 
 	if (move_failed) {
-		if (trigger == RPG::EventPage::Trigger_collision) {
-			int new_x = Game_Map::XwithDirection(GetX(), move_dir);
-			int new_y = Game_Map::YwithDirection(GetY(), move_dir);
-
-			if (Main_Data::game_player->IsInPosition(new_x, new_y)) {
-				SetStopCount(0);
-				return;
-			}
-		}
-
 		if (GetStopCount() >= GetMaxStopCount() + 20) {
 			if (GetStopCount() >= GetMaxStopCount() + 60) {
 				Move(ReverseDir(move_dir));

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -335,11 +335,16 @@ void Game_Event::OnFinishForegroundEvent() {
 	SetPaused(false);
 }
 
-void Game_Event::CheckEventTriggers() {
-	if (trigger == RPG::EventPage::Trigger_auto_start) {
+void Game_Event::CheckEventAutostart() {
+	if (trigger == RPG::EventPage::Trigger_auto_start
+			&& GetRemainingStep() == 0) {
 		SetAsWaitingForegroundExecution(false, false);
 		return;
-	} else if (trigger == RPG::EventPage::Trigger_collision) {
+	}
+}
+
+void Game_Event::CheckEventCollision() {
+	if (trigger == RPG::EventPage::Trigger_collision) {
 		CheckEventTriggerTouch(GetX(),GetY());
 		return;
 	}
@@ -554,7 +559,8 @@ void Game_Event::Update() {
 		}
 	}
 
-	CheckEventTriggers();
+	CheckEventAutostart();
+	CheckEventCollision();
 
 	auto was_moving = !IsStopping();
 	Game_Character::UpdateMovement();

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -101,6 +101,8 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 		interpreter.reset();
 	}
 
+	SetPaused(false);
+
 	if (page == nullptr) {
 		SetSpriteName("");
 		SetSpriteIndex(0);
@@ -322,6 +324,7 @@ void Game_Event::Start(bool by_decision_key) {
 
 	starting = true;
 	data()->triggered_by_decision_key = by_decision_key;
+	SetPaused(true);
 }
 
 const std::vector<RPG::EventCommand>& Game_Event::GetList() const {
@@ -334,11 +337,12 @@ void Game_Event::StartTalkToHero() {
 	}
 }
 
-void Game_Event::StopTalkToHero() {
+void Game_Event::OnFinishForegroundEvent() {
 	if (!(IsDirectionFixed() || IsFacingLocked() || IsSpinning())) {
 		SetSpriteDirection(GetDirection());
 	}
 
+	SetPaused(false);
 	halting = true;
 }
 
@@ -378,7 +382,7 @@ bool Game_Event::CheckEventTriggerTouch(int x, int y) {
 }
 
 void Game_Event::UpdateSelfMovement() {
-	if (running)
+	if (IsPaused())
 		return;
 	if (!Game_Message::GetContinueEvents() && Game_Map::GetInterpreter().IsRunning())
 		return;

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -344,8 +344,13 @@ void Game_Event::CheckEventAutostart() {
 }
 
 void Game_Event::CheckEventCollision() {
-	if (trigger == RPG::EventPage::Trigger_collision) {
-		CheckEventTriggerTouch(GetX(),GetY());
+	if (trigger == RPG::EventPage::Trigger_collision
+			&& GetLayer() != RPG::EventPage::Layers_same
+			&& !Main_Data::game_player->IsMoveRouteOverwritten()
+			&& !Game_Map::GetInterpreter().IsRunning()
+			&& !Main_Data::game_player->InAirship()
+			&& Main_Data::game_player->IsInPosition(GetX(), GetY())) {
+		SetAsWaitingForegroundExecution(true, false);
 		return;
 	}
 }

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -556,11 +556,18 @@ void Game_Event::Update() {
 	}
 
 	CheckEventAutostart();
-	CheckEventCollision();
+
+	if (!IsMoveRouteOverwritten() || IsMoving()) {
+		CheckEventCollision();
+	}
 
 	auto was_moving = !IsStopping();
 	Game_Character::UpdateMovement();
 	Game_Character::UpdateAnimation(was_moving);
+
+	if (IsStopping()) {
+		CheckEventCollision();
+	}
 }
 
 const RPG::EventPage* Game_Event::GetPage(int page) const {

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -355,26 +355,17 @@ void Game_Event::CheckEventCollision() {
 	}
 }
 
-bool Game_Event::CheckEventTriggerTouch(int x, int y) {
-	if (Game_Map::GetInterpreter().IsRunning())
-		return false;
-
-	if (trigger == RPG::EventPage::Trigger_collision) {
-		if (Main_Data::game_player->IsInPosition(GetX(), GetY()) && GetLayer() == RPG::EventPage::Layers_same) {
-			return false;
-		}
-
-		if (Main_Data::game_player->IsInPosition(x, y)) {
-			if (Main_Data::game_player->InAirship() && GetLayer() == RPG::EventPage::Layers_same) {
-				return false;
-			}
-
-			SetAsWaitingForegroundExecution(false, false);
-			return true;
-		}
+void Game_Event::OnMoveFailed(int x, int y) {
+	if (Main_Data::game_player->InAirship()
+			|| GetLayer() != RPG::EventPage::Layers_same
+			|| trigger != RPG::EventPage::Trigger_collision) {
+		return;
 	}
 
-	return false;
+	if (Main_Data::game_player->IsInPosition(x, y)) {
+		SetAsWaitingForegroundExecution(false, false);
+		return;
+	}
 }
 
 void Game_Event::UpdateSelfMovement() {

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -33,7 +33,7 @@
 #include <cmath>
 
 Game_Event::Game_Event(int map_id, const RPG::Event& event) :
-	Game_Character(new RPG::SaveMapEvent()),
+	Game_Character(Event, new RPG::SaveMapEvent()),
 	_data_copy(this->data()),
 	event(event),
 	from_save(false)
@@ -45,7 +45,7 @@ Game_Event::Game_Event(int map_id, const RPG::Event& event) :
 }
 
 Game_Event::Game_Event(int map_id, const RPG::Event& event, const RPG::SaveMapEvent& orig_data) :
-	Game_Character(new RPG::SaveMapEvent(orig_data)),
+	Game_Character(Event, new RPG::SaveMapEvent(orig_data)),
 	_data_copy(this->data()),
 	event(event),
 	from_save(true)

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -306,14 +306,6 @@ RPG::EventPage::Trigger Game_Event::GetTrigger() const {
 	return static_cast<RPG::EventPage::Trigger>(trigger);
 }
 
-void Game_Event::SetActive(bool active) {
-	data()->active = active;
-	SetVisible(active);
-}
-
-bool Game_Event::GetActive() const {
-	return data()->active;
-}
 
 bool Game_Event::SetAsWaitingForegroundExecution(bool face_hero, bool by_decision_key) {
 	// RGSS scripts consider list empty if size <= 1. Why?

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -39,7 +39,6 @@ Game_Event::Game_Event(int map_id, const RPG::Event& event) :
 	from_save(false)
 {
 	SetMapId(map_id);
-	SetProcessed(true); // RPG_RT compatibility
 	SetMoveSpeed(3);
 	MoveTo(event.x, event.y);
 	Refresh();
@@ -53,7 +52,6 @@ Game_Event::Game_Event(int map_id, const RPG::Event& event, const RPG::SaveMapEv
 {
 	// Savegames have 0 for the mapid for compatibility with RPG_RT.
 	SetMapId(map_id);
-	SetProcessed(true); // RPG_RT compatibility
 
 	this->event.ID = data()->ID;
 
@@ -549,6 +547,11 @@ void Game_Event::Update() {
 	if (!data()->active || page == NULL) {
 		return;
 	}
+
+	if (IsProcessed()) {
+		return;
+	}
+	SetProcessed(true);
 
 	auto was_moving = !IsStopping();
 	Game_Character::UpdateMovement();

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -83,7 +83,6 @@ void Game_Event::SetThrough(bool through) {
 
 void Game_Event::ClearStarting() {
 	starting = false;
-	started_by_decision_key = false;
 }
 
 void Game_Event::Setup(const RPG::EventPage* new_page) {
@@ -300,7 +299,7 @@ bool Game_Event::GetStarting() const {
 }
 
 bool Game_Event::WasStartedByDecisionKey() const {
-	return started_by_decision_key;
+	return data()->triggered_by_decision_key;
 }
 
 RPG::EventPage::Trigger Game_Event::GetTrigger() const {
@@ -322,7 +321,7 @@ void Game_Event::Start(bool by_decision_key) {
 		return;
 
 	starting = true;
-	started_by_decision_key = by_decision_key;
+	data()->triggered_by_decision_key = by_decision_key;
 }
 
 const std::vector<RPG::EventCommand>& Game_Event::GetList() const {

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -303,8 +303,8 @@ bool Game_Event::WasStartedByDecisionKey() const {
 	return started_by_decision_key;
 }
 
-int Game_Event::GetTrigger() const {
-	return trigger;
+RPG::EventPage::Trigger Game_Event::GetTrigger() const {
+	return static_cast<RPG::EventPage::Trigger>(trigger);
 }
 
 void Game_Event::SetActive(bool active) {

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -52,11 +52,6 @@ public:
 	/** @} */
 
 	/**
-	 * Clears starting flag.
-	 */
-	void ClearStarting();
-
-	/**
 	 * Does refresh.
 	 */
 	void Refresh();
@@ -78,12 +73,11 @@ public:
 	 */
 	std::string GetName() const;
 
-	/**
-	 * Gets starting flag.
-	 *
-	 * @return starting flag.
-	 */
-	bool GetStarting() const;
+	/** Clears waiting_execution flag */
+	void ClearWaitingForegroundExecution();
+
+	/** @return waiting_execution flag.  */
+	bool IsWaitingForegroundExecution() const;
 
 	/**
 	 * If the event is starting, whether or not it was started
@@ -108,21 +102,18 @@ public:
 	const std::vector<RPG::EventCommand>& GetList() const;
 
 	/**
-	 * Event's sprite looks towards the hero but its original direction is remembered.
-	 */
-	void StartTalkToHero();
-
-	/**
 	 * Event returns to its original direction before talking to the hero.
 	 */
 	void OnFinishForegroundEvent();
+
+	/** Mark the event as waiting for execution */
+	bool SetAsWaitingForegroundExecution(bool face_hero, bool triggered_by_decision_key);
 
 	/** Update this for the current frame */
 	void Update();
 
 	void CheckEventTriggers();
 	bool CheckEventTriggerTouch(int x, int y) override;
-	void Start(bool triggered_by_decision_key = false);
 	void UpdateParallel();
 	bool AreConditionsMet(const RPG::EventPage& page);
 
@@ -216,16 +207,12 @@ private:
 	// reference.
 	std::unique_ptr<RPG::SaveMapEvent> _data_copy;
 
-	bool starting = false, running = false, halting = false;
 	int trigger = -1;
 	RPG::Event event;
 	const RPG::EventPage* page = nullptr;
 	std::vector<RPG::EventCommand> list;
 	std::shared_ptr<Game_Interpreter> interpreter;
 	bool from_save;
-	bool updating = false;
-
-	int frame_count_at_last_auto_start_check = -1;
 };
 
 inline RPG::SaveMapEvent* Game_Event::data() {

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -115,7 +115,7 @@ public:
 	/**
 	 * Event returns to its original direction before talking to the hero.
 	 */
-	void StopTalkToHero();
+	void OnFinishForegroundEvent();
 
 	/** Update this for the current frame */
 	void Update();

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -112,7 +112,6 @@ public:
 	/** Update this for the current frame */
 	void Update();
 
-	void CheckEventTriggers();
 	bool CheckEventTriggerTouch(int x, int y) override;
 	void UpdateParallel();
 	bool AreConditionsMet(const RPG::EventPage& page);
@@ -154,6 +153,8 @@ protected:
 
 private:
 	void UpdateSelfMovement() override;
+	void CheckEventAutostart();
+	void CheckEventCollision();
 
 	/**
 	 * Moves on a random route.

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -118,20 +118,6 @@ public:
 	bool AreConditionsMet(const RPG::EventPage& page);
 
 	/**
-	 * Activates or deactivates the event.
-	 *
-	 * @param active enables or disables the event.
-	 */
-	void SetActive(bool active);
-
-	/**
-	 * Gets if the event is active.
-	 *
-	 * @return if the event is active (or inactive via EraseEvent-EventCommand).
-	 */
-	bool GetActive() const;
-
-	/**
 	 * Returns current index of a "Movement Type Custom" move route.
 	 *
 	 * @return current original move route index

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -217,7 +217,6 @@ private:
 	std::unique_ptr<RPG::SaveMapEvent> _data_copy;
 
 	bool starting = false, running = false, halting = false;
-	bool started_by_decision_key = false;
 	int trigger = -1;
 	RPG::Event event;
 	const RPG::EventPage* page = nullptr;

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -98,7 +98,7 @@ public:
 	 *
 	 * @return trigger condition.
 	 */
-	int GetTrigger() const;
+	RPG::EventPage::Trigger GetTrigger() const;
 
 	/**
 	 * Gets event commands list.

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -49,6 +49,7 @@ public:
 	bool GetThrough() const override;
 	void SetThrough(bool through) override;
 	bool IsMoveRouteActive() const override;
+	void OnMoveFailed(int x, int y) override;
 	/** @} */
 
 	/**
@@ -112,7 +113,6 @@ public:
 	/** Update this for the current frame */
 	void Update();
 
-	bool CheckEventTriggerTouch(int x, int y) override;
 	void UpdateParallel();
 	bool AreConditionsMet(const RPG::EventPage& page);
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -548,7 +548,7 @@ bool Game_Interpreter::CommandEnd() { // code 10
 	if (main_flag && depth == 0 && event_id > 0) {
 		Game_Event* evnt = Game_Map::GetEvent(event_id);
 		if (evnt)
-			evnt->StopTalkToHero();
+			evnt->OnFinishForegroundEvent();
 	}
 
 	Scene::instance->onCommandEnd();

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -209,7 +209,7 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 			break;
 		}
 
-		if (Game_Temp::to_title || Game_Temp::gameover) {
+		if (Game_Temp::to_title) {
 			break;
 		}
 
@@ -276,7 +276,9 @@ void Game_Interpreter::Setup(Game_CommonEvent* ev, int caller_id) {
 void Game_Interpreter::CheckGameOver() {
 	if (!Game_Temp::battle_running && !Main_Data::game_party->IsAnyActive()) {
 		// Empty party is allowed
-		Game_Temp::gameover = Main_Data::game_party->GetBattlerCount() > 0;
+		if (Main_Data::game_party->GetBattlerCount() > 0) {
+			Scene::instance->SetRequestedScene(Scene::Gameover);
+		}
 	}
 }
 
@@ -1534,8 +1536,9 @@ bool Game_Interpreter::CommandGameOver(RPG::EventCommand const& /* com */) { // 
 	if (Game_Message::visible) {
 		return false;
 	}
-	Game_Temp::gameover = true;
-	SetContinuation(&Game_Interpreter::DefaultContinuation);
+
+	Scene::instance->SetRequestedScene(Scene::Gameover);
+	++index;
 	return false;
 }
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -229,7 +229,7 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 				break;
 		}
 
-		if (!Main_Data::game_player->IsTeleporting() && Game_Map::GetNeedRefresh()) {
+		if (Game_Map::GetNeedRefresh()) {
 			Game_Map::Refresh();
 		}
 
@@ -1710,17 +1710,11 @@ bool Game_Interpreter::CommandSetVehicleLocation(RPG::EventCommand const& com) {
 		// The implementation of this bug does a normal teleport with transition because other solution would be too
 		// invasive for little gain.
 
-		if (Main_Data::game_player->IsTeleporting() ||
-			Game_Message::visible) {
-			return false;
-		}
-
 		if (vehicle) {
 			vehicle->SetPosition(map_id, x, y);
 		}
 
-		Main_Data::game_player->ReserveTeleport(map_id, x, y);
-		Main_Data::game_player->StartTeleport();
+		Main_Data::game_player->ReserveTeleport(map_id, x, y, -1);
 
 		// Parallel events should keep on running in 2k and 2k3, unlike in later versions
 		if (!main_flag)
@@ -1800,10 +1794,6 @@ bool Game_Interpreter::CommandEraseScreen(RPG::EventCommand const& com) { // cod
 	if (Game_Temp::transition_processing || Game_Message::visible)
 		return false;
 
-	if (!main_flag) {
-		Game_Map::SetTeleportDelayed(true);
-	}
-
 	Game_Temp::transition_processing = true;
 	Game_Temp::transition_erase = true;
 	transition_owner = this;
@@ -1882,10 +1872,6 @@ bool Game_Interpreter::CommandEraseScreen(RPG::EventCommand const& com) { // cod
 bool Game_Interpreter::CommandShowScreen(RPG::EventCommand const& com) { // code 11020
 	if (Game_Temp::transition_processing || Game_Message::visible)
 		return false;
-
-	if (!main_flag) {
-		Game_Map::SetTeleportDelayed(true);
-	}
 
 	Game_Temp::transition_processing = true;
 	Game_Temp::transition_erase = false;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -57,8 +57,6 @@ namespace {
 	static Game_Interpreter* transition_owner = nullptr;
 }
 
-Scene::SceneType Game_Interpreter::scene_call = Scene::Null;
-
 Game_Interpreter::Game_Interpreter(int _depth, bool _main_flag) {
 	depth = _depth;
 	main_flag = _main_flag;
@@ -178,7 +176,7 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 
 		// If something is calling a menu, we're allowed to execute only 1 command per interpreter. So we pass through if loop_count == 0, and stop at 1 or greater.
 		// RPG_RT compatible behavior.
-		if (loop_count > 0 && IsImmediateCall()) {
+		if (loop_count > 0 && Scene::instance->HasRequestedScene()) {
 			break;
 		}
 
@@ -3074,14 +3072,6 @@ bool Game_Interpreter::DefaultContinuation(RPG::EventCommand const& /* com */) {
 	index++;
 	return true;
 }
-
-void Game_Interpreter::ResetSceneCalling() {
-	scene_call = Scene::Null;
-}
-
-bool Game_Interpreter::IsImmediateCall() {
-	return scene_call != Scene::Null;
-};
 
 // Dummy Continuations
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -119,8 +119,10 @@ void Game_Interpreter::Setup(
 
 	CancelMenuCall();
 
-	if (main_flag && depth == 0)
+	if (main_flag && depth == 0) {
 		Game_Message::SetFaceName("");
+		Main_Data::game_player->SetMenuCalling(false);
+	}
 }
 
 void Game_Interpreter::CancelMenuCall() {

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -122,6 +122,7 @@ void Game_Interpreter::Setup(
 	if (main_flag && depth == 0) {
 		Game_Message::SetFaceName("");
 		Main_Data::game_player->SetMenuCalling(false);
+		Main_Data::game_player->SetEncounterCalling(false);
 	}
 }
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -142,11 +142,18 @@ void Game_Interpreter::SetContinuation(Game_Interpreter::ContinuationFunction fu
 	continuation = func;
 }
 
+bool Game_Interpreter::ReachedLoopLimit() const {
+	return loop_count >= 10000;
+}
+
 // Update
-void Game_Interpreter::Update() {
+void Game_Interpreter::Update(bool reset_loop_count) {
 	updating = true;
 	// 10000 based on: https://gist.github.com/4406621
-	for (loop_count = 0; loop_count < 10000; ++loop_count) {
+	if (reset_loop_count) {
+		loop_count = 0;
+	}
+	for (; loop_count < 10000; ++loop_count) {
 		/* If map is different than event startup time
 		set event_id to 0 */
 		if (Game_Map::GetMapId() != map_id) {
@@ -261,7 +268,6 @@ void Game_Interpreter::Setup(Game_Event* ev) {
 	event_info.x = ev->GetX();
 	event_info.y = ev->GetY();
 	event_info.page = ev->GetActivePage();
-	ev->ClearStarting();
 }
 
 void Game_Interpreter::Setup(Game_CommonEvent* ev, int caller_id) {

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -53,6 +53,7 @@ public:
 	void Clear();
 
 	bool IsRunning() const;
+	int GetLoopCount() const;
 	bool ReachedLoopLimit() const;
 	void Update(bool reset_loop_count=true);
 
@@ -252,6 +253,10 @@ protected:
 
 	static Scene::SceneType scene_call;
 };
+
+inline int Game_Interpreter::GetLoopCount() const {
+	return loop_count;
+}
 
 inline Scene::SceneType Game_Interpreter::GetSceneCalling() {
 	return scene_call;

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -27,7 +27,6 @@
 #include "rpg_eventcommand.h"
 #include "system.h"
 #include "command_codes.h"
-#include "scene.h"
 
 class Game_Event;
 class Game_CommonEvent;
@@ -69,19 +68,6 @@ public:
 	void SetupChoices(const std::vector<std::string>& choices);
 
 	virtual bool ExecuteCommand();
-
-	/**
-	 * @return true if an immediate call is requested
-	 */
-	static bool IsImmediateCall();
-
-	/**
-	 * Reset the event calling flags
-	 */
-	static void ResetSceneCalling();
-
-	/** @return the scene requested by events */
-	static Scene::SceneType GetSceneCalling();
 
 protected:
 	friend class Game_Interpreter_Map;
@@ -252,15 +238,10 @@ protected:
 
 	FileRequestBinding request_id;
 
-	static Scene::SceneType scene_call;
 };
 
 inline int Game_Interpreter::GetLoopCount() const {
 	return loop_count;
-}
-
-inline Scene::SceneType Game_Interpreter::GetSceneCalling() {
-	return scene_call;
 }
 
 #endif

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -53,7 +53,8 @@ public:
 	void Clear();
 
 	bool IsRunning() const;
-	void Update();
+	bool ReachedLoopLimit() const;
+	void Update(bool reset_loop_count=true);
 
 	void Setup(
 			const std::vector<RPG::EventCommand>& _list,

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -80,6 +80,7 @@ public:
 	 */
 	static void ResetSceneCalling();
 
+	/** @return the scene requested by events */
 	static Scene::SceneType GetSceneCalling();
 
 protected:

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -46,6 +46,7 @@
 #include "util_macro.h"
 #include "game_interpreter_map.h"
 #include "reader_lcf.h"
+#include "transition.h"
 
 Game_Interpreter_Map::Game_Interpreter_Map(int depth, bool main_flag) :
 	Game_Interpreter(depth, main_flag) {

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -251,7 +251,7 @@ bool Game_Interpreter_Map::CommandEnemyEncounter(RPG::EventCommand const& com) {
 		Game_Battle::SetBattleMode(com.parameters[6]); // 0 normal, 1 initiative, 2 surround, 3 back attack, 4 pincer
 
 	Game_Temp::battle_result = Game_Temp::BattleVictory;
-	scene_call = Scene::Battle;
+	Scene::instance->SetRequestedScene(Scene::Battle);
 
 	SetContinuation(static_cast<ContinuationFunction>(&Game_Interpreter_Map::ContinuationEnemyEncounter));
 	return false;
@@ -341,7 +341,7 @@ bool Game_Interpreter_Map::CommandOpenShop(RPG::EventCommand const& com) { // co
 		Game_Temp::shop_goods.push_back(*it);
 
 	Game_Temp::shop_transaction = false;
-	scene_call = Scene::Shop;
+	Scene::instance->SetRequestedScene(Scene::Shop);
 	SetContinuation(static_cast<ContinuationFunction>(&Game_Interpreter_Map::ContinuationOpenShop));
 	return false;
 }
@@ -562,7 +562,7 @@ bool Game_Interpreter_Map::CommandEnterHeroName(RPG::EventCommand const& com) { 
 		Game_Temp::hero_name.clear();
 	}
 
-	scene_call = Scene::Name;
+	Scene::instance->SetRequestedScene(Scene::Name);
 	++index;
 	return false;
 }
@@ -701,7 +701,7 @@ bool Game_Interpreter_Map::CommandOpenSaveMenu(RPG::EventCommand const& /* com *
 		return false;
 	}
 
-	scene_call = Scene::Save;
+	Scene::instance->SetRequestedScene(Scene::Save);
 	++index;
 	return false;
 }
@@ -711,7 +711,7 @@ bool Game_Interpreter_Map::CommandOpenMainMenu(RPG::EventCommand const& /* com *
 		return false;
 	}
 
-	scene_call = Scene::Menu;
+	Scene::instance->SetRequestedScene(Scene::Menu);
 	++index;
 	return false;
 }
@@ -721,7 +721,7 @@ bool Game_Interpreter_Map::CommandOpenLoadMenu(RPG::EventCommand const& /* com *
 		return false;
 	}
 
-	scene_call = Scene::Load;
+	Scene::instance->SetRequestedScene(Scene::Load);
 	++index;
 	return false;
 }

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -469,7 +469,7 @@ bool Game_Interpreter_Map::CommandShowInn(RPG::EventCommand const& com) { // cod
 	return false;
 }
 
-bool Game_Interpreter_Map::ContinuationShowInnStart(RPG::EventCommand const& /* com */) {
+bool Game_Interpreter_Map::ContinuationShowInnStart(RPG::EventCommand const& com) {
 	if (Game_Message::visible) {
 		return false;
 	}
@@ -489,10 +489,9 @@ bool Game_Interpreter_Map::ContinuationShowInnStart(RPG::EventCommand const& /* 
 			actor->ChangeHp(actor->GetMaxHp());
 			actor->SetSp(actor->GetMaxSp());
 		}
-		Graphics::GetTransition().Init(Transition::TransitionFadeOut, Scene::instance.get(), 36, true);
 		Game_System::BgmFade(800);
-		SetContinuation(static_cast<ContinuationFunction>(&Game_Interpreter_Map::ContinuationShowInnContinue));
-		return false;
+		Player::TransitionErase(Transition::TransitionFadeOut, 36, Scene::instance.get());
+		return Game_Interpreter_Map::ContinuationShowInnContinue(com);
 	}
 
 	if (Game_Temp::inn_handlers)
@@ -502,9 +501,6 @@ bool Game_Interpreter_Map::ContinuationShowInnStart(RPG::EventCommand const& /* 
 }
 
 bool Game_Interpreter_Map::ContinuationShowInnContinue(RPG::EventCommand const& /* com */) {
-	if (Graphics::IsTransitionPending())
-		return false;
-
 	const RPG::Music& bgm_inn = Game_System::GetSystemBGM(Game_System::BGM_Inn);
 	// FIXME: Abusing before_battle_music (Which is unused when calling an Inn)
 	// Is there also before_inn_music in the savegame?
@@ -518,9 +514,6 @@ bool Game_Interpreter_Map::ContinuationShowInnContinue(RPG::EventCommand const& 
 }
 
 bool Game_Interpreter_Map::ContinuationShowInnFinish(RPG::EventCommand const& /* com */) {
-	if (Graphics::IsTransitionPending())
-		return false;
-
 	const RPG::Music& bgm_inn = Game_System::GetSystemBGM(Game_System::BGM_Inn);
 	if (bgm_inn.name.empty() ||
 		bgm_inn.name == "(OFF)" ||
@@ -530,8 +523,9 @@ bool Game_Interpreter_Map::ContinuationShowInnFinish(RPG::EventCommand const& /*
 
 		Game_System::BgmStop();
 		continuation = NULL;
-		Graphics::GetTransition().Init(Transition::TransitionFadeIn, Scene::instance.get(), 36, false);
 		Game_System::BgmPlay(Main_Data::game_data.system.before_battle_music);
+
+		Player::TransitionShow(Transition::TransitionFadeIn, 36, Scene::instance.get());
 
 		if (Game_Temp::inn_handlers)
 			SkipTo(Cmd::Stay, Cmd::EndInn);

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -203,18 +203,7 @@ bool Game_Interpreter_Map::CommandRecallToLocation(RPG::EventCommand const& com)
 	int x = Game_Variables.Get(var_x);
 	int y = Game_Variables.Get(var_y);
 
-	if (map_id == Game_Map::GetMapId()) {
-		player->MoveTo(x, y);
-		return true;
-	};
-
-	if (Main_Data::game_player->IsTeleporting() ||
-		Game_Message::visible) {
-			return false;
-	}
-
-	Main_Data::game_player->ReserveTeleport(map_id, x, y);
-	Main_Data::game_player->StartTeleport();
+	Main_Data::game_player->ReserveTeleport(map_id, x, y, -1);
 
 	// Parallel events should keep on running in 2k and 2k3, unlike in later versions
 	if (!main_flag)
@@ -580,11 +569,6 @@ bool Game_Interpreter_Map::CommandEnterHeroName(RPG::EventCommand const& com) { 
 
 bool Game_Interpreter_Map::CommandTeleport(RPG::EventCommand const& com) { // Code 10810
 																		   // TODO: if in battle return true
-	if (Main_Data::game_player->IsTeleporting() || Game_Temp::transition_processing ||
-		Game_Message::visible) {
-		return false;
-	}
-
 	int map_id = com.parameters[0];
 	int x = com.parameters[1];
 	int y = com.parameters[2];
@@ -593,7 +577,6 @@ bool Game_Interpreter_Map::CommandTeleport(RPG::EventCommand const& com) { // Co
 	int direction = com.parameters.size() > 3 ? com.parameters[3] - 1 : -1;
 
 	Main_Data::game_player->ReserveTeleport(map_id, x, y, direction);
-	Main_Data::game_player->StartTeleport();
 
 	// Parallel events should keep on running in 2k and 2k3, unlike in later versions
 	if (!main_flag)

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -996,10 +996,12 @@ void Game_Map::Update(bool is_preupdate) {
 	for (Game_Event& ev : events) {
 		ev.SetProcessed(false);
 	}
-	Main_Data::game_player->SetProcessed(false);
-	for (auto& vehicle: vehicles) {
-		if (vehicle->GetMapId() == location.map_id) {
-			vehicle->SetProcessed(false);
+	if (!is_preupdate) {
+		Main_Data::game_player->SetProcessed(false);
+		for (auto& vehicle: vehicles) {
+			if (vehicle->IsInCurrentMap()) {
+				vehicle->SetProcessed(false);
+			}
 		}
 	}
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -84,10 +84,6 @@ namespace {
 
 	int last_encounter_idx = 0;
 
-	// RPG_RT doesn't update player or vehicle movement or animation on the first frame
-	// of a new map. We use this flag to emulate that behavior.
-	bool first_frame = false;
-
 	//FIXME: Find a better way to do this.
 	bool reset_panorama_x_on_next_init = true;
 	bool reset_panorama_y_on_next_init = true;
@@ -149,7 +145,6 @@ void Game_Map::Quit() {
 
 void Game_Map::Setup(int _id) {
 	Dispose();
-	first_frame = true;
 	SetupCommon(_id, false);
 	map_info.encounter_rate = GetMapInfo().encounter_steps;
 	SetEncounterSteps(0);
@@ -617,7 +612,7 @@ bool Game_Map::MakeWay(int x, int y, int d, const Game_Character& self, bool for
 			&& !Main_Data::game_player->GetThrough()
 			&& self.GetLayer() == RPG::EventPage::Layers_same) {
 		// Update the Player to see if they'll move and recheck.
-		Main_Data::game_player->Update(!first_frame);
+		Main_Data::game_player->Update();
 		if (Main_Data::game_player->IsInPosition(new_x, new_y)) {
 			return false;
 		}
@@ -909,7 +904,7 @@ int Game_Map::CheckEvent(int x, int y) {
 	return 0;
 }
 
-void Game_Map::Update(bool only_parallel) {
+void Game_Map::Update(bool is_preupdate) {
 	if (GetNeedRefresh() != Refresh_None) Refresh();
 	Parallax::Update();
 	if (animation) {
@@ -937,15 +932,16 @@ void Game_Map::Update(bool only_parallel) {
 		ev.Update();
 	}
 
-	if (only_parallel)
+	if (is_preupdate) {
 		return;
+	}
 
-	Main_Data::game_player->Update(!first_frame);
+	Main_Data::game_player->Update();
 	UpdatePan();
 
 	for (auto& vehicle: vehicles) {
 		if (vehicle->GetMapId() == location.map_id) {
-			vehicle->Update(!first_frame);
+			vehicle->Update();
 		}
 	}
 
@@ -997,8 +993,6 @@ void Game_Map::Update(bool only_parallel) {
 	}
 
 	free_interpreters.clear();
-
-	first_frame = false;
 }
 
 RPG::MapInfo const& Game_Map::GetMapInfo() {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -934,17 +934,17 @@ void Game_Map::Update(bool only_parallel) {
 		ev.CheckEventTriggers();
 	}
 
-	Main_Data::game_player->Update(!first_frame);
-	UpdatePan();
-	GetInterpreter().Update();
+	for (Game_CommonEvent& ev : common_events) {
+		ev.Update();
+	}
 
 	for (Game_Event& ev : events) {
 		ev.Update();
 	}
 
-	for (Game_CommonEvent& ev : common_events) {
-		ev.Update();
-	}
+	Main_Data::game_player->Update(!first_frame);
+	UpdatePan();
+	GetInterpreter().Update();
 
 	for (auto& vehicle: vehicles) {
 		if (vehicle->GetMapId() == location.map_id) {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -981,9 +981,13 @@ void Game_Map::Update(bool is_preupdate) {
 			}
 		}
 		if (run_ev) {
-			interp.Setup(run_ev);
+			if (run_ev->IsActive()) {
+				interp.Setup(run_ev);
+			}
 			run_ev->ClearWaitingForegroundExecution();
-			interp.Update(false);
+			if (run_ev->IsActive()) {
+				interp.Update(false);
+			}
 			if (interp.IsRunning()) {
 				break;
 			}

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -930,7 +930,7 @@ void Game_Map::Update(bool only_parallel) {
 	}
 
 	for (Game_CommonEvent& ev : common_events) {
-		ev.UpdateParallel();
+		ev.Update();
 	}
 
 	for (Game_Event& ev : events) {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -720,58 +720,6 @@ bool Game_Map::MakeWay(const Game_Character& self, int x, int y) {
 	return IsPassableTile(&self, bit, x, y);
 }
 
-bool Game_Map::IsPassable(int x, int y, int d, const Game_Character* self_event) {
-	// TODO: this and MakeWay share a lot of code.
-	if (!Game_Map::IsValid(x, y)) return false;
-
-	int bit = DirToMask(d);
-
-	int tile_id;
-
-	if (self_event) {
-		bool pass = false;
-		std::vector<Game_Event*> events;
-		std::vector<Game_Event*>::iterator it;
-
-		Game_Map::GetEventsXY(events, x, y);
-		for (it = events.begin(); it != events.end(); ++it) {
-			if (*it == self_event || (*it)->GetThrough()) {
-				continue;
-			}
-
-			if (self_event != Main_Data::game_player.get()) {
-				if (self_event->IsOverlapForbidden() || (*it)->IsOverlapForbidden())
-					return false;
-			}
-
-			if ((*it)->GetLayer() == self_event->GetLayer()) {
-				if (self_event->IsInPosition(x, y))
-					pass = true;
-				else
-					return false;
-			}
-			else if ((*it)->GetLayer() == RPG::EventPage::Layers_below) {
-				// Event layer Chipset Tile
-				tile_id = (*it)->GetTileId();
-				if ((passages_up[tile_id] & Passable::Above) != 0)
-					continue;
-				if ((passages_up[tile_id] & bit) != 0)
-					pass = true;
-				else
-					return false;
-			}
-		}
-
-		if (!self_event->IsInPosition(x, y) && (vehicles[0]->IsInPosition(x, y) || vehicles[1]->IsInPosition(x, y)))
-			return false;
-
-		if (pass) // All events here are passable
-			return true;
-	}
-
-	return IsPassableTile(nullptr, bit, x, y);
-}
-
 bool Game_Map::CanLandAirship(int x, int y) {
 	if (!Game_Map::IsValid(x, y)) return false;
 
@@ -799,6 +747,24 @@ bool Game_Map::CanLandAirship(int x, int y) {
 	}
 
 	const int bit = Passable::Down | Passable::Right | Passable::Left | Passable::Up;
+
+	return IsPassableTile(nullptr, bit, x, y);
+}
+
+bool Game_Map::CanDisembarkShip(Game_Player& player, int x, int y) {
+	if (!Game_Map::IsValid(x, y)) {
+		return false;
+	}
+
+	for (auto& ev: GetEvents()) {
+		if (ev.IsInPosition(x, y)
+			&& ev.GetLayer() == RPG::EventPage::Layers_same
+			&& ev.IsActive()) {
+			return false;
+		}
+	}
+
+	int bit = GetPassableMask(x, y, player.GetX(), player.GetY());
 
 	return IsPassableTile(nullptr, bit, x, y);
 }

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1117,19 +1117,19 @@ int Game_Map::GetEncounterSteps() {
 	return location.encounter_steps;
 }
 
-void Game_Map::UpdateEncounterSteps() {
+bool Game_Map::UpdateEncounterSteps() {
 	if (Player::debug_flag &&
 		Input::IsPressed(Input::DEBUG_THROUGH)) {
-			return;
+			return false;
 	}
 
 	if(Main_Data::game_player->InAirship()) {
-		return;
+		return false;
 	}
 
 	if (GetEncounterRate() <= 0) {
 		location.encounter_steps = 0;
-		return;
+		return false;
 	}
 
 	int x = Main_Data::game_player->GetX();
@@ -1138,7 +1138,7 @@ void Game_Map::UpdateEncounterSteps() {
 	const RPG::Terrain* terrain = ReaderUtil::GetElement(Data::terrains, GetTerrainTag(x,y));
 	if (!terrain) {
 		Output::Warning("UpdateEncounterSteps: Invalid terrain at (%d, %d)", x, y);
-		return;
+		return false;
 	}
 
 	location.encounter_steps += terrain->encounter_rate;
@@ -1186,8 +1186,10 @@ void Game_Map::UpdateEncounterSteps() {
 
 	if (Utils::PercentChance(p)) {
 		SetEncounterSteps(0);
-		PrepareEncounter();
+		return true;
 	}
+
+	return false;
 }
 
 void Game_Map::SetEncounterSteps(int steps) {
@@ -1242,10 +1244,6 @@ std::vector<int> Game_Map::GetEncountersAt(int x, int y) {
 }
 
 bool Game_Map::PrepareEncounter() {
-	if (GetEncounterRate() <= 0) {
-		return false;
-	}
-
 	int x = Main_Data::game_player->GetX();
 	int y = Main_Data::game_player->GetY();
 
@@ -1257,7 +1255,6 @@ bool Game_Map::PrepareEncounter() {
 	}
 
 	Game_Temp::battle_troop_id = encounters[Utils::GetRandomNumber(0, encounters.size() - 1)];
-	Game_Temp::battle_calling = true;
 
 	if (Utils::GetRandomNumber(1, 32) == 1) {
 		Game_Temp::battle_first_strike = true;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -919,6 +919,16 @@ void Game_Map::Update(bool only_parallel) {
 		}
 	}
 
+	for (Game_Event& ev : events) {
+		ev.SetProcessed(false);
+	}
+	Main_Data::game_player->SetProcessed(false);
+	for (auto& vehicle: vehicles) {
+		if (vehicle->GetMapId() == location.map_id) {
+			vehicle->SetProcessed(false);
+		}
+	}
+
 	for (Game_CommonEvent& ev : common_events) {
 		ev.UpdateParallel();
 	}

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -571,14 +571,14 @@ static CollisionResult TestCollisionDuringMove(
 	return NoCollision;
 }
 
-bool Game_Map::MakeWay(int x, int y, int d, const Game_Character& self, bool force_through) {
+bool Game_Map::MakeWay(int x, int y, int d, const Game_Character& self) {
 	int new_x = RoundX(x + (d == Game_Character::Right ? 1 : d == Game_Character::Left ? -1 : 0));
 	int new_y = RoundY(y + (d == Game_Character::Down ? 1 : d == Game_Character::Up ? -1 : 0));
 
 	if (!Game_Map::IsValid(new_x, new_y))
 		return false;
 
-	if (self.GetThrough() || force_through) return true;
+	if (self.GetThrough()) return true;
 
 	// A character can move to a position with an impassable tile by
 	// standing on top of an event below it. These flags track whether

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -751,6 +751,11 @@ bool Game_Map::CanLandAirship(int x, int y) {
 	return IsPassableTile(nullptr, bit, x, y);
 }
 
+bool Game_Map::CanEmbarkShip(Game_Player& player, int x, int y) {
+	auto bit = GetPassableMask(player.GetX(), player.GetY(), x, y);
+	return IsPassableTile(&player, bit, player.GetX(), player.GetY());
+}
+
 bool Game_Map::CanDisembarkShip(Game_Player& player, int x, int y) {
 	if (!Game_Map::IsValid(x, y)) {
 		return false;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -954,6 +954,12 @@ void Game_Map::Update(bool only_parallel) {
 	// Run any event loaded from last frame.
 	interp.Update(true);
 	while (!interp.IsRunning() && !interp.ReachedLoopLimit()) {
+		// This logic is probably one big loop in RPG_RT. We have to replicate
+		// it here because once we stop executing from this we should not
+		// clear anymore waiting flags.
+		if (interp.IsImmediateCall() && interp.GetLoopCount() > 0) {
+			break;
+		}
 		Game_CommonEvent* run_ce = nullptr;
 
 		for (auto& ce: common_events) {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -43,6 +43,7 @@
 #include "player.h"
 #include "input.h"
 #include "utils.h"
+#include "scene.h"
 
 namespace {
 	constexpr int default_pan_x = 9 * SCREEN_TILE_SIZE;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -527,7 +527,7 @@ static CollisionResult TestCollisionDuringMove(
 	const Game_Character& self,
 	const Game_Event& other
 ) {
-	if (!other.GetActive()) {
+	if (!other.IsActive()) {
 		return NoCollision;
 	}
 
@@ -856,7 +856,7 @@ bool Game_Map::AirshipLandOk(int const x, int const y) {
 
 void Game_Map::GetEventsXY(std::vector<Game_Event*>& events, int x, int y) {
 	for (Game_Event& ev : GetEvents()) {
-		if (ev.IsInPosition(x, y) && ev.GetActive()) {
+		if (ev.IsInPosition(x, y) && ev.IsActive()) {
 			events.push_back(&ev);
 		}
 	}
@@ -1398,7 +1398,7 @@ Game_Vehicle* Game_Map::GetVehicle(Game_Vehicle::Type which) {
 
 bool Game_Map::IsAnyEventStarting() {
 	for (Game_Event& ev : events)
-		if (ev.IsWaitingForegroundExecution() && !ev.GetList().empty() && ev.GetActive())
+		if (ev.IsWaitingForegroundExecution() && !ev.GetList().empty() && ev.IsActive())
 			return true;
 
 	for (Game_CommonEvent& ev : common_events)

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1034,7 +1034,7 @@ void Game_Map::Update(bool is_preupdate) {
 		// This logic is probably one big loop in RPG_RT. We have to replicate
 		// it here because once we stop executing from this we should not
 		// clear anymore waiting flags.
-		if (interp.IsImmediateCall() && interp.GetLoopCount() > 0) {
+		if (Scene::instance->HasRequestedScene() && interp.GetLoopCount() > 0) {
 			break;
 		}
 		Game_CommonEvent* run_ce = nullptr;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -571,56 +571,153 @@ static CollisionResult TestCollisionDuringMove(
 	return NoCollision;
 }
 
-bool Game_Map::MakeWay(int x, int y, int d, const Game_Character& self) {
-	int new_x = RoundX(x + (d == Game_Character::Right ? 1 : d == Game_Character::Left ? -1 : 0));
-	int new_y = RoundY(y + (d == Game_Character::Down ? 1 : d == Game_Character::Up ? -1 : 0));
+static int GetPassableMask(int old_x, int old_y, int new_x, int new_y) {
+	int bit = 0;
+	if (new_x > old_x) { bit |= Passable::Right; }
+	if (new_x < old_x) { bit |= Passable::Left; }
+	if (new_y > old_y) { bit |= Passable::Down; }
+	if (new_y < old_y) { bit |= Passable::Up; }
+	return bit;
+}
 
-	if (!Game_Map::IsValid(new_x, new_y))
+static bool WouldCollide(const Game_Character& self, const Game_Character& other, bool self_conflict) {
+	if (self.GetThrough() || other.GetThrough()) {
 		return false;
+	}
 
-	if (self.GetThrough()) return true;
+	if (self.IsFlying() || other.IsFlying()) {
+		return false;
+	}
 
-	// A character can move to a position with an impassable tile by
-	// standing on top of an event below it. These flags track whether
-	// we stepped off an event and therefore don't need to check the
-	// passability of the tile layer below.
-	bool stepped_off_event = false;
-	bool stepped_onto_event = false;
+	if (!self.IsActive() || !other.IsActive()) {
+		return false;
+	}
 
-	for (Game_Event& other : GetEvents()) {
-		CollisionResult result = TestCollisionDuringMove(x, y, new_x, new_y, d, self, other);
-		if (result == Collision) {
-			// Try updating the offending event to give it a chance to move out of the
-			// way and recheck.
-			other.Update();
-			if (TestCollisionDuringMove(x, y, new_x, new_y, d, self, other) == Collision) {
+	if (self.GetType() == Game_Character::Event
+			&& other.GetType() == Game_Character::Event
+			&& (self.IsOverlapForbidden() || other.IsOverlapForbidden())) {
+		return true;
+	}
+
+	if (other.GetLayer() == RPG::EventPage::Layers_same && self_conflict) {
+		return true;
+	}
+
+	if (self.GetLayer() == other.GetLayer()) {
+		return true;
+	}
+
+	return false;
+}
+
+template <typename T>
+static bool MakeWayCollideEvent(int x, int y, const Game_Character& self, T& other, bool self_conflict) {
+	if (&self == &other) {
+		return false;
+	}
+
+	if (!other.IsInPosition(x, y)) {
+		return false;
+	}
+
+	// Force the other event to update, allowing them to possibly move out of the way.
+	other.Update();
+
+	if (!other.IsInPosition(x, y)) {
+		return false;
+	}
+
+	return WouldCollide(self, other, self_conflict);
+}
+
+bool Game_Map::MakeWay(const Game_Character& self, int x, int y) {
+	// Moving to same tile (used for jumps) always succeeds
+	if (x == self.GetX() && y == self.GetY()) {
+		return true;
+	}
+	if (!self.IsJumping() && x != self.GetX() && y != self.GetY()) {
+		// Handle diagonal stepping.
+		// Must be able to step on at least one of the 2 adjacent tiles and also the target tile.
+		// Verified behavior: Always checks vertical first, only checks horizontal if vertical fails.
+		bool vertical_ok = MakeWay(self, self.GetX(), y);
+		if (!vertical_ok) {
+			bool horizontal_ok = MakeWay(self, x, self.GetY());
+			if (!horizontal_ok) {
 				return false;
 			}
 		}
-		else if (result == CanStepOffCurrentTile) {
-			stepped_off_event = true;
-		} else if (result == CanStepOntoNewTile) {
-			stepped_onto_event = true;
-		}
 	}
 
-	if (vehicles[0]->IsInPosition(new_x, new_y) || vehicles[1]->IsInPosition(new_x, new_y)) {
+	// Note, even for diagonal, if the tile is invalid we still check vertical/horizontal first!
+	if (!Game_Map::IsValid(x, y)) {
 		return false;
 	}
 
-	if (Main_Data::game_player->IsInPosition(new_x, new_y)
-			&& !Main_Data::game_player->GetThrough()
-			&& self.GetLayer() == RPG::EventPage::Layers_same) {
-		// Update the Player to see if they'll move and recheck.
-		Main_Data::game_player->Update();
-		if (Main_Data::game_player->IsInPosition(new_x, new_y)) {
-			return false;
+	if (self.GetThrough()) {
+		return true;
+	}
+
+	const auto vehicle_type = static_cast<Game_Vehicle::Type>(self.GetVehicleType());
+
+	bool self_conflict = false;
+	if (!self.IsJumping()) {
+		auto bit = GetPassableMask(self.GetX(), self.GetY(), x, y);
+		// Check for self conflict.
+		// If this event has a tile graphic and the tile itself has passage blocked in the direction
+		// we want to move, flag it as "self conflicting" for use later.
+		if (self.GetLayer() == RPG::EventPage::Layers_below && self.GetTileId() != 0) {
+			int tile_id = self.GetTileId();
+			if ((passages_up[tile_id] & bit) == 0) {
+				self_conflict = true;
+			}
+		}
+
+		if (vehicle_type == Game_Vehicle::None) {
+			// Check that we are allowed to step off of the current tile.
+			// Note: Vehicles can always step off a tile.
+			if (!IsPassableTile(&self, bit, self.GetX(), self.GetY())) {
+				return false;
+			}
 		}
 	}
 
-	return
-		(stepped_off_event || IsPassableTile(DirToMask(d), x + y * GetWidth()))
-		&& (stepped_onto_event || IsPassableTile(DirToMask(Game_Character::ReverseDir(d)), new_x + new_y * GetWidth()));
+	if (vehicle_type != Game_Vehicle::Airship) {
+		// Check for collision with events on the target tile.
+		for (auto& other: GetEvents()) {
+			if (MakeWayCollideEvent(x, y, self, other, self_conflict)) {
+				return false;
+			}
+		}
+		auto& player = Main_Data::game_player;
+		if (player->GetVehicleType() == Game_Vehicle::None) {
+			if (MakeWayCollideEvent(x, y, self, *Main_Data::game_player, self_conflict)) {
+				return false;
+			}
+		}
+		for (auto vid: { Game_Vehicle::Boat, Game_Vehicle::Ship}) {
+			auto& other = vehicles[vid - 1];
+			if (other->IsInCurrentMap()) {
+				if (MakeWayCollideEvent(x, y, self, *other, self_conflict)) {
+					return false;
+				}
+			}
+		}
+		auto& airship = vehicles[Game_Vehicle::Airship - 1];
+		if (airship->IsInCurrentMap() && self.GetType() != Game_Character::Player) {
+			if (MakeWayCollideEvent(x, y, self, *airship, self_conflict)) {
+				return false;
+			}
+		}
+	}
+
+	int bit = 0;
+	if (self.IsJumping()) {
+		bit = Passable::Down | Passable::Up | Passable::Left | Passable::Right;
+	} else {
+		bit = GetPassableMask(x, y, self.GetX(), self.GetY());
+	}
+
+	return IsPassableTile(&self, bit, x, y);
 }
 
 bool Game_Map::IsPassable(int x, int y, int d, const Game_Character* self_event) {
@@ -672,7 +769,7 @@ bool Game_Map::IsPassable(int x, int y, int d, const Game_Character* self_event)
 			return true;
 	}
 
-	return IsPassableTile(bit, x + y * GetWidth());
+	return IsPassableTile(nullptr, bit, x, y);
 }
 
 bool Game_Map::IsPassableVehicle(int x, int y, Game_Vehicle::Type vehicle_type) {
@@ -728,6 +825,7 @@ bool Game_Map::IsPassableVehicle(int x, int y, Game_Vehicle::Type vehicle_type) 
 	return true;
 }
 
+
 bool Game_Map::IsLandable(int x, int y, const Game_Character *self_event) {
 	if (!Game_Map::IsValid(x, y)) return false;
 
@@ -753,12 +851,73 @@ bool Game_Map::IsLandable(int x, int y, const Game_Character *self_event) {
 		}
 	}
 
-	return IsPassableTile(bit, x + y * GetWidth());
+	return IsPassableTile(nullptr, bit, x, y);
 }
 
-bool Game_Map::IsPassableTile(int bit, int tile_index) {
+bool Game_Map::IsPassableTile(const Game_Character* self, int bit, int x, int y) {
+	if (!IsValid(x, y)) return false;
+
+	auto vehicle_type = (self != nullptr)
+		? self->GetVehicleType() : Game_Vehicle::None;
+
+	if (vehicle_type != Game_Vehicle::None) {
+		const auto* terrain = ReaderUtil::GetElement(Data::terrains, GetTerrainTag(x, y));
+		if (!terrain) {
+			Output::Warning("MakeWay: Invalid terrain at (%d, %d)", x, y);
+			return false;
+		}
+		if (vehicle_type == Game_Vehicle::Boat && !terrain->boat_pass) {
+			return false;
+		}
+		if (vehicle_type == Game_Vehicle::Ship && !terrain->ship_pass) {
+			return false;
+		}
+		if (vehicle_type == Game_Vehicle::Airship) {
+			return terrain->airship_pass;
+		}
+	}
+
+	// Highest ID event with layer=below, not through, and a tile graphic wins.
+	int event_tile_id = 0;
+	for (auto& ev: events) {
+		if (self == &ev) {
+			continue;
+		}
+		if (!ev.IsActive() || ev.GetThrough()) {
+			continue;
+		}
+		if (ev.IsInPosition(x, y) && ev.GetLayer() == RPG::EventPage::Layers_below) {
+			int tile_id = ev.GetTileId();
+			if (tile_id > 0) {
+				event_tile_id = tile_id;
+			}
+		}
+	}
+
+	// If there was a below tile event, and the tile is not above
+	// Override the chipset with event tile behavior.
+	if (event_tile_id > 0
+			&& ((passages_up[event_tile_id] & Passable::Above) == 0)) {
+		switch (vehicle_type) {
+			case Game_Vehicle::None:
+				return ((passages_up[event_tile_id] & bit) != 0);
+			case Game_Vehicle::Boat:
+			case Game_Vehicle::Ship:
+				return false;
+			case Game_Vehicle::Airship:
+				break;
+		};
+	}
+
+	int tile_index = x + y * GetWidth();
 	int tile_id = map->upper_layer[tile_index] - BLOCK_F;
 	tile_id = map_info.upper_tiles[tile_id];
+
+	if (vehicle_type == Game_Vehicle::Boat || vehicle_type == Game_Vehicle::Ship) {
+		if ((passages_up[tile_id] & Passable::Above) == 0)
+			return false;
+		return true;
+	}
 
 	if ((passages_up[tile_id] & bit) == 0)
 		return false;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -78,8 +78,6 @@ namespace {
 
 	int last_map_id;
 
-	bool teleport_delay;
-
 	RPG::Chipset* chipset;
 
 	int last_encounter_idx = 0;
@@ -120,8 +118,6 @@ void Game_Map::Init() {
 	location.pan_current_x = default_pan_x;
 	location.pan_current_y = default_pan_y;
 	last_map_id = -1;
-
-	teleport_delay = false;
 }
 
 void Game_Map::Dispose() {
@@ -1637,14 +1633,6 @@ int Game_Map::GetTargetPanX() {
 
 int Game_Map::GetTargetPanY() {
 	return location.pan_finish_y;
-}
-
-bool Game_Map::IsTeleportDelayed() {
-	return teleport_delay;
-}
-
-void Game_Map::SetTeleportDelayed(bool delay) {
-	teleport_delay = delay;
 }
 
 FileRequestAsync* Game_Map::RequestMap(int map_id) {

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -25,6 +25,7 @@
 #include "game_commonevent.h"
 #include "game_event.h"
 #include "game_vehicle.h"
+#include "game_player.h"
 #include "rpg_encounter.h"
 #include "rpg_map.h"
 #include "rpg_mapinfo.h"
@@ -152,18 +153,6 @@ namespace Game_Map {
 	bool MakeWay(const Game_Character& self, int x, int y);
 
 	/**
-	 * Gets if a tile coordinate is passable in a direction.
-	 *
-	 * @param x tile x.
-	 * @param y tile y.
-	 * @param d direction (0, 2, 4, 6, 8, 10).
-	 *		    0,10 = determine if all directions are impassable.
-	 * @param self_event Current character for doing passability check
-	 * @return whether is passable.
-	 */
-	bool IsPassable(int x, int y, int d, const Game_Character* self_event = NULL);
-
-	/**
 	 * Gets if possible to land the airship at (x,y)
 	 *
 	 * @param x tile x.
@@ -171,6 +160,16 @@ namespace Game_Map {
 	 * @return whether is posible to land airship
 	 */
 	bool CanLandAirship(int x, int y);
+
+	/**
+	 * Gets if possible to disembark the boat or ship to (x,y)
+	 *
+	 * @param player the player
+	 * @param x tile x.
+	 * @param y tile y.
+	 * @return whether is posible to disembark the boat or ship
+	 */
+	bool CanDisembarkShip(Game_Player& player, int x, int y);
 
 	/**
 	 * Gets the bush depth at a certain tile.

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -138,19 +138,18 @@ namespace Game_Map {
 	bool IsValid(int x, int y);
 
 	/**
-	 * Clears the way for a move by self from (x,y) in the direction d. Any events
-	 * that block the way are updated early (by UpdateParallel) to give them a
+	 * Clears the way for a move by self to (x,y). Any events
+	 * that block the way are updated early to give them a
 	 * chance to move out of the way.
 	 *
-	 * Returns true if everything is clear to make the move.
+	 * Returns true if move is possible.
 	 *
-	 * @param x tile x.
-	 * @param y tile y.
-	 * @param d direction
 	 * @param self Character to move.
+	 * @param x new tile x.
+	 * @param y new tile y.
 	 * @return whether is passable.
 	 */
-	bool MakeWay(int x, int y, int d, const Game_Character& self);
+	bool MakeWay(const Game_Character& self, int x, int y);
 
 	/**
 	 * Gets if a tile coordinate is passable in a direction.
@@ -565,7 +564,20 @@ namespace Game_Map {
 	int SubstituteDown(int old_id, int new_id);
 	int SubstituteUp(int old_id, int new_id);
 
-	bool IsPassableTile(int bit, int tile_index);
+	/**
+	 * Checks if its possible to step onto the tile at (x,y)
+	 * The check includes tile graphic events checks.
+	 *
+	 * Returns true if move is possible.
+	 *
+	 * @param self Character to move. If not nullptr, checks the vehicle type and performs vehicle specific checks if is vehicle.
+	 *        Also ignores self in the event tile graphic checks if self is not nullptr.
+	 * @param bit which direction bits to check
+	 * @param x target tile x.
+	 * @param y target tile y.
+	 * @return whether is passable.
+	 */
+	bool IsPassableTile(const Game_Character* self, int bit, int x, int y);
 
 	enum PanDirection {
 		PanUp,

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -162,6 +162,16 @@ namespace Game_Map {
 	bool CanLandAirship(int x, int y);
 
 	/**
+	 * Gets if possible to embark the boat or ship at (x,y)
+	 *
+	 * @param player the player
+	 * @param x tile x.
+	 * @param y tile y.
+	 * @return whether is posible to disembark the boat or ship
+	 */
+	bool CanEmbarkShip(Game_Player& player, int x, int y);
+
+	/**
 	 * Gets if possible to disembark the boat or ship to (x,y)
 	 *
 	 * @param player the player

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -289,8 +289,10 @@ namespace Game_Map {
 
 	/**
 	 * Updates encounter steps according to terrain.
+	 *
+	 * @return true if an encounter should trigger.
 	 */
-	void UpdateEncounterSteps();
+	bool UpdateEncounterSteps();
 
 	/**
 	 * Sets encounter_steps to steps.

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -233,9 +233,9 @@ namespace Game_Map {
 	/**
 	 * Updates the map state.
 	 *
-	 * @param only_parallel Update only parallel interpreters
+	 * @param is_preupdate Update only common events and map events
 	 */
-	void Update(bool only_parallel = false);
+	void Update(bool is_preupdate = false);
 
 	/**
 	 * Gets current map_info.

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -148,10 +148,9 @@ namespace Game_Map {
 	 * @param y tile y.
 	 * @param d direction
 	 * @param self Character to move.
-	 * @param force_through act as if self.SetThrough() == true
 	 * @return whether is passable.
 	 */
-	bool MakeWay(int x, int y, int d, const Game_Character& self, bool force_through);
+	bool MakeWay(int x, int y, int d, const Game_Character& self);
 
 	/**
 	 * Gets if a tile coordinate is passable in a direction.

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -568,6 +568,17 @@ namespace Game_Map {
 	 */
 	bool IsPassableTile(const Game_Character* self, int bit, int x, int y);
 
+	/**
+	 * Checks if the lower tile at (x,y) is passable by the player.
+	 *
+	 * Returns true if move is possible.
+	 *
+	 * @param bit which direction bits to check
+	 * @param tile_index the tile index
+	 * @return whether is passable.
+	 */
+	bool IsPassableLowerTile(int bit, int tile_index);
+
 	enum PanDirection {
 		PanUp,
 		PanRight,

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -613,23 +613,6 @@ namespace Game_Map {
 	int GetTargetPanX();
 	int GetTargetPanY();
 
-	/**
-	 * Gets if pending teleportations will be ignored.
-	 *
-	 * @return true: teleport ignored, false: teleport processed normally
-	 */
-	bool IsTeleportDelayed();
-
-	/**
-	 * Enables/Disables the processing of teleports.
-	 * This is used by Show/EraseScreen in Parallel processes to prevent
-	 * too early execution of teleports (Show/EraseScreen don't yield the
-	 * interpreter in RPG_RT).
-	 *
-	 * @param delay enable/disable delay
-	 */
-	void SetTeleportDelayed(bool delay);
-
 	FileRequestAsync* RequestMap(int map_id);
 
 	namespace Parallax {

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -164,24 +164,13 @@ namespace Game_Map {
 	bool IsPassable(int x, int y, int d, const Game_Character* self_event = NULL);
 
 	/**
-	 * Gets if a tile coordinate is passable in a direction by a vehicle.
+	 * Gets if possible to land the airship at (x,y)
 	 *
 	 * @param x tile x.
 	 * @param y tile y.
-	 * @param vehicle_type type of vehicle
-	 * @return whether is passable.
+	 * @return whether is posible to land airship
 	 */
-	bool IsPassableVehicle(int x, int y, Game_Vehicle::Type vehicle_type);
-
-	/**
-	 * Gets if a tile coordinate can be jumped to.
-	 *
-	 * @param x tile x.
-	 * @param y tile y.
-	 * @param self_event Current character attemping to jump.
-	 * @return whether is posible to jump.
-	 */
-	bool IsLandable(int x, int y, const Game_Character* self_event = NULL);
+	bool CanLandAirship(int x, int y);
 
 	/**
 	 * Gets the bush depth at a certain tile.
@@ -209,15 +198,6 @@ namespace Game_Map {
 	 * @return terrain tag ID.
 	 */
 	int GetTerrainTag(int x, int y);
-
-	/**
-	 * Gets if a tile can land airship.
-	 *
-	 * @param x tile x.
-	 * @param y tile y.
-	 * @return terrain tag ID.
-	 */
-	bool AirshipLandOk(int x, int y);
 
 	/**
 	 * Gets designated position event.

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -251,6 +251,10 @@ void Game_Player::Update() {
 	Game_Character::UpdateMovement();
 	Game_Character::UpdateAnimation(was_moving);
 
+	if (IsAboard() && GetVehicle()) {
+		GetVehicle()->SyncWithPlayer();
+	}
+
 	UpdateScroll(old_sprite_x, old_sprite_y);
 
 	if (IsMoving()) return;

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -251,8 +251,12 @@ void Game_Player::Update() {
 	Game_Character::UpdateMovement();
 	Game_Character::UpdateAnimation(was_moving);
 
-	if (IsAboard() && GetVehicle()) {
-		GetVehicle()->SyncWithPlayer();
+	if (IsAboard()) {
+		auto* vehicle = GetVehicle();
+		if (vehicle) {
+			GetVehicle()->SyncWithPlayer();
+			vehicle->AnimateAscentDescent();
+		}
 	}
 
 	UpdateScroll(old_sprite_x, old_sprite_y);

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -36,7 +36,7 @@
 #include <cmath>
 
 Game_Player::Game_Player():
-	Game_Character(&Main_Data::game_data.party_location)
+	Game_Character(Player, &Main_Data::game_data.party_location)
 {
 	SetDirection(RPG::EventPage::Direction_down);
 	SetMoveSpeed(4);

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -123,9 +123,6 @@ bool Game_Player::MakeWay(int x, int y) const {
 }
 
 void Game_Player::MoveTo(int x, int y) {
-	x = max(0, min(x, Game_Map::GetWidth() - 1));
-	y = max(0, min(y, Game_Map::GetHeight() - 1));
-
 	Game_Character::MoveTo(x, y);
 	Game_Map::SetPositionX(GetSpriteX() - data()->pan_current_x);
 	Game_Map::SetPositionY(GetSpriteY() - data()->pan_current_y);

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -229,7 +229,7 @@ void Game_Player::UpdateSelfMovement() {
 
 }
 
-void Game_Player::Update(bool process_movement) {
+void Game_Player::Update() {
 	if (IsProcessed()) {
 		return;
 	}
@@ -245,40 +245,36 @@ void Game_Player::Update(bool process_movement) {
 
 	auto was_moving = !IsStopping();
 
-	if (process_movement) {
-		Game_Character::UpdateMovement();
-		Game_Character::UpdateAnimation(was_moving);
-	}
+	Game_Character::UpdateMovement();
+	Game_Character::UpdateAnimation(was_moving);
 
 	UpdateScroll(old_sprite_x, old_sprite_y);
 
 	if (IsMoving()) return;
 
-	if (process_movement) {
-		if (data()->boarding) {
-			// Boarding completed
-			data()->aboard = true;
-			data()->boarding = false;
-			auto* vehicle = GetVehicle();
-			if (vehicle->IsMoveRouteOverwritten()) {
-				vehicle->CancelMoveRoute();
-			}
-			SetMoveSpeed(vehicle->GetMoveSpeed());
-			vehicle->SetDirection(GetDirection());
-			vehicle->SetSpriteDirection(Left);
-			// Note: RPG_RT ignores the lock_facing flag here!
-			SetSpriteDirection(Left);
-			vehicle->SetX(GetX());
-			vehicle->SetY(GetY());
-			return;
+	if (data()->boarding) {
+		// Boarding completed
+		data()->aboard = true;
+		data()->boarding = false;
+		auto* vehicle = GetVehicle();
+		if (vehicle->IsMoveRouteOverwritten()) {
+			vehicle->CancelMoveRoute();
 		}
+		SetMoveSpeed(vehicle->GetMoveSpeed());
+		vehicle->SetDirection(GetDirection());
+		vehicle->SetSpriteDirection(Left);
+		// Note: RPG_RT ignores the lock_facing flag here!
+		SetSpriteDirection(Left);
+		vehicle->SetX(GetX());
+		vehicle->SetY(GetY());
+		return;
+	}
 
-		if (data()->unboarding) {
-			// Unboarding completed
-			data()->unboarding = false;
-			CheckTouchEvent();
-			return;
-		}
+	if (data()->unboarding) {
+		// Unboarding completed
+		data()->unboarding = false;
+		CheckTouchEvent();
+		return;
 	}
 
 	if (was_blocked) return;

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -114,15 +114,12 @@ void Game_Player::PerformTeleport() {
 		GetVehicle()->MoveTo(new_x, new_y);
 }
 
-bool Game_Player::MakeWay(int x, int y, int d) const {
-	if (data()->aboard)
-		return GetVehicle()->MakeWay(x, y, d);
-
-	if (d > 3) {
-		return MakeWayDiagonal(x, y, d);
+bool Game_Player::MakeWay(int x, int y) const {
+	if (data()->aboard) {
+		return GetVehicle()->MakeWay(x, y);
 	}
 
-	return Game_Map::MakeWay(x, y, d, *this);
+	return Game_Character::MakeWay(x, y);
 }
 
 bool Game_Player::IsTeleporting() const {

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -191,7 +191,9 @@ void Game_Player::UpdateVehicleActions() {
 		auto* vehicle = GetVehicle();
 		if (vehicle) {
 			vehicle->SyncWithPlayer();
-			vehicle->AnimateAscentDescent();
+			if (IsStopping()) {
+				vehicle->AnimateAscentDescent();
+			}
 		}
 	}
 
@@ -522,11 +524,12 @@ bool Game_Player::GetOffVehicle() {
 	return true;
 }
 
-bool Game_Player::IsStopping() const {
-	// Prevent MoveRoute execution while the airship is ascending/descending (Issue #1268)
-	if (InAirship() && !GetVehicle()->IsMovable())
-		return false;
-	return Game_Character::IsStopping();
+void Game_Player::UpdateMoveRoute(int32_t& current_index, const RPG::MoveRoute& current_route) {
+	auto* vehicle = GetVehicle();
+	if (vehicle && vehicle->IsAscendingOrDescending()) {
+		return;
+	}
+	Game_Character::UpdateMoveRoute(current_index, current_route);
 }
 
 bool Game_Player::IsMovable() const {

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -39,7 +39,6 @@ Game_Player::Game_Player():
 	Game_Character(&Main_Data::game_data.party_location)
 {
 	SetDirection(RPG::EventPage::Direction_down);
-	SetProcessed(true); // RPG_RT compatibility
 	SetMoveSpeed(4);
 	SetAnimationType(RPG::EventPage::AnimType_non_continuous);
 }
@@ -231,12 +230,10 @@ void Game_Player::UpdateSelfMovement() {
 }
 
 void Game_Player::Update(bool process_movement) {
-	int cur_frame_count = Player::GetFrames();
-	// Only update the event once per frame
-	if (cur_frame_count == frame_count_at_last_update_parallel) {
+	if (IsProcessed()) {
 		return;
 	}
-	frame_count_at_last_update_parallel = cur_frame_count;
+	SetProcessed(true);
 
 	const bool last_moving = IsMoving() || IsJumping();
 

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -255,6 +255,7 @@ void Game_Player::Update() {
 
 	if (IsMoving()) return;
 
+	bool finished_boarding_or_unboarding = false;
 	if (data()->boarding) {
 		// Boarding completed
 		data()->aboard = true;
@@ -270,13 +271,13 @@ void Game_Player::Update() {
 		SetSpriteDirection(Left);
 		vehicle->SetX(GetX());
 		vehicle->SetY(GetY());
-		return;
+		finished_boarding_or_unboarding = true;
 	}
 
 	if (data()->unboarding) {
 		// Unboarding completed
 		data()->unboarding = false;
-		return;
+		finished_boarding_or_unboarding = true;
 	}
 
 	if (IsMoveRouteOverwritten()) return;
@@ -294,6 +295,10 @@ void Game_Player::Update() {
 		if(CheckTouchEvent()) {
 			return;
 		}
+	}
+
+	if (finished_boarding_or_unboarding) {
+		return;
 	}
 
 	if (!Game_Map::GetInterpreter().IsRunning() && !Game_Map::IsAnyEventStarting()) {

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -439,6 +439,10 @@ bool Game_Player::GetOnVehicle() {
 		return false;
 	}
 
+	if (type != Game_Vehicle::Airship && !Game_Map::CanEmbarkShip(*this, front_x, front_y)) {
+		return false;
+	}
+
 	data()->vehicle = type;
 	data()->preboard_move_speed = GetMoveSpeed();
 	if (type != Game_Vehicle::Airship) {

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -126,6 +126,7 @@ void Game_Player::MoveTo(int x, int y) {
 	Game_Character::MoveTo(x, y);
 	Game_Map::SetPositionX(GetSpriteX() - data()->pan_current_x);
 	Game_Map::SetPositionY(GetSpriteY() - data()->pan_current_y);
+	SetMenuCalling(false);
 }
 
 void Game_Player::UpdateScroll(int old_x, int old_y) {
@@ -220,11 +221,20 @@ void Game_Player::UpdateVehicleActions() {
 }
 
 void Game_Player::UpdateSelfMovement() {
+	bool did_call_menu = false;
+	if (IsMenuCalling()) {
+		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
+		Scene::instance->SetRequestedScene(Scene::Menu);
+		SetMenuCalling(false);
+		did_call_menu = true;
+	}
+
 	if (!IsBoardingOrUnboarding()
 			&& !Game_Map::GetInterpreter().IsRunning()
 			&& !Game_Message::visible
 			&& !IsMoveRouteOverwritten()
 			&& !IsPaused() // RPG_RT compatible logic, but impossible to set pause on player
+			&& !did_call_menu
 			&& !Game_Map::IsAnyEventStarting())
 	{
 		if (IsStopping()) {
@@ -273,8 +283,7 @@ void Game_Player::UpdateSelfMovement() {
 			&& !Game_Map::GetInterpreter().IsRunning())
 	{
 		if (Input::IsTriggered(Input::CANCEL)) {
-			Main_Data::game_data.party_location.menu_calling = true;
-			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
+			SetMenuCalling(true);
 		}
 	}
 }
@@ -331,7 +340,6 @@ void Game_Player::Update() {
 			return;
 		}
 	}
-
 
 	if (was_moving) {
 		Game_Map::UpdateEncounterSteps();

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -102,7 +102,9 @@ void Game_Player::PerformTeleport() {
 
 	if (teleport_target.GetDirection() >= 0) {
 		SetDirection(teleport_target.GetDirection());
-		SetSpriteDirection(teleport_target.GetDirection());
+		if (!IsFacingLocked()) {
+			SetSpriteDirection(teleport_target.GetDirection());
+		}
 	}
 
 	if (InVehicle()) {

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -325,24 +325,22 @@ bool Game_Player::CheckCollisionEvent() {
 	return CheckEventTriggerHere({RPG::EventPage::Trigger_collision});
 }
 
-bool Game_Player::CheckEventTriggerHere(const std::vector<int>& triggers, bool triggered_by_decision_key) {
+bool Game_Player::CheckEventTriggerHere(TriggerSet triggers, bool triggered_by_decision_key) {
 	bool result = false;
 
 	std::vector<Game_Event*> events;
 	Game_Map::GetEventsXY(events, GetX(), GetY());
 
-	std::vector<Game_Event*>::iterator i;
-	for (i = events.begin(); i != events.end(); ++i) {
-		if (((*i)->GetLayer() != RPG::EventPage::Layers_same)
-			&& std::find(triggers.begin(), triggers.end(), (*i)->GetTrigger() ) != triggers.end() ) {
-			(*i)->Start(triggered_by_decision_key);
-			result = (*i)->GetStarting();
+	for (auto* ev: events) {
+		if (ev->GetLayer() != RPG::EventPage::Layers_same && triggers[ev->GetTrigger()]) {
+			ev->Start(triggered_by_decision_key);
+			result = ev->GetStarting();
 		}
 	}
 	return result;
 }
 
-bool Game_Player::CheckEventTriggerThere(const std::vector<int>& triggers, bool triggered_by_decision_key) {
+bool Game_Player::CheckEventTriggerThere(TriggerSet triggers, bool triggered_by_decision_key) {
 	if ( Game_Map::GetInterpreter().IsRunning() ) return false;
 
 	bool result = false;
@@ -354,10 +352,7 @@ bool Game_Player::CheckEventTriggerThere(const std::vector<int>& triggers, bool 
 	Game_Map::GetEventsXY(events, front_x, front_y);
 
 	for (const auto& ev : events) {
-		if ( ev->GetLayer() == RPG::EventPage::Layers_same &&
-			std::find(triggers.begin(), triggers.end(), ev->GetTrigger() ) != triggers.end()
-		)
-		{
+		if ( ev->GetLayer() == RPG::EventPage::Layers_same && triggers[ev->GetTrigger()]) {
 			if (!ev->GetList().empty()) {
 				ev->StartTalkToHero();
 			}
@@ -373,10 +368,7 @@ bool Game_Player::CheckEventTriggerThere(const std::vector<int>& triggers, bool 
 		Game_Map::GetEventsXY(events, front_x, front_y);
 
 		for (const auto& ev : events) {
-			if ( ev->GetLayer() == 1 &&
-				std::find(triggers.begin(), triggers.end(), ev->GetTrigger() ) != triggers.end()
-			)
-			{
+			if ( ev->GetLayer() == RPG::EventPage::Layers_same && triggers[ev->GetTrigger()]) {
 				if (!ev->GetList().empty()) {
 					ev->StartTalkToHero();
 				}

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -330,8 +330,7 @@ bool Game_Player::CheckEventTriggerHere(TriggerSet triggers, bool triggered_by_d
 
 	for (auto* ev: events) {
 		if (ev->GetLayer() != RPG::EventPage::Layers_same && triggers[ev->GetTrigger()]) {
-			ev->Start(triggered_by_decision_key);
-			result = ev->GetStarting();
+			result |= ev->SetAsWaitingForegroundExecution(true, triggered_by_decision_key);
 		}
 	}
 	return result;
@@ -350,11 +349,7 @@ bool Game_Player::CheckEventTriggerThere(TriggerSet triggers, bool triggered_by_
 
 	for (const auto& ev : events) {
 		if ( ev->GetLayer() == RPG::EventPage::Layers_same && triggers[ev->GetTrigger()]) {
-			if (!ev->GetList().empty()) {
-				ev->StartTalkToHero();
-			}
-			ev->Start(triggered_by_decision_key);
-			result = true;
+			result |= ev->SetAsWaitingForegroundExecution(true, triggered_by_decision_key);
 		}
 	}
 
@@ -366,11 +361,7 @@ bool Game_Player::CheckEventTriggerThere(TriggerSet triggers, bool triggered_by_
 
 		for (const auto& ev : events) {
 			if ( ev->GetLayer() == RPG::EventPage::Layers_same && triggers[ev->GetTrigger()]) {
-				if (!ev->GetList().empty()) {
-					ev->StartTalkToHero();
-				}
-				ev->Start(triggered_by_decision_key);
-				result = true;
+				result |= ev->SetAsWaitingForegroundExecution(true, triggered_by_decision_key);
 			}
 		}
 	}
@@ -389,11 +380,7 @@ bool Game_Player::CheckEventTriggerTouch(int x, int y) {
 		if (ev->GetLayer() == RPG::EventPage::Layers_same &&
 			(ev->GetTrigger() == RPG::EventPage::Trigger_touched ||
 			ev->GetTrigger() == RPG::EventPage::Trigger_collision) ) {
-			if (!ev->GetList().empty()) {
-				ev->StartTalkToHero();
-			}
-			ev->Start();
-			result = true;
+			result |= ev->SetAsWaitingForegroundExecution(true, false);
 
 		}
 	}

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -474,10 +474,9 @@ bool Game_Player::GetOffVehicle() {
 	if (!InAirship()) {
 		int front_x = Game_Map::XwithDirection(GetX(), GetDirection());
 		int front_y = Game_Map::YwithDirection(GetY(), GetDirection());
-		if (!CanWalk(front_x, front_y)
-			&& !Game_Map::GetVehicle(Game_Vehicle::Boat)->IsInPosition(front_x, front_y)
-			&& !Game_Map::GetVehicle(Game_Vehicle::Ship)->IsInPosition(front_x, front_y))
+		if (!Game_Map::CanDisembarkShip(*this, front_x, front_y)) {
 			return false;
+		}
 	}
 	auto* vehicle = GetVehicle();
 
@@ -522,10 +521,6 @@ bool Game_Player::InAirship() const {
 
 Game_Vehicle* Game_Player::GetVehicle() const {
 	return Game_Map::GetVehicle((Game_Vehicle::Type) data()->vehicle);
-}
-
-bool Game_Player::CanWalk(int x, int y) {
-	return Game_Map::IsPassable(x, y, GetDirection(), this);
 }
 
 void Game_Player::BeginMove() {

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -26,6 +26,7 @@
 #include "game_temp.h"
 #include "graphics.h"
 #include "input.h"
+#include "scene.h"
 #include "main_data.h"
 #include "player.h"
 #include "util_macro.h"

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -536,8 +536,6 @@ void Game_Player::UpdateMoveRoute(int32_t& current_index, const RPG::MoveRoute& 
 bool Game_Player::IsMovable() const {
 	if (IsMoving() || IsJumping())
 		return false;
-	if (Graphics::IsTransitionPending())
-		return false;
 	if (IsMoveRouteOverwritten())
 		return false;
 	if (data()->boarding || data()->unboarding)

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -46,7 +46,6 @@ public:
 	bool GetVisible() const override;
 	bool MakeWay(int x, int y) const override;
 	void BeginMove() override;
-	void CancelMoveRoute() override;
 	int GetVehicleType() const override;
 	void UpdateSelfMovement() override;
 	/** @} */

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -106,6 +106,7 @@ private:
 	bool GetOnVehicle();
 	bool GetOffVehicle();
 	void Unboard();
+	void UpdateVehicleActions();
 
 	TeleportTarget teleport_target;
 };

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -22,6 +22,7 @@
 #include "rpg_music.h"
 #include "rpg_savepartylocation.h"
 #include "game_character.h"
+#include "flag_set.h"
 #include <vector>
 
 class Game_Vehicle;
@@ -103,6 +104,7 @@ protected:
 	RPG::SavePartyLocation* data();
 	const RPG::SavePartyLocation* data() const;
 private:
+	using TriggerSet = FlagSet<RPG::EventPage::Trigger>;
 
 	bool teleporting = false;
 	int new_map_id = 0, new_x = 0, new_y = 0, new_direction = 0;
@@ -112,8 +114,8 @@ private:
 	bool CheckTouchEvent();
 	bool CheckCollisionEvent();
 	bool CheckActionEvent();
-	bool CheckEventTriggerHere(const std::vector<int>& triggers, bool triggered_by_decision_key = false);
-	bool CheckEventTriggerThere(const std::vector<int>& triggers, bool triggered_by_decision_key = false);
+	bool CheckEventTriggerHere(TriggerSet triggers, bool triggered_by_decision_key = false);
+	bool CheckEventTriggerThere(TriggerSet triggers, bool triggered_by_decision_key = false);
 	bool GetOnVehicle();
 	bool GetOffVehicle();
 	void Unboard();

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -100,8 +100,6 @@ private:
 
 	void UpdateScroll(int prev_x, int prev_y);
 	void UpdatePan();
-	bool CheckTouchEvent();
-	bool CheckCollisionEvent();
 	bool CheckActionEvent();
 	bool CheckEventTriggerHere(TriggerSet triggers, bool face_hero, bool triggered_by_decision_key);
 	bool CheckEventTriggerThere(TriggerSet triggers, int x, int y, bool face_hero, bool triggered_by_decision_key);

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -88,9 +88,6 @@ public:
 	Game_Vehicle* GetVehicle() const;
 	bool CanWalk(int x, int y);
 
-	/** Workaround used to avoid blocking the player with move routes that are completeable in a single frame */
-	bool IsBlockedByMoveRoute() const;
-
 	/**
 	 * Callback function invoked by the Vehicle to notify that the unboarding has finished
 	 */

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -66,12 +66,8 @@ public:
 	void PerformTeleport();
 	void MoveTo(int x, int y) override;
 
-	/** 
-	 * Update this for the current frame
-	 *
-	 * @param process_movement if false, we will not process movement or animations
-	 * */
-	void Update(bool process_movement);
+	/** Update this for the current frame */
+	void Update();
 
 	void Refresh();
 

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -48,6 +48,7 @@ public:
 	void BeginMove() override;
 	int GetVehicleType() const override;
 	void UpdateSelfMovement() override;
+	void OnMoveFailed(int x, int y) override;
 	/** @} */
 
 	bool IsPendingTeleport() const;
@@ -71,8 +72,6 @@ public:
 	void Update();
 
 	void Refresh();
-
-	bool CheckEventTriggerTouch(int x, int y) override;
 
 	/*
 	 * Overridden to convince Game_Character we aren't stopped if boarding/unboarding.
@@ -104,8 +103,8 @@ private:
 	bool CheckTouchEvent();
 	bool CheckCollisionEvent();
 	bool CheckActionEvent();
-	bool CheckEventTriggerHere(TriggerSet triggers, bool triggered_by_decision_key = false);
-	bool CheckEventTriggerThere(TriggerSet triggers, bool triggered_by_decision_key = false);
+	bool CheckEventTriggerHere(TriggerSet triggers, bool face_hero, bool triggered_by_decision_key);
+	bool CheckEventTriggerThere(TriggerSet triggers, int x, int y, bool face_hero, bool triggered_by_decision_key);
 	bool GetOnVehicle();
 	bool GetOffVehicle();
 	void Unboard();

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -49,6 +49,7 @@ public:
 	int GetVehicleType() const override;
 	void UpdateSelfMovement() override;
 	void OnMoveFailed(int x, int y) override;
+	void UpdateMoveRoute(int32_t& current_index, const RPG::MoveRoute& current_route) override;
 	/** @} */
 
 	bool IsPendingTeleport() const;
@@ -72,12 +73,6 @@ public:
 	void Update();
 
 	void Refresh();
-
-	/*
-	 * Overridden to convince Game_Character we aren't stopped if boarding/unboarding.
-	 * Consider calling this 'IsReadyToMove' or something, and 'IsMovable' -> 'IsPlayerMovable'
-	 */
-	bool IsStopping() const override;
 
 	bool GetOnOffVehicle();
 	bool IsMovable() const;

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -102,6 +102,16 @@ public:
 	/** @return the menu calling flag */
 	bool IsMenuCalling() const;
 
+	/**
+	 * Set the encounter callling flag
+	 *
+	 * @param value the value of the flag to set
+	 */
+	void SetEncounterCalling(bool value);
+
+	/** @return the encounter calling flag */
+	bool IsEncounterCalling() const;
+
 protected:
 	RPG::SavePartyLocation* data();
 	const RPG::SavePartyLocation* data() const;
@@ -143,6 +153,14 @@ inline void Game_Player::SetMenuCalling(bool value) {
 
 inline bool Game_Player::IsMenuCalling() const {
 	return data()->menu_calling;
+}
+
+inline void Game_Player::SetEncounterCalling(bool value) {
+	data()->encounter_calling = value;
+}
+
+inline bool Game_Player::IsEncounterCalling() const {
+	return data()->encounter_calling;
 }
 
 #endif

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -43,7 +43,7 @@ public:
 	/** @{ */
 	int GetScreenZ(bool apply_shift = false) const override;
 	bool GetVisible() const override;
-	bool MakeWay(int x, int y, int d) const override;
+	bool MakeWay(int x, int y) const override;
 	void BeginMove() override;
 	void CancelMoveRoute() override;
 	int GetVehicleType() const override;

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -92,6 +92,16 @@ public:
 	 */
 	void UnboardingFinished();
 
+	/**
+	 * Set the menu callling flag
+	 *
+	 * @param value the value of the flag to set
+	 */
+	void SetMenuCalling(bool value);
+
+	/** @return the menu calling flag */
+	bool IsMenuCalling() const;
+
 protected:
 	RPG::SavePartyLocation* data();
 	const RPG::SavePartyLocation* data() const;
@@ -125,6 +135,14 @@ inline bool Game_Player::IsPendingTeleport() const {
 
 inline TeleportTarget Game_Player::GetTeleportTarget() const {
 	return teleport_target;
+}
+
+inline void Game_Player::SetMenuCalling(bool value) {
+	data()->menu_calling = value;
+}
+
+inline bool Game_Player::IsMenuCalling() const {
+	return data()->menu_calling;
 }
 
 #endif

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -23,6 +23,7 @@
 #include "rpg_savepartylocation.h"
 #include "game_character.h"
 #include "flag_set.h"
+#include "teleport_target.h"
 #include <vector>
 
 class Game_Vehicle;
@@ -50,7 +51,8 @@ public:
 	void UpdateSelfMovement() override;
 	/** @} */
 
-	bool IsTeleporting() const;
+	bool IsPendingTeleport() const;
+	TeleportTarget GetTeleportTarget() const;
 
 	/**
 	 * Sets the map, position and direction that the game player must have after the teleport is over
@@ -60,10 +62,10 @@ public:
 	 * @param y new y position after teleport
 	 * @param direction New direction after teleport. If -1, the direction isn't changed.
 	 */
-	void ReserveTeleport(int map_id, int x, int y, int direction = -1);
+	void ReserveTeleport(int map_id, int x, int y, int direction);
 	void ReserveTeleport(const RPG::SaveTarget& target);
-	void StartTeleport();
 	void PerformTeleport();
+
 	void MoveTo(int x, int y) override;
 
 	/** Update this for the current frame */
@@ -98,9 +100,6 @@ protected:
 private:
 	using TriggerSet = FlagSet<RPG::EventPage::Trigger>;
 
-	bool teleporting = false;
-	int new_map_id = 0, new_x = 0, new_y = 0, new_direction = 0;
-
 	void UpdateScroll(int prev_x, int prev_y);
 	void UpdatePan();
 	bool CheckTouchEvent();
@@ -111,6 +110,8 @@ private:
 	bool GetOnVehicle();
 	bool GetOffVehicle();
 	void Unboard();
+
+	TeleportTarget teleport_target;
 };
 
 inline RPG::SavePartyLocation* Game_Player::data() {
@@ -119,6 +120,14 @@ inline RPG::SavePartyLocation* Game_Player::data() {
 
 inline const RPG::SavePartyLocation* Game_Player::data() const {
 	return static_cast<const RPG::SavePartyLocation*>(Game_Character::data());
+}
+
+inline bool Game_Player::IsPendingTeleport() const {
+	return teleport_target.IsActive();
+}
+
+inline TeleportTarget Game_Player::GetTeleportTarget() const {
+	return teleport_target;
 }
 
 #endif

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -86,7 +86,6 @@ public:
 	bool IsAboard() const;
 	bool IsBoardingOrUnboarding() const;
 	Game_Vehicle* GetVehicle() const;
-	bool CanWalk(int x, int y);
 
 	/**
 	 * Callback function invoked by the Vehicle to notify that the unboarding has finished

--- a/src/game_temp.cpp
+++ b/src/game_temp.cpp
@@ -17,13 +17,9 @@
 
 // Headers
 #include "game_temp.h"
-#include "transition.h"
 
 bool Game_Temp::inn_calling;
 bool Game_Temp::to_title;
-bool Game_Temp::transition_processing;
-Transition::TransitionType Game_Temp::transition_type;
-bool Game_Temp::transition_erase;
 bool Game_Temp::transition_menu;
 bool Game_Temp::shop_buys;
 bool Game_Temp::shop_sells;
@@ -48,9 +44,6 @@ int Game_Temp::battle_result;
 void Game_Temp::Init() {
 	inn_calling = false;
 	to_title = false;
-	transition_processing = false;
-	transition_type = Transition::TransitionNone;
-	transition_erase = false;
 	transition_menu = false;
 	shop_buys = true;
 	shop_sells = true;

--- a/src/game_temp.cpp
+++ b/src/game_temp.cpp
@@ -19,7 +19,6 @@
 #include "game_temp.h"
 #include "transition.h"
 
-bool Game_Temp::battle_calling;
 bool Game_Temp::inn_calling;
 bool Game_Temp::to_title;
 bool Game_Temp::transition_processing;
@@ -47,7 +46,6 @@ bool Game_Temp::battle_first_strike;
 int Game_Temp::battle_result;
 
 void Game_Temp::Init() {
-	battle_calling = false;
 	inn_calling = false;
 	to_title = false;
 	transition_processing = false;

--- a/src/game_temp.cpp
+++ b/src/game_temp.cpp
@@ -22,7 +22,6 @@
 bool Game_Temp::battle_calling;
 bool Game_Temp::inn_calling;
 bool Game_Temp::to_title;
-bool Game_Temp::gameover;
 bool Game_Temp::transition_processing;
 Transition::TransitionType Game_Temp::transition_type;
 bool Game_Temp::transition_erase;
@@ -51,7 +50,6 @@ void Game_Temp::Init() {
 	battle_calling = false;
 	inn_calling = false;
 	to_title = false;
-	gameover = false;
 	transition_processing = false;
 	transition_type = Transition::TransitionNone;
 	transition_erase = false;

--- a/src/game_temp.h
+++ b/src/game_temp.h
@@ -33,7 +33,6 @@ public:
 	 */
 	static void Init();
 
-	static bool battle_calling;
 	static bool inn_calling;
 	static bool to_title;
 

--- a/src/game_temp.h
+++ b/src/game_temp.h
@@ -36,7 +36,6 @@ public:
 	static bool battle_calling;
 	static bool inn_calling;
 	static bool to_title;
-	static bool gameover;
 
 	static bool transition_processing;
 	static Transition::TransitionType transition_type;

--- a/src/game_temp.h
+++ b/src/game_temp.h
@@ -21,7 +21,6 @@
 // Headers
 #include <string>
 #include "game_battler.h"
-#include "transition.h"
 
 /**
  * Game Temp static class.
@@ -36,9 +35,6 @@ public:
 	static bool inn_calling;
 	static bool to_title;
 
-	static bool transition_processing;
-	static Transition::TransitionType transition_type;
-	static bool transition_erase;
 	static bool transition_menu;
 
 	static bool shop_buys;

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -253,9 +253,6 @@ void Game_Vehicle::UpdateAnimationShip() {
 }
 
 void Game_Vehicle::AnimateAscentDescent() {
-	if (!IsStopping()) {
-		return;
-	}
 	if (IsAscending()) {
 		data()->remaining_ascent = data()->remaining_ascent - 8;
 	} else if (IsDescending()) {

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -284,10 +284,7 @@ void Game_Vehicle::UpdateAnimationShip() {
 	}
 }
 
-void Game_Vehicle::Update(bool process_movement) {
-	if (!process_movement) {
-		return;
-	}
+void Game_Vehicle::Update() {
 	if (IsProcessed()) {
 		return;
 	}

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -225,19 +225,7 @@ bool Game_Vehicle::IsMovable() {
 }
 
 bool Game_Vehicle::CanLand() const {
-	if (!Game_Map::AirshipLandOk(GetX(), GetY()))
-		return false;
-	std::vector<Game_Event*> events;
-	Game_Map::GetEventsXY(events, GetX(), GetY());
-	if (!events.empty())
-		return false;
-	if (!Game_Map::IsLandable(GetX(), GetY(), nullptr))
-		return false;
-	if (Game_Map::GetVehicle(Ship)->IsInPosition(GetX(), GetY()))
-		return false;
-	if (Game_Map::GetVehicle(Boat)->IsInPosition(GetX(), GetY()))
-		return false;
-	return true;
+	return Game_Map::CanLandAirship(GetX(), GetY());
 }
 
 void Game_Vehicle::UpdateAnimationAirship() {

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -48,7 +48,7 @@ static RPG::SaveVehicleLocation* getDataFromType(Game_Vehicle::Type ty) {
 }
 
 Game_Vehicle::Game_Vehicle(Type _type) :
-	Game_Character(getDataFromType(_type))
+	Game_Character(Vehicle, getDataFromType(_type))
 {
 	type = _type;
 	SetDirection(Left);

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -258,9 +258,7 @@ void Game_Vehicle::Update() {
 	}
 	SetProcessed(true);
 
-	if (IsAboard()) {
-		SyncWithPlayer();
-	} else {
+	if (!IsAboard()) {
 		Game_Character::UpdateMovement();
 	}
 

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -58,26 +58,6 @@ Game_Vehicle::Game_Vehicle(Type _type) :
 	LoadSystemSettings();
 }
 
-bool Game_Vehicle::MakeWay(int x, int y, int d) const {
-	if (d > 3) {
-		return MakeWayDiagonal(x, y, d);
-	}
-
-	int new_x = Game_Map::RoundX(x + (d == Right ? 1 : d == Left ? -1 : 0));
-	int new_y = Game_Map::RoundY(y + (d == Down ? 1 : d == Up ? -1 : 0));
-
-	if (!Game_Map::IsValid(new_x, new_y))
-		return false;
-
-	if (GetThrough()) return true;
-
-	if (!Game_Map::IsPassableVehicle(new_x, new_y, type))
-		return false;
-
-	return true;
-}
-
-
 void Game_Vehicle::LoadSystemSettings() {
 	switch (type) {
 		case None:

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -252,6 +252,27 @@ void Game_Vehicle::UpdateAnimationShip() {
 	}
 }
 
+void Game_Vehicle::AnimateAscentDescent() {
+	if (!IsStopping()) {
+		return;
+	}
+	if (IsAscending()) {
+		data()->remaining_ascent = data()->remaining_ascent - 8;
+	} else if (IsDescending()) {
+		data()->remaining_descent = data()->remaining_descent - 8;
+		if (!IsDescending()) {
+			if (CanLand()) {
+				Main_Data::game_player->UnboardingFinished();
+				SetFlying(false);
+				Main_Data::game_player->SetFlying(false);
+			} else {
+				// Can't land here, ascend again
+				data()->remaining_ascent = SCREEN_TILE_SIZE;
+			}
+		}
+	}
+}
+
 void Game_Vehicle::Update() {
 	if (IsProcessed()) {
 		return;
@@ -260,26 +281,6 @@ void Game_Vehicle::Update() {
 
 	if (!IsAboard()) {
 		Game_Character::UpdateMovement();
-	}
-
-	if (type == Airship) {
-		if (IsStopping()) {
-			if (IsAscending()) {
-				data()->remaining_ascent = data()->remaining_ascent - 8;
-			} else if (IsDescending()) {
-				data()->remaining_descent = data()->remaining_descent - 8;
-				if (!IsDescending()) {
-					if (CanLand()) {
-						Main_Data::game_player->UnboardingFinished();
-						SetFlying(false);
-						Main_Data::game_player->SetFlying(false);
-					} else {
-						// Can't land here, ascend again
-						data()->remaining_ascent = SCREEN_TILE_SIZE;
-					}
-				}
-			}
-		}
 	}
 
 	if (type == Airship) {

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -127,7 +127,6 @@ void Game_Vehicle::Refresh() {
 	if (IsInUse()) {
 		SetMapId(Game_Map::GetMapId());
 	} else if (IsInCurrentMap()) {
-		SetProcessed(true); // RPG_RT compatibility
 		MoveTo(GetX(), GetY());
 	}
 
@@ -286,10 +285,13 @@ void Game_Vehicle::UpdateAnimationShip() {
 }
 
 void Game_Vehicle::Update(bool process_movement) {
-
 	if (!process_movement) {
 		return;
 	}
+	if (IsProcessed()) {
+		return;
+	}
+	SetProcessed(true);
 
 	if (IsAboard()) {
 		SyncWithPlayer();

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -290,10 +290,6 @@ void Game_Vehicle::Update() {
 	}
 }
 
-bool Game_Vehicle::CheckEventTriggerTouch(int /* x */, int /* y */) {
-	return false;
-}
-
 int Game_Vehicle::GetVehicleType() const {
 	return data()->vehicle;
 }

--- a/src/game_vehicle.h
+++ b/src/game_vehicle.h
@@ -70,7 +70,6 @@ public:
 	int GetScreenY(bool apply_shift = false) const override;
 	bool IsMovable();
 	bool CanLand() const;
-	bool CheckEventTriggerTouch(int x, int y) override;
 	void UpdateAnimationShip();
 	void UpdateAnimationAirship();
 

--- a/src/game_vehicle.h
+++ b/src/game_vehicle.h
@@ -44,7 +44,6 @@ public:
 	 * Implementation of abstract methods
 	 */
 	/** @{ */
-	bool MakeWay(int x, int y, int d) const override;
 	int GetVehicleType() const override;
 	/** @} */
 

--- a/src/game_vehicle.h
+++ b/src/game_vehicle.h
@@ -66,6 +66,7 @@ public:
 	bool IsInUse() const;
 	bool IsAboard() const;
 	void SyncWithPlayer();
+	void AnimateAscentDescent();
 	int GetScreenY(bool apply_shift = false) const override;
 	bool IsMovable();
 	bool CanLand() const;

--- a/src/game_vehicle.h
+++ b/src/game_vehicle.h
@@ -48,12 +48,8 @@ public:
 	int GetVehicleType() const override;
 	/** @} */
 
-	/** 
-	 * Update this for the current frame
-	 *
-	 * @param process_movement if false, we will not process movement or animations
-	 * */
-	void Update(bool process_movement);
+	/** Update this for the current frame */
+	void Update();
 
 	void LoadSystemSettings();
 	RPG::Music& GetBGM();

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -179,6 +179,10 @@ bool Graphics::IsTransitionPending() {
 	return (transition ? transition->IsActive() : false);
 }
 
+bool Graphics::IsTransitionErased() {
+	return (transition ? transition->IsErased() : false);
+}
+
 void Graphics::FrameReset() {
 	next_fps_time = (uint32_t)DisplayUi->GetTicks() + 1000;
 	fps_overlay->ResetCounter();

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -72,6 +72,11 @@ namespace Graphics {
 	 */
 	bool IsTransitionPending();
 
+	/**
+	 * Gets if the screen is erased due to transition.
+	 */
+	bool IsTransitionErased();
+
 	void Draw();
 
 	void RegisterDrawable(Drawable* drawable);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -208,19 +208,19 @@ void Player::Run() {
 	emscripten_set_main_loop(Player::MainLoop, 0, 0);
 #else
 	while (Graphics::IsTransitionPending() || Scene::instance->type != Scene::Null) {
-#  if defined(_3DS)
-		if (!aptMainLoop())
-			Exit();
-#  elif defined(__SWITCH__)
-		if(!appletMainLoop())
-			Exit();
-#  endif
 		MainLoop();
 	}
 #endif
 }
 
 void Player::MainLoop() {
+#  if defined(_3DS)
+	if (!aptMainLoop())
+		Exit();
+#  elif defined(__SWITCH__)
+	if(!appletMainLoop())
+		Exit();
+#  endif
 	Scene::instance->MainFunction();
 
 	Scene::old_instances.clear();
@@ -333,7 +333,7 @@ void DoTransition(Transition::TransitionType type, int frames, bool erase, Scene
 	}
 
 	while (transition.IsActive()) {
-		Player::Update(false);
+		Player::MainLoop();
 	}
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -306,7 +306,11 @@ void Player::Update(bool update_scene) {
 	int speed_modifier = GetSpeedModifier();
 
 	for (int i = 0; i < speed_modifier; ++i) {
+		bool was_transition_pending = Graphics::IsTransitionPending();
 		Graphics::Update();
+		if (was_transition_pending && !Graphics::IsTransitionPending() && Scene::instance->IsInitialized()) {
+			Scene::instance->OnTransitionFinish();
+		}
 		if (update_scene) {
 			Scene::instance->Update();
 			++frames;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -69,6 +69,7 @@
 #include "scene_battle.h"
 #include "scene_logo.h"
 #include "utils.h"
+#include "transition.h"
 #include "version.h"
 
 #ifndef EMSCRIPTEN
@@ -326,6 +327,23 @@ void Player::Update(bool update_scene) {
 	}
 
 	start_time = next_frame;
+}
+
+void DoTransition(Transition::TransitionType type, int frames, bool erase, Scene* scene) {
+	auto& transition = Graphics::GetTransition();
+	transition.Init(type, scene, frames, erase);
+
+	while (transition.IsActive()) {
+		Player::Update(false);
+	}
+}
+
+void Player::TransitionShow(Transition::TransitionType type, int frames, Scene* scene) {
+	DoTransition(type, frames, false, scene);
+}
+
+void Player::TransitionErase(Transition::TransitionType type, int frames, Scene* scene) {
+	DoTransition(type, frames, true, scene);
 }
 
 void Player::FrameReset() {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -307,11 +307,7 @@ void Player::Update(bool update_scene) {
 	int speed_modifier = GetSpeedModifier();
 
 	for (int i = 0; i < speed_modifier; ++i) {
-		bool was_transition_pending = Graphics::IsTransitionPending();
 		Graphics::Update();
-		if (was_transition_pending && !Graphics::IsTransitionPending() && Scene::instance->IsInitialized()) {
-			Scene::instance->OnTransitionFinish();
-		}
 		if (update_scene) {
 			Scene::instance->Update();
 			++frames;
@@ -329,9 +325,12 @@ void Player::Update(bool update_scene) {
 	start_time = next_frame;
 }
 
-void DoTransition(Transition::TransitionType type, int frames, bool erase, Scene* scene) {
+void DoTransition(Transition::TransitionType type, int frames, bool erase, Scene* scene, bool is_battle=false) {
 	auto& transition = Graphics::GetTransition();
 	transition.Init(type, scene, frames, erase);
+	if (is_battle) {
+		transition.AppendBefore(Color(255, 255, 255, 255), 12, 2);
+	}
 
 	while (transition.IsActive()) {
 		Player::Update(false);
@@ -344,6 +343,10 @@ void Player::TransitionShow(Transition::TransitionType type, int frames, Scene* 
 
 void Player::TransitionErase(Transition::TransitionType type, int frames, Scene* scene) {
 	DoTransition(type, frames, true, scene);
+}
+
+void Player::TransitionEraseBattle(Transition::TransitionType type, int frames, Scene* scene) {
+	DoTransition(type, frames, true, scene, true);
 }
 
 void Player::FrameReset() {

--- a/src/player.h
+++ b/src/player.h
@@ -86,6 +86,11 @@ namespace Player {
 	void TransitionErase(Transition::TransitionType type, int frames, Scene* scene);
 
 	/**
+	 * Executions a battle transition erase right now
+	 */
+	void TransitionEraseBattle(Transition::TransitionType type, int frames, Scene* scene);
+
+	/**
 	 * Returns executed game frames since player start.
 	 * Should be 60 fps when game ran fast enough.
 	 *

--- a/src/player.h
+++ b/src/player.h
@@ -20,7 +20,10 @@
 
 // Headers
 #include "baseui.h"
+#include "transition.h"
 #include <vector>
+
+class Scene;
 
 /**
  * Player namespace.
@@ -71,6 +74,16 @@ namespace Player {
 	 * @param update_scene Whether to update the current scene.
 	 */
 	void Update(bool update_scene = true);
+
+	/**
+	 * Executions a transition show right now
+	 */
+	void TransitionShow(Transition::TransitionType type, int frames, Scene* scene);
+
+	/**
+	 * Executions a transition erase right now
+	 */
+	void TransitionErase(Transition::TransitionType type, int frames, Scene* scene);
 
 	/**
 	 * Returns executed game frames since player start.

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -137,14 +137,11 @@ void Scene::Suspend() {
 }
 
 void Scene::TransitionIn() {
-	Graphics::GetTransition().Init(Transition::TransitionFadeIn, this, 6);
+	Player::TransitionShow(Transition::TransitionFadeIn, 6, this);
 }
 
 void Scene::TransitionOut() {
-	Graphics::GetTransition().Init(Transition::TransitionFadeOut, this, 6, true);
-}
-
-void Scene::OnTransitionFinish() {
+	Player::TransitionErase(Transition::TransitionFadeOut, 6, this);
 }
 
 void Scene::Update() {

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -144,6 +144,9 @@ void Scene::TransitionOut() {
 	Graphics::GetTransition().Init(Transition::TransitionFadeOut, this, 6, true);
 }
 
+void Scene::OnTransitionFinish() {
+}
+
 void Scene::Update() {
 }
 

--- a/src/scene.h
+++ b/src/scene.h
@@ -183,6 +183,19 @@ public:
 	/** @return true if the Scene has been initialized */
 	bool IsInitialized() const;
 
+	/** @return the scene requested by events */
+	SceneType GetRequestedScene();
+
+	/** @return true if a scene is being requested */
+	bool HasRequestedScene();
+
+	/**
+	 * Sets the requested scene to change to
+	 *
+	 * @param scene the scene to call
+	 */
+	void SetRequestedScene(SceneType scene);
+
 private:
 	/** Scene stack. */
 	static std::vector<std::shared_ptr<Scene> > instances;
@@ -202,10 +215,25 @@ private:
 	Graphics::State state;
 
 	static void DebugValidate(const char* caller);
+
+	Scene::SceneType request_scene = Null;
 };
 
 inline bool Scene::IsInitialized() const {
 	return initialized;
 }
+
+inline Scene::SceneType Scene::GetRequestedScene() {
+	return request_scene;
+}
+
+inline bool Scene::HasRequestedScene() {
+	return GetRequestedScene() != Null;
+}
+
+inline void Scene::SetRequestedScene(SceneType scene) {
+	request_scene = scene;
+}
+
 
 #endif

--- a/src/scene.h
+++ b/src/scene.h
@@ -117,11 +117,6 @@ public:
 	virtual void TransitionOut();
 
 	/**
-	 * Called when a transition is finished and scene has been initialized
-	 */
-	virtual void OnTransitionFinish();
-
-	/**
 	 * Called every frame.
 	 * The scene should redraw all elements.
 	 */

--- a/src/scene.h
+++ b/src/scene.h
@@ -117,6 +117,11 @@ public:
 	virtual void TransitionOut();
 
 	/**
+	 * Called when a transition is finished and scene has been initialized
+	 */
+	virtual void OnTransitionFinish();
+
+	/**
 	 * Called every frame.
 	 * The scene should redraw all elements.
 	 */
@@ -175,6 +180,9 @@ public:
 	/** Called by the interpreter when an event finishes processing */
 	virtual void onCommandEnd() {}
 
+	/** @return true if the Scene has been initialized */
+	bool IsInitialized() const;
+
 private:
 	/** Scene stack. */
 	static std::vector<std::shared_ptr<Scene> > instances;
@@ -195,5 +203,9 @@ private:
 
 	static void DebugValidate(const char* caller);
 };
+
+inline bool Scene::IsInitialized() const {
+	return initialized;
+}
 
 #endif

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -101,7 +101,7 @@ void Scene_Battle::TransitionIn() {
 		Game_Temp::transition_menu = false;
 		Scene::TransitionIn();
 	} else {
-		Graphics::GetTransition().Init((Transition::TransitionType)Game_System::GetTransition(Game_System::Transition_BeginBattleShow), this, 32);
+		Player::TransitionShow((Transition::TransitionType)Game_System::GetTransition(Game_System::Transition_BeginBattleShow), 32, this);
 	}
 }
 
@@ -110,7 +110,7 @@ void Scene_Battle::TransitionOut() {
 		Scene::TransitionOut();
 	}
 	else {
-		Graphics::GetTransition().Init((Transition::TransitionType)Game_System::GetTransition(Game_System::Transition_EndBattleErase), this, 32, true);
+		Player::TransitionErase((Transition::TransitionType)Game_System::GetTransition(Game_System::Transition_EndBattleErase), 32, this);
 	}
 }
 

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -165,8 +165,8 @@ void Scene_Battle::Update() {
 
 	bool events_finished = Game_Battle::UpdateEvents();
 
-	if (Game_Temp::gameover) {
-		Game_Temp::gameover = false;
+	if (GetRequestedScene() == Gameover) {
+		SetRequestedScene(Null);
 		Scene::Push(std::make_shared<Scene_Gameover>());
 	}
 

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -247,7 +247,6 @@ void Scene_Debug::Update() {
 							Game_Temp::battle_first_strike = 0;
 							Game_Temp::battle_result = Game_Temp::BattleVictory;
 							Game_Battle::SetBattleMode(0);
-							Game_Temp::battle_calling = true;
 							Game_Temp::transition_menu = false;
 							static_cast<Scene_Map*>(Scene::instance.get())->CallBattle();
 						}

--- a/src/scene_gameover.cpp
+++ b/src/scene_gameover.cpp
@@ -23,6 +23,7 @@
 #include "input.h"
 #include "main_data.h"
 #include "transition.h"
+#include "player.h"
 
 Scene_Gameover::Scene_Gameover() {
 	type = Scene::Gameover;
@@ -51,9 +52,9 @@ void Scene_Gameover::OnBackgroundReady(FileRequestResult* result) {
 }
 
 void Scene_Gameover::TransitionIn() {
-	Graphics::GetTransition().Init(Transition::TransitionFadeIn, this, 80);
+	Player::TransitionShow(Transition::TransitionFadeIn, 80, this);
 }
 
 void Scene_Gameover::TransitionOut() {
-	Graphics::GetTransition().Init(Transition::TransitionFadeOut, this, 80, true);
+	Player::TransitionErase(Transition::TransitionFadeOut, 80, this);
 }

--- a/src/scene_item.cpp
+++ b/src/scene_item.cpp
@@ -29,6 +29,7 @@
 #include "scene_map.h"
 #include "scene_teleport.h"
 #include "output.h"
+#include "transition.h"
 
 Scene_Item::Scene_Item(int item_index) :
 	item_index(item_index) {
@@ -104,5 +105,19 @@ void Scene_Item::Update() {
 		} else {
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Buzzer));
 		}
+	}
+}
+
+void Scene_Item::TransitionOut() {
+	const auto* item = item_window->GetItem();
+	const RPG::Skill* skill = nullptr;
+	if (item && item->type == RPG::Item::Type_special && item->skill_id > 0) {
+		skill = ReaderUtil::GetElement(Data::skills, item->skill_id);
+	}
+
+	if (Scene::instance && Scene::instance->type == Map && skill && skill->type == RPG::Skill::Type_escape) {
+		Graphics::GetTransition().Init(Transition::TransitionFadeOut, this, 32, true);
+	} else {
+		Scene::TransitionOut();
 	}
 }

--- a/src/scene_item.cpp
+++ b/src/scene_item.cpp
@@ -30,6 +30,7 @@
 #include "scene_teleport.h"
 #include "output.h"
 #include "transition.h"
+#include "player.h"
 
 Scene_Item::Scene_Item(int item_index) :
 	item_index(item_index) {
@@ -116,7 +117,7 @@ void Scene_Item::TransitionOut() {
 	}
 
 	if (Scene::instance && Scene::instance->type == Map && skill && skill->type == RPG::Skill::Type_escape) {
-		Graphics::GetTransition().Init(Transition::TransitionFadeOut, this, 32, true);
+		Player::TransitionErase(Transition::TransitionFadeOut, 32, this);
 	} else {
 		Scene::TransitionOut();
 	}

--- a/src/scene_item.cpp
+++ b/src/scene_item.cpp
@@ -83,7 +83,6 @@ void Scene_Item::Update() {
 					Game_System::SePlay(skill->sound_effect);
 
 					Main_Data::game_player->ReserveTeleport(*Game_Targets::GetEscapeTarget());
-					Main_Data::game_player->StartTeleport();
 
 					Scene::PopUntil(Scene::Map);
 				} else if (skill->type == RPG::Skill::Type_switch) {

--- a/src/scene_item.h
+++ b/src/scene_item.h
@@ -39,6 +39,7 @@ public:
 	void Start() override;
 	void Continue() override;
 	void Update() override;
+	void TransitionOut() override;
 
 private:
 	/** Displays description about the selected item. */

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -67,7 +67,7 @@ void Scene_Map::Start() {
 }
 
 void Scene_Map::Continue() {
-	if (Game_Temp::battle_calling) {
+	if (called_battle) {
 		// Came from battle
 		Game_System::BgmPlay(Main_Data::game_data.system.before_battle_music);
 	}
@@ -78,11 +78,11 @@ void Scene_Map::Continue() {
 }
 
 void Scene_Map::Resume() {
-	Game_Temp::battle_calling = false;
+	called_battle = false;
 }
 
 void Scene_Map::TransitionIn() {
-	if (Game_Temp::battle_calling) {
+	if (called_battle) {
 		Graphics::GetTransition().Init((Transition::TransitionType)Game_System::GetTransition(Game_System::Transition_EndBattleShow), this, 32);
 	} else if (Game_Temp::transition_menu) {
 		Game_Temp::transition_menu = false;
@@ -93,7 +93,7 @@ void Scene_Map::TransitionIn() {
 }
 
 void Scene_Map::TransitionOut() {
-	if (Game_Temp::battle_calling) {
+	if (called_battle) {
 		Graphics::GetTransition().Init((Transition::TransitionType)Game_System::GetTransition(Game_System::Transition_BeginBattleErase), this, 32, true);
 		Graphics::GetTransition().AppendBefore(Color(255, 255, 255, 255), 12, 2);
 	}
@@ -195,10 +195,6 @@ void Scene_Map::UpdateSceneCalling() {
 
 	auto call = GetRequestedScene();
 
-	if (Game_Temp::battle_calling) {
-		call = Scene::Battle;
-	}
-
 	SetRequestedScene(Null);
 	switch (call) {
 		case Scene::Menu:
@@ -257,7 +253,7 @@ void Scene_Map::FinishPendingTeleport() {
 // Scene calling stuff.
 
 void Scene_Map::CallBattle() {
-	Game_Temp::battle_calling = true;
+	called_battle = true;
 	Main_Data::game_data.system.before_battle_music = Game_System::GetCurrentBGM();
 	Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_BeginBattle));
 	Game_System::BgmPlay(Game_System::GetSystemBGM(Game_System::BGM_Battle));

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -199,8 +199,8 @@ void Scene_Map::UpdateSceneCalling() {
 		}
 	}
 
-	if (!Main_Data::game_player->IsMoving() || Game_Interpreter::IsImmediateCall() || force_menu_calling) {
-		auto call = Game_Interpreter::GetSceneCalling();
+	if (!Main_Data::game_player->IsMoving() || HasRequestedScene() || force_menu_calling) {
+		auto call = GetRequestedScene();
 
 		if (Main_Data::game_data.party_location.menu_calling || force_menu_calling) {
 			call = Scene::Menu;
@@ -209,7 +209,7 @@ void Scene_Map::UpdateSceneCalling() {
 			call = Scene::Battle;
 		}
 
-		Game_Interpreter::ResetSceneCalling();
+		SetRequestedScene(Null);
 		switch (call) {
 			case Scene::Menu:
 				CallMenu();

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -62,7 +62,7 @@ void Scene_Map::Start() {
 
 	Player::FrameReset();
 
-	Game_Map::Update(true);
+	PreUpdate();
 	spriteset->Update();
 }
 
@@ -109,10 +109,23 @@ void Scene_Map::TransitionOut() {
 	}
 }
 
+void Scene_Map::OnTransitionFinish() {
+	if (do_preupdate) {
+		UpdateSceneCalling();
+		do_preupdate = false;
+	}
+}
+
 void Scene_Map::DrawBackground() {
 	if (spriteset->RequireBackground(GetGraphicsState().drawable_list)) {
 		DisplayUi->CleanDisplay();
 	}
+}
+
+void Scene_Map::PreUpdate() {
+	Game_Map::Update(true);
+	// Tells the next OnTransitionFinish() to allow scene changes.
+	do_preupdate = true;
 }
 
 void Scene_Map::Update() {
@@ -153,7 +166,10 @@ void Scene_Map::Update() {
 	message_window->Update();
 
 	StartTeleportPlayer();
+	UpdateSceneCalling();
+}
 
+void Scene_Map::UpdateSceneCalling() {
 	if (Game_Temp::gameover) {
 		Game_Temp::gameover = false;
 		Scene::Push(std::make_shared<Scene_Gameover>());

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -96,20 +96,22 @@ void Scene_Map::TransitionOut() {
 	if (called_battle) {
 		Graphics::GetTransition().Init((Transition::TransitionType)Game_System::GetTransition(Game_System::Transition_BeginBattleErase), this, 32, true);
 		Graphics::GetTransition().AppendBefore(Color(255, 255, 255, 255), 12, 2);
+		return;
 	}
-	else if (Scene::instance && Scene::instance->type == Scene::Gameover) {
+
+	screen_erased_by_event = false;
+	if (Scene::instance && Scene::instance->type == Scene::Gameover) {
 		Graphics::GetTransition().Init(Transition::TransitionFadeOut, this, 32, true);
+		return;
 	}
-	else {
-		Scene::TransitionOut();
-	}
+	Scene::TransitionOut();
 }
 
 void Scene_Map::OnTransitionFinish() {
 	if (Graphics::IsTransitionErased()) {
 		if (Main_Data::game_player->IsPendingTeleport()) {
 			FinishPendingTeleport();
-			if (!Game_Temp::transition_erase) {
+			if (!screen_erased_by_event) {
 				if (!Game_Temp::transition_menu) {
 					Graphics::GetTransition().Init((Transition::TransitionType)Game_System::GetTransition(Game_System::Transition_TeleportShow), this, 32, false);
 				} else {
@@ -142,16 +144,15 @@ void Scene_Map::PreUpdate() {
 }
 
 void Scene_Map::Update() {
-	if (Game_Temp::transition_processing) {
-		Game_Temp::transition_processing = false;
-
-		Graphics::GetTransition().Init(Game_Temp::transition_type, this, 32, Game_Temp::transition_erase);
-	}
-
 	Main_Data::game_party->UpdateTimers();
 
 	Main_Data::game_screen->Update();
 	Game_Map::Update();
+
+	if (Graphics::IsTransitionErased()) {
+		screen_erased_by_event = true;
+	}
+
 	spriteset->Update();
 	message_window->Update();
 

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -163,11 +163,6 @@ void Scene_Map::Update() {
 }
 
 void Scene_Map::UpdateSceneCalling() {
-	if (Game_Temp::gameover) {
-		Game_Temp::gameover = false;
-		Scene::Push(std::make_shared<Scene_Gameover>());
-	}
-
 	if (Game_Temp::to_title) {
 		Game_Temp::to_title = false;
 		Scene::PopUntil(Scene::Title);
@@ -228,6 +223,9 @@ void Scene_Map::UpdateSceneCalling() {
 				break;
 			case Scene::Battle:
 				CallBattle();
+				break;
+			case Scene::Gameover:
+				CallGameover();
 				break;
 			default:
 				break;
@@ -316,4 +314,8 @@ void Scene_Map::CallDebug() {
 		Game_Temp::transition_menu = true;
 		Scene::Push(std::make_shared<Scene_Debug>());
 	}
+}
+
+void Scene_Map::CallGameover() {
+	Scene::Push(std::make_shared<Scene_Gameover>());
 }

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -171,14 +171,13 @@ void Scene_Map::UpdateSceneCalling() {
 	if (Game_Message::visible)
 		return;
 
-	bool force_menu_calling = false;
 	if (Player::debug_flag) {
 		// ESC-Menu calling can be force called when TestPlay mode is on and cancel is pressed 5 times while holding SHIFT
 		if (Input::IsPressed(Input::SHIFT)) {
 			if (Input::IsTriggered(Input::CANCEL)) {
 				debug_menuoverwrite_counter++;
 				if (debug_menuoverwrite_counter >= 5) {
-					force_menu_calling = true;
+					SetRequestedScene(Menu);
 					debug_menuoverwrite_counter = 0;
 				}
 			}
@@ -187,49 +186,47 @@ void Scene_Map::UpdateSceneCalling() {
 		}
 
 		if (Input::IsTriggered(Input::DEBUG_MENU)) {
-			CallDebug();
+			SetRequestedScene(Debug);
 		}
 		else if (Input::IsTriggered(Input::DEBUG_SAVE)) {
-			CallSave();
+			SetRequestedScene(Save);
 		}
 	}
 
-	if (HasRequestedScene() || force_menu_calling) {
-		auto call = GetRequestedScene();
+	auto call = GetRequestedScene();
 
-		if (force_menu_calling) {
-			call = Scene::Menu;
-		}
-		if (Game_Temp::battle_calling) {
-			call = Scene::Battle;
-		}
+	if (Game_Temp::battle_calling) {
+		call = Scene::Battle;
+	}
 
-		SetRequestedScene(Null);
-		switch (call) {
-			case Scene::Menu:
-				CallMenu();
-				break;
-			case Scene::Shop:
-				CallShop();
-				break;
-			case Scene::Name:
-				CallName();
-				break;
-			case Scene::Save:
-				CallSave();
-				break;
-			case Scene::Load:
-				CallLoad();
-				break;
-			case Scene::Battle:
-				CallBattle();
-				break;
-			case Scene::Gameover:
-				CallGameover();
-				break;
-			default:
-				break;
-		}
+	SetRequestedScene(Null);
+	switch (call) {
+		case Scene::Menu:
+			CallMenu();
+			break;
+		case Scene::Shop:
+			CallShop();
+			break;
+		case Scene::Name:
+			CallName();
+			break;
+		case Scene::Save:
+			CallSave();
+			break;
+		case Scene::Load:
+			CallLoad();
+			break;
+		case Scene::Battle:
+			CallBattle();
+			break;
+		case Scene::Gameover:
+			CallGameover();
+			break;
+		case Scene::Debug:
+			CallDebug();
+			break;
+		default:
+			break;
 	}
 }
 

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -109,7 +109,12 @@ void Scene_Map::OnTransitionFinish() {
 	if (Graphics::IsTransitionErased()) {
 		if (Main_Data::game_player->IsPendingTeleport()) {
 			FinishPendingTeleport();
-			Graphics::GetTransition().Init((Transition::TransitionType)Game_System::GetTransition(Game_System::Transition_TeleportShow), this, 32, false);
+			if (!Game_Temp::transition_menu) {
+				Graphics::GetTransition().Init((Transition::TransitionType)Game_System::GetTransition(Game_System::Transition_TeleportShow), this, 32, false);
+			} else {
+				// Escape / Teleport spell always uses fade.
+				Graphics::GetTransition().Init(Transition::TransitionFadeIn, this, 32, false);
+			}
 		}
 	} else {
 		if (call_scenes_on_transition_in) {

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -109,11 +109,13 @@ void Scene_Map::OnTransitionFinish() {
 	if (Graphics::IsTransitionErased()) {
 		if (Main_Data::game_player->IsPendingTeleport()) {
 			FinishPendingTeleport();
-			if (!Game_Temp::transition_menu) {
-				Graphics::GetTransition().Init((Transition::TransitionType)Game_System::GetTransition(Game_System::Transition_TeleportShow), this, 32, false);
-			} else {
-				// Escape / Teleport spell always uses fade.
-				Graphics::GetTransition().Init(Transition::TransitionFadeIn, this, 32, false);
+			if (!Game_Temp::transition_erase) {
+				if (!Game_Temp::transition_menu) {
+					Graphics::GetTransition().Init((Transition::TransitionType)Game_System::GetTransition(Game_System::Transition_TeleportShow), this, 32, false);
+				} else {
+					// Escape / Teleport spell always uses fade.
+					Graphics::GetTransition().Init(Transition::TransitionFadeIn, this, 32, false);
+				}
 			}
 		}
 	} else {

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -194,10 +194,10 @@ void Scene_Map::UpdateSceneCalling() {
 		}
 	}
 
-	if (!Main_Data::game_player->IsMoving() || HasRequestedScene() || force_menu_calling) {
+	if (HasRequestedScene() || force_menu_calling) {
 		auto call = GetRequestedScene();
 
-		if (Main_Data::game_data.party_location.menu_calling || force_menu_calling) {
+		if (force_menu_calling) {
 			call = Scene::Menu;
 		}
 		if (Game_Temp::battle_calling) {
@@ -281,7 +281,6 @@ void Scene_Map::CallName() {
 }
 
 void Scene_Map::CallMenu() {
-	Main_Data::game_data.party_location.menu_calling = false;
 	Game_Temp::transition_menu = true;
 
 	// TODO: Main_Data::game_player->Straighten();

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -41,6 +41,7 @@
 #include "screen.h"
 #include "scene_load.h"
 #include "player.h"
+#include "output.h"
 
 Scene_Map::Scene_Map(bool from_save) :
 	from_save(from_save) {
@@ -243,6 +244,10 @@ int Scene_Map::HandleTeleportPreUpdateLoop() {
 		HandleTeleport();
 		PreUpdate();
 		++i;
+
+		if (i > 10000) {
+			Output::Error("Infinite teleport event loop detected!");
+		}
 	}
 	return i;
 }

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -42,6 +42,7 @@ public:
 	void Resume() override;
 	void TransitionIn() override;
 	void TransitionOut() override;
+	void OnTransitionFinish() override;
 	void DrawBackground() override;
 
 	void CallBattle();
@@ -57,12 +58,15 @@ public:
 private:
 	void StartTeleportPlayer();
 	void FinishTeleportPlayer();
+	void PreUpdate();
+	void UpdateSceneCalling();
 
 	std::unique_ptr<Window_Message> message_window;
 
 	bool from_save;
 	bool auto_transition = false;
 	bool auto_transition_erase = false;
+	bool do_preupdate = false;
 	int debug_menuoverwrite_counter = 0;
 };
 

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -66,6 +66,7 @@ private:
 
 	bool from_save;
 	bool call_scenes_on_transition_in = false;
+	bool called_battle = false;
 	int debug_menuoverwrite_counter = 0;
 };
 

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -52,6 +52,7 @@ public:
 	void CallSave();
 	void CallLoad();
 	void CallDebug();
+	void CallGameover();
 
 	std::unique_ptr<Spriteset_Map> spriteset;
 

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -56,17 +56,15 @@ public:
 	std::unique_ptr<Spriteset_Map> spriteset;
 
 private:
-	void StartTeleportPlayer();
-	void FinishTeleportPlayer();
+	void StartPendingTeleport();
+	void FinishPendingTeleport();
 	void PreUpdate();
 	void UpdateSceneCalling();
 
 	std::unique_ptr<Window_Message> message_window;
 
 	bool from_save;
-	bool auto_transition = false;
-	bool auto_transition_erase = false;
-	bool do_preupdate = false;
+	bool call_scenes_on_transition_in = false;
 	int debug_menuoverwrite_counter = 0;
 };
 

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -65,6 +65,7 @@ private:
 	std::unique_ptr<Window_Message> message_window;
 
 	bool from_save;
+	bool screen_erased_by_event = false;
 	bool call_scenes_on_transition_in = false;
 	bool called_battle = false;
 	int debug_menuoverwrite_counter = 0;

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -42,7 +42,6 @@ public:
 	void Resume() override;
 	void TransitionIn() override;
 	void TransitionOut() override;
-	void OnTransitionFinish() override;
 	void DrawBackground() override;
 
 	void CallBattle();
@@ -57,8 +56,8 @@ public:
 	std::unique_ptr<Spriteset_Map> spriteset;
 
 private:
-	void StartPendingTeleport();
-	void FinishPendingTeleport();
+	int HandleTeleportPreUpdateLoop();
+	void HandleTeleport();
 	void PreUpdate();
 	void UpdateSceneCalling();
 

--- a/src/scene_skill.cpp
+++ b/src/scene_skill.cpp
@@ -76,7 +76,6 @@ void Scene_Skill::Update() {
 				Game_System::SePlay(skill->sound_effect);
 				Main_Data::game_party->UseSkill(skill_id, actor, actor);
 				Main_Data::game_player->ReserveTeleport(*Game_Targets::GetEscapeTarget());
-				Main_Data::game_player->StartTeleport();
 
 				Scene::PopUntil(Scene::Map);
 			}

--- a/src/scene_skill.cpp
+++ b/src/scene_skill.cpp
@@ -26,6 +26,7 @@
 #include "scene_actortarget.h"
 #include "scene_teleport.h"
 #include "transition.h"
+#include "player.h"
 
 Scene_Skill::Scene_Skill(int actor_index, int skill_index) :
 	actor_index(actor_index), skill_index(skill_index) {
@@ -88,7 +89,7 @@ void Scene_Skill::Update() {
 void Scene_Skill::TransitionOut() {
 	const auto* skill = skill_window->GetSkill();
 	if (Scene::instance && Scene::instance->type == Map && skill && skill->type == RPG::Skill::Type_escape) {
-		Graphics::GetTransition().Init(Transition::TransitionFadeOut, this, 32, true);
+		Player::TransitionErase(Transition::TransitionFadeOut, 32, this);
 	} else {
 		Scene::TransitionOut();
 	}

--- a/src/scene_skill.cpp
+++ b/src/scene_skill.cpp
@@ -86,7 +86,8 @@ void Scene_Skill::Update() {
 }
 
 void Scene_Skill::TransitionOut() {
-	if (Scene::instance->type == Map) {
+	const auto* skill = skill_window->GetSkill();
+	if (Scene::instance && Scene::instance->type == Map && skill && skill->type == RPG::Skill::Type_escape) {
 		Graphics::GetTransition().Init(Transition::TransitionFadeOut, this, 32, true);
 	} else {
 		Scene::TransitionOut();

--- a/src/scene_teleport.cpp
+++ b/src/scene_teleport.cpp
@@ -22,6 +22,7 @@
 #include "game_system.h"
 #include "input.h"
 #include "transition.h"
+#include "player.h"
 
 Scene_Teleport::Scene_Teleport(Game_Actor& actor, const RPG::Skill& skill)
 		: actor(&actor), skill(&skill) {
@@ -66,7 +67,7 @@ void Scene_Teleport::Update() {
 
 void Scene_Teleport::TransitionOut() {
 	if (Scene::instance->type == Map) {
-		Graphics::GetTransition().Init(Transition::TransitionFadeOut, this, 32, true);
+		Player::TransitionErase(Transition::TransitionFadeOut, 32, this);
 	} else {
 		Scene::TransitionOut();
 	}

--- a/src/scene_teleport.cpp
+++ b/src/scene_teleport.cpp
@@ -55,7 +55,6 @@ void Scene_Teleport::Update() {
 		const RPG::SaveTarget& target = teleport_window->GetTarget();
 
 		Main_Data::game_player->ReserveTeleport(target);
-		Main_Data::game_player->StartTeleport();
 
 		Scene::PopUntil(Scene::Map);
 	} else if (Input::IsTriggered(Input::CANCEL)) {

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -35,6 +35,7 @@
 #include "scene_load.h"
 #include "scene_map.h"
 #include "window_command.h"
+#include "player.h"
 
 Scene_Title::Scene_Title() {
 	type = Scene::Title;
@@ -72,9 +73,9 @@ void Scene_Title::TransitionIn() {
 		Scene::TransitionIn();
 	}
 	else if (!Player::hide_title_flag) {
-		Graphics::GetTransition().Init(Transition::TransitionFadeIn, this, 32);
+		Player::TransitionShow(Transition::TransitionFadeIn, 32, this);
 	} else {
-		Graphics::GetTransition().Init(Transition::TransitionFadeIn, this, 6);
+		Player::TransitionShow(Transition::TransitionFadeIn, 6, this);
 	}
 }
 
@@ -206,7 +207,7 @@ void Scene_Title::CommandContinue() {
 
 void Scene_Title::CommandShutdown() {
 	Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
-	Graphics::GetTransition().Init(Transition::TransitionFadeOut, this, 32, true);
+	Player::TransitionErase(Transition::TransitionFadeOut, 32, this);
 	Scene::Pop();
 }
 

--- a/src/teleport_target.h
+++ b/src/teleport_target.h
@@ -1,0 +1,91 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_TELEPORT_TARGET_H
+#define EP_TELEPORT_TARGET_H
+
+#include <cstdint>
+
+/**
+ * Defines a target for teleportation
+ */
+class TeleportTarget {
+	public:
+		/** Construct an inactive target */
+		TeleportTarget() = default;
+
+		/** 
+		 * Activate and set the target
+		 * @param map_id map id
+		 * @param x x position
+		 * @param y y position
+		 * @param d d direction, or -1 if retain direction.
+		 */
+		TeleportTarget(int map_id, int x, int y, int d);
+
+		/** @return map id */
+		int GetMapId() const;
+
+		/** @return x position */
+		int GetX() const;
+
+		/** @return x position */
+		int GetY() const;
+
+		/** @return direction, or -1 if retain direction */
+		int GetDirection() const;
+
+		/** @return whether this is active */
+		bool IsActive() const;
+	private:
+		int _map_id = 0;
+		int _x = 0;
+		int _y = 0;
+		int16_t _d = -1;
+		bool _active = false;
+};
+
+
+inline TeleportTarget::TeleportTarget(int map_id, int x, int y, int d)
+	: _map_id(map_id)
+	  , _x(x)
+	  , _y(y)
+	  , _d(d)
+	  , _active(true)
+{ }
+
+inline int TeleportTarget::GetMapId() const {
+	return _map_id;
+}
+
+inline int TeleportTarget::GetX() const {
+	return _x;
+}
+
+inline int TeleportTarget::GetY() const {
+	return _y;
+}
+
+inline int TeleportTarget::GetDirection() const {
+	return _d;
+}
+
+inline bool TeleportTarget::IsActive() const {
+	return _active;
+}
+
+#endif

--- a/src/transition.h
+++ b/src/transition.h
@@ -23,7 +23,9 @@
 #include <string>
 #include "drawable.h"
 #include "system.h"
-#include "scene.h"
+#include "color.h"
+
+class Scene;
 
 
 /**
@@ -77,7 +79,7 @@ public:
 
 	int GetZ() const override;
 	DrawableType GetType() const override;
-	
+
 	/**
 	 * Defines a screen transition.
 	 *


### PR DESCRIPTION
Depends on #1714 

This PR changes screen transitions to act immediately by calling a function and doing an internal main loop while the transition runs.

This matches RPG_RT and allows for correct interpreter behavior when events call screen transitions. It also simplifies the scene stack logic as we don't need to handle asynchronous transitions anymore.