### PR TITLE
Implement fully async transitions

### DIFF
--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -125,7 +125,13 @@ void Game_Battle::Quit() {
 
 void Game_Battle::Update() {
 	interpreter->Update();
+	if (interpreter->IsAsyncPending()) {
+		terminate = true;
+		return;
+	}
+
 	Main_Data::game_screen->Update();
+
 	spriteset->Update();
 	if (animation) {
 		animation->Update();

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -37,14 +37,21 @@ void Game_CommonEvent::SetSaveData(const RPG::SaveEventExecState& data) {
 	}
 }
 
-void Game_CommonEvent::Update() {
+bool Game_CommonEvent::Update() {
 	if (interpreter && IsWaitingBackgroundExecution()) {
 		if (!interpreter->IsRunning()) {
 			interpreter->Clear();
 			interpreter->Push(this);
 		}
 		interpreter->Update();
+
+		// Suspend due to async op ...
+		if (interpreter->IsAsyncPending()) {
+			return false;
+		}
 	}
+
+	return true;
 }
 
 int Game_CommonEvent::GetIndex() const {

--- a/src/game_commonevent.h
+++ b/src/game_commonevent.h
@@ -46,8 +46,10 @@ public:
 
 	/**
 	 * Updates common event parallel interpreter.
+	 *
+	 * @return false if we must suspend due to an async operation.
 	 */
-	void Update();
+	bool Update();
 
 	/**
 	 * Gets common event index.
@@ -99,6 +101,9 @@ public:
 	/** @return true if waiting for background execution */
 	bool IsWaitingBackgroundExecution() const;
 
+	/** @return true if parallel event waiting for async op */
+	bool IsAsyncPending() const;
+
 private:
 	bool IsWaitingExecution(RPG::EventPage::Trigger trigger) const;
 
@@ -107,5 +112,9 @@ private:
 	/** Interpreter for parallel common events. */
 	std::unique_ptr<Game_Interpreter_Map> interpreter;
 };
+
+inline bool Game_CommonEvent::IsAsyncPending() const {
+	return interpreter && interpreter->IsAsyncPending();
+}
 
 #endif

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -491,9 +491,9 @@ void Game_Event::MoveTypeAwayFromPlayer() {
 	MoveTypeTowardsOrAwayPlayer(false);
 }
 
-void Game_Event::Update() {
+bool Game_Event::Update() {
 	if (!data()->active || page == NULL) {
-		return;
+		return true;
 	}
 
 	// RPG_RT runs the parallel interpreter everytime Update is called.
@@ -509,15 +509,20 @@ void Game_Event::Update() {
 		}
 		interpreter->Update();
 
+		// Suspend due to async op ...
+		if (interpreter->IsAsyncPending()) {
+			return false;
+		}
+
 		// RPG_RT only exits if active is false here, but not if there is
 		// no active page...
 		if (!data()->active) {
-			return;
+			return true;
 		}
 	}
 
 	if (IsProcessed()) {
-		return;
+		return true;
 	}
 	SetProcessed(true);
 
@@ -535,6 +540,7 @@ void Game_Event::Update() {
 	if (IsStopping()) {
 		CheckEventCollision();
 	}
+	return true;
 }
 
 const RPG::EventPage* Game_Event::GetPage(int page) const {

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -108,10 +108,13 @@ public:
 	/** Mark the event as waiting for execution */
 	bool SetAsWaitingForegroundExecution(bool face_hero, bool triggered_by_decision_key);
 
-	/** Update this for the current frame */
-	void Update();
+	/** 
+	 * Update this for the current frame
+	 *
+	 * @return false if we must suspend due to an async operation.
+	 */
+	bool Update();
 
-	void UpdateParallel();
 	bool AreConditionsMet(const RPG::EventPage& page);
 
 	/**
@@ -145,6 +148,7 @@ public:
 	const RPG::EventPage* GetActivePage() const;
 
 	const RPG::SaveMapEvent& GetSaveData();
+
 protected:
 	RPG::SaveMapEvent* data();
 	const RPG::SaveMapEvent* data() const;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -3084,7 +3084,6 @@ bool Game_Interpreter::CommandCallEvent(RPG::EventCommand const& com) { // code 
 
 bool Game_Interpreter::CommandReturnToTitleScreen(RPG::EventCommand const& /* com */) { // code 12510
 	Game_Temp::to_title = true;
-	SetContinuation(&Game_Interpreter::DefaultContinuation);
 	return false;
 }
 
@@ -3274,5 +3273,5 @@ bool Game_Interpreter::ContinuationEnemyEncounter(RPG::EventCommand const& /* co
 
 
 bool Game_Interpreter::IsAsyncPending() {
-	return Game_Temp::transition_processing;
+	return Game_Temp::transition_processing || Game_Temp::to_title;
 }

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -58,6 +58,8 @@ namespace {
 	static Game_Interpreter* transition_owner = nullptr;
 }
 
+bool Game_Interpreter::to_title = false;
+
 Game_Interpreter::Game_Interpreter(bool _main_flag) {
 	main_flag = _main_flag;
 
@@ -331,10 +333,6 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 						(_keyinput.wait_frames * 10) / Graphics::GetDefaultFps());
 			}
 			_keyinput.wait = false;
-		}
-
-		if (Game_Temp::to_title) {
-			break;
 		}
 
 		auto* frame = GetFrame();
@@ -3083,7 +3081,7 @@ bool Game_Interpreter::CommandCallEvent(RPG::EventCommand const& com) { // code 
 }
 
 bool Game_Interpreter::CommandReturnToTitleScreen(RPG::EventCommand const& /* com */) { // code 12510
-	Game_Temp::to_title = true;
+	to_title = true;
 	return false;
 }
 
@@ -3273,5 +3271,5 @@ bool Game_Interpreter::ContinuationEnemyEncounter(RPG::EventCommand const& /* co
 
 
 bool Game_Interpreter::IsAsyncPending() {
-	return Game_Temp::transition_processing || Game_Temp::to_title;
+	return Game_Temp::transition_processing || to_title;
 }

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -52,12 +52,6 @@
 #include "utils.h"
 #include "transition.h"
 
-namespace {
-	// Used to ensure that the interpreter that runs after a Erase/ShowScreen
-	// is the invoker of the transition
-	static Game_Interpreter* transition_owner = nullptr;
-}
-
 bool Game_Interpreter::to_title = false;
 bool Game_Interpreter::exit_game = false;
 
@@ -293,12 +287,6 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 
 		if (Game_Temp::transition_processing) {
 			break;
-		}
-
-		if (transition_owner && transition_owner != this) {
-			break;
-		} else {
-			transition_owner = nullptr;
 		}
 
 		if (_state.wait_time > 0) {
@@ -1983,7 +1971,6 @@ bool Game_Interpreter::CommandEraseScreen(RPG::EventCommand const& com) { // cod
 
 	Game_Temp::transition_processing = true;
 	Game_Temp::transition_erase = true;
-	transition_owner = this;
 
 	switch (com.parameters[0]) {
 	case -1:
@@ -2062,7 +2049,6 @@ bool Game_Interpreter::CommandShowScreen(RPG::EventCommand const& com) { // code
 
 	Game_Temp::transition_processing = true;
 	Game_Temp::transition_erase = false;
-	transition_owner = this;
 
 	switch (com.parameters[0]) {
 	case -1:

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -59,6 +59,7 @@ namespace {
 }
 
 bool Game_Interpreter::to_title = false;
+bool Game_Interpreter::exit_game = false;
 
 Game_Interpreter::Game_Interpreter(bool _main_flag) {
 	main_flag = _main_flag;
@@ -3237,12 +3238,8 @@ bool Game_Interpreter::CommandChangeBattleCommands(RPG::EventCommand const& com)
 }
 
 bool Game_Interpreter::CommandExitGame(RPG::EventCommand const& /* com */) {
-	if (Scene::Find(Scene::GameBrowser)) {
-		Scene::PopUntil(Scene::GameBrowser);
-	} else {
-		Player::exit_flag = true;
-	}
-	return true;
+	exit_game = true;
+	return false;
 }
 
 bool Game_Interpreter::CommandToggleFullscreen(RPG::EventCommand const& /* com */) {
@@ -3271,5 +3268,5 @@ bool Game_Interpreter::ContinuationEnemyEncounter(RPG::EventCommand const& /* co
 
 
 bool Game_Interpreter::IsAsyncPending() {
-	return Game_Temp::transition_processing || to_title;
+	return Game_Temp::transition_processing || to_title || exit_game;
 }

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -3272,3 +3272,7 @@ bool Game_Interpreter::ContinuationShowInnStart(RPG::EventCommand const& /* com 
 bool Game_Interpreter::ContinuationShowInnFinish(RPG::EventCommand const& /* com */) { return true; }
 bool Game_Interpreter::ContinuationEnemyEncounter(RPG::EventCommand const& /* com */) { return true; }
 
+
+bool Game_Interpreter::IsAsyncPending() {
+	return Game_Temp::transition_processing;
+}

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -92,9 +92,17 @@ public:
 	/** @return the event_id of the event at the base of the call stack */
 	int GetOriginalEventId() const;
 
+	/** @return true if any interpreter requested to return to title screen */
+	static bool GetReturnToTitle();
+
+	/** Resets the return to title flag */
+	static void ResetReturnToTitle();
+
 protected:
 	static constexpr int loop_limit = 10000;
 	static constexpr int call_stack_limit = 1000;
+
+	static bool to_title;
 
 	const RPG::SaveEventExecFrame* GetFrame() const;
 	RPG::SaveEventExecFrame* GetFrame();
@@ -287,5 +295,14 @@ inline int Game_Interpreter::GetOriginalEventId() const {
 inline int Game_Interpreter::GetLoopCount() const {
 	return loop_count;
 }
+
+inline bool Game_Interpreter::GetReturnToTitle() {
+	return to_title;
+}
+
+inline void Game_Interpreter::ResetReturnToTitle() {
+	to_title = false;
+}
+
 
 #endif

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -59,9 +59,6 @@ public:
 
 	void Update(bool reset_loop_count=true);
 
-	/** Return true if the interpreter is waiting for an async operation and needs to be resumed */
-	bool IsAsyncPending();
-
 	void Push(
 			const std::vector<RPG::EventCommand>& _list,
 			int _event_id,
@@ -91,6 +88,9 @@ public:
 
 	/** @return the event_id of the event at the base of the call stack */
 	int GetOriginalEventId() const;
+
+	/** Return true if the interpreter is waiting for an async operation and needs to be resumed */
+	static bool IsAsyncPending();
 
 	/** @return true if any interpreter requested to return to title screen */
 	static bool GetReturnToTitle();

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -98,11 +98,18 @@ public:
 	/** Resets the return to title flag */
 	static void ResetReturnToTitle();
 
+	/** @return true if any interpreter requested to return to title screen */
+	static bool GetExitGame();
+
+	/** Resets the return to title flag */
+	static void ResetExitGame();
+
 protected:
 	static constexpr int loop_limit = 10000;
 	static constexpr int call_stack_limit = 1000;
 
 	static bool to_title;
+	static bool exit_game;
 
 	const RPG::SaveEventExecFrame* GetFrame() const;
 	RPG::SaveEventExecFrame* GetFrame();
@@ -304,5 +311,12 @@ inline void Game_Interpreter::ResetReturnToTitle() {
 	to_title = false;
 }
 
+inline bool Game_Interpreter::GetExitGame() {
+	return exit_game;
+}
+
+inline void Game_Interpreter::ResetExitGame() {
+	exit_game = false;
+}
 
 #endif

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -56,7 +56,11 @@ public:
 	bool IsRunning() const;
 	int GetLoopCount() const;
 	bool ReachedLoopLimit() const;
+
 	void Update(bool reset_loop_count=true);
+
+	/** Return true if the interpreter is waiting for an async operation and needs to be resumed */
+	bool IsAsyncPending();
 
 	void Push(
 			const std::vector<RPG::EventCommand>& _list,

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -915,25 +915,10 @@ void Game_Map::Update(bool is_preupdate) {
 		}
 	}
 
-	for (Game_Event& ev : events) {
-		ev.SetProcessed(false);
-	}
-	if (!is_preupdate) {
-		Main_Data::game_player->SetProcessed(false);
-		for (auto& vehicle: vehicles) {
-			if (vehicle->IsInCurrentMap()) {
-				vehicle->SetProcessed(false);
-			}
-		}
-	}
+	UpdateProcessedFlags(is_preupdate);
 
-	for (Game_CommonEvent& ev : common_events) {
-		ev.Update();
-	}
-
-	for (Game_Event& ev : events) {
-		ev.Update();
-	}
+	UpdateCommonEvents();
+	UpdateMapEvents();
 
 	if (is_preupdate) {
 		return;
@@ -954,6 +939,32 @@ void Game_Map::Update(bool is_preupdate) {
 	UpdateForegroundEvents();
 
 	Parallax::Update();
+}
+
+void Game_Map::UpdateProcessedFlags(bool is_preupdate) {
+	for (Game_Event& ev : events) {
+		ev.SetProcessed(false);
+	}
+	if (!is_preupdate) {
+		Main_Data::game_player->SetProcessed(false);
+		for (auto& vehicle: vehicles) {
+			if (vehicle->IsInCurrentMap()) {
+				vehicle->SetProcessed(false);
+			}
+		}
+	}
+}
+
+void Game_Map::UpdateCommonEvents() {
+	for (Game_CommonEvent& ev : common_events) {
+		ev.Update();
+	}
+}
+
+void Game_Map::UpdateMapEvents() {
+	for (Game_Event& ev : events) {
+		ev.Update();
+	}
 }
 
 void Game_Map::UpdateForegroundEvents() {

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -611,6 +611,9 @@ namespace Game_Map {
 	int GetTargetPanX();
 	int GetTargetPanY();
 
+	void UpdateProcessedFlags(bool is_preupdate);
+	void UpdateCommonEvents();
+	void UpdateMapEvents();
 	void UpdateForegroundEvents();
 
 	FileRequestAsync* RequestMap(int map_id);

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -45,9 +45,12 @@ class MapUpdateAsyncContext {
 		static MapUpdateAsyncContext FromMapEvent(int ce);
 		static MapUpdateAsyncContext FromForegroundEvent();
 
-		int GetCommonEvent() const;
-		int GetMapEvent() const;
+		int GetParallelCommonEvent() const;
+		int GetParallelMapEvent() const;
+
 		bool IsForegroundEvent() const;
+		bool IsParallelCommonEvent() const;
+		bool IsParallelMapEvent() const;
 		bool IsActive() const;
 	private:
 		int common_event = 0;
@@ -722,11 +725,11 @@ inline MapUpdateAsyncContext MapUpdateAsyncContext::FromForegroundEvent() {
 	return actx;
 }
 
-inline int MapUpdateAsyncContext::GetCommonEvent() const {
+inline int MapUpdateAsyncContext::GetParallelCommonEvent() const {
 	return common_event;
 }
 
-inline int MapUpdateAsyncContext::GetMapEvent() const {
+inline int MapUpdateAsyncContext::GetParallelMapEvent() const {
 	return map_event;
 }
 
@@ -734,8 +737,17 @@ inline bool MapUpdateAsyncContext::IsForegroundEvent() const {
 	return foreground_event;
 }
 
+inline bool MapUpdateAsyncContext::IsParallelCommonEvent() const {
+	return common_event > 0;
+}
+
+inline bool MapUpdateAsyncContext::IsParallelMapEvent() const {
+	return map_event > 0;
+}
+
+
 inline bool MapUpdateAsyncContext::IsActive() const {
-	return GetCommonEvent() || GetMapEvent() || IsForegroundEvent();
+	return IsParallelCommonEvent() || IsParallelMapEvent() || IsForegroundEvent();
 }
 
 #endif

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -66,7 +66,7 @@ void Game_Player::ReserveTeleport(const RPG::SaveTarget& target) {
 		map_id = Game_Map::GetParentId(target.map_id);
 	}
 
-	ReserveTeleport(map_id, target.map_x, target.map_y, Down, TeleportTarget::eNormalTeleport);
+	ReserveTeleport(map_id, target.map_x, target.map_y, Down, TeleportTarget::eSkillTeleport);
 
 	if (target.switch_on) {
 		Game_Switches.Set(target.switch_id, true);
@@ -116,7 +116,7 @@ void Game_Player::PerformTeleport() {
 		GetVehicle()->SyncWithPlayer();
 	}
 
-	teleport_target = {};
+	ResetTeleportTarget();
 }
 
 bool Game_Player::MakeWay(int x, int y) const {

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -54,6 +54,7 @@ public:
 
 	bool IsPendingTeleport() const;
 	TeleportTarget GetTeleportTarget() const;
+	void ResetTeleportTarget();
 
 	/**
 	 * Sets the map, position and direction that the game player must have after the teleport is over
@@ -140,6 +141,10 @@ inline bool Game_Player::IsPendingTeleport() const {
 
 inline TeleportTarget Game_Player::GetTeleportTarget() const {
 	return teleport_target;
+}
+
+inline void Game_Player::ResetTeleportTarget() {
+	teleport_target = {};
 }
 
 inline void Game_Player::SetMenuCalling(bool value) {

--- a/src/game_temp.cpp
+++ b/src/game_temp.cpp
@@ -20,7 +20,6 @@
 #include "transition.h"
 
 bool Game_Temp::inn_calling;
-bool Game_Temp::to_title;
 bool Game_Temp::transition_processing;
 Transition::TransitionType Game_Temp::transition_type;
 bool Game_Temp::transition_erase;
@@ -46,7 +45,6 @@ int Game_Temp::battle_result;
 
 void Game_Temp::Init() {
 	inn_calling = false;
-	to_title = false;
 	transition_processing = false;
 	transition_type = Transition::TransitionNone;
 	transition_erase = false;

--- a/src/game_temp.h
+++ b/src/game_temp.h
@@ -34,7 +34,6 @@ public:
 	static void Init();
 
 	static bool inn_calling;
-	static bool to_title;
 
 	static bool transition_processing;
 	static Transition::TransitionType transition_type;

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -25,6 +25,7 @@
 #include "output.h"
 #include "audio.h"
 #include "transition.h"
+#include "game_interpreter.h"
 
 #ifndef NDEBUG
 #define DEBUG_VALIDATE(x) Scene::DebugValidate(x)
@@ -262,6 +263,27 @@ void Scene::DrawBackground() {
 Graphics::State &Scene::GetGraphicsState() {
 	return state;
 }
+
+bool Scene::CheckInterpreterExit() {
+	if (Game_Interpreter::GetExitGame()) {
+		Game_Interpreter::ResetExitGame();
+		if (Scene::Find(Scene::GameBrowser)) {
+			Scene::PopUntil(Scene::GameBrowser);
+		} else {
+			Player::exit_flag = true;
+		}
+		return true;
+	}
+
+	if (Game_Interpreter::GetReturnToTitle()) {
+		Game_Interpreter::ResetReturnToTitle();
+		Scene::PopUntil(Scene::Title);
+		return true;
+	}
+
+	return false;
+}
+
 
 
 inline void Scene::DebugValidate(const char* caller) {

--- a/src/scene.h
+++ b/src/scene.h
@@ -211,6 +211,11 @@ public:
 	 */
 	void SetRequestedScene(SceneType scene);
 
+	/**
+	 * Check if the interpreter wants to end the game
+	 */
+	static bool CheckInterpreterExit();
+
 protected:
 	using AsyncContinuation = std::function<void(void)>;
 	AsyncContinuation async_continuation;

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -189,6 +189,9 @@ void Scene_Battle::Update() {
 		// we need this so it can update automatically the status_window
 		status_window->Refresh();
 	}
+	if (CheckInterpreterExit()) {
+		return;
+	}
 
 	if (Game_Battle::IsTerminating()) {
 		Scene::Pop();

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -202,11 +202,6 @@ void Scene_Map::UpdateStage2() {
 }
 
 void Scene_Map::UpdateSceneCalling() {
-	if (Game_Temp::to_title) {
-		Game_Temp::to_title = false;
-		Scene::PopUntil(Scene::Title);
-	}
-
 	if (Game_Message::visible)
 		return;
 
@@ -378,6 +373,12 @@ void Scene_Map::AsyncNext(F&& f) {
 
 template <typename F>
 void Scene_Map::OnAsyncSuspend(F&& f, bool is_preupdate) {
+	if (Game_Temp::to_title) {
+		Game_Temp::to_title = false;
+		Scene::PopUntil(Scene::Title);
+		return;
+	}
+
 	if (Game_Temp::transition_processing) {
 		Graphics::GetTransition().Init(Game_Temp::transition_type, this, 32, Game_Temp::transition_erase);
 		if (!Game_Temp::transition_erase || !is_preupdate) {

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -373,19 +373,7 @@ void Scene_Map::AsyncNext(F&& f) {
 
 template <typename F>
 void Scene_Map::OnAsyncSuspend(F&& f, bool is_preupdate) {
-	if (Game_Interpreter::GetExitGame()) {
-		Game_Interpreter::ResetExitGame();
-		if (Scene::Find(Scene::GameBrowser)) {
-			Scene::PopUntil(Scene::GameBrowser);
-		} else {
-			Player::exit_flag = true;
-		}
-		return;
-	}
-
-	if (Game_Interpreter::GetReturnToTitle()) {
-		Game_Interpreter::ResetReturnToTitle();
-		Scene::PopUntil(Scene::Title);
+	if (CheckInterpreterExit()) {
 		return;
 	}
 

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -373,8 +373,8 @@ void Scene_Map::AsyncNext(F&& f) {
 
 template <typename F>
 void Scene_Map::OnAsyncSuspend(F&& f, bool is_preupdate) {
-	if (Game_Temp::to_title) {
-		Game_Temp::to_title = false;
+	if (Game_Interpreter::GetReturnToTitle()) {
+		Game_Interpreter::ResetReturnToTitle();
 		Scene::PopUntil(Scene::Title);
 		return;
 	}

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -373,6 +373,16 @@ void Scene_Map::AsyncNext(F&& f) {
 
 template <typename F>
 void Scene_Map::OnAsyncSuspend(F&& f, bool is_preupdate) {
+	if (Game_Interpreter::GetExitGame()) {
+		Game_Interpreter::ResetExitGame();
+		if (Scene::Find(Scene::GameBrowser)) {
+			Scene::PopUntil(Scene::GameBrowser);
+		} else {
+			Player::exit_flag = true;
+		}
+		return;
+	}
+
 	if (Game_Interpreter::GetReturnToTitle()) {
 		Game_Interpreter::ResetReturnToTitle();
 		Scene::PopUntil(Scene::Title);

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -65,7 +65,7 @@ private:
 
 	void Start2(MapUpdateAsyncContext actx);
 
-	void StartPendingTeleport(bool use_default_transition);
+	void StartPendingTeleport(bool use_default_transition, bool no_erase);
 	void FinishPendingTeleport(bool use_default_transition, bool defer_recursive_teleports);
 	void FinishPendingTeleport2(MapUpdateAsyncContext actx, bool use_default_transition, bool defer_recursive_teleports);
 

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -78,7 +78,7 @@ private:
 	void UpdateSceneCalling();
 
 	template <typename F> void AsyncNext(F&& f);
-	template <typename F> void OnAsyncSuspend(F&& f);
+	template <typename F> void OnAsyncSuspend(F&& f, bool is_preupdate);
 
 	std::unique_ptr<Window_Message> message_window;
 

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -55,8 +55,8 @@ public:
 	std::unique_ptr<Spriteset_Map> spriteset;
 
 private:
-	void StartPendingTeleport();
-	void FinishPendingTeleport();
+	void StartPendingTeleport(bool use_default_transition);
+	void FinishPendingTeleport(bool use_default_transition);
 	void PreUpdate();
 	// Handles event requested transitions.
 	void UpdateStage2();
@@ -68,8 +68,6 @@ private:
 
 	int debug_menuoverwrite_counter = 0;
 	bool from_save;
-	// Teleport from new game or Teleport / Escape skill from menu.
-	bool teleport_from_other_scene = false;
 	bool screen_erased_by_event = false;
 };
 

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -23,6 +23,7 @@
 #include "spriteset_map.h"
 #include "window_message.h"
 #include "window_varlist.h"
+#include "game_map.h"
 
 /**
  * Scene Map class.
@@ -55,16 +56,29 @@ public:
 	std::unique_ptr<Spriteset_Map> spriteset;
 
 private:
+	enum TeleportTransitionRule {
+		eTransitionNormal,
+		eTransitionFade,
+		eTransitionForceFade,
+		eTransitionNone
+	};
+
+	void Start2(MapUpdateAsyncContext actx);
+
 	void StartPendingTeleport(bool use_default_transition);
 	void FinishPendingTeleport(bool use_default_transition, bool defer_recursive_teleports);
-	void PreUpdate();
-	// Handles event requested transitions.
-	void UpdateStage2();
+	void FinishPendingTeleport2(MapUpdateAsyncContext actx, bool use_default_transition, bool defer_recursive_teleports);
+
+	void PreUpdate(MapUpdateAsyncContext& actx);
+
+	// Calls map update
+	void UpdateStage1(MapUpdateAsyncContext actx);
 	// Handles pending teleport and scene changes.
-	void UpdateStage3();
+	void UpdateStage2();
 	void UpdateSceneCalling();
 
 	template <typename F> void AsyncNext(F&& f);
+	template <typename F> void OnAsyncSuspend(F&& f);
 
 	std::unique_ptr<Window_Message> message_window;
 

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -64,6 +64,8 @@ private:
 	void UpdateStage3();
 	void UpdateSceneCalling();
 
+	template <typename F> void AsyncNext(F&& f);
+
 	std::unique_ptr<Window_Message> message_window;
 
 	int debug_menuoverwrite_counter = 0;

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -56,7 +56,7 @@ public:
 
 private:
 	void StartPendingTeleport(bool use_default_transition);
-	void FinishPendingTeleport(bool use_default_transition);
+	void FinishPendingTeleport(bool use_default_transition, bool defer_recursive_teleports);
 	void PreUpdate();
 	// Handles event requested transitions.
 	void UpdateStage2();

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -75,6 +75,7 @@ private:
 	void UpdateStage1(MapUpdateAsyncContext actx);
 	// Handles pending teleport and scene changes.
 	void UpdateStage2();
+
 	void UpdateSceneCalling();
 
 	template <typename F> void AsyncNext(F&& f);

--- a/src/teleport_target.h
+++ b/src/teleport_target.h
@@ -29,6 +29,8 @@ class TeleportTarget {
 		enum Type {
 			/** A normal teleport action */
 			eNormalTeleport,
+			/** An escape or teleport skill */
+			eSkillTeleport,
 			/** A hacky teleport from a SetVehicleLocation() (RPG_RT bug) */
 			eVehicleHackTeleport,
 		};


### PR DESCRIPTION
~~Depends on #1782~~
~~Depends on #1779~~

Fix: #1783
Fix: #1787 
Fix: #1819 
Part of fixing #1261 

This PR implements fully asynchronous transitions which correctly suspend and resume the `Game_Map::Update()` loop. Supports suspending and resuming common events, map events, and foreground events.

Also support the various graphical and timing behaviors of transitions done during pre-update.