### PR TITLE
Frozen Triggers Optimizations // Minor AsyncHandler Optimizations

### DIFF
--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -273,10 +273,7 @@ FileRequestBinding FileRequestAsync::Bind(std::function<void(FileRequestResult*)
 }
 
 void FileRequestAsync::CallListeners(bool success) {
-	FileRequestResult result;
-	result.directory = directory;
-	result.file = file;
-	result.success = success;
+	FileRequestResult result { directory, file, success };
 
 	for (auto& listener : listeners) {
 		if (!listener.first.expired()) {

--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -39,12 +39,12 @@
 //#define EP_DEBUG_SIMULATE_ASYNC
 
 namespace {
-	std::map<std::string, FileRequestAsync> async_requests;
-	std::map<std::string, std::string> file_mapping;
+	std::unordered_map<std::string, FileRequestAsync> async_requests;
+	std::unordered_map<std::string, std::string> file_mapping;
 	int next_id = 0;
 
 	FileRequestAsync* GetRequest(const std::string& path) {
-		std::map<std::string, FileRequestAsync>::iterator it = async_requests.find(path);
+		auto it = async_requests.find(path);
 
 		if (it != async_requests.end()) {
 			return &(it->second);

--- a/src/async_handler.h
+++ b/src/async_handler.h
@@ -227,8 +227,8 @@ private:
  * success: true if requested was successful, otherwise false.
  */
 struct FileRequestResult {
-	std::string directory;
-	std::string file;
+	const std::string& directory;
+	const std::string& file;
 	bool success;
 };
 


### PR DESCRIPTION
Depends on: #1896 #1897 

These are some player optimizations to fix some of the issues in #1883 

Debug build in master

![](https://raw.githubusercontent.com/fmatthew5876/EasyRPG-perf/master/master-2-pr1884/frozen_triggers_dbg.svg?sanitize=true)

Debug build after "Don't reallocate Sprite"

![](https://raw.githubusercontent.com/fmatthew5876/EasyRPG-perf/master/pr1895/frozen_triggers_noalloc.svg?sanitize=true)

Debug build after "Add Player::GetTicks()"

![](https://raw.githubusercontent.com/fmatthew5876/EasyRPG-perf/master/pr1895/frozen_triggers_noalloc.svg?sanitize=true)

Debug build after "Add AsyncFileRequest::BindStart()"

![](https://raw.githubusercontent.com/fmatthew5876/EasyRPG-perf/master/pr1895/frozen_triggers_nobind.svg?sanitize=true)

Debug build after "Don't update picture sprites after load"

![](https://raw.githubusercontent.com/fmatthew5876/EasyRPG-perf/master/pr1895/frozen_triggers_noupd.svg?sanitize=true)

These show improvements, but I still get 0 FPS so far.