### PR TITLE
Add support for calling events from debug scene + Code Refactor

### DIFF
--- a/src/scene_debug.h
+++ b/src/scene_debug.h
@@ -69,17 +69,29 @@ private:
 	enum Mode {
 		eMain,
 		eSwitch,
+		eSwitchSelect,
 		eVariable,
+		eVariableSelect,
+		eVariableValue,
 		eGold,
 		eItem,
+		eItemSelect,
+		eItemValue,
 		eBattle,
+		eBattleSelect,
 		eMap,
+		eMapSelect,
 		eMapX,
 		eMapY,
-		eFullHeal
+		eFullHeal,
 	};
 	/** Current variables being displayed (Switches or Integers). */
 	Mode mode = eMain;
+
+	struct PrevIndex;
+	struct IndexSet;
+
+	static PrevIndex prev;
 
 	/** Current Page being displayed */
 	int range_page = 0;
@@ -98,6 +110,36 @@ private:
 	/** Get the last page for the current mode */
 	int GetLastPage();
 
+	void SetupListOption(Mode mode, Window_VarList::Mode winmode, const IndexSet& idx);
+	void UseRangeWindow();
+	void UseVarWindow();
+	void UseNumberWindow();
+
+	void EnterFromMain();
+	void EnterFromListOption(Mode m, const IndexSet& idx);
+	void EnterFromListOptionToValue(Mode m, int init_value, int digits, bool show_operator);
+
+	void EnterGold();
+	void EnterMapSelectX();
+	void EnterMapSelectY();
+	void EnterFullHeal();
+
+	void CancelListOption(IndexSet& idx, int from_idx);
+	void CancelListOptionSelect(Mode m, IndexSet& idx);
+	void CancelListOptionValue(Mode m);
+
+	void CancelMapSelectY();
+
+	void ReturnToMain(int from_idx);
+
+	void DoSwitch();
+	void DoVariable();
+	void DoGold();
+	void DoItem();
+	void DoBattle();
+	void DoMap();
+	void DoFullHeal();
+
 	/** Displays a range selection for mode. */
 	std::unique_ptr<Window_Command> range_window;
 	/** Displays the vars inside the current range. */
@@ -108,6 +150,7 @@ private:
 	int pending_map_id = 0;
 	int pending_map_x = 0;
 	int pending_map_y = 0;
+
 };
 
 #endif

--- a/src/scene_debug.h
+++ b/src/scene_debug.h
@@ -84,6 +84,8 @@ private:
 		eMapX,
 		eMapY,
 		eFullHeal,
+		eCallEvent,
+		eCallEventSelect
 	};
 	/** Current variables being displayed (Switches or Integers). */
 	Mode mode = eMain;
@@ -139,6 +141,7 @@ private:
 	void DoBattle();
 	void DoMap();
 	void DoFullHeal();
+	void DoCallEvent();
 
 	/** Displays a range selection for mode. */
 	std::unique_ptr<Window_Command> range_window;

--- a/src/window_varlist.cpp
+++ b/src/window_varlist.cpp
@@ -78,6 +78,7 @@ void Window_VarList::DrawItemValue(int index){
 		case eTroop:
 		case eMap:
 		case eHeal:
+		case eCommonEvent:
 			{
 				DrawItem(index, Font::ColorDefault);
 				contents->TextDraw(GetWidth() - 16, 16 * index + 2, Font::ColorDefault, "", Text::AlignRight);
@@ -132,6 +133,10 @@ void Window_VarList::UpdateList(int first_value){
 					auto* actor = Main_Data::game_party->GetActors()[first_value + i-2];
 					ss << actor->GetName() << " " << actor->GetHp() << " / " << actor->GetMaxHp();
 				}
+				break;
+			case eCommonEvent:
+				ss << ReaderUtil::GetElement(Data::commonevents, first_value+i)->name;
+				break;
 			default:
 				break;
 		}
@@ -175,6 +180,8 @@ bool Window_VarList::DataIsValid(int range_index) {
 			return range_index > 0 && range_index <= (Data::treemap.maps.size() > 0 ? Data::treemap.maps.back().ID : 0);
 		case eHeal:
 			return range_index > 0 && range_index <= Main_Data::game_party->GetActors().size() + 1;
+		case eCommonEvent:
+			return range_index > 0 && range_index <= Data::commonevents.size();
 		default:
 			break;
 	}

--- a/src/window_varlist.h
+++ b/src/window_varlist.h
@@ -32,6 +32,7 @@ public:
 		eTroop,
 		eMap,
 		eHeal,
+		eCommonEvent,
 	};
 
 	/**


### PR DESCRIPTION
~~Depends on: #1784~~

TBD:
- [x] Run common events on FG map interpreter
- [x] Run common events on FG battle interpreter

TBD later Pr's:

- [ ] Run common events on Parallel interpreter in map
- [ ] Run map events on FG map interpreter
- [ ] Run map events on Parallel interpreter in map
- [ ] Figure out save game incompatibility with forced parallel execution

When an event is forced onto the foreground interpreter, its like a call event was executed. This works as expected and survives saving and loading since the `forground_event_execstate.stack` will have the event commands pushed to it.

Saving and loading will break if an event is forced to run in parallel when it normally shouldn't. While we can push the event commands onto `parallel_event_execstate.stack`, there is no LSD chunk to save the fact that we want to force execution to happen even if the controlling conditions are not met (or the event trigger isn't parallel).

We could add a custom chunk for this, or just let save games break here since this is a debug feature.

