### PR TITLE
 Run foreground events during preupdate after teleport 

### DIFF
--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -151,7 +151,9 @@ bool Game_Interpreter_Map::CommandRecallToLocation(RPG::EventCommand const& com)
 	int x = Game_Variables.Get(var_x);
 	int y = Game_Variables.Get(var_y);
 
-	Main_Data::game_player->ReserveTeleport(map_id, x, y, -1);
+	auto tt = main_flag ? TeleportTarget::eForegroundTeleport : TeleportTarget::eParallelTeleport;
+
+	Main_Data::game_player->ReserveTeleport(map_id, x, y, -1, tt);
 
 	// Parallel events should keep on running in 2k and 2k3, unlike in later versions
 	if (!main_flag)
@@ -548,7 +550,9 @@ bool Game_Interpreter_Map::CommandTeleport(RPG::EventCommand const& com) { // Co
 	// RPG2k3 feature
 	int direction = com.parameters.size() > 3 ? com.parameters[3] - 1 : -1;
 
-	Main_Data::game_player->ReserveTeleport(map_id, x, y, direction);
+	auto tt = main_flag ? TeleportTarget::eForegroundTeleport : TeleportTarget::eParallelTeleport;
+
+	Main_Data::game_player->ReserveTeleport(map_id, x, y, direction, tt);
 
 	// Parallel events should keep on running in 2k and 2k3, unlike in later versions
 	if (!main_flag)

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -91,7 +91,7 @@ namespace Game_Map {
 	 * @param map_id map ID.
 	 * @param tt the type of teleport used to setup the map
 	 */
-	void Setup(int map_id, TeleportTarget::Type tt = TeleportTarget::eNormalTeleport);
+	void Setup(int map_id, TeleportTarget::Type tt);
 
 	/**
 	 * Setups a map from a savegame.

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -65,7 +65,7 @@ public:
 	 * @param direction New direction after teleport. If -1, the direction isn't changed.
 	 * @param tt teleport type
 	 */
-	void ReserveTeleport(int map_id, int x, int y, int direction, TeleportTarget::Type tt = TeleportTarget::eNormalTeleport);
+	void ReserveTeleport(int map_id, int x, int y, int direction, TeleportTarget::Type tt);
 	void ReserveTeleport(const RPG::SaveTarget& target);
 	void PerformTeleport();
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -952,7 +952,7 @@ static void OnMapFileReady(FileRequestResult*) {
 		}
 	}
 
-	Game_Map::Setup(map_id);
+	Game_Map::Setup(map_id, TeleportTarget::eParallelTeleport);
 	Main_Data::game_player->MoveTo(x_pos, y_pos);
 	Main_Data::game_player->Refresh();
 	Game_Map::PlayBgm();

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -431,7 +431,7 @@ void Scene_Debug::Update() {
 				int pending_map_y = numberinput_window->GetNumber();
 				Scene::PopUntil(Scene::Map);
 				if (Scene::instance) {
-					Main_Data::game_player->ReserveTeleport(pending_map_id, pending_map_x, pending_map_y, -1);
+					Main_Data::game_player->ReserveTeleport(pending_map_id, pending_map_x, pending_map_y, -1, TeleportTarget::eSkillTeleport);
 
 					// FIXME: Fixes emscripten, but this should be done in Continue/Resume in scene_map
 					FileRequestAsync* request = Game_Map::RequestMap(pending_map_id);

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -65,11 +65,19 @@ private:
 
 	void Start2(MapUpdateAsyncContext actx);
 
-	void StartPendingTeleport(bool use_default_transition, bool no_erase);
-	void FinishPendingTeleport(bool use_default_transition, bool defer_recursive_teleports);
-	void FinishPendingTeleport2(MapUpdateAsyncContext actx, bool use_default_transition, bool defer_recursive_teleports);
+	struct TeleportParams {
+		bool run_foreground_events = false;
+		bool erase_screen = false;
+		bool use_default_transition_in = false;
+		bool defer_recursive_teleports = false;
+	};
+	void StartPendingTeleport(TeleportParams tp);
+	void FinishPendingTeleport(TeleportParams tp);
+	void FinishPendingTeleport2(MapUpdateAsyncContext actx, TeleportParams tp);
+	void FinishPendingTeleport3(MapUpdateAsyncContext actx, TeleportParams tp);
 
 	void PreUpdate(MapUpdateAsyncContext& actx);
+	void PreUpdateForegroundEvents(MapUpdateAsyncContext& actx);
 
 	// Calls map update
 	void UpdateStage1(MapUpdateAsyncContext actx);

--- a/src/teleport_target.h
+++ b/src/teleport_target.h
@@ -27,8 +27,10 @@ class TeleportTarget {
 	public:
 		/** The type of teleport */
 		enum Type {
-			/** A normal teleport action */
-			eNormalTeleport,
+			/** A teleport command from a parallel event */
+			eParallelTeleport,
+			/** A teleport command from a foreground event*/
+			eForegroundTeleport,
 			/** An escape or teleport skill */
 			eSkillTeleport,
 			/** A hacky teleport from a SetVehicleLocation() (RPG_RT bug) */
@@ -70,7 +72,7 @@ class TeleportTarget {
 		int x = 0;
 		int y = 0;
 		int16_t d = -1;
-		uint8_t tt = eNormalTeleport;
+		uint8_t tt = eParallelTeleport;
 		bool active = false;
 };
 


### PR DESCRIPTION
~~Depends on #1784~~

When RPG_RT executes a TransferPlayer command..

From a foreground event -> FG events run in preupdate
From a parallel event -> FG events do not run in preupdate
From a parallel event in a preupdate chain started by a
foreground event -> FG events run in preupdate

FG events do *not* run in preupdate for new game
or after a teleport / escape skill.

Fix: #1261
Fix: #1840