### PR TITLE
Fix Message Blocking rules - Messages 1 of N

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -436,8 +436,8 @@ endif
 @DX_RULES@
 
 # FIXME make filefinder work without external scripting
-check_PROGRAMS = directorytree output rtp utils wordwrap
-TESTS = directorytree output rtp utils wordwrap
+check_PROGRAMS = directorytree output rtp utils wordwrap utf
+TESTS = directorytree output rtp utils wordwrap utf
 directorytree_SOURCES = tests/directorytree.cpp
 directorytree_CXXFLAGS = $(libeasyrpg_player_a_CXXFLAGS)
 directorytree_LDADD = $(easyrpg_player_LDADD)
@@ -456,6 +456,9 @@ utils_LDADD = $(easyrpg_player_LDADD)
 wordwrap_SOURCES = tests/wordwrap.cpp tests/doctest.h
 wordwrap_CXXFLAGS = $(libeasyrpg_player_a_CXXFLAGS)
 wordwrap_LDADD = $(easyrpg_player_LDADD)
+utf_SOURCES = tests/utf.cpp tests/doctest.h
+utf_CXXFLAGS = $(libeasyrpg_player_a_CXXFLAGS)
+utf_LDADD = $(easyrpg_player_LDADD)
 
 # Some tests will create this file
 # make distcheck will fail if it is not cleaned after running these tests

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -807,13 +807,9 @@ bool Game_Interpreter::CommandShowMessage(RPG::EventCommand const& com) { // cod
 	const auto& list = frame->commands;
 	auto& index = frame->current_command;
 
-	// If there's a text already, return immediately
-	if (Game_Message::message_waiting)
+	if (!Game_Message::CanShowMessage(main_flag)) {
 		return false;
-
-	// Parallel interpreters must wait until the message window is closed
-	if (!main_flag && Game_Message::visible)
-		return false;
+	}
 
 	wait_messages = true;
 	unsigned int line_count = 0;
@@ -863,6 +859,10 @@ bool Game_Interpreter::CommandShowMessage(RPG::EventCommand const& com) { // cod
 }
 
 bool Game_Interpreter::CommandMessageOptions(RPG::EventCommand const& com) { //code 10120
+	if (!Game_Message::CanShowMessage(main_flag)) {
+		return false;
+	}
+
 	Game_Message::SetTransparent(com.parameters[0] != 0);
 	Game_Message::SetPosition(com.parameters[1]);
 	Game_Message::SetPositionFixed(com.parameters[2] == 0);
@@ -871,8 +871,9 @@ bool Game_Interpreter::CommandMessageOptions(RPG::EventCommand const& com) { //c
 }
 
 bool Game_Interpreter::CommandChangeFaceGraphic(RPG::EventCommand const& com) { // Code 10130
-	if (Game_Message::message_waiting && Game_Message::owner_id != GetOriginalEventId())
+	if (!Game_Message::CanShowMessage(main_flag)) {
 		return false;
+	}
 
 	Game_Message::SetFaceName(com.string);
 	Game_Message::SetFaceIndex(com.parameters[0]);
@@ -915,7 +916,8 @@ bool Game_Interpreter::CommandShowChoices(RPG::EventCommand const& com) { // cod
 	auto* frame = GetFrame();
 	assert(frame);
 	auto& index = frame->current_command;
-	if (!Game_Message::texts.empty()) {
+
+	if (!Game_Message::CanShowMessage(main_flag)) {
 		return false;
 	}
 
@@ -943,7 +945,7 @@ bool Game_Interpreter::CommandShowChoiceEnd(RPG::EventCommand const& com) { //co
 
 
 bool Game_Interpreter::CommandInputNumber(RPG::EventCommand const& com) { // code 10150
-	if (Game_Message::message_waiting) {
+	if (!Game_Message::CanShowMessage(main_flag)) {
 		return false;
 	}
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -72,7 +72,6 @@ Game_Interpreter::~Game_Interpreter() {
 // Clear.
 void Game_Interpreter::Clear() {
 	continuation = NULL;			// function to execute to resume command
-	wait_messages = false;			// wait if message window is visible
 	_state = {};
 	_keyinput = {};
 	_async_op = {};
@@ -326,9 +325,12 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 			if (Game_Message::message_waiting)
 				break;
 		} else {
-			if ((Game_Message::IsMessageActive()) && wait_messages)
+			if ((Game_Message::IsMessageActive()) && _state.show_message) {
 				break;
+			}
 		}
+
+		_state.show_message = false;
 
 		if (_state.wait_time > 0) {
 			_state.wait_time--;
@@ -811,11 +813,10 @@ bool Game_Interpreter::CommandShowMessage(RPG::EventCommand const& com) { // cod
 		return false;
 	}
 
-	wait_messages = true;
 	unsigned int line_count = 0;
 
 	Game_Message::message_waiting = true;
-	Game_Message::owner_id = GetOriginalEventId();
+	_state.show_message = true;
 
 	// Set first line
 	Game_Message::texts.push_back(com.string);
@@ -922,8 +923,8 @@ bool Game_Interpreter::CommandShowChoices(RPG::EventCommand const& com) { // cod
 	}
 
 	Game_Message::message_waiting = true;
-	Game_Message::owner_id = GetOriginalEventId();
-	wait_messages = true;
+	_state.show_message = true;
+
 	// Choices setup
 	std::vector<std::string> choices = GetChoices();
 	Game_Message::choice_cancel_type = com.parameters[0];
@@ -950,8 +951,7 @@ bool Game_Interpreter::CommandInputNumber(RPG::EventCommand const& com) { // cod
 	}
 
 	Game_Message::message_waiting = true;
-	Game_Message::owner_id = GetOriginalEventId();
-	wait_messages = true;
+	_state.show_message = true;
 
 	Game_Message::num_input_start = 0;
 	Game_Message::num_input_variable_id = com.parameters[1];

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1780,7 +1780,7 @@ bool Game_Interpreter::CommandGameOver(RPG::EventCommand const& /* com */) { // 
 	assert(frame);
 	auto& index = frame->current_command;
 
-	if (Game_Message::visible) {
+	if (Game_Message::IsMessageActive()) {
 		return false;
 	}
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -326,7 +326,7 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 			if (Game_Message::message_waiting)
 				break;
 		} else {
-			if ((Game_Message::visible || Game_Message::message_waiting) && wait_messages)
+			if ((Game_Message::IsMessageActive()) && wait_messages)
 				break;
 		}
 
@@ -1726,7 +1726,7 @@ bool Game_Interpreter::CommandWait(RPG::EventCommand const& com) { // code 11410
 		return true;
 	}
 
-	if (Game_Message::visible) {
+	if (Game_Message::IsMessageActive()) {
 		return false;
 	}
 
@@ -2033,8 +2033,9 @@ bool Game_Interpreter::CommandStoreEventID(RPG::EventCommand const& com) { // co
 }
 
 bool Game_Interpreter::CommandEraseScreen(RPG::EventCommand const& com) { // code 11010
-	if (Game_Message::visible)
+	if (Game_Message::IsMessageActive()) {
 		return false;
+	}
 
 	int tt = Transition::TransitionNone;
 
@@ -2114,8 +2115,9 @@ bool Game_Interpreter::CommandEraseScreen(RPG::EventCommand const& com) { // cod
 }
 
 bool Game_Interpreter::CommandShowScreen(RPG::EventCommand const& com) { // code 11020
-	if (Game_Message::visible)
+	if (Game_Message::IsMessageActive()) {
 		return false;
+	}
 
 	int tt = Transition::TransitionNone;
 
@@ -2651,9 +2653,9 @@ bool Game_Interpreter::CommandKeyInputProc(RPG::EventCommand const& com) { // co
 		Game_Map::SetNeedRefresh(Game_Map::Refresh_Map);
 	}
 
-	// FIXME: Is this valid?
-	if (wait && Game_Message::visible)
+	if (wait && Game_Message::IsMessageActive()) {
 		return false;
+	}
 
 	_keyinput = {};
 	_keyinput.wait = wait;
@@ -3176,6 +3178,10 @@ bool Game_Interpreter::CommandCallEvent(RPG::EventCommand const& com) { // code 
 }
 
 bool Game_Interpreter::CommandReturnToTitleScreen(RPG::EventCommand const& /* com */) { // code 12510
+	if (Game_Message::IsMessageActive()) {
+		return false;
+	}
+
 	_async_op = AsyncOp::MakeToTitle();
 	return true;
 }
@@ -3332,6 +3338,10 @@ bool Game_Interpreter::CommandChangeBattleCommands(RPG::EventCommand const& com)
 }
 
 bool Game_Interpreter::CommandExitGame(RPG::EventCommand const& /* com */) {
+	if (Game_Message::IsMessageActive()) {
+		return false;
+	}
+
 	_async_op = AsyncOp::MakeExitGame();
 	return true;
 }

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -107,7 +107,6 @@ protected:
 	bool main_flag;
 
 	int loop_count = 0;
-	bool wait_messages;
 
 	typedef bool (Game_Interpreter::*ContinuationFunction)(RPG::EventCommand const& com);
 	ContinuationFunction continuation;

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -146,8 +146,7 @@ bool Game_Interpreter_Map::ExecuteCommand() {
 		case Cmd::ToggleAtbMode:
 			return CommandToggleAtbMode(com);
 		case Cmd::OpenVideoOptions:
-			Output::Warning("OpenVideoOptions: Command not supported");
-			return true;
+			return CommandOpenVideoOptions(com);
 		default:
 			return Game_Interpreter::ExecuteCommand();
 	}
@@ -157,6 +156,10 @@ bool Game_Interpreter_Map::ExecuteCommand() {
  * Commands
  */
 bool Game_Interpreter_Map::CommandRecallToLocation(RPG::EventCommand const& com) { // Code 10830
+	if (Game_Message::IsMessageActive()) {
+		return false;
+	}
+
 	auto* frame = GetFrame();
 	assert(frame);
 	auto& index = frame->current_command;
@@ -533,13 +536,14 @@ bool Game_Interpreter_Map::CommandEnterHeroName(RPG::EventCommand const& com) { 
 
 bool Game_Interpreter_Map::CommandTeleport(RPG::EventCommand const& com) { // Code 10810
 																		   // TODO: if in battle return true
+	if (Game_Message::IsMessageActive()) {
+		return false;
+	}
+
 	auto* frame = GetFrame();
 	assert(frame);
 	auto& index = frame->current_command;
 
-	if (Game_Message::IsMessageActive()) {
-		return false;
-	}
 	int map_id = com.parameters[0];
 	int x = com.parameters[1];
 	int y = com.parameters[2];
@@ -658,6 +662,10 @@ bool Game_Interpreter_Map::CommandHaltAllMovement(RPG::EventCommand const& /* co
 }
 
 bool Game_Interpreter_Map::CommandPlayMovie(RPG::EventCommand const& com) { // code 11560
+	if (Game_Message::IsMessageActive()) {
+		return false;
+	}
+
 	const std::string& filename = com.string;
 	int pos_x = ValueOrVariable(com.parameters[0], com.parameters[1]);
 	int pos_y = ValueOrVariable(com.parameters[0], com.parameters[2]);
@@ -715,6 +723,15 @@ bool Game_Interpreter_Map::CommandOpenLoadMenu(RPG::EventCommand const& /* com *
 
 bool Game_Interpreter_Map::CommandToggleAtbMode(RPG::EventCommand const& /* com */) {
 	Main_Data::game_data.system.atb_mode = !Main_Data::game_data.system.atb_mode;
+	return true;
+}
+
+bool Game_Interpreter_Map::CommandOpenVideoOptions(RPG::EventCommand const& com) {
+	if (Game_Message::IsMessageActive()) {
+		return false;
+	}
+
+	Output::Warning("OpenVideoOptions: Command not supported");
 	return true;
 }
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -372,6 +372,11 @@ bool Game_Interpreter_Map::CommandShowInn(RPG::EventCommand const& com) { // cod
 		return ContinuationShowInnStart(com);
 	}
 
+	// Emulates RPG_RT behavior (Bug?) Inn's called by parallel events
+	// overwrite the current message.
+	if (main_flag && !Game_Message::CanShowMessage(main_flag)) {
+		return false;
+	}
 	Game_Message::message_waiting = true;
 
 	Game_Message::texts.clear();

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -186,7 +186,7 @@ bool Game_Interpreter_Map::CommandEnemyEncounter(RPG::EventCommand const& com) {
 	assert(frame);
 	auto& index = frame->current_command;
 
-	if (Game_Message::visible) {
+	if (Game_Message::IsMessageActive()) {
 		return false;
 	}
 
@@ -290,7 +290,7 @@ bool Game_Interpreter_Map::CommandOpenShop(RPG::EventCommand const& com) { // co
 	assert(frame);
 	auto& index = frame->current_command;
 
-	if (Game_Message::visible) {
+	if (Game_Message::IsMessageActive()) {
 		return false;
 	}
 
@@ -507,7 +507,7 @@ bool Game_Interpreter_Map::CommandEnterHeroName(RPG::EventCommand const& com) { 
 	assert(frame);
 	auto& index = frame->current_command;
 
-	if (Game_Message::visible) {
+	if (Game_Message::IsMessageActive()) {
 		return false;
 	}
 
@@ -537,7 +537,7 @@ bool Game_Interpreter_Map::CommandTeleport(RPG::EventCommand const& com) { // Co
 	assert(frame);
 	auto& index = frame->current_command;
 
-	if (Game_Message::visible) {
+	if (Game_Message::IsMessageActive()) {
 		return false;
 	}
 	int map_id = com.parameters[0];
@@ -676,7 +676,7 @@ bool Game_Interpreter_Map::CommandOpenSaveMenu(RPG::EventCommand const& /* com *
 	assert(frame);
 	auto& index = frame->current_command;
 
-	if (Game_Message::visible) {
+	if (Game_Message::IsMessageActive()) {
 		return false;
 	}
 
@@ -690,7 +690,7 @@ bool Game_Interpreter_Map::CommandOpenMainMenu(RPG::EventCommand const& /* com *
 	assert(frame);
 	auto& index = frame->current_command;
 
-	if (Game_Message::visible) {
+	if (Game_Message::IsMessageActive()) {
 		return false;
 	}
 
@@ -704,7 +704,7 @@ bool Game_Interpreter_Map::CommandOpenLoadMenu(RPG::EventCommand const& /* com *
 	assert(frame);
 	auto& index = frame->current_command;
 
-	if (Game_Message::visible) {
+	if (Game_Message::IsMessageActive()) {
 		return false;
 	}
 

--- a/src/game_interpreter_map.h
+++ b/src/game_interpreter_map.h
@@ -81,6 +81,7 @@ private:
 	bool CommandOpenMainMenu(RPG::EventCommand const& com);
 	bool CommandOpenLoadMenu(RPG::EventCommand const& com);
 	bool CommandToggleAtbMode(RPG::EventCommand const& com);
+	bool CommandOpenVideoOptions(RPG::EventCommand const& com);
 
 	bool ContinuationOpenShop(RPG::EventCommand const& com) override;
 	bool ContinuationShowInnStart(RPG::EventCommand const& com) override;

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -27,8 +27,6 @@ namespace Game_Message {
 	std::vector<std::string> texts;
 	bool is_word_wrapped;
 
-	unsigned int owner_id;
-
 	int choice_start;
 	int num_input_start;
 

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -41,6 +41,7 @@ namespace Game_Message {
 	int num_input_digits_max;
 
 	bool message_waiting;
+	bool closing;
 	bool visible;
 	bool choice_reset_color = false;
 
@@ -215,3 +216,20 @@ int Game_Message::WordWrap(const std::string& line, const int limit, const std::
 
 	return line_count;
 }
+
+bool Game_Message::CanShowMessage(bool foreground) {
+	// If there's a text already, return immediately
+	if (Game_Message::message_waiting)
+		return false;
+
+	// Forground interpreters: If the message box already started animating we wait for it to finish.
+	if (foreground && Game_Message::visible && Game_Message::closing)
+		return false;
+
+	// Parallel interpreters must wait until the message window is closed
+	if (!foreground && Game_Message::visible)
+		return false;
+
+	return true;
+}
+

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -222,18 +222,31 @@ namespace Game_Message {
 	extern int num_input_variable_id;
 	extern int num_input_digits_max;
 
-	/** Don't wait for a key to be pressed. */
-	extern bool dont_halt;
-
 	/** Reset the text color for each choice */
 	extern bool choice_reset_color;
 
-	/** If a message is currently being processed. */
+	/** If we're waiting for a message to finish processing. This flag is set to true from when the
+	 * message box is requested up until it's finished writing text and ready to close.
+	 */
 	extern bool message_waiting;
+	/**
+	 * Set to true when after the message box has started animating closed
+	 * FIXME: Implement this flag in Game_Message logic.
+	 **/
+	extern bool closing;
+	/** Set to true while the message box is visible on the screen */
 	extern bool visible;
 
 	/** Selected option (4 => cancel). */
 	extern int choice_result;
+
+	/**
+	 * Return if it's legal to show a new message box.
+	 *
+	 * @param foreground true if this is in the foreground context, otherwise parallel context.
+	 * @return true if we can show a message box.
+	 */
+	bool CanShowMessage(bool foreground);
 }
 
 #endif

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -41,9 +41,6 @@ namespace Game_Message {
 	/** Contains the different lines of text. */
 	extern std::vector<std::string> texts;
 
-	/** ID of the event that activated this message */
-	extern unsigned int owner_id;
-
 	/**
 	 * Returns name of file that contains the face.
 	 *

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -247,6 +247,16 @@ namespace Game_Message {
 	 * @return true if we can show a message box.
 	 */
 	bool CanShowMessage(bool foreground);
+
+	/**
+	 * True if a message is currently pending or still visible
+	 * @return true if message_waiting || visible
+	 */
+	bool IsMessageActive();
+}
+
+inline bool Game_Message::IsMessageActive() {
+	return message_waiting || visible;
 }
 
 #endif

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -260,8 +260,7 @@ void Game_Player::UpdateSelfMovement() {
 
 	if (!is_boarding
 			&& !Game_Map::GetInterpreter().IsRunning()
-			&& !Game_Message::message_waiting
-			&& !Game_Message::visible
+			&& !Game_Message::IsMessageActive()
 			&& !IsMoveRouteOverwritten()
 			&& !IsPaused() // RPG_RT compatible logic, but impossible to set pause on player
 			&& !did_call_encounter
@@ -320,8 +319,7 @@ void Game_Player::UpdateSelfMovement() {
 
 	// ESC-Menu calling
 	if (Game_System::GetAllowMenu()
-			&& !Game_Message::message_waiting
-			&& !Game_Message::visible
+			&& !Game_Message::IsMessageActive()
 			&& !Game_Map::GetInterpreter().IsRunning())
 	{
 		if (Input::IsTriggered(Input::CANCEL)) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -95,6 +95,7 @@ namespace Player {
 	bool touch_flag;
 	std::string encoding;
 	std::string escape_symbol;
+	uint32_t escape_char;
 	int engine;
 	std::string game_title;
 	std::shared_ptr<Meta> meta;
@@ -638,6 +639,7 @@ void Player::ParseCommandLine(int argc, char *argv[]) {
 void Player::CreateGameObjects() {
 	GetEncoding();
 	escape_symbol = ReaderUtil::Recode("\\", encoding);
+	escape_char = Utils::DecodeUTF32(Player::escape_symbol).front();
 	if (escape_symbol.empty()) {
 		Output::Error("Invalid encoding: %s.", encoding.c_str());
 	}
@@ -1004,6 +1006,7 @@ std::string Player::GetEncoding() {
 			// When yes is a good encoding. Otherwise try the next ones.
 
 			escape_symbol = ReaderUtil::Recode("\\", enc);
+			escape_char = Utils::DecodeUTF32(Player::escape_symbol).front();
 			if (escape_symbol.empty()) {
 				// Bad encoding
 				Output::Debug("Bad encoding: %s. Trying next.", enc.c_str());
@@ -1030,6 +1033,7 @@ std::string Player::GetEncoding() {
 		}
 
 		escape_symbol = "";
+		escape_char = 0;
 
 		if (!encoding.empty()) {
 			Output::Debug("Detected encoding: %s", encoding.c_str());

--- a/src/player.h
+++ b/src/player.h
@@ -289,8 +289,11 @@ namespace Player {
 	/** Encoding used */
 	extern std::string encoding;
 
-	/** Backslash recoded */
+	/** Backslash recoded to utf8 string */
 	extern std::string escape_symbol;
+
+	/** Backslash recoded to character */
+	extern uint32_t escape_char;
 
 	/** Currently interpreted engine. */
 	extern int engine;

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -237,13 +237,14 @@ void Scene_Map::UpdateStage2() {
 }
 
 void Scene_Map::UpdateSceneCalling() {
-	if (Game_Message::visible)
-		return;
 
 	auto call = GetRequestedScene();
 	SetRequestedScene(Null);
 
-	if (call == Null && Player::debug_flag) {
+	if (call == Null
+			&& Player::debug_flag
+			&& !Game_Message::IsMessageActive())
+	{
 		// ESC-Menu calling can be force called when TestPlay mode is on and cancel is pressed 5 times while holding SHIFT
 		if (Input::IsPressed(Input::SHIFT)) {
 			if (Input::IsTriggered(Input::CANCEL)) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -92,6 +92,20 @@ namespace Utils {
 	 */
 	std::string EncodeUTF(const std::u32string& str);
 
+	struct UtfNextResult {
+		uint32_t ch;
+		const char* iter;
+	};
+
+	/**
+	 * Decodes the next UTF-8 character and returns it and the iterator to the next
+	 *
+	 * @param iter begginning of the range to convert from
+	 * @param end end of the range to convert from
+	 * @return the converted string.
+	 */
+	UtfNextResult UTF8Next(const char* iter, const char* end);
+
 #if !defined(__amigaos4__) && !defined(__AROS__)
 	/**
 	 * Converts UTF-8 string to std::wstring.

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -353,7 +353,6 @@ void Window_Message::Update() {
 		} else if (!visible) {
 			// The closing animation has finished
 			Game_Message::visible = false;
-			Game_Message::owner_id = 0;
 		}
 	}
 }

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -64,7 +64,6 @@ Window_Message::Window_Message(int ix, int iy, int iwidth, int iheight) :
 	// Above other windows
 	SetZ(Priority_Window + 100);
 
-	escape_char = Utils::DecodeUTF32(Player::escape_symbol).front();
 	active = false;
 	index = -1;
 	text_color = Font::ColorDefault;
@@ -100,7 +99,7 @@ void Window_Message::ApplyTextInsertingCommands() {
 			case 'n':
 			case 'v':
 			{
-				if (*text_index != escape_char) {
+				if (*text_index != Player::escape_char) {
 					continue;
 				}
 				++text_index;
@@ -405,7 +404,7 @@ void Window_Message::UpdateMessage() {
 				// instant_speed stops at the end of the line, unless
 				// there's a /> at the beginning of the next line
 				if (std::distance(text_index, end) > 2 &&
-					*(text_index + 1) == escape_char &&
+					*(text_index + 1) == Player::escape_char &&
 					*(text_index + 2) == '>') {
 					text_index += 2;
 				} else {
@@ -424,7 +423,7 @@ void Window_Message::UpdateMessage() {
 				new_page_after_pause = true;
 			}
 			break;
-		} else if (*text_index == escape_char && std::distance(text_index, end) > 1) {
+		} else if (*text_index == Player::escape_char && std::distance(text_index, end) > 1) {
 			// Special message codes
 			++text_index;
 
@@ -485,7 +484,7 @@ void Window_Message::UpdateMessage() {
 				--text_index;
 				break;
 			default:
-				if (*text_index == escape_char) {
+				if (*text_index == Player::escape_char) {
 					// Show Escape Symbol
 					contents->TextDraw(contents_x, contents_y, text_color, Player::escape_symbol);
 					contents_x += Font::Default()->GetSize(Player::escape_symbol).width;

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -179,9 +179,6 @@ protected:
 	/** If true inserts a new page after pause ended */
 	bool new_page_after_pause;
 
-	/** Character used before message commands. */
-	uint32_t escape_char;
-
 	/**
 	 * Table contains how many frames drawing one single char takes.
 	 * 0 means: 2 chars per frame.

--- a/tests/utf.cpp
+++ b/tests/utf.cpp
@@ -1,0 +1,87 @@
+#include <cassert>
+#include <cstdlib>
+#include "utils.h"
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+// Correct Tests
+
+struct TestSet {
+	std::string u8;
+	std::u16string u16;
+	std::u32string u32;
+};
+
+#define CONCAT2(x, y) x ## y
+#define CONCAT(x, y) CONCAT2(x, y)
+#define STRINGIZE(x) #x
+//#define TS(X) { CONCAT(u8, STRINGIZE(X)), CONCAT(u, STRINGIZE(X)), CONCAT(U, STRINGIZE(X)) }
+#define TS(X) { CONCAT(u8, X), CONCAT(u, X), CONCAT(U, X) }
+
+TestSet tests[] = {
+	//Valid Strings
+	TS("κόσμε"),
+	//First Char tests
+	TS("\U00000000"),
+	TS("\U00000080"),
+	TS("\U00000800"),
+	TS("\U00010000"),
+//	TS("\U00200000"),
+//	TS("\U04000000"),
+//	//Last char tests
+	TS("\U0000007F"),
+	TS("\U000007FF"),
+	TS("\U0000FFFF"),
+//	TS("\U001FFFFF"),
+//	TS("\U03FFFFFF"),
+//	TS("\U7FFFFFFF"),
+//	//Other boundary tests
+	TS("\U0000D7FF"),
+	TS("\U0000E000"),
+	TS("\U0000FFFD"),
+	TS("\U0010FFFF"),
+//	TS("\U00110000"),
+};
+
+TEST_CASE("8to16") {
+	for (auto& ts: tests) {
+		auto u16 = Utils::DecodeUTF16(ts.u8);
+		REQUIRE_EQ(u16, ts.u16);
+	}
+}
+
+TEST_CASE("8to32") {
+	for (auto& ts: tests) {
+		auto u32 = Utils::DecodeUTF32(ts.u8);
+		REQUIRE_EQ(u32, ts.u32);
+	}
+}
+
+TEST_CASE("16to8") {
+	for (auto& ts: tests) {
+		auto u8 = Utils::EncodeUTF(ts.u16);
+		REQUIRE_EQ(u8, ts.u8);
+	}
+}
+
+TEST_CASE("32to8") {
+	for (auto& ts: tests) {
+		auto u8 = Utils::EncodeUTF(ts.u32);
+		REQUIRE_EQ(u8, ts.u8);
+	}
+}
+
+TEST_CASE("next") {
+	for (auto& ts: tests) {
+		const char* iter = ts.u8.data();
+		const char* const e = ts.u8.data() + ts.u8.size();
+		int i = 0;
+		while (iter < e) {
+			auto ret = Utils::UTF8Next(iter, e);
+			REQUIRE_EQ(ret.ch, ts.u32[i]);
+			iter = ret.iter;
+			++i;
+		}
+	}
+}

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -2,13 +2,12 @@
 #include <cstdlib>
 #include "utils.h"
 
-static void LowerCase() {
-	assert(Utils::LowerCase("EasyRPG") == "easyrpg");
-	assert(Utils::LowerCase("player") == "player");
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+
+TEST_CASE("Lower") {
+	REQUIRE_EQ(Utils::LowerCase("EasyRPG"), "easyrpg");
+	REQUIRE_EQ(Utils::LowerCase("player"), "player");
 }
 
-extern "C" int main(int, char**) {
-	LowerCase();
-
-	return EXIT_SUCCESS;
-}


### PR DESCRIPTION
Depends on #1905
Fix: #1781 

I took the commits from #1876 which relate to the conditions which cause the interpreter to block. This is arguably one of the more important pieces of the message refactor. Also includes the LSD `show_message` chunk.

Related Test cases:
* https://github.com/EasyRPG/Player/issues/1706#issuecomment-525077134

There is an additional case where autostart events will wait for the message box to close if they run 1 frame after the previous message finishes. While I added the variable for this, it is not yet implemented. Implementing it correctly requires a lot of frame timing surgery in `Window_Message` and is deferred until later.