### PR TITLE
Amendment for "Cache improvements and effect caching"

### DIFF
--- a/src/color.h
+++ b/src/color.h
@@ -18,8 +18,8 @@
 #ifndef EP_COLOR_H
 #define EP_COLOR_H
 
-// Headers
-#include "system.h"
+#include <cstdint>
+#include <tuple>
 
 /**
  * Color class.
@@ -77,10 +77,9 @@ inline bool operator!=(const Color &l, const Color& r) {
 }
 
 inline bool operator<(const Color &l, const Color& r) {
-	return l.red < r.red
-		   && l.green < r.green
-		   && l.blue < r.blue
-		   && l.alpha < r.alpha;
+	return
+		std::tie(l.red, l.green, l.blue, l.alpha) <
+		std::tie(r.red, r.green, r.blue, r.alpha);
 }
 
 #endif

--- a/src/fps_overlay.h
+++ b/src/fps_overlay.h
@@ -21,6 +21,7 @@
 #include <deque>
 #include <string>
 #include "drawable.h"
+#include "memory_management.h"
 #include "rect.h"
 
 /**

--- a/src/message_overlay.h
+++ b/src/message_overlay.h
@@ -22,6 +22,7 @@
 #include <string>
 #include "color.h"
 #include "drawable.h"
+#include "memory_management.h"
 #include "tone.h"
 
 class MessageOverlayItem {

--- a/src/rect.h
+++ b/src/rect.h
@@ -18,7 +18,7 @@
 #ifndef EP_RECT_H
 #define EP_RECT_H
 
-#include "system.h"
+#include <tuple>
 
 /**
  * Rect.
@@ -146,10 +146,9 @@ inline bool operator!=(const Rect &l, const Rect& r) {
 }
 
 inline bool operator<(const Rect &l, const Rect& r) {
-	return l.x < r.x
-		   && l.y < r.y
-		   && l.width < r.width
-		   && l.height < r.height;
+	return
+		std::tie(l.x, l.y, l.width, l.height) <
+		std::tie(r.x, r.y, r.width, r.height);
 }
 
 #endif

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -21,6 +21,7 @@
 // Headers
 #include "color.h"
 #include "drawable.h"
+#include "memory_management.h"
 #include "rect.h"
 #include "tone.h"
 

--- a/src/tone.h
+++ b/src/tone.h
@@ -18,6 +18,8 @@
 #ifndef EP_TONE_H
 #define EP_TONE_H
 
+#include <tuple>
+
 /**
  * Tone class.
  */
@@ -80,10 +82,9 @@ inline bool operator!=(const Tone &l, const Tone& r) {
 }
 
 inline bool operator<(const Tone &l, const Tone& r) {
-	return l.red < r.red
-		   && l.green < r.green
-		   && l.blue < r.blue
-		   && l.gray < r.gray;
+	return
+		std::tie(l.red, l.green, l.blue, l.gray) <
+		std::tie(r.red, r.green, r.blue, r.gray);
 }
 
 #endif


### PR DESCRIPTION
I failed to implement operator "<" correctly... this breaks the cache lookup and picks incorrect assets in some cases resulting in wrong colors. It uses now std::tie from tuple which is constexpr and offloads the proper operator implementation to the std.

Noticed this in Vampires Dawn, while testing the memory usage :/.
Didn't happen in Yume2kki, hmpf.

Removed system.h include from these files, requires including memory_management now in some.
