### PR TITLE
Cache improvements and effect caching

### DIFF
--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -207,6 +207,14 @@ Rect Bitmap::GetRect() const {
 	return Rect(0, 0, width(), height());
 }
 
+size_t Bitmap::GetSize() const {
+	if (!bitmap) {
+		return 0;
+	}
+
+	return pitch() * height();
+}
+
 bool Bitmap::GetTransparent() const {
 	return format.alpha_type != PF::NoAlpha;
 }
@@ -961,7 +969,7 @@ void Bitmap::ToneBlit(int x, int y, Bitmap const& src, Rect const& src_rect, con
 		}
 
 	}
-	
+
 }
 
 void Bitmap::BlendBlit(int x, int y, Bitmap const& src, Rect const& src_rect, const Color& color, Opacity const& opacity) {

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -168,6 +168,13 @@ public:
 	Rect GetRect() const;
 
 	/**
+	 * Gets how many bytes the bitmap consumes.
+	 *
+	 * @return bitmap size in bytes
+	 */
+	size_t GetSize() const;
+
+	/**
 	 * Gets if bitmap allows transparency.
 	 *
 	 * @return if bitmap allows transparency.

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -445,29 +445,29 @@ BitmapRef Cache::SpriteEffect(const BitmapRef& src_bitmap, const Rect& rect, boo
 	if (it == cache_effects.end() || it->second.expired()) {
 		BitmapRef bitmap_effects;
 
-		auto create = [&src_bitmap] () -> BitmapRef {
-			return Bitmap::Create(src_bitmap->GetWidth(), src_bitmap->GetHeight(), true);
+		auto create = [&rect] () -> BitmapRef {
+			return Bitmap::Create(rect.width, rect.height, true);
 		};
 
 		if (tone != Tone()) {
 			bitmap_effects = create();
-			bitmap_effects->ToneBlit(rect.x, rect.y, *src_bitmap, rect, tone, Opacity::opaque);
+			bitmap_effects->ToneBlit(0, 0, *src_bitmap, rect, tone, Opacity::opaque);
 		}
 
 		if (blend != Color()) {
 			if (bitmap_effects) {
 				// Tone blit was applied
-				bitmap_effects->BlendBlit(rect.x, rect.y, *bitmap_effects, rect, blend, Opacity::opaque);
+				bitmap_effects->BlendBlit(0, 0, *bitmap_effects, bitmap_effects->GetRect(), blend, Opacity::opaque);
 			} else {
 				bitmap_effects = create();
-				bitmap_effects->BlendBlit(rect.x, rect.y, *src_bitmap, rect, blend, Opacity::opaque);
+				bitmap_effects->BlendBlit(0, 0, *src_bitmap, rect, blend, Opacity::opaque);
 			}
 		}
 
 		if (flip_x || flip_y) {
 			if (bitmap_effects) {
 				// Tone or blend blit was applied
-				bitmap_effects->Flip(rect, flip_x, flip_y);
+				bitmap_effects->Flip(bitmap_effects->GetRect(), flip_x, flip_y);
 			} else {
 				bitmap_effects = create();
 				bitmap_effects->FlipBlit(rect.x, rect.y, *src_bitmap, rect, flip_x, flip_y, Opacity::opaque);

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -69,14 +69,14 @@ namespace {
 		}
 	}
 
-	BitmapRef LoadBitmap(std::string const& folder_name, const std::string& filename,
-						 bool transparent, uint32_t const flags) {
-		KeyType const key(folder_name, filename, transparent);
+	BitmapRef LoadBitmap(const std::string& folder_name, const std::string& filename,
+						 bool transparent, const uint32_t flags) {
+		const KeyType key(folder_name, filename, transparent);
 
-		cache_type::iterator const it = cache.find(key);
+		const cache_type::iterator it = cache.find(key);
 
 		if (it == cache.end() || !it->second.bitmap) {
-			std::string const path = FileFinder::FindImage(folder_name, filename);
+			const std::string path = FileFinder::FindImage(folder_name, filename);
 
 			BitmapRef bmp = BitmapRef();
 
@@ -174,7 +174,7 @@ namespace {
 	BitmapRef DrawCheckerboard() {
 		static_assert(Material::REND < T && T < Material::END, "Invalid material.");
 
-		Spec const& s = spec[T];
+		const Spec& s = spec[T];
 
 		BitmapRef bitmap = Bitmap::Create(s.max_width, s.max_height, false);
 
@@ -193,12 +193,12 @@ namespace {
 	}
 
 	template<Material::Type T>
-	BitmapRef LoadDummyBitmap(std::string const& folder_name, const std::string& filename) {
+	BitmapRef LoadDummyBitmap(const std::string& folder_name, const std::string& filename) {
 		static_assert(Material::REND < T && T < Material::END, "Invalid material.");
 
-		Spec const& s = spec[T];
+		const Spec& s = spec[T];
 
-		KeyType const key(folder_name, filename, false);
+		const KeyType key(folder_name, filename, false);
 
 		BitmapRef bitmap = s.dummy_renderer();
 
@@ -206,10 +206,10 @@ namespace {
 	}
 
 	template<Material::Type T>
-	BitmapRef LoadBitmap(std::string const& f, bool transparent) {
+	BitmapRef LoadBitmap(const std::string& f, bool transparent) {
 		static_assert(Material::REND < T && T < Material::END, "Invalid material.");
 
-		Spec const& s = spec[T];
+		const Spec& s = spec[T];
 
 		if (f == CACHE_DEFAULT_BITMAP) {
 			return LoadDummyBitmap<T>(s.directory, f);
@@ -255,41 +255,85 @@ namespace {
 
 		return ret;
 	}
+
+	template<Material::Type T>
+	BitmapRef LoadBitmap(const std::string& f) {
+		static_assert(Material::REND < T && T < Material::END, "Invalid material.");
+
+		const Spec& s = spec[T];
+
+		return LoadBitmap<T>(f, s.transparent);
+	}
 }
 
 std::vector<uint8_t> Cache::exfont_custom;
 
-#define cache(elem) \
-	BitmapRef Cache::elem(const std::string& f) { \
-		bool trans = spec[Material::elem].transparent; \
-		return LoadBitmap<Material::elem>(f, trans); \
-	}
-	cache(Backdrop)
-	cache(Battle)
-	cache(Battle2)
-	cache(Battlecharset)
-	cache(Battleweapon)
-	cache(Charset)
-	cache(Chipset)
-	cache(Faceset)
-	cache(Gameover)
-	cache(Monster)
-	cache(Panorama)
-	cache(System2)
-	cache(Title)
-	cache(System)
-#undef cache
-
-BitmapRef Cache::Frame(const std::string& f, bool trans) {
-	return LoadBitmap<Material::Frame>(f, trans);
+BitmapRef Cache::Backdrop(const std::string& file) {
+	return LoadBitmap<Material::Backdrop>(file);
 }
 
-BitmapRef Cache::Picture(const std::string& f, bool trans) {
-	return LoadBitmap<Material::Picture>(f, trans);
+BitmapRef Cache::Battle(const std::string& file) {
+	return LoadBitmap<Material::Battle>(file);
+}
+
+BitmapRef Cache::Battle2(const std::string& file) {
+	return LoadBitmap<Material::Battle2>(file);
+}
+
+BitmapRef Cache::Battlecharset(const std::string& file) {
+	return LoadBitmap<Material::Battlecharset>(file);
+}
+
+BitmapRef Cache::Battleweapon(const std::string& file) {
+	return LoadBitmap<Material::Battleweapon>(file);
+}
+
+BitmapRef Cache::Charset(const std::string& file) {
+	return LoadBitmap<Material::Charset>(file);
+}
+
+BitmapRef Cache::Chipset(const std::string& file) {
+	return LoadBitmap<Material::Chipset>(file);
+}
+
+BitmapRef Cache::Faceset(const std::string& file) {
+	return LoadBitmap<Material::Faceset>(file);
+}
+
+BitmapRef Cache::Frame(const std::string& file, bool transparent) {
+	return LoadBitmap<Material::Frame>(file, transparent);
+}
+
+BitmapRef Cache::Gameover(const std::string& file) {
+	return LoadBitmap<Material::Gameover>(file);
+}
+
+BitmapRef Cache::Monster(const std::string& file) {
+	return LoadBitmap<Material::Monster>(file);
+}
+
+BitmapRef Cache::Panorama(const std::string& file) {
+	return LoadBitmap<Material::Panorama>(file);
+}
+
+BitmapRef Cache::Picture(const std::string& file, bool transparent) {
+	return LoadBitmap<Material::Picture>(file, transparent);
+}
+
+BitmapRef Cache::System2(const std::string& file) {
+	return LoadBitmap<Material::System2>(file);
+}
+
+BitmapRef Cache::Title(const std::string& file) {
+	return LoadBitmap<Material::Title>(file);
+}
+
+BitmapRef Cache::System(const std::string& file) {
+	return LoadBitmap<Material::System>(file);
 }
 
 BitmapRef Cache::Exfont() {
-	KeyType const hash("ExFont", "ExFont", false);
+	const KeyType hash("ExFont", "ExFont", false);
 
 	cache_type::iterator const it = cache.find(hash);
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -23,10 +23,13 @@
 #include <vector>
 
 #include "system.h"
-#include "color.h"
 #include "memory_management.h"
 
 #define CACHE_DEFAULT_BITMAP "\x01"
+
+class Color;
+class Rect;
+class Tone;
 
 /**
  * Cache namespace.
@@ -49,7 +52,9 @@ namespace Cache {
 	BitmapRef Title(const std::string& filename);
 	BitmapRef System(const std::string& filename);
 	BitmapRef System2(const std::string& filename);
+
 	BitmapRef Tile(const std::string& filename, int tile_id);
+	BitmapRef SpriteEffect(const BitmapRef& src_bitmap, const Rect& rect, bool flip_x, bool flip_y, const Tone& tone, const Color& blend);
 
 	void Clear();
 

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -32,15 +32,6 @@ Color::Color(uint8_t red, uint8_t green, uint8_t blue, uint8_t alpha) :
 	alpha(alpha) {
 }
 
-
-bool Color::operator==(const Color &other) const {
-	return red == other.red && green == other.green && blue == other.blue && alpha == other.alpha;
-}
-
-bool Color::operator!=(const Color &other) const {
-	return red != other.red || green != other.green || blue != other.blue || alpha != other.alpha;
-}
-
 void Color::Set(uint8_t nred, uint8_t ngreen, uint8_t nblue, uint8_t nalpha) {
 	red = nred;
 	green = ngreen;

--- a/src/color.h
+++ b/src/color.h
@@ -43,16 +43,6 @@ public:
 	Color(uint8_t red, uint8_t green, uint8_t blue, uint8_t alpha);
 
 	/**
-	 * Equality operator.
-	 */
-	bool operator==(const Color &other) const;
-
-	/**
-	 * Inequality operator.
-	 */
-	bool operator!=(const Color &other) const;
-
-	/**
 	 * Sets all color properties.
 	 *
 	 * @param red red component.
@@ -74,5 +64,23 @@ public:
 	/** Alpha component. */
 	uint8_t alpha;
 };
