### PR TITLE
Fixes for async operations and parallel events

### DIFF
--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -49,10 +49,10 @@ void Game_CommonEvent::SetSaveData(const RPG::SaveEventExecState& data) {
 	}
 }
 
-AsyncOp Game_CommonEvent::Update() {
-	if (interpreter && IsWaitingBackgroundExecution()) {
+AsyncOp Game_CommonEvent::Update(bool resume_async) {
+	if (interpreter && IsWaitingBackgroundExecution(resume_async)) {
 		assert(interpreter->IsRunning());
-		interpreter->Update();
+		interpreter->Update(!resume_async);
 
 		// Suspend due to async op ...
 		if (interpreter->IsAsyncPending()) {
@@ -108,8 +108,8 @@ bool Game_CommonEvent::IsWaitingForegroundExecution() const {
 		&& !ce->event_commands.empty();
 }
 
-bool Game_CommonEvent::IsWaitingBackgroundExecution() const {
+bool Game_CommonEvent::IsWaitingBackgroundExecution(bool force_run) const {
 	auto* ce = ReaderUtil::GetElement(Data::commonevents, common_event_id);
 	return ce->trigger == RPG::EventPage::Trigger_parallel &&
-		(!ce->switch_flag || Game_Switches.Get(ce->switch_id));
+		(force_run || !ce->switch_flag || Game_Switches.Get(ce->switch_id));
 }

--- a/src/game_commonevent.h
+++ b/src/game_commonevent.h
@@ -48,9 +48,10 @@ public:
 	/**
 	 * Updates common event parallel interpreter.
 	 *
+	 * @param resume_async If we're resuming from an async operation.
 	 * @return async operation if we should suspend, otherwise returns AsyncOp::eNone
 	 */
-	AsyncOp Update();
+	AsyncOp Update(bool resume_async);
 
 	/**
 	 * Gets common event index.
@@ -99,8 +100,11 @@ public:
 	/** @return true if waiting for foreground execution */
 	bool IsWaitingForegroundExecution() const;
 
-	/** @return true if waiting for background execution */
-	bool IsWaitingBackgroundExecution() const;
+	/**
+	 * @param force_run force the event to execute even if conditions not met.
+	 * @return true if waiting for background execution
+	 */
+	bool IsWaitingBackgroundExecution(bool force_run) const;
 
 private:
 	int common_event_id;

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -506,7 +506,7 @@ void Game_Event::MoveTypeAwayFromPlayer() {
 	MoveTypeTowardsOrAwayPlayer(false);
 }
 
-AsyncOp Game_Event::Update() {
+AsyncOp Game_Event::Update(bool resume_async) {
 	if (!data()->active || page == NULL) {
 		return {};
 	}
@@ -517,7 +517,7 @@ AsyncOp Game_Event::Update() {
 	// This results in event waits to finish quicker during collisions as
 	// the wait will tick by 1 each time the interpreter is invoked.
 	if (GetTrigger() == RPG::EventPage::Trigger_parallel && interpreter) {
-		interpreter->Update();
+		interpreter->Update(!resume_async);
 
 		// Suspend due to async op ...
 		if (interpreter->IsAsyncPending()) {

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -128,8 +128,8 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 			if (!interpreter) {
 				interpreter.reset(new Game_Interpreter_Map());
 			}
-			interpreter->Clear();
-			interpreter->Push(this);
+			// RPG_RT will wait until the next call to Update() to push the interpreter code.
+			// This forces the interpreter to yield when it changes it's own page.
 		}
 	}
 }
@@ -513,6 +513,9 @@ AsyncOp Game_Event::Update(bool resume_async) {
 	// This results in event waits to finish quicker during collisions as
 	// the wait will tick by 1 each time the interpreter is invoked.
 	if ((resume_async || GetTrigger() == RPG::EventPage::Trigger_parallel) && interpreter) {
+		if (!interpreter->IsRunning() && page && !page->event_commands.empty()) {
+			interpreter->Push(this);
+		}
 		interpreter->Update(!resume_async);
 
 		// Suspend due to async op ...

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -123,10 +123,6 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 	SetLayer(page->layer);
 	data()->overlap_forbidden = page->overlap_forbidden;
 
-	if (interpreter) {
-		interpreter->Clear();
-	}
-
 	if (GetTrigger() == RPG::EventPage::Trigger_parallel) {
 		if (!page->event_commands.empty()) {
 			if (!interpreter) {
@@ -507,7 +503,7 @@ void Game_Event::MoveTypeAwayFromPlayer() {
 }
 
 AsyncOp Game_Event::Update(bool resume_async) {
-	if (!data()->active || page == NULL) {
+	if (!data()->active || (!resume_async && page == NULL)) {
 		return {};
 	}
 
@@ -516,7 +512,7 @@ AsyncOp Game_Event::Update(bool resume_async) {
 	// the interpreter will run multiple times per frame.
 	// This results in event waits to finish quicker during collisions as
 	// the wait will tick by 1 each time the interpreter is invoked.
-	if (GetTrigger() == RPG::EventPage::Trigger_parallel && interpreter) {
+	if ((resume_async || GetTrigger() == RPG::EventPage::Trigger_parallel) && interpreter) {
 		interpreter->Update(!resume_async);
 
 		// Suspend due to async op ...

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -112,9 +112,10 @@ public:
 	/** 
 	 * Update this for the current frame
 	 *
+	 * @param resume_async If we're resuming from an async operation.
 	 * @return async operation if we should suspend, otherwise returns AsyncOp::eNone
 	 */
-	AsyncOp Update();
+	AsyncOp Update(bool resume_async);
 
 	bool AreConditionsMet(const RPG::EventPage& page);
 

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -106,7 +106,7 @@ protected:
 
 	bool main_flag;
 
-	int loop_count;
+	int loop_count = 0;
 	bool wait_messages;
 
 	typedef bool (Game_Interpreter::*ContinuationFunction)(RPG::EventCommand const& com);


### PR DESCRIPTION
* If a parallel common event disables it's switch and
  then does an async operation, we need to force it to
  rerun on resume, despite the switch being off.
* If a parallel common or map event resumes, we should not
  reset the loop counter.

Fix: #1913