### PR TITLE
Refactor Interpreter command execution

### DIFF
--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -63,7 +63,7 @@ namespace {
 }
 
 void Game_Battle::Init() {
-	interpreter.reset(new Game_Interpreter_Battle(0, true));
+	interpreter.reset(new Game_Interpreter_Battle());
 	spriteset.reset(new Spriteset_Battle());
 	animation.reset();
 

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -33,7 +33,7 @@ Game_CommonEvent::Game_CommonEvent(int common_event_id) :
 
 void Game_CommonEvent::SetSaveData(const RPG::SaveEventExecState& data) {
 	if (interpreter && !data.stack.empty()) {
-		interpreter->SetupFromSave(data.stack);
+		interpreter->SetState(data);
 	}
 }
 
@@ -73,13 +73,11 @@ std::vector<RPG::EventCommand>& Game_CommonEvent::GetList() {
 }
 
 RPG::SaveEventExecState Game_CommonEvent::GetSaveData() {
-	RPG::SaveEventExecState event_data;
-
+	RPG::SaveEventExecState state;
 	if (interpreter) {
-		event_data.stack = interpreter->GetSaveData();
+		state = interpreter->GetState();
 	}
-
-	return event_data;
+	return state;
 }
 
 bool Game_CommonEvent::IsWaitingExecution(RPG::EventPage::Trigger trigger) const {

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -25,22 +25,15 @@
 
 Game_CommonEvent::Game_CommonEvent(int common_event_id) :
 	common_event_id(common_event_id) {
+
+	if (GetTrigger() == RPG::EventPage::Trigger_parallel) {
+		interpreter.reset(new Game_Interpreter_Map());
+	}
 }
 
 void Game_CommonEvent::SetSaveData(const RPG::SaveEventExecState& data) {
-	if (!data.stack.empty()) {
-		interpreter.reset(new Game_Interpreter_Map());
+	if (interpreter && !data.stack.empty()) {
 		interpreter->SetupFromSave(data.stack);
-	}
-
-	Refresh();
-}
-
-void Game_CommonEvent::Refresh() {
-	if (GetTrigger() == RPG::EventPage::Trigger_parallel) {
-		if (!interpreter) {
-			interpreter.reset(new Game_Interpreter_Map());
-		}
 	}
 }
 

--- a/src/game_commonevent.h
+++ b/src/game_commonevent.h
@@ -45,11 +45,6 @@ public:
 	void SetSaveData(const RPG::SaveEventExecState& data);
 
 	/**
-	 * Refreshes the common event.
-	 */
-	void Refresh();
-
-	/**
 	 * Updates common event parallel interpreter.
 	 */
 	void Update();

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -57,7 +57,7 @@ Game_Event::Game_Event(int map_id, const RPG::Event& event, const RPG::SaveMapEv
 
 	if (!data()->parallel_event_execstate.stack.empty()) {
 		interpreter.reset(new Game_Interpreter_Map());
-		static_cast<Game_Interpreter_Map*>(interpreter.get())->SetupFromSave(data()->parallel_event_execstate.stack);
+		static_cast<Game_Interpreter_Map*>(interpreter.get())->SetState(data()->parallel_event_execstate);
 	}
 
 	Refresh();
@@ -562,7 +562,8 @@ const RPG::EventPage *Game_Event::GetActivePage() const {
 
 const RPG::SaveMapEvent& Game_Event::GetSaveData() {
 	if (interpreter) {
-		data()->parallel_event_execstate.stack = static_cast<Game_Interpreter_Map*>(interpreter.get())->GetSaveData();
+		auto* imap = static_cast<Game_Interpreter_Map*>(interpreter.get());
+		data()->parallel_event_execstate = imap->GetState();
 	}
 	data()->ID = event.ID;
 

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -96,7 +96,6 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 		SetSpriteIndex(0);
 		SetDirection(RPG::EventPage::Direction_down);
 		trigger = -1;
-		list.clear();
 		return;
 	}
 
@@ -134,7 +133,6 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 	SetLayer(page->layer);
 	data()->overlap_forbidden = page->overlap_forbidden;
 	trigger = page->trigger;
-	list = page->event_commands;
 
 	if (!interpreter && trigger == RPG::EventPage::Trigger_parallel) {
 		interpreter.reset(new Game_Interpreter_Map());
@@ -146,13 +144,11 @@ void Game_Event::SetupFromSave(const RPG::EventPage* new_page) {
 
 	if (page == nullptr) {
 		trigger = -1;
-		list.clear();
 		return;
 	}
 
 	original_move_frequency = page->move_frequency;
 	trigger = page->trigger;
-	list = page->event_commands;
 
 	// Trigger parallel events when the interpreter wasn't already running
 	// (because it was the middle of a parallel event while saving)
@@ -299,7 +295,7 @@ RPG::EventPage::Trigger Game_Event::GetTrigger() const {
 
 bool Game_Event::SetAsWaitingForegroundExecution(bool face_hero, bool by_decision_key) {
 	// RGSS scripts consider list empty if size <= 1. Why?
-	if (list.empty() || !data()->active) {
+	if (GetList().empty() || !data()->active) {
 		return false;
 	}
 
@@ -314,8 +310,10 @@ bool Game_Event::SetAsWaitingForegroundExecution(bool face_hero, bool by_decisio
 	return true;
 }
 
+static std::vector<RPG::EventCommand> _empty_list = {};
+
 const std::vector<RPG::EventCommand>& Game_Event::GetList() const {
-	return list;
+	return page ? page->event_commands : _empty_list;
 }
 
 void Game_Event::OnFinishForegroundEvent() {

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -87,7 +87,6 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 		// carry on executing its command list during this frame
 		if (page)
 			interpreter->Clear();
-		Game_Map::ReserveInterpreterDeletion(interpreter);
 		interpreter.reset();
 	}
 
@@ -519,6 +518,11 @@ void Game_Event::Update() {
 		if (!interpreter->IsRunning()) {
 			interpreter->Setup(this);
 		}
+		// Event code could run which changes the current page of this event.
+		// That can then result in the interpreter shared_ptr getting reset.
+		// To prevent a crash, we make a copy of the interpreter shared_ptr
+		// here to prevent it from getting deleted until after Update() returns.
+		auto interpreter_guard = interpreter;
 		interpreter->Update();
 
 		// RPG_RT only exits if active is false here, but not if there is

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -36,8 +36,7 @@
 Game_Event::Game_Event(int map_id, const RPG::Event& event) :
 	Game_Character(Event, new RPG::SaveMapEvent()),
 	_data_copy(this->data()),
-	event(event),
-	from_save(false)
+	event(event)
 {
 	SetMapId(map_id);
 	SetMoveSpeed(3);
@@ -49,8 +48,7 @@ Game_Event::Game_Event(int map_id, const RPG::Event& event, const RPG::SaveMapEv
 	//FIXME: This will leak if Game_Character() throws.
 	Game_Character(Event, new RPG::SaveMapEvent(orig_data)),
 	_data_copy(this->data()),
-	event(event),
-	from_save(true)
+	event(event)
 {
 	// Savegames have 0 for the mapid for compatibility with RPG_RT.
 	SetMapId(map_id);
@@ -62,7 +60,7 @@ Game_Event::Game_Event(int map_id, const RPG::Event& event, const RPG::SaveMapEv
 		interpreter->SetState(data()->parallel_event_execstate);
 	}
 
-	Refresh();
+	Refresh(true);
 }
 
 int Game_Event::GetOriginalMoveRouteIndex() const {
@@ -153,11 +151,10 @@ void Game_Event::SetupFromSave(const RPG::EventPage* new_page) {
 	}
 }
 
-void Game_Event::Refresh() {
+void Game_Event::Refresh(bool from_save) {
 	if (!data()->active) {
 		if (from_save) {
 			SetVisible(false);
-			from_save = false;
 		}
 		return;
 	}
@@ -182,7 +179,6 @@ void Game_Event::Refresh() {
 	// don't setup event, already done
 	if (from_save) {
 		SetupFromSave(new_page);
-		from_save = false;
 	}
 	else if (new_page != this->page) {
 		ClearWaitingForegroundExecution();

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -53,7 +53,7 @@ public:
 	/**
 	 * Does refresh.
 	 */
-	void Refresh();
+	void Refresh(bool from_save = false);
 
 	void Setup(const RPG::EventPage* new_page);
 	void SetupFromSave(const RPG::EventPage* new_page);
@@ -201,7 +201,6 @@ private:
 	RPG::Event event;
 	const RPG::EventPage* page = nullptr;
 	std::unique_ptr<Game_Interpreter_Map> interpreter;
-	bool from_save;
 };
 
 inline RPG::SaveMapEvent* Game_Event::data() {

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -201,7 +201,6 @@ private:
 	int trigger = -1;
 	RPG::Event event;
 	const RPG::EventPage* page = nullptr;
-	std::vector<RPG::EventCommand> list;
 	std::unique_ptr<Game_Interpreter_Map> interpreter;
 	bool from_save;
 };

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -198,7 +198,6 @@ private:
 	// reference.
 	std::unique_ptr<RPG::SaveMapEvent> _data_copy;
 
-	int trigger = -1;
 	RPG::Event event;
 	const RPG::EventPage* page = nullptr;
 	std::unique_ptr<Game_Interpreter_Map> interpreter;

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -24,7 +24,7 @@
 #include "game_character.h"
 #include "rpg_event.h"
 #include "rpg_savemapevent.h"
-#include "game_interpreter.h"
+#include "game_interpreter_map.h"
 
 /**
  * Game_Event class.
@@ -202,7 +202,7 @@ private:
 	RPG::Event event;
 	const RPG::EventPage* page = nullptr;
 	std::vector<RPG::EventCommand> list;
-	std::shared_ptr<Game_Interpreter> interpreter;
+	std::unique_ptr<Game_Interpreter_Map> interpreter;
 	bool from_save;
 };
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2596,7 +2596,14 @@ bool Game_Interpreter::CommandKeyInputProc(RPG::EventCommand const& com) { // co
 	assert(frame);
 	auto& index = frame->current_command;
 
+	int var_id = com.parameters[0];
 	bool wait = com.parameters[1] != 0;
+
+	if (wait) {
+		// While waiting the variable is reset to 0 each frame.
+		Game_Variables.Set(var_id, 0);
+		Game_Map::SetNeedRefresh(Game_Map::Refresh_Map);
+	}
 
 	// FIXME: Is this valid?
 	if (wait && Game_Message::visible)
@@ -2604,7 +2611,7 @@ bool Game_Interpreter::CommandKeyInputProc(RPG::EventCommand const& com) { // co
 
 	_keyinput = {};
 	_keyinput.wait = wait;
-	_keyinput.variable = com.parameters[0];
+	_keyinput.variable = var_id;
 
 	_keyinput.keys[Keys::eDecision] = com.parameters[3] != 0;
 	_keyinput.keys[Keys::eCancel] = com.parameters[4] != 0;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -58,9 +58,6 @@ namespace {
 	static Game_Interpreter* transition_owner = nullptr;
 }
 
-// 10000 based on: https://gist.github.com/4406621
-constexpr int loop_limit = 10000;
-
 Game_Interpreter::Game_Interpreter(bool _main_flag) {
 	main_flag = _main_flag;
 	updating = false;
@@ -3047,8 +3044,9 @@ bool Game_Interpreter::CommandCallEvent(RPG::EventCommand const& com) { // code 
 	int evt_id;
 	int event_page;
 
-	//FIXME: Max call stack depth of 100??
-
+	if ((int)_state.stack.size() > call_stack_limit) {
+		Output::Error("Call Event limit has been exceeded");
+	}
 
 	RPG::SaveEventExecFrame new_frame;
 	new_frame.ID = _state.stack.size() + 1;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -197,6 +197,13 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 			_state.wait_key_enter = false;
 		}
 
+		if (_state.wait_movement) {
+			if (Game_Map::IsAnyMovePending()) {
+				break;
+			}
+			_state.wait_movement = false;
+		}
+
 		if (Game_Temp::to_title) {
 			break;
 		}

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -3064,7 +3064,9 @@ bool Game_Interpreter::CommandCallEvent(RPG::EventCommand const& com) { // code 
 		new_frame.current_command = 0;
 		new_frame.event_id = 0;
 
-		_state.stack.push_back(new_frame);
+		if (!new_frame.commands.empty()) {
+			_state.stack.push_back(new_frame);
+		}
 		return true;
 	}
 	case 1: // Map Event
@@ -3095,7 +3097,9 @@ bool Game_Interpreter::CommandCallEvent(RPG::EventCommand const& com) { // code 
 	new_frame.current_command = 0;
 	new_frame.event_id = event->GetId();
 
-	_state.stack.push_back(new_frame);
+	if (!new_frame.commands.empty()) {
+		_state.stack.push_back(new_frame);
+	}
 
 	return true;
 }

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -83,7 +83,6 @@ void Game_Interpreter::Clear() {
 	event_id = 0;					// event ID
 	wait_count = 0;					// wait count
 	waiting_battle_anim = false;
-	triggered_by_decision_key = false;
 	continuation = NULL;			// function to execute to resume command
 	button_timer = 0;
 	wait_messages = false;			// wait if message window is visible
@@ -119,11 +118,10 @@ void Game_Interpreter::Setup(
 		_state.stack[0].commands = _list;
 	}
 
-	triggered_by_decision_key = started_by_decision_key;
-
 	auto* frame = GetFrame();
 	if (frame) {
 		frame->current_command = 0;
+		frame->triggered_by_decision_key = started_by_decision_key;
 	}
 
 	CancelMenuCall();
@@ -2654,6 +2652,9 @@ bool Game_Interpreter::CommandChangeMainMenuAccess(RPG::EventCommand const& com)
 }
 
 bool Game_Interpreter::CommandConditionalBranch(RPG::EventCommand const& com) { // Code 12010
+	auto* frame = GetFrame();
+	assert(frame);
+
 	bool result = false;
 	int value1, value2;
 	int actor_id;
@@ -2807,7 +2808,7 @@ bool Game_Interpreter::CommandConditionalBranch(RPG::EventCommand const& com) { 
 	}
 	case 8:
 		// Key decision initiated this event
-		result = triggered_by_decision_key;
+		result = frame->triggered_by_decision_key;
 		break;
 	case 9:
 		// BGM looped at least once

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -3045,7 +3045,7 @@ bool Game_Interpreter::CommandCallEvent(RPG::EventCommand const& com) { // code 
 	int event_page;
 
 	if ((int)_state.stack.size() > call_stack_limit) {
-		Output::Error("Call Event limit has been exceeded");
+		Output::Error("Call Event limit (%d) has been exceeded", call_stack_limit);
 	}
 
 	RPG::SaveEventExecFrame new_frame;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -79,7 +79,6 @@ Game_Interpreter::~Game_Interpreter() {
 
 // Clear.
 void Game_Interpreter::Clear() {
-	map_id = 0;						// map ID when starting up
 	event_id = 0;					// event ID
 	wait_count = 0;					// wait count
 	waiting_battle_anim = false;
@@ -109,7 +108,6 @@ void Game_Interpreter::Setup(
 ) {
 	Clear();
 
-	map_id = Game_Map::GetMapId();
 	event_id = _event_id;
 
 	if (depth <= 100) {
@@ -162,12 +160,6 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 	}
 
 	for (; loop_count < loop_limit; ++loop_count) {
-		/* If map is different than event startup time
-		set event_id to 0 */
-		if (Game_Map::GetMapId() != map_id) {
-			event_id = 0;
-		}
-
 		/* If there's any active child interpreter, update it */
 		if (child_interpreter) {
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -60,7 +60,6 @@ namespace {
 
 Game_Interpreter::Game_Interpreter(bool _main_flag) {
 	main_flag = _main_flag;
-	updating = false;
 
 	Clear();
 }
@@ -259,7 +258,6 @@ int Game_Interpreter::GetThisEventId() const {
 
 // Update
 void Game_Interpreter::Update(bool reset_loop_count) {
-	updating = true;
 	if (reset_loop_count) {
 		loop_count = 0;
 	}
@@ -401,8 +399,6 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 		// Executed Events Count exceeded (10000)
 		Output::Debug("Event %d exceeded execution limit", event_id);
 	}
-
-	updating = false;
 
 	if (Game_Map::GetNeedRefresh()) {
 		Game_Map::Refresh();

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -325,7 +325,7 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 			if (_keyinput.timed) {
 				// 10 per second
 				Game_Variables.Set(_keyinput.time_variable,
-						(int)((float)_keyinput.wait_frames / Graphics::GetDefaultFps() * 10));
+						(_keyinput.wait_frames * 10) / Graphics::GetDefaultFps());
 			}
 			_keyinput.wait = false;
 		}

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2548,40 +2548,44 @@ bool Game_Interpreter::CommandPlayMemorizedBGM(RPG::EventCommand const& /* com *
 int Game_Interpreter::KeyInputState::CheckInput() const {
 	auto check = wait ? Input::IsTriggered : Input::IsPressed;
 
-	if (keys[Keys::eDown] && check(Input::DOWN)) {
-		return 1;
-	}
-	if (keys[Keys::eLeft] && check(Input::LEFT)) {
-		return 2;
-	}
-	if (keys[Keys::eRight] && check(Input::RIGHT)) {
-		return 3;
-	}
-	if (keys[Keys::eUp] && check(Input::UP)) {
-		return 4;
-	}
-	if (keys[Keys::eDecision] && check(Input::DECISION)) {
-		return 5;
-	}
-	if (keys[Keys::eCancel] && check(Input::CANCEL)) {
-		return 6;
-	}
-	if (keys[Keys::eShift] && check(Input::SHIFT)) {
-		return 7;
+	// RPG processes keys from highest variable value to lowest.
+	if (keys[Keys::eOperators]) {
+		for (int i = 5; i > 0;) {
+			--i;
+			if (check((Input::InputButton)(Input::PLUS + i))) {
+				return 20 + i;
+			}
+		}
 	}
 	if (keys[Keys::eNumbers]) {
-		for (int i = 0; i < 10; ++i) {
+		for (int i = 10; i > 0;) {
+			--i;
 			if (check((Input::InputButton)(Input::N0 + i))) {
 				return 10 + i;
 			}
 		}
 	}
-	if (keys[Keys::eOperators]) {
-		for (int i = 0; i < 5; ++i) {
-			if (check((Input::InputButton)(Input::PLUS + i))) {
-				return 20 + i;
-			}
-		}
+
+	if (keys[Keys::eShift] && check(Input::SHIFT)) {
+		return 7;
+	}
+	if (keys[Keys::eCancel] && check(Input::CANCEL)) {
+		return 6;
+	}
+	if (keys[Keys::eDecision] && check(Input::DECISION)) {
+		return 5;
+	}
+	if (keys[Keys::eUp] && check(Input::UP)) {
+		return 4;
+	}
+	if (keys[Keys::eRight] && check(Input::RIGHT)) {
+		return 3;
+	}
+	if (keys[Keys::eLeft] && check(Input::LEFT)) {
+		return 2;
+	}
+	if (keys[Keys::eDown] && check(Input::DOWN)) {
+		return 1;
 	}
 
 	return 0;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -73,7 +73,6 @@ Game_Interpreter::~Game_Interpreter() {
 
 // Clear.
 void Game_Interpreter::Clear() {
-	wait_count = 0;					// wait count
 	waiting_battle_anim = false;
 	continuation = NULL;			// function to execute to resume command
 	button_timer = 0;
@@ -114,9 +113,9 @@ void Game_Interpreter::Setup(
 void Game_Interpreter::SetupWait(int duration) {
 	if (duration == 0) {
 		// 0.0 waits 1 frame
-		wait_count = 1;
+		_state.wait_time = 1;
 	} else {
-		wait_count = duration * DEFAULT_FPS / 10;
+		_state.wait_time = duration * DEFAULT_FPS / 10;
 	}
 }
 
@@ -186,8 +185,8 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 			transition_owner = nullptr;
 		}
 
-		if (wait_count > 0) {
-			wait_count--;
+		if (_state.wait_time > 0) {
+			_state.wait_time--;
 			break;
 		}
 

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -83,6 +83,9 @@ public:
 protected:
 	friend class Game_Interpreter_Map;
 
+	static constexpr int loop_limit = 10000;
+	static constexpr int call_stack_limit = 1000;
+
 	const RPG::SaveEventExecFrame* GetFrame() const;
 	RPG::SaveEventExecFrame* GetFrame();
 

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -96,8 +96,6 @@ protected:
 	bool updating;
 	bool clear_child;
 
-	bool triggered_by_decision_key = false;
-
 	/**
 	 * Gets strings for choice selection.
 	 * This is just a helper (private) method

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -99,8 +99,6 @@ protected:
 	int loop_count;
 	bool wait_messages;
 
-	int wait_count;
-
 	typedef bool (Game_Interpreter::*ContinuationFunction)(RPG::EventCommand const& com);
 	ContinuationFunction continuation;
 

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -27,6 +27,7 @@
 #include "rpg_eventcommand.h"
 #include "system.h"
 #include "command_codes.h"
+#include "rpg_saveeventexecstate.h"
 
 class Game_Event;
 class Game_CommonEvent;
@@ -73,6 +74,9 @@ public:
 protected:
 	friend class Game_Interpreter_Map;
 
+	const RPG::SaveEventExecFrame* GetFrame() const;
+	RPG::SaveEventExecFrame* GetFrame();
+
 	int depth;
 	bool main_flag;
 
@@ -87,8 +91,6 @@ protected:
 	std::unique_ptr<Game_Interpreter> child_interpreter;
 	typedef bool (Game_Interpreter::*ContinuationFunction)(RPG::EventCommand const& com);
 	ContinuationFunction continuation;
-
-	std::vector<RPG::EventCommand> list;
 
 	int button_timer;
 	bool waiting_battle_anim;
@@ -238,7 +240,18 @@ protected:
 	} event_info;
 
 	FileRequestBinding request_id;
+
+	RPG::SaveEventExecState _state;
 };
+
+
+inline const RPG::SaveEventExecFrame* Game_Interpreter::GetFrame() const {
+	return !_state.stack.empty() ? &_state.stack.back() : nullptr;
+}
+
+inline RPG::SaveEventExecFrame* Game_Interpreter::GetFrame() {
+	return !_state.stack.empty() ? &_state.stack.back() : nullptr;
+}
 
 inline int Game_Interpreter::GetLoopCount() const {
 	return loop_count;

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -28,6 +28,7 @@
 #include "system.h"
 #include "command_codes.h"
 #include "rpg_saveeventexecstate.h"
+#include "flag_set.h"
 
 class Game_Event;
 class Game_CommonEvent;
@@ -77,7 +78,7 @@ public:
 	 *
 	 * @return interpreter commands stored in SaveEventCommands
 	 */
-	const RPG::SaveEventExecState& GetState() const;
+	RPG::SaveEventExecState GetState() const;
 
 protected:
 	friend class Game_Interpreter_Map;
@@ -102,7 +103,6 @@ protected:
 	typedef bool (Game_Interpreter::*ContinuationFunction)(RPG::EventCommand const& com);
 	ContinuationFunction continuation;
 
-	int button_timer;
 	bool waiting_battle_anim;
 	bool updating;
 
@@ -238,13 +238,34 @@ protected:
 	void OnChangeSystemGraphicReady(FileRequestResult* result);
 
 	FileRequestBinding request_id;
+	enum class Keys {
+		eDown,
+		eLeft,
+		eRight,
+		eUp,
+		eDecision,
+		eCancel,
+		eShift,
+		eNumbers,
+		eOperators
+	};
+
+	struct KeyInputState {
+		FlagSet<Keys> keys = {};
+		int variable = 0;
+		int time_variable = 0;
+		int wait_frames = 0;
+		bool wait = false;
+		bool timed = false;
+
+		int CheckInput() const;
+		void fromSave(const RPG::SaveEventExecState& save);
+		void toSave(RPG::SaveEventExecState& save) const;
+	};
 
 	RPG::SaveEventExecState _state;
+	KeyInputState _keyinput;
 };
-
-inline const RPG::SaveEventExecState& Game_Interpreter::GetState() const {
-	return _state;
-}
 
 inline const RPG::SaveEventExecFrame* Game_Interpreter::GetFrame() const {
 	return !_state.stack.empty() ? &_state.stack.back() : nullptr;

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -83,7 +83,6 @@ protected:
 	int loop_count;
 	bool wait_messages;
 
-	unsigned int index;
 	int map_id;
 	unsigned int event_id;
 	int wait_count;

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -81,8 +81,6 @@ public:
 	RPG::SaveEventExecState GetState() const;
 
 protected:
-	friend class Game_Interpreter_Map;
-
 	static constexpr int loop_limit = 10000;
 	static constexpr int call_stack_limit = 1000;
 

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -238,7 +238,6 @@ protected:
 	} event_info;
 
 	FileRequestBinding request_id;
-
 };
 
 inline int Game_Interpreter::GetLoopCount() const {

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -105,7 +105,6 @@ protected:
 	ContinuationFunction continuation;
 
 	bool waiting_battle_anim;
-	bool updating;
 
 	/**
 	 * Gets strings for choice selection.

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -83,7 +83,6 @@ protected:
 	int loop_count;
 	bool wait_messages;
 
-	int map_id;
 	unsigned int event_id;
 	int wait_count;
 

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -41,6 +41,7 @@ bool Game_Interpreter_Battle::ExecuteCommand() {
 	auto* frame = GetFrame();
 	assert(frame);
 	const auto& list = frame->commands;
+	auto& index = frame->current_command;
 
 	if (index >= list.size()) {
 		return CommandEnd();

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -32,9 +32,8 @@
 #include "spriteset_battle.h"
 #include <cassert>
 
-Game_Interpreter_Battle::Game_Interpreter_Battle(int depth, bool main_flag) :
-	Game_Interpreter(depth, main_flag) {
-}
+Game_Interpreter_Battle::Game_Interpreter_Battle()
+	: Game_Interpreter(true) {}
 
 // Execute Command.
 bool Game_Interpreter_Battle::ExecuteCommand() {
@@ -84,9 +83,6 @@ bool Game_Interpreter_Battle::ExecuteCommand() {
 // Commands
 
 bool Game_Interpreter_Battle::CommandCallCommonEvent(RPG::EventCommand const& com) {
-	if (child_interpreter)
-		return false;
-
 	int evt_id = com.parameters[0];
 
 	Game_CommonEvent* common_event = ReaderUtil::GetElement(Game_Map::GetCommonEvents(), evt_id);
@@ -95,8 +91,14 @@ bool Game_Interpreter_Battle::CommandCallCommonEvent(RPG::EventCommand const& co
 		return true;
 	}
 
-	child_interpreter.reset(new Game_Interpreter_Battle(depth + 1));
-	child_interpreter->Setup(common_event, 0);
+	RPG::SaveEventExecFrame new_frame;
+
+	new_frame.ID = _state.stack.size() + 1;
+	new_frame.commands = common_event->GetList();
+	new_frame.current_command = 0;
+	new_frame.event_id = 0;
+
+	_state.stack.push_back(new_frame);
 
 	return true;
 }

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -102,7 +102,9 @@ bool Game_Interpreter_Battle::CommandCallCommonEvent(RPG::EventCommand const& co
 	new_frame.current_command = 0;
 	new_frame.event_id = 0;
 
-	_state.stack.push_back(new_frame);
+	if (!new_frame.commands.empty()) {
+		_state.stack.push_back(new_frame);
+	}
 
 	return true;
 }

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -30,6 +30,7 @@
 #include "game_temp.h"
 #include "game_map.h"
 #include "spriteset_battle.h"
+#include <cassert>
 
 Game_Interpreter_Battle::Game_Interpreter_Battle(int depth, bool main_flag) :
 	Game_Interpreter(depth, main_flag) {
@@ -37,6 +38,10 @@ Game_Interpreter_Battle::Game_Interpreter_Battle(int depth, bool main_flag) :
 
 // Execute Command.
 bool Game_Interpreter_Battle::ExecuteCommand() {
+	auto* frame = GetFrame();
+	assert(frame);
+	const auto& list = frame->commands;
+
 	if (index >= list.size()) {
 		return CommandEnd();
 	}

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -92,7 +92,7 @@ bool Game_Interpreter_Battle::CommandCallCommonEvent(RPG::EventCommand const& co
 	}
 
 	if ((int)_state.stack.size() > call_stack_limit) {
-		Output::Error("Call Event limit has been exceeded");
+		Output::Error("Call Event limit (%d) has been exceeded", call_stack_limit);
 	}
 
 	RPG::SaveEventExecFrame new_frame;

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -91,6 +91,10 @@ bool Game_Interpreter_Battle::CommandCallCommonEvent(RPG::EventCommand const& co
 		return true;
 	}
 
+	if ((int)_state.stack.size() > call_stack_limit) {
+		Output::Error("Call Event limit has been exceeded");
+	}
+
 	RPG::SaveEventExecFrame new_frame;
 
 	new_frame.ID = _state.stack.size() + 1;

--- a/src/game_interpreter_battle.h
+++ b/src/game_interpreter_battle.h
@@ -36,7 +36,7 @@ class Game_CommonEvent;
 class Game_Interpreter_Battle : public Game_Interpreter
 {
 public:
-	Game_Interpreter_Battle(int _depth = 0, bool _main_flag = false);
+	Game_Interpreter_Battle();
 
 	bool ExecuteCommand() override;
 private:

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -51,6 +51,7 @@
 void Game_Interpreter_Map::SetState(const RPG::SaveEventExecState& save) {
 	Clear();
 	_state = save;
+	_keyinput.fromSave(save);
 }
 
 void Game_Interpreter_Map::OnMapChange() {

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -64,7 +64,7 @@ bool Game_Interpreter_Map::SetState(const RPG::SaveEventExecState& save, int _in
 		}
 		// FIXME: Update this when we remove child interpreters
 		_state.stack = { stack[_index] };
-		index = stack[_index].current_command;
+		GetFrame()->current_command = stack[_index].current_command;
 		triggered_by_decision_key = stack[_index].triggered_by_decision_key;
 
 		child_interpreter.reset(new Game_Interpreter_Map());
@@ -94,8 +94,8 @@ RPG::SaveEventExecState Game_Interpreter_Map::GetState() const {
 		RPG::SaveEventExecFrame save_frame;
 		if (frame) {
 			save_frame.commands = frame->commands;
+			save_frame.current_command = frame->current_command;
 		}
-		save_frame.current_command = save_interpreter->index;
 		save_frame.ID = i++;
 		save_frame.event_id = event_id;
 		save_frame.triggered_by_decision_key = triggered_by_decision_key;
@@ -113,6 +113,7 @@ bool Game_Interpreter_Map::ExecuteCommand() {
 	auto* frame = GetFrame();
 	assert(frame);
 	const auto& list = frame->commands;
+	auto& index = frame->current_command;
 
 	if (index >= list.size()) {
 		return CommandEnd();
@@ -183,6 +184,10 @@ bool Game_Interpreter_Map::ExecuteCommand() {
  * Commands
  */
 bool Game_Interpreter_Map::CommandRecallToLocation(RPG::EventCommand const& com) { // Code 10830
+	auto* frame = GetFrame();
+	assert(frame);
+	auto& index = frame->current_command;
+
 	Game_Character *player = Main_Data::game_player.get();
 	int var_map_id = com.parameters[0];
 	int var_x = com.parameters[1];
@@ -246,6 +251,10 @@ bool Game_Interpreter_Map::CommandEnemyEncounter(RPG::EventCommand const& com) {
 }
 
 bool Game_Interpreter_Map::ContinuationEnemyEncounter(RPG::EventCommand const& com) {
+	auto* frame = GetFrame();
+	assert(frame);
+	auto& index = frame->current_command;
+
 	continuation = NULL;
 
 	switch (Game_Temp::battle_result) {
@@ -335,6 +344,10 @@ bool Game_Interpreter_Map::CommandOpenShop(RPG::EventCommand const& com) { // co
 }
 
 bool Game_Interpreter_Map::ContinuationOpenShop(RPG::EventCommand const& /* com */) {
+	auto* frame = GetFrame();
+	assert(frame);
+	auto& index = frame->current_command;
+
 	continuation = nullptr;
 	if (!Game_Temp::shop_handlers) {
 		index++;
@@ -457,6 +470,10 @@ bool Game_Interpreter_Map::CommandShowInn(RPG::EventCommand const& com) { // cod
 }
 
 bool Game_Interpreter_Map::ContinuationShowInnStart(RPG::EventCommand const& /* com */) {
+	auto* frame = GetFrame();
+	assert(frame);
+	auto& index = frame->current_command;
+
 	if (Game_Message::visible) {
 		return false;
 	}
@@ -503,6 +520,10 @@ bool Game_Interpreter_Map::ContinuationShowInnContinue(RPG::EventCommand const& 
 }
 
 bool Game_Interpreter_Map::ContinuationShowInnFinish(RPG::EventCommand const& /* com */) {
+	auto* frame = GetFrame();
+	assert(frame);
+	auto& index = frame->current_command;
+
 	if (Graphics::IsTransitionPending())
 		return false;
 
@@ -528,6 +549,10 @@ bool Game_Interpreter_Map::ContinuationShowInnFinish(RPG::EventCommand const& /*
 }
 
 bool Game_Interpreter_Map::CommandEnterHeroName(RPG::EventCommand const& com) { // code 10740
+	auto* frame = GetFrame();
+	assert(frame);
+	auto& index = frame->current_command;
+
 	if (Game_Message::visible) {
 		return false;
 	}
@@ -554,6 +579,10 @@ bool Game_Interpreter_Map::CommandEnterHeroName(RPG::EventCommand const& com) { 
 
 bool Game_Interpreter_Map::CommandTeleport(RPG::EventCommand const& com) { // Code 10810
 																		   // TODO: if in battle return true
+	auto* frame = GetFrame();
+	assert(frame);
+	auto& index = frame->current_command;
+
 	if (Game_Message::visible) {
 		return false;
 	}
@@ -686,6 +715,10 @@ bool Game_Interpreter_Map::CommandPlayMovie(RPG::EventCommand const& com) { // c
 }
 
 bool Game_Interpreter_Map::CommandOpenSaveMenu(RPG::EventCommand const& /* com */) { // code 11910
+	auto* frame = GetFrame();
+	assert(frame);
+	auto& index = frame->current_command;
+
 	if (Game_Message::visible) {
 		return false;
 	}
@@ -696,6 +729,10 @@ bool Game_Interpreter_Map::CommandOpenSaveMenu(RPG::EventCommand const& /* com *
 }
 
 bool Game_Interpreter_Map::CommandOpenMainMenu(RPG::EventCommand const& /* com */) { // code 11950
+	auto* frame = GetFrame();
+	assert(frame);
+	auto& index = frame->current_command;
+
 	if (Game_Message::visible) {
 		return false;
 	}
@@ -706,6 +743,10 @@ bool Game_Interpreter_Map::CommandOpenMainMenu(RPG::EventCommand const& /* com *
 }
 
 bool Game_Interpreter_Map::CommandOpenLoadMenu(RPG::EventCommand const& /* com */) {
+	auto* frame = GetFrame();
+	assert(frame);
+	auto& index = frame->current_command;
+
 	if (Game_Message::visible) {
 		return false;
 	}

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -64,8 +64,9 @@ bool Game_Interpreter_Map::SetState(const RPG::SaveEventExecState& save, int _in
 		}
 		// FIXME: Update this when we remove child interpreters
 		_state.stack = { stack[_index] };
-		GetFrame()->current_command = stack[_index].current_command;
-		triggered_by_decision_key = stack[_index].triggered_by_decision_key;
+		auto* frame = GetFrame();
+		frame->current_command = stack[_index].current_command;
+		frame->triggered_by_decision_key = stack[_index].triggered_by_decision_key;
 
 		child_interpreter.reset(new Game_Interpreter_Map());
 		bool result = static_cast<Game_Interpreter_Map*>(child_interpreter.get())->SetState(save, _index + 1);
@@ -95,10 +96,10 @@ RPG::SaveEventExecState Game_Interpreter_Map::GetState() const {
 		if (frame) {
 			save_frame.commands = frame->commands;
 			save_frame.current_command = frame->current_command;
+			save_frame.triggered_by_decision_key = frame->triggered_by_decision_key;
 		}
 		save_frame.ID = i++;
 		save_frame.event_id = event_id;
-		save_frame.triggered_by_decision_key = triggered_by_decision_key;
 		save.stack.push_back(std::move(save_frame));
 		save_interpreter = static_cast<Game_Interpreter_Map*>(save_interpreter->child_interpreter.get());
 	}

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -594,8 +594,9 @@ bool Game_Interpreter_Map::CommandPanScreen(RPG::EventCommand const& com) { // c
 		break;
 	}
 
-	if (waiting_pan_screen)
-		wait_count = distance * (2 << (6 - speed));
+	if (waiting_pan_screen) {
+		_state.wait_time = distance * (2 << (6 - speed));
+	}
 
 	return true;
 }

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -647,7 +647,8 @@ bool Game_Interpreter_Map::CommandFlashSprite(RPG::EventCommand const& com) { //
 }
 
 bool Game_Interpreter_Map::CommandProceedWithMovement(RPG::EventCommand const& /* com */) { // code 11340
-	return !Game_Map::IsAnyMovePending();
+	_state.wait_movement = true;
+	return true;
 }
 
 bool Game_Interpreter_Map::CommandHaltAllMovement(RPG::EventCommand const& /* com */) { // code 11350

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -57,16 +57,12 @@ bool Game_Interpreter_Map::SetState(const RPG::SaveEventExecState& save, int _in
 	_state = save;
 	auto& stack = save.stack;
 	if (_index < (int)stack.size()) {
-		event_id = stack[_index].event_id;
-		if (event_id != 0) {
-			// When 0 the event is from a different map
-			map_id = Game_Map::GetMapId();
-		}
 		// FIXME: Update this when we remove child interpreters
 		_state.stack = { stack[_index] };
 		auto* frame = GetFrame();
 		frame->current_command = stack[_index].current_command;
 		frame->triggered_by_decision_key = stack[_index].triggered_by_decision_key;
+		frame->event_id = stack[_index].event_id;
 
 		child_interpreter.reset(new Game_Interpreter_Map());
 		bool result = static_cast<Game_Interpreter_Map*>(child_interpreter.get())->SetState(save, _index + 1);
@@ -105,6 +101,14 @@ RPG::SaveEventExecState Game_Interpreter_Map::GetState() const {
 	}
 
 	return save;
+}
+
+void Game_Interpreter_Map::OnMapChange() {
+	// When we change the map, we reset all event id's to 0.
+	event_id = 0;
+	if (child_interpreter) {
+		static_cast<Game_Interpreter_Map*>(child_interpreter.get())->OnMapChange();
+	}
 }
 
 /**

--- a/src/game_interpreter_map.h
+++ b/src/game_interpreter_map.h
@@ -23,7 +23,7 @@
 #include <vector>
 #include "game_character.h"
 #include "rpg_eventcommand.h"
-#include "rpg_saveeventexecframe.h"
+#include "rpg_saveeventexecstate.h"
 #include "system.h"
 #include "game_interpreter.h"
 
@@ -39,21 +39,21 @@ public:
 	Game_Interpreter_Map(int _depth = 0, bool _main_flag = false);
 
 	/**
-	 * Parses a SaveEventCommand to create an interpreter.
+	 * Sets up the interpreter with given state.
 	 *
 	 * @param save event to load.
 	 * @param index index in the event list.
 	 *
 	 * @return If the setup was successful (fails when index out of range)
 	 */
-	bool SetupFromSave(const std::vector<RPG::SaveEventExecFrame>& save, int index = 0);
+	bool SetState(const RPG::SaveEventExecState& save, int index = 0);
 
 	/**
-	 * Generates a SaveEventCommands vector needed for the savefile.
+	 * Returns a SaveEventExecState needed for the savefile.
 	 *
 	 * @return interpreter commands stored in SaveEventCommands
 	 */
-	std::vector<RPG::SaveEventExecFrame> GetSaveData() const;
+	RPG::SaveEventExecState GetState() const;
 
 	bool ExecuteCommand() override;
 

--- a/src/game_interpreter_map.h
+++ b/src/game_interpreter_map.h
@@ -55,6 +55,11 @@ public:
 	 */
 	RPG::SaveEventExecState GetState() const;
 
+	/**
+	 * Called when we change maps.
+	 */
+	void OnMapChange();
+
 	bool ExecuteCommand() override;
 
 private:

--- a/src/game_interpreter_map.h
+++ b/src/game_interpreter_map.h
@@ -36,24 +36,15 @@ class Game_CommonEvent;
 class Game_Interpreter_Map : public Game_Interpreter
 {
 public:
-	Game_Interpreter_Map(int _depth = 0, bool _main_flag = false);
+	using Game_Interpreter::Game_Interpreter;
 
 	/**
 	 * Sets up the interpreter with given state.
 	 *
 	 * @param save event to load.
-	 * @param index index in the event list.
 	 *
-	 * @return If the setup was successful (fails when index out of range)
 	 */
-	bool SetState(const RPG::SaveEventExecState& save, int index = 0);
-
-	/**
-	 * Returns a SaveEventExecState needed for the savefile.
-	 *
-	 * @return interpreter commands stored in SaveEventCommands
-	 */
-	RPG::SaveEventExecState GetState() const;
+	void SetState(const RPG::SaveEventExecState& save);
 
 	/**
 	 * Called when we change maps.

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -391,12 +391,6 @@ void Game_Map::Refresh() {
 		for (Game_Event& ev : events) {
 			ev.Refresh();
 		}
-
-		if (refresh_type == Refresh_All) {
-			for (Game_CommonEvent& ev : common_events) {
-				ev.Refresh();
-			}
-		}
 	}
 
 	refresh_type = Refresh_None;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -97,7 +97,7 @@ void Game_Map::Init() {
 	refresh_type = Refresh_All;
 
 	location.map_id = 0;
-	interpreter.reset(new Game_Interpreter_Map(0, true));
+	interpreter.reset(new Game_Interpreter_Map(true));
 	map_info.encounter_rate = 0;
 
 	common_events.clear();

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -209,6 +209,10 @@ void Game_Map::Setup(int _id) {
 	Game_System::SetAllowSave(can_save != RPG::MapInfo::TriState_forbid);
 	Game_System::SetAllowEscape(can_escape != RPG::MapInfo::TriState_forbid);
 	Game_System::SetAllowTeleport(can_teleport != RPG::MapInfo::TriState_forbid);
+
+	if (interpreter) {
+		interpreter->OnMapChange();
+	}
 }
 
 void Game_Map::SetupFromSave() {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -69,7 +69,6 @@ namespace {
 	std::unique_ptr<RPG::Map> map;
 
 	std::unique_ptr<Game_Interpreter_Map> interpreter;
-	std::vector<std::shared_ptr<Game_Interpreter> > free_interpreters;
 	std::vector<std::shared_ptr<Game_Vehicle> > vehicles;
 	std::vector<Game_Character*> pending;
 
@@ -399,10 +398,6 @@ void Game_Map::Refresh() {
 Game_Interpreter_Map& Game_Map::GetInterpreter() {
 	assert(interpreter);
 	return *interpreter;
-}
-
-void Game_Map::ReserveInterpreterDeletion(std::shared_ptr<Game_Interpreter> interpreter) {
-	free_interpreters.push_back(interpreter);
 }
 
 void Game_Map::ScrollRight(int distance) {
@@ -1021,7 +1016,6 @@ void Game_Map::Update(bool is_preupdate) {
 		do_map_event = !do_map_event;
 	}
 
-	free_interpreters.clear();
 	Parallax::Update();
 }
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -216,7 +216,7 @@ void Game_Map::SetupFromSave() {
 	SetupCommon(location.map_id, true);
 
 	// Make main interpreter "busy" if save contained events to prevent auto-events from starting
-	interpreter->SetupFromSave(Main_Data::game_data.foreground_event_execstate.stack);
+	interpreter->SetState(Main_Data::game_data.foreground_event_execstate);
 
 	events.reserve(map->events.size());
 	for (size_t i = 0; i < map->events.size(); ++i) {
@@ -341,7 +341,7 @@ void Game_Map::SetupCommon(int _id, bool is_load_savegame) {
 }
 
 void Game_Map::PrepareSave() {
-	Main_Data::game_data.foreground_event_execstate.stack = interpreter->GetSaveData();
+	Main_Data::game_data.foreground_event_execstate = interpreter->GetState();
 
 	map_info.events.clear();
 	map_info.events.reserve(events.size());

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -437,13 +437,6 @@ namespace Game_Map {
 	Game_Interpreter_Map& GetInterpreter();
 
 	/**
-	 * Destroy an interpreter after all events and common events have been updated.
-	 *
-	 * @param interpreter to destroy.
-	 */
-	void ReserveInterpreterDeletion(std::shared_ptr<Game_Interpreter> interpreter);
-
-	/**
 	 * Sets the need refresh flag.
 	 *
 	 * @param refresh_mode need refresh state.


### PR DESCRIPTION
This PR modifies the interpreter to use `SaveEventExecState` and `SaveEventExecFrame` chunks so that it executes more accurately and allows correct saving and loading of LSD chunks while events are running.

Changes include
* Refactoring call stack to use frame array instead of child interpreters
* Fixing wait commands
* Fixing key input proc
* Fixing wait for all movement
* Other cleanups

Control flow refactors using `subcommand_path` chunks will come in the next PR.

~~Depends: #1717~~
~~Depends: #1739~~
~~Depends: https://github.com/EasyRPG/liblcf/pull/324~~

Fix: #757
Fix: #1777

Test Cases from #1707 addressed by this PR
- [x] 9
- [x] 10
- [x] 11
- [x] 12
- [x] 13 - commands work in rm2k3e mode
- [ ] 13 - commands crash otherwise (We currently print a warning)
- [x] 14
- [x] 15
- [x] 16
- [x] 17
- [x] 18
