### PR TITLE
Refactor interpreter control flow

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -492,6 +492,27 @@ bool Game_Interpreter::SkipTo(int code, int code2, int min_indent, int max_inden
 	return true;
 }
 
+void Game_Interpreter::SkipToNextConditional(std::initializer_list<int> codes, int indent) {
+	auto* frame = GetFrame();
+	assert(frame);
+	const auto& list = frame->commands;
+	auto& index = frame->current_command;
+
+	if (index >= (int)list.size()) {
+		return;
+	}
+
+	for (++index; index < (int)list.size(); ++index) {
+		const auto& com = list[index];
+		if (com.indent > indent) {
+			continue;
+		}
+		if (std::find(codes.begin(), codes.end(), com.code) != codes.end()) {
+			break;
+		}
+	}
+}
+
 int Game_Interpreter::DecodeInt(std::vector<int32_t>::const_iterator& it) {
 	int value = 0;
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -584,9 +584,9 @@ bool Game_Interpreter::ExecuteCommand() {
 		case Cmd::ShowChoice:
 			return CommandShowChoices(com);
 		case Cmd::ShowChoiceOption:
-			return SkipTo(Cmd::ShowChoiceEnd);
+			return CommandShowChoiceOption(com);
 		case Cmd::ShowChoiceEnd:
-			return true;
+			return CommandShowChoiceEnd(com);
 		case Cmd::InputNumber:
 			return CommandInputNumber(com);
 		case Cmd::ControlSwitches:
@@ -865,7 +865,7 @@ bool Game_Interpreter::CommandShowMessage(RPG::EventCommand const& com) { // cod
 					index++;
 					Game_Message::choice_start = line_count;
 					Game_Message::choice_cancel_type = list[index].parameters[0];
-					SetupChoices(s_choices);
+					SetupChoices(s_choices, com.indent);
 				}
 			} else if (list[index+1].code == Cmd::InputNumber) {
 				// If next event command is input number
@@ -904,7 +904,7 @@ bool Game_Interpreter::CommandChangeFaceGraphic(RPG::EventCommand const& com) { 
 	return true;
 }
 
-void Game_Interpreter::SetupChoices(const std::vector<std::string>& choices) {
+void Game_Interpreter::SetupChoices(const std::vector<std::string>& choices, int indent) {
 	Game_Message::choice_start = Game_Message::texts.size();
 	Game_Message::choice_max = choices.size();
 	Game_Message::choice_disabled.reset();
@@ -916,36 +916,27 @@ void Game_Interpreter::SetupChoices(const std::vector<std::string>& choices) {
 	}
 
 	SetContinuation(&Game_Interpreter::ContinuationChoices);
+
+	// save game compatibility with RPG_RT
+	ReserveSubcommandIndex(indent);
 }
 
 bool Game_Interpreter::ContinuationChoices(RPG::EventCommand const& com) {
 	auto* frame = GetFrame();
 	assert(frame);
-	const auto& list = frame->commands;
 	auto& index = frame->current_command;
 
-	continuation = NULL;
-	int indent = com.indent;
-	for (;;) {
-		if (!SkipTo(Cmd::ShowChoiceOption, Cmd::ShowChoiceEnd, indent, indent))
-			return false;
-		auto& cmd = list[index];
-		if (cmd.code == Cmd::ShowChoiceEnd) {
-			return false;
-		}
-		int which = cmd.parameters[0];
-		index++;
-		if (which > Game_Message::choice_result)
-			return false;
-		if (which < Game_Message::choice_result)
-			continue;
-		break;
-	}
+	SetSubcommandIndex(com.indent, Game_Message::choice_result);
+
+	continuation = nullptr;
 
 	return true;
 }
 
 bool Game_Interpreter::CommandShowChoices(RPG::EventCommand const& com) { // code 10140
+	auto* frame = GetFrame();
+	assert(frame);
+	auto& index = frame->current_command;
 	if (!Game_Message::texts.empty()) {
 		return false;
 	}
@@ -956,10 +947,22 @@ bool Game_Interpreter::CommandShowChoices(RPG::EventCommand const& com) { // cod
 	// Choices setup
 	std::vector<std::string> choices = GetChoices();
 	Game_Message::choice_cancel_type = com.parameters[0];
-	SetupChoices(choices);
+	SetupChoices(choices, com.indent);
 
+	++index;
+	return false;
+}
+
+
+bool Game_Interpreter::CommandShowChoiceOption(RPG::EventCommand const& com) { //code 20140
+	const auto opt_sub_idx = com.parameters[0];
+	return CommandOptionGeneric(com, opt_sub_idx, {Cmd::ShowChoiceOption, Cmd::ShowChoiceEnd});
+}
+
+bool Game_Interpreter::CommandShowChoiceEnd(RPG::EventCommand const& com) { //code 20141
 	return true;
 }
+
 
 bool Game_Interpreter::CommandInputNumber(RPG::EventCommand const& com) { // code 10150
 	if (Game_Message::message_waiting) {

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -816,37 +816,39 @@ bool Game_Interpreter::CommandShowMessage(RPG::EventCommand const& com) { // cod
 	Game_Message::texts.push_back(com.string);
 	line_count++;
 
-	for (; index + 1 < list.size(); index++) {
-		// If next event command is the following parts of the message
-		if (list[index+1].code == Cmd::ShowMessage_2) {
-			// Add second (another) line
-			line_count++;
-			Game_Message::texts.push_back(list[index+1].string);
-		} else {
-			// If next event command is show choices
-			if (list[index+1].code == Cmd::ShowChoice) {
-				std::vector<std::string> s_choices = GetChoices();
-				// If choices fit on screen
-				if (s_choices.size() <= (4 - line_count)) {
-					index++;
-					Game_Message::choice_start = line_count;
-					Game_Message::choice_cancel_type = list[index].parameters[0];
-					SetupChoices(s_choices, com.indent);
-				}
-			} else if (list[index+1].code == Cmd::InputNumber) {
-				// If next event command is input number
-				// If input number fits on screen
-				if (line_count < 4) {
-					index++;
-					Game_Message::num_input_start = line_count;
-					Game_Message::num_input_digits_max = list[index].parameters[0];
-					Game_Message::num_input_variable_id = list[index].parameters[1];
-				}
-			}
+	++index;
 
-			break;
+	// Check for continued lines via ShowMessage_2
+	while (index < list.size() && list[index].code == Cmd::ShowMessage_2) {
+		// Add second (another) line
+		line_count++;
+		Game_Message::texts.push_back(list[index].string);
+		++index;
+	}
+
+	// Handle Choices or number
+	if (index < list.size()) {
+		// If next event command is show choices
+		if (list[index].code == Cmd::ShowChoice) {
+			std::vector<std::string> s_choices = GetChoices();
+			// If choices fit on screen
+			if (s_choices.size() <= (4 - line_count)) {
+				Game_Message::choice_start = line_count;
+				Game_Message::choice_cancel_type = list[index].parameters[0];
+				SetupChoices(s_choices, com.indent);
+				++index;
+			}
+		} else if (list[index].code == Cmd::InputNumber) {
+			// If next event command is input number
+			// If input number fits on screen
+			if (line_count < 4) {
+				Game_Message::num_input_start = line_count;
+				Game_Message::num_input_digits_max = list[index].parameters[0];
+				Game_Message::num_input_variable_id = list[index].parameters[1];
+				++index;
+			}
 		}
-	} // End for
+	}
 
 	return true;
 }

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -3070,6 +3070,11 @@ bool Game_Interpreter::CommandEndLoop(RPG::EventCommand const& com) { // code 22
 		break;
 	}
 
+	// Jump past the Cmd::Loop to the first command.
+	if (index < (int)frame->commands.size()) {
+		++index;
+	}
+
 	return true;
 }
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -55,6 +55,9 @@
 bool Game_Interpreter::to_title = false;
 bool Game_Interpreter::exit_game = false;
 
+enum BranchSubcommand {
+	eOptionBranchElse = 1
+};
 
 constexpr int Game_Interpreter::loop_limit;
 constexpr int Game_Interpreter::call_stack_limit;
@@ -2994,7 +2997,7 @@ bool Game_Interpreter::CommandConditionalBranch(RPG::EventCommand const& com) { 
 
 	int sub_idx = subcommand_sentinel;
 	if (!result) {
-		sub_idx = 1;
+		sub_idx = eOptionBranchElse;
 		SkipToNextConditional({Cmd::ElseBranch, Cmd::EndBranch}, com.indent);
 	}
 
@@ -3004,7 +3007,7 @@ bool Game_Interpreter::CommandConditionalBranch(RPG::EventCommand const& com) { 
 
 
 bool Game_Interpreter::CommandElseBranch(RPG::EventCommand const& com) { //code 22010
-	return CommandOptionGeneric(com, 1, {Cmd::EndBranch});
+	return CommandOptionGeneric(com, eOptionBranchElse, {Cmd::EndBranch});
 }
 
 bool Game_Interpreter::CommandEndBranch(RPG::EventCommand const& com) { //code 22011

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -377,10 +377,9 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 				result = (this->*continuation)(list[index]);
 			}
 
-			if (result)
-				continue;
-			else
+			if (!result) {
 				break;
+			}
 		}
 
 		if (Game_Map::GetNeedRefresh()) {

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -461,38 +461,6 @@ void Game_Interpreter::CheckGameOver() {
 	}
 }
 
-bool Game_Interpreter::SkipTo(int code, int code2, int min_indent, int max_indent, bool otherwise_end) {
-	auto* frame = GetFrame();
-	assert(frame);
-	const auto& list = frame->commands;
-	auto& index = frame->current_command;
-
-	if (code2 < 0)
-		code2 = code;
-	if (min_indent < 0)
-		min_indent = list[index].indent;
-	if (max_indent < 0)
-		max_indent = list[index].indent;
-
-	int idx;
-	for (idx = index; (size_t) idx < list.size(); idx++) {
-		if (list[idx].indent < min_indent)
-			return false;
-		if (list[idx].indent > max_indent)
-			continue;
-		if (list[idx].code != code &&
-			list[idx].code != code2)
-			continue;
-		index = idx;
-		return true;
-	}
-
-	if (otherwise_end)
-		index = idx;
-
-	return true;
-}
-
 void Game_Interpreter::SkipToNextConditional(std::initializer_list<int> codes, int indent) {
 	auto* frame = GetFrame();
 	assert(frame);

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -55,6 +55,11 @@
 bool Game_Interpreter::to_title = false;
 bool Game_Interpreter::exit_game = false;
 
+
+constexpr int Game_Interpreter::loop_limit;
+constexpr int Game_Interpreter::call_stack_limit;
+constexpr int Game_Interpreter::subcommand_sentinel;
+
 Game_Interpreter::Game_Interpreter(bool _main_flag) {
 	main_flag = _main_flag;
 
@@ -257,6 +262,34 @@ int Game_Interpreter::GetThisEventId() const {
 	return event_id;
 }
 
+uint8_t& Game_Interpreter::ReserveSubcommandIndex(int indent) {
+	auto* frame = GetFrame();
+	assert(frame);
+
+	auto& path = frame->subcommand_path;
+	if (indent >= (int)path.size()) {
+		// This fixes an RPG_RT bug where RPG_RT would resize
+		// the array with uninitialized values.
+		path.resize(indent + 1, subcommand_sentinel);
+	}
+	return path[indent];
+}
+
+void Game_Interpreter::SetSubcommandIndex(int indent, int idx) {
+	ReserveSubcommandIndex(indent) = idx;
+}
+
+int Game_Interpreter::GetSubcommandIndex(int indent) const {
+	auto* frame = GetFrame();
+	if (frame == nullptr) {
+		return subcommand_sentinel;
+	}
+	auto& path = frame->subcommand_path;
+	if ((int)path.size() <= indent) {
+		return subcommand_sentinel;
+	}
+	return path[indent];
+}
 
 // Update
 void Game_Interpreter::Update(bool reset_loop_count) {

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -107,6 +107,7 @@ public:
 protected:
 	static constexpr int loop_limit = 10000;
 	static constexpr int call_stack_limit = 1000;
+	static constexpr int subcommand_sentinel = 255;
 
 	static bool to_title;
 	static bool exit_game;
@@ -256,6 +257,10 @@ protected:
 	int DecodeInt(std::vector<int32_t>::const_iterator& it);
 	const std::string DecodeString(std::vector<int32_t>::const_iterator& it);
 	RPG::MoveCommand DecodeMove(std::vector<int32_t>::const_iterator& it);
+
+	void SetSubcommandIndex(int indent, int idx);
+	uint8_t& ReserveSubcommandIndex(int indent);
+	int GetSubcommandIndex(int indent) const;
 
 	FileRequestBinding request_id;
 	enum class Keys {

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -68,7 +68,7 @@ public:
 	void Push(Game_CommonEvent* ev);
 
 	void InputButton();
-	void SetupChoices(const std::vector<std::string>& choices);
+	void SetupChoices(const std::vector<std::string>& choices, int indent);
 
 	virtual bool ExecuteCommand();
 
@@ -187,6 +187,8 @@ protected:
 	bool CommandMessageOptions(RPG::EventCommand const& com);
 	bool CommandChangeFaceGraphic(RPG::EventCommand const& com);
 	bool CommandShowChoices(RPG::EventCommand const& com);
+	bool CommandShowChoiceOption(RPG::EventCommand const& com);
+	bool CommandShowChoiceEnd(RPG::EventCommand const& com);
 	bool CommandInputNumber(RPG::EventCommand const& com);
 	bool CommandControlSwitches(RPG::EventCommand const& com);
 	bool CommandControlVariables(RPG::EventCommand const& com);

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -143,6 +143,18 @@ protected:
 	Game_Character* GetCharacter(int character_id) const;
 
 	bool SkipTo(int code, int code2 = -1, int min_indent = -1, int max_indent = -1, bool otherwise_end = false);
+
+	/**
+	 * Skips to the next option in a chain of conditional commands.
+	 * Works by skipping until we hit the end or the next command
+	 * with com.indent <= indent.
+	 * The <= protects against broken game code which terminates without
+	 * a proper conditional.
+	 *
+	 * @param codes which codes to check.
+	 * @param indent the indentation level to check
+	 */
+	void SkipToNextConditional(std::initializer_list<int> codes, int indent);
 	void SetContinuation(ContinuationFunction func);
 
 	/**

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -142,8 +142,6 @@ protected:
 	int OperateValue(int operation, int operand_type, int operand);
 	Game_Character* GetCharacter(int character_id) const;
 
-	bool SkipTo(int code, int code2 = -1, int min_indent = -1, int max_indent = -1, bool otherwise_end = false);
-
 	/**
 	 * Skips to the next option in a chain of conditional commands.
 	 * Works by skipping until we hit the end or the next command

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -181,6 +181,8 @@ protected:
 	 */
 	void CheckGameOver();
 
+	bool CommandOptionGeneric(RPG::EventCommand const& com, int option_sub_idx, std::initializer_list<int> next);
+
 	bool CommandShowMessage(RPG::EventCommand const& com);
 	bool CommandMessageOptions(RPG::EventCommand const& com);
 	bool CommandChangeFaceGraphic(RPG::EventCommand const& com);
@@ -248,6 +250,8 @@ protected:
 	bool CommandChangeSaveAccess(RPG::EventCommand const& com);
 	bool CommandChangeMainMenuAccess(RPG::EventCommand const& com);
 	bool CommandConditionalBranch(RPG::EventCommand const& com);
+	bool CommandElseBranch(RPG::EventCommand const& com);
+	bool CommandEndBranch(RPG::EventCommand const& com);
 	bool CommandJumpToLabel(RPG::EventCommand const& com);
 	bool CommandBreakLoop(RPG::EventCommand const& com);
 	bool CommandEndLoop(RPG::EventCommand const& com);

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -70,9 +70,9 @@ bool Game_Interpreter_Battle::ExecuteCommand() {
 		case Cmd::ConditionalBranch_B:
 			return CommandConditionalBranchBattle(com);
 		case Cmd::ElseBranch_B:
-			return SkipTo(Cmd::EndBranch_B);
+			return CommandElseBranchBattle(com);
 		case Cmd::EndBranch_B:
-			return true;
+			return CommandEndBranchBattle(com);
 		default:
 			return Game_Interpreter::ExecuteCommand();
 	}
@@ -357,8 +357,10 @@ bool Game_Interpreter_Battle::CommandConditionalBranchBattle(RPG::EventCommand c
 
 			if (!actor) {
 				Output::Warning("ConditionalBranchBattle: Invalid actor ID %d", com.parameters[1]);
-				// Use Else branch
-				return SkipTo(Cmd::ElseBranch_B, Cmd::EndBranch_B);
+				// Use Else Branch
+				SetSubcommandIndex(com.indent, 1);
+				SkipToNextConditional({Cmd::ElseBranch_B, Cmd::EndBranch_B}, com.indent);
+				return true;
 			}
 
 			result = actor->CanAct();
@@ -381,7 +383,9 @@ bool Game_Interpreter_Battle::CommandConditionalBranchBattle(RPG::EventCommand c
 			if (!actor) {
 				Output::Warning("ConditionalBranchBattle: Invalid actor ID %d", com.parameters[1]);
 				// Use Else branch
-				return SkipTo(Cmd::ElseBranch_B, Cmd::EndBranch_B);
+				SetSubcommandIndex(com.indent, 1);
+				SkipToNextConditional({Cmd::ElseBranch_B, Cmd::EndBranch_B}, com.indent);
+				return true;
 			}
 
 			result = actor->GetLastBattleAction() == com.parameters[2];
@@ -389,8 +393,21 @@ bool Game_Interpreter_Battle::CommandConditionalBranchBattle(RPG::EventCommand c
 		}
 	}
 
-	if (result)
-		return true;
+	int sub_idx = subcommand_sentinel;
+	if (!result) {
+		sub_idx = 1;
+		SkipToNextConditional({Cmd::ElseBranch_B, Cmd::EndBranch_B}, com.indent);
+	}
 
-	return SkipTo(Cmd::ElseBranch_B, Cmd::EndBranch_B);
+	SetSubcommandIndex(com.indent, sub_idx);
+	return true;
 }
+
+bool Game_Interpreter_Battle::CommandElseBranchBattle(RPG::EventCommand const& com) { //code 23310
+	return CommandOptionGeneric(com, 1, {Cmd::EndBranch_B});
+}
+
+bool Game_Interpreter_Battle::CommandEndBranchBattle(RPG::EventCommand const& com) { //code 23311
+	return true;
+}
+

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -32,6 +32,10 @@
 #include "spriteset_battle.h"
 #include <cassert>
 
+enum BranchBattleSubcommand {
+	eOptionBranchBattleElse = 1
+};
+
 Game_Interpreter_Battle::Game_Interpreter_Battle()
 	: Game_Interpreter(true) {}
 
@@ -395,7 +399,7 @@ bool Game_Interpreter_Battle::CommandConditionalBranchBattle(RPG::EventCommand c
 
 	int sub_idx = subcommand_sentinel;
 	if (!result) {
-		sub_idx = 1;
+		sub_idx = eOptionBranchBattleElse;
 		SkipToNextConditional({Cmd::ElseBranch_B, Cmd::EndBranch_B}, com.indent);
 	}
 
@@ -404,7 +408,7 @@ bool Game_Interpreter_Battle::CommandConditionalBranchBattle(RPG::EventCommand c
 }
 
 bool Game_Interpreter_Battle::CommandElseBranchBattle(RPG::EventCommand const& com) { //code 23310
-	return CommandOptionGeneric(com, 1, {Cmd::EndBranch_B});
+	return CommandOptionGeneric(com, eOptionBranchBattleElse, {Cmd::EndBranch_B});
 }
 
 bool Game_Interpreter_Battle::CommandEndBranchBattle(RPG::EventCommand const& com) { //code 23311

--- a/src/game_interpreter_battle.h
+++ b/src/game_interpreter_battle.h
@@ -51,6 +51,8 @@ private:
 	bool CommandShowBattleAnimation(RPG::EventCommand const& com);
 	bool CommandTerminateBattle(RPG::EventCommand const& com);
 	bool CommandConditionalBranchBattle(RPG::EventCommand const& com);
+	bool CommandElseBranchBattle(RPG::EventCommand const& com);
+	bool CommandEndBranchBattle(RPG::EventCommand const& com);
 };
 
 #endif

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -48,6 +48,22 @@
 #include "game_interpreter_map.h"
 #include "reader_lcf.h"
 
+enum EnemyEncounterSubcommand {
+	eOptionEnemyEncounterVictory = 0,
+	eOptionEnemyEncounterEscape = 1,
+	eOptionEnemyEncounterDefeat = 2,
+};
+
+enum ShopSubcommand {
+	eOptionShopTransaction = 0,
+	eOptionShopNoTransaction = 1,
+};
+
+enum InnSubcommand {
+	eOptionInnStay = 0,
+	eOptionInnNoStay = 1,
+};
+
 void Game_Interpreter_Map::SetState(const RPG::SaveEventExecState& save) {
 	Clear();
 	_state = save;
@@ -228,11 +244,11 @@ bool Game_Interpreter_Map::ContinuationEnemyEncounter(RPG::EventCommand const& c
 	int sub_idx = subcommand_sentinel;
 
 	if (Game_Temp::battle_result == Game_Temp::BattleVictory) {
-		sub_idx = 0;
+		sub_idx = eOptionEnemyEncounterVictory;
 	}
 
 	if (Game_Temp::battle_result == Game_Temp::BattleEscape) {
-		sub_idx = 1;
+		sub_idx = eOptionEnemyEncounterEscape;
 		//FIXME: subidx set before this anyway??
 		if (Game_Temp::battle_escape_mode == 1) {
 			return CommandEndEventProcessing(com);
@@ -240,7 +256,7 @@ bool Game_Interpreter_Map::ContinuationEnemyEncounter(RPG::EventCommand const& c
 	}
 
 	if (Game_Temp::battle_result == Game_Temp::BattleDefeat) {
-		sub_idx = 2;
+		sub_idx = eOptionEnemyEncounterDefeat;
 		//FIXME: subidx set before this anyway??
 		if (Game_Temp::battle_defeat_mode == 0) {
 			return CommandGameOver(com);
@@ -253,15 +269,15 @@ bool Game_Interpreter_Map::ContinuationEnemyEncounter(RPG::EventCommand const& c
 }
 
 bool Game_Interpreter_Map::CommandVictoryHandler(RPG::EventCommand const& com) { // code 20710
-	return CommandOptionGeneric(com, 0, {Cmd::EscapeHandler, Cmd::DefeatHandler, Cmd::EndBattle});
+	return CommandOptionGeneric(com, eOptionEnemyEncounterVictory, {Cmd::EscapeHandler, Cmd::DefeatHandler, Cmd::EndBattle});
 }
 
 bool Game_Interpreter_Map::CommandEscapeHandler(RPG::EventCommand const& com) { // code 20711
-	return CommandOptionGeneric(com, 1, {Cmd::DefeatHandler, Cmd::EndBattle});
+	return CommandOptionGeneric(com, eOptionEnemyEncounterEscape, {Cmd::DefeatHandler, Cmd::EndBattle});
 }
 
 bool Game_Interpreter_Map::CommandDefeatHandler(RPG::EventCommand const& com) { // code 20712
-	return CommandOptionGeneric(com, 2, {Cmd::EndBattle});
+	return CommandOptionGeneric(com, eOptionEnemyEncounterDefeat, {Cmd::EndBattle});
 }
 
 bool Game_Interpreter_Map::CommandEndBattle(RPG::EventCommand const& com) { // code 20713
@@ -321,7 +337,7 @@ bool Game_Interpreter_Map::ContinuationOpenShop(RPG::EventCommand const& com) {
 
 	continuation = nullptr;
 
-	int sub_idx = Game_Temp::shop_transaction ? 0 : 1;
+	int sub_idx = Game_Temp::shop_transaction ? eOptionShopTransaction : eOptionShopNoTransaction;
 
 	SetSubcommandIndex(com.indent, sub_idx);
 
@@ -329,11 +345,11 @@ bool Game_Interpreter_Map::ContinuationOpenShop(RPG::EventCommand const& com) {
 }
 
 bool Game_Interpreter_Map::CommandTransaction(RPG::EventCommand const& com) { // code 20720
-	return CommandOptionGeneric(com, 0, {Cmd::NoTransaction, Cmd::EndShop});
+	return CommandOptionGeneric(com, eOptionShopTransaction, {Cmd::NoTransaction, Cmd::EndShop});
 }
 
 bool Game_Interpreter_Map::CommandNoTransaction(RPG::EventCommand const& com) { // code 20721
-	return CommandOptionGeneric(com, 1, {Cmd::EndShop});
+	return CommandOptionGeneric(com, eOptionShopNoTransaction, {Cmd::EndShop});
 }
 
 bool Game_Interpreter_Map::CommandEndShop(RPG::EventCommand const& com) { // code 20722
@@ -461,7 +477,7 @@ bool Game_Interpreter_Map::ContinuationShowInnStart(RPG::EventCommand const& com
 
 	bool inn_stay = Game_Message::choice_result == 0;
 
-	SetSubcommandIndex(com.indent, inn_stay ? 0 : 1);
+	SetSubcommandIndex(com.indent, inn_stay ? eOptionInnStay : eOptionInnNoStay);
 
 	Game_Temp::inn_calling = false;
 
@@ -527,11 +543,11 @@ bool Game_Interpreter_Map::ContinuationShowInnFinish(RPG::EventCommand const& co
 }
 
 bool Game_Interpreter_Map::CommandStay(RPG::EventCommand const& com) { // code 20730
-	return CommandOptionGeneric(com, 0, {Cmd::NoStay, Cmd::EndInn});
+	return CommandOptionGeneric(com, eOptionInnStay, {Cmd::NoStay, Cmd::EndInn});
 }
 
 bool Game_Interpreter_Map::CommandNoStay(RPG::EventCommand const& com) { // code 20731
-	return CommandOptionGeneric(com, 1, {Cmd::EndInn});
+	return CommandOptionGeneric(com, eOptionInnNoStay, {Cmd::EndInn});
 }
 
 bool Game_Interpreter_Map::CommandEndInn(RPG::EventCommand const& com) { // code 20732

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -96,10 +96,11 @@ bool Game_Interpreter_Map::ExecuteCommand() {
 		case Cmd::ShowInn:
 			return CommandShowInn(com);
 		case Cmd::Stay:
+			return CommandStay(com);
 		case Cmd::NoStay:
-			return SkipTo(Cmd::EndInn);
+			return CommandNoStay(com);
 		case Cmd::EndInn:
-			return true;
+			return CommandEndInn(com);
 		case Cmd::EnterHeroName:
 			return CommandEnterHeroName(com);
 		case Cmd::Teleport:
@@ -338,7 +339,8 @@ bool Game_Interpreter_Map::CommandEndShop(RPG::EventCommand const& com) { // cod
 bool Game_Interpreter_Map::CommandShowInn(RPG::EventCommand const& com) { // code 10730
 	int inn_type = com.parameters[0];
 	Game_Temp::inn_price = com.parameters[1];
-	Game_Temp::inn_handlers = com.parameters[2] != 0;
+	// Not used, but left here for documentation purposes
+	// bool has_inn_handlers = com.parameters[2] != 0;
 
 	if (Game_Temp::inn_price == 0) {
 		// Skip prompt.
@@ -436,10 +438,14 @@ bool Game_Interpreter_Map::CommandShowInn(RPG::EventCommand const& com) { // cod
 	Game_Message::choice_result = 4;
 
 	SetContinuation(static_cast<ContinuationFunction>(&Game_Interpreter_Map::ContinuationShowInnStart));
+
+	// save game compatibility with RPG_RT
+	ReserveSubcommandIndex(com.indent);
+
 	return false;
 }
 
-bool Game_Interpreter_Map::ContinuationShowInnStart(RPG::EventCommand const& /* com */) {
+bool Game_Interpreter_Map::ContinuationShowInnStart(RPG::EventCommand const& com) {
 	auto* frame = GetFrame();
 	assert(frame);
 	auto& index = frame->current_command;
@@ -450,6 +456,8 @@ bool Game_Interpreter_Map::ContinuationShowInnStart(RPG::EventCommand const& /* 
 	continuation = NULL;
 
 	bool inn_stay = Game_Message::choice_result == 0;
+
+	SetSubcommandIndex(com.indent, inn_stay ? 0 : 1);
 
 	Game_Temp::inn_calling = false;
 
@@ -467,9 +475,7 @@ bool Game_Interpreter_Map::ContinuationShowInnStart(RPG::EventCommand const& /* 
 		return false;
 	}
 
-	if (Game_Temp::inn_handlers)
-		SkipTo(Cmd::NoStay, Cmd::EndInn);
-	index++;
+	++index;
 	return true;
 }
 
@@ -489,7 +495,7 @@ bool Game_Interpreter_Map::ContinuationShowInnContinue(RPG::EventCommand const& 
 	return false;
 }
 
-bool Game_Interpreter_Map::ContinuationShowInnFinish(RPG::EventCommand const& /* com */) {
+bool Game_Interpreter_Map::ContinuationShowInnFinish(RPG::EventCommand const& com) {
 	auto* frame = GetFrame();
 	assert(frame);
 	auto& index = frame->current_command;
@@ -509,13 +515,23 @@ bool Game_Interpreter_Map::ContinuationShowInnFinish(RPG::EventCommand const& /*
 		Graphics::GetTransition().Init(Transition::TransitionFadeIn, Scene::instance.get(), 36, false);
 		Game_System::BgmPlay(Main_Data::game_data.system.before_battle_music);
 
-		if (Game_Temp::inn_handlers)
-			SkipTo(Cmd::Stay, Cmd::EndInn);
-		index++;
+		++index;
 		return false;
 	}
 
 	return false;
+}
+
+bool Game_Interpreter_Map::CommandStay(RPG::EventCommand const& com) { // code 20730
+	return CommandOptionGeneric(com, 0, {Cmd::NoStay, Cmd::EndInn});
+}
+
+bool Game_Interpreter_Map::CommandNoStay(RPG::EventCommand const& com) { // code 20731
+	return CommandOptionGeneric(com, 1, {Cmd::EndInn});
+}
+
+bool Game_Interpreter_Map::CommandEndInn(RPG::EventCommand const& com) { // code 20732
+	return true;
 }
 
 bool Game_Interpreter_Map::CommandEnterHeroName(RPG::EventCommand const& com) { // code 10740

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -80,11 +80,13 @@ bool Game_Interpreter_Map::ExecuteCommand() {
 		case Cmd::EnemyEncounter:
 			return CommandEnemyEncounter(com);
 		case Cmd::VictoryHandler:
+			return CommandVictoryHandler(com);
 		case Cmd::EscapeHandler:
+			return CommandEscapeHandler(com);
 		case Cmd::DefeatHandler:
-			return SkipTo(Cmd::EndBattle);
+			return CommandDefeatHandler(com);
 		case Cmd::EndBattle:
-			return true;
+			return CommandEndBattle(com);
 		case Cmd::OpenShop:
 			return CommandOpenShop(com);
 		case Cmd::Transaction:
@@ -164,6 +166,10 @@ bool Game_Interpreter_Map::CommandRecallToLocation(RPG::EventCommand const& com)
 }
 
 bool Game_Interpreter_Map::CommandEnemyEncounter(RPG::EventCommand const& com) { // code 10710
+	auto* frame = GetFrame();
+	assert(frame);
+	auto& index = frame->current_command;
+
 	if (Game_Message::visible) {
 		return false;
 	}
@@ -204,6 +210,11 @@ bool Game_Interpreter_Map::CommandEnemyEncounter(RPG::EventCommand const& com) {
 	Scene::instance->SetRequestedScene(Scene::Battle);
 
 	SetContinuation(static_cast<ContinuationFunction>(&Game_Interpreter_Map::ContinuationEnemyEncounter));
+
+	// save game compatibility with RPG_RT
+	ReserveSubcommandIndex(com.indent);
+
+	++index;
 	return false;
 }
 
@@ -214,54 +225,47 @@ bool Game_Interpreter_Map::ContinuationEnemyEncounter(RPG::EventCommand const& c
 
 	continuation = NULL;
 
-	switch (Game_Temp::battle_result) {
-	case Game_Temp::BattleVictory:
-		if ((Game_Temp::battle_defeat_mode == 0 && Game_Temp::battle_escape_mode != 2) || !SkipTo(Cmd::VictoryHandler, Cmd::EndBattle)) {
-			index++;
-			return false;
-		}
-		index++;
-		return true;
-	case Game_Temp::BattleEscape:
-		switch (Game_Temp::battle_escape_mode) {
-		case 0:	// disallowed - shouldn't happen
-			return true;
-		case 1:
-			return CommandEndEventProcessing(com);
-		case 2:
-			if (!SkipTo(Cmd::EscapeHandler, Cmd::EndBattle)) {
-				index++;
-				return false;
-			}
-			index++;
-			return true;
-		default:
-			return false;
-		}
-	case Game_Temp::BattleDefeat:
-		switch (Game_Temp::battle_defeat_mode) {
-		case 0:
-			return CommandGameOver(com);
-		case 1:
-			if (!SkipTo(Cmd::DefeatHandler, Cmd::EndBattle)) {
-				index++;
-				return false;
-			}
-			index++;
-			return true;
-		default:
-			return false;
-		}
-	case Game_Temp::BattleAbort:
-		if (!SkipTo(Cmd::EndBattle)) {
-			index++;
-			return false;
-		}
-		index++;
-		return true;
-	default:
-		return false;
+	int sub_idx = subcommand_sentinel;
+
+	if (Game_Temp::battle_result == Game_Temp::BattleVictory) {
+		sub_idx = 0;
 	}
+
+	if (Game_Temp::battle_result == Game_Temp::BattleEscape) {
+		sub_idx = 1;
+		//FIXME: subidx set before this anyway??
+		if (Game_Temp::battle_escape_mode == 1) {
+			return CommandEndEventProcessing(com);
+		}
+	}
+
+	if (Game_Temp::battle_result == Game_Temp::BattleDefeat) {
+		sub_idx = 2;
+		//FIXME: subidx set before this anyway??
+		if (Game_Temp::battle_defeat_mode == 0) {
+			return CommandGameOver(com);
+		}
+	}
+
+	SetSubcommandIndex(com.indent, sub_idx);
+
+	return true;
+}
+
+bool Game_Interpreter_Map::CommandVictoryHandler(RPG::EventCommand const& com) { // code 20710
+	return CommandOptionGeneric(com, 0, {Cmd::EscapeHandler, Cmd::DefeatHandler, Cmd::EndBattle});
+}
+
+bool Game_Interpreter_Map::CommandEscapeHandler(RPG::EventCommand const& com) { // code 20711
+	return CommandOptionGeneric(com, 1, {Cmd::DefeatHandler, Cmd::EndBattle});
+}
+
+bool Game_Interpreter_Map::CommandDefeatHandler(RPG::EventCommand const& com) { // code 20712
+	return CommandOptionGeneric(com, 2, {Cmd::EndBattle});
+}
+
+bool Game_Interpreter_Map::CommandEndBattle(RPG::EventCommand const& com) { // code 20713
+	return true;
 }
 
 bool Game_Interpreter_Map::CommandOpenShop(RPG::EventCommand const& com) { // code 10720

--- a/src/game_interpreter_map.h
+++ b/src/game_interpreter_map.h
@@ -57,6 +57,9 @@ private:
 	bool CommandRecallToLocation(RPG::EventCommand const& com);
 	bool CommandEnemyEncounter(RPG::EventCommand const& com);
 	bool CommandOpenShop(RPG::EventCommand const& com);
+	bool CommandTransaction(RPG::EventCommand const& com);
+	bool CommandNoTransaction(RPG::EventCommand const& com);
+	bool CommandEndShop(RPG::EventCommand const& com);
 	bool CommandShowInn(RPG::EventCommand const& com);
 	bool CommandEnterHeroName(RPG::EventCommand const& com);
 	bool CommandTeleport(RPG::EventCommand const& com);

--- a/src/game_interpreter_map.h
+++ b/src/game_interpreter_map.h
@@ -61,6 +61,9 @@ private:
 	bool CommandNoTransaction(RPG::EventCommand const& com);
 	bool CommandEndShop(RPG::EventCommand const& com);
 	bool CommandShowInn(RPG::EventCommand const& com);
+	bool CommandStay(RPG::EventCommand const& com);
+	bool CommandNoStay(RPG::EventCommand const& com);
+	bool CommandEndInn(RPG::EventCommand const& com);
 	bool CommandEnterHeroName(RPG::EventCommand const& com);
 	bool CommandTeleport(RPG::EventCommand const& com);
 	bool CommandEnterExitVehicle(RPG::EventCommand const& com);

--- a/src/game_interpreter_map.h
+++ b/src/game_interpreter_map.h
@@ -56,6 +56,10 @@ public:
 private:
 	bool CommandRecallToLocation(RPG::EventCommand const& com);
 	bool CommandEnemyEncounter(RPG::EventCommand const& com);
+	bool CommandVictoryHandler(RPG::EventCommand const& com);
+	bool CommandEscapeHandler(RPG::EventCommand const& com);
+	bool CommandDefeatHandler(RPG::EventCommand const& com);
+	bool CommandEndBattle(RPG::EventCommand const& com);
 	bool CommandOpenShop(RPG::EventCommand const& com);
 	bool CommandTransaction(RPG::EventCommand const& com);
 	bool CommandNoTransaction(RPG::EventCommand const& com);

--- a/src/game_temp.cpp
+++ b/src/game_temp.cpp
@@ -26,7 +26,6 @@ bool Game_Temp::transition_erase;
 bool Game_Temp::shop_buys;
 bool Game_Temp::shop_sells;
 int Game_Temp::shop_type;
-bool Game_Temp::shop_handlers;
 std::vector<int> Game_Temp::shop_goods;
 bool Game_Temp::shop_transaction;
 int Game_Temp::inn_price;
@@ -51,7 +50,6 @@ void Game_Temp::Init() {
 	shop_buys = true;
 	shop_sells = true;
 	shop_type = 0;
-	shop_handlers = false;
 	shop_goods = {};
 	shop_transaction = false;
 	inn_price = 0;

--- a/src/game_temp.cpp
+++ b/src/game_temp.cpp
@@ -29,7 +29,6 @@ int Game_Temp::shop_type;
 std::vector<int> Game_Temp::shop_goods;
 bool Game_Temp::shop_transaction;
 int Game_Temp::inn_price;
-bool Game_Temp::inn_handlers;
 std::string Game_Temp::hero_name;
 int Game_Temp::hero_name_id;
 int Game_Temp::hero_name_charset;
@@ -53,7 +52,6 @@ void Game_Temp::Init() {
 	shop_goods = {};
 	shop_transaction = false;
 	inn_price = 0;
-	inn_handlers = false;
 	hero_name = "";
 	hero_name_id = 0;
 	hero_name_charset = 0;

--- a/src/game_temp.h
+++ b/src/game_temp.h
@@ -44,11 +44,7 @@ public:
 	static int shop_type;		// message set A, B, or C
 	static std::vector<int> shop_goods;
 	static bool shop_transaction;
-
-	static int inn_type;		// message set A or B
 	static int inn_price;
-	static bool inn_handlers;	// custom stay/no-stay handlers
-	static bool inn_stay;
 
 	static std::string hero_name;
 	static int hero_name_id;

--- a/src/game_temp.h
+++ b/src/game_temp.h
@@ -42,7 +42,6 @@ public:
 	static bool shop_buys;
 	static bool shop_sells;
 	static int shop_type;		// message set A, B, or C
-	static bool shop_handlers;	// custom transaction/no-transaction handlers
 	static std::vector<int> shop_goods;
 	static bool shop_transaction;
 


### PR DESCRIPTION
~~Depends on #1740~~

The PR refactors control flow to use `subcommand_path` chunks. The goal is to ensure that every event command is either executed or skipped the same as `RPG_RT`. The practical results of this are:
* Events which run 10k commands will abort the interpreter at the right time
* Save games that are saved and loaded during executing conditionals will load correctly and be compatible between RPG_RT and Player.

Fixes most of #1707

Retested: #1613