+
+inline bool operator==(const Color &l, const Color& r) {
+	return l.red == r.red
+		   && l.green == r.green
+		   && l.blue == r.blue
+		   && l.alpha == r.alpha;
+}
+
+inline bool operator!=(const Color &l, const Color& r) {
+	return !(l == r);
+}
+
+inline bool operator<(const Color &l, const Color& r) {
+	return l.red < r.red
+		   && l.green < r.green
+		   && l.blue < r.blue
+		   && l.alpha < r.alpha;
+}
 
 #endif

--- a/src/rect.cpp
+++ b/src/rect.cpp
@@ -32,14 +32,6 @@ Rect::Rect(int x, int y, int width, int height) :
 	height(height) {
 }
 
-bool Rect::operator==(const Rect &other) const {
-	return	x == other.x && y == other.y && width == other.width && height == other.height;
-}
-
-bool Rect::operator!=(const Rect &other) const {
-	return	x != other.x || y != other.y || width != other.width || height != other.height;
-}
-
 void Rect::Set(int new_x, int new_y, int new_width, int new_height) {
 	x = new_x;
 	y = new_y;

--- a/src/rect.h
+++ b/src/rect.h
@@ -41,16 +41,6 @@ public:
 	Rect(int x, int y, int width, int height);
 
 	/**
-	 * Equality operator.
-	 */
-	bool operator==(Rect const& other) const;
-
-	/**
-	 * Inequality operator.
-	 */
-	bool operator!=(Rect const& other) const;
-
-	/**
 	 * Sets all rect values simultaneously.
 	 *
 	 * @param x new x.
@@ -143,5 +133,23 @@ public:
 	 */
 	void Halve();
 };
