### PR TITLE
fixes #1748. Reviving items does not revive.

### DIFF
--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1263,6 +1263,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 			if (IsRevived() && !skill.affect_hp) {
 				this->hp = std::max<int>(0, std::min<int>(GetTarget()->GetMaxHp() - GetTarget()->GetHp(),
 							GetTarget()->GetMaxHp() * effect / 10));
+				this->healed_conditions.push_back(1);
 				this->success = true;
 			}
 		}


### PR DESCRIPTION
fixes #1748.
maybe this solution only fixes the revive issue. I am not aware if condition healing items in general are broken in 2k3 maybe it can be refactored as a common condition heal fix.