### PR TITLE
Fix Player getting stuck at 0 FPS.

### DIFF
--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -88,7 +88,7 @@ void Graphics::Update() {
 		if (fps_overlay->GetFps() == 0) {
 			Output::Debug("Framerate is 0 FPS!");
 			Draw();
-			Player::FrameReset();
+			Player::FrameReset(current_time);
 		} else {
 			next_fps_time = current_time + 1000;
 			fps_overlay->ResetCounter();
@@ -185,8 +185,8 @@ bool Graphics::IsTransitionErased() {
 	return (transition ? transition->IsErased() : false);
 }
 
-void Graphics::FrameReset() {
-	next_fps_time = (uint32_t)DisplayUi->GetTicks() + 1000;
+void Graphics::FrameReset(uint32_t start_ticks) {
+	next_fps_time = start_ticks + 1000;
 	fps_overlay->ResetCounter();
 }
 

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -88,10 +88,12 @@ void Graphics::Update() {
 		if (fps_overlay->GetFps() == 0) {
 			Output::Debug("Framerate is 0 FPS!");
 			Draw();
+			Player::FrameReset();
+		} else {
+			next_fps_time = current_time + 1000;
+			fps_overlay->ResetCounter();
 		}
 
-		next_fps_time = current_time + 1000;
-		fps_overlay->ResetCounter();
 		UpdateTitle();
 	}
 

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -57,9 +57,11 @@ namespace Graphics {
 
 	/**
 	 * Resets the fps count.
-	 * Don't call this function directly, use Player::FrameReset.
+	 * Don't call this. Use Player::FrameReset instead.
+	 *
+	 * @param start_ticks time in ticks
 	 */
-	void FrameReset();
+	void FrameReset(uint32_t start_ticks);
 
 	/**
 	 * Gets a bitmap with the actual contents of the screen.

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -350,15 +350,17 @@ void Player::IncFrame() {
 
 void Player::FrameReset() {
 	// When update started
-	start_time = (double)DisplayUi->GetTicks();
+	FrameReset(DisplayUi->GetTicks());
+}
 
+void Player::FrameReset(uint32_t start_ticks) {
 	// available ms per frame, game logic expects 60 fps
 	static const double framerate_interval = 1000.0 / Graphics::GetDefaultFps();
 
 	// When next frame is expected
-	next_frame = start_time + framerate_interval;
+	next_frame = start_ticks + framerate_interval;
 
-	Graphics::FrameReset();
+	Graphics::FrameReset(start_ticks);
 }
 
 int Player::GetFrames() {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -322,6 +322,8 @@ void Player::Update(bool update_scene) {
 		}
 	}
 
+	start_time = next_frame;
+
 #ifdef EMSCRIPTEN
 	Graphics::Draw();
 #else
@@ -338,8 +340,6 @@ void Player::Update(bool update_scene) {
 #endif
 	}
 #endif
-
-	start_time = next_frame;
 }
 
 void Player::IncFrame() {

--- a/src/player.h
+++ b/src/player.h
@@ -87,6 +87,16 @@ namespace Player {
 	void FrameReset();
 
 	/**
+	 * Resets the fps count (both updates and frames per second).
+	 * Should be called after an expensive operation.
+	 * Instead of using DisplayUi->GetTicks uses the start_ticks arg which
+	 * saves a system call.
+	 *
+	 * @param start_ticks time in ticks when this function was called
+	 */
+	void FrameReset(uint32_t start_ticks);
+
+	/**
 	 * Increment the frame counters.
 	 */
 	void IncFrame();


### PR DESCRIPTION
When the Player runs at 0 FPS the next_frame will fall behind start_time which means the Player will continue running at 0 FPS even when the current screen could run faster.
next_frame and start_time are now properly reset when 0 FPS are reached.

For testing wait for ~10 sec in Frozen Triggers, then leave the screen to the left to enter the shop. With my patch the FPS go up to 60 again, in master it stays at 0 FPS for a long time until it recovers.

This should also fix some Android bug reports where the logfile was spammed with 0 FPS.