### PR TITLE
Battle animation sprites affect by screen flash

### DIFF
--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -59,6 +59,13 @@ DrawableType BattleAnimation::GetType() const {
 }
 
 void BattleAnimation::Update() {
+	auto flash_color = Main_Data::game_screen->GetFlashColor();
+	if (flash_color.alpha > 0) {
+		Sprite::Flash(flash_color, 0);
+	} else {
+		Sprite::Flash(Color(), 0);
+	}
+
 	Sprite::Update();
 
 	if (frame_update) {


### PR DESCRIPTION
All this flash sprite stuff is due for a larger refactor, we need to remove that quad and flash the sprites individually. 

That will be a 6.2 thing. I'm putting this one in to fix #985 for 6.1

~~Depends on #1772~~
Fix #985