### PR TITLE
Fix erased by event logic on show screen during preupdate

### DIFF
--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -313,6 +313,11 @@ void Scene_Map::FinishPendingTeleport() {
 	PreUpdate();
 	// FIXME: Handle transitions requested on the preupdate frame after a teleport!
 	if (Game_Temp::transition_processing) {
+		// Show screen command allows screen to be visible from normal transitions, even
+		// though currently we don't emulate the actual transition caused by it.
+		if (!Game_Temp::transition_erase) {
+			screen_erased_by_event = false;
+		}
 		Game_Temp::transition_processing = false;
 		Game_Temp::transition_erase = false;
 		Game_Temp::transition_type = Transition::TransitionNone;


### PR DESCRIPTION
We don't yet emulate transitions that happen on preupdate,
but we should disable the erased by screen flag so that normal
fade in and out still works.

Fix: #1802