### PR TITLE
Refactor Game_Message / Window_Message interface - Messages 3 of N

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,8 @@ add_library(${PROJECT_NAME}
 	src/options.h
 	src/output.cpp
 	src/output.h
+	src/pending_message.h
+	src/pending_message.cpp
 	src/picojson.h
 	src/pixel_format.h
 	src/plane.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -174,6 +174,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/options.h \
 	src/output.cpp \
 	src/output.h \
+	src/pending_message.h \
+	src/pending_message.cpp \
 	src/picojson.h \
 	src/pixel_format.h \
 	src/plane.cpp \

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -812,9 +812,12 @@ void Game_Actor::ChangeLevel(int new_level, bool level_up_message) {
 	SetLevel(new_level);
 	new_level = GetLevel(); // Level adjusted to max
 
+	auto pm = PendingMessage();
+
 	if (new_level > old_level) {
 		if (level_up_message) {
-			Game_Message::texts.push_back(GetLevelUpMessage(new_level));
+			//FIXME: If message box already active??
+			pm.PushLine(GetLevelUpMessage(new_level));
 			level_up = true;
 		}
 
@@ -824,15 +827,14 @@ void Game_Actor::ChangeLevel(int new_level, bool level_up_message) {
 			if (learn.level > old_level && learn.level <= new_level) {
 				LearnSkill(learn.skill_id);
 				if (level_up_message) {
-					Game_Message::texts.push_back(GetLearningMessage(learn));
+					pm.PushLine(GetLearningMessage(learn));
 					level_up = true;
 				}
 			}
 		}
 
 		if (level_up) {
-			Game_Message::texts.back().append("\f");
-			Game_Message::message_waiting = true;
+			pm.PushPageEnd();
 		}
 
 		// Experience adjustment:
@@ -844,6 +846,10 @@ void Game_Actor::ChangeLevel(int new_level, bool level_up_message) {
 		if (GetExp() >= GetNextExp()) {
 			SetExp(GetBaseExp());
 		}
+	}
+
+	if (pm.NumLines()) {
+		Game_Message::SetPendingMessage(std::move(pm));
 	}
 }
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -104,7 +104,7 @@ void Game_Interpreter::Push(
 	frame.event_id = event_id;
 
 	if (_state.stack.empty() && main_flag) {
-		Game_Message::SetFaceName("");
+		Game_Message::ClearFace();
 		Main_Data::game_player->SetMenuCalling(false);
 		Main_Data::game_player->SetEncounterCalling(false);
 	}
@@ -734,7 +734,7 @@ bool Game_Interpreter::OnFinishStackFrame() {
 	const bool is_base_frame = _state.stack.size() == 1;
 
 	if (main_flag && is_base_frame) {
-		Game_Message::SetFaceName("");
+		Game_Message::ClearFace();
 	}
 
 	int event_id = frame->event_id;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -322,7 +322,7 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 			if (Main_Data::game_player->InVehicle() && Main_Data::game_player->GetVehicle()->IsAscendingOrDescending())
 				break;
 
-			if (Game_Message::message_waiting)
+			if (Game_Message::IsMessagePending())
 				break;
 		} else {
 			if ((Game_Message::IsMessageActive()) && _state.show_message) {

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -887,22 +887,12 @@ void Game_Interpreter::SetupChoices(const std::vector<std::string>& choices, int
 		pm.PushChoice(choices[i]);
 	}
 
-	SetContinuation(&Game_Interpreter::ContinuationChoices);
+	pm.SetChoiceContinuation([this, indent](int choice_result) {
+		SetSubcommandIndex(indent, choice_result);
+	});
 
 	// save game compatibility with RPG_RT
 	ReserveSubcommandIndex(indent);
-}
-
-bool Game_Interpreter::ContinuationChoices(RPG::EventCommand const& com) {
-	auto* frame = GetFrame();
-	assert(frame);
-	auto& index = frame->current_command;
-
-	SetSubcommandIndex(com.indent, Game_Message::choice_result);
-
-	continuation = nullptr;
-
-	return true;
 }
 
 bool Game_Interpreter::CommandShowChoices(RPG::EventCommand const& com) { // code 10140
@@ -3400,6 +3390,5 @@ bool Game_Interpreter::DefaultContinuation(RPG::EventCommand const& /* com */) {
 // Dummy Continuations
 
 bool Game_Interpreter::ContinuationOpenShop(RPG::EventCommand const& /* com */) { return true; }
-bool Game_Interpreter::ContinuationShowInnStart(RPG::EventCommand const& /* com */) { return true; }
 bool Game_Interpreter::ContinuationEnemyEncounter(RPG::EventCommand const& /* com */) { return true; }
 

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -251,9 +251,7 @@ protected:
 	bool CommandToggleFullscreen(RPG::EventCommand const& com);
 
 	virtual bool DefaultContinuation(RPG::EventCommand const& com);
-	virtual bool ContinuationChoices(RPG::EventCommand const& com);
 	virtual bool ContinuationOpenShop(RPG::EventCommand const& com);
-	virtual bool ContinuationShowInnStart(RPG::EventCommand const& com);
 	virtual bool ContinuationEnemyEncounter(RPG::EventCommand const& com);
 
 	int DecodeInt(std::vector<int32_t>::const_iterator& it);

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -33,6 +33,7 @@
 
 class Game_Event;
 class Game_CommonEvent;
+class PendingMessage;
 
 namespace RPG {
 	class EventPage;
@@ -69,7 +70,7 @@ public:
 	void Push(Game_CommonEvent* ev);
 
 	void InputButton();
-	void SetupChoices(const std::vector<std::string>& choices, int indent);
+	void SetupChoices(const std::vector<std::string>& choices, int indent, PendingMessage& pm);
 
 	virtual bool ExecuteCommand();
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -367,6 +367,10 @@ bool Game_Interpreter_Map::CommandShowInn(RPG::EventCommand const& com) { // cod
 	// bool has_inn_handlers = com.parameters[2] != 0;
 
 	if (Game_Temp::inn_price == 0) {
+		if (Game_Message::IsMessageActive()) {
+			return false;
+		}
+
 		// Skip prompt.
 		ContinuationShowInnStart(com.indent, 0);
 		return true;

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -454,7 +454,7 @@ bool Game_Interpreter_Map::CommandShowInn(RPG::EventCommand const& com) { // cod
 			return false;
 	}
 
-	Game_Temp::inn_calling = true;
+	pm.SetShowGoldWindow(true);
 
 	Game_Message::SetPendingMessage(std::move(pm));
 	_state.show_message = true;
@@ -480,8 +480,6 @@ bool Game_Interpreter_Map::ContinuationShowInnStart(RPG::EventCommand const& com
 	bool inn_stay = Game_Message::choice_result == 0;
 
 	SetSubcommandIndex(com.indent, inn_stay ? eOptionInnStay : eOptionInnNoStay);
-
-	Game_Temp::inn_calling = false;
 
 	if (inn_stay) {
 		Main_Data::game_party->GainGold(-Game_Temp::inn_price);

--- a/src/game_interpreter_map.h
+++ b/src/game_interpreter_map.h
@@ -84,7 +84,7 @@ private:
 	bool CommandOpenVideoOptions(RPG::EventCommand const& com);
 
 	bool ContinuationOpenShop(RPG::EventCommand const& com) override;
-	bool ContinuationShowInnStart(RPG::EventCommand const& com) override;
+	void ContinuationShowInnStart(int indent, int choice_result);
 	bool ContinuationEnemyEncounter(RPG::EventCommand const& com) override;
 
 	static std::vector<Game_Character*> pending;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -32,6 +32,7 @@
 #include "game_temp.h"
 #include "game_player.h"
 #include "game_party.h"
+#include "game_message.h"
 #include "lmu_reader.h"
 #include "reader_lcf.h"
 #include "map_data.h"
@@ -994,7 +995,7 @@ void Game_Map::Update(MapUpdateAsyncContext& actx, Window_Message& message, bool
 			}
 		}
 
-		message.Update();
+		Game_Message::Update();
 		Main_Data::game_party->UpdateTimers();
 		Main_Data::game_screen->Update();
 	}

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -44,7 +44,6 @@
 #include "player.h"
 #include "input.h"
 #include "utils.h"
-#include "window_message.h"
 #include "scope_guard.h"
 
 namespace {
@@ -955,7 +954,7 @@ int Game_Map::CheckEvent(int x, int y) {
 	return 0;
 }
 
-void Game_Map::Update(MapUpdateAsyncContext& actx, Window_Message& message, bool is_preupdate) {
+void Game_Map::Update(MapUpdateAsyncContext& actx, bool is_preupdate) {
 	scrolled_right = 0;
 	scrolled_down = 0;
 
@@ -1001,7 +1000,7 @@ void Game_Map::Update(MapUpdateAsyncContext& actx, Window_Message& message, bool
 	}
 
 	if (!actx.IsActive() || actx.IsForegroundEvent()) {
-		if (!UpdateForegroundEvents(actx, message)) {
+		if (!UpdateForegroundEvents(actx)) {
 			// Suspend due to foreground event async op ...
 			return;
 		}
@@ -1081,13 +1080,11 @@ bool Game_Map::UpdateMapEvents(MapUpdateAsyncContext& actx) {
 	return true;
 }
 
-bool Game_Map::UpdateForegroundEvents(MapUpdateAsyncContext& actx, Window_Message& message) {
+bool Game_Map::UpdateForegroundEvents(MapUpdateAsyncContext& actx) {
 	auto& interp = GetInterpreter();
 
 	// If we resume from async op, we don't clear the loop index.
 	const bool resume_fg = actx.IsForegroundEvent();
-
-	auto sg = makeScopeGuard([&]() { message.UpdatePostEvents(); });
 
 	// Run any event loaded from last frame.
 	interp.Update(!resume_fg);

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -32,7 +32,6 @@
 #include "async_op.h"
 
 class FileRequestAsync;
-class Window_Message;
 
 // These are in sixteenths of a pixel.
 constexpr int SCREEN_TILE_SIZE = 256;
@@ -261,10 +260,9 @@ namespace Game_Map {
 	 * @param actx asynchronous operations context. In out param.
 	 *        If IsActive() when passed in, will resume to that point.
 	 *        If IsActive() after return in, will suspend from that point.
-	 * @param the scene message window
 	 * @param is_preupdate Update only common events and map events
 	 */
-	void Update(MapUpdateAsyncContext& actx, Window_Message& message, bool is_preupdate = false);
+	void Update(MapUpdateAsyncContext& actx, bool is_preupdate = false);
 
 	/**
 	 * Gets current map_info.
@@ -649,7 +647,7 @@ namespace Game_Map {
 	void UpdateProcessedFlags(bool is_preupdate);
 	bool UpdateCommonEvents(MapUpdateAsyncContext& actx);
 	bool UpdateMapEvents(MapUpdateAsyncContext& actx);
-	bool UpdateForegroundEvents(MapUpdateAsyncContext& actx, Window_Message& message);
+	bool UpdateForegroundEvents(MapUpdateAsyncContext& actx);
 
 	FileRequestAsync* RequestMap(int map_id);
 

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -26,10 +26,6 @@
 
 #include <cctype>
 
-namespace Game_Message {
-	bool closing = false;
-}
-
 static Window_Message* window = nullptr;
 
 RPG::SaveSystem& data = Main_Data::game_data.system;
@@ -45,7 +41,6 @@ void Game_Message::ClearFace() {
 
 void Game_Message::SetWindow(Window_Message* w) {
 	window = w;
-	closing = false;
 }
 
 Window_Message* Game_Message::GetWindow() {
@@ -203,7 +198,7 @@ bool Game_Message::CanShowMessage(bool foreground) {
 		return false;
 
 	// Forground interpreters: If the message box already started animating we wait for it to finish.
-	if (foreground && IsMessageVisible() && closing)
+	if (foreground && IsMessageVisible() && !window->GetAllowNextMessage())
 		return false;
 
 	// Parallel interpreters must wait until the message window is closed
@@ -214,21 +209,8 @@ bool Game_Message::CanShowMessage(bool foreground) {
 }
 
 void Game_Message::Update() {
-	if (!window) {
-		closing = false;
-		return;
-	}
-
-	// This flag goes into effect 1 frame after the closing
-	// animation starts.
-	if (window->IsClosing()) {
-		closing = true;
-	}
-
-	window->Update();
-
-	if (!IsMessageVisible()) {
-		closing = false;
+	if (window) {
+		window->Update();
 	}
 }
 

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -24,6 +24,8 @@
 #include "font.h"
 #include "player.h"
 
+#include <cctype>
+
 namespace Game_Message {
 	PendingMessage pending_message;
 

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -27,7 +27,6 @@
 #include <cctype>
 
 namespace Game_Message {
-	bool message_waiting = false;
 	bool closing = false;
 }
 
@@ -47,7 +46,6 @@ void Game_Message::ClearFace() {
 void Game_Message::SetWindow(Window_Message* w) {
 	window = w;
 	closing = false;
-	message_waiting = false;
 }
 
 Window_Message* Game_Message::GetWindow() {
@@ -217,7 +215,6 @@ bool Game_Message::CanShowMessage(bool foreground) {
 
 void Game_Message::Update() {
 	if (!window) {
-		message_waiting = false;
 		closing = false;
 		return;
 	}
@@ -236,18 +233,13 @@ void Game_Message::Update() {
 }
 
 void Game_Message::SetPendingMessage(PendingMessage&& pm) {
-	message_waiting = true;
 	if (window) {
 		window->StartMessageProcessing(std::move(pm));
 	}
 }
 
-void Game_Message::ResetPendingMessage() {
-	message_waiting = false;
-}
-
 bool Game_Message::IsMessagePending() {
-	return message_waiting;
+	return window ? window->GetPendingMessage().IsActive() : false;
 }
 
 bool Game_Message::IsMessageVisible() {

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -247,6 +247,9 @@ void Game_Message::Update() {
 void Game_Message::SetPendingMessage(PendingMessage&& pm) {
 	pending_message = std::move(pm);
 	message_waiting = true;
+	if (window) {
+		window->StartMessageProcessing();
+	}
 }
 
 const PendingMessage& Game_Message::GetPendingMessage() {

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -30,8 +30,6 @@ namespace Game_Message {
 	bool message_waiting;
 	bool closing;
 	bool visible;
-
-	int choice_result;
 }
 
 static Window_Message* window = nullptr;
@@ -247,7 +245,6 @@ void Game_Message::Update() {
 void Game_Message::SetPendingMessage(PendingMessage&& pm) {
 	pending_message = std::move(pm);
 	message_waiting = true;
-	choice_result = 4;
 }
 
 const PendingMessage& Game_Message::GetPendingMessage() {
@@ -258,4 +255,5 @@ void Game_Message::ResetPendingMessage() {
 	pending_message = {};
 	message_waiting = false;
 }
+
 

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -46,6 +46,8 @@ namespace Game_Message {
 	int choice_result;
 }
 
+static Window_Message* window = nullptr;
+
 RPG::SaveSystem& data = Main_Data::game_data.system;
 
 void Game_Message::Init() {
@@ -68,6 +70,14 @@ void Game_Message::FullClear() {
 	SemiClear();
 	SetFaceName("");
 	SetFaceIndex(0);
+}
+
+void Game_Message::SetWindow(Window_Message* w) {
+	window = w;
+}
+
+Window_Message* Game_Message::GetWindow() {
+	return window;
 }
 
 std::string Game_Message::GetFaceName() {

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -20,6 +20,7 @@
 #include "game_player.h"
 #include "game_temp.h"
 #include "main_data.h"
+#include "window_message.h"
 #include "font.h"
 #include "player.h"
 
@@ -74,6 +75,9 @@ void Game_Message::FullClear() {
 
 void Game_Message::SetWindow(Window_Message* w) {
 	window = w;
+	visible = false;
+	closing = false;
+	// FIXME: message_waiting?
 }
 
 Window_Message* Game_Message::GetWindow() {
@@ -241,3 +245,26 @@ bool Game_Message::CanShowMessage(bool foreground) {
 	return true;
 }
 
+void Game_Message::Update() {
+	if (!window) {
+		message_waiting = false;
+		visible = false;
+		closing = false;
+		return;
+	}
+
+	// This flag goes into effect 1 frame after the closing
+	// animation starts.
+	if (window->IsClosing()) {
+		closing = true;
+	}
+
+	window->Update();
+
+	if (window->GetVisible()) {
+		visible = true;
+	} else {
+		visible = false;
+		closing = false;
+	}
+}

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -25,24 +25,11 @@
 #include "player.h"
 
 namespace Game_Message {
-	std::vector<std::string> texts;
-	bool is_word_wrapped;
-
-	int choice_start;
-	int num_input_start;
-
-	int choice_max;
-	std::bitset<8> choice_disabled;
-
-	int choice_cancel_type;
-
-	int num_input_variable_id;
-	int num_input_digits_max;
+	PendingMessage pending_message;
 
 	bool message_waiting;
 	bool closing;
 	bool visible;
-	bool choice_reset_color = false;
 
 	int choice_result;
 }
@@ -52,23 +39,11 @@ static Window_Message* window = nullptr;
 RPG::SaveSystem& data = Main_Data::game_data.system;
 
 void Game_Message::Init() {
-	FullClear();
+	ClearFace();
+	pending_message = {};
 }
 
-void Game_Message::SemiClear() {
-	texts.clear();
-	choice_disabled.reset();
-	choice_start = 99;
-	choice_max = 0;
-	choice_cancel_type = 0;
-	num_input_start = -1;
-	num_input_variable_id = 0;
-	num_input_digits_max = 0;
-	is_word_wrapped = false;
-}
-
-void Game_Message::FullClear() {
-	SemiClear();
+void Game_Message::ClearFace() {
 	SetFaceName("");
 	SetFaceIndex(0);
 }
@@ -268,3 +243,19 @@ void Game_Message::Update() {
 		closing = false;
 	}
 }
+
+void Game_Message::SetPendingMessage(PendingMessage&& pm) {
+	pending_message = std::move(pm);
+	message_waiting = true;
+	choice_result = 4;
+}
+
+const PendingMessage& Game_Message::GetPendingMessage() {
+	return pending_message;
+}
+
+void Game_Message::ResetPendingMessage() {
+	pending_message = {};
+	message_waiting = false;
+}
+

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -27,7 +27,6 @@
 #include <cctype>
 
 namespace Game_Message {
-	PendingMessage pending_message;
 	bool message_waiting = false;
 	bool closing = false;
 }
@@ -38,7 +37,6 @@ RPG::SaveSystem& data = Main_Data::game_data.system;
 
 void Game_Message::Init() {
 	ClearFace();
-	pending_message = {};
 }
 
 void Game_Message::ClearFace() {
@@ -238,19 +236,13 @@ void Game_Message::Update() {
 }
 
 void Game_Message::SetPendingMessage(PendingMessage&& pm) {
-	pending_message = std::move(pm);
 	message_waiting = true;
 	if (window) {
-		window->StartMessageProcessing();
+		window->StartMessageProcessing(std::move(pm));
 	}
 }
 
-const PendingMessage& Game_Message::GetPendingMessage() {
-	return pending_message;
-}
-
 void Game_Message::ResetPendingMessage() {
-	pending_message = {};
 	message_waiting = false;
 }
 

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -22,6 +22,7 @@
 #include <bitset>
 #include <string>
 #include <functional>
+#include "pending_message.h"
 
 class Window_Message;
 
@@ -31,21 +32,15 @@ namespace Game_Message {
 
 	void Init();
 
-	/**
-	 * Used by Window_Message to reset some flags.
-	 */
-	void SemiClear();
-	/**
-	 * Used by the Game_Interpreter to completly reset all flags.
-	 */
-	void FullClear();
-
 	/** Set the window used to display the text */
 	void SetWindow(Window_Message* window);
 
 	Window_Message* GetWindow();
 
 	void Update();
+
+	/** Reset the face graphic. */
+	void ClearFace();
 
 	/** Contains the different lines of text. */
 	extern std::vector<std::string> texts;
@@ -173,6 +168,12 @@ namespace Game_Message {
 	 */
 	int GetRealPosition();
 
+	void SetPendingMessage(PendingMessage&& pm);
+
+	const PendingMessage& GetPendingMessage();
+
+	void ResetPendingMessage();
+
 	/**
 	 * Breaks the line into lines, each of which is equal
 	 * or less than a specified limit in pixels in the
@@ -192,44 +193,6 @@ namespace Game_Message {
 	 * @param callback a function to be called for each word-wrapped line
 	 */
 	int WordWrap(const std::string& line, int limit, const std::function<void(const std::string &line)> callback);
-
-	/**
-	 * Whether the texts are word-wrapped
-	 */
-	extern bool is_word_wrapped;
-
-	/**
-	 * Number of lines before the start
-	 * of selection options.
-	 * +-----------------------------------+
-	 * |	Hi, hero, What's your name?    |
-	 * |- Alex                             |
-	 * |- Brian                            |
-	 * |- Carol                            |
-	 * +-----------------------------------+
-	 * In this case, choice_start would be 1.
-	 * Same with num_input_start.
-	 */
-	extern int choice_start;
-	extern int num_input_start;
-
-	/** Number of choices */
-	extern int choice_max;
-
-	/**
-	 * Disabled choices:
-	 * choice_disabled is true if choice is disabled (zero-based).
-	 */
-	extern std::bitset<8> choice_disabled;
-
-	/** Option to choose if cancel. */
-	extern int choice_cancel_type;
-
-	extern int num_input_variable_id;
-	extern int num_input_digits_max;
-
-	/** Reset the text color for each choice */
-	extern bool choice_reset_color;
 
 	/** If we're waiting for a message to finish processing. This flag is set to true from when the
 	 * message box is requested up until it's finished writing text and ready to close.

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -23,6 +23,8 @@
 #include <string>
 #include <functional>
 
+class Window_Message;
+
 namespace Game_Message {
 
 	static const int MAX_LINE = 4;
@@ -37,6 +39,11 @@ namespace Game_Message {
 	 * Used by the Game_Interpreter to completly reset all flags.
 	 */
 	void FullClear();
+
+	/** Set the window used to display the text */
+	void SetWindow(Window_Message* window);
+
+	Window_Message* GetWindow();
 
 	/** Contains the different lines of text. */
 	extern std::vector<std::string> texts;

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -45,6 +45,8 @@ namespace Game_Message {
 
 	Window_Message* GetWindow();
 
+	void Update();
+
 	/** Contains the different lines of text. */
 	extern std::vector<std::string> texts;
 

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -170,8 +170,6 @@ namespace Game_Message {
 
 	void SetPendingMessage(PendingMessage&& pm);
 
-	void ResetPendingMessage();
-
 	/**
 	 * Breaks the line into lines, each of which is equal
 	 * or less than a specified limit in pixels in the

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -194,15 +194,6 @@ namespace Game_Message {
 	 */
 	int WordWrap(const std::string& line, int limit, const std::function<void(const std::string &line)> callback);
 
-	/** If we're waiting for a message to finish processing. This flag is set to true from when the
-	 * message box is requested up until it's finished writing text and ready to close.
-	 */
-	extern bool message_waiting;
-	/** Set to true when after the message box has started animating closed */
-	extern bool closing;
-	/** Set to true while the message box is visible on the screen */
-	extern bool visible;
-
 	/**
 	 * Return if it's legal to show a new message box.
 	 *
@@ -211,15 +202,13 @@ namespace Game_Message {
 	 */
 	bool CanShowMessage(bool foreground);
 
-	/**
-	 * True if a message is currently pending or still visible
-	 * @return true if message_waiting || visible
-	 */
+	/** @return true if there is message text pending */
+	bool IsMessagePending();
+	/** @return true if the message window is visible */
+	bool IsMessageVisible();
+	/** @return true if IsMessagePending() || IsMessageVisible() */
 	bool IsMessageActive();
 }
 
-inline bool Game_Message::IsMessageActive() {
-	return message_waiting || visible;
-}
 
 #endif

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -170,8 +170,6 @@ namespace Game_Message {
 
 	void SetPendingMessage(PendingMessage&& pm);
 
-	const PendingMessage& GetPendingMessage();
-
 	void ResetPendingMessage();
 
 	/**

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -203,9 +203,6 @@ namespace Game_Message {
 	/** Set to true while the message box is visible on the screen */
 	extern bool visible;
 
-	/** Selected option (4 => cancel). */
-	extern int choice_result;
-
 	/**
 	 * Return if it's legal to show a new message box.
 	 *

--- a/src/game_temp.cpp
+++ b/src/game_temp.cpp
@@ -19,7 +19,6 @@
 #include "game_temp.h"
 #include "transition.h"
 
-bool Game_Temp::inn_calling;
 bool Game_Temp::shop_buys;
 bool Game_Temp::shop_sells;
 int Game_Temp::shop_type;
@@ -40,7 +39,6 @@ int Game_Temp::battle_result;
 bool Game_Temp::battle_random_encounter;
 
 void Game_Temp::Init() {
-	inn_calling = false;
 	shop_buys = true;
 	shop_sells = true;
 	shop_type = 0;

--- a/src/game_temp.h
+++ b/src/game_temp.h
@@ -33,8 +33,6 @@ public:
 	 */
 	static void Init();
 
-	static bool inn_calling;
-
 	static bool shop_buys;
 	static bool shop_sells;
 	static int shop_type;		// message set A, B, or C

--- a/src/pending_message.cpp
+++ b/src/pending_message.cpp
@@ -1,0 +1,50 @@
+#include "pending_message.h"
+#include <cassert>
+
+int PendingMessage::PushLine(std::string msg) {
+	assert(!HasChoices());
+	assert(!HasNumberInput());
+	texts.push_back(std::move(msg));
+	return texts.size();
+}
+
+int PendingMessage::PushChoice(std::string msg, bool enabled) {
+	assert(!HasNumberInput());
+	if (!HasChoices()) {
+		choice_start = NumLines();
+	}
+	choice_enabled[GetNumChoices()] = enabled;
+	texts.push_back(std::move(msg));
+	return texts.size();
+}
+
+int PendingMessage::PushNumInput(int variable_id, int num_digits) {
+	assert(!HasChoices());
+	assert(!HasNumberInput());
+	num_input_variable = variable_id;
+	num_input_digits = num_digits;
+	return NumLines();
+}
+
+void PendingMessage::PushPageEnd() {
+	assert(!HasChoices());
+	assert(!HasNumberInput());
+	if (texts.empty()) {
+		texts.push_back("");
+	}
+	texts.back().push_back('\f');
+}
+
+void PendingMessage::SetWordWrapped(bool value) {
+	assert(texts.empty());
+	word_wrapped = true;
+}
+
+void PendingMessage::SetChoiceCancelType(int value) {
+	choice_cancel_type = value;
+}
+
+void PendingMessage::SetChoiceResetColors(bool value) {
+	choice_reset_color = value;
+}
+

--- a/src/pending_message.h
+++ b/src/pending_message.h
@@ -31,11 +31,13 @@ class PendingMessage {
 		void SetWordWrapped(bool value);
 		void SetChoiceCancelType(int value);
 		void SetChoiceResetColors(bool value);
+		void SetShowGoldWindow(bool value) { show_gold_window = value; }
 
 		const std::vector<std::string>& GetLines() const { return texts; }
 
 		int NumLines() const { return texts.size(); }
 		bool IsWordWrapped() const { return word_wrapped; }
+		bool ShowGoldWindow() const { return show_gold_window; }
 
 		bool HasChoices() const { return choice_start >= 0; }
 		int GetChoiceStartLine() const { return choice_start; }
@@ -57,6 +59,7 @@ class PendingMessage {
 		std::bitset<8> choice_enabled = {};
 		bool word_wrapped = false;
 		bool choice_reset_color = false;
+		bool show_gold_window = false;
 };
 
 

--- a/src/pending_message.h
+++ b/src/pending_message.h
@@ -1,0 +1,66 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_PENDING_MESSAGE_H
+#define EP_PENDING_MESSAGE_H
+#include <string>
+#include <vector>
+#include <bitset>
+
+class PendingMessage {
+	public:
+		int PushLine(std::string msg);
+		int PushChoice(std::string msg, bool enabled = true);
+		int PushNumInput(int variable_id, int num_digits);
+		void PushPageEnd();
+
+		void SetWordWrapped(bool value);
+		void SetChoiceCancelType(int value);
+		void SetChoiceResetColors(bool value);
+
+		const std::vector<std::string>& GetLines() const { return texts; }
+
+		int NumLines() const { return texts.size(); }
+		bool IsWordWrapped() const { return word_wrapped; }
+
+		bool HasChoices() const { return choice_start >= 0; }
+		int GetChoiceStartLine() const { return choice_start; }
+		int GetNumChoices() const { return HasChoices() ? NumLines() - choice_start : 0; }
+		int GetChoiceCancelType() const { return choice_cancel_type; }
+		bool IsChoiceEnabled(int idx) const { return choice_enabled[idx]; }
+		bool GetChoiceResetColor() const { return choice_reset_color; }
+
+		bool HasNumberInput() const { return num_input_digits > 0; }
+		int GetNumberInputDigits() const { return num_input_digits; }
+		int GetNumberInputVariable() const { return num_input_variable; }
+		int GetNumberInputStartLine() const { return NumLines(); }
+	private:
+		std::vector<std::string> texts;
+		int choice_start = -1;
+		int choice_cancel_type = 5;
+		int num_input_variable = 0;
+		int num_input_digits = 0;
+		std::bitset<8> choice_enabled = {};
+		bool word_wrapped = false;
+		bool choice_reset_color = false;
+};
+
+
+
+#endif
+
+

--- a/src/pending_message.h
+++ b/src/pending_message.h
@@ -56,6 +56,8 @@ class PendingMessage {
 		int GetNumberInputVariable() const { return num_input_variable; }
 		int GetNumberInputStartLine() const { return NumLines(); }
 	private:
+		int PushLineImpl(std::string msg);
+	private:
 		ChoiceContinuation choice_continuation;
 		std::vector<std::string> texts;
 		int choice_start = -1;

--- a/src/pending_message.h
+++ b/src/pending_message.h
@@ -20,9 +20,12 @@
 #include <string>
 #include <vector>
 #include <bitset>
+#include <functional>
 
 class PendingMessage {
 	public:
+		using ChoiceContinuation = std::function<void(int)>;
+
 		int PushLine(std::string msg);
 		int PushChoice(std::string msg, bool enabled = true);
 		int PushNumInput(int variable_id, int num_digits);
@@ -32,6 +35,7 @@ class PendingMessage {
 		void SetChoiceCancelType(int value);
 		void SetChoiceResetColors(bool value);
 		void SetShowGoldWindow(bool value) { show_gold_window = value; }
+		void SetChoiceContinuation(ChoiceContinuation f) { choice_continuation = std::move(f); }
 
 		const std::vector<std::string>& GetLines() const { return texts; }
 
@@ -45,12 +49,14 @@ class PendingMessage {
 		int GetChoiceCancelType() const { return choice_cancel_type; }
 		bool IsChoiceEnabled(int idx) const { return choice_enabled[idx]; }
 		bool GetChoiceResetColor() const { return choice_reset_color; }
+		const ChoiceContinuation& GetChoiceContinuation() const { return choice_continuation; }
 
 		bool HasNumberInput() const { return num_input_digits > 0; }
 		int GetNumberInputDigits() const { return num_input_digits; }
 		int GetNumberInputVariable() const { return num_input_variable; }
 		int GetNumberInputStartLine() const { return NumLines(); }
 	private:
+		ChoiceContinuation choice_continuation;
 		std::vector<std::string> texts;
 		int choice_start = -1;
 		int choice_cancel_type = 5;

--- a/src/pending_message.h
+++ b/src/pending_message.h
@@ -39,6 +39,7 @@ class PendingMessage {
 
 		const std::vector<std::string>& GetLines() const { return texts; }
 
+		bool IsActive() const { return NumLines() || HasNumberInput(); }
 		int NumLines() const { return texts.size(); }
 		bool IsWordWrapped() const { return word_wrapped; }
 		bool ShowGoldWindow() const { return show_gold_window; }

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -163,7 +163,7 @@ void Scene_Battle::Update() {
 	item_window->Update();
 	skill_window->Update();
 	target_window->Update();
-	message_window->Update();
+	Game_Message::Update();
 
 	// Query Timer before and after update.
 	// If it reached zero during update was a running battle timer.

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -101,6 +101,8 @@ void Scene_Battle::Start() {
 }
 
 void Scene_Battle::Continue(SceneType prev_scene) {
+	Game_Message::SetWindow(message_window.get());
+
 	// Debug scene / other scene could have changed party status.
 	status_window->Refresh();
 }
@@ -150,6 +152,7 @@ void Scene_Battle::CreateUi() {
 	status_window.reset(new Window_BattleStatus(0, (SCREEN_TARGET_HEIGHT-80), SCREEN_TARGET_WIDTH - option_command_mov, 80));
 
 	message_window.reset(new Window_Message(0, (SCREEN_TARGET_HEIGHT - 80), SCREEN_TARGET_WIDTH, 80));
+	Game_Message::SetWindow(message_window.get());
 }
 
 void Scene_Battle::Update() {

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -182,7 +182,7 @@ void Scene_Battle::Update() {
 		Scene::Push(std::make_shared<Scene_Gameover>());
 	}
 
-	if (!Game_Message::visible && events_finished) {
+	if (!Game_Message::IsMessageVisible() && events_finished) {
 		ProcessActions();
 		ProcessInput();
 	}

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -26,6 +26,10 @@
 #include "window_battlemessage.h"
 #include "game_battlealgorithm.h"
 
+namespace Game_Message {
+class PendingMessage;
+};
+
 /**
  * Scene_Battle class.
  * Manages the battles.
@@ -131,7 +135,7 @@ protected:
 	 *
 	 * @param money Number of gold to display.
 	 */
-	void PushGoldReceivedMessage(int money);
+	void PushGoldReceivedMessage(PendingMessage& pm, int money);
 
 	/**
 	 * Adds a message about the experience received into
@@ -139,7 +143,7 @@ protected:
 	 *
 	 * @param exp Number of experience to display.
 	 */
-	void PushExperienceGainedMessage(int exp);
+	void PushExperienceGainedMessage(PendingMessage& pm, int exp);
 
 	/**
 	 * Adds messages about the items obtained after the battle
@@ -147,7 +151,7 @@ protected:
 	 *
 	 * @param drops Vector of item IDs
 	 */
-	void PushItemRecievedMessages(std::vector<int> drops);
+	void PushItemRecievedMessages(PendingMessage& pm, std::vector<int> drops);
 
 	void OptionSelected();
 	void CommandSelected();

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1078,19 +1078,24 @@ bool Scene_Battle_Rpg2k3::CheckWin() {
 		std::vector<int> drops;
 		Main_Data::game_enemyparty->GenerateDrops(drops);
 
-		Game_Message::texts.push_back(Data::terms.victory + Player::escape_symbol + "|");
+		auto pm = PendingMessage();
+
+		pm.PushLine(Data::terms.victory + Player::escape_symbol + "|");
+		pm.PushPageEnd();
 
 		std::string space = Player::IsRPG2k3E() ? " " : "";
 
 		std::stringstream ss;
 		if (exp > 0) {
 			ss << exp << space << Data::terms.exp_received;
-			Game_Message::texts.push_back(ss.str());
+			pm.PushLine(ss.str());
+			pm.PushPageEnd();
 		}
 		if (money > 0) {
 			ss.str("");
 			ss << Data::terms.gold_recieved_a << " " << money << Data::terms.gold << Data::terms.gold_recieved_b;
-			Game_Message::texts.push_back(ss.str());
+			pm.PushLine(ss.str());
+			pm.PushPageEnd();
 		}
 		for (std::vector<int>::iterator it = drops.begin(); it != drops.end(); ++it) {
 			const RPG::Item* item = ReaderUtil::GetElement(Data::items, *it);
@@ -1102,11 +1107,12 @@ bool Scene_Battle_Rpg2k3::CheckWin() {
 
 			ss.str("");
 			ss << item_name << space << Data::terms.item_recieved;
-			Game_Message::texts.push_back(ss.str());
+			pm.PushLine(ss.str());
+			pm.PushPageEnd();
 		}
 
 		message_window->SetHeight(32);
-		Game_Message::message_waiting = true;
+		Game_Message::SetPendingMessage(std::move(pm));
 
 		Game_System::BgmPlay(Game_System::GetSystemBGM(Game_System::BGM_Victory));
 
@@ -1118,14 +1124,6 @@ bool Scene_Battle_Rpg2k3::CheckWin() {
 			it != ally_battlers.end(); ++it) {
 				Game_Actor* actor = static_cast<Game_Actor*>(*it);
 				actor->ChangeExp(actor->GetExp() + exp, true);
-		}
-
-		for (std::string& str : Game_Message::texts) {
-			// FIXME: We really need a more sane API for injecting breaks after each line
-
-			if (!str.empty() && str[str.size() - 1] != '\f') {
-				str += '\f';
-			}
 		}
 
 		Main_Data::game_party->GainGold(money);
@@ -1148,11 +1146,12 @@ bool Scene_Battle_Rpg2k3::CheckLose() {
 		Game_Message::SetPositionFixed(true);
 		Game_Message::SetPosition(0);
 		Game_Message::SetTransparent(false);
-		Game_Message::message_waiting = true;
 
-		Game_Message::texts.push_back(Data::terms.defeat);
+		auto pm = PendingMessage();
+		pm.PushLine(Data::terms.defeat);
 
 		Game_System::BgmPlay(Game_System::GetSystemBGM(Game_System::BGM_GameOver));
+		Game_Message::SetPendingMessage(std::move(pm));
 
 		return true;
 	}

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -204,12 +204,12 @@ void Scene_Map::DrawBackground() {
 }
 
 void Scene_Map::PreUpdate(MapUpdateAsyncContext& actx) {
-	Game_Map::Update(actx, *message_window, true);
+	Game_Map::Update(actx, true);
 	UpdateGraphics();
 }
 
 void Scene_Map::PreUpdateForegroundEvents(MapUpdateAsyncContext& actx) {
-	Game_Map::UpdateForegroundEvents(actx, *message_window);
+	Game_Map::UpdateForegroundEvents(actx);
 	UpdateGraphics();
 }
 
@@ -223,7 +223,7 @@ void Scene_Map::Update() {
 }
 
 void Scene_Map::UpdateStage1(MapUpdateAsyncContext actx) {
-	Game_Map::Update(actx, *message_window);
+	Game_Map::Update(actx);
 	UpdateGraphics();
 
 	// Waiting for async operation from map update.

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -70,6 +70,8 @@ void Scene_Map::Start() {
 	spriteset.reset(new Spriteset_Map());
 	message_window.reset(new Window_Message(0, SCREEN_TARGET_HEIGHT - 80, SCREEN_TARGET_WIDTH, 80));
 
+	Game_Message::SetWindow(message_window.get());
+
 	// Called here instead of Scene Load, otherwise wrong graphic stack
 	// is used.
 	if (from_save) {
@@ -107,6 +109,8 @@ void Scene_Map::Start2(MapUpdateAsyncContext actx) {
 }
 
 void Scene_Map::Continue(SceneType prev_scene) {
+	Game_Message::SetWindow(message_window.get());
+
 	if (prev_scene == Scene::Battle) {
 		Game_Map::OnContinueFromBattle();
 	} else {

--- a/src/sprite_timer.cpp
+++ b/src/sprite_timer.cpp
@@ -91,7 +91,7 @@ void Sprite_Timer::Update() {
 	if (Game_Temp::battle_running) {
 		SetY(SCREEN_TARGET_HEIGHT / 3 * 2 - 20);
 	}
-	else if (Game_Message::visible && Game_Message::GetRealPosition() == 0) {
+	else if (Game_Message::IsMessageVisible() && Game_Message::GetRealPosition() == 0) {
 		SetY(SCREEN_TARGET_HEIGHT - 20);
 	}
 	else {

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -141,6 +141,7 @@ void Window_Message::ApplyTextInsertingCommands() {
 void Window_Message::StartMessageProcessing(PendingMessage pm) {
 	contents->Clear();
 	pending_message = std::move(pm);
+	allow_next_message = false;
 
 	const auto& lines = pending_message.GetLines();
 	if (!(pending_message.NumLines() > 0 || pending_message.HasNumberInput())) {
@@ -320,6 +321,7 @@ void Window_Message::ResetWindow() {
 
 void Window_Message::Update() {
 	bool update_message_processing = false;
+	allow_next_message = false;
 
 	if (pending_message.ShowGoldWindow()) {
 		ShowGoldWindow();
@@ -354,6 +356,8 @@ void Window_Message::Update() {
 		if (!Game_Message::IsMessagePending() && visible && !closing) {
 			// Start the closing animation
 			SetCloseAnimation(Game_Temp::battle_running ? 0 : message_animation_frames);
+			// This frame a foreground event may push a new message and interupt the close animation.
+			allow_next_message = true;
 		}
 	}
 

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -179,6 +179,11 @@ void Window_Message::StartMessageProcessing(PendingMessage pm) {
 	ApplyTextInsertingCommands();
 	text_index = text.begin();
 
+	// If we're displaying a new message, reset the closing animation.
+	if (closing) {
+		SetCloseAnimation(Game_Temp::battle_running ? 0 : message_animation_frames);
+	}
+
 	InsertNewPage();
 }
 

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -142,6 +142,10 @@ void Window_Message::StartMessageProcessing() {
 
 	const auto& pm = Game_Message::GetPendingMessage();
 
+	if (pm.ShowGoldWindow()) {
+		ShowGoldWindow();
+	}
+
 	const auto& lines = pm.GetLines();
 
 	if (pm.IsWordWrapped()) {
@@ -342,11 +346,6 @@ void Window_Message::Update() {
 				FinishMessageProcessing();
 			}
 		} else if (IsNextMessagePossible()) {
-			// Output a new page
-			if (Game_Temp::inn_calling) {
-				ShowGoldWindow();
-			}
-
 			StartMessageProcessing();
 			//printf("Text: %s\n", text.c_str());
 			if (!visible) {

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -739,11 +739,14 @@ void Window_Message::WaitForInput() {
 void Window_Message::InputChoice() {
 	const auto& pm = Game_Message::GetPendingMessage();
 
+	bool do_terminate = false;
+	int choice_result = -1;
+
 	if (Input::IsTriggered(Input::CANCEL)) {
 		if (pm.GetChoiceCancelType() > 0) {
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cancel));
-			Game_Message::choice_result = pm.GetChoiceCancelType() - 1; // Cancel
-			TerminateMessage();
+			choice_result = pm.GetChoiceCancelType() - 1; // Cancel
+			do_terminate = true;
 		}
 	} else if (Input::IsTriggered(Input::DECISION)) {
 		if (!pm.IsChoiceEnabled(index)) {
@@ -752,7 +755,17 @@ void Window_Message::InputChoice() {
 		}
 
 		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
-		Game_Message::choice_result = index;
+		choice_result = index;
+		do_terminate = true;
+	}
+
+	if (do_terminate) {
+		if (choice_result >= 0) {
+			auto& continuation = pm.GetChoiceContinuation();
+			if (continuation) {
+				continuation(choice_result);
+			}
+		}
 		TerminateMessage();
 	}
 }

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -359,7 +359,7 @@ void Window_Message::Update() {
 			}
 		}
 
-		if (!Game_Message::message_waiting && visible && !closing) {
+		if (!Game_Message::IsMessagePending() && visible && !closing) {
 			// Start the closing animation
 			SetCloseAnimation(Game_Temp::battle_running ? 0 : message_animation_frames);
 		}

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -53,6 +53,7 @@ Window_Message::Window_Message(int ix, int iy, int iwidth, int iheight) :
 		Data::battlecommands.transparency == RPG::BattleCommands::Transparency_transparent) {
 		SetBackOpacity(128);
 	}
+	gold_window->SetBackOpacity(GetBackOpacity());
 
 	visible = false;
 	// Above other windows
@@ -238,8 +239,10 @@ void Window_Message::InsertNewPage() {
 
 	if (Game_Message::IsTransparent()) {
 		SetOpacity(0);
+		gold_window->SetBackOpacity(0);
 	} else {
 		SetOpacity(255);
+		gold_window->SetBackOpacity(GetBackOpacity());
 	}
 
 	if (!Game_Message::GetFaceName().empty()) {

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -309,8 +309,9 @@ void Window_Message::TerminateMessage() {
 	if (gold_window->GetVisible()) {
 		gold_window->SetCloseAnimation(message_animation_frames);
 	}
+
+	// This clears the active flag.
 	pending_message = {};
-	Game_Message::ResetPendingMessage();
 }
 
 void Window_Message::ResetWindow() {

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -72,7 +72,6 @@ Window_Message::Window_Message(int ix, int iy, int iwidth, int iheight) :
 
 Window_Message::~Window_Message() {
 	TerminateMessage();
-	Game_Message::visible = false;
 	if (Game_Message::GetWindow() == this) {
 		Game_Message::SetWindow(nullptr);
 	}
@@ -348,19 +347,11 @@ void Window_Message::Update() {
 				// Cancel closing animation
 				SetOpenAnimation(0);
 			}
-			Game_Message::visible = true;
 		}
 
-		if (!Game_Message::message_waiting && Game_Message::visible) {
-			if (visible) {
-				if (!closing) {
-					// Start the closing animation
-					SetCloseAnimation(Game_Temp::battle_running ? 0 : message_animation_frames);
-				} else {
-					// Closing animation has started, prevent new messages from starting.
-					Game_Message::closing = true;
-				}
-			}
+		if (!Game_Message::message_waiting && visible && !closing) {
+			// Start the closing animation
+			SetCloseAnimation(Game_Temp::battle_running ? 0 : message_animation_frames);
 		}
 	}
 
@@ -375,12 +366,6 @@ void Window_Message::Update() {
 
 	if (update_message_processing) {
 		UpdateMessage();
-	}
-
-	if (!visible) {
-		// The closing animation has finished
-		Game_Message::visible = false;
-		Game_Message::closing = false;
 	}
 }
 

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -67,11 +67,15 @@ Window_Message::Window_Message(int ix, int iy, int iwidth, int iheight) :
 	gold_window->SetVisible(false);
 
 	Game_Message::Init();
+	Game_Message::SetWindow(this);
 }
 
 Window_Message::~Window_Message() {
 	TerminateMessage();
 	Game_Message::visible = false;
+	if (Game_Message::GetWindow() == this) {
+		Game_Message::SetWindow(nullptr);
+	}
 }
 
 void Window_Message::ApplyTextInsertingCommands() {

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -567,7 +567,6 @@ void Window_Message::DrawGlyph(const std::string& glyph, bool instant_speed) {
 	if (!instant_speed && glyph_width > 0) {
 		// RPG_RT compatible for half-width (6) and full-width (12)
 		// generalizes the algo for even bigger glyphs
-		// FIXME: Verify RPG_RT on full width
 		SetWaitForCharacter(width);
 	}
 	IncrementLineCharCounter(width);

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -85,20 +85,11 @@ public:
 	void TerminateMessage();
 
 	/**
-	 * Checks if the next message page can be displayed.
-	 *
-	 * @return If the text output can start.
-	 */
-	bool IsNextMessagePossible();
-
-	/**
 	 * Stub.
 	 */
 	void ResetWindow();
 
 	void Update() override;
-
-	void UpdatePostEvents();
 
 	/**
 	 * Continues outputting more text. Also handles the

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -23,6 +23,7 @@
 #include "window_gold.h"
 #include "window_numberinput.h"
 #include "window_selectable.h"
+#include "pending_message.h"
 
 /**
  * Window Message Class.
@@ -45,7 +46,7 @@ public:
 	 * Starts message processing by reading all
 	 * non-displayed from Game_Message.
 	 */
-	void StartMessageProcessing();
+	void StartMessageProcessing(PendingMessage pm);
 
 	/**
 	 * Ends the message processing.
@@ -180,6 +181,8 @@ protected:
 	/** Used by the number input event. */
 	std::unique_ptr<Window_NumberInput> number_input_window;
 	std::unique_ptr<Window_Gold> gold_window;
+
+	PendingMessage pending_message;
 
 	void DrawGlyph(const std::string& glyph, bool instant_speed);
 	void IncrementLineCharCounter(int width);

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -154,6 +154,9 @@ public:
 	/** @return the stored PendingMessage */
 	const PendingMessage& GetPendingMessage() const;
 
+	/** @return true if we can push a new message this frame */
+	bool GetAllowNextMessage() const;
+
 protected:
 	/** X-position of next char. */
 	int contents_x = 0;
@@ -173,6 +176,8 @@ protected:
 	int speed = 1;
 	/** If true inserts a new page after pause ended */
 	bool new_page_after_pause = false;
+	/** If true, we allow a new message to be pushed this frame */
+	bool allow_next_message = false;
 
 	/** Frames to wait when a message wait command was used */
 	int wait_count = 0;
@@ -197,6 +202,10 @@ protected:
 
 inline const PendingMessage& Window_Message::GetPendingMessage() const {
 	return pending_message;
+}
+
+inline bool Window_Message::GetAllowNextMessage() const {
+	return allow_next_message;
 }
 
 #endif

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -151,6 +151,9 @@ public:
 	 */
 	void InputNumber();
 
+	/** @return the stored PendingMessage */
+	const PendingMessage& GetPendingMessage() const;
+
 protected:
 	/** X-position of next char. */
 	int contents_x = 0;
@@ -191,5 +194,9 @@ protected:
 	void SetWaitForPage();
 	void SetWait(int frames);
 };
+
+inline const PendingMessage& Window_Message::GetPendingMessage() const {
+	return pending_message;
+}
 
 #endif


### PR DESCRIPTION
Depends on: #1900 
Fix: #1908 
Fix: #1873 
Fix: #1909

This PR refactors the messaging interface to better separate concerns between Game_Message and Window_Message. It also fixes more frame timing edge cases from #1706 


Tests from #1706
- [x] Tests 1-11 - All pass
- [x] Tests 13-16 - All pass
- [x] Tests 19-20 - All pass
- [x] Tests 21-25 - All Pass
- [x] Tests 30-32 - All Pass
- [x] Test 33 - Passes with #1955
- [x] Tests 34-38 - All Pass

Failing tests #1706:
- [ ] Test 12 - Not 100% compatible
    * Doesn't crash when RPG_RT crashes
    * Embedded variables supported in Player but not RPG_RT
    * Embedded variables in actor name itself also supported in Player but not RPG_RT
- [ ] Tests 17 - Doesn't accurately emulate the glitch in test 1, everything else works
- [ ] Tests 26 - Inn cost with wait 0.5s
- [ ] Tests 28 - Multiple level up messages don't work at all
- [ ] Tests 29 - Doesn't behave right with message
- [ ] Tests 32 - Fails because we don't render the transitions properly. Message timing is accurate.

Passing with/without minor glitches #1706:
- [ ] Tests 18 - We don't emulate the glitch
- [ ] Tests 27 - Same behavior, but doesn't emulate glitches
    * No Wait - Message box doesn't appear briefly
    * Wait 0.5s - Box doesn't close when game over scene happens
- [ ] Tests 31 - We don't emulate corruption, and probably don't care