### PR TITLE
Fix Message Color is reset on multiple choices.

### DIFF
--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -274,9 +274,6 @@ void Window_Message::InsertNewLine() {
 	++line_count;
 
 	if (line_count >= Game_Message::choice_start && Game_Message::choice_max > 0) {
-		// A choice resets the font color
-		text_color = Font::ColorDefault;
-
 		unsigned choice_index = line_count - Game_Message::choice_start;
 		// Check for disabled choices
 		if (Game_Message::choice_disabled.test(choice_index)) {


### PR DESCRIPTION
In RPG_RT text color is not reset between multiple choices, this pr will apply this behavior to the player.
New Message boxes resets the color to default in rpg_rt and player.

Fix: #1361