### PR TITLE
Refactor Battle Animations

### DIFF
--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -177,8 +177,11 @@ void BattleAnimation::ProcessAnimationTiming(const RPG::AnimationTiming& timing)
 			break;
 		case RPG::AnimationTiming::ScreenShake_screen:
 			Game_Screen* screen = Main_Data::game_screen.get();
-			// FIXME: 8,7,3 are made up
-			screen->ShakeOnce(8, 7, 3);
+			// FIXME: This is not proven accurate. Screen captures show that
+			// the shake effect lasts for 16 animation frames (32 real frames).
+			// The maximum offset observed was 6 or 7, which makes these numbers
+			// seem reasonable.
+			screen->ShakeOnce(3, 5, 32);
 			break;
 		}
 	}

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -173,7 +173,8 @@ void BattleAnimation::ProcessAnimationTiming(const RPG::AnimationTiming& timing)
 		case RPG::AnimationTiming::ScreenShake_nothing:
 			break;
 		case RPG::AnimationTiming::ScreenShake_target:
-			// TODO: shake the targets
+			// FIXME: Estimate, see below for screen shake.
+			ShakeTargets(3, 5, 32);
 			break;
 		case RPG::AnimationTiming::ScreenShake_screen:
 			Game_Screen* screen = Main_Data::game_screen.get();
@@ -219,7 +220,7 @@ void BattleAnimation::UpdateScreenFlash() {
 void BattleAnimation::UpdateTargetFlash() {
 	int r, g, b, p;
 	UpdateFlashGeneric(target_flash_timing, r, g, b, p);
-	SetFlash(r, g, b, p);
+	FlashTargets(r, g, b, p);
 }
 
 // For handling the vertical position.
@@ -285,8 +286,11 @@ void BattleAnimationMap::DrawSingle() {
 	DrawAt(target.GetScreenX(), vertical_center + offset);
 }
 
-void BattleAnimationMap::SetFlash(int r, int g, int b, int p) {
+void BattleAnimationMap::FlashTargets(int r, int g, int b, int p) {
 	target.Flash(r, g, b, p, 0);
+}
+
+void BattleAnimationMap::ShakeTargets(int str, int spd, int time) {
 }
 
 /////////
@@ -318,13 +322,18 @@ void BattleAnimationBattle::Draw() {
 		DrawAt(battler.GetBattleX(), battler.GetBattleY() + offset);
 	}
 }
-void BattleAnimationBattle::SetFlash(int r, int g, int b, int p) {
+void BattleAnimationBattle::FlashTargets(int r, int g, int b, int p) {
 	auto color = MakeFlashColor(r, g, b, p);
-	for (std::vector<Game_Battler*>::const_iterator it = battlers.begin();
-	     it != battlers.end(); ++it) {
-		Sprite_Battler* sprite = Game_Battle::GetSpriteset().FindBattler(*it);
+	for (auto& battler: battlers) {
+		Sprite_Battler* sprite = Game_Battle::GetSpriteset().FindBattler(battler);
 		if (sprite)
 			sprite->Flash(color, 0);
+	}
+}
+
+void BattleAnimationBattle::ShakeTargets(int str, int spd, int time) {
+	for (auto& battler: battlers) {
+		battler->ShakeOnce(str, spd, time);
 	}
 }
 

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -34,22 +34,42 @@ struct FileRequestResult;
 
 class BattleAnimation : public Sprite {
 public:
-	BattleAnimation(const RPG::Animation& anim, bool only_sound = false, int cutoff_frame = -1);
+	BattleAnimation(const RPG::Animation& anim, bool only_sound = false, int cutoff = -1);
 
 	DrawableType GetType() const override;
 
+	/** Update the animation to the next animation **/
 	void Update();
+
+	/** @return the current timing frame (2x the number of frames in the underlying animation **/
 	int GetFrame() const;
+
+	/** @return the animation frame that is currently being displayed **/
+	int GetRealFrame() const;
+
+	/** @return the number of frames the animation will play for **/
 	int GetFrames() const;
-	void SetFrame(int);
+
+	/** @return the number of frames in the underlying animation **/
+	int GetRealFrames() const;
+
+	/**
+	 * Set the current running frame
+	 *
+	 * @param frame the frame to set.
+	 **/
+	void SetFrame(int frame);
+
+	/** @return true if the animation has finished **/
 	bool IsDone() const;
+
+	/** @return true if the animation only plays audio and doesn't display **/
 	bool ShouldOnlySound() const;
 
 protected:
 	virtual void SetFlash(int r, int g, int b, int p) = 0;
 	virtual bool ShouldScreenFlash() const = 0;
 	void DrawAt(int x, int y);
-	void RunTimedSfx();
 	void ProcessAnimationTiming(const RPG::AnimationTiming& timing);
 	void OnBattleSpriteReady(FileRequestResult* result);
 	void OnBattle2SpriteReady(FileRequestResult* result);
@@ -57,8 +77,7 @@ protected:
 	bool should_only_sound;
 	const RPG::Animation& animation;
 	int frame;
-	bool frame_update;
-	int cutoff;
+	int num_frames;
 
 	FileRequestBinding request_id;
 };
@@ -99,5 +118,30 @@ protected:
 	virtual void SetFlash(int r, int g, int b, int p) override;
 	bool ShouldScreenFlash() const override;
 };
+
+inline void BattleAnimation::SetFrame(int frame) {
+	this->frame = frame;
+}
+
+inline int BattleAnimation::GetFrame() const {
+	return frame;
+}
+
+inline int BattleAnimation::GetRealFrame() const {
+	return GetFrame() / 2;
+}
+
+inline int BattleAnimation::GetFrames() const {
+	return num_frames;
+}
+
+inline int BattleAnimation::GetRealFrames() const {
+	return animation.frames.size();
+}
+
+inline bool BattleAnimation::IsDone() const {
+	return GetFrame() >= GetFrames();
+}
+
 
 #endif

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -67,7 +67,8 @@ public:
 protected:
 	BattleAnimation(const RPG::Animation& anim, bool only_sound = false, int cutoff = -1);
 
-	virtual void SetFlash(int r, int g, int b, int p) = 0;
+	virtual void FlashTargets(int r, int g, int b, int p) = 0;
+	virtual void ShakeTargets(int str, int spd, int time) = 0;
 	void DrawAt(int x, int y);
 	void ProcessAnimationTiming(const RPG::AnimationTiming& timing);
 	void ProcessAnimationFlash(const RPG::AnimationTiming& timing);
@@ -94,7 +95,8 @@ public:
 	~BattleAnimationMap() override;
 	void Draw() override;
 protected:
-	virtual void SetFlash(int r, int g, int b, int p) override;
+	void FlashTargets(int r, int g, int b, int p) override;
+	void ShakeTargets(int str, int spd, int time) override;
 	void DrawSingle();
 	void DrawGlobal();
 
@@ -109,7 +111,8 @@ public:
 	~BattleAnimationBattle() override;
 	void Draw() override;
 protected:
-	virtual void SetFlash(int r, int g, int b, int p) override;
+	void FlashTargets(int r, int g, int b, int p) override;
+	void ShakeTargets(int str, int spd, int time) override;
 	std::vector<Game_Battler*> battlers;
 };
 

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -64,11 +64,10 @@ public:
 	bool IsDone() const;
 
 	/** @return true if the animation only plays audio and doesn't display **/
-	bool ShouldOnlySound() const;
+	bool IsOnlySound() const;
 
 protected:
 	virtual void SetFlash(int r, int g, int b, int p) = 0;
-	virtual bool ShouldScreenFlash() const = 0;
 	void DrawAt(int x, int y);
 	void ProcessAnimationTiming(const RPG::AnimationTiming& timing);
 	void ProcessAnimationFlash(const RPG::AnimationTiming& timing);
@@ -78,7 +77,7 @@ protected:
 	void UpdateTargetFlash();
 	void UpdateFlashGeneric(int timing_idx, int& r, int& g, int& b, int& p);
 
-	bool should_only_sound;
+	bool only_sound;
 	const RPG::Animation& animation;
 	int frame;
 	int num_frames;
@@ -96,7 +95,6 @@ public:
 	void Draw() override;
 protected:
 	virtual void SetFlash(int r, int g, int b, int p) override;
-	bool ShouldScreenFlash() const override;
 	void DrawSingle();
 	void DrawGlobal();
 
@@ -105,17 +103,14 @@ protected:
 };
 
 // For playing animations against a (group of) battlers in battle.
