### PR TITLE
Async improvements + Async Inn Sequence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(${PROJECT_NAME}
 	src/3ds_ui.h
 	src/async_handler.cpp
 	src/async_handler.h
+	src/async_op.h
 	src/audio_3ds.cpp
 	src/audio_3ds.h
 	src/audio_al.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,6 +11,7 @@ libeasyrpg_player_a_SOURCES = \
 	src/3ds_ui.h \
 	src/async_handler.cpp \
 	src/async_handler.h \
+	src/async_op.h \
 	src/audio.cpp \
 	src/audio.h \
 	src/audio_3ds.cpp \

--- a/src/async_op.h
+++ b/src/async_op.h
@@ -34,6 +34,7 @@ class AsyncOp {
 			eNone,
 			eShowScreen,
 			eEraseScreen,
+			eCallInn,
 			eToTitle,
 			eExitGame
 		};
@@ -45,6 +46,9 @@ class AsyncOp {
 
 		/** @return an EraseScreen async operation */
 		static AsyncOp MakeEraseScreen(int transition_type);
+
+		/** @return an CallInn async operation */
+		static AsyncOp MakeCallInn();
 
 		/** @return a ToTitle async operation */
 		static AsyncOp MakeToTitle();
@@ -97,6 +101,10 @@ inline AsyncOp AsyncOp::MakeShowScreen(int transition_type) {
 
 inline AsyncOp AsyncOp::MakeEraseScreen(int transition_type) {
 	return AsyncOp(eEraseScreen, transition_type);
+}
+
+inline AsyncOp AsyncOp::MakeCallInn() {
+	return AsyncOp(eCallInn);
 }
 
 inline AsyncOp AsyncOp::MakeToTitle() {

--- a/src/async_op.h
+++ b/src/async_op.h
@@ -1,0 +1,111 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_ASYNC_OP_H
+#define EP_ASYNC_OP_H
+
+#include <utility>
+#include <cassert>
+
+/**
+ * Represents an asynchronous game operation. These are usually created
+ * by event interpreters. When an async operation starts, the entire game
+ * loop is supposed to suspend, perform the async operation, and
+ * then resume from the suspension point.
+ **/
+class AsyncOp {
+	public:
+		/** The different types of async operations */
+		enum Type {
+			eNone,
+			eShowScreen,
+			eEraseScreen,
+			eToTitle,
+			eExitGame
+		};
+
+		AsyncOp() = default;
+
+		/** @return a ShowScreen async operation */
+		static AsyncOp MakeShowScreen(int transition_type);
+
+		/** @return an EraseScreen async operation */
+		static AsyncOp MakeEraseScreen(int transition_type);
+
+		/** @return a ToTitle async operation */
+		static AsyncOp MakeToTitle();
+
+		/** @return an ExitGame async operation */
+		static AsyncOp MakeExitGame();
+
+		/** @return the type of async operation */
+		Type GetType() const;
+
+		/** @return true if this AsyncOp is active */
+		bool IsActive() const;
+
+		/**
+		 * @return the type of screen transition to perform
+		 * @pre If GetType() is not eShowScreen or eEraseScreen, the return value is undefined.
+		 **/
+		int GetTransitionType() const;
+
+	private:
+		Type _type = eNone;
+		int _args[1] = {};
+
+		template <typename... Args>
+		explicit AsyncOp(Type type, Args&&... args);
+
+};
+
+inline AsyncOp::Type AsyncOp::GetType() const {
+	return _type;
+}
+
+inline bool AsyncOp::IsActive() const {
+	return GetType() != eNone;
+}
+
+inline int AsyncOp::GetTransitionType() const {
+	assert(GetType() == eShowScreen || GetType() == eEraseScreen);
+	return _args[0];
+}
+
+template <typename... Args>
+inline AsyncOp::AsyncOp(Type type, Args&&... args)
+	: _type(type), _args{std::forward<Args>(args)...}
+{}
+
+inline AsyncOp AsyncOp::MakeShowScreen(int transition_type) {
+	return AsyncOp(eShowScreen, transition_type);
+}
+
+inline AsyncOp AsyncOp::MakeEraseScreen(int transition_type) {
+	return AsyncOp(eEraseScreen, transition_type);
+}
+
+inline AsyncOp AsyncOp::MakeToTitle() {
+	return AsyncOp(eToTitle);
+}
+
+inline AsyncOp AsyncOp::MakeExitGame() {
+	return AsyncOp(eExitGame);
+}
+
+#endif
+

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -49,18 +49,18 @@ void Game_CommonEvent::SetSaveData(const RPG::SaveEventExecState& data) {
 	}
 }
 
-bool Game_CommonEvent::Update() {
+AsyncOp Game_CommonEvent::Update() {
 	if (interpreter && IsWaitingBackgroundExecution()) {
 		assert(interpreter->IsRunning());
 		interpreter->Update();
 
 		// Suspend due to async op ...
 		if (interpreter->IsAsyncPending()) {
-			return false;
+			return interpreter->GetAsyncOp();
 		}
 	}
 
-	return true;
+	return {};
 }
 
 int Game_CommonEvent::GetIndex() const {

--- a/src/game_commonevent.h
+++ b/src/game_commonevent.h
@@ -24,6 +24,7 @@
 #include "game_interpreter_map.h"
 #include "rpg_commonevent.h"
 #include "rpg_saveeventexecstate.h"
+#include "async_op.h"
 
 /**
  * Game_CommonEvent class.
@@ -47,9 +48,9 @@ public:
 	/**
 	 * Updates common event parallel interpreter.
 	 *
-	 * @return false if we must suspend due to an async operation.
+	 * @return async operation if we should suspend, otherwise returns AsyncOp::eNone
 	 */
-	bool Update();
+	AsyncOp Update();
 
 	/**
 	 * Gets common event index.
@@ -101,18 +102,11 @@ public:
 	/** @return true if waiting for background execution */
 	bool IsWaitingBackgroundExecution() const;
 
-	/** @return true if parallel event waiting for async op */
-	bool IsAsyncPending() const;
-
 private:
 	int common_event_id;
 
 	/** Interpreter for parallel common events. */
 	std::unique_ptr<Game_Interpreter_Map> interpreter;
 };
-
-inline bool Game_CommonEvent::IsAsyncPending() const {
-	return interpreter && interpreter->IsAsyncPending();
-}
 
 #endif

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -498,9 +498,9 @@ void Game_Event::MoveTypeAwayFromPlayer() {
 	MoveTypeTowardsOrAwayPlayer(false);
 }
 
-bool Game_Event::Update() {
+AsyncOp Game_Event::Update() {
 	if (!data()->active || page == NULL) {
-		return true;
+		return {};
 	}
 
 	// RPG_RT runs the parallel interpreter everytime Update is called.
@@ -516,18 +516,18 @@ bool Game_Event::Update() {
 
 		// Suspend due to async op ...
 		if (interpreter->IsAsyncPending()) {
-			return false;
+			return interpreter->GetAsyncOp();
 		}
 
 		// RPG_RT only exits if active is false here, but not if there is
 		// no active page...
 		if (!data()->active) {
-			return true;
+			return {};
 		}
 	}
 
 	if (IsProcessed()) {
-		return true;
+		return {};
 	}
 	SetProcessed(true);
 
@@ -545,7 +545,7 @@ bool Game_Event::Update() {
 	if (IsStopping()) {
 		CheckEventCollision();
 	}
-	return true;
+	return {};
 }
 
 const RPG::EventPage* Game_Event::GetPage(int page) const {

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -25,6 +25,7 @@
 #include "rpg_event.h"
 #include "rpg_savemapevent.h"
 #include "game_interpreter_map.h"
+#include "async_op.h"
 
 /**
  * Game_Event class.
@@ -111,9 +112,9 @@ public:
 	/** 
 	 * Update this for the current frame
 	 *
-	 * @return false if we must suspend due to an async operation.
+	 * @return async operation if we should suspend, otherwise returns AsyncOp::eNone
 	 */
-	bool Update();
+	AsyncOp Update();
 
 	bool AreConditionsMet(const RPG::EventPage& page);
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -387,6 +387,11 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 			}
 		}
 
+		// continuation triggered an async operation.
+		if (IsAsyncPending()) {
+			break;
+		}
+
 		if (Game_Map::GetNeedRefresh()) {
 			Game_Map::Refresh();
 		}
@@ -3346,6 +3351,5 @@ bool Game_Interpreter::DefaultContinuation(RPG::EventCommand const& /* com */) {
 
 bool Game_Interpreter::ContinuationOpenShop(RPG::EventCommand const& /* com */) { return true; }
 bool Game_Interpreter::ContinuationShowInnStart(RPG::EventCommand const& /* com */) { return true; }
-bool Game_Interpreter::ContinuationShowInnFinish(RPG::EventCommand const& /* com */) { return true; }
 bool Game_Interpreter::ContinuationEnemyEncounter(RPG::EventCommand const& /* com */) { return true; }
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -52,9 +52,6 @@
 #include "utils.h"
 #include "transition.h"
 
-bool Game_Interpreter::to_title = false;
-bool Game_Interpreter::exit_game = false;
-
 enum BranchSubcommand {
 	eOptionBranchElse = 1
 };
@@ -79,6 +76,7 @@ void Game_Interpreter::Clear() {
 	wait_messages = false;			// wait if message window is visible
 	_state = {};
 	_keyinput = {};
+	_async_op = {};
 }
 
 // Is interpreter running.
@@ -300,6 +298,9 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 		loop_count = 0;
 	}
 
+	// Always reset async status when we enter interpreter loop.
+	_async_op = {};
+
 	if (!IsRunning()) {
 		return;
 	}
@@ -308,6 +309,11 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 		// If something is calling a menu, we're allowed to execute only 1 command per interpreter. So we pass through if loop_count == 0, and stop at 1 or greater.
 		// RPG_RT compatible behavior.
 		if (loop_count > 0 && Scene::instance->HasRequestedScene()) {
+			break;
+		}
+
+		// Previous command triggered an async operation.
+		if (IsAsyncPending()) {
 			break;
 		}
 
@@ -323,10 +329,6 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 		} else {
 			if ((Game_Message::visible || Game_Message::message_waiting) && wait_messages)
 				break;
-		}
-
-		if (Game_Temp::transition_processing) {
-			break;
 		}
 
 		if (_state.wait_time > 0) {
@@ -2020,159 +2022,164 @@ bool Game_Interpreter::CommandStoreEventID(RPG::EventCommand const& com) { // co
 }
 
 bool Game_Interpreter::CommandEraseScreen(RPG::EventCommand const& com) { // code 11010
-	if (Game_Temp::transition_processing || Game_Message::visible)
+	if (Game_Message::visible)
 		return false;
 
-	Game_Temp::transition_processing = true;
-	Game_Temp::transition_erase = true;
+	int tt = Transition::TransitionNone;
 
 	switch (com.parameters[0]) {
 	case -1:
-		Game_Temp::transition_type = (Transition::TransitionType)Game_System::GetTransition(
+		tt = (Transition::TransitionType)Game_System::GetTransition(
 			Game_System::Transition_TeleportErase);
-		return true;
+		break;
 	case 0:
-		Game_Temp::transition_type = Transition::TransitionFadeOut;
-		return true;
+		tt = Transition::TransitionFadeOut;
+		break;
 	case 1:
-		Game_Temp::transition_type = Transition::TransitionRandomBlocks;
-		return true;
+		tt = Transition::TransitionRandomBlocks;
+		break;
 	case 2:
-		Game_Temp::transition_type = Transition::TransitionRandomBlocksUp;
-		return true;
+		tt = Transition::TransitionRandomBlocksUp;
+		break;
 	case 3:
-		Game_Temp::transition_type = Transition::TransitionRandomBlocksDown;
-		return true;
+		tt = Transition::TransitionRandomBlocksDown;
+		break;
 	case 4:
-		Game_Temp::transition_type = Transition::TransitionBlindClose;
-		return true;
+		tt = Transition::TransitionBlindClose;
+		break;
 	case 5:
-		Game_Temp::transition_type = Transition::TransitionVerticalStripesOut;
-		return true;
+		tt = Transition::TransitionVerticalStripesOut;
+		break;
 	case 6:
-		Game_Temp::transition_type = Transition::TransitionHorizontalStripesOut;
-		return true;
+		tt = Transition::TransitionHorizontalStripesOut;
+		break;
 	case 7:
-		Game_Temp::transition_type = Transition::TransitionBorderToCenterOut;
-		return true;
+		tt = Transition::TransitionBorderToCenterOut;
+		break;
 	case 8:
-		Game_Temp::transition_type = Transition::TransitionCenterToBorderOut;
-		return true;
+		tt = Transition::TransitionCenterToBorderOut;
+		break;
 	case 9:
-		Game_Temp::transition_type = Transition::TransitionScrollUpOut;
-		return true;
+		tt = Transition::TransitionScrollUpOut;
+		break;
 	case 10:
-		Game_Temp::transition_type = Transition::TransitionScrollDownOut;
-		return true;
+		tt = Transition::TransitionScrollDownOut;
+		break;
 	case 11:
-		Game_Temp::transition_type = Transition::TransitionScrollLeftOut;
-		return true;
+		tt = Transition::TransitionScrollLeftOut;
+		break;
 	case 12:
-		Game_Temp::transition_type = Transition::TransitionScrollRightOut;
-		return true;
+		tt = Transition::TransitionScrollRightOut;
+		break;
 	case 13:
-		Game_Temp::transition_type = Transition::TransitionVerticalDivision;
-		return true;
+		tt = Transition::TransitionVerticalDivision;
+		break;
 	case 14:
-		Game_Temp::transition_type = Transition::TransitionHorizontalDivision;
-		return true;
+		tt = Transition::TransitionHorizontalDivision;
+		break;
 	case 15:
-		Game_Temp::transition_type = Transition::TransitionCrossDivision;
-		return true;
+		tt = Transition::TransitionCrossDivision;
+		break;
 	case 16:
-		Game_Temp::transition_type = Transition::TransitionZoomIn;
-		return true;
+		tt = Transition::TransitionZoomIn;
+		break;
 	case 17:
-		Game_Temp::transition_type = Transition::TransitionMosaicOut;
-		return true;
+		tt = Transition::TransitionMosaicOut;
+		break;
 	case 18:
-		Game_Temp::transition_type = Transition::TransitionWaveOut;
-		return true;
+		tt = Transition::TransitionWaveOut;
+		break;
 	case 19:
-		Game_Temp::transition_type = Transition::TransitionErase;
-		return true;
+		tt = Transition::TransitionErase;
+		break;
 	default:
-		Game_Temp::transition_type = Transition::TransitionNone;
-		return true;
+		tt = Transition::TransitionNone;
+		break;
 	}
+
+	_async_op = AsyncOp::MakeEraseScreen(tt);
+
+	return true;
 }
 
 bool Game_Interpreter::CommandShowScreen(RPG::EventCommand const& com) { // code 11020
-	if (Game_Temp::transition_processing || Game_Message::visible)
+	if (Game_Message::visible)
 		return false;
 
-	Game_Temp::transition_processing = true;
-	Game_Temp::transition_erase = false;
+	int tt = Transition::TransitionNone;
 
 	switch (com.parameters[0]) {
 	case -1:
-		Game_Temp::transition_type = (Transition::TransitionType)Game_System::GetTransition(
+		tt = (Transition::TransitionType)Game_System::GetTransition(
 			Game_System::Transition_TeleportShow);
-		return true;
+		break;
 	case 0:
-		Game_Temp::transition_type = Transition::TransitionFadeIn;
-		return true;
+		tt = Transition::TransitionFadeIn;
+		break;
 	case 1:
-		Game_Temp::transition_type = Transition::TransitionRandomBlocks;
-		return true;
+		tt = Transition::TransitionRandomBlocks;
+		break;
 	case 2:
-		Game_Temp::transition_type = Transition::TransitionRandomBlocksUp;
-		return true;
+		tt = Transition::TransitionRandomBlocksUp;
+		break;
 	case 3:
-		Game_Temp::transition_type = Transition::TransitionRandomBlocksDown;
-		return true;
+		tt = Transition::TransitionRandomBlocksDown;
+		break;
 	case 4:
-		Game_Temp::transition_type = Transition::TransitionBlindOpen;
-		return true;
+		tt = Transition::TransitionBlindOpen;
+		break;
 	case 5:
-		Game_Temp::transition_type = Transition::TransitionVerticalStripesIn;
-		return true;
+		tt = Transition::TransitionVerticalStripesIn;
+		break;
 	case 6:
-		Game_Temp::transition_type = Transition::TransitionHorizontalStripesIn;
-		return true;
+		tt = Transition::TransitionHorizontalStripesIn;
+		break;
 	case 7:
-		Game_Temp::transition_type = Transition::TransitionBorderToCenterIn;
-		return true;
+		tt = Transition::TransitionBorderToCenterIn;
+		break;
 	case 8:
-		Game_Temp::transition_type = Transition::TransitionCenterToBorderIn;
-		return true;
+		tt = Transition::TransitionCenterToBorderIn;
+		break;
 	case 9:
-		Game_Temp::transition_type = Transition::TransitionScrollUpIn;
-		return true;
+		tt = Transition::TransitionScrollUpIn;
+		break;
 	case 10:
-		Game_Temp::transition_type = Transition::TransitionScrollDownIn;
-		return true;
+		tt = Transition::TransitionScrollDownIn;
+		break;
 	case 11:
-		Game_Temp::transition_type = Transition::TransitionScrollLeftIn;
-		return true;
+		tt = Transition::TransitionScrollLeftIn;
+		break;
 	case 12:
-		Game_Temp::transition_type = Transition::TransitionScrollRightIn;
-		return true;
+		tt = Transition::TransitionScrollRightIn;
+		break;
 	case 13:
-		Game_Temp::transition_type = Transition::TransitionVerticalCombine;
-		return true;
+		tt = Transition::TransitionVerticalCombine;
+		break;
 	case 14:
-		Game_Temp::transition_type = Transition::TransitionHorizontalCombine;
-		return true;
+		tt = Transition::TransitionHorizontalCombine;
+		break;
 	case 15:
-		Game_Temp::transition_type = Transition::TransitionCrossCombine;
-		return true;
+		tt = Transition::TransitionCrossCombine;
+		break;
 	case 16:
-		Game_Temp::transition_type = Transition::TransitionZoomOut;
-		return true;
+		tt = Transition::TransitionZoomOut;
+		break;
 	case 17:
-		Game_Temp::transition_type = Transition::TransitionMosaicIn;
-		return true;
+		tt = Transition::TransitionMosaicIn;
+		break;
 	case 18:
-		Game_Temp::transition_type = Transition::TransitionWaveIn;
-		return true;
+		tt = Transition::TransitionWaveIn;
+		break;
 	case 19:
-		Game_Temp::transition_type = Transition::TransitionErase;
-		return true;
+		tt = Transition::TransitionErase;
+		break;
 	default:
-		Game_Temp::transition_type = Transition::TransitionNone;
-		return true;
+		tt = Transition::TransitionNone;
+		break;
 	}
+
+	_async_op = AsyncOp::MakeShowScreen(tt);
+	return true;
 }
 
 bool Game_Interpreter::CommandTintScreen(RPG::EventCommand const& com) { // code 11030
@@ -3158,8 +3165,8 @@ bool Game_Interpreter::CommandCallEvent(RPG::EventCommand const& com) { // code 
 }
 
 bool Game_Interpreter::CommandReturnToTitleScreen(RPG::EventCommand const& /* com */) { // code 12510
-	to_title = true;
-	return false;
+	_async_op = AsyncOp::MakeToTitle();
+	return true;
 }
 
 bool Game_Interpreter::CommandChangeClass(RPG::EventCommand const& com) { // code 1008
@@ -3314,8 +3321,8 @@ bool Game_Interpreter::CommandChangeBattleCommands(RPG::EventCommand const& com)
 }
 
 bool Game_Interpreter::CommandExitGame(RPG::EventCommand const& /* com */) {
-	exit_game = true;
-	return false;
+	_async_op = AsyncOp::MakeExitGame();
+	return true;
 }
 
 bool Game_Interpreter::CommandToggleFullscreen(RPG::EventCommand const& /* com */) {
@@ -3342,7 +3349,3 @@ bool Game_Interpreter::ContinuationShowInnStart(RPG::EventCommand const& /* com 
 bool Game_Interpreter::ContinuationShowInnFinish(RPG::EventCommand const& /* com */) { return true; }
 bool Game_Interpreter::ContinuationEnemyEncounter(RPG::EventCommand const& /* com */) { return true; }
 
-
-bool Game_Interpreter::IsAsyncPending() {
-	return Game_Temp::transition_processing || to_title || exit_game;
-}

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -29,6 +29,7 @@
 #include "command_codes.h"
 #include "rpg_saveeventexecstate.h"
 #include "flag_set.h"
+#include "async_op.h"
 
 class Game_Event;
 class Game_CommonEvent;
@@ -90,27 +91,15 @@ public:
 	int GetOriginalEventId() const;
 
 	/** Return true if the interpreter is waiting for an async operation and needs to be resumed */
-	static bool IsAsyncPending();
+	bool IsAsyncPending();
 
-	/** @return true if any interpreter requested to return to title screen */
-	static bool GetReturnToTitle();
-
-	/** Resets the return to title flag */
-	static void ResetReturnToTitle();
-
-	/** @return true if any interpreter requested to return to title screen */
-	static bool GetExitGame();
-
-	/** Resets the return to title flag */
-	static void ResetExitGame();
+	/** Return true if the interpreter is waiting for an async operation and needs to be resumed */
+	AsyncOp GetAsyncOp() const;
 
 protected:
 	static constexpr int loop_limit = 10000;
 	static constexpr int call_stack_limit = 1000;
 	static constexpr int subcommand_sentinel = 255;
-
-	static bool to_title;
-	static bool exit_game;
 
 	const RPG::SaveEventExecFrame* GetFrame() const;
 	RPG::SaveEventExecFrame* GetFrame();
@@ -306,6 +295,7 @@ protected:
 
 	RPG::SaveEventExecState _state;
 	KeyInputState _keyinput;
+	AsyncOp _async_op = {};
 };
 
 inline const RPG::SaveEventExecFrame* Game_Interpreter::GetFrame() const {
@@ -328,20 +318,12 @@ inline int Game_Interpreter::GetLoopCount() const {
 	return loop_count;
 }
 
-inline bool Game_Interpreter::GetReturnToTitle() {
-	return to_title;
+inline bool Game_Interpreter::IsAsyncPending() {
+	return GetAsyncOp().IsActive();
 }
 
-inline void Game_Interpreter::ResetReturnToTitle() {
-	to_title = false;
-}
-
-inline bool Game_Interpreter::GetExitGame() {
-	return exit_game;
-}
-
-inline void Game_Interpreter::ResetExitGame() {
-	exit_game = false;
+inline AsyncOp Game_Interpreter::GetAsyncOp() const {
+	return _async_op;
 }
 
 #endif

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -256,7 +256,6 @@ protected:
 	virtual bool ContinuationChoices(RPG::EventCommand const& com);
 	virtual bool ContinuationOpenShop(RPG::EventCommand const& com);
 	virtual bool ContinuationShowInnStart(RPG::EventCommand const& com);
-	virtual bool ContinuationShowInnFinish(RPG::EventCommand const& com);
 	virtual bool ContinuationEnemyEncounter(RPG::EventCommand const& com);
 
 	int DecodeInt(std::vector<int32_t>::const_iterator& it);

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -396,9 +396,8 @@ bool Game_Interpreter_Map::CommandShowInn(RPG::EventCommand const& com) { // cod
 			}
 			else {
 				out << Data::terms.inn_a_greeting_1
-					<< " " << Game_Temp::inn_price
-					<< " " << Data::terms.gold
-					<< Data::terms.inn_a_greeting_2;
+					<< " " << Game_Temp::inn_price << Data::terms.gold
+					<< " " << Data::terms.inn_a_greeting_2;
 				Game_Message::texts.push_back(out.str());
 				Game_Message::texts.push_back(Data::terms.inn_a_greeting_3);
 			}
@@ -423,9 +422,8 @@ bool Game_Interpreter_Map::CommandShowInn(RPG::EventCommand const& com) { // cod
 			}
 			else {
 				out << Data::terms.inn_b_greeting_1
-					<< " " << Game_Temp::inn_price
-					<< " " << Data::terms.gold
-					<< Data::terms.inn_b_greeting_2;
+					<< " " << Game_Temp::inn_price << Data::terms.gold
+					<< " " << Data::terms.inn_b_greeting_2;
 				Game_Message::texts.push_back(out.str());
 				Game_Message::texts.push_back(Data::terms.inn_b_greeting_3);
 			}

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -366,8 +366,7 @@ bool Game_Interpreter_Map::CommandShowInn(RPG::EventCommand const& com) { // cod
 	if (Game_Temp::inn_price == 0) {
 		// Skip prompt.
 		Game_Message::choice_result = 0;
-		SetContinuation(static_cast<ContinuationFunction>(&Game_Interpreter_Map::ContinuationShowInnStart));
-		return false;
+		return ContinuationShowInnStart(com);
 	}
 
 	Game_Message::message_waiting = true;
@@ -463,7 +462,7 @@ bool Game_Interpreter_Map::CommandShowInn(RPG::EventCommand const& com) { // cod
 	// save game compatibility with RPG_RT
 	ReserveSubcommandIndex(com.indent);
 
-	return false;
+	return true;
 }
 
 bool Game_Interpreter_Map::ContinuationShowInnStart(RPG::EventCommand const& com) {
@@ -485,62 +484,11 @@ bool Game_Interpreter_Map::ContinuationShowInnStart(RPG::EventCommand const& com
 	if (inn_stay) {
 		Main_Data::game_party->GainGold(-Game_Temp::inn_price);
 
-		// Full heal
-		std::vector<Game_Actor*> actors = Main_Data::game_party->GetActors();
-		for (Game_Actor* actor : actors) {
-			actor->FullHeal();
-		}
-		Graphics::GetTransition().Init(Transition::TransitionFadeOut, Scene::instance.get(), 36, true);
-		Game_System::BgmFade(800);
-		SetContinuation(static_cast<ContinuationFunction>(&Game_Interpreter_Map::ContinuationShowInnContinue));
-		return false;
+		_async_op = AsyncOp::MakeCallInn();
+		return true;
 	}
 
-	++index;
 	return true;
-}
-
-bool Game_Interpreter_Map::ContinuationShowInnContinue(RPG::EventCommand const& /* com */) {
-	if (Graphics::IsTransitionPending())
-		return false;
-
-	const RPG::Music& bgm_inn = Game_System::GetSystemBGM(Game_System::BGM_Inn);
-	// FIXME: Abusing before_battle_music (Which is unused when calling an Inn)
-	// Is there also before_inn_music in the savegame?
-	Main_Data::game_data.system.before_battle_music = Game_System::GetCurrentBGM();
-
-	Game_System::BgmPlay(bgm_inn);
-
-	SetContinuation(static_cast<ContinuationFunction>(&Game_Interpreter_Map::ContinuationShowInnFinish));
-
-	return false;
-}
-
-bool Game_Interpreter_Map::ContinuationShowInnFinish(RPG::EventCommand const& com) {
-	auto* frame = GetFrame();
-	assert(frame);
-	auto& index = frame->current_command;
-
-	if (Graphics::IsTransitionPending())
-		return false;
-
-	const RPG::Music& bgm_inn = Game_System::GetSystemBGM(Game_System::BGM_Inn);
-	if (bgm_inn.name.empty() ||
-		bgm_inn.name == "(OFF)" ||
-		bgm_inn.name == "(Brak)" ||
-		!Audio().BGM_IsPlaying() ||
-		Audio().BGM_PlayedOnce()) {
-
-		Game_System::BgmStop();
-		continuation = NULL;
-		Graphics::GetTransition().Init(Transition::TransitionFadeIn, Scene::instance.get(), 36, false);
-		Game_System::BgmPlay(Main_Data::game_data.system.before_battle_music);
-
-		++index;
-		return false;
-	}
-
-	return false;
 }
 
 bool Game_Interpreter_Map::CommandStay(RPG::EventCommand const& com) { // code 20730

--- a/src/game_interpreter_map.h
+++ b/src/game_interpreter_map.h
@@ -84,8 +84,6 @@ private:
 
 	bool ContinuationOpenShop(RPG::EventCommand const& com) override;
 	bool ContinuationShowInnStart(RPG::EventCommand const& com) override;
-	bool ContinuationShowInnContinue(RPG::EventCommand const& com);
-	bool ContinuationShowInnFinish(RPG::EventCommand const& com) override;
 	bool ContinuationEnemyEncounter(RPG::EventCommand const& com) override;
 
 	static std::vector<Game_Character*> pending;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1015,9 +1015,10 @@ bool Game_Map::UpdateCommonEvents(MapUpdateAsyncContext& actx) {
 			}
 		}
 
-		if (!ev.Update()) {
+		auto aop = ev.Update();
+		if (aop.IsActive()) {
 			// Suspend due to this event ..
-			actx = MapUpdateAsyncContext::FromCommonEvent(ev.GetIndex());
+			actx = MapUpdateAsyncContext::FromCommonEvent(ev.GetIndex(), aop);
 			return false;
 		}
 	}
@@ -1039,9 +1040,10 @@ bool Game_Map::UpdateMapEvents(MapUpdateAsyncContext& actx) {
 			}
 		}
 
-		if (!ev.Update()) {
+		auto aop = ev.Update();
+		if (aop.IsActive()) {
 			// Suspend due to this event ..
-			actx = MapUpdateAsyncContext::FromMapEvent(ev.GetId());
+			actx = MapUpdateAsyncContext::FromMapEvent(ev.GetId(), aop);
 			return false;
 		}
 	}
@@ -1060,7 +1062,7 @@ bool Game_Map::UpdateForegroundEvents(MapUpdateAsyncContext& actx) {
 	interp.Update(!resume_fg);
 	if (interp.IsAsyncPending()) {
 		// Suspend due to this event ..
-		actx = MapUpdateAsyncContext::FromForegroundEvent();
+		actx = MapUpdateAsyncContext::FromForegroundEvent(interp.GetAsyncOp());
 		return false;
 	}
 
@@ -1109,7 +1111,7 @@ bool Game_Map::UpdateForegroundEvents(MapUpdateAsyncContext& actx) {
 		interp.Update(false);
 		if (interp.IsAsyncPending()) {
 			// Suspend due to this event ..
-			actx = MapUpdateAsyncContext::FromForegroundEvent();
+			actx = MapUpdateAsyncContext::FromForegroundEvent(interp.GetAsyncOp());
 			return false;
 		}
 	}

--- a/src/game_system.h
+++ b/src/game_system.h
@@ -269,6 +269,28 @@ namespace Game_System {
 	void OnBgmReady(FileRequestResult* result);
 	void OnSeReady(FileRequestResult* result, int volume, int tempo, bool stop_sounds);
 	void ReloadSystemGraphic();
+
+	/**
+	 * Determines if the requested file is supposed to Stop BGM/SE play.
+	 * For empty string and (OFF) this is always the case.
+	 * Many RPG Maker translation overtranslated the (OFF) reserved string,
+	 * e.g. (Brak) and (Kein Sound).
+	 * A file is detected as "Stop BGM/SE" when the file is missing in the
+	 * filesystem and the name is wrapped in (), otherwise it is a regular
+	 * file.
+	 *
+	 * @param name File to find
+	 * @param find_func Find function to use (FindSound or FindMusic)
+	 * @param found_name Name of the found file to play
+	 * @return true when the file is supposed to Stop playback.
+	 *         false otherwise and file to play is returned as found_name
+	 */
+	bool IsStopFilename(const std::string& name, std::string (*find_func) (const std::string&), std::string& found_name);
+
+	bool IsStopMusicFilename(const std::string& name, std::string& found_name);
+	bool IsStopMusicFilename(const std::string& name);
+	bool IsStopSoundFilename(const std::string& name, std::string& found_name);
+	bool IsStopSoundFilename(const std::string& name);
 }
 
 inline bool Game_System::HasSystemGraphic() {
@@ -277,6 +299,15 @@ inline bool Game_System::HasSystemGraphic() {
 
 inline bool Game_System::HasSystem2Graphic() {
 	return !GetSystem2Name().empty();
+}
+
+inline bool Game_System::IsStopMusicFilename(const std::string& name) {
+	std::string s;
+	return IsStopMusicFilename(name, s);
+}
+inline bool Game_System::IsStopSoundFilename(const std::string& name) {
+	std::string s;
+	return IsStopSoundFilename(name, s);
 }
 
 #endif

--- a/src/game_temp.cpp
+++ b/src/game_temp.cpp
@@ -20,9 +20,6 @@
 #include "transition.h"
 
 bool Game_Temp::inn_calling;
-bool Game_Temp::transition_processing;
-Transition::TransitionType Game_Temp::transition_type;
-bool Game_Temp::transition_erase;
 bool Game_Temp::shop_buys;
 bool Game_Temp::shop_sells;
 int Game_Temp::shop_type;
@@ -44,9 +41,6 @@ bool Game_Temp::battle_random_encounter;
 
 void Game_Temp::Init() {
 	inn_calling = false;
-	transition_processing = false;
-	transition_type = Transition::TransitionNone;
-	transition_erase = false;
 	shop_buys = true;
 	shop_sells = true;
 	shop_type = 0;

--- a/src/game_temp.h
+++ b/src/game_temp.h
@@ -35,10 +35,6 @@ public:
 
 	static bool inn_calling;
 
-	static bool transition_processing;
-	static Transition::TransitionType transition_type;
-	static bool transition_erase;
-
 	static bool shop_buys;
 	static bool shop_sells;
 	static int shop_type;		// message set A, B, or C

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -264,9 +264,8 @@ Graphics::State &Scene::GetGraphicsState() {
 	return state;
 }
 
-bool Scene::CheckInterpreterExit() {
-	if (Game_Interpreter::GetExitGame()) {
-		Game_Interpreter::ResetExitGame();
+bool Scene::CheckSceneExit(AsyncOp aop) {
+	if (aop.GetType() == AsyncOp::eExitGame) {
 		if (Scene::Find(Scene::GameBrowser)) {
 			Scene::PopUntil(Scene::GameBrowser);
 		} else {
@@ -275,8 +274,7 @@ bool Scene::CheckInterpreterExit() {
 		return true;
 	}
 
-	if (Game_Interpreter::GetReturnToTitle()) {
-		Game_Interpreter::ResetReturnToTitle();
+	if (aop.GetType() == AsyncOp::eToTitle) {
 		Scene::PopUntil(Scene::Title);
 		return true;
 	}

--- a/src/scene.h
+++ b/src/scene.h
@@ -21,6 +21,7 @@
 // Headers
 #include "graphics.h"
 #include "system.h"
+#include "async_op.h"
 #include <vector>
 
 /**
@@ -212,9 +213,11 @@ public:
 	void SetRequestedScene(SceneType scene);
 
 	/**
-	 * Check if the interpreter wants to end the game
+	 * Check if the async operation wants to end the scene.
+	 *
+	 * @param aop The pending async operation
 	 */
-	static bool CheckInterpreterExit();
+	static bool CheckSceneExit(AsyncOp aop);
 
 protected:
 	using AsyncContinuation = std::function<void(void)>;

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -189,8 +189,13 @@ void Scene_Battle::Update() {
 		// we need this so it can update automatically the status_window
 		status_window->Refresh();
 	}
-	if (CheckInterpreterExit()) {
-		return;
+	if (interp.IsAsyncPending()) {
+		auto aop = interp.GetAsyncOp();
+		if (CheckSceneExit(aop)) {
+			return;
+		}
+
+		// Note: ShowScreen / HideScreen is ignored.
 	}
 
 	if (Game_Battle::IsTerminating()) {

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -86,6 +86,10 @@ private:
 
 	void UpdateSceneCalling();
 
+	void StartInn();
+	void UpdateInn();
+	void FinishInn();
+
 	template <typename F> void AsyncNext(F&& f);
 	template <typename F> void OnAsyncSuspend(F&& f, AsyncOp aop, bool is_preupdate);
 
@@ -94,6 +98,10 @@ private:
 	int debug_menuoverwrite_counter = 0;
 	bool from_save;
 	bool screen_erased_by_event = false;
+
+	RPG::Music music_before_inn = {};
+	AsyncContinuation inn_continuation = {};
+	bool activate_inn = false;
 };
 
 #endif

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -87,7 +87,7 @@ private:
 	void UpdateSceneCalling();
 
 	template <typename F> void AsyncNext(F&& f);
-	template <typename F> void OnAsyncSuspend(F&& f, bool is_preupdate);
+	template <typename F> void OnAsyncSuspend(F&& f, AsyncOp aop, bool is_preupdate);
 
 	std::unique_ptr<Window_Message> message_window;
 


### PR DESCRIPTION
~~Depends on #1742~~

The PR has 2 goals:
* Refactor the async framework:
    * Don't use globals
    * Kill `transition` game temp vars
    * Support parameters for async ops
* Change Inn Fade Out, BGM, Fade In sequence to be asynchronous

Test Cases of #1689 
- [x] Test 1
- [ ] Test 2 - Requires message fixes - to be done in a later PR after message refactor commits get in.
- [x] Tests 3 - 5
- [ ] Test 6 - not sure we even want to emulate this..?