### PR TITLE
Fix foreground exec order (temporary workaround)

### DIFF
--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -55,6 +55,7 @@ public:
 	int GetLoopCount() const;
 	bool ReachedLoopLimit() const;
 	void Update(bool reset_loop_count=true);
+	bool IsRunningMapEvent() const;
 
 	void Setup(
 			const std::vector<RPG::EventCommand>& _list,
@@ -242,6 +243,10 @@ protected:
 
 inline int Game_Interpreter::GetLoopCount() const {
 	return loop_count;
+}
+
+inline bool Game_Interpreter::IsRunningMapEvent() const {
+	return event_id != 0;
 }
 
 #endif

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -915,6 +915,10 @@ static bool RunNextForegroundMapEvent(Game_Interpreter_Map& interp) {
 	Game_Event* run_ev = nullptr;
 	for (auto& ev: events) {
 		if (ev.IsWaitingForegroundExecution()) {
+			if (!ev.IsActive()) {
+				ev.ClearWaitingForegroundExecution();
+				continue;
+			}
 			run_ev = &ev;
 			break;
 		}
@@ -924,13 +928,9 @@ static bool RunNextForegroundMapEvent(Game_Interpreter_Map& interp) {
 		return false;
 	}
 
-	if (run_ev->IsActive()) {
-		interp.Setup(run_ev);
-	}
+	interp.Setup(run_ev);
 	run_ev->ClearWaitingForegroundExecution();
-	if (run_ev->IsActive()) {
-		interp.Update(false);
-	}
+	interp.Update(false);
 	return true;
 }
 


### PR DESCRIPTION
Map and Common events take turns executing
in the foreground.

Fixes the game bug in #1761 and most of the test cases 

Proper solution is in #1779 