### PR TITLE
AsyncHandler: Normalize file requests

### DIFF
--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -107,12 +107,20 @@ void AsyncHandler::CreateRequestMapping(const std::string& file) {
 	} else {
 		using fn = std::function<void(const picojson::object&,const std::string&)>;
 		fn parse = [&] (const picojson::object& obj, const std::string& path) {
+			std::string dirname;
+			for (const auto& value : obj) {
+				if (value.first == "_dirname" && value.second.is<std::string>()) {
+					dirname = value.second.to_str();
+				}
+			}
+			dirname = FileFinder::MakePath(path, dirname);
+
 			for (const auto& value : obj) {
 				const auto& second = value.second;
 				if (second.is<picojson::object>()) {
-					parse(second.get<picojson::object>(), FileFinder::MakePath(path, value.first));
+					parse(second.get<picojson::object>(), dirname);
 				} else if (second.is<std::string>()){
-					file_mapping[FileFinder::MakePath(path, value.first)] = FileFinder::MakePath(path, second.to_str());
+					file_mapping[FileFinder::MakePath(Utils::LowerCase(dirname), value.first)] = FileFinder::MakePath(dirname, second.to_str());
 				}
 			}
 		};

--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -16,11 +16,13 @@
  */
 
 #include <cstdlib>
+#include <fstream>
 #include <map>
 
 #ifdef EMSCRIPTEN
 #  include <emscripten.h>
 #  include <regex>
+#  include <lcf/reader_util.h>
 #  include "picojson.h"
 #endif
 
@@ -31,7 +33,6 @@
 #include "output.h"
 #include "player.h"
 #include "main_data.h"
-#include <fstream>
 #include "utils.h"
 #include "transition.h"
 #include "rand.h"
@@ -190,13 +191,8 @@ void FileRequestAsync::Start() {
 		request_path += "default/";
 	}
 
-	std::string real_path = Utils::LowerCase(path);
-	if (directory != ".") {
-		// Don't alter the path when the file is in the main directory
-		real_path = FileFinder::MakeCanonical(real_path, 1);
-	}
+	auto it = file_mapping.find(ReaderUtil::Normalize(path));
 
-	auto it = file_mapping.find(real_path);
 	if (it != file_mapping.end()) {
 		request_path += it->second;
 	} else {


### PR DESCRIPTION
Forgot this one

Test case, created with new gencache from gencache PR:
https://easyrpg.org/play/pr1729/?game=yume_nikki_test

Title screen is renamed to "１２３４５①.xyz" and NASU contains some １s.

Also works because of version check:
https://easyrpg.org/play/pr1729/?game=yume_nikki

Master, fails to load assets in the new normalized one:
https://easyrpg.org/play/master/?game=yume_nikki_test
