### PR TITLE
 Correct autostart events execution order

### DIFF
--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -385,7 +385,8 @@ bool Game_Battle::UpdateEvents() {
 
 	for (const auto& page : troop->pages) {
 		if (page_can_run[page.ID - 1]) {
-			interpreter->Setup(page.event_commands, 0);
+			interpreter->Clear();
+			interpreter->Push(page.event_commands, 0);
 			page_can_run[page.ID - 1] = false;
 			page_executed[page.ID - 1] = true;
 			return false;

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -40,7 +40,8 @@ void Game_CommonEvent::SetSaveData(const RPG::SaveEventExecState& data) {
 void Game_CommonEvent::Update() {
 	if (interpreter && IsWaitingBackgroundExecution()) {
 		if (!interpreter->IsRunning()) {
-			interpreter->Setup(this, 0);
+			interpreter->Clear();
+			interpreter->Push(this);
 		}
 		interpreter->Update();
 	}

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -504,7 +504,8 @@ void Game_Event::Update() {
 	if (GetTrigger() == RPG::EventPage::Trigger_parallel) {
 		assert(interpreter != nullptr);
 		if (!interpreter->IsRunning()) {
-			interpreter->Setup(this);
+			interpreter->Clear();
+			interpreter->Push(this);
 		}
 		interpreter->Update();
 

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -57,15 +57,14 @@ public:
 	int GetLoopCount() const;
 	bool ReachedLoopLimit() const;
 	void Update(bool reset_loop_count=true);
-	bool IsRunningMapEvent() const;
 
-	void Setup(
+	void Push(
 			const std::vector<RPG::EventCommand>& _list,
 			int _event_id,
 			bool started_by_decision_key = false
 	);
-	void Setup(Game_Event* ev);
-	void Setup(Game_CommonEvent* ev, int caller_id);
+	void Push(Game_Event* ev);
+	void Push(Game_CommonEvent* ev);
 
 	void InputButton();
 	void SetupChoices(const std::vector<std::string>& choices);
@@ -285,10 +284,6 @@ inline int Game_Interpreter::GetOriginalEventId() const {
 
 inline int Game_Interpreter::GetLoopCount() const {
 	return loop_count;
-}
-
-inline bool Game_Interpreter::IsRunningMapEvent() const {
-	return GetOriginalEventId() != 0;
 }
 
 #endif

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -91,20 +91,7 @@ bool Game_Interpreter_Battle::CommandCallCommonEvent(RPG::EventCommand const& co
 		return true;
 	}
 
-	if ((int)_state.stack.size() > call_stack_limit) {
-		Output::Error("Call Event limit (%d) has been exceeded", call_stack_limit);
-	}
-
-	RPG::SaveEventExecFrame new_frame;
-
-	new_frame.ID = _state.stack.size() + 1;
-	new_frame.commands = common_event->GetList();
-	new_frame.current_command = 0;
-	new_frame.event_id = 0;
-
-	if (!new_frame.commands.empty()) {
-		_state.stack.push_back(new_frame);
-	}
+	Push(common_event);
 
 	return true;
 }

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -611,6 +611,8 @@ namespace Game_Map {
 	int GetTargetPanX();
 	int GetTargetPanY();
 
+	void UpdateForegroundEvents();
+
 	FileRequestAsync* RequestMap(int map_id);
 
 	namespace Parallax {


### PR DESCRIPTION
If both a common event and a map event are autostart and can
run on the current frame, RPG_RT will push both of them onto
the stack and execute the interpreter. This is very similar to
as if the common event called the map event.

* Rename Setup() to Push()
* Explicitly call Clear() before pushing
* Change CommandEnd() to pop the
  stack instead of just clearing commands.
* Change IsRunning() to just check for empty stack.

~~Depends on: #1740~~
Fix: #1761 all test cases