### PR TITLE
Yume Nikki: Fix Forest World Music not stopping when returning to the Nexus

### DIFF
--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -371,9 +371,9 @@ void Game_Map::PlayBgm() {
 		return;
 	}
 
-	int current_index = GetMapIndex(location.map_id);
-	last_map_id = current_index;
+	last_map_id = location.map_id;
 
+	int current_index = GetMapIndex(location.map_id);
 	while (Data::treemap.maps[current_index].music_type == 0 && GetMapIndex(Data::treemap.maps[current_index].parent_map) != current_index) {
 		current_index = GetMapIndex(Data::treemap.maps[current_index].parent_map);
 	}


### PR DESCRIPTION
Because the tree ID and not the map ID was used when checking if a map has changed, the BGM music was not always modified when changing the map.

Fixes going to the Forest World (top-left door right next to the Madotsuki room door) in Yume Nikki.

I guess this also means that in some cases the BGM was reset when toggling the menu but I'm not aware of any reports mentioning this.