### PR TITLE
Fix 1594

### DIFF
--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -840,10 +840,15 @@ FileFinder::Directory FileFinder::GetDirectoryMembers(const std::string& path, F
 			result.files[ReaderUtil::Normalize(MakePath(parent, name))] = MakePath(parent, name);
 			continue;
 		}
+		std::string name_norm = ReaderUtil::Normalize(name);
 		if (is_directory) {
-			result.directories[ReaderUtil::Normalize(name)] = name;
+			if (result.directories.find(name_norm) != result.directories.end()) {
+				Output::Warning("This game provides the folder \"%s\" twice.", name.c_str());
+				Output::Warning("This can lead to file not found errors. Merge the directories manually in a file browser."); 
+			}
+			result.directories[name_norm] = name;
 		} else {
-			result.files[ReaderUtil::Normalize(name)] = name;
+			result.files[name_norm] = name;
 		}
 	}
 

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -278,12 +278,18 @@ void FileFinder::SetDirectoryTree(std::shared_ptr<DirectoryTree> directory_tree)
 	game_directory_tree = directory_tree;
 }
 
-std::shared_ptr<FileFinder::DirectoryTree> FileFinder::CreateDirectoryTree(const std::string& p, bool recursive) {
+std::shared_ptr<FileFinder::DirectoryTree> FileFinder::CreateDirectoryTree(const std::string& p, Mode mode) {
 	if(! (Exists(p) && IsDirectory(p))) { return std::shared_ptr<DirectoryTree>(); }
 	std::shared_ptr<DirectoryTree> tree = std::make_shared<DirectoryTree>();
 	tree->directory_path = p;
 
-	Directory mem = GetDirectoryMembers(tree->directory_path, ALL);
+	bool recursive = false;
+	if (mode == RECURSIVE) {
+		mode = ALL;
+		recursive = true;
+	}
+
+	Directory mem = GetDirectoryMembers(tree->directory_path, mode);
 	for (auto& i : mem.files) {
 		tree->files[i.first] = i.second;
 	}
@@ -844,7 +850,7 @@ FileFinder::Directory FileFinder::GetDirectoryMembers(const std::string& path, F
 		if (is_directory) {
 			if (result.directories.find(name_norm) != result.directories.end()) {
 				Output::Warning("This game provides the folder \"%s\" twice.", name.c_str());
-				Output::Warning("This can lead to file not found errors. Merge the directories manually in a file browser."); 
+				Output::Warning("This can lead to file not found errors. Merge the directories manually in a file browser.");
 			}
 			result.directories[name_norm] = name;
 		} else {

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -269,7 +269,7 @@ namespace FileFinder {
 	 */
 	const std::shared_ptr<DirectoryTree> GetDirectoryTree();
 	const std::shared_ptr<DirectoryTree> CreateSaveDirectoryTree();
-	std::shared_ptr<DirectoryTree> CreateDirectoryTree(std::string const& p, bool recursive = true);
+	std::shared_ptr<DirectoryTree> CreateDirectoryTree(std::string const& p, Mode mode = RECURSIVE);
 
 	bool IsValidProject(DirectoryTree const& dir);
 	bool IsRPG2kProject(DirectoryTree const& dir);

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -62,7 +62,7 @@ void Scene_Logo::Update() {
 		}
 #endif
 
-		std::shared_ptr<FileFinder::DirectoryTree> tree = FileFinder::CreateDirectoryTree(Main_Data::GetProjectPath(), false);
+		std::shared_ptr<FileFinder::DirectoryTree> tree = FileFinder::CreateDirectoryTree(Main_Data::GetProjectPath(), FileFinder::FILES);
 
 		if (!tree) {
 			Output::Error("%s is not a valid path", Main_Data::GetProjectPath().c_str());

--- a/src/window_gamelist.cpp
+++ b/src/window_gamelist.cpp
@@ -29,23 +29,23 @@ Window_GameList::Window_GameList(int ix, int iy, int iwidth, int iheight) :
 }
 
 void Window_GameList::Refresh() {
-	tree = FileFinder::CreateDirectoryTree(Main_Data::GetProjectPath(), false);
+	tree = FileFinder::CreateDirectoryTree(Main_Data::GetProjectPath(), FileFinder::DIRECTORIES);
 	game_directories.clear();
 
 	// Find valid game diectories
 	for (auto dir : tree.get()->directories) {
-		std::shared_ptr<FileFinder::DirectoryTree> subtree = FileFinder::CreateDirectoryTree(FileFinder::MakePath(Main_Data::GetProjectPath(), dir.second), false);
+		std::shared_ptr<FileFinder::DirectoryTree> subtree = FileFinder::CreateDirectoryTree(FileFinder::MakePath(Main_Data::GetProjectPath(), dir.second), FileFinder::FILES);
 		if (FileFinder::IsValidProject(*subtree)) {
 			game_directories.push_back(dir.second);
 		}
 	}
-	
+
 	// Sort game list in place
 	std::sort(game_directories.begin(), game_directories.end(),
 			  [](const std::string& s, const std::string& s2) {
 				  return strcmp(Utils::LowerCase(s).c_str(), Utils::LowerCase(s2).c_str()) <= 0;
 			  });
-	
+
 	if (HasValidGames()) {
 		item_max = game_directories.size();
 
@@ -67,7 +67,7 @@ void Window_GameList::Refresh() {
 void Window_GameList::DrawItem(int index) {
 	Rect rect = GetItemRect(index);
 	contents->ClearRect(rect);
-	
+
 	std::string text;
 
 	if (HasValidGames()) {


### PR DESCRIPTION
Warn when a game folder contains folders that map to the same directory after normalizing+lowercasing.

The first commit is basicly the proposed patch by c1, just with the additional list removed.

The second commit fixes the two defects (by using FILES that skips directories which is enough to decide whether a folder is a RPG Maker project):

* displays the message twice upon game load
* displays message when game list is read from game browser

Fix #1594