### PR TITLE
Refactor game system

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -57,6 +57,8 @@ namespace {
 	std::string system_name;
 	BitmapRef default_system;
 
+	std::string system2_name;
+
 	constexpr int cache_limit = 10 * 1024 * 1024;
 	size_t cache_size = 0;
 
@@ -498,6 +500,10 @@ void Cache::SetSystemName(std::string const& filename) {
 	system_name = filename;
 }
 
+void Cache::SetSystem2Name(std::string const& filename) {
+	system2_name = filename;
+}
+
 BitmapRef Cache::System() {
 	if (!system_name.empty()) {
 		return Cache::System(system_name);
@@ -506,5 +512,13 @@ BitmapRef Cache::System() {
 			default_system = Bitmap::Create(160, 80, false);
 		}
 		return default_system;
+	}
+}
+
+BitmapRef Cache::System2() {
+	if (!system2_name.empty()) {
+		return Cache::System2(system2_name);
+	} else {
+		return nullptr;
 	}
 }

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -508,11 +508,19 @@ BitmapRef Cache::System() {
 	if (!system_name.empty()) {
 		return Cache::System(system_name);
 	} else {
-		if (!default_system) {
-			default_system = Bitmap::Create(160, 80, false);
-		}
-		return default_system;
+		return nullptr;
 	}
+}
+
+BitmapRef Cache::SystemOrBlack() {
+	auto system = Cache::System();
+	if (system) {
+		return system;
+	}
+	if (!default_system) {
+		default_system = Bitmap::Create(160, 80, false);
+	}
+	return default_system;
 }
 
 BitmapRef Cache::System2() {

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -55,6 +55,7 @@ namespace {
 	cache_effect_type cache_effects;
 
 	std::string system_name;
+	BitmapRef default_system;
 
 	constexpr int cache_limit = 10 * 1024 * 1024;
 	size_t cache_size = 0;
@@ -501,11 +502,9 @@ BitmapRef Cache::System() {
 	if (!system_name.empty()) {
 		return Cache::System(system_name);
 	} else {
-		if (!Data::system.system_name.empty()) {
-			// Load the system file for the shadow and text color
-			return Cache::System(Data::system.system_name);
-		} else {
-			return Bitmap::Create(160, 80, false);
+		if (!default_system) {
+			default_system = Bitmap::Create(160, 80, false);
 		}
+		return default_system;
 	}
 }

--- a/src/cache.h
+++ b/src/cache.h
@@ -58,8 +58,11 @@ namespace Cache {
 
 	void Clear();
 
-	/** @return the configured system bitmap, or a default black bitmap if there is no system */
+	/** @return the configured system bitmap, or nullptr if there is no system */
 	BitmapRef System();
+
+	/** @return the configured system bitmap, or a default black bitmap if there is no system */
+	BitmapRef SystemOrBlack();
 
 	/** @return the configured system2 bitmap, or nullptr if there is no system2 */
 	BitmapRef System2();

--- a/src/cache.h
+++ b/src/cache.h
@@ -58,8 +58,14 @@ namespace Cache {
 
 	void Clear();
 
+	/** @return the configured system bitmap, or a default black bitmap if there is no system */
 	BitmapRef System();
+
+	/** @return the configured system2 bitmap, or nullptr if there is no system2 */
+	BitmapRef System2();
+
 	void SetSystemName(std::string const& filename);
+	void SetSystem2Name(std::string const& filename);
 
 	extern std::vector<uint8_t> exfont_custom;
 }

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -373,7 +373,9 @@ Rect Font::GetSize(std::string const& txt) const {
 void Font::Render(Bitmap& bmp, int const x, int const y, Bitmap const& sys, int color, char32_t code) {
 	if(color != ColorShadow) {
 		BitmapRef system = Cache::System();
-		Render(bmp, x + 1, y + 1, system->GetShadowColor(), code);
+		if (system) {
+			Render(bmp, x + 1, y + 1, system->GetShadowColor(), code);
+		}
 	}
 
 	BitmapRef bm = Glyph(code);

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -326,7 +326,7 @@ bool FTFont::check_face() {
 #endif
 
 FontRef Font::Default() {
-	return Default(Game_System::GetFontId() == 1);
+	return Default(Game_System::GetFontId() == RPG::System::Font_mincho);
 }
 
 FontRef Font::Default(bool const m) {

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1831,26 +1831,10 @@ bool Game_Interpreter::CommandChangeSystemSFX(RPG::EventCommand const& com) { //
 	return true;
 }
 
-void Game_Interpreter::OnChangeSystemGraphicReady(FileRequestResult* result) {
-	Game_System::SetSystemName(result->file);
-
-	Scene_Map* scene = (Scene_Map*)Scene::Find(Scene::Map).get();
-
-	if (!scene)
-		return;
-
-	scene->spriteset->SystemGraphicUpdated();
-}
-
 bool Game_Interpreter::CommandChangeSystemGraphics(RPG::EventCommand const& com) { // code 10680
-	FileRequestAsync* request = AsyncHandler::RequestFile("System", com.string);
-	request_id = request->Bind(&Game_Interpreter::OnChangeSystemGraphicReady, this);
-	request->SetImportantFile(true);
-	request->SetGraphicFile(true);
-	request->Start();
-
-	Game_System::SetMessageStretch((RPG::System::Stretch)com.parameters[0]);
-	Game_System::SetFontId(com.parameters[1]);
+	Game_System::SetSystemGraphic(com.string,
+			(RPG::System::Stretch)com.parameters[0],
+			(RPG::System::Font)com.parameters[1]);
 
 	return true;
 }

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -235,8 +235,6 @@ protected:
 	const std::string DecodeString(std::vector<int32_t>::const_iterator& it);
 	RPG::MoveCommand DecodeMove(std::vector<int32_t>::const_iterator& it);
 
-	void OnChangeSystemGraphicReady(FileRequestResult* result);
-
 	FileRequestBinding request_id;
 	enum class Keys {
 		eDown,

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -30,9 +30,11 @@
 #include "player.h"
 #include "reader_util.h"
 #include "scene_save.h"
+#include "scene_map.h"
 
 namespace {
 	FileRequestBinding music_request_id;
+	FileRequestBinding system_request_id;
 	std::map<std::string, FileRequestBinding> se_request_ids;
 
 	/**
@@ -196,13 +198,51 @@ void Game_System::SePlay(const RPG::Animation &animation) {
 }
 
 std::string Game_System::GetSystemName() {
-	return data.graphics_name;
+	return !data.graphics_name.empty() ?
+		data.graphics_name : Data::system.system_name;
 }
 
-void Game_System::SetSystemName(std::string const& new_system_name) {
-	data.graphics_name = new_system_name;
-	Cache::SetSystemName(new_system_name);
+static void OnChangeSystemGraphicReady(FileRequestResult* result) {
+	Cache::SetSystemName(result->file);
 	DisplayUi->SetBackcolor(Cache::System()->GetBackgroundColor());
+
+	Scene_Map* scene = (Scene_Map*)Scene::Find(Scene::Map).get();
+
+	if (!scene)
+		return;
+
+	scene->spriteset->SystemGraphicUpdated();
+}
+
+void Game_System::ReloadSystemGraphic() {
+	FileRequestAsync* request = AsyncHandler::RequestFile("System", Game_System::GetSystemName());
+	system_request_id = request->Bind(&OnChangeSystemGraphicReady);
+	request->SetImportantFile(true);
+	request->SetGraphicFile(true);
+	request->Start();
+}
+
+void Game_System::SetSystemGraphic(const std::string& new_system_name,
+		RPG::System::Stretch message_stretch,
+		RPG::System::Font font) {
+
+	bool changed = (GetSystemName() != new_system_name);
+
+	data.graphics_name = new_system_name;
+	data.message_stretch = message_stretch;
+	data.font_id = font;
+
+	if (changed) {
+		ReloadSystemGraphic();
+	}
+}
+
+void Game_System::ResetSystemGraphic() {
+	data.graphics_name = "";
+	data.message_stretch = (RPG::System::Stretch)0;
+	data.font_id = (RPG::System::Font)0;
+
+	ReloadSystemGraphic();
 }
 
 RPG::Music& Game_System::GetSystemBGM(int which) {
@@ -290,19 +330,15 @@ bool Game_System::GetAllowMenu() {
 }
 
 RPG::System::Stretch Game_System::GetMessageStretch() {
-	return (RPG::System::Stretch)data.message_stretch;
+	return static_cast<RPG::System::Stretch>(!data.graphics_name.empty()
+		? data.message_stretch
+		: Data::system.message_stretch);
 }
 
-void Game_System::SetMessageStretch(RPG::System::Stretch stretch) {
-	data.message_stretch = stretch;
-}
-
-int Game_System::GetFontId() {
-	return data.font_id;
-}
-
-void Game_System::SetFontId(int id) {
-	data.font_id = id;
+RPG::System::Font Game_System::GetFontId() {
+	return static_cast<RPG::System::Font>(!data.graphics_name.empty()
+		? data.font_id
+		: Data::system.font_id);
 }
 
 int Game_System::GetTransition(int which) {

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -204,7 +204,7 @@ const std::string& Game_System::GetSystemName() {
 
 static void OnChangeSystemGraphicReady(FileRequestResult* result) {
 	Cache::SetSystemName(result->file);
-	DisplayUi->SetBackcolor(Cache::System()->GetBackgroundColor());
+	DisplayUi->SetBackcolor(Cache::SystemOrBlack()->GetBackgroundColor());
 
 	Scene_Map* scene = (Scene_Map*)Scene::Find(Scene::Map).get();
 

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -197,7 +197,7 @@ void Game_System::SePlay(const RPG::Animation &animation) {
 	}
 }
 
-std::string Game_System::GetSystemName() {
+const std::string& Game_System::GetSystemName() {
 	return !data.graphics_name.empty() ?
 		data.graphics_name : Data::system.system_name;
 }
@@ -243,6 +243,10 @@ void Game_System::ResetSystemGraphic() {
 	data.font_id = (RPG::System::Font)0;
 
 	ReloadSystemGraphic();
+}
+
+const std::string& Game_System::GetSystem2Name() {
+	return Data::system.system2_name;
 }
 
 RPG::Music& Game_System::GetSystemBGM(int which) {

--- a/src/game_system.h
+++ b/src/game_system.h
@@ -130,7 +130,7 @@ namespace Game_System {
 	void SePlay(const RPG::Animation& animation);
 
 	/** @return system graphic filename.  */
-	std::string GetSystemName();
+	const std::string& GetSystemName();
 
 	/** @return message stretch style */
 	RPG::System::Stretch GetMessageStretch();
@@ -151,6 +151,15 @@ namespace Game_System {
 
 	/** Resets the system graphic to the default value. */
 	void ResetSystemGraphic();
+
+	/** @return the system2 graphic name */
+	const std::string& GetSystem2Name();
+
+	/** @return true if the game has a configured system graphic */
+	bool HasSystemGraphic();
+
+	/** @return true if the game has a configured system2 graphic */
+	bool HasSystem2Graphic();
 
 	/**
 	 * Gets the system music.
@@ -260,6 +269,14 @@ namespace Game_System {
 	void OnBgmReady(FileRequestResult* result);
 	void OnSeReady(FileRequestResult* result, int volume, int tempo, bool stop_sounds);
 	void ReloadSystemGraphic();
+}
+
+inline bool Game_System::HasSystemGraphic() {
+	return !GetSystemName().empty();
+}
+
+inline bool Game_System::HasSystem2Graphic() {
+	return !GetSystem2Name().empty();
 }
 
 #endif

--- a/src/game_system.h
+++ b/src/game_system.h
@@ -129,19 +129,28 @@ namespace Game_System {
 	 */
 	void SePlay(const RPG::Animation& animation);
 
-	/**
-	 * Gets system graphic name.
-	 *
-	 * @return system graphic filename.
-	 */
+	/** @return system graphic filename.  */
 	std::string GetSystemName();
+
+	/** @return message stretch style */
+	RPG::System::Stretch GetMessageStretch();
+
+	/** @return system font */
+	RPG::System::Font GetFontId();
 
 	/**
 	 * Sets the system graphic.
 	 *
 	 * @param system_name new system name.
+	 * @param message_stretch message stretch style
+	 * @param font_id The system font to use.
 	 */
-	void SetSystemName(std::string const& system_name);
+	void SetSystemGraphic(const std::string& system_name,
+			RPG::System::Stretch stretch,
+			RPG::System::Font font);
+
+	/** Resets the system graphic to the default value. */
+	void ResetSystemGraphic();
 
 	/**
 	 * Gets the system music.
@@ -241,10 +250,6 @@ namespace Game_System {
 	void SetAllowSave(bool allow);
 	bool GetAllowMenu();
 	void SetAllowMenu(bool allow);
-	RPG::System::Stretch GetMessageStretch();
-	void SetMessageStretch(RPG::System::Stretch stretch);
-	int GetFontId();
-	void SetFontId(int id);
 
 	int GetSaveCount();
 
@@ -254,6 +259,7 @@ namespace Game_System {
 
 	void OnBgmReady(FileRequestResult* result);
 	void OnSeReady(FileRequestResult* result, int volume, int tempo, bool stop_sounds);
+	void ReloadSystemGraphic();
 }
 
 #endif

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -632,10 +632,6 @@ void Player::ParseCommandLine(int argc, char *argv[]) {
 #endif
 }
 
-static void OnSystemFileReady(FileRequestResult* result) {
-	Game_System::SetSystemName(result->file);
-}
-
 void Player::CreateGameObjects() {
 	GetEncoding();
 	escape_symbol = ReaderUtil::Recode("\\", encoding);
@@ -758,13 +754,7 @@ void Player::CreateGameObjects() {
 }
 
 void Player::ResetGameObjects() {
-	if (Data::system.system_name != Game_System::GetSystemName()) {
-		FileRequestAsync* request = AsyncHandler::RequestFile("System", Data::system.system_name);
-		request->SetImportantFile(true);
-		request->SetGraphicFile(true);
-		system_request_id = request->Bind(&OnSystemFileReady);
-		request->Start();
-	}
+	Game_System::ResetSystemGraphic();
 
 	// The init order is important
 	Main_Data::Cleanup();
@@ -942,13 +932,9 @@ void Player::LoadSavegame(const std::string& save_name) {
 	save_request_id = map->Bind(&OnMapSaveFileReady);
 	map->SetImportantFile(true);
 
-	FileRequestAsync* system = AsyncHandler::RequestFile("System", Game_System::GetSystemName());
-	system->SetImportantFile(true);
-	system->SetGraphicFile(true);
-	system_request_id = system->Bind(&OnSystemFileReady);
+	Game_System::ReloadSystemGraphic();
 
 	map->Start();
-	system->Start();
 }
 
 static void OnMapFileReady(FileRequestResult*) {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -107,7 +107,16 @@ void Scene_Battle_Rpg2k3::Update() {
 }
 
 void Scene_Battle_Rpg2k3::OnSystem2Ready(FileRequestResult* result) {
-	BitmapRef system2 = Cache::System2(result->file);
+	Cache::SetSystem2Name(result->file);
+
+	SetupSystem2Graphics();
+}
+
+void Scene_Battle_Rpg2k3::SetupSystem2Graphics() {
+	BitmapRef system2 = Cache::System2();
+	if (!system2) {
+		return;
+	}
 
 	ally_cursor->SetBitmap(system2);
 	ally_cursor->SetZ(Priority_Window);
@@ -116,6 +125,8 @@ void Scene_Battle_Rpg2k3::OnSystem2Ready(FileRequestResult* result) {
 	enemy_cursor->SetBitmap(system2);
 	enemy_cursor->SetZ(Priority_Window);
 	enemy_cursor->SetVisible(false);
+
+	enemy_status_window->Refresh();
 }
 
 void Scene_Battle_Rpg2k3::CreateUi() {
@@ -154,10 +165,14 @@ void Scene_Battle_Rpg2k3::CreateUi() {
 		enemy_status_window->SetBackOpacity(transp);
 	}
 
-	FileRequestAsync* request = AsyncHandler::RequestFile("System2", Data::system.system2_name);
-	request->SetGraphicFile(true);
-	request_id = request->Bind(&Scene_Battle_Rpg2k3::OnSystem2Ready, this);
-	request->Start();
+	if (!Cache::System2() && Game_System::HasSystem2Graphic()) {
+		FileRequestAsync* request = AsyncHandler::RequestFile("System2", Game_System::GetSystem2Name());
+		request->SetGraphicFile(true);
+		request_id = request->Bind(&Scene_Battle_Rpg2k3::OnSystem2Ready, this);
+		request->Start();
+	} else {
+		SetupSystem2Graphics();
+	}
 }
 
 void Scene_Battle_Rpg2k3::UpdateCursors() {

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -77,6 +77,7 @@ public:
 
 protected:
 	void OnSystem2Ready(FileRequestResult* result);
+	void SetupSystem2Graphics();
 	void CreateUi() override;
 
 	void CreateBattleTargetWindow();

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -39,7 +39,7 @@ Scene_File::Scene_File(std::string message) :
 }
 
 static std::unique_ptr<Sprite> makeBorderSprite(int y) {
-	auto bitmap = Bitmap::Create(SCREEN_TARGET_WIDTH, 8, Cache::System()->GetBackgroundColor());
+	auto bitmap = Bitmap::Create(SCREEN_TARGET_WIDTH, 8, Cache::SystemOrBlack()->GetBackgroundColor());
 	auto sprite = std::unique_ptr<Sprite>(new Sprite());
 	sprite->SetVisible(true);
 	sprite->SetZ(Priority_Window + 1);

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -39,8 +39,7 @@ Scene_GameBrowser::Scene_GameBrowser() {
 }
 
 void Scene_GameBrowser::Start() {
-	Game_System::SetSystemName(CACHE_DEFAULT_BITMAP);
-	Game_System::SetMessageStretch(RPG::System::Stretch_stretch);
+	Game_System::SetSystemGraphic(CACHE_DEFAULT_BITMAP, RPG::System::Stretch_stretch, RPG::System::Font_gothic);
 	CreateWindows();
 	Player::FrameReset();
 }
@@ -61,8 +60,7 @@ void Scene_GameBrowser::Continue(SceneType prev_scene) {
 	Player::game_title = "";
 	Player::engine = Player::EngineNone;
 
-	Game_System::SetSystemName(CACHE_DEFAULT_BITMAP);
-	Game_System::SetMessageStretch(RPG::System::Stretch_stretch);
+	Game_System::SetSystemGraphic(CACHE_DEFAULT_BITMAP, RPG::System::Stretch_stretch, RPG::System::Font_gothic);
 	Game_System::BgmStop();
 }
 

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -42,6 +42,8 @@ Scene_Title::Scene_Title() {
 }
 
 void Scene_Title::Start() {
+	Game_System::ResetSystemGraphic();
+
 	// Skip background image and music if not used
 	if (CheckEnableTitleGraphicAndMusic()) {
 		CreateTitleGraphic();
@@ -52,6 +54,8 @@ void Scene_Title::Start() {
 }
 
 void Scene_Title::Continue(SceneType prev_scene) {
+	Game_System::ResetSystemGraphic();
+
 	if (restart_title_cache) {
 		// Clear the cache when the game returns to the title screen
 		// e.g. by pressing F12, except the Title Load menu

--- a/src/sprite_airshipshadow.cpp
+++ b/src/sprite_airshipshadow.cpp
@@ -42,10 +42,7 @@ Sprite_AirshipShadow::Sprite_AirshipShadow(CloneType type) {
 void Sprite_AirshipShadow::RecreateShadow() {
 	GetBitmap()->Clear();
 
-	std::string system_name = Game_System::GetSystemName();
-	if (system_name.empty()) return;
-
-	BitmapRef system = Cache::System(system_name);
+	BitmapRef system = Cache::System();
 
 	// Offset of the shadow in the System graphic as per
 	// https://wiki.easyrpg.org/development/technical-details/system-graphics

--- a/src/sprite_airshipshadow.cpp
+++ b/src/sprite_airshipshadow.cpp
@@ -43,7 +43,7 @@ void Sprite_AirshipShadow::RecreateShadow() {
 	GetBitmap()->Clear();
 
 	// RPG_RT never displays shadows if there is no system graphic.
-	if (Game_System::GetSystemName().empty()) {
+	if (!Game_System::HasSystemGraphic()) {
 		return;
 	}
 

--- a/src/sprite_airshipshadow.cpp
+++ b/src/sprite_airshipshadow.cpp
@@ -43,11 +43,10 @@ void Sprite_AirshipShadow::RecreateShadow() {
 	GetBitmap()->Clear();
 
 	// RPG_RT never displays shadows if there is no system graphic.
-	if (!Game_System::HasSystemGraphic()) {
+	BitmapRef system = Cache::System();
+	if (!system) {
 		return;
 	}
-
-	BitmapRef system = Cache::System();
 
 	// Offset of the shadow in the System graphic as per
 	// https://wiki.easyrpg.org/development/technical-details/system-graphics

--- a/src/sprite_airshipshadow.cpp
+++ b/src/sprite_airshipshadow.cpp
@@ -42,6 +42,11 @@ Sprite_AirshipShadow::Sprite_AirshipShadow(CloneType type) {
 void Sprite_AirshipShadow::RecreateShadow() {
 	GetBitmap()->Clear();
 
+	// RPG_RT never displays shadows if there is no system graphic.
+	if (Game_System::GetSystemName().empty()) {
+		return;
+	}
+
 	BitmapRef system = Cache::System();
 
 	// Offset of the shadow in the System graphic as per

--- a/src/sprite_timer.cpp
+++ b/src/sprite_timer.cpp
@@ -44,7 +44,7 @@ void Sprite_Timer::Draw() {
 	}
 
 	// RPG_RT never displays timers if there is no system graphic.
-	if (Game_System::GetSystemName().empty()) {
+	if (!Game_System::HasSystemGraphic()) {
 		return;
 	}
 

--- a/src/sprite_timer.cpp
+++ b/src/sprite_timer.cpp
@@ -43,6 +43,11 @@ void Sprite_Timer::Draw() {
 		return;
 	}
 
+	// RPG_RT never displays timers if there is no system graphic.
+	if (Game_System::GetSystemName().empty()) {
+		return;
+	}
+
 	BitmapRef system = Cache::System();
 
 	GetBitmap()->Clear();

--- a/src/sprite_timer.cpp
+++ b/src/sprite_timer.cpp
@@ -44,11 +44,10 @@ void Sprite_Timer::Draw() {
 	}
 
 	// RPG_RT never displays timers if there is no system graphic.
-	if (!Game_System::HasSystemGraphic()) {
+	BitmapRef system = Cache::System();
+	if (!system) {
 		return;
 	}
-
-	BitmapRef system = Cache::System();
 
 	GetBitmap()->Clear();
 	for (int i = 0; i < 5; ++i) {

--- a/src/sprite_timer.cpp
+++ b/src/sprite_timer.cpp
@@ -43,12 +43,7 @@ void Sprite_Timer::Draw() {
 		return;
 	}
 
-	const auto& system_name = Game_System::GetSystemName();
-	if (system_name.empty()) {
-		return;
-	}
-
-	BitmapRef system = Cache::System(system_name);
+	BitmapRef system = Cache::System();
 
 	GetBitmap()->Clear();
 	for (int i = 0; i < 5; ++i) {

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -51,7 +51,7 @@ void Text::Draw(Bitmap& dest, int x, int y, int color, FontRef font, std::string
 	text_surface = Bitmap::Create(dst_rect.width, dst_rect.height, true);
 	text_surface->Clear();
 
-	BitmapRef system = Cache::System();
+	BitmapRef system = Cache::SystemOrBlack();
 
 	// Where to draw the next glyph (x pos)
 	int next_glyph_pos = 0;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -346,6 +346,9 @@ BitmapRef const& Window::GetWindowskin() const {
 	return windowskin;
 }
 void Window::SetWindowskin(BitmapRef const& nwindowskin) {
+	if (windowskin == nwindowskin) {
+		return;
+	}
 	background_needs_refresh = true;
 	frame_needs_refresh = true;
 	cursor_needs_refresh = true;

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -306,15 +306,10 @@ void Window_Base::DrawCurrencyValue(int money, int cx, int cy) const {
 }
 
 void Window_Base::DrawGauge(const Game_Battler& actor, int cx, int cy) const {
-	FileRequestAsync* request = AsyncHandler::RequestFile("System2", Data::system.system2_name);
-	request->SetGraphicFile(true);
-	if (!request->IsReady()) {
-		// Gauge refreshed each frame, so we can wait via polling
-		request->Start();
+	BitmapRef system2 = Cache::System2();
+	if (!system2) {
 		return;
 	}
-
-	BitmapRef system2 = Cache::System2(Data::system.system2_name);
 
 	bool full = actor.IsGaugeFull();
 	int gauge_w = actor.GetGauge() / 4;

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -27,12 +27,7 @@
 #include "player.h"
 
 Window_Base::Window_Base(int x, int y, int width, int height) {
-	windowskin_name = Game_System::GetSystemName();
-	if (!windowskin_name.empty()) {
-		SetWindowskin(Cache::System(windowskin_name));
-	} else {
-		SetWindowskin(Bitmap::Create(160, 80, false));
-	}
+	SetWindowskin(Cache::System());
 
 	SetX(x);
 	SetY(y);
@@ -59,10 +54,7 @@ bool Window_Base::IsMovementActive() {
 
 void Window_Base::Update() {
 	Window::Update();
-	if (Game_System::GetSystemName() != windowskin_name) {
-		windowskin_name = Game_System::GetSystemName();
-		SetWindowskin(Cache::System(windowskin_name));
-	}
+	SetWindowskin(Cache::System());
 	SetStretch(Game_System::GetMessageStretch() == RPG::System::Stretch_stretch);
 	UpdateMovement();
 }

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -27,7 +27,7 @@
 #include "player.h"
 
 Window_Base::Window_Base(int x, int y, int width, int height) {
-	SetWindowskin(Cache::System());
+	SetWindowskin(Cache::SystemOrBlack());
 
 	SetX(x);
 	SetY(y);
@@ -54,7 +54,7 @@ bool Window_Base::IsMovementActive() {
 
 void Window_Base::Update() {
 	Window::Update();
-	SetWindowskin(Cache::System());
+	SetWindowskin(Cache::SystemOrBlack());
 	SetStretch(Game_System::GetMessageStretch() == RPG::System::Stretch_stretch);
 	UpdateMovement();
 }

--- a/src/window_base.h
+++ b/src/window_base.h
@@ -82,8 +82,6 @@ public:
 protected:
 	void OnFaceReady(FileRequestResult* result, int face_index, int cx, int cy, bool flip);
 
-	std::string windowskin_name;
-
 	std::vector<FileRequestBinding> face_request_ids;
 
 	int current_frame = 0;

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -73,16 +73,7 @@ void Window_BattleStatus::Refresh() {
 		}
 
 		if (!enemy && Data::battlecommands.battle_type == RPG::BattleCommands::BattleType_gauge) {
-			FileRequestAsync* request = AsyncHandler::RequestFile("System2", Data::system.system2_name);
-			request->SetGraphicFile(true);
-			if (!request->IsReady()) {
-				request_id = request->Bind(&Window_BattleStatus::OnSystem2Ready, this);
-				request->Start();
-				break;
-			}
-			else {
-				DrawActorFace(*static_cast<const Game_Actor*>(actor), 80 * i, 24);
-			}
+			DrawActorFace(*static_cast<const Game_Actor*>(actor), 80 * i, 24);
 		}
 		else {
 			int y = 2 + i * 16;
@@ -118,16 +109,8 @@ void Window_BattleStatus::RefreshGauge() {
 			}
 
 			if (!enemy && Data::battlecommands.battle_type == RPG::BattleCommands::BattleType_gauge) {
-				FileRequestAsync* request = AsyncHandler::RequestFile("System2", Data::system.system2_name);
-				request->SetGraphicFile(true);
-				if (!request->IsReady()) {
-					request_id = request->Bind(&Window_BattleStatus::OnSystem2Ready, this);
-					request->Start();
-					break;
-				}
-				else {
-					BitmapRef system2 = Cache::System2(Data::system.system2_name);
-
+				BitmapRef system2 = Cache::System2();
+				if (system2) {
 					// Clear number drawing area
 					contents->ClearRect(Rect(40 + 80 * i, 24, 8 * 4, 16));
 					contents->ClearRect(Rect(40 + 80 * i, 24 + 12 + 4, 8 * 4, 16));
@@ -165,7 +148,8 @@ void Window_BattleStatus::RefreshGauge() {
 }
 
 void Window_BattleStatus::DrawGaugeSystem2(int x, int y, int cur_value, int max_value, int which) {
-	BitmapRef system2 = Cache::System2(Data::system.system2_name);
+	BitmapRef system2 = Cache::System2();
+	assert(system2);
 
 	int gauge_x;
 	if (cur_value == max_value) {
@@ -185,7 +169,8 @@ void Window_BattleStatus::DrawGaugeSystem2(int x, int y, int cur_value, int max_
 }
 
 void Window_BattleStatus::DrawNumberSystem2(int x, int y, int value) {
-	BitmapRef system2 = Cache::System2(Data::system.system2_name);
+	BitmapRef system2 = Cache::System2();
+	assert(system2);
 
 	bool handle_zero = false;
 
@@ -307,6 +292,3 @@ bool Window_BattleStatus::IsChoiceValid(const Game_Battler& battler) const {
 	}
 }
 
-void Window_BattleStatus::OnSystem2Ready(FileRequestResult*) {
-	Refresh();
-}

--- a/src/window_battlestatus.h
+++ b/src/window_battlestatus.h
@@ -91,8 +91,6 @@ protected:
 
 	ChoiceMode mode;
 
-	void OnSystem2Ready(FileRequestResult* result);
-
 	// Debug helper
 	bool enemy;
 

--- a/src/window_shopparty.cpp
+++ b/src/window_shopparty.cpp
@@ -89,7 +89,7 @@ static bool IsEquipment(const RPG::Item* item) {
 void Window_ShopParty::Refresh() {
 	contents->Clear();
 
-	BitmapRef system = Cache::System();
+	BitmapRef system = Cache::SystemOrBlack();
 
 	if (item_id < 0 || item_id > static_cast<int>(Data::items.size()))
 		return;


### PR DESCRIPTION
* RPG_RT compatible LSD chunks
* If graphics_name.empty(), message_stretch and font_id are 0
  and we fallback to database
* If !graphics_name.empty(), all 3 parameters are taken literally

* Refactor the Game_System Set() interface to uphold these invariants
* Refactor the Game_System Get() interface to fallback

* Encapsulate graphic change logic within the Cache to simplify users of
system graphics.

* Reset system graphic when returning the to the title screen.

Depends on: https://github.com/EasyRPG/liblcf/pull/333

Tests:

- [ ] Test async cases with emscripten
- [ ] Test multiple change system commands on same frame behavior.
- [x] No System Graphic - Title Screen
- [x] No System Graphic - Show Message
- [x] No System Graphic - Timer
- [x] No System Graphic - Airship Shadow
- [x] No System Graphic - Shop
- [x] No System Graphic - Main Menu
- [x] No System2 Graphic - Battle types A, B, and C