+
+inline bool operator==(const Rect &l, const Rect& r) {
+	return l.x == r.x
+		   && l.y == r.y
+		   && l.width == r.width
+		   && l.height == r.height;
+}
+
+inline bool operator!=(const Rect &l, const Rect& r) {
+	return !(l == r);
+}
+
+inline bool operator<(const Rect &l, const Rect& r) {
+	return l.x < r.x
+		   && l.y < r.y
+		   && l.width < r.width
+		   && l.height < r.height;
+}
 
 #endif

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -52,7 +52,6 @@ Sprite::Sprite() :
 	waver_effect_phase(0.0),
 	flash_effect(Color(0,0,0,0)),
 	bitmap_effects_src_rect(Rect()),
-	bitmap_effects_valid(false),
 
 	current_tone(Tone()),
 	current_flash(Color(0,0,0,0)),
@@ -111,7 +110,7 @@ BitmapRef Sprite::Refresh(Rect& rect) {
 		// but even without this will catch most of the cases
 		if (Rect(x - ox, y - oy, GetWidth(), GetHeight()).IsOutOfBounds(Rect(0, 0, SCREEN_TARGET_WIDTH, SCREEN_TARGET_HEIGHT))) {
 			return BitmapRef();
-		};
+		}
 	}
 
 	rect.Adjust(bitmap->GetWidth(), bitmap->GetHeight());
