### PR TITLE
Refactor Interpreter Stack Frame Completion 

### DIFF
--- a/src/game_commonevent.h
+++ b/src/game_commonevent.h
@@ -105,8 +105,6 @@ public:
 	bool IsAsyncPending() const;
 
 private:
-	bool IsWaitingExecution(RPG::EventPage::Trigger trigger) const;
-
 	int common_event_id;
 
 	/** Interpreter for parallel common events. */

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -159,6 +159,11 @@ protected:
 	static int ValueOrVariable(int mode, int val);
 
 	/**
+	 * When current frame finishes executing we pop the stack
+	 */
+	bool OnFinishStackFrame();
+
+	/**
 	 * Triggers a game over when all party members are dead.
 	 */
 	void CheckGameOver();
@@ -240,7 +245,6 @@ protected:
 	bool CommandChangeBattleCommands(RPG::EventCommand const& com);
 	bool CommandExitGame(RPG::EventCommand const& com);
 	bool CommandToggleFullscreen(RPG::EventCommand const& com);
-	bool CommandEnd();
 
 	virtual bool DefaultContinuation(RPG::EventCommand const& com);
 	virtual bool ContinuationChoices(RPG::EventCommand const& com);

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -42,9 +42,7 @@ bool Game_Interpreter_Battle::ExecuteCommand() {
 	const auto& list = frame->commands;
 	auto& index = frame->current_command;
 
-	if (index >= list.size()) {
-		return CommandEnd();
-	}
+	assert(index < (int)list.size());
 
 	RPG::EventCommand const& com = list[index];
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -70,9 +70,7 @@ bool Game_Interpreter_Map::ExecuteCommand() {
 	const auto& list = frame->commands;
 	auto& index = frame->current_command;
 
-	if (index >= list.size()) {
-		return CommandEnd();
-	}
+	assert(index < (int)list.size());
 
 	RPG::EventCommand const& com = list[index];
 


### PR DESCRIPTION
Fix: #1871 

This should also fix: #1764  once we solve #1883

Supercedes #1879 If we merge this we don't need that one.

* Rename CommandEnd() to OnFinishStackFrame()

This name and it's nearby comment was very misleading. The
interpreter has actually always ignored `CommandEnd` commands.
This function was only called when the index ran past end of the stack
frame.

* Do OnFinishStackFrame() before execution loop.

Call this in one place and handle multiple stack pops. Also,
don't hang on empty events.

* Optimize parallel events

Reset the index and never pop the base stack frame. RPG_RT
does this and we avoid copying parallel event data every frame.

RPG_RT will always create a stack frame for parallel events,
even if they are empty.