### PR TITLE
Battle2k: Fix bug in self destruct logic

### DIFF
--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -300,12 +300,15 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 
 		break;
 	case State_Battle:
-		// If no battle action is running, we need to check for battle events which could have
-		// triggered win/loss.
-		if (!battle_action_pending && CheckResultConditions()) {
-			return;
+		if (!battle_action_pending) {
+			// If no battle action is running, we need to check for battle events which could have
+			// triggered win/loss.
+			if (CheckResultConditions()) {
+				return;
+			}
+			// Don't remove actions until the current action is done.
+			RemoveActionsForNonExistantBattlers();
 		}
-		RemoveActionsForNonExistantBattlers();
 		if (!battle_actions.empty()) {
 			auto* battler = battle_actions.front();
 			if (!battle_action_pending) {


### PR DESCRIPTION
Self destruct would set the enemy as hidden, and then later
RemoveActionsForNonExistantBattlers() would remove it before
it completed, causing the next battle algorithm to start running
midway.

If the next algo was a defend or something with no target, it will
crash. If it's an attack, it can cause the battle not to finish.

Fix #1875