### PR TITLE
Multi-Game save Import support and Metadata file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,8 @@ add_library(${PROJECT_NAME}
 	src/memory_management.h
 	src/message_overlay.cpp
 	src/message_overlay.h
+	src/meta.cpp
+	src/meta.h
 	src/options.h
 	src/output.cpp
 	src/output.h
@@ -203,6 +205,8 @@ add_library(${PROJECT_NAME}
 	src/scene_gameover.cpp
 	src/scene_gameover.h
 	src/scene.h
+	src/scene_import.cpp
+	src/scene_import.h
 	src/scene_item.cpp
 	src/scene_item.h
 	src/scene_load.cpp
@@ -310,6 +314,8 @@ add_library(${PROJECT_NAME}
 	src/window.h
 	src/window_help.cpp
 	src/window_help.h
+	src/window_import_progress.cpp
+	src/window_import_progress.h
 	src/window_item.cpp
 	src/window_item.h
 	src/window_keyboard.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -167,6 +167,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/memory_management.h \
 	src/message_overlay.cpp \
 	src/message_overlay.h \
+	src/meta.cpp \
+	src/meta.h \
 	src/options.h \
 	src/output.cpp \
 	src/output.h \
@@ -188,6 +190,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/rtp_table.cpp \
 	src/scene.cpp \
 	src/scene.h \
+	src/scene_import.cpp \
+	src/scene_import.h \
 	src/scene_actortarget.cpp \
 	src/scene_actortarget.h \
 	src/scene_battle.cpp \
@@ -319,6 +323,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/window_gold.h \
 	src/window_help.cpp \
 	src/window_help.h \
+	src/window_import_progress.cpp \
+	src/window_import_progress.h \
 	src/window_item.cpp \
 	src/window_item.h \
 	src/window_keyboard.cpp \

--- a/resources/shared/easyrpg.ini
+++ b/resources/shared/easyrpg.ini
@@ -1,14 +1,14 @@
 [EasyRPG]
 FileFormatVersion=1
 
-[783aa77b/*]
+[ff3d8719/*]
 Name=The Way: Episode 1
 Crc32LDB=59ea95a5
 
 [23fa0fb7/55257547]
 Name=The Way: Episode 2
 Vocab_ImportSave=Import journey
-ImportSaveParent=783aa77b/*
+ImportSaveParent=ff3d8719/*
 ImportSavePivotMap=5
 
 [1954d31a/*]
@@ -32,7 +32,7 @@ Vocab_ImportSave=Import journey
 ImportSaveParent=cec21ae7/*
 ImportSavePivotMap=5
 
-[799c58da/*]
+[e868be31/*]
 Name=The Way: Episode 6
 Crc32LDB=1518161c
 Vocab_ImportSave=Import journey
@@ -48,4 +48,9 @@ Name=Legion Saga II
 Crc32LDB=473b0b53
 ImportSaveParent=ec9de7f8/*
 ImportSavePivotMap=133
+
+[999e9fb4/*]
+Name=Legion Saga III
+Crc32LDB=28ea6edc
+
 

--- a/resources/shared/easyrpg.ini
+++ b/resources/shared/easyrpg.ini
@@ -1,0 +1,51 @@
+[EasyRPG]
+FileFormatVersion=1
+
+[783aa77b/*]
+Name=The Way: Episode 1
+Crc32LDB=59ea95a5
+
+[23fa0fb7/55257547]
+Name=The Way: Episode 2
+Vocab_ImportSave=Import journey
+ImportSaveParent=783aa77b/*
+ImportSavePivotMap=5
+
+[1954d31a/*]
+Name=The Way: Episode 3
+Crc32LDB=16a7b30b
+Vocab_ImportSave=Import journey
+ImportSaveParent=23fa0fb7/55257547
+ImportSavePivotMap=5
+
+[cec21ae7/*]
+Name=The Way: Episode 4
+Crc32LDB=5503cdf7
+Vocab_ImportSave=Import journey
+ImportSaveParent=1954d31a/*
+ImportSavePivotMap=5
+
+[81b7345c/*]
+Name=The Way: Episode 5
+Crc32LDB=b7094417
+Vocab_ImportSave=Import journey
+ImportSaveParent=cec21ae7/*
+ImportSavePivotMap=5
+
+[799c58da/*]
+Name=The Way: Episode 6
+Crc32LDB=1518161c
+Vocab_ImportSave=Import journey
+ImportSaveParent=81b7345c/*
+ImportSavePivotMap=5
+
+[ec9de7f8/*]
+Name=Legion Saga
+Crc32LDB=71ad9378
+
+[a4627550/*]
+Name=Legion Saga II
+Crc32LDB=473b0b53
+ImportSaveParent=ec9de7f8/*
+ImportSavePivotMap=133
+

--- a/src/meta.cpp
+++ b/src/meta.cpp
@@ -72,7 +72,7 @@ Meta::Meta(const std::string& meta_file) {
 		if (version == "1") {
 			IdentifyCanonName();
 		} else {
-			Output::Warning("Metadata error in %s, format property %s:%s is missing or invalid: '%s'", MTINI_EASY_RPG_SECTION, MTINI_FILE_FORMAT_VERSION, version.c_str());
+			Output::Warning("Metadata error in %s, format property %s:%s is missing or invalid: '%s'", meta_file.c_str(), MTINI_EASY_RPG_SECTION, MTINI_FILE_FORMAT_VERSION, version.c_str());
 		}
 	}
 

--- a/src/meta.cpp
+++ b/src/meta.cpp
@@ -1,0 +1,223 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <iostream>
+
+// Headers
+#include <fstream>
+#include <iomanip>
+#include <zlib.h>
+#include "data.h"
+#include "filefinder.h"
+#include "lmt_reader.h"
+#include "lsd_reader.h"
+#include "main_data.h"
+#include "meta.h"
+#include "output.h"
+#include "player.h"
+#include "reader_util.h"
+
+
+// Constants used for identifying fields in the easyrpg.ini file.
+#define MTINI_NAME "Name"
+#define MTINI_IMPORT_SAVE_PIVOT_MAP "ImportSavePivotMap"
+#define MTINI_IMPORT_SAVE_PARENT "ImportSaveParent"
+#define MTINI_EASY_RPG_SECTION "EasyRPG"
+#define MTINI_FILE_FORMAT_VERSION "FileFormatVersion"
+
+// Extended vocab key/value pairs
+#define MTINI_EXVOCAB_IMPORT_SAVE_HELP_KEY "Vocab_ImportSaveHelp"
+#define MTINI_EXVOCAB_IMPORT_SAVE_HELP_VALUE "Import Existing Save (Multi-Games Only)"
+#define MTINI_EXVOCAB_IMPORT_SAVE_TITLE_KEY "Vocab_ImportSave"
+#define MTINI_EXVOCAB_IMPORT_SAVE_TITLE_VALUE "Import Save"
+
+
+// Helper: Get the CRC32 of a given file as a hex string
+std::string crc32file(std::string fileName) {
+	if (!fileName.empty()) {
+		std::ifstream in(fileName.c_str(), std::ios::binary);
+		if (in.is_open()) {
+			std::string buffer((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+			unsigned long crc = ::crc32(0, reinterpret_cast<const unsigned char*>(buffer.c_str()), buffer.length());
+
+			std::stringstream res;
+			res <<std::hex <<std::setfill('0') <<std::setw(8) <<crc;
+			return res.str();
+		}
+	}
+	return "";
+}
+
+
+Meta::Meta(const std::string& meta_file) {
+	ini.reset(new INIReader(meta_file));
+
+	// Cache per-game lookups
+	if (!Empty()) {
+		std::string version = ini->GetString(MTINI_EASY_RPG_SECTION, MTINI_FILE_FORMAT_VERSION, "");
+		if (version == "1") {
+			IdentifyCanonName();
+		} else {
+			Output::Warning("Metadata error in %s, format property %s:%s is missing or invalid: '%s'", MTINI_EASY_RPG_SECTION, MTINI_FILE_FORMAT_VERSION, version.c_str());
+		}
+	}
+
+}
+
+int Meta::GetPivotMap() const {
+	if (!Empty()) {
+		return ini->GetInteger(canon_ini_lookup, MTINI_IMPORT_SAVE_PIVOT_MAP, 0);
+	}
+
+	return 0;
+}
+
+std::string Meta::GetParentGame() const {
+	if (!Empty()) {
+		return ini->GetString(canon_ini_lookup, MTINI_IMPORT_SAVE_PARENT, "");
+	}
+
+	return "";
+}
+
+std::vector<std::string> Meta::GetImportChildPaths(const FileFinder::DirectoryTree& parentTree) const {
+	std::vector<std::string> res;
+	if (!Empty()) {
+		for (const auto& paths : parentTree.directories) {
+			res.push_back(paths.second);
+		}
+	}
+	return res;
+}
+
+std::vector<Meta::FileItem> Meta::SearchImportPaths(const FileFinder::DirectoryTree& parentTree, const std::string& child_path) const {
+	if (!Empty()) {
+		int pivotMapId = GetPivotMap();
+		auto parent = GetParentGame();
+		return BuildImportCandidateList(parentTree, child_path, parent, pivotMapId);
+	}
+
+	return std::vector<Meta::FileItem>();
+}
+
+
+std::vector<Meta::FileItem> Meta::BuildImportCandidateList(const FileFinder::DirectoryTree& parentTree, const std::string& child_path, const std::string& parentGameName, int pivotMapId) const {
+	// Scan each folder, looking for an ini file
+	// For now, this only works with "standard" folder layouts, since we need Game files + Save files
+	std::vector<Meta::FileItem> res;
+
+	// Try to read the game name. Note that we assume the games all have the same encoding (and use Player::encoding)
+	auto childPath = FileFinder::MakePath(parentTree.directory_path, child_path);
+	auto childTree = FileFinder::CreateDirectoryTree(childPath, FileFinder::FILES);
+	bool isMatch = false;
+	if (childTree != nullptr) { 
+		// Try to match the parent game name
+		std::string lmtPath = FileFinder::FindDefault(*childTree, TREEMAP_NAME);
+		std::string crcLMT = crc32file(lmtPath);
+		std::string crcLDB = "*";
+		if (parentGameName.find(crcLMT)==0) {
+			if (parentGameName == crcLMT + "/" + crcLDB) {
+				isMatch = true;
+			} else {
+				std::string ldbPath = FileFinder::FindDefault(*childTree, DATABASE_NAME);
+				crcLDB = crc32file(ldbPath);
+				if (parentGameName == crcLMT + "/" + crcLDB) {
+					isMatch = true;
+				}
+			}
+		}
+	}
+
+	if (isMatch) {
+		// Scan over every possible save file and see if any match.
+		for (int saveId = 0; saveId < 15; saveId++) {
+			std::stringstream ss;
+			ss << "Save" << (saveId <= 8 ? "0" : "") << (saveId + 1) << ".lsd";
+
+			// Check for an existing, non-corrupt file with the right mapID
+			// Note that corruptness is checked later (in window_savefile.cpp)
+			std::string file = FileFinder::FindDefault(*childTree, ss.str());
+			if (!file.empty()) {
+				std::unique_ptr<RPG::Save> savegame = LSD_Reader::Load(file, Player::encoding);
+				if (savegame != nullptr) {
+					if (savegame->party_location.map_id == pivotMapId || pivotMapId==0) {
+						FileItem item;
+						item.fullPath = file;
+						item.shortPath = FileFinder::MakeCanonical(child_path, 1);
+						item.fileId = saveId + 1;
+						res.push_back(item);
+					}
+				}
+			}
+		}
+	}
+
+	return res;
+}
+
+bool Meta::IsImportEnabled() const {
+	return !GetParentGame().empty();
+}
+
+
+std::string Meta::GetExVocabImportSaveHelpText() const {
+	return GetExVocab(MTINI_EXVOCAB_IMPORT_SAVE_HELP_KEY, MTINI_EXVOCAB_IMPORT_SAVE_HELP_VALUE);
+}
+
+std::string Meta::GetExVocabImportSaveTitleText() const {
+	return GetExVocab(MTINI_EXVOCAB_IMPORT_SAVE_TITLE_KEY, MTINI_EXVOCAB_IMPORT_SAVE_TITLE_VALUE);
+}
+
+std::string Meta::GetExVocab(const std::string& term, const std::string& defValue) const {
+	if (!Empty()) {
+		return ini->GetString(canon_ini_lookup, term, defValue);
+	}
+
+	return defValue;
+}
+
+bool Meta::IdentifyCanonName() {
+	std::string lmtPath = FileFinder::FindDefault(TREEMAP_NAME);
+
+	// Calculate the lookup based on the LMT/LDB hashes, preferring to use LMT only if possible.
+	// This requires a mandatory field, for which we will use "Name".
+	if (!Empty()) {
+		std::string crcLMT = crc32file(lmtPath);
+		std::string crcLDB = "*";
+		if (ini->HasValue(crcLMT + "/" + crcLDB , MTINI_NAME)) {
+			canon_ini_lookup = crcLMT + "/" + crcLDB;
+		} else {
+			std::string ldbPath = FileFinder::FindDefault(DATABASE_NAME);
+			crcLDB = crc32file(ldbPath);
+			if (ini->HasValue(crcLMT + "/" + crcLDB , MTINI_NAME)) {
+				canon_ini_lookup = crcLMT + "/" + crcLDB;
+			}
+		}
+	}
+
+	return !canon_ini_lookup.empty();
+}
+
+bool Meta::Empty() const {
+	return ini == nullptr || ini->ParseError() == -1;
+}
+
+
+
+
+
+

--- a/src/meta.h
+++ b/src/meta.h
@@ -1,0 +1,87 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_META_H
+#define EP_META_H
+
+// Headers
+#include <map>
+#include <memory>
+#include <string>
+#include "filefinder.h"
+#include "inireader.h"
+
+
+/**
+ * The Meta class loads from a file (easyrpg.ini) and contains 
+ * additional information on a per-game basis.
+ */
+
+class Meta {
+public:
+	// @ini_file - The path to the ini file to load
+	Meta(const std::string& meta_file);
+
+	// Map to use for pivoting between multi-game
+	// Returns 0 on error (i.e., "no map restriction")
+	int GetPivotMap() const;
+
+	// Parent game ID
+	std::string GetParentGame() const;
+
+	// Used for loading a list of potential import saves piecemeal
+	struct FileItem {
+		FileItem() : fileId(0) {}
+
+		std::string shortPath;
+		std::string fullPath;
+		int fileId;
+	};
+	std::vector<std::string> GetImportChildPaths(const FileFinder::DirectoryTree& parentTree) const;
+	std::vector<FileItem> SearchImportPaths(const FileFinder::DirectoryTree& parentTree, const std::string& child_path) const;
+
+	// Is multi-game importing enabled?
+	bool IsImportEnabled() const;
+
+	// Helpers for specific extended vocabulary items
+	std::string GetExVocabImportSaveHelpText() const;
+	std::string GetExVocabImportSaveTitleText() const;
+	
+
+private:
+	// Retrieve an extended vocabulary item
+	// Look up the string value of the default.
+	std::string GetExVocab(const std::string& term, const std::string& defValue) const;
+	
+	// Heuristically tries to guess the canonical name of this game,
+	//  and stores it locally in this Meta object.
+	bool IdentifyCanonName();
+
+	std::vector<FileItem> BuildImportCandidateList(const FileFinder::DirectoryTree& parentTree, const std::string& child_path, const std::string& parentGameName, int pivotMapId) const;
+
+	// Returns true if no metadata (file) exists
+	bool Empty() const;
+
+	// Root of the INIReader
+	std::unique_ptr<INIReader> ini;
+
+	// Current canonical lookup string in easyrpg.ini
+	// Can be "Crc32LMT/Crc32LDB" or "Crc32LMT/*"
+	std::string canon_ini_lookup;
+};
+
+#endif  // EP_META_H

--- a/src/meta.h
+++ b/src/meta.h
@@ -29,58 +29,114 @@
 /**
  * The Meta class loads from a file (easyrpg.ini) and contains 
  * additional information on a per-game basis.
+ * Every public function in this class is safe to call and
+ * returns sensible defaults, even if the INI file passed
+ * in to the constructor is missing or invalid.
  */
 
 class Meta {
 public:
-	// @ini_file - The path to the ini file to load
+	/**
+	 * Construct a Meta object by parsing a file
+	 * @param meta_file The path to the ini file to load
+	 */
 	Meta(const std::string& meta_file);
 
-	// Map to use for pivoting between multi-game
-	// Returns 0 on error (i.e., "no map restriction")
+	/**
+	 * Retrieves the map used for pivoting between multi-game save files
+	 * All save files listed will match the given pivot map ID (i.e., "last saved here")
+	 * @return the pivot map ID, or 0 (on error) for "no map restriction"
+	 */
 	int GetPivotMap() const;
 
-	// Parent game ID
+	/**
+	 * Retrieves the canonical name of the parent game (i.e., the prequel) for multi-game save files.
+	 * @return the parent game name
+	 */
 	std::string GetParentGame() const;
 
-	// Used for loading a list of potential import saves piecemeal
+	/** Small struct used for loading a list of potential import saves piecemeal */
 	struct FileItem {
-		FileItem() : fileId(0) {}
-
-		std::string shortPath;
-		std::string fullPath;
-		int fileId;
+		std::string short_path;
+		std::string full_path;
+		int file_id = 0;
 	};
-	std::vector<std::string> GetImportChildPaths(const FileFinder::DirectoryTree& parentTree) const;
-	std::vector<FileItem> SearchImportPaths(const FileFinder::DirectoryTree& parentTree, const std::string& child_path) const;
 
-	// Is multi-game importing enabled?
+	/**
+	 * Retrieves a vector of paths of child games (../ from the current game) that may be 
+	 * considered when searching for multi-game save files. These should be passed to SearchImportPaths()
+	 * @param parent_tree the tree for the parent folder of the current game (../)
+	 * @return vector of paths of child game folders, including that of the current game
+	 */
+	std::vector<std::string> GetImportChildPaths(const FileFinder::DirectoryTree& parent_tree) const;
+
+	/**
+	 * Given a parent/child game, retrieves a vector of save files that are considered for multi-game importing.
+	 * @param parent_tree the tree for the parent folder of the current game (../)
+	 * @param child_path the path of the child relative to parent_tree
+	 * @return vector of FileItems; one for each valid save file on this child_path
+	 */
+	std::vector<FileItem> SearchImportPaths(const FileFinder::DirectoryTree& parent_tree, const std::string& child_path) const;
+
+	/**
+	 * Is multi-game save importing enabled? If so, the title screen should show an Import option.
+	 * @return true if the meta INI file contains a parentGame for this game
+	 */
 	bool IsImportEnabled() const;
 
-	// Helpers for specific extended vocabulary items
+	/**
+	 * Retrieve the Help window text for Scene_Import
+	 * @return the INI-defined value, or the defualt value for this vocabulary term
+	 */
 	std::string GetExVocabImportSaveHelpText() const;
+
+	/**
+	 * Retrieve the menu item text for Scene_Ttile importing
+	 * @return the INI-defined value, or the defualt value for this vocabulary term
+	 */
 	std::string GetExVocabImportSaveTitleText() const;
 	
 
 private:
-	// Retrieve an extended vocabulary item
-	// Look up the string value of the default.
-	std::string GetExVocab(const std::string& term, const std::string& defValue) const;
+	/**
+	 * Retrieve an extended vocabulary term (something defined in easyrpg.ini)
+	 * A list of terms and default values can be found in meta.cpp
+	 * @param term The keyword to search for
+	 * @param def_value The default value to return if the ini contains no override.
+	 * @return the INI-defined value, or the defualt value for this vocabulary term
+	 */
+	std::string GetExVocab(const std::string& term, const std::string& def_value) const;
 	
-	// Heuristically tries to guess the canonical name of this game,
-	//  and stores it locally in this Meta object.
-	bool IdentifyCanonName();
+	/**
+	 * Heuristically tries to guess the canonical name of this game,
+	 *  and stores it locally in this Meta object.
+	 */
+	void IdentifyCanonName();
 
-	std::vector<FileItem> BuildImportCandidateList(const FileFinder::DirectoryTree& parentTree, const std::string& child_path, const std::string& parentGameName, int pivotMapId) const;
+	/**
+	 * Internal function called by SearchImportPaths
+	 * @param parent_tree the tree for the parent folder of the current game (../)
+	 * @param child_path the path of the child relative to parent_tree
+	 * @param parent_game_name canonical name of the parent game
+	 * @param pivot_map_id the id of the map used to pivot between the prequel and the current game
+	 * @return vector of FileItems; one for each valid save file on this child_path
+	 */
+	std::vector<FileItem> BuildImportCandidateList(const FileFinder::DirectoryTree& parent_tree, const std::string& child_path, const std::string& parent_game_name, int pivot_map_id) const;
 
-	// Returns true if no metadata (file) exists
+	/**
+	 * Was the INI file passed to the constructor invalid or empty?
+	 * @return true if this class should be considered "empty"
+	 */
 	bool Empty() const;
 
-	// Root of the INIReader
+	/** Root of the INIReader */
 	std::unique_ptr<INIReader> ini;
 
-	// Current canonical lookup string in easyrpg.ini
-	// Can be "Crc32LMT/Crc32LDB" or "Crc32LMT/*"
+	/**
+	 * Current canonical lookup string in easyrpg.ini
+	 * Format is "Crc32LMT/Crc32LDB", where
+	 * Crc32LDB can be "*" to represent "any".
+	 */
 	std::string canon_ini_lookup;
 };
 

--- a/src/options.h
+++ b/src/options.h
@@ -65,6 +65,9 @@
 #define TREEMAP_NAME "RPG_RT.lmt"
 #define TREEMAP_NAME_EASYRPG "EASY_RT.emt"
 
+/** File name for additional metadata, such as multi-game save imports. */
+#define META_NAME "easyrpg.ini"
+
 /**
  * RPG_RT.exe (official engine) filename.
  * Not used by emscripten.

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -97,6 +97,7 @@ namespace Player {
 	std::string escape_symbol;
 	int engine;
 	std::string game_title;
+	std::shared_ptr<Meta> meta;
 	int frames;
 	std::string replay_input_path;
 	std::string record_input_path;
@@ -649,6 +650,11 @@ void Player::CreateGameObjects() {
 	}
 
 	LoadDatabase();
+
+	// Load the meta information file.
+	// Note: This should eventually be split across multiple folders as described in Issue #1210
+	std::string meta_file = FileFinder::FindDefault(META_NAME);
+	meta.reset(new Meta(meta_file));
 
 	bool no_rtp_warning_flag = false;
 	std::string ini_file = FileFinder::FindDefault(INI_NAME);

--- a/src/player.h
+++ b/src/player.h
@@ -20,7 +20,9 @@
 
 // Headers
 #include "baseui.h"
+#include "meta.h"
 #include <vector>
+#include <memory>
 
 /**
  * Player namespace.
@@ -291,6 +293,9 @@ namespace Player {
 
 	/** Game title. */
 	extern std::string game_title;
+
+	/** Meta class containing additional external data for this game. */
+	extern std::shared_ptr<Meta> meta;
 
 	/**
 	 * The default speed modifier applied when the speed up button is pressed

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -32,9 +32,7 @@
 #include "reader_util.h"
 
 Scene_File::Scene_File(std::string message) :
-	message(message), latest_time(0), latest_slot(0) {
-	top_index = 0;
-	index = 0;
+	message(message) {
 }
 
 std::unique_ptr<Sprite> Scene_File::MakeBorderSprite(int y) {

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -27,7 +27,6 @@
 #include "input.h"
 #include "lsd_reader.h"
 #include "player.h"
-#include "rpg_save.h"
 #include "scene_file.h"
 #include "bitmap.h"
 #include "reader_util.h"
@@ -38,8 +37,8 @@ Scene_File::Scene_File(std::string message) :
 	index = 0;
 }
 
-static std::unique_ptr<Sprite> makeBorderSprite(int y) {
-	auto bitmap = Bitmap::Create(SCREEN_TARGET_WIDTH, 8, Cache::SystemOrBlack()->GetBackgroundColor());
+std::unique_ptr<Sprite> Scene_File::MakeBorderSprite(int y) {
+	auto bitmap = Bitmap::Create(SCREEN_TARGET_WIDTH, 8, Cache::System()->GetBackgroundColor());
 	auto sprite = std::unique_ptr<Sprite>(new Sprite());
 	sprite->SetVisible(true);
 	sprite->SetZ(Priority_Window + 1);
@@ -49,13 +48,76 @@ static std::unique_ptr<Sprite> makeBorderSprite(int y) {
 	return sprite;
 }
 
-void Scene_File::Start() {
-	// Create the windows
+void Scene_File::CreateHelpWindow() {
 	help_window.reset(new Window_Help(0, 0, SCREEN_TARGET_WIDTH, 32));
 	help_window->SetText(message);
 	help_window->SetZ(Priority_Window + 1);
+}
 
-	border_top = makeBorderSprite(32);
+void Scene_File::PopulatePartyFaces(Window_SaveFile& win, int id, RPG::Save& savegame) {
+	std::vector<std::pair<int, std::string> > party;
+
+	// When a face_name is empty the party list ends
+	int party_size =
+		savegame.title.face1_name.empty() ? 0 :
+		savegame.title.face2_name.empty() ? 1 :
+		savegame.title.face3_name.empty() ? 2 :
+		savegame.title.face4_name.empty() ? 3 : 4;
+
+	party.resize(party_size);
+
+	if (party_size > 3) {
+		party[3].first = savegame.title.face4_id;
+		party[3].second = savegame.title.face4_name;
+	}
+	if (party_size > 2) {
+		party[2].first = savegame.title.face3_id;
+		party[2].second = savegame.title.face3_name;
+	}
+	if (party_size > 1) {
+		party[1].first = savegame.title.face2_id;
+		party[1].second = savegame.title.face2_name;
+	}
+	if (party_size > 0) {
+		party[0].first = savegame.title.face1_id;
+		party[0].second = savegame.title.face1_name;
+	}
+
+	win.SetParty(party, savegame.title.hero_name, savegame.title.hero_hp, savegame.title.hero_level);
+	win.SetHasSave(true);
+}
+
+void Scene_File::UpdateLatestTimestamp(Window_SaveFile& win, int id, RPG::Save& savegame) {
+	if (savegame.title.timestamp > latest_time) {
+		latest_time = savegame.title.timestamp;
+		latest_slot = id;
+	}
+}
+
+void Scene_File::PopulateSaveWindow(Window_SaveFile& win, int id) {
+	// Try to access file
+	std::stringstream ss;
+	ss << "Save" << (id <= 8 ? "0" : "") << (id + 1) << ".lsd";
+
+	std::string file = FileFinder::FindDefault(*tree, ss.str());
+
+	if (!file.empty()) {
+		// File found
+		std::unique_ptr<RPG::Save> savegame =
+			LSD_Reader::Load(file, Player::encoding);
+
+		if (savegame.get()) {
+			PopulatePartyFaces(win, id, *savegame);
+			UpdateLatestTimestamp(win, id, *savegame);
+		} else {
+			win.SetCorrupted(true);
+		}
+	}
+}
+
+void Scene_File::Start() {
+	CreateHelpWindow();
+	border_top = Scene_File::MakeBorderSprite(32);
 
 	// Refresh File Finder Save Folder
 	tree = FileFinder::CreateSaveDirectoryTree();
@@ -65,66 +127,13 @@ void Scene_File::Start() {
 			w(new Window_SaveFile(0, 40 + i * 64, SCREEN_TARGET_WIDTH, 64));
 		w->SetIndex(i);
 		w->SetZ(Priority_Window);
-
-		// Try to access file
-		std::stringstream ss;
-		ss << "Save" << (i <= 8 ? "0" : "") << (i+1) << ".lsd";
-
-		std::string file = FileFinder::FindDefault(*tree, ss.str());
-
-		if (!file.empty()) {
-			// File found
-			std::unique_ptr<RPG::Save> savegame =
-				LSD_Reader::Load(file, Player::encoding);
-
-			if (savegame.get())	{
-				std::vector<std::pair<int, std::string> > party;
-
-				// When a face_name is empty the party list ends
-				int party_size =
-					savegame->title.face1_name.empty() ? 0 :
-					savegame->title.face2_name.empty() ? 1 :
-					savegame->title.face3_name.empty() ? 2 :
-					savegame->title.face4_name.empty() ? 3 : 4;
-
-				party.resize(party_size);
-
-				if (party_size > 3) {
-					party[3].first = savegame->title.face4_id;
-					party[3].second = savegame->title.face4_name;
-				}
-				if (party_size > 2) {
-					party[2].first = savegame->title.face3_id;
-					party[2].second = savegame->title.face3_name;
-				}
-				if (party_size > 1) {
-					party[1].first = savegame->title.face2_id;
-					party[1].second = savegame->title.face2_name;
-				}
-				if (party_size > 0) {
-					party[0].first = savegame->title.face1_id;
-					party[0].second = savegame->title.face1_name;
-				}
-
-				w->SetParty(party, savegame->title.hero_name, savegame->title.hero_hp,
-					savegame->title.hero_level);
-				w->SetHasSave(true);
-
-				if (savegame->title.timestamp > latest_time) {
-					latest_time = savegame->title.timestamp;
-					latest_slot = i;
-				}
-			} else {
-				w->SetCorrupted(true);
-			}
-		}
-
+		PopulateSaveWindow(*w, i);
 		w->Refresh();
 
 		file_windows.push_back(w);
 	}
 
-	border_bottom = makeBorderSprite(232);
+	border_bottom = Scene_File::MakeBorderSprite(232);
 
 	index = latest_slot;
 	top_index = std::max(0, index - 2);

--- a/src/scene_file.h
+++ b/src/scene_file.h
@@ -20,10 +20,12 @@
 
 // Headers
 #include <vector>
-#include "scene.h"
 #include "filefinder.h"
+#include "rpg_save.h"
+#include "scene.h"
 #include "window_help.h"
 #include "window_savefile.h"
+
 
 /**
  * Base class used by the save and load scenes.
@@ -48,6 +50,12 @@ public:
 	bool IsWindowMoving() const;
 
 protected:
+	virtual void CreateHelpWindow();
+	virtual void PopulateSaveWindow(Window_SaveFile& win, int id);
+	virtual void PopulatePartyFaces(Window_SaveFile& win, int id, RPG::Save& savegame);
+	virtual void UpdateLatestTimestamp(Window_SaveFile& win, int id, RPG::Save& savegame);
+	static std::unique_ptr<Sprite> MakeBorderSprite(int y);
+
 	void Refresh();
 	void MoveFileWindows(int dy, int dt);
 

--- a/src/scene_file.h
+++ b/src/scene_file.h
@@ -59,8 +59,8 @@ protected:
 	void Refresh();
 	void MoveFileWindows(int dy, int dt);
 
-	int index;
-	int top_index;
+	int index = 0;
+	int top_index = 0;
 	std::unique_ptr<Window_Help> help_window;
 	std::vector<std::shared_ptr<Window_SaveFile> > file_windows;
 	std::unique_ptr<Sprite> border_top;
@@ -69,8 +69,8 @@ protected:
 
 	std::shared_ptr<FileFinder::DirectoryTree> tree;
 
-	double latest_time;
-	int latest_slot;
+	double latest_time = 0;
+	int latest_slot = 0;
 };
 
 #endif

--- a/src/scene_import.cpp
+++ b/src/scene_import.cpp
@@ -32,18 +32,17 @@
 
 
 Scene_Import::Scene_Import() :
-	Scene_File(Player::meta->GetExVocabImportSaveHelpText()),
-	curr_child_id(0), firstFrameSkipped(false) {
+	Scene_File(Player::meta->GetExVocabImportSaveHelpText()) {
 	Scene::type = Scene::Load;  // For all intents and purposes, treat Import as an extension of Load
 }
 
 void Scene_Import::PopulateSaveWindow(Window_SaveFile& win, int id) {
 	// File access is already determined
 	if (id < files.size()) {
-		win.SetDisplayOverride(files[id].shortPath, files[id].fileId);
+		win.SetDisplayOverride(files[id].short_path, files[id].file_id);
 
 		std::unique_ptr<RPG::Save> savegame =
-			LSD_Reader::Load(files[id].fullPath, Player::encoding);
+			LSD_Reader::Load(files[id].full_path, Player::encoding);
 
 		if (savegame.get()) {
 			PopulatePartyFaces(win, id, *savegame);
@@ -103,8 +102,8 @@ void Scene_Import::UpdateScanAndProgress() {
 	}
 
 	// Leads to better fading.
-	if (!firstFrameSkipped) {
-		firstFrameSkipped = true;
+	if (!first_frame_skipped) {
+		first_frame_skipped = true;
 		return;
 	}
 
@@ -112,16 +111,16 @@ void Scene_Import::UpdateScanAndProgress() {
 	if (children.empty()) {
 		if (Main_Data::GetSavePath() == Main_Data::GetProjectPath()) {
 			auto parentPath = FileFinder::MakePath(Main_Data::GetSavePath(), "..");
-			parentTree = FileFinder::CreateDirectoryTree(parentPath, FileFinder::DIRECTORIES);
-			if (parentTree != nullptr) {
-				children = Player::meta->GetImportChildPaths(*parentTree);
+			parent_tree = FileFinder::CreateDirectoryTree(parentPath, FileFinder::DIRECTORIES);
+			if (parent_tree != nullptr) {
+				children = Player::meta->GetImportChildPaths(*parent_tree);
 			}
 		}
 		if (children.empty()) {
 			FinishScan();
 		}
 	} else if (curr_child_id < children.size()) {
-		auto candidates = Player::meta->SearchImportPaths(*parentTree, children[curr_child_id]);
+		auto candidates = Player::meta->SearchImportPaths(*parent_tree, children[curr_child_id]);
 		files.insert(files.end(), candidates.begin(), candidates.end());
 
 		progress_window->SetProgress((curr_child_id*100)/children.size(), children[curr_child_id]);
@@ -142,7 +141,7 @@ void Scene_Import::FinishScan() {
 }
 
 void Scene_Import::Action(int index) {
-	Player::LoadSavegame(files[index].fullPath);
+	Player::LoadSavegame(files[index].full_path);
 
 	auto title_scene = Scene::Find(Scene::Title);
 	if (title_scene) {

--- a/src/scene_import.cpp
+++ b/src/scene_import.cpp
@@ -1,0 +1,157 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Headers
+#include <sstream>
+#include "filefinder.h"
+#include "game_system.h"
+#include "game_temp.h"
+#include "graphics.h"
+#include "input.h"
+#include "lsd_reader.h"
+#include "output.h"
+#include "player.h"
+#include "scene_file.h"
+#include "scene_import.h"
+#include "scene_map.h"
+#include "scene_title.h"
+
+
+Scene_Import::Scene_Import() :
+	Scene_File(Player::meta->GetExVocabImportSaveHelpText()),
+	curr_child_id(0), firstFrameSkipped(false) {
+	Scene::type = Scene::Load;  // For all intents and purposes, treat Import as an extension of Load
+}
+
+void Scene_Import::PopulateSaveWindow(Window_SaveFile& win, int id) {
+	// File access is already determined
+	if (id < files.size()) {
+		win.SetDisplayOverride(files[id].shortPath, files[id].fileId);
+
+		std::unique_ptr<RPG::Save> savegame =
+			LSD_Reader::Load(files[id].fullPath, Player::encoding);
+
+		if (savegame.get()) {
+			PopulatePartyFaces(win, id, *savegame);
+			UpdateLatestTimestamp(win, id, *savegame);
+		} else {
+			win.SetCorrupted(true);
+		}
+	} else {
+		win.SetDisplayOverride("No Data", 0);
+	}
+}
+
+void Scene_Import::Start() {
+	CreateHelpWindow();
+	border_top = Scene_File::MakeBorderSprite(32);
+
+	// For consistency, we only show 15 windows
+	// We don't populate them until later (once we've loaded all potential importable files).
+	for (int i = 0; i < 15; i++) {
+		std::shared_ptr<Window_SaveFile>
+			w(new Window_SaveFile(0, 40 + i * 64, SCREEN_TARGET_WIDTH, 64));
+		w->SetIndex(i);
+		w->SetVisible(false);
+		w->SetZ(Priority_Window);
+
+		file_windows.push_back(w);
+	}
+
+	// Create a window to show scanning progress, since this can take a while.
+	progress_window.reset(new Window_ImportProgress(SCREEN_TARGET_WIDTH/4, 40 + 64, SCREEN_TARGET_WIDTH/2, 64));
+	progress_window->SetZ(Priority_Window + 1);
+
+	border_bottom = Scene_File::MakeBorderSprite(232);
+
+	index = latest_slot;
+	top_index = std::max(0, index - 2);
+
+	Refresh();
+	Update();
+}
+
+void Scene_Import::Update() {
+	if (progress_window->GetVisible()) {
+		UpdateScanAndProgress();
+		return;
+	}
+
+	Scene_File::Update();
+}
+
+void Scene_Import::UpdateScanAndProgress() {
+	// Every tick, we still check for user input specifically for canceling...
+	if (Input::IsTriggered(Input::CANCEL)) {
+		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cancel));
+		Scene::Pop();
+		return;
+	}
+
+	// Leads to better fading.
+	if (!firstFrameSkipped) {
+		firstFrameSkipped = true;
+		return;
+	}
+
+	// Gather the list of children, if it does not exist.
+	if (children.empty()) {
+		if (Main_Data::GetSavePath() == Main_Data::GetProjectPath()) {
+			auto parentPath = FileFinder::MakePath(Main_Data::GetSavePath(), "..");
+			parentTree = FileFinder::CreateDirectoryTree(parentPath, FileFinder::DIRECTORIES);
+			if (parentTree != nullptr) {
+				children = Player::meta->GetImportChildPaths(*parentTree);
+			}
+		}
+		if (children.empty()) {
+			FinishScan();
+		}
+	} else if (curr_child_id < children.size()) {
+		auto candidates = Player::meta->SearchImportPaths(*parentTree, children[curr_child_id]);
+		files.insert(files.end(), candidates.begin(), candidates.end());
+
+		progress_window->SetProgress((curr_child_id*100)/children.size(), children[curr_child_id]);
+		curr_child_id += 1;
+	} else {
+		FinishScan();
+	}
+}
+
+void Scene_Import::FinishScan() {
+	for (int i = 0; i < 15; i++) {
+		auto w = file_windows[i];
+		PopulateSaveWindow(*w, i);
+		w->Refresh();
+		w->SetVisible(true);
+	}
+	progress_window->SetVisible(false);
+}
+
+void Scene_Import::Action(int index) {
+	Player::LoadSavegame(files[index].fullPath);
+
+	auto title_scene = Scene::Find(Scene::Title);
+	if (title_scene) {
+		static_cast<Scene_Title*>(title_scene.get())->OnGameLoad();
+	}
+
+	Scene::Push(std::make_shared<Scene_Map>(true));
+}
+
+bool Scene_Import::IsSlotValid(int index) {
+	return index < files.size();
+}

--- a/src/scene_import.h
+++ b/src/scene_import.h
@@ -32,9 +32,6 @@
 class Scene_Import : public Scene_File {
 
 public:
-	/**
-	 * Constructor.
-	 */
 	Scene_Import();
 
 	void Start() override;
@@ -50,19 +47,19 @@ private:
 	void UpdateScanAndProgress();
 	void FinishScan();
 
-	// Visually track scanning
+	/** Visually track scanning of other game folders */
 	std::unique_ptr<Window_ImportProgress> progress_window;
 
-	// Collection of all folders in ../
-	std::shared_ptr<FileFinder::DirectoryTree> parentTree;
+	/** Collection of all folders in ../ */
+	std::shared_ptr<FileFinder::DirectoryTree> parent_tree;
 
-	// Tracking status: vector of child folders to check and current index in that list
+	/** Tracking status: vector of child folders to check and current index in that list */
 	std::vector<std::string> children;
-	size_t curr_child_id;
+	size_t curr_child_id = 0;
 
-	bool firstFrameSkipped;
+	bool first_frame_skipped = false;
 
-	// Final file list; used for the Import windows
+	/** Final file list; used for the Import windows */
 	std::vector<Meta::FileItem> files;
 };
 

--- a/src/scene_import.h
+++ b/src/scene_import.h
@@ -1,0 +1,69 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_SCENE_IMPORT_H
+#define EP_SCENE_IMPORT_H
+
+// Headers
+#include <memory>
+#include <vector>
+#include <string>
+#include "meta.h"
+#include "scene_file.h"
+#include "window_import_progress.h"
+
+/**
+ * Scene_Item class.
+ */
+class Scene_Import : public Scene_File {
+
+public:
+	/**
+	 * Constructor.
+	 */
+	Scene_Import();
+
+	void Start() override;
+	void Update() override;
+
+	void Action(int index) override;
+	bool IsSlotValid(int index) override;
+
+protected:
+	virtual void PopulateSaveWindow(Window_SaveFile& win, int id) override;
+
+private:
+	void UpdateScanAndProgress();
+	void FinishScan();
+
+	// Visually track scanning
+	std::unique_ptr<Window_ImportProgress> progress_window;
+
+	// Collection of all folders in ../
+	std::shared_ptr<FileFinder::DirectoryTree> parentTree;
+
+	// Tracking status: vector of child folders to check and current index in that list
+	std::vector<std::string> children;
+	size_t curr_child_id;
+
+	bool firstFrameSkipped;
+
+	// Final file list; used for the Import windows
+	std::vector<Meta::FileItem> files;
+};
+
+#endif

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -17,6 +17,7 @@
 
 // Headers
 #include <fstream>
+#include <sstream>
 #include <vector>
 #include "scene_title.h"
 #include "audio.h"
@@ -29,15 +30,17 @@
 #include "transition.h"
 #include "input.h"
 #include "main_data.h"
+#include "meta.h"
 #include "output.h"
 #include "player.h"
 #include "scene_battle.h"
+#include "scene_import.h"
 #include "scene_load.h"
 #include "scene_map.h"
 #include "window_command.h"
 #include "baseui.h"
 
-Scene_Title::Scene_Title() {
+Scene_Title::Scene_Title() : new_game_index(0), continue_index(1), exit_index(2), import_index(-1) {
 	type = Scene::Title;
 }
 
@@ -52,6 +55,7 @@ void Scene_Title::Start() {
 
 	CreateCommandWindow();
 }
+
 
 void Scene_Title::Continue(SceneType prev_scene) {
 	Game_System::ResetSystemGraphic();
@@ -110,14 +114,14 @@ void Scene_Title::Update() {
 	command_window->Update();
 
 	if (Input::IsTriggered(Input::DECISION)) {
-		switch (command_window->GetIndex()) {
-		case 0: // New Game
+		int index = command_window->GetIndex();
+		if (index == new_game_index) {  // New Game
 			CommandNewGame();
-			break;
-		case 1: // Load Game
+		} else if (index == continue_index) {  // Load Game
 			CommandContinue();
-			break;
-		case 2: // Exit Game
+		} else if (index == import_index) {  // Import (multi-part games)
+			CommandImport();
+		} else if (index == exit_index) {  // Exit Game
 			CommandShutdown();
 		}
 	}
@@ -142,6 +146,14 @@ void Scene_Title::CreateCommandWindow() {
 	std::vector<std::string> options;
 	options.push_back(Data::terms.new_game);
 	options.push_back(Data::terms.load_game);
+
+	// Set "Import" based on metadata
+	if (Player::meta->IsImportEnabled()) {
+		options.push_back(Player::meta->GetExVocabImportSaveTitleText());
+		import_index = 2;
+		exit_index = 3;
+	}
+
 	options.push_back(Data::terms.exit_game);
 
 	command_window.reset(new Window_Command(options));
@@ -218,6 +230,13 @@ void Scene_Title::CommandContinue() {
 
 	restart_title_cache = false;
 	Scene::Push(std::make_shared<Scene_Load>());
+}
+
+void Scene_Title::CommandImport() {
+	Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
+
+	restart_title_cache = false;
+	Scene::Push(std::make_shared<Scene_Import>());
 }
 
 void Scene_Title::CommandShutdown() {

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -40,7 +40,7 @@
 #include "window_command.h"
 #include "baseui.h"
 
-Scene_Title::Scene_Title() : new_game_index(0), continue_index(1), exit_index(2), import_index(-1) {
+Scene_Title::Scene_Title() {
 	type = Scene::Title;
 }
 

--- a/src/scene_title.h
+++ b/src/scene_title.h
@@ -24,6 +24,7 @@
 #include "window_command.h"
 #include "async_handler.h"
 
+
 /**
  * Scene Title class.
  */
@@ -88,6 +89,12 @@ public:
 	void CommandContinue();
 
 	/**
+	 * Option Import.
+	 * Shows the Import screen, for use with multi-game save files.
+	 */
+	void CommandImport();
+
+	/**
 	 * Option Shutdown.
 	 * Does a player shutdown.
 	 */
@@ -106,6 +113,12 @@ private:
 
 	/** Background graphic. */
 	std::unique_ptr<Sprite> title;
+
+	/** Offsets for each selection, in case "Import" is enabled. */
+	int new_game_index;
+	int continue_index;
+	int exit_index;
+	int import_index;
 
 	/** Contains the state of continue button. */
 	bool continue_enabled;

--- a/src/scene_title.h
+++ b/src/scene_title.h
@@ -115,13 +115,13 @@ private:
 	std::unique_ptr<Sprite> title;
 
 	/** Offsets for each selection, in case "Import" is enabled. */
-	int new_game_index;
-	int continue_index;
-	int exit_index;
-	int import_index;
+	int new_game_index =  0;
+	int continue_index =  1;
+	int exit_index     =  2;
+	int import_index   = -1;
 
 	/** Contains the state of continue button. */
-	bool continue_enabled;
+	bool continue_enabled = false;
 
 	bool restart_title_cache = true;
 

--- a/src/window_import_progress.cpp
+++ b/src/window_import_progress.cpp
@@ -1,0 +1,52 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Headers
+#include "window_import_progress.h"
+#include "bitmap.h"
+#include "color.h"
+#include "font.h"
+
+Window_ImportProgress::Window_ImportProgress(int ix, int iy, int iwidth, int iheight) :
+	Window_Base(ix, iy, iwidth, iheight),
+	percent(0) {
+
+	SetContents(Bitmap::Create(width - 16, height - 16));
+	Refresh();
+}
+
+void Window_ImportProgress::SetProgress(int pct, const std::string& path) {
+	percent = pct;
+	currPath = path;
+	Refresh();
+}
+
+void Window_ImportProgress::Refresh() {
+	contents->Clear();
+
+	contents->TextDraw(0, 2, Font::ColorDefault, "Searching for files...", Text::AlignLeft);
+
+	Rect inner(1, 16+3, 142, 16-6);
+	Rect outer(inner.x-1, inner.y-1, inner.width+2, inner.height+2);
+
+	contents->FillRect(outer, Color(0x00, 0x00, 0x00, 0xFF));
+	contents->FillRect(inner, Color(0x66, 0x66, 0x66, 0xFF));
+	inner.width = (inner.width*percent) / 100;
+	contents->FillRect(inner, Color(0xFF, 0x00, 0x00, 0xFF));
+
+	contents->TextDraw(0, 2 + 32, Font::ColorDefault, std::string("Folder: ") + currPath, Text::AlignLeft);
+}

--- a/src/window_import_progress.cpp
+++ b/src/window_import_progress.cpp
@@ -22,8 +22,7 @@
 #include "font.h"
 
 Window_ImportProgress::Window_ImportProgress(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight),
-	percent(0) {
+	Window_Base(ix, iy, iwidth, iheight) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 	Refresh();
@@ -31,7 +30,7 @@ Window_ImportProgress::Window_ImportProgress(int ix, int iy, int iwidth, int ihe
 
 void Window_ImportProgress::SetProgress(int pct, const std::string& path) {
 	percent = pct;
-	currPath = path;
+	curr_path = path;
 	Refresh();
 }
 
@@ -48,5 +47,5 @@ void Window_ImportProgress::Refresh() {
 	inner.width = (inner.width*percent) / 100;
 	contents->FillRect(inner, Color(0xFF, 0x00, 0x00, 0xFF));
 
-	contents->TextDraw(0, 2 + 32, Font::ColorDefault, std::string("Folder: ") + currPath, Text::AlignLeft);
+	contents->TextDraw(0, 2 + 32, Font::ColorDefault, std::string("Folder: ") + curr_path, Text::AlignLeft);
 }

--- a/src/window_import_progress.h
+++ b/src/window_import_progress.h
@@ -31,11 +31,17 @@ class Window_ImportProgress : public Window_Base {
 public:
 	/**
 	 * Constructor.
+	 * @param ix x position of the window
+	 * @param iy y position of the window
+	 * @param iwidth width of the window
+	 * @param iheight height of the window
 	 */
 	Window_ImportProgress(int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Update to display scanning progress and the directory currently being scanned
+	 * @param pct percent of the scan that is complete
+	 * @param path current directory being scanned
 	 */
 	void SetProgress(int pct, const std::string& path);
 	
@@ -43,9 +49,10 @@ private:
 	void Refresh();
 
 	/** Current progress as a percentage */
-	int percent;
+	int percent = 0;
+
 	/** Current file/path being scanned */
-	std::string currPath;
+	std::string curr_path;
 };
 
 #endif

--- a/src/window_import_progress.h
+++ b/src/window_import_progress.h
@@ -1,0 +1,51 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_WINDOW_IMPORT_PROGRESS_H
+#define EP_WINDOW_IMPORT_PROGRESS_H
+
+// Headers
+#include "window_base.h"
+#include "text.h"
+
+/**
+ * Window_ImportProgress class.
+ * Used to inform the user of progress as save files are scanned for Scene_Import
+ */
+class Window_ImportProgress : public Window_Base {
+
+public:
+	/**
+	 * Constructor.
+	 */
+	Window_ImportProgress(int ix, int iy, int iwidth, int iheight);
+
+	/**
+	 * Update to display scanning progress and the directory currently being scanned
+	 */
+	void SetProgress(int pct, const std::string& path);
+	
+private:
+	void Refresh();
+
+	/** Current progress as a percentage */
+	int percent;
+	/** Current file/path being scanned */
+	std::string currPath;
+};
+
+#endif

--- a/src/window_savefile.cpp
+++ b/src/window_savefile.cpp
@@ -27,8 +27,7 @@
 #include "player.h"
 
 Window_SaveFile::Window_SaveFile(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight),
-	index(0), overrideIndex(0), hero_hp(0), hero_level(0), corrupted(false), has_save(false) {
+	Window_Base(ix, iy, iwidth, iheight) {
 
 	SetBorderX(4);
 	SetContents(Bitmap::Create(width - 8, height - 16));
@@ -49,11 +48,11 @@ void Window_SaveFile::UpdateCursorRect() {
 
 std::string Window_SaveFile::GetSaveFileName() const {
 	std::ostringstream out;
-	if (!overrideName.empty()) {
-		if (overrideName.size() > 14 && !party.empty()) {
-			out << overrideName.substr(0, 11) << "...";
+	if (!override_name.empty()) {
+		if (override_name.size() > 14 && !party.empty()) {
+			out << override_name.substr(0, 11) << "...";
 		} else {
-			out << overrideName;
+			out << override_name;
 		}
 	} else {
 		out << Data::terms.file << std::setw(2) << std::setfill(' ') << index + 1;
@@ -66,8 +65,8 @@ void Window_SaveFile::SetIndex(int id) {
 }
 
 void Window_SaveFile::SetDisplayOverride(const std::string& name, int index) {
-	overrideName = name;
-	overrideIndex = index;
+	override_name = name;
+	override_index = index;
 }
 
 void Window_SaveFile::SetParty(const std::vector<std::pair<int, std::string> >& actors,
@@ -107,8 +106,8 @@ void Window_SaveFile::Refresh() {
 
 
 	std::stringstream out;
-	if (overrideIndex > 0) {
-		out << Data::terms.file << std::setw(2) << std::setfill(' ') << overrideIndex;
+	if (override_index > 0) {
+		out << Data::terms.file << std::setw(2) << std::setfill(' ') << override_index;
 		contents->TextDraw(4, 16+2, fc, out.str());
 	} else {
 		contents->TextDraw(4, 16 + 2, fc, hero_name);

--- a/src/window_savefile.h
+++ b/src/window_savefile.h
@@ -91,15 +91,15 @@ protected:
 	void UpdateCursorRect();
 	std::string GetSaveFileName() const;
 
-	int index;
-	std::string overrideName;
-	int overrideIndex;
+	int index = 0;
+	std::string override_name;
+	int override_index = 0;
 	std::vector<std::pair<int, std::string> > party;
 	std::string hero_name;
-	int hero_hp;
-	int hero_level;
-	bool corrupted;
-	bool has_save;
+	int hero_hp = 0;
+	int hero_level = 0;
+	bool corrupted = false;
+	bool has_save = false;
 };
 
 #endif

--- a/src/window_savefile.h
+++ b/src/window_savefile.h
@@ -45,6 +45,16 @@ public:
 	void SetIndex(int id);
 
 	/**
+	 * Sets a name (usually a path) to show instead of the File ID, and
+	 *  push file ID display to Line 2.
+	 * Useful for save file importing, where multiple "Save01.lsd" files may exist.
+	 *
+	 * @param name The name to show instead of the file ID
+	 * @param index The file index override, shown on line 2
+	 */
+	void SetDisplayOverride(const std::string& name, int index);
+
+	/**
 	 * Party data displayed in the savegame slot.
 	 *
 	 * @param actors face_id and face_name of all party members.
@@ -79,8 +89,11 @@ public:
 
 protected:
 	void UpdateCursorRect();
+	std::string GetSaveFileName() const;
 
 	int index;
+	std::string overrideName;
+	int overrideIndex;
 	std::vector<std::pair<int, std::string> > party;
 	std::string hero_name;
 	int hero_hp;


### PR DESCRIPTION
This PR adds support for "Multi-Game Saves", which are games like Legion Saga and The Way that allow you to import a previous game's save file when continuing into the next game. This requires some amount of metadata to be added to the game, which I created a class for (that uses the existing json parser). 

A larger discussion of features and motiviations is in Issue https://github.com/EasyRPG/Player/issues/1854

Tested building/running on Windows, OSX, Linux, and PS-Classic.