### PR TITLE
Emscripten: Support non-canonical paths

### DIFF
--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -34,6 +34,10 @@
 #include "utils.h"
 #include "graphics.h"
 
+// When this option is enabled async requests are randomly delayed.
+// This allows testing some aspects of async file fetching locally.
+//#define EP_DEBUG_SIMULATE_ASYNC
+
 namespace {
 	std::map<std::string, FileRequestAsync> async_requests;
 	std::map<std::string, std::string> file_mapping;
@@ -110,8 +114,10 @@ FileRequestAsync* AsyncHandler::RequestFile(const std::string& file_name) {
 bool AsyncHandler::IsFilePending(bool important, bool graphic) {
 	for (auto& ap: async_requests) {
 		FileRequestAsync& request = ap.second;
-		// remove comment for fake download testing
-		//request.UpdateProgress();
+
+#ifdef EP_DEBUG_SIMULATE_ASYNC
+		request.UpdateProgress();
+#endif
 
 		if (!request.IsReady()
 				&& (!important || request.IsImportantFile())
@@ -223,8 +229,10 @@ void FileRequestAsync::Start() {
 #  ifdef EM_GAME_URL
 #    warning EM_GAME_URL set and not an Emscripten build!
 #  endif
-	// add comment for fake download testing
+
+#  ifndef EP_DEBUG_SIMULATE_ASYNC
 	DownloadDone(true);
+#  endif
 #endif
 }
 

--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -21,6 +21,7 @@
 #ifdef EMSCRIPTEN
 #  include <emscripten.h>
 #  include <regex>
+#  include "picojson.h"
 #endif
 
 #include "async_handler.h"
@@ -29,7 +30,6 @@
 #include "output.h"
 #include "player.h"
 #include "main_data.h"
-#include "picojson.h"
 #include <fstream>
 #include "utils.h"
 #include "graphics.h"
@@ -72,6 +72,7 @@ namespace {
 }
 
 void AsyncHandler::CreateRequestMapping(const std::string& file) {
+#ifdef EMSCRIPTEN
 	std::shared_ptr<std::fstream> f = FileFinder::openUTF8(file, std::ios_base::in | std::ios_base::binary);
 	picojson::value v;
 	picojson::parse(v, *f);
@@ -79,6 +80,10 @@ void AsyncHandler::CreateRequestMapping(const std::string& file) {
 	for (const auto& value : v.get<picojson::object>()) {
 		file_mapping[value.first] = value.second.to_str();
 	}
+#else
+	// no-op
+	(void)file;
+#endif
 }
 
 FileRequestAsync* AsyncHandler::RequestFile(const std::string& folder_name, const std::string& file_name) {

--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -204,7 +204,13 @@ void FileRequestAsync::Start() {
 		request_path += "default/";
 	}
 
-	auto it = file_mapping.find(Utils::LowerCase(path));
+	std::string real_path = Utils::LowerCase(path);
+	if (directory != ".") {
+		// Don't alter the path when the file is in the main directory
+		real_path = FileFinder::MakeCanonical(real_path, 1);
+	}
+
+	auto it = file_mapping.find(real_path);
 	if (it != file_mapping.end()) {
 		request_path += it->second;
 	} else {

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -140,18 +140,15 @@ namespace {
 		if (combined_path != canon) {
 			// Very few games (e.g. Yume2kki) use path traversal (..) in the filenames to point
 			// to files outside of the actual directory.
-			// Fix the path and search the file again with the correct root directory set.
-			if (dir != ".") {
-				// Prevent "path adjusted" debug log when searching for ExFont
-				Output::Debug("Path adjusted: %s -> %s", combined_path.c_str(), canon.c_str());
+			// Fix the path and continue searching.
+			size_t pos = canon.find_first_of("/");
+			if (pos == std::string::npos) {
+				corrected_dir = ".";
+				corrected_name = canon;
+			} else {
+				corrected_dir = canon.substr(0, pos);
+				corrected_name = canon.substr(pos + 1);
 			}
-			for (char const** c = exts; *c != NULL; ++c) {
-				std::string res = FileFinder::FindDefault(tree, canon + *c);
-				if (!res.empty()) {
-					return res;
-				}
-			}
-			return "";
 		}
 
 #ifdef _WIN32


### PR DESCRIPTION
Emscripten makes now the path canonical before doing a lookup and the FileFinder does not flood the log with "Path adjusted" and "File not found bla.xyz", "File not Found bla.png" (when probing for the adjusted file) anymore.

This adds some minor enhancements: Picojson not included anymore outside of emscripten and added a async testing macro.