@@ -127,21 +126,13 @@ BitmapRef Sprite::Refresh(Rect& rect) {
 	bool effects_rect_changed = rect != bitmap_effects_src_rect;
 
 	if (effects_changed || effects_rect_changed || bitmap_changed) {
-		bitmap_effects_valid = false;
+		bitmap_effects.reset();
 	}
 
 	if (no_effects)
 		return bitmap;
-
-	if (bitmap_effects && bitmap_effects_valid)
+	else if (bitmap_effects)
 		return bitmap_effects;
-
-	BitmapRef src_bitmap;
-
-	if (no_effects)
-		src_bitmap = bitmap;
-	else if (bitmap_effects_valid)
-		src_bitmap = bitmap_effects;
 	else {
 		current_tone = tone_effect;
 		current_flash = flash_effect;
@@ -149,9 +140,9 @@ BitmapRef Sprite::Refresh(Rect& rect) {
 		current_flip_y = flipy_effect;
 
 		if (bitmap_effects &&
-			bitmap_effects->GetWidth() < rect.x + rect.width &&
-			bitmap_effects->GetHeight() < rect.y + rect.height) {
-		bitmap_effects.reset();
+				bitmap_effects->GetWidth() < rect.x + rect.width &&
+				bitmap_effects->GetHeight() < rect.y + rect.height) {
+			bitmap_effects.reset();
 		}
 
 		if (!bitmap_effects)
@@ -183,12 +174,9 @@ BitmapRef Sprite::Refresh(Rect& rect) {
 		}
 
 		bitmap_effects_src_rect = rect;
-		bitmap_effects_valid = true;
 
-		src_bitmap = bitmap_effects;
+		return bitmap_effects;
 	}
-
-	return src_bitmap;
 }
 
 int Sprite::GetWidth() const {

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -105,8 +105,9 @@ void Sprite::BlitScreenIntern(Bitmap const& draw_bitmap,
 }
 
 BitmapRef Sprite::Refresh(Rect& rect) {
-	if (zoom_x_effect != 1.0 && zoom_y_effect != 1.0 && angle_effect != 0.0 && waver_effect_depth != 0) {
-		// TODO: Out of bounds check adjustments for zoom, angle and waver
+	if (zoom_x_effect == 1.0 && zoom_y_effect == 1.0 && angle_effect == 0.0 && waver_effect_depth == 0) {
+		// Prevent effect sprite creation when not in the viewport
+		// TODO: Out of bounds math adjustments for zoom, angle and waver
 		// but even without this will catch most of the cases
 		if (Rect(x - ox, y - oy, GetWidth(), GetHeight()).IsOutOfBounds(Rect(0, 0, SCREEN_TARGET_WIDTH, SCREEN_TARGET_HEIGHT))) {
 			return BitmapRef();

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -79,14 +79,20 @@ void Sprite::BlitScreen() {
 	if (!bitmap || (opacity_top_effect <= 0 && opacity_bottom_effect <= 0))
 		return;
 
-	Rect rect = src_rect_effect.GetSubRect(src_rect);
-
-	BitmapRef draw_bitmap = Refresh(rect);
+	BitmapRef draw_bitmap = Refresh(src_rect_effect);
 
 	bitmap_changed = false;
 	needs_refresh = false;
 
 	if (draw_bitmap) {
+		Rect rect = src_rect_effect.GetSubRect(src_rect);
+		if (draw_bitmap == bitmap_effects) {
+			// When a "sprite rect" (src_rect_effect) is used bitmap_effects
+			// only has the size of this subrect instead of the whole bitmap
+			rect.x %= bitmap_effects->GetWidth();
+			rect.y %= bitmap_effects->GetHeight();
+		}
+
 		BlitScreenIntern(*draw_bitmap, rect, bush_effect);
 	}
 }

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -124,7 +124,6 @@ private:
 	BitmapRef bitmap_effects;
 
 	Rect bitmap_effects_src_rect;
-	bool bitmap_effects_valid;
 
 	Tone current_tone;
 	Color current_flash;

--- a/src/tone.h
+++ b/src/tone.h
@@ -79,5 +79,11 @@ inline bool operator!=(const Tone &l, const Tone& r) {
 	return !(l == r);
 }
 
+inline bool operator<(const Tone &l, const Tone& r) {
+	return l.red < r.red
+		   && l.green < r.green
+		   && l.blue < r.blue
+		   && l.gray < r.gray;
+}
 
 #endif


### PR DESCRIPTION
not ready yet, have strange flickering.

Improved the caching strategy, before our Cache was unlimited and never cleared any recently (<5s) used assets. Now the clear is forced when the memory usage is 10 MB (+3 MB SE).

Which means the memory foodprint is in simple games (havn't used the MSVC memory profiler yet) ~20 MB plus Database. 

Besides reduced memory usage the effect cache should also help in some situations to make the effect faster because tone & flash are only calculated once now per same charset.

Related #1177