### PR TITLE
Fix Message text and window animation timings - Messages 2 of N

### DIFF
--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -43,6 +43,7 @@
 #include "player.h"
 #include "input.h"
 #include "utils.h"
+#include "window_message.h"
 
 namespace {
 	constexpr int default_pan_x = 9 * SCREEN_TILE_SIZE;
@@ -943,7 +944,7 @@ int Game_Map::CheckEvent(int x, int y) {
 	return 0;
 }
 
-void Game_Map::Update(MapUpdateAsyncContext& actx, bool is_preupdate) {
+void Game_Map::Update(MapUpdateAsyncContext& actx, Window_Message& message, bool is_preupdate) {
 	if (GetNeedRefresh() != Refresh_None) Refresh();
 
 	if (!actx.IsActive()) {
@@ -980,6 +981,7 @@ void Game_Map::Update(MapUpdateAsyncContext& actx, bool is_preupdate) {
 			}
 		}
 
+		message.Update();
 		Main_Data::game_party->UpdateTimers();
 		Main_Data::game_screen->Update();
 	}

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -32,6 +32,7 @@
 #include "async_op.h"
 
 class FileRequestAsync;
+class Window_Message;
 
 // These are in sixteenths of a pixel.
 constexpr int SCREEN_TILE_SIZE = 256;
@@ -254,9 +255,10 @@ namespace Game_Map {
 	 * @param actx asynchronous operations context. In out param.
 	 *        If IsActive() when passed in, will resume to that point.
 	 *        If IsActive() after return in, will suspend from that point.
+	 * @param the scene message window
 	 * @param is_preupdate Update only common events and map events
 	 */
-	void Update(MapUpdateAsyncContext& actx, bool is_preupdate = false);
+	void Update(MapUpdateAsyncContext& actx, Window_Message& message, bool is_preupdate = false);
 
 	/**
 	 * Gets current map_info.

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -641,7 +641,7 @@ namespace Game_Map {
 	void UpdateProcessedFlags(bool is_preupdate);
 	bool UpdateCommonEvents(MapUpdateAsyncContext& actx);
 	bool UpdateMapEvents(MapUpdateAsyncContext& actx);
-	bool UpdateForegroundEvents(MapUpdateAsyncContext& actx);
+	bool UpdateForegroundEvents(MapUpdateAsyncContext& actx, Window_Message& message);
 
 	FileRequestAsync* RequestMap(int map_id);
 

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -226,10 +226,7 @@ namespace Game_Message {
 	 * message box is requested up until it's finished writing text and ready to close.
 	 */
 	extern bool message_waiting;
-	/**
-	 * Set to true when after the message box has started animating closed
-	 * FIXME: Implement this flag in Game_Message logic.
-	 **/
+	/** Set to true when after the message box has started animating closed */
 	extern bool closing;
 	/** Set to true while the message box is visible on the screen */
 	extern bool visible;

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -187,7 +187,7 @@ void Scene_Map::DrawBackground() {
 }
 
 void Scene_Map::PreUpdate(MapUpdateAsyncContext& actx) {
-	Game_Map::Update(actx, true);
+	Game_Map::Update(actx, *message_window, true);
 	spriteset->Update();
 }
 
@@ -206,7 +206,7 @@ void Scene_Map::Update() {
 }
 
 void Scene_Map::UpdateStage1(MapUpdateAsyncContext actx) {
-	Game_Map::Update(actx);
+	Game_Map::Update(actx, *message_window);
 	spriteset->Update();
 
 	// Waiting for async operation from map update.
@@ -214,8 +214,6 @@ void Scene_Map::UpdateStage1(MapUpdateAsyncContext actx) {
 		OnAsyncSuspend([this,actx]() { UpdateStage1(actx); }, actx.GetAsyncOp(), false);
 		return;
 	}
-
-	message_window->Update();
 
 	// On platforms with async loading (emscripten) graphical assets loaded this frame
 	// may require us to wait for them to download before we can start the transitions.

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -192,7 +192,7 @@ void Scene_Map::PreUpdate(MapUpdateAsyncContext& actx) {
 }
 
 void Scene_Map::PreUpdateForegroundEvents(MapUpdateAsyncContext& actx) {
-	Game_Map::UpdateForegroundEvents(actx);
+	Game_Map::UpdateForegroundEvents(actx, *message_window);
 	spriteset->Update();
 }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -25,12 +25,13 @@
 #include "window.h"
 #include "bitmap.h"
 
+constexpr int pause_animation_frames = 20;
+
 Window::Window():
 	type(TypeWindow),
 	stretch(true),
 	active(true),
 	visible(true),
-	pause(false),
 	closing(false),
 	up_arrow(false),
 	down_arrow(false),
@@ -46,9 +47,6 @@ Window::Window():
 	opacity(255),
 	back_opacity(255),
 	contents_opacity(255),
-	cursor_frame(0),
-	pause_frame(0),
-	animation_frames(0),
 	animation_count(0.0),
 	animation_increment(0.0) {
 
@@ -171,7 +169,7 @@ void Window::Draw() {
 		}
 	}
 
-	if (pause && pause_frame > 16 && animation_frames <= 0) {
+	if ((pause && pause_frame < pause_animation_frames && animation_frames <= 0) || down_arrow) {
 		Rect src_rect(40, 16, 16, 8);
 		dst->Blit(x + width / 2 - 8, y + height - 8, *windowskin, src_rect, 255);
 	}
@@ -179,11 +177,6 @@ void Window::Draw() {
 	if (up_arrow) {
 		Rect src_rect(40, 8, 16, 8);
 		dst->Blit(x + width / 2 - 8, y, *windowskin, src_rect, 255);
-	}
-
-	if (down_arrow) {
-		Rect src_rect(40, 16, 16, 8);
-		dst->Blit(x + width / 2 - 8, y + height - 8, *windowskin, src_rect, 255);
 	}
 }
 
@@ -326,8 +319,7 @@ void Window::Update() {
 		cursor_frame += 1;
 		if (cursor_frame > 20) cursor_frame = 0;
 		if (pause) {
-			pause_frame += 1;
-			if (pause_frame == 40) pause_frame = 0;
+			pause_frame = (pause_frame + 1) % (pause_animation_frames * 2);
 		}
 	}
 
@@ -397,6 +389,7 @@ bool Window::GetPause() const {
 }
 void Window::SetPause(bool npause) {
 	pause = npause;
+	pause_frame = 0;
 }
 
 bool Window::GetUpArrow() const {

--- a/src/window.h
+++ b/src/window.h
@@ -93,7 +93,6 @@ protected:
 	Rect cursor_rect;
 	bool active;
 	bool visible;
-	bool pause;
 	bool closing;
 	bool up_arrow;
 	bool down_arrow;
@@ -122,10 +121,11 @@ private:
 	bool background_needs_refresh;
 	bool frame_needs_refresh;
 	bool cursor_needs_refresh;
+	bool pause = false;
 
-	int cursor_frame;
-	int pause_frame;
-	int animation_frames;
+	int cursor_frame = 0;
+	int pause_frame = 0;
+	int animation_frames = 0;
 	double animation_count;
 	double animation_increment;
 };

--- a/src/window.h
+++ b/src/window.h
@@ -79,6 +79,10 @@ public:
 	void SetOpenAnimation(int frames);
 	void SetCloseAnimation(int frames);
 
+	bool IsOpening() const;
+	bool IsClosing() const;
+	bool IsOpeningOrClosing() const;
+
 	DrawableType GetType() const override;
 
 protected:
@@ -125,5 +129,17 @@ private:
 	double animation_count;
 	double animation_increment;
 };
+
+inline bool Window::IsOpening() const {
+	return animation_frames > 0 && !closing;
+}
+
+inline bool Window::IsClosing() const {
+	return animation_frames > 0 && closing;
+}
+
+inline bool Window::IsOpeningOrClosing() const {
+	return animation_frames > 0;
+}
 
 #endif

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -180,7 +180,7 @@ void Window_Message::FinishMessageProcessing() {
 	} else if (kill_message) {
 		TerminateMessage();
 	} else {
-		pause = true;
+		SetPause(true);
 	}
 
 	text.clear();
@@ -285,7 +285,7 @@ void Window_Message::InsertNewLine() {
 
 void Window_Message::TerminateMessage() {
 	active = false;
-	pause = false;
+	SetPause(false);
 	kill_message = false;
 	line_char_counter = 0;
 	index = -1;
@@ -314,7 +314,7 @@ void Window_Message::ResetWindow() {
 void Window_Message::Update() {
 	bool update_message_processing = false;
 	if (wait_count == 0) {
-		if (pause) {
+		if (GetPause()) {
 			WaitForInput();
 		} else if (active) {
 			InputChoice();
@@ -403,7 +403,7 @@ void Window_Message::UpdateMessage() {
 
 		if (line_count == 4) {
 			// FIXME: Unify pause logic
-			pause = true;
+			SetPause(true);
 			new_page_after_pause = true;
 			if (!instant_speed) {
 				//FIXME: Does this wait happen when pause is enabled?
@@ -412,7 +412,7 @@ void Window_Message::UpdateMessage() {
 			break;
 		}
 
-		if (pause) {
+		if (GetPause()) {
 			break;
 		}
 
@@ -447,7 +447,7 @@ void Window_Message::UpdateMessage() {
 				++text_index;
 			}
 			if (text_index != end) {
-				pause = true;
+				SetPause(true);
 				new_page_after_pause = true;
 			}
 			//FIXME: Delays formfeed?
@@ -488,7 +488,7 @@ void Window_Message::UpdateMessage() {
 				break;
 			case '!':
 				// Text pause
-				pause = true;
+				SetPause(true);
 				break;
 			case '^':
 				// Force message close
@@ -711,7 +711,7 @@ void Window_Message::WaitForInput() {
 	if (Input::IsTriggered(Input::DECISION) ||
 		Input::IsTriggered(Input::CANCEL)) {
 		active = false;
-		pause = false;
+		SetPause(false);
 
 		if (text.empty()) {
 			TerminateMessage();

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -348,9 +348,14 @@ void Window_Message::Update() {
 		}
 
 		if (!Game_Message::message_waiting && Game_Message::visible) {
-			if (visible && !closing) {
-				// Start the closing animation
-				SetCloseAnimation(Game_Temp::battle_running ? 0 : message_animation_frames);
+			if (visible) {
+				if (!closing) {
+					// Start the closing animation
+					SetCloseAnimation(Game_Temp::battle_running ? 0 : message_animation_frames);
+				} else {
+					// Closing animation has started, prevent new messages from starting.
+					Game_Message::closing = true;
+				}
 			}
 		}
 	}
@@ -371,6 +376,7 @@ void Window_Message::Update() {
 	if (!visible) {
 		// The closing animation has finished
 		Game_Message::visible = false;
+		Game_Message::closing = false;
 	}
 }
 

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -293,7 +293,7 @@ void Window_Message::TerminateMessage() {
 	Game_Message::message_waiting = false;
 	if (number_input_window->GetVisible()) {
 		number_input_window->SetActive(false);
-		number_input_window->SetCloseAnimation(message_animation_frames);
+		number_input_window->SetVisible(false);
 	}
 
 	if (gold_window->GetVisible()) {

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -380,6 +380,14 @@ void Window_Message::Update() {
 	}
 }
 
+void Window_Message::UpdatePostEvents() {
+	// Foreground events can spawn a new message. When this happens
+	// we immediately cancel the closing animation.
+	if (closing && !Game_Message::texts.empty()) {
+		SetOpenAnimation(0);
+	}
+}
+
 void Window_Message::UpdateMessage() {
 	if (IsOpeningOrClosing()) {
 		return;

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -35,9 +35,6 @@
 #include "bitmap.h"
 #include "font.h"
 
-const int Window_Message::speed_table[21] = {0, 0, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6,
-											7, 7, 8, 8, 9, 9, 10, 10, 11};
-
 constexpr int message_animation_frames = 8;
 
 // C4428 is nonsense
@@ -47,9 +44,6 @@ constexpr int message_animation_frames = 8;
 
 Window_Message::Window_Message(int ix, int iy, int iwidth, int iheight) :
 	Window_Selectable(ix, iy, iwidth, iheight),
-	contents_x(0), contents_y(0), line_count(0),
-	kill_message(false), speed_modifier(0),
-	speed_frame_counter(0), new_page_after_pause(false),
 	number_input_window(new Window_NumberInput(0, 0)),
 	gold_window(new Window_Gold(232, 0, 88, 32))
 {
@@ -254,12 +248,13 @@ void Window_Message::InsertNewPage() {
 	contents_y = 2;
 	line_count = 0;
 	text_color = Font::ColorDefault;
-	speed_modifier = 0;
+	speed = 1;
 
 	if (Game_Message::num_input_start == 0 && Game_Message::num_input_variable_id > 0) {
 		// If there is an input window on the first line
 		StartNumberInputProcessing();
 	}
+	num_chars_printed_this_line = 0;
 }
 
 void Window_Message::InsertNewLine() {
@@ -285,12 +280,14 @@ void Window_Message::InsertNewLine() {
 
 		contents_x += 12;
 	}
+	num_chars_printed_this_line = 0;
 }
 
 void Window_Message::TerminateMessage() {
 	active = false;
 	pause = false;
 	kill_message = false;
+	num_chars_printed_this_line = 0;
 	index = -1;
 
 	Game_Message::message_waiting = false;
@@ -318,6 +315,11 @@ void Window_Message::Update() {
 	Window_Selectable::Update();
 	number_input_window->Update();
 	gold_window->Update();
+
+	if (wait_count > 0) {
+		--wait_count;
+		return;
+	}
 
 	if (pause) {
 		WaitForInput();
@@ -358,61 +360,68 @@ void Window_Message::Update() {
 
 void Window_Message::UpdateMessage() {
 	// Message Box Show Message rendering loop
-
 	bool instant_speed = false;
+	bool instant_speed_forced = false;
 
 	if (Player::debug_flag && Input::IsPressed(Input::SHIFT)) {
-		wait_count = 0;
 		instant_speed = true;
+		instant_speed_forced = true;
 	}
 
-	if (wait_count > 0) {
-		--wait_count;
-		return;
-	}
-
-	int loop_count = 0;
-	int loop_max = speed_table[speed_modifier] == 0 ? 2 : 1;
-
-	while (instant_speed || loop_count < loop_max) {
-		if (!instant_speed) {
-			// It's assumed that speed_modifier is between 0 and 20
-			++speed_frame_counter;
-
-			if (speed_table[speed_modifier] != 0 &&
-				speed_table[speed_modifier] != speed_frame_counter) {
-				break;
-			}
-
-			speed_frame_counter = 0;
+	while (true) {
+		if (wait_count > 0) {
+			--wait_count;
+			break;
 		}
 
-		++loop_count;
 		if (text_index == end) {
+			if (!instant_speed) {
+				SetWaitForPage();
+			}
 			FinishMessageProcessing();
 			break;
-		} else if (line_count == 4) {
+		}
+
+		if (line_count == 4) {
+			// FIXME: Unify pause logic
 			pause = true;
 			new_page_after_pause = true;
+			if (!instant_speed) {
+				//FIXME: Does this wait happen when pause is enabled?
+				SetWaitForPage();
+			}
 			break;
-		} else if (pause) {
+		}
+
+		if (pause) {
 			break;
+		}
+
+		if (*text_index == '\r') {
+			// Not handled
+			++text_index;
+			continue;
 		}
 
 		if (*text_index == '\n') {
-			if (instant_speed) {
-				// instant_speed stops at the end of the line, unless
-				// there's a /> at the beginning of the next line
-				if (std::distance(text_index, end) > 2 &&
-					*(text_index + 1) == Player::escape_char &&
-					*(text_index + 2) == '>') {
-					text_index += 2;
-				} else {
+			if (text_index + 1 != end) {
+				if (!instant_speed && num_chars_printed_this_line == 0) {
+					// RPG_RT will always wait 1 frame for each empty line.
+					SetWait(1);
+				}
+				if (instant_speed && !instant_speed_forced) {
+					// instant_speed stops at the end of the line
+					// unless it was triggered by the shift key.
 					instant_speed = false;
 				}
 			}
 			InsertNewLine();
-		} else if (*text_index == '\f') {
+			++text_index;
+			continue;
+		}
+
+		if (*text_index == '\f') {
+			// Used by our code to inject form feeds.
 			instant_speed = false;
 			++text_index;
 			if (*text_index == '\n') {
@@ -422,8 +431,11 @@ void Window_Message::UpdateMessage() {
 				pause = true;
 				new_page_after_pause = true;
 			}
+			//FIXME: Delays formfeed?
 			break;
-		} else if (*text_index == Player::escape_char && std::distance(text_index, end) > 1) {
+		}
+
+		if (*text_index == Player::escape_char && std::distance(text_index, end) > 1) {
 			// Special message codes
 			++text_index;
 
@@ -438,15 +450,22 @@ void Window_Message::UpdateMessage() {
 			case 's':
 				// Speed modifier
 				parameter = ParseParameter(is_valid);
-				speed_modifier = max(0, min(parameter, 20));
+				speed = Utils::Clamp(parameter, 1, 20);
 				break;
 			case '_':
 				// Insert half size space
 				contents_x += Font::Default()->GetSize(" ").width / 2;
+				if (!instant_speed) {
+					SetWaitForCharacter(1);
+				}
+				++num_chars_printed_this_line;
 				break;
 			case '$':
 				// Show Gold Window
 				ShowGoldWindow();
+				if (!instant_speed) {
+					SetWait(speed);
+				}
 				break;
 			case '!':
 				// Text pause
@@ -463,21 +482,26 @@ void Window_Message::UpdateMessage() {
 				instant_speed = true;
 				break;
 			case '<':
-				// Instant speed stop
+				// Instant speed stop - also cancels shift key and forces a delay.
 				instant_speed = false;
+				instant_speed_forced = false;
+				SetWait(speed);
 				break;
 			case '.':
 				// 1/4 second sleep
-				if (instant_speed) break;
-				wait_count = 60 / 4;
-				++text_index;
-				return;
+				if (!instant_speed) {
+					// Despite documentation saying 1/4 second, RPG_RT waits for 20 frames.
+					SetWait(20);
+				}
+				break;
 			case '|':
 				// Second sleep
-				if (instant_speed) break;
-				wait_count = 60;
-				++text_index;
-				return;
+				if (!instant_speed) {
+					// Despite documentation saying 1 second, RPG_RT waits for 61 frames.
+					SetWait(61);
+				}
+				break;
+			case '\r':
 			case '\n':
 			case '\f':
 				// \ followed by linebreak, don't skip them
@@ -485,33 +509,43 @@ void Window_Message::UpdateMessage() {
 				break;
 			default:
 				if (*text_index == Player::escape_char) {
-					// Show Escape Symbol
-					contents->TextDraw(contents_x, contents_y, text_color, Player::escape_symbol);
-					contents_x += Font::Default()->GetSize(Player::escape_symbol).width;
+					DrawGlyph(Player::escape_symbol, instant_speed);
 				}
+				break;
 			}
-		} else if (*text_index == '$'
+			++text_index;
+			continue;
+		}
+
+		if (*text_index == '$'
 				   && std::distance(text_index, end) > 1
 				   && std::isalpha(*std::next(text_index))) {
 			// ExFont
-			std::string const glyph(Utils::EncodeUTF(std::u32string(text_index, std::next(text_index, 2))));
-			contents->TextDraw(contents_x, contents_y, text_color, glyph);
-			contents_x += 12;
-			++loop_count;
-			++text_index;
-		} else {
-			std::string const glyph(Utils::EncodeUTF(std::u32string(text_index, std::next(text_index))));
-
-			contents->TextDraw(contents_x, contents_y, text_color, glyph);
-			int glyph_width = Font::Default()->GetSize(glyph).width;
-			// Show full-width characters twice as slow as half-width characters
-			if (glyph_width >= 12)
-				loop_count++;
-			contents_x += glyph_width;
+			DrawGlyph(Utils::EncodeUTF(std::u32string(text_index, std::next(text_index, 2))), instant_speed);
+			text_index += 2;
+			continue;
 		}
 
+		DrawGlyph(Utils::EncodeUTF(std::u32string(text_index, std::next(text_index))), instant_speed);
 		++text_index;
 	}
+}
+
+void Window_Message::DrawGlyph(const std::string& glyph, bool instant_speed) {
+#ifdef EP_DEBUG_MESSAGE
+	Output::Debug("Msg Draw Glyph %s %d", glyph.c_str(), instant_speed);
+#endif
+	contents->TextDraw(contents_x, contents_y, text_color, glyph);
+	int glyph_width = Font::Default()->GetSize(glyph).width;
+	contents_x += glyph_width;
+	int width = (glyph_width - 1) / 6 + 1;
+	if (!instant_speed && glyph_width > 0) {
+		// RPG_RT compatible for half-width (6) and full-width (12)
+		// generalizes the algo for even bigger glyphs
+		// FIXME: Verify RPG_RT on full width
+		SetWaitForCharacter(width);
+	}
+	num_chars_printed_this_line += width;
 }
 
 int Window_Message::ParseParameter(bool& is_valid) {
@@ -683,4 +717,33 @@ void Window_Message::InputNumber() {
 		TerminateMessage();
 		number_input_window->SetNumber(0);
 	}
+}
+
+void Window_Message::SetWaitForCharacter(int width) {
+	int frames = 0;
+	if (width > 0) {
+		if (speed > 1) {
+			frames = speed * width / 2 + 1;
+		} else {
+			frames = width / 2;
+			if (width & 1) {
+				// For odd widths, speed 1 adds a 1 frame delay for every odd character printed.
+				// This logic assumes num chars is incremented after the wait.
+				frames += !(num_chars_printed_this_line & 1);
+			}
+		}
+	}
+	SetWait(frames);
+}
+
+void Window_Message::SetWaitForPage() {
+	SetWait(speed);
+}
+
+void Window_Message::SetWait(int frames) {
+	assert(speed >= 1 && speed <= 20);
+#ifdef EP_DEBUG_MESSAGE
+	Output::Debug("Msg Wait %d", frames);
+#endif
+	wait_count = frames;
 }

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -375,6 +375,10 @@ void Window_Message::Update() {
 }
 
 void Window_Message::UpdateMessage() {
+	if (IsOpeningOrClosing()) {
+		return;
+	}
+
 	// Message Box Show Message rendering loop
 	bool instant_speed = false;
 	bool instant_speed_forced = false;

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -159,38 +159,39 @@ public:
 
 protected:
 	/** X-position of next char. */
-	int contents_x;
+	int contents_x = 0;
 	/** Y-position of next char. */
-	int contents_y;
+	int contents_y = 0;
 	/** Current number of lines on this page. */
-	int line_count;
+	int line_count = 0;
 	/** Index of the next char in text that will be output. */
 	std::u32string::iterator text_index, end;
 	/** text message that will be displayed. */
 	std::u32string text;
 	/** Used by Message kill command \^. */
-	bool kill_message;
+	bool kill_message = false;
 	/** Text color. */
-	int text_color;
+	int text_color = 0;
 	/** Current speed modifier. */
-	int speed_modifier;
-	/** Counts the frames since the last char rendering. */
-	int speed_frame_counter;
+	int speed = 1;
 	/** If true inserts a new page after pause ended */
-	bool new_page_after_pause;
-
-	/**
-	 * Table contains how many frames drawing one single char takes.
-	 * 0 means: 2 chars per frame.
-	 */
-	static const int speed_table[21];
+	bool new_page_after_pause = false;
 
 	/** Frames to wait when a message wait command was used */
 	int wait_count = 0;
 
+	/** How many printable characters we have rendered to the current line */
+	int num_chars_printed_this_line = 0;
+
 	/** Used by the number input event. */
 	std::unique_ptr<Window_NumberInput> number_input_window;
 	std::unique_ptr<Window_Gold> gold_window;
+
+	void DrawGlyph(const std::string& glyph, bool instant_speed);
+
+	void SetWaitForCharacter(int width);
+	void SetWaitForPage();
+	void SetWait(int frames);
 };
 
 #endif

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -180,14 +180,16 @@ protected:
 	/** Frames to wait when a message wait command was used */
 	int wait_count = 0;
 
-	/** How many printable characters we have rendered to the current line */
-	int num_chars_printed_this_line = 0;
+	/** Incremented by 1 each time we print a half width character with speed 1,
+	 * or by 2 for any other character */
+	int line_char_counter = 0;
 
 	/** Used by the number input event. */
 	std::unique_ptr<Window_NumberInput> number_input_window;
 	std::unique_ptr<Window_Gold> gold_window;
 
 	void DrawGlyph(const std::string& glyph, bool instant_speed);
+	void IncrementLineCharCounter(int width);
 
 	void SetWaitForCharacter(int width);
 	void SetWaitForPage();

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -98,6 +98,8 @@ public:
 
 	void Update() override;
 
+	void UpdatePostEvents();
+
 	/**
 	 * Continues outputting more text. Also handles the
 	 * CommandCode parsing.


### PR DESCRIPTION
Depends on #1890 #1905 

This PR adds a bunch of changes to get frame accurate text rendering, open and closing of the text window, and timing of how foreground and parallel interpreters run w.r.t. messages.

There are some hacks added to this to fix regressions without adding more refactoring. They are removed in #1909 

- [x] #1706 Test 7 - text timing
- [x] #1706 Test 8 - msg end
- [x] #1706 Test 9 - gold window 
- [x] #1706 Test 10 - multi line
- [x] #1706 Test 13 - multi message window anim
- [x] #1706 Test 33 - exfont timing
- [x] #1706 Test 34 - mixed speeds timing
- [x] #1706 Test 35 - multi message timing
- [x] #1706 Test 36 - Japanese wide char timing
- [x] #1706 Test 37 - Transparent window
- [x] #1869 Test 9 - inn text vs message text
