### PR TITLE
Fix Tile Memory Leak w.r.t the cache_effects map

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -481,6 +481,7 @@ BitmapRef Cache::SpriteEffect(const BitmapRef& src_bitmap, const Rect& rect, boo
 }
 
 void Cache::Clear() {
+	cache_effects.clear();
 	cache.clear();
 	cache_size = 0;
 


### PR DESCRIPTION
There is an issue with RPG Maker 2003 games (and likely others) when played in Easy RPG wherein the cache_effects map will hold on to Tile resources for events that use Tiles for their visual elements. You can observe this with the minimal example below:
https://drive.google.com/file/d/1hBFYKPiB0LaKrjAgkmxVj8hy3Qsh_Zjf/view?usp=sharing

Run the game and hit F12 to restart it; the Debug console will show:
`  Debug: possible leak in cached tilemap Snow/0`

This bug is caused by the "Snow/0" tile being cached in the '''key''' of the cache_effects map. I changed that key to use a weak_ptr, a.k.a.:
` using effect_key_type = std::tuple<std::weak_ptr<Bitmap>, Rect, bool, bool, Tone, Color>; `

The change required some additional structuring to use std::owner_less() to compare these two. This should have been pulled in automatically, but since the weak_ptr is inside a tuple, it's possible the compiler got a little confused. (Using the struct is fine, so I'm not worried about this.)

Using a weak_ptr as the key (instead of a shared_ptr) makes sense to me ---the key should not participate in ownership, and the code does not rely on this. FYI, the sample map has a single "Tint Screen" in an event ---this is enough to trigger the bug.

In case you're curious, this also seems to fix the issue of some games (like the test game) crashing with a segfault on OSX  --at least for me. 


