### PR TITLE
Refactor Battle2k message timings + state fixes 1 /  2

### DIFF
--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -116,6 +116,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Reset() {
 	healing = false;
 	success = false;
 	lethal = false;
+	killed_by_dmg = false;
 	critical_hit = false;
 	absorb = false;
 	revived = false;
@@ -288,6 +289,10 @@ bool Game_BattleAlgorithm::AlgorithmBase::IsSuccess() const {
 
 bool Game_BattleAlgorithm::AlgorithmBase::IsLethal() const {
 	return lethal;
+}
+
+bool Game_BattleAlgorithm::AlgorithmBase::IsKilledByDamage() const {
+	return killed_by_dmg;
 }
 
 bool Game_BattleAlgorithm::AlgorithmBase::IsCriticalHit() const {
@@ -1016,6 +1021,7 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 		if (GetTarget()->GetHp() - this->hp <= 0) {
 			// Death state
 			lethal = true;
+			killed_by_dmg = true;
 		}
 		else {
 			// Conditions healed by physical attack:
@@ -1293,6 +1299,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				if (GetTarget()->GetHp() - this->hp <= 0) {
 					// Death state
 					lethal = true;
+					killed_by_dmg = true;
 				}
 			}
 
@@ -1831,6 +1838,7 @@ bool Game_BattleAlgorithm::SelfDestruct::Execute() {
 	if (GetTarget()->GetHp() - this->hp <= 0) {
 		// Death state
 		lethal = true;
+		killed_by_dmg = true;
 	}
 
 	healed_conditions = GetTarget()->BattlePhysicalStateHeal(GetPhysicalDamageRate());

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -570,25 +570,9 @@ void Game_BattleAlgorithm::AlgorithmBase::GetResultMessages(std::vector<std::str
 		return;
 	}
 
-	if (GetAffectedHp() != -1) {
-
-		if (IsPositive()) {
-			if (!IsRevived() && (GetAffectedHp() > 0 || GetType() != Type::Item)) {
-				out.push_back(GetHpSpRecoveredMessage(GetAffectedHp(), Data::terms.health_points));
-			}
-		}
-		else {
-			if (GetAffectedHp() == 0) {
-				out.push_back(GetUndamagedMessage());
-			}
-			else {
-				if (IsAbsorb()) {
-					out.push_back(GetHpSpAbsorbedMessage(GetAffectedHp(), Data::terms.health_points));
-				}
-				else {
-					out.push_back(GetDamagedMessage());
-				}
-			}
+	if (IsPositive() && GetAffectedHp() != -1) {
+		if (!IsRevived() && (GetAffectedHp() > 0 || GetType() != Type::Item)) {
+			out.push_back(GetHpSpRecoveredMessage(GetAffectedHp(), Data::terms.health_points));
 		}
 	}
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1803,6 +1803,10 @@ const RPG::Sound* Game_BattleAlgorithm::SelfDestruct::GetStartSe() const {
 	return &Game_System::GetSystemSE(Game_System::SFX_EnemyKill);
 }
 
+int Game_BattleAlgorithm::SelfDestruct::GetPhysicalDamageRate() const {
+	return 100;
+}
+
 bool Game_BattleAlgorithm::SelfDestruct::Execute() {
 	Reset();
 
@@ -1829,10 +1833,7 @@ bool Game_BattleAlgorithm::SelfDestruct::Execute() {
 		lethal = true;
 	}
 
-	// Conditions healed by physical attack:
-	for (auto state_id: healed_conditions) {
-		GetTarget()->RemoveState(state_id);
-	}
+	healed_conditions = GetTarget()->BattlePhysicalStateHeal(GetPhysicalDamageRate());
 
 	success = true;
 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -226,9 +226,14 @@ public:
 	bool IsSuccess() const;
 
 	/**
-	 * @return truen when this action inflicts death on the target.
+	 * @return true when this action inflicts death on the target.
 	 */
 	bool IsLethal() const;
+
+	/**
+	 * @return true when the target was killed by damage.
+	 */
+	bool IsKilledByDamage() const;
 
 	/**
 	 * Gets if the last action was a critical hit.
@@ -431,6 +436,7 @@ protected:
 	bool healing;
 	bool success;
 	bool lethal = false;
+	bool killed_by_dmg = false;
 	bool critical_hit;
 	bool absorb;
 	bool revived = false;

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -155,6 +155,27 @@ public:
 	int GetAffectedAgility() const;
 
 	/**
+	 * Gets which conditions were healed by physical attack.
+	 *
+	 * @return healed conditions
+	 */
+	const std::vector<int16_t>& GetPhysicalHealedConditions() const;
+
+	/**
+	 * Gets which conditions were inflicted / healed directly.
+	 *
+	 * @return inflicted conditions
+	 */
+	const std::vector<int16_t>& GetAffectedConditions() const;
+
+	/**
+	 * Gets which attributes were shifited.
+	 *
+	 * @return shifted attributes
+	 */
+	const std::vector<int16_t>& GetShiftedAttributes() const;
+
+	/**
 	 * Gets activated switch.
 	 *
 	 * @return switch id or -1 when algorithm didn't affect a switch
@@ -209,13 +230,6 @@ public:
 	void PlaySecondAnimation(bool on_source = false);
 
 	void PlaySoundAnimation(bool on_source = false, int cutoff = -1);
-
-	/**
-	 * Returns a list of all inflicted/removed conditions.
-	 *
-	 * @return List of all inflicted/removed conditions
-	 */
-	const std::vector<int16_t>& GetAffectedConditions() const;
 
 	/**
 	 * Returns whether the action hit the target.
@@ -316,7 +330,6 @@ public:
 	 */
 	virtual const RPG::Sound* GetStartSe() const;
 
-
 	/**
 	 * Gets the sound effect that is played then the action fails. 
 	 *
@@ -354,15 +367,6 @@ public:
 	 * @return death message
 	 */
 	virtual std::string GetDeathMessage() const;
-
-	/**
-	 * Returns all inflicted/healed conditions.
-	 * This must be called before calling Execute, otherwise the conditions
-	 * are reported incorrectly.
-	 *
-	 * @param out filled with all conditions in text form
-	 */
-	virtual void GetResultMessages(std::vector<std::string>& out) const;
 
 	/**
 	 * Returns the physical rate of the attack.
@@ -407,6 +411,10 @@ public:
 	std::string GetUndamagedMessage() const;
 	std::string GetHpSpAbsorbedMessage(int value, const std::string& points) const;
 	std::string GetDamagedMessage() const;
+	std::string GetHpSpRecoveredMessage(int value, const std::string& points) const;
+	std::string GetParameterChangeMessage(bool is_positive, int value, const std::string& points) const;
+	std::string GetStateMessage(const std::string& message) const;
+	std::string GetAttributeShiftMessage(const std::string& attribute) const;
 
 protected:
 	AlgorithmBase(Type t, Game_Battler* source);
@@ -414,10 +422,6 @@ protected:
 	AlgorithmBase(Type t, Game_Battler* source, Game_Party_Base* target);
 
 	std::string GetAttackFailureMessage(const std::string& points) const;
-	std::string GetHpSpRecoveredMessage(int value, const std::string& points) const;
-	std::string GetParameterChangeMessage(bool is_positive, int value, const std::string& points) const;
-	std::string GetStateMessage(const std::string& message) const;
-	std::string GetAttributeShiftMessage(const std::string& attribute) const;
 
 	void ApplyActionSwitches();
 
@@ -507,7 +511,6 @@ public:
 	const RPG::Sound* GetFailureSe() const override;
 	const RPG::Sound* GetResultSe() const override;
 	std::string GetFailureMessage() const override;
-	void GetResultMessages(std::vector<std::string>& out) const override;
 	int GetPhysicalDamageRate() const override;
 	bool IsReflected() const override;
 	bool ActionIsPossible() const override;
@@ -531,7 +534,6 @@ public:
 	std::string GetStartMessage() const override;
 	int GetSourceAnimationState() const override;
 	const RPG::Sound* GetStartSe() const override;
-	void GetResultMessages(std::vector<std::string>& out) const override;
 	bool ActionIsPossible() const override;
 
 private:

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -404,6 +404,10 @@ public:
 	 */
 	std::string GetCriticalHitMessage() const;
 
+	std::string GetUndamagedMessage() const;
+	std::string GetHpSpAbsorbedMessage(int value, const std::string& points) const;
+	std::string GetDamagedMessage() const;
+
 protected:
 	AlgorithmBase(Type t, Game_Battler* source);
 	AlgorithmBase(Type t, Game_Battler* source, Game_Battler* target);
@@ -411,9 +415,6 @@ protected:
 
 	std::string GetAttackFailureMessage(const std::string& points) const;
 	std::string GetHpSpRecoveredMessage(int value, const std::string& points) const;
-	std::string GetUndamagedMessage() const;
-	std::string GetHpSpAbsorbedMessage(int value, const std::string& points) const;
-	std::string GetDamagedMessage() const;
 	std::string GetParameterChangeMessage(bool is_positive, int value, const std::string& points) const;
 	std::string GetStateMessage(const std::string& message) const;
 	std::string GetAttributeShiftMessage(const std::string& attribute) const;

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -316,6 +316,14 @@ public:
 	 */
 	virtual const RPG::Sound* GetStartSe() const;
 
+
+	/**
+	 * Gets the sound effect that is played then the action fails. 
+	 *
+	 * @return result se
+	 */
+	virtual const RPG::Sound* GetFailureSe() const;
+
 	/**
 	 * Gets the sound effect that is played then the action took place.
 	 *
@@ -329,6 +337,13 @@ public:
 	 * @return death se
 	 */
 	virtual const RPG::Sound* GetDeathSe() const;
+
+	/**
+	 * Returns the message used when the action fails.
+	 *
+	 * @return failure message
+	 */
+	virtual std::string GetFailureMessage() const;
 
 	/**
 	 * This is used to handle a corner case in the RPG2k battle system.
@@ -488,7 +503,9 @@ public:
 	std::string GetSecondStartMessage() const override;
 	int GetSourceAnimationState() const override;
 	const RPG::Sound* GetStartSe() const override;
+	const RPG::Sound* GetFailureSe() const override;
 	const RPG::Sound* GetResultSe() const override;
+	std::string GetFailureMessage() const override;
 	void GetResultMessages(std::vector<std::string>& out) const override;
 	int GetPhysicalDamageRate() const override;
 	bool IsReflected() const override;
@@ -568,8 +585,6 @@ public:
 	const RPG::Sound* GetStartSe() const override;
 	bool Execute() override;
 	void Apply() override;
-
-	void GetResultMessages(std::vector<std::string>& out) const override;
 };
 
 class Transform : public AlgorithmBase {

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -471,7 +471,7 @@ protected:
 	bool has_animation2_played = false;
 
 	std::vector<int16_t> conditions;
-	std::vector<int16_t> healed_conditions;
+	std::vector<int16_t> phys_healed_conditions;
 	std::vector<int16_t> shift_attributes;
 	std::vector<int> switch_on;
 	std::vector<int> switch_off;

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -548,6 +548,7 @@ public:
 	std::string GetStartMessage() const override;
 	int GetSourceAnimationState() const override;
 	const RPG::Sound* GetStartSe() const override;
+	int GetPhysicalDamageRate() const override;
 	bool Execute() override;
 	void Apply() override;
 };

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -645,6 +645,15 @@ bool Scene_Battle_Rpg2k::ProcessActionApply(Game_BattleAlgorithm::AlgorithmBase*
 		return ProcessNextAction(BattleActionState_Finished, action);
 	}
 
+	// This is a hack to ensure the sprite's death animation doesn't happen
+	// until we actually transition to the death state in the battle system.
+	if (action->IsLethal()) {
+		auto* target_sprite = Game_Battle::GetSpriteset().FindBattler(target);
+		if (target_sprite) {
+			target_sprite->SetForcedAlive(true);
+		}
+	}
+
 	if (!action->IsPositive() && action->GetAffectedHp() >= 0) {
 		return ProcessNextAction(BattleActionState_Damage, action);
 	}
@@ -791,6 +800,7 @@ bool Scene_Battle_Rpg2k::ProcessActionDeath(Game_BattleAlgorithm::AlgorithmBase*
 			Game_System::SePlay(*se);
 		}
 		if (target_sprite) {
+			target_sprite->SetForcedAlive(false);
 			target_sprite->DetectStateChange();
 		}
 

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -385,13 +385,7 @@ bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase
 		battle_action_pending = true;
 	}
 
-	const bool wait = battle_action_wait > 0;
-	if (battle_action_wait > 0 && !Input::IsPressed(Input::CANCEL)) {
-		--battle_action_wait;
-		if (Input::IsPressed(Input::DECISION) && battle_action_wait > 0) {
-			--battle_action_wait;
-		}
-	}
+	const bool wait = !CheckWait();
 
 	if (Game_Battle::IsBattleAnimationWaiting()) {
 		return false;
@@ -474,7 +468,7 @@ bool Scene_Battle_Rpg2k::ProcessActionConditionHeal(Game_BattleAlgorithm::Algori
 			// If state is inflicted, only prints if msg not empty.
 			if (pri_was_healed || !msg.empty()) {
 				battle_message_window->PushWithSubject(msg, action->GetSource()->GetName());
-				battle_action_wait = GetDelayForWindow();
+				SetWait(20, 40);
 
 				battle_action_state = BattleActionState_Usage1;
 				return ProcessBattleAction(action);
@@ -513,7 +507,7 @@ bool Scene_Battle_Rpg2k::ProcessActionUsage1(Game_BattleAlgorithm::AlgorithmBase
 		battle_message_window->ScrollToEnd();
 
 		if (action->HasSecondStartMessage()) {
-			battle_action_wait = GetDelayForWindow();
+			SetWait(20, 40);
 
 			battle_action_state = BattleActionState_Usage2;
 			return ProcessBattleAction(action);
@@ -572,9 +566,9 @@ bool Scene_Battle_Rpg2k::ProcessActionAnimation(Game_BattleAlgorithm::AlgorithmB
 	if (action->GetSource()->Exists()) {
 		battle_action_state = BattleActionState_Execute;
 		if (action->GetType() != Game_BattleAlgorithm::Type::NoMove) {
-			battle_action_wait = GetDelayForWindow();
+			SetWait(20, 40);
 		} else {
-			battle_action_wait = 1;
+			SetWait(1, 1);
 		}
 		return ProcessBattleAction(action);
 	}
@@ -591,7 +585,7 @@ bool Scene_Battle_Rpg2k::ProcessActionExecute(Game_BattleAlgorithm::AlgorithmBas
 	if (action->IsSuccess() && action->IsCriticalHit()) {
 		battle_message_window->Push(action->GetCriticalHitMessage());
 		battle_message_window->ScrollToEnd();
-		battle_action_wait = GetDelayForWindow();
+		SetWait(20, 40);
 
 		battle_action_state = BattleActionState_Apply;
 		return ProcessBattleAction(action);
@@ -651,7 +645,7 @@ bool Scene_Battle_Rpg2k::ProcessActionResults(Game_BattleAlgorithm::AlgorithmBas
 
 	battle_message_window->Push(*battle_result_messages_it);
 	battle_message_window->ScrollToEnd();
-	battle_action_wait = GetDelayForWindow();
+	SetWait(20, 40);
 	++battle_result_messages_it;
 
 	return false;
@@ -663,7 +657,7 @@ bool Scene_Battle_Rpg2k::ProcessActionDeath(Game_BattleAlgorithm::AlgorithmBase*
 		auto* target_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetTarget());
 		battle_message_window->Push(action->GetDeathMessage());
 		battle_message_window->ScrollToEnd();
-		battle_action_wait = GetDelayForWindow();
+		SetWait(20, 40);
 
 		battle_action_state = BattleActionState_Finished;
 
@@ -1012,24 +1006,6 @@ void Scene_Battle_Rpg2k::CreateEnemyActions() {
 		if (action) {
 			CreateEnemyAction(static_cast<Game_Enemy*>(battler), action);
 		}
-	}
-}
-
-int Scene_Battle_Rpg2k::GetDelayForWindow() {
-	if (Player::IsRPG2kE()) {
-		return 40;
-	}
-	else {
-		return 60 / 2;
-	}
-}
-
-int Scene_Battle_Rpg2k::GetDelayForLine() {
-	if (Player::IsRPG2kE()) {
-		return 60 / 10;
-	}
-	else {
-		return 60 / 7;
 	}
 }
 

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -836,6 +836,10 @@ void Scene_Battle_Rpg2k::CommandSelected() {
 }
 
 void Scene_Battle_Rpg2k::Escape() {
+	if (!CheckWait()) {
+		return;
+	}
+
 	if (begin_escape) {
 		battle_message_window->Clear();
 
@@ -844,40 +848,33 @@ void Scene_Battle_Rpg2k::Escape() {
 		escape_success = escape_alg.Execute();
 		escape_alg.Apply();
 
-		battle_result_messages.clear();
-		escape_alg.GetResultMessages(battle_result_messages);
-
-		battle_message_window->Push(battle_result_messages[0]);
+		if (escape_success) {
+			battle_message_window->Push(Data::terms.escape_success);
+		} else {
+			battle_message_window->Push(Data::terms.escape_failure);
+		}
 		begin_escape = false;
+		SetWait(10, 60);
+		return;
 	}
-	else {
-		if (Input::IsPressed(Input::DECISION)) {
-			++escape_counter;
-		}
 
-		++escape_counter;
+	begin_escape = true;
 
-		if (escape_counter > 60) {
-			begin_escape = true;
-			escape_counter = 0;
+	if (escape_success) {
+		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Escape));
 
-			if (escape_success) {
-				Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Escape));
+		Game_Temp::battle_result = Game_Temp::BattleEscape;
 
-				Game_Temp::battle_result = Game_Temp::BattleEscape;
-
-				Scene::Pop();
-			}
-			else {
-				SetState(State_Battle);
-				NextTurn();
-
-				CreateEnemyActions();
-				CreateExecutionOrder();
-				Game_Battle::RefreshEvents();
-			}
-		}
+		Scene::Pop();
+		return;
 	}
+
+	SetState(State_Battle);
+	NextTurn();
+
+	CreateEnemyActions();
+	CreateExecutionOrder();
+	Game_Battle::RefreshEvents();
 }
 
 void Scene_Battle_Rpg2k::SelectNextActor() {

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -177,7 +177,6 @@ protected:
 
 	bool begin_escape = true;
 	bool escape_success = false;
-	int escape_counter = 0;
 
 	bool message_box_got_visible = false;
 	bool move_screen = false;

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -65,6 +65,11 @@ public:
 		BattleActionState_Execute,
 		/**
 		 * Called once per target.
+		 * Used to display critical hit message.
+		 */
+		BattleActionState_Critical,
+		/**
+		 * Called once per target.
 		 * Used to apply the new conditions, play an optional battle animation and sound, and print the second line of a technique.
 		 */
 		BattleActionState_Apply,
@@ -181,6 +186,7 @@ protected:
 	bool ProcessActionUsage2(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionAnimation(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionExecute(Game_BattleAlgorithm::AlgorithmBase* action);
+	bool ProcessActionCritical(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionApply(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionResults(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionDeath(Game_BattleAlgorithm::AlgorithmBase* action);

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -140,21 +140,6 @@ protected:
 	void SelectNextActor();
 	void SelectPreviousActor();
 
-	/**
-	 * Gets the time during before hiding a windowful of
-	 * text.
-	 *
-	 * @return int seconds to wait
-	 */
-	int GetDelayForWindow();
-
-	/**
-	 * Gets delay between showing two lines of text.
-	 *
-	 * @return int seconds to wait
-	 */
-	int GetDelayForLine();
-
 	void CreateExecutionOrder();
 	void CreateEnemyActions();
 

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -172,19 +172,23 @@ protected:
 	bool ProcessActionDeath(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionFinished(Game_BattleAlgorithm::AlgorithmBase* action);
 
+	void SetWait(int min_wait, int max_wait);
+	bool CheckWait();
+
 	std::unique_ptr<Window_BattleMessage> battle_message_window;
 	std::vector<std::string> battle_result_messages;
 	std::vector<std::string>::iterator battle_result_messages_it;
 	bool battle_action_pending = false;
-	int battle_action_wait = 0;
 	int battle_action_state = BattleActionState_ConditionHeal;
 	int battle_action_start_index = 0;
 	int battle_action_results_index = 0;
 
 	int select_target_flash_count = 0;
 	bool encounter_message_first_monster = true;
-	int encounter_message_wait = 0;
 	bool encounter_message_first_strike = false;
+
+	int battle_action_wait = 0;
+	int battle_action_min_wait = 0;
 
 	bool begin_escape = true;
 	bool escape_success = false;

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -34,9 +34,14 @@ public:
 	enum BattleActionState {
 		/**
 		 * Called once
+		 * Flashes enemy sprite and a small delay to start action.
+		 */
+		BattleActionState_Begin,
+		/**
+		 * Called once
 		 * Handles healing of conditions that get auto removed after X turns.
 		 */
-		BattleActionState_ConditionHeal,
+		BattleActionState_Conditions,
 		/**
 		 * Called once
 		 * Handles first start message
@@ -169,7 +174,8 @@ protected:
 	bool ProcessNextSubState(int substate, Game_BattleAlgorithm::AlgorithmBase* action);
 
 	// BattleAction State Machine Handlers
-	bool ProcessActionConditionHeal(Game_BattleAlgorithm::AlgorithmBase* action);
+	bool ProcessActionBegin(Game_BattleAlgorithm::AlgorithmBase* action);
+	bool ProcessActionConditions(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionUsage1(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionUsage2(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionAnimation(Game_BattleAlgorithm::AlgorithmBase* action);
@@ -186,7 +192,7 @@ protected:
 	std::vector<std::string> battle_result_messages;
 	std::vector<std::string>::iterator battle_result_messages_it;
 	bool battle_action_pending = false;
-	int battle_action_state = BattleActionState_ConditionHeal;
+	int battle_action_state = BattleActionState_Begin;
 	int battle_action_substate = 0;
 	int battle_action_start_index = 0;
 	int battle_action_results_index = 0;

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -79,6 +79,11 @@ public:
 		 */
 		BattleActionState_Failure,
 		/**
+		 * Called once per target.
+		 * Used to handle damage.
+		 */
+		BattleActionState_Damage,
+		/**
 		* Called repeatedly.
 		* Used for the results, to push and pop each message.
 		*/
@@ -194,6 +199,7 @@ protected:
 	bool ProcessActionCritical(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionApply(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionFailure(Game_BattleAlgorithm::AlgorithmBase* action);
+	bool ProcessActionDamage(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionResults(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionDeath(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionFinished(Game_BattleAlgorithm::AlgorithmBase* action);

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -146,6 +146,28 @@ protected:
 	// Battle Start Handlers
 	bool DisplayMonstersInMessageWindow();
 
+	void SetBattleActionState(BattleActionState state);
+	void SetBattleActionSubState(int substate);
+
+	/**
+	 * Switch to the next action state, resetting the substate.
+	 *
+	 * @param state the state to change to
+	 * @param action the action we're processing
+	 * @return the return value of the state handler
+	 * @post battle_action_substate is reset to 0
+	 */
+	bool ProcessNextAction(BattleActionState state, Game_BattleAlgorithm::AlgorithmBase* action);
+
+	/**
+	 * Switch to the next action substate
+	 *
+	 * @param substate the substate to change to
+	 * @param action the action we're processing
+	 * @return the return value of the state handler
+	 */
+	bool ProcessNextSubState(int substate, Game_BattleAlgorithm::AlgorithmBase* action);
+
 	// BattleAction State Machine Handlers
 	bool ProcessActionConditionHeal(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionUsage1(Game_BattleAlgorithm::AlgorithmBase* action);
@@ -165,6 +187,7 @@ protected:
 	std::vector<std::string>::iterator battle_result_messages_it;
 	bool battle_action_pending = false;
 	int battle_action_state = BattleActionState_ConditionHeal;
+	int battle_action_substate = 0;
 	int battle_action_start_index = 0;
 	int battle_action_results_index = 0;
 
@@ -174,9 +197,6 @@ protected:
 
 	int battle_action_wait = 0;
 	int battle_action_min_wait = 0;
-
-	bool begin_escape = true;
-	bool escape_success = false;
 
 	bool message_box_got_visible = false;
 	bool move_screen = false;

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -168,7 +168,7 @@ protected:
 	bool DisplayMonstersInMessageWindow();
 
 	void SetBattleActionState(BattleActionState state);
-	void SetBattleActionSubState(int substate);
+	void SetBattleActionSubState(int substate, bool reset_index = true);
 
 	/**
 	 * Switch to the next action state, resetting the substate.
@@ -185,9 +185,10 @@ protected:
 	 *
 	 * @param substate the substate to change to
 	 * @param action the action we're processing
+	 * @param reset_index if true, reset the substate index
 	 * @return the return value of the state handler
 	 */
-	bool ProcessNextSubState(int substate, Game_BattleAlgorithm::AlgorithmBase* action);
+	bool ProcessNextSubState(int substate, Game_BattleAlgorithm::AlgorithmBase* action, bool reset_index = true);
 
 	// BattleAction State Machine Handlers
 	bool ProcessActionBegin(Game_BattleAlgorithm::AlgorithmBase* action);
@@ -216,6 +217,8 @@ protected:
 	int battle_action_substate = 0;
 	int battle_action_start_index = 0;
 	int battle_action_results_index = 0;
+	std::string pending_message;
+	int battle_action_substate_index = 0;
 
 	int select_target_flash_count = 0;
 	bool encounter_message_first_monster = true;

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -24,6 +24,7 @@
 
 #include "window_command.h"
 #include "window_battlemessage.h"
+#include "game_battlealgorithm.h"
 
 /**
  * Scene_Battle class.
@@ -186,6 +187,7 @@ protected:
 	bool ProcessActionFinished(Game_BattleAlgorithm::AlgorithmBase* action);
 
 	void SetWait(int min_wait, int max_wait);
+	void SetWaitForUsage(Game_BattleAlgorithm::Type type);
 	bool CheckWait();
 
 	std::unique_ptr<Window_BattleMessage> battle_message_window;

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -74,6 +74,11 @@ public:
 		 */
 		BattleActionState_Apply,
 		/**
+		 * Called once per target.
+		 * Used to handle action failure.
+		 */
+		BattleActionState_Failure,
+		/**
 		* Called repeatedly.
 		* Used for the results, to push and pop each message.
 		*/
@@ -188,6 +193,7 @@ protected:
 	bool ProcessActionExecute(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionCritical(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionApply(Game_BattleAlgorithm::AlgorithmBase* action);
+	bool ProcessActionFailure(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionResults(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionDeath(Game_BattleAlgorithm::AlgorithmBase* action);
 	bool ProcessActionFinished(Game_BattleAlgorithm::AlgorithmBase* action);

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -217,6 +217,7 @@ protected:
 	int battle_action_substate = 0;
 	int battle_action_start_index = 0;
 	int battle_action_results_index = 0;
+	int battle_action_dmg_index = 0;
 	std::string pending_message;
 	int battle_action_substate_index = 0;
 

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1023,10 +1023,12 @@ void Scene_Battle_Rpg2k3::Escape() {
 	escape_alg.Apply();
 
 	if (!escape_success) {
-		std::vector<std::string> battle_result_messages;
-		escape_alg.GetResultMessages(battle_result_messages);
 		SetState(State_SelectActor);
-		ShowNotification(battle_result_messages[0]);
+		if (escape_success) {
+			ShowNotification(Data::terms.escape_success);
+		} else {
+			ShowNotification(Data::terms.escape_failure);
+		}
 	}
 	else {
 		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Escape));

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -756,6 +756,8 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 			status_window->Refresh();
 		} while (action->TargetNext());
 
+		//FIXME: Figure out specific logic for 2k3 and remove GetResultSe() method.
+		//This method is no longer used in 2k battle system.
 		if (action->GetResultSe()) {
 			Game_System::SePlay(*action->GetResultSe());
 		}

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -332,6 +332,10 @@ void Sprite_Battler::CreateSprite() {
 	SetVisible(!battler->IsHidden());
 }
 
+void Sprite_Battler::SetForcedAlive(bool value) {
+	forced_alive = value;
+}
+
 void Sprite_Battler::DoIdleAnimation() {
 	if (battler->IsDefending()) {
 		SetAnimationState(AnimationState_Defending);
@@ -344,7 +348,7 @@ void Sprite_Battler::DoIdleAnimation() {
 	if (battler->GetBattleAnimationId() <= 0) {
 		// Monster
 		// Only visually different state is Death
-		if (state && state->ID == 1) {
+		if (state && state->ID == 1 && !forced_alive) {
 			idling_anim = AnimationState_Dead;
 		} else {
 			idling_anim = AnimationState_Idle;

--- a/src/sprite_battler.h
+++ b/src/sprite_battler.h
@@ -96,6 +96,15 @@ public:
 	int GetWidth() const override;
 	int GetHeight() const override;
 
+	/**
+	 * A hack for 2k battle system. Treat the sprite as not dead
+	 * even if the battler is dead. This is needed because battler "dies"
+	 * before the 2k battle system animates the death
+	 *
+	 * @param value whether to force alive or not
+	 */
+	void SetForcedAlive(bool value);
+
 protected:
 	void CreateSprite();
 	void DoIdleAnimation();
@@ -119,6 +128,7 @@ protected:
 	std::unique_ptr<BattleAnimation> animation;
 	// false when a newly set animation didn't loop once
 	bool idling = true;
+	bool forced_alive = false;
 	float zoom = 1.0;
 
 	FileRequestBinding request_id;


### PR DESCRIPTION
This is yet another 2k battle system refactor.

In order to emulate all of the waits RPG_RT does in #1677 I've had to add more states and substates.

I've also taken this opportunity to do some cleanup. In particular I've removed `GetResultMessages()` from `Game_BattleAlgorithm` and nearly all of the 2k message processing logic into `SceneBattleRpg2k`.

I also fixed a self-destruct bug and #1725 using a hack that hopefully can be dismantled later.

Related: #1725 
Related: #1677
Related: #1748
Related: #1770
Related: #821
Related: #1490
(they are all closed with #1785)

Tested:
- [x] Test all message timing cases in #1677 
- [x] Test all weapon state cases in #1677
- [x] Test all skill state cases in #1677
- [x] Test all item state cases in #1677
- [x] Test all self-destruct state cases in #1677
- [x] Test the last state for off by 1 errors.
