### PR TITLE
FileFinder: Support directory symlinks on linux

### DIFF
--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -185,9 +185,10 @@ namespace FileFinder {
 	 * This function is case sensitve on some platform.
 	 *
 	 * @param file file to check.
+	 * @param follow_symlinks if true, follow symlinks and report about the target.
 	 * @return true if file is directory, otherwise false.
 	 */
-	bool IsDirectory(const std::string& file);
+	bool IsDirectory(const std::string& file, bool follow_symlinks);
 
 	/**
 	 * Checks whether passed file exists.

--- a/tests/filefinder.cpp
+++ b/tests/filefinder.cpp
@@ -14,7 +14,8 @@ namespace {
 	}
 
 	void CheckIsDirectory() {
-		assert(FileFinder::IsDirectory("."));
+		assert(FileFinder::IsDirectory(".", false));
+		assert(FileFinder::IsDirectory(".", true));
 	}
 
 	void CheckEnglishFilename() {


### PR DESCRIPTION
On linux, master won't let you point to a `--project-path` which is a symlink to a game directory.