### PR TITLE
Speedup Startup + RTP detection

### DIFF
--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -73,17 +73,17 @@ namespace {
 	std::string fonts_path;
 
 	struct {
-		// all RTP search paths
+		/** all RTP search paths */
 		search_path_list search_paths;
-		// RTP was disabled with --disable-rtp
+		/** RTP was disabled with --disable-rtp */
 		bool disable_rtp = true;
-		// Game has FullPackageFlag=1, RTP will still be used as RPG_RT does
+		/** Game has FullPackageFlag=1, RTP will still be used as RPG_RT does */
 		bool game_has_full_package_flag = false;
-		// warning about "game has FullPackageFlag=1 but needs RTP" shown
+		/** warning about "game has FullPackageFlag=1 but needs RTP" shown */
 		bool warning_broken_rtp_game_shown = false;
-		// RTP candidates per search_pathwarning_broken_rtp_game_shown
+		/** RTP candidates per search_path */
 		std::vector<RTP::RtpHitInfo> detected_rtp;
-		// the RTP the game uses, when only one left the RTP of the game is known
+		/** the RTP the game uses, when only one left the RTP of the game is known */
 		std::vector<RTP::Type> game_rtp;
 	} rtp_state;
 

--- a/src/registry_wine.cpp
+++ b/src/registry_wine.cpp
@@ -85,8 +85,8 @@ std::string Registry::ReadStrValue(HKEY hkey, const std::string& key, const std:
 
 	// Custom, simple INI parser because liblcf ini is not efficient enough
 	// (lcf ini stores all keys/values but we only need one)
-	std::string formatted_key_search = "[" + Utils::LowerCase(formatted_key) + "]";
-	formatted_val = Utils::LowerCase(formatted_val);
+	std::string formatted_key_search = "[" + Utils::LowerCaseInPlace(formatted_key) + "]";
+	Utils::LowerCaseInPlace(formatted_val);
 	std::string path;
 	std::ifstream registry(registry_file);
 	if (!registry) {
@@ -101,7 +101,7 @@ std::string Registry::ReadStrValue(HKEY hkey, const std::string& key, const std:
 		if (!in_section) {
 			if (line.empty() || line[0] != '[') {
 				continue;
-			} else if (Utils::StartsWith(Utils::LowerCase(line), formatted_key_search)) {
+			} else if (Utils::StartsWith(Utils::LowerCaseInPlace(line), formatted_key_search)) {
 				// Found the section
 				in_section = true;
 			}

--- a/src/registry_wine.cpp
+++ b/src/registry_wine.cpp
@@ -20,10 +20,11 @@
 #ifdef USE_WINE_REGISTRY
 
 #include <cstdlib>
+#include <fstream>
 #include "registry.h"
 #include "filefinder.h"
 #include "output.h"
-#include "inireader.h"
+#include "utils.h"
 
 /*
 Wine registry file example:
@@ -51,8 +52,8 @@ std::string Registry::ReadStrValue(HKEY hkey, const std::string& key, const std:
 		pos += 2;
 	}
 
-	// Puts value between quotes
-	std::string formatted_val = "\"" + val + "\"";
+	// Puts value between quotes and add =
+	std::string formatted_val = "\"" + val + "\""  + "=";
 
 	if (prefix.empty() || !FileFinder::Exists(prefix)) {
 		Output::Debug("wine prefix not found: \"%s\"", prefix.c_str());
@@ -82,12 +83,43 @@ std::string Registry::ReadStrValue(HKEY hkey, const std::string& key, const std:
 		formatted_key.insert(pos, R"(\\Wow6432Node)");
 	}
 
-	INIReader registry(registry_file);
+	// Custom, simple INI parser because liblcf ini is not efficient enough
+	// (lcf ini stores all keys/values but we only need one)
+	std::string formatted_key_search = "[" + Utils::LowerCase(formatted_key) + "]";
+	formatted_val = Utils::LowerCase(formatted_val);
 	std::string path;
+	std::ifstream registry(registry_file);
+	if (!registry) {
+		return path;
+	}
 
-	if (registry.ParseError() != -1) {
-		string_value = registry.Get(formatted_key, formatted_val, "");
+	bool in_section = false;
+	std::string line;
+	line.reserve(1024);
+	do {
+		std::getline(registry, line);
+		if (!in_section) {
+			if (line.empty() || line[0] != '[') {
+				continue;
+			} else if (Utils::StartsWith(Utils::LowerCase(line), formatted_key_search)) {
+				// Found the section
+				in_section = true;
+			}
+		} else {
+			if (!line.empty() && line[0] == '[') {
+				// value not found
+				break;
+			}
 
+			if (Utils::StartsWith(Utils::LowerCase(line), formatted_val)) {
+				// value found
+				string_value = line.substr(formatted_val.length());
+				break;
+			}
+		}
+	} while (!registry.eof());
+
+	if (!string_value.empty()) {
 		// Removes begin and end quotes but keeps all other inner just in case
 		if (!string_value.empty()) {
 			string_value.erase(0, 1);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -36,13 +36,34 @@ namespace {
 
 std::string Utils::LowerCase(const std::string& str) {
 	std::string result = str;
-	std::transform(result.begin(), result.end(), result.begin(), tolower);
+	LowerCaseInPlace(result);
 	return result;
 }
 
+std::string& Utils::LowerCaseInPlace(std::string& str) {
+	auto lower = [](char& c) -> char {
+		if (c >= 'A' && c <= 'Z') {
+			return c + 'a' - 'A';
+		} else {
+			return c;
+		}
+	};
+
+	std::transform(str.begin(), str.end(), str.begin(), lower);
+	return str;
+}
+
 std::string Utils::UpperCase(const std::string& str) {
+	auto upper = [](char& c) -> char {
+		if (c >= 'a' && c <= 'z') {
+			return c + 'A' - 'a';
+		} else {
+			return c;
+		}
+	};
+
 	std::string result = str;
-	std::transform(result.begin(), result.end(), result.begin(), toupper);
+	std::transform(result.begin(), result.end(), result.begin(), upper);
 	return result;
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -27,7 +27,7 @@
 
 namespace Utils {
 	/**
-	 * Converts a string to lower case.
+	 * Converts a string to lower case (ASCII only)
 	 *
 	 * @param str string to convert.
 	 * @return the converted string.
@@ -35,7 +35,15 @@ namespace Utils {
 	std::string LowerCase(const std::string& str);
 
 	/**
-	 * Converts a string to upper case.
+	 * Converts a string to lower case in-place (ASCII only, faster)
+	 *
+	 * @param str string to convert.
+	 * @return the passed and lowered string
+	 */
+	std::string& LowerCaseInPlace(std::string& str);
+
+	/**
+	 * Converts a string to upper case. (ASCII only)
 	 *
 	 * @param str string to convert.
 	 * @return the converted string.

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -8,6 +8,13 @@ TEST_SUITE_BEGIN("Utils");
 TEST_CASE("Lower") {
 	REQUIRE_EQ(Utils::LowerCase("EasyRPG"), "easyrpg");
 	REQUIRE_EQ(Utils::LowerCase("player"), "player");
+	REQUIRE_EQ(Utils::LowerCase("!A/b"), "!a/b");
+}
+
+TEST_CASE("Upper") {
+	REQUIRE_EQ(Utils::UpperCase("EasyRPG"), "EASYRPG");
+	REQUIRE_EQ(Utils::UpperCase("player"), "PLAYER");
+	REQUIRE_EQ(Utils::UpperCase("!A/b"), "!A/B");
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
Two improvements:

- The RTP is now initialized the first time a file is missing. This way there is no startup delay, instead the delay is now when the first RTP asset is requested. Yes this only moves the problem but for some games this means 0 delay.
- lcf INI parser replaced with a simple parser that just reads all lines and skips until the Key/Value pair is found. No extra caching, that's why I don't consider this a fix for #1903, likely can be improved more.