-class BattleAnimationBattlers : public BattleAnimation {
+class BattleAnimationBattle : public BattleAnimation {
 public:
-	BattleAnimationBattlers(const RPG::Animation& anim, Game_Battler& batt, bool flash = true, bool only_sound = false, int cutoff_frame = -1);
-	BattleAnimationBattlers(const RPG::Animation& anim, const std::vector<Game_Battler*>& batts, bool flash = true, bool only_sound = false, int cutoff_frame = -1);
-	~BattleAnimationBattlers() override;
+	BattleAnimationBattle(const RPG::Animation& anim, std::vector<Game_Battler*> battlers, bool only_sound = false, int cutoff_frame = -1);
+	~BattleAnimationBattle() override;
 	void Draw() override;
 protected:
 	virtual void SetFlash(int r, int g, int b, int p) override;
-	bool ShouldScreenFlash() const override;
 	std::vector<Game_Battler*> battlers;
-	bool should_flash;
 };
 
 inline int BattleAnimation::GetFrame() const {
@@ -137,6 +132,11 @@ inline int BattleAnimation::GetRealFrames() const {
 inline bool BattleAnimation::IsDone() const {
 	return GetFrame() >= GetFrames();
 }
+
+inline bool BattleAnimation::IsOnlySound() const {
+	return only_sound;
+}
+
 
 
 #endif

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -34,8 +34,6 @@ struct FileRequestResult;
 
 class BattleAnimation : public Sprite {
 public:
-	BattleAnimation(const RPG::Animation& anim, bool only_sound = false, int cutoff = -1);
-
 	DrawableType GetType() const override;
 
 	/** Update the animation to the next animation **/
@@ -67,6 +65,8 @@ public:
 	bool IsOnlySound() const;
 
 protected:
+	BattleAnimation(const RPG::Animation& anim, bool only_sound = false, int cutoff = -1);
+
 	virtual void SetFlash(int r, int g, int b, int p) = 0;
 	void DrawAt(int x, int y);
 	void ProcessAnimationTiming(const RPG::AnimationTiming& timing);

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -71,13 +71,19 @@ protected:
 	virtual bool ShouldScreenFlash() const = 0;
 	void DrawAt(int x, int y);
 	void ProcessAnimationTiming(const RPG::AnimationTiming& timing);
+	void ProcessAnimationFlash(const RPG::AnimationTiming& timing);
 	void OnBattleSpriteReady(FileRequestResult* result);
 	void OnBattle2SpriteReady(FileRequestResult* result);
+	void UpdateScreenFlash();
+	void UpdateTargetFlash();
+	void UpdateFlashGeneric(int timing_idx, int& r, int& g, int& b, int& p);
 
 	bool should_only_sound;
 	const RPG::Animation& animation;
 	int frame;
 	int num_frames;
+	int screen_flash_timing = -1;
+	int target_flash_timing = -1;
 
 	FileRequestBinding request_id;
 };
@@ -118,10 +124,6 @@ protected:
 	virtual void SetFlash(int r, int g, int b, int p) override;
 	bool ShouldScreenFlash() const override;
 };
-
-inline void BattleAnimation::SetFrame(int frame) {
-	this->frame = frame;
-}
 
 inline int BattleAnimation::GetFrame() const {
 	return frame;

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -88,16 +88,20 @@ protected:
 	FileRequestBinding request_id;
 };
 
-// For playing animations against a character on the map.
-class BattleAnimationChara : public BattleAnimation {
+// For playing animations on the map.
+class BattleAnimationMap : public BattleAnimation {
 public:
-	BattleAnimationChara(const RPG::Animation& anim, Game_Character& chara);
-	~BattleAnimationChara() override;
+	BattleAnimationMap(const RPG::Animation& anim, Game_Character& target, bool global);
+	~BattleAnimationMap() override;
 	void Draw() override;
 protected:
 	virtual void SetFlash(int r, int g, int b, int p) override;
 	bool ShouldScreenFlash() const override;
-	Game_Character& character;
+	void DrawSingle();
+	void DrawGlobal();
+
+	Game_Character& target;
+	bool global = false;
 };
 
 // For playing animations against a (group of) battlers in battle.
@@ -112,17 +116,6 @@ protected:
 	bool ShouldScreenFlash() const override;
 	std::vector<Game_Battler*> battlers;
 	bool should_flash;
-};
-
-// For playing "Show on the entire map" animations.
-class BattleAnimationGlobal : public BattleAnimation {
-public:
-	BattleAnimationGlobal(const RPG::Animation& anim);
-	~BattleAnimationGlobal() override;
-	void Draw() override;
-protected:
-	virtual void SetFlash(int r, int g, int b, int p) override;
-	bool ShouldScreenFlash() const override;
 };
 
 inline int BattleAnimation::GetFrame() const {

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -195,28 +195,32 @@ Spriteset_Battle& Game_Battle::GetSpriteset() {
 	return *spriteset;
 }
 
-void Game_Battle::ShowBattleAnimation(int animation_id, Game_Battler* target, bool flash, bool only_sound, int cutoff) {
+int Game_Battle::ShowBattleAnimation(int animation_id, Game_Battler* target, bool flash, bool only_sound, int cutoff) {
 	Main_Data::game_data.screen.battleanim_id = animation_id;
 
 	const RPG::Animation* anim = ReaderUtil::GetElement(Data::animations, animation_id);
 	if (!anim) {
 		Output::Warning("ShowBattleAnimation Single: Invalid animation ID %d", animation_id);
-		return;
+		return 0;
 	}
 
 	animation.reset(new BattleAnimationBattlers(*anim, *target, flash, only_sound, cutoff));
+	auto frames = animation->GetFrames();
+	return cutoff >= 0 ? std::min(frames, cutoff) : frames;
 }
 
-void Game_Battle::ShowBattleAnimation(int animation_id, const std::vector<Game_Battler*>& targets, bool flash, bool only_sound, int cutoff) {
+int Game_Battle::ShowBattleAnimation(int animation_id, const std::vector<Game_Battler*>& targets, bool flash, bool only_sound, int cutoff) {
 	Main_Data::game_data.screen.battleanim_id = animation_id;
 
 	const RPG::Animation* anim = ReaderUtil::GetElement(Data::animations, animation_id);
 	if (!anim) {
 		Output::Warning("ShowBattleAnimation Many: Invalid animation ID %d", animation_id);
-		return;
+		return 0;
 	}
 
 	animation.reset(new BattleAnimationBattlers(*anim, targets, flash, only_sound, cutoff));
+	auto frames = animation->GetFrames();
+	return cutoff >= 0 ? std::min(frames, cutoff) : frames;
 }
 
 bool Game_Battle::IsBattleAnimationWaiting() {

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -195,21 +195,7 @@ Spriteset_Battle& Game_Battle::GetSpriteset() {
 	return *spriteset;
 }
 
-int Game_Battle::ShowBattleAnimation(int animation_id, Game_Battler* target, bool flash, bool only_sound, int cutoff) {
-	Main_Data::game_data.screen.battleanim_id = animation_id;
-
-	const RPG::Animation* anim = ReaderUtil::GetElement(Data::animations, animation_id);
-	if (!anim) {
-		Output::Warning("ShowBattleAnimation Single: Invalid animation ID %d", animation_id);
-		return 0;
-	}
-
-	animation.reset(new BattleAnimationBattlers(*anim, *target, flash, only_sound, cutoff));
-	auto frames = animation->GetFrames();
-	return cutoff >= 0 ? std::min(frames, cutoff) : frames;
-}
-
-int Game_Battle::ShowBattleAnimation(int animation_id, const std::vector<Game_Battler*>& targets, bool flash, bool only_sound, int cutoff) {
+int Game_Battle::ShowBattleAnimation(int animation_id, std::vector<Game_Battler*> targets, bool only_sound, int cutoff) {
 	Main_Data::game_data.screen.battleanim_id = animation_id;
 
 	const RPG::Animation* anim = ReaderUtil::GetElement(Data::animations, animation_id);
@@ -218,7 +204,7 @@ int Game_Battle::ShowBattleAnimation(int animation_id, const std::vector<Game_Ba
 		return 0;
 	}
 
-	animation.reset(new BattleAnimationBattlers(*anim, targets, flash, only_sound, cutoff));
+	animation.reset(new BattleAnimationBattle(*anim, std::move(targets), only_sound, cutoff));
 	auto frames = animation->GetFrames();
 	return cutoff >= 0 ? std::min(frames, cutoff) : frames;
 }

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -196,8 +196,6 @@ Spriteset_Battle& Game_Battle::GetSpriteset() {
 }
 
 int Game_Battle::ShowBattleAnimation(int animation_id, std::vector<Game_Battler*> targets, bool only_sound, int cutoff) {
-	Main_Data::game_data.screen.battleanim_id = animation_id;
-
 	const RPG::Animation* anim = ReaderUtil::GetElement(Data::animations, animation_id);
 	if (!anim) {
 		Output::Warning("ShowBattleAnimation Many: Invalid animation ID %d", animation_id);

--- a/src/game_battle.h
+++ b/src/game_battle.h
@@ -70,8 +70,10 @@ namespace Game_Battle {
 	 * @param animation_id the animation ID
 	 * @param target pointer to the battler to play against
 	 * @param flash whether or not the screen should flash during the animation
+	 *
+	 * @return the number of frames of the animation.
 	 */
-	void ShowBattleAnimation(int animation_id, Game_Battler* target, bool flash = true, bool only_sound = false, int cutoff = -1);
+	int ShowBattleAnimation(int animation_id, Game_Battler* target, bool flash = true, bool only_sound = false, int cutoff = -1);
 
 	/**
 	 * Plays a battle animation against several targets simultaneously.
@@ -79,8 +81,10 @@ namespace Game_Battle {
 	 * @param animation_id the animation ID
 	 * @param targets a vector of pointer to the battlers to play against
 	 * @param flash whether or not the screen should flash during the animation
+	 *
+	 * @return the number of frames of the animation.
 	 */
-	void ShowBattleAnimation(int animation_id, const std::vector<Game_Battler*>& targets, bool flash = true, bool only_sound = false, int cutoff = -1);
+	int ShowBattleAnimation(int animation_id, const std::vector<Game_Battler*>& targets, bool flash = true, bool only_sound = false, int cutoff = -1);
 
 	/**
 	 * Whether or not a battle animation is currently playing.

--- a/src/game_battle.h
+++ b/src/game_battle.h
@@ -65,26 +65,14 @@ namespace Game_Battle {
 	Spriteset_Battle& GetSpriteset();
 
 	/**
-	 * Plays a battle animation against the given target.
-	 *
-	 * @param animation_id the animation ID
-	 * @param target pointer to the battler to play against
-	 * @param flash whether or not the screen should flash during the animation
-	 *
-	 * @return the number of frames of the animation.
-	 */
-	int ShowBattleAnimation(int animation_id, Game_Battler* target, bool flash = true, bool only_sound = false, int cutoff = -1);
-
-	/**
 	 * Plays a battle animation against several targets simultaneously.
 	 *
 	 * @param animation_id the animation ID
 	 * @param targets a vector of pointer to the battlers to play against
-	 * @param flash whether or not the screen should flash during the animation
 	 *
 	 * @return the number of frames of the animation.
 	 */
-	int ShowBattleAnimation(int animation_id, const std::vector<Game_Battler*>& targets, bool flash = true, bool only_sound = false, int cutoff = -1);
+	int ShowBattleAnimation(int animation_id, std::vector<Game_Battler*> targets, bool only_sound = false, int cutoff = -1);
 
 	/**
 	 * Whether or not a battle animation is currently playing.

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -281,7 +281,6 @@ void Game_BattleAlgorithm::AlgorithmBase::PlaySoundAnimation(bool on_source, int
 	}
 
 	if (on_source) {
-		std::vector<Game_Battler*> anim_targets = { GetSource() };
 		Game_Battle::ShowBattleAnimation(GetAnimation()->ID, { GetSource() }, true, cutoff);
 		return;
 	}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -223,8 +223,7 @@ void Game_BattleAlgorithm::AlgorithmBase::PlayAnimation(bool on_source) {
 	}
 
 	if (on_source) {
-		std::vector<Game_Battler*> anim_targets = { GetSource() };
-		Game_Battle::ShowBattleAnimation(GetAnimation()->ID, anim_targets);
+		Game_Battle::ShowBattleAnimation(GetAnimation()->ID, { GetSource() });
 		has_animation_played = true;
 		return;
 	}
@@ -253,8 +252,7 @@ void Game_BattleAlgorithm::AlgorithmBase::PlaySecondAnimation(bool on_source) {
 	}
 
 	if (on_source) {
-		std::vector<Game_Battler*> anim_targets = { GetSource() };
-		Game_Battle::ShowBattleAnimation(GetSecondAnimation()->ID, anim_targets);
+		Game_Battle::ShowBattleAnimation(GetSecondAnimation()->ID, { GetSource() });
 		has_animation2_played = true;
 		return;
 	}
@@ -284,7 +282,7 @@ void Game_BattleAlgorithm::AlgorithmBase::PlaySoundAnimation(bool on_source, int
 
 	if (on_source) {
 		std::vector<Game_Battler*> anim_targets = { GetSource() };
-		Game_Battle::ShowBattleAnimation(GetAnimation()->ID, anim_targets, false, true, cutoff);
+		Game_Battle::ShowBattleAnimation(GetAnimation()->ID, { GetSource() }, true, cutoff);
 		return;
 	}
 
@@ -299,7 +297,7 @@ void Game_BattleAlgorithm::AlgorithmBase::PlaySoundAnimation(bool on_source, int
 
 	Game_Battle::ShowBattleAnimation(
 		GetAnimation()->ID,
-		anim_targets, false, true, cutoff);
+		anim_targets, true, cutoff);
 
 	current_target = old_current_target;
 	first_attack = old_first_attack;

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -672,7 +672,7 @@ int Game_Battler::GetAgi() const {
 }
 
 int Game_Battler::GetDisplayX() const {
-	int shake_pos = Main_Data::game_data.screen.shake_position;
+	int shake_pos = Main_Data::game_data.screen.shake_position + shake_position;
 	return GetBattleX() + shake_pos;
 }
 
@@ -731,7 +731,15 @@ int Game_Battler::GetFlyingOffset() const {
 }
 
 void Game_Battler::UpdateBattle() {
-	// no-op
+	if (shake_time_left > 0) {
+		--shake_time_left;
+		if (shake_time_left > 0) {
+			shake_position = Game_Screen::AnimateShake(shake_strength, shake_speed, shake_time_left, shake_position);
+		} else {
+			shake_position = 0;
+			shake_time_left = 0;
+		}
+	}
 }
 
 const BattleAlgorithmRef Game_Battler::GetBattleAlgorithm() const {
@@ -873,3 +881,11 @@ int Game_Battler::GetHitChanceModifierFromStates() const {
 	}
 	return modifier;
 }
+
+void Game_Battler::ShakeOnce(int strength, int speed, int frames) {
+	shake_strength = strength;
+	shake_speed = speed;
+	shake_time_left = frames;
+	// FIXME: RPG_RT doesn't reset position for screen shake. So we guess? it doesn't do so here either.
+}
+

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -654,6 +654,15 @@ public:
 	 */
 	int GetHitChanceModifierFromStates() const;
 
+	/**
+	 * Animate a shake for the sprite
+	 *
+	 * @param strength strength of the shake
+	 * @param speed speed of the shake
+	 * @param frames how many frames to shake
+	 */
+	void ShakeOnce(int strength, int speed, int frames);
+
 protected:
 	/** Gauge for RPG2k3 Battle */
 	int gauge;
@@ -675,6 +684,11 @@ protected:
 	std::vector<int> attribute_shift;
 
 	int battle_order = 0;
+
+	int shake_position = 0;
+	int shake_time_left = 0;
+	int shake_strength = 0;
+	int shake_speed = 0;
 };
 
 #endif

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -244,6 +244,7 @@ void Game_Enemy::UpdateBattle() {
 			flying_offset = frames[cycle / levitation_frame_cycle];
 		}
 	}
+	Game_Battler::UpdateBattle();
 }
 
 bool Game_Enemy::IsActionValid(const RPG::EnemyAction& action) {

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -71,7 +71,6 @@ Game_Interpreter::~Game_Interpreter() {
 
 // Clear.
 void Game_Interpreter::Clear() {
-	waiting_battle_anim = false;
 	continuation = NULL;			// function to execute to resume command
 	wait_messages = false;			// wait if message window is visible
 	_state = {};

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -112,8 +112,6 @@ protected:
 	typedef bool (Game_Interpreter::*ContinuationFunction)(RPG::EventCommand const& com);
 	ContinuationFunction continuation;
 
-	bool waiting_battle_anim;
-
 	/**
 	 * Gets strings for choice selection.
 	 * This is just a helper (private) method

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -291,7 +291,7 @@ bool Game_Interpreter_Battle::CommandShowBattleAnimation(RPG::EventCommand const
 		}
 
 		if (battler_target) {
-			frames = Game_Battle::ShowBattleAnimation(animation_id, battler_target);
+			frames = Game_Battle::ShowBattleAnimation(animation_id, { battler_target });
 		}
 	}
 

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -252,19 +252,16 @@ bool Game_Interpreter_Battle::CommandChangeBattleBG(RPG::EventCommand const& com
 }
 
 bool Game_Interpreter_Battle::CommandShowBattleAnimation(RPG::EventCommand const& com) {
-	if (waiting_battle_anim) {
-		waiting_battle_anim = Game_Battle::IsBattleAnimationWaiting();
-		return !waiting_battle_anim;
-	}
-
 	int animation_id = com.parameters[0];
 	int target = com.parameters[1];
-	waiting_battle_anim = com.parameters[2] != 0;
+	bool waiting_battle_anim = com.parameters[2] != 0;
 	bool allies = false;
 
 	if (Player::IsRPG2k3()) {
 		allies = com.parameters[3] != 0;
 	}
+
+	int frames = 0;
 
 	if (target < 0) {
 		std::vector<Game_Battler*> v;
@@ -275,9 +272,7 @@ bool Game_Interpreter_Battle::CommandShowBattleAnimation(RPG::EventCommand const
 			Main_Data::game_enemyparty->GetActiveBattlers(v);
 		}
 
-		Game_Battle::ShowBattleAnimation(animation_id, v, false);
-
-		return !waiting_battle_anim;
+		frames = Game_Battle::ShowBattleAnimation(animation_id, v, false);
 	}
 	else {
 		Game_Battler* battler_target = nullptr;
@@ -295,14 +290,16 @@ bool Game_Interpreter_Battle::CommandShowBattleAnimation(RPG::EventCommand const
 			}
 		}
 
-		if (!battler_target) {
-			return !waiting_battle_anim;
+		if (battler_target) {
+			frames = Game_Battle::ShowBattleAnimation(animation_id, battler_target);
 		}
-
-		Game_Battle::ShowBattleAnimation(animation_id, battler_target);
 	}
 
-	return !waiting_battle_anim;
+	if (waiting_battle_anim) {
+		_state.wait_time = frames;
+	}
+
+	return true;
 }
 
 bool Game_Interpreter_Battle::CommandTerminateBattle(RPG::EventCommand const& /* com */) {

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -604,11 +604,6 @@ bool Game_Interpreter_Map::CommandPanScreen(RPG::EventCommand const& com) { // c
 }
 
 bool Game_Interpreter_Map::CommandShowBattleAnimation(RPG::EventCommand const& com) { // code 11210
-	if (waiting_battle_anim) {
-		waiting_battle_anim = Game_Map::IsBattleAnimationWaiting();
-		return !waiting_battle_anim;
-	}
-
 	int animation_id = com.parameters[0];
 	int evt_id = com.parameters[1];
 	waiting_battle_anim = com.parameters[2] > 0;
@@ -621,9 +616,13 @@ bool Game_Interpreter_Map::CommandShowBattleAnimation(RPG::EventCommand const& c
 	if (evt_id == Game_Character::CharThisEvent)
 		evt_id = GetThisEventId();
 
-	Game_Map::ShowBattleAnimation(animation_id, evt_id, global);
+	int frames = Game_Map::ShowBattleAnimation(animation_id, evt_id, global);
 
-	return !waiting_battle_anim;
+	if (waiting_battle_anim) {
+		_state.wait_time = frames;
+	}
+
+	return true;
 }
 
 bool Game_Interpreter_Map::CommandFlashSprite(RPG::EventCommand const& com) { // code 11320

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -606,7 +606,7 @@ bool Game_Interpreter_Map::CommandPanScreen(RPG::EventCommand const& com) { // c
 bool Game_Interpreter_Map::CommandShowBattleAnimation(RPG::EventCommand const& com) { // code 11210
 	int animation_id = com.parameters[0];
 	int evt_id = com.parameters[1];
-	waiting_battle_anim = com.parameters[2] > 0;
+	bool waiting_battle_anim = com.parameters[2] > 0;
 	bool global = com.parameters[3] > 0;
 
 	Game_Character* chara = GetCharacter(evt_id);

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -616,7 +616,7 @@ bool Game_Interpreter_Map::CommandShowBattleAnimation(RPG::EventCommand const& c
 	if (evt_id == Game_Character::CharThisEvent)
 		evt_id = GetThisEventId();
 
-	int frames = Game_Map::ShowBattleAnimation(animation_id, evt_id, global);
+	int frames = Main_Data::game_screen->ShowBattleAnimation(animation_id, evt_id, global);
 
 	if (waiting_battle_anim) {
 		_state.wait_time = frames;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -271,6 +271,12 @@ void Game_Map::SetupFromSave() {
 
 	SetEncounterSteps(location.encounter_steps);
 
+	if (Main_Data::game_data.screen.battleanim_active) {
+		ShowBattleAnimation(Main_Data::game_data.screen.battleanim_id,
+				Main_Data::game_data.screen.battleanim_target,
+				Main_Data::game_data.screen.battleanim_global,
+				Main_Data::game_data.screen.battleanim_frame);
+	}
 
 	// We want to support loading rm2k3e panning chunks
 	// but also not break other saves which don't have them.
@@ -1327,7 +1333,7 @@ void Game_Map::SetupBattle() {
 	}
 }
 
-int Game_Map::ShowBattleAnimation(int animation_id, int target_id, bool global) {
+int Game_Map::ShowBattleAnimation(int animation_id, int target_id, bool global, int start_frame) {
 	const RPG::Animation* anim = ReaderUtil::GetElement(Data::animations, animation_id);
 	if (!anim) {
 		Output::Warning("ShowBattleAnimation: Invalid battle animation ID %d", animation_id);
@@ -1338,7 +1344,7 @@ int Game_Map::ShowBattleAnimation(int animation_id, int target_id, bool global) 
 	Main_Data::game_data.screen.battleanim_target = target_id;
 	Main_Data::game_data.screen.battleanim_global = global;
 	Main_Data::game_data.screen.battleanim_active = true;
-	Main_Data::game_data.screen.battleanim_frame = 0;
+	Main_Data::game_data.screen.battleanim_frame = start_frame;
 
 	Game_Character* chara = Game_Character::GetCharacter(target_id, target_id);
 
@@ -1351,7 +1357,11 @@ int Game_Map::ShowBattleAnimation(int animation_id, int target_id, bool global) 
 		}
 	}
 
-	return anim->frames.size() * 2;
+	if (start_frame) {
+		animation->SetFrame(start_frame);
+	}
+
+	return animation->GetFrames();
 }
 
 void Game_Map::UpdateBattleAnimation() {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1333,11 +1333,11 @@ void Game_Map::SetupBattle() {
 	}
 }
 
-void Game_Map::ShowBattleAnimation(int animation_id, int target_id, bool global) {
+int Game_Map::ShowBattleAnimation(int animation_id, int target_id, bool global) {
 	const RPG::Animation* anim = ReaderUtil::GetElement(Data::animations, animation_id);
 	if (!anim) {
 		Output::Warning("ShowBattleAnimation: Invalid battle animation ID %d", animation_id);
-		return;
+		return 0;
 	}
 
 	Main_Data::game_data.screen.battleanim_id = animation_id;
@@ -1354,6 +1354,8 @@ void Game_Map::ShowBattleAnimation(int animation_id, int target_id, bool global)
 			animation.reset(new BattleAnimationChara(*anim, *chara));
 		}
 	}
+
+	return anim->frames.size() * 2;
 }
 
 bool Game_Map::IsBattleAnimationWaiting() {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -268,13 +268,6 @@ void Game_Map::SetupFromSave() {
 
 	SetEncounterSteps(location.encounter_steps);
 
-	if (Main_Data::game_data.screen.battleanim_active) {
-		Main_Data::game_screen->ShowBattleAnimation(Main_Data::game_data.screen.battleanim_id,
-				Main_Data::game_data.screen.battleanim_target,
-				Main_Data::game_data.screen.battleanim_global,
-				Main_Data::game_data.screen.battleanim_frame);
-	}
-
 	// We want to support loading rm2k3e panning chunks
 	// but also not break other saves which don't have them.
 	// To solve this problem, we reuse the scrolling methods

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -358,33 +358,6 @@ namespace Game_Map {
 	void SetupBattle();
 
 	/**
-	 * Plays the given animation against a character.
-	 *
-	 * @param animation_id the animation ID
-	 * @param target_id the ID of the targeted character
-	 * @param global whether to "show on the entire map"
-	 * @param which frame to start on.
-	 *
-	 * @return the number of frames the animation will run.
-	 */
-	int ShowBattleAnimation(int animation_id, int target_id, bool global, int start_frame = 0);
-
-	/**
-	 * Update the currently running battle animation by 1 frame.
-	 */
-	void UpdateBattleAnimation();
-
-	/**
-	 * Cancel the currently running battle animation.
-	 */
-	void CancelBattleAnimation();
-
-	/**
-	 * Whether or not a battle animation is currently playing.
-	 */
-	bool IsBattleAnimationWaiting();
-
-	/**
 	 * Gets lower layer map data.
 	 *
 	 * @return lower layer map data.

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -363,8 +363,10 @@ namespace Game_Map {
 	 * @param animation_id the animation ID
 	 * @param target_id the ID of the targeted character
 	 * @param global whether to "show on the entire map"
+	 *
+	 * @return the number of frames the animation will run.
 	 */
-	void ShowBattleAnimation(int animation_id, int target_id, bool global);
+	int ShowBattleAnimation(int animation_id, int target_id, bool global);
 
 	/**
 	 * Whether or not a battle animation is currently playing.

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -369,6 +369,16 @@ namespace Game_Map {
 	int ShowBattleAnimation(int animation_id, int target_id, bool global);
 
 	/**
+	 * Update the currently running battle animation by 1 frame.
+	 */
+	void UpdateBattleAnimation();
+
+	/**
+	 * Cancel the currently running battle animation.
+	 */
+	void CancelBattleAnimation();
+
+	/**
 	 * Whether or not a battle animation is currently playing.
 	 */
 	bool IsBattleAnimationWaiting();

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -363,10 +363,11 @@ namespace Game_Map {
 	 * @param animation_id the animation ID
 	 * @param target_id the ID of the targeted character
 	 * @param global whether to "show on the entire map"
+	 * @param which frame to start on.
 	 *
 	 * @return the number of frames the animation will run.
 	 */
-	int ShowBattleAnimation(int animation_id, int target_id, bool global);
+	int ShowBattleAnimation(int animation_id, int target_id, bool global, int start_frame = 0);
 
 	/**
 	 * Update the currently running battle animation by 1 frame.

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -356,12 +356,7 @@ int Game_Screen::ShowBattleAnimation(int animation_id, int target_id, bool globa
 	Game_Character* chara = Game_Character::GetCharacter(target_id, target_id);
 
 	if (chara) {
-		chara->SetFlashTimeLeft(0); // Any flash always ends
-		if (global) {
-			animation.reset(new BattleAnimationGlobal(*anim));
-		} else {
-			animation.reset(new BattleAnimationChara(*anim, *chara));
-		}
+		animation.reset(new BattleAnimationMap(*anim, *chara, global));
 	}
 
 	if (start_frame) {

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -38,6 +38,17 @@ Game_Screen::Game_Screen() :
 	Reset();
 }
 
+void Game_Screen::SetupFromSave() {
+	CreatePicturesFromSave();
+
+	if (Main_Data::game_data.screen.battleanim_active) {
+		ShowBattleAnimation(Main_Data::game_data.screen.battleanim_id,
+				Main_Data::game_data.screen.battleanim_target,
+				Main_Data::game_data.screen.battleanim_global,
+				Main_Data::game_data.screen.battleanim_frame);
+	}
+}
+
 void Game_Screen::CreatePicturesFromSave() {
 	std::vector<RPG::SavePicture>& save_pics = Main_Data::game_data.pictures;
 

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -246,6 +246,14 @@ void Game_Screen::UpdateSnowRain(int speed) {
 	}
 }
 
+int Game_Screen::AnimateShake(int strength, int speed, int time_left, int position) {
+	int amplitude = 1 + 2 * strength;
+	int newpos = amplitude * sin((time_left * 4 * (speed + 2)) % 256 * M_PI / 128);
+	int cutoff = (speed * amplitude / 8) + 1;
+
+	return Utils::Clamp<int>(newpos, position - cutoff, position + cutoff);
+}
+
 void Game_Screen::Update() {
 	if (data.tint_time_left > 0) {
 		data.tint_current_red = interpolate(data.tint_time_left, data.tint_current_red, data.tint_finish_red);
@@ -276,11 +284,7 @@ void Game_Screen::Update() {
 			if (data.shake_time_left < 0 && data.shake_continuous) {
 				data.shake_time_left = kShakeContinuousTimeStart;
 			}
-			int amplitude = 1 + 2 * data.shake_strength;
-			int newpos = amplitude * sin((data.shake_time_left * 4 * (data.shake_speed + 2)) % 256 * M_PI / 128);
-			int cutoff = (data.shake_speed * amplitude / 8) + 1;
-
-			data.shake_position = Utils::Clamp<int>(newpos, data.shake_position - cutoff, data.shake_position + cutoff);
+			data.shake_position = AnimateShake(data.shake_strength, data.shake_speed, data.shake_time_left, data.shake_position);
 		} else {
 			data.shake_position = 0;
 			data.shake_time_left = 0;

--- a/src/game_screen.h
+++ b/src/game_screen.h
@@ -22,6 +22,7 @@
 #include "system.h"
 #include "game_picture.h"
 #include "game_character.h"
+#include "battle_animation.h"
 
 class Game_Battler;
 class Screen;
@@ -94,8 +95,36 @@ public:
 		Weather_Sandstorm
 	};
 
+	/**
+	 * Plays the given animation against a character.
+	 *
+	 * @param animation_id the animation ID
+	 * @param target_id the ID of the targeted character
+	 * @param global whether to "show on the entire map"
+	 * @param which frame to start on.
+	 *
+	 * @return the number of frames the animation will run.
+	 */
+	int ShowBattleAnimation(int animation_id, int target_id, bool global, int start_frame = 0);
+
+	/**
+	 * Update the currently running battle animation by 1 frame.
+	 */
+	void UpdateBattleAnimation();
+
+	/**
+	 * Cancel the currently running battle animation.
+	 */
+	void CancelBattleAnimation();
+
+	/**
+	 * Whether or not a battle animation is currently playing.
+	 */
+	bool IsBattleAnimationWaiting();
+
 private:
 	std::vector<std::unique_ptr<Game_Picture>> pictures;
+	std::unique_ptr<BattleAnimation> animation;
 
 	RPG::SaveScreen& data;
 	int flash_sat;		// RPGMaker bug: this isn't saved

--- a/src/game_screen.h
+++ b/src/game_screen.h
@@ -121,6 +121,18 @@ public:
 	 */
 	bool IsBattleAnimationWaiting();
 
+	/**
+	 * Animates the screen shake algorithm given the parameters
+	 *
+	 * @param strength the strength of the shake
+	 * @param speed of the shake
+	 * @param time_left how much time is left in frames
+	 * @param current shake displacement
+	 *
+	 * @return next shake displacement
+	 */
+	static int AnimateShake(int strength, int speed, int time_left, int position);
+
 private:
 	std::vector<std::unique_ptr<Game_Picture>> pictures;
 	std::unique_ptr<BattleAnimation> animation;

--- a/src/game_screen.h
+++ b/src/game_screen.h
@@ -100,7 +100,7 @@ public:
 	 * @param animation_id the animation ID
 	 * @param target_id the ID of the targeted character
 	 * @param global whether to "show on the entire map"
-	 * @param which frame to start on.
+	 * @param start_frame which frame to start on.
 	 *
 	 * @return the number of frames the animation will run.
 	 */
@@ -127,7 +127,7 @@ public:
 	 * @param strength the strength of the shake
 	 * @param speed of the shake
 	 * @param time_left how much time is left in frames
-	 * @param current shake displacement
+	 * @param position current shake displacement
 	 *
 	 * @return next shake displacement
 	 */

--- a/src/game_screen.h
+++ b/src/game_screen.h
@@ -31,8 +31,7 @@ class Game_Screen {
 
 public:
 	Game_Screen();
-
-	void CreatePicturesFromSave();
+	void SetupFromSave();
 
 	Game_Picture* GetPicture(int id);
 
@@ -142,6 +141,7 @@ protected:
 	void StopWeather();
 	void InitSnowRain();
 	void UpdateSnowRain(int speed);
+	void CreatePicturesFromSave();
 };
 
 #endif

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -128,8 +128,9 @@ void Scene::MainFunction() {
 
 		Graphics::Update();
 
-		Suspend();
-		TransitionOut(instance ? instance->type : Null);
+		auto next_scene = instance ? instance->type : Null;
+		Suspend(next_scene);
+		TransitionOut(next_scene);
 
 		// TransitionOut stored a screenshot of the last scene
 		Graphics::UpdateSceneCallback();
@@ -147,7 +148,7 @@ void Scene::Continue(SceneType prev_scene) {
 void Scene::Resume(SceneType prev_scene) {
 }
 
-void Scene::Suspend() {
+void Scene::Suspend(SceneType next_scene) {
 }
 
 void Scene::TransitionIn(SceneType) {

--- a/src/scene.h
+++ b/src/scene.h
@@ -106,8 +106,10 @@ public:
 	 * This function is executed before the fade out for
 	 * the scene change, either when terminating the scene
 	 * or switching to a nested scene
+	 *
+	 * @param next_scene the scene we will transition to
 	 */
-	virtual void Suspend();
+	virtual void Suspend(SceneType next_scene);
 
 	/**
 	 * Does the transition upon starting or resuming

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -54,6 +54,10 @@ Scene_Battle::~Scene_Battle() {
 }
 
 void Scene_Battle::Start() {
+	// RPG_RT will cancel any active screen flash from the map, including
+	// wiping out all flash LSD chunks.
+	Main_Data::game_screen->FlashOnce(0, 0, 0, 0, 0);
+
 	if (Game_Battle::battle_test.enabled) {
 		Game_Temp::battle_troop_id = Game_Battle::battle_test.troop_id;
 	}

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -598,7 +598,7 @@ bool Scene_Battle_Rpg2k::ProcessActionAnimation(Game_BattleAlgorithm::AlgorithmB
 		if (action->GetTarget()->GetType() == Game_Battler::Type_Enemy) {
 			action->PlayAnimation();
 		} else {
-			action->PlaySoundAnimation(false, 20);
+			action->PlaySoundAnimation(false, 40);
 		}
 	}
 

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -162,6 +162,12 @@ void Scene_Map::TransitionIn(SceneType prev_scene) {
 	Graphics::GetTransition().Init(Transition::TransitionFadeIn, this, 32);
 }
 
+void Scene_Map::Suspend(SceneType next_scene) {
+	if (next_scene == Scene::Battle) {
+		Game_Map::CancelBattleAnimation();
+	}
+}
+
 void Scene_Map::TransitionOut(SceneType next_scene) {
 	if (next_scene != Scene::Battle
 			&& next_scene != Scene::Debug) {

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -164,7 +164,7 @@ void Scene_Map::TransitionIn(SceneType prev_scene) {
 
 void Scene_Map::Suspend(SceneType next_scene) {
 	if (next_scene == Scene::Battle) {
-		Game_Map::CancelBattleAnimation();
+		Main_Data::game_screen->CancelBattleAnimation();
 	}
 }
 

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -162,12 +162,6 @@ void Scene_Map::TransitionIn(SceneType prev_scene) {
 	Graphics::GetTransition().Init(Transition::TransitionFadeIn, this, 32);
 }
 
-void Scene_Map::Suspend(SceneType next_scene) {
-	if (next_scene == Scene::Battle) {
-		Main_Data::game_screen->CancelBattleAnimation();
-	}
-}
-
 void Scene_Map::TransitionOut(SceneType next_scene) {
 	if (next_scene != Scene::Battle
 			&& next_scene != Scene::Debug) {

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -69,7 +69,7 @@ void Scene_Map::Start() {
 	// Called here instead of Scene Load, otherwise wrong graphic stack
 	// is used.
 	if (from_save) {
-		Main_Data::game_screen->CreatePicturesFromSave();
+		Main_Data::game_screen->SetupFromSave();
 	}
 
 	Player::FrameReset();

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -41,6 +41,7 @@ public:
 	void Continue(SceneType prev_scene) override;
 	void Update() override;
 	void TransitionIn(SceneType prev_scene) override;
+	void Suspend(SceneType next_scene) override;
 	void TransitionOut(SceneType next_scene) override;
 	void DrawBackground() override;
 

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -41,7 +41,6 @@ public:
 	void Continue(SceneType prev_scene) override;
 	void Update() override;
 	void TransitionIn(SceneType prev_scene) override;
-	void Suspend(SceneType next_scene) override;
 	void TransitionOut(SceneType next_scene) override;
 	void DrawBackground() override;
 

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -222,7 +222,7 @@ void Sprite_Battler::SetAnimationState(int state, LoopState loop) {
 					Output::Warning("Invalid battle animation ID %d", ext->animation_id);
 					animation.reset();
 				} else {
-					animation.reset(new BattleAnimationBattlers(*battle_anim, *battler));
+					animation.reset(new BattleAnimationBattle(*battle_anim, { battler }));
 					animation->SetZ(GetZ());
 				}
 			}


### PR DESCRIPTION
Fix: #1757 
Fix: #1372

~~Depends on #1784~~

This supports RPG_RT compatible saving and loading of map battle animations

TBD:
- [x] battle animation screen effects vs event screen effects.
    - [x] Do they use the LSD chunks and affect saving and loading?
- [x] battle animation screen effects and sounds when start battle before anim finishes
    - [x] What if a battle animation in the battle runs? Will it interrupt the map anim?
    - [x] Loading a save before battle?
    - [x] Can we make a very long battle anim with a very short battle that conyinues running after battle exits?
- [x] Frame specific behavior of timing effects when load game
- [x] Verify flash length with OpenSaveMenu test
- [x] Behavior when screen flash is active when animation starts
- [x] Behavior when other event flashes while anim is running