### PR TITLE
Preparations for new emscripten backend

### DIFF
--- a/resources/emscripten/emscripten-post.js
+++ b/resources/emscripten/emscripten-post.js
@@ -1,47 +1,10 @@
-function parseargs() {
-    var tmp = [];
-    var ret = [];
-    var items = location.search.substr(1).split("&");
-
-    // Store saves in subdirectory Save
-    ret.push("--save-path");
-    ret.push("Save");
-
-    for (var index = 0; index < items.length; index++) {
-        tmp = items[index].split("=");
-
-        if (tmp[0] == "project-path" || tmp[0] == "save-path") {
-            // Filter arguments that are set by us
-            continue;
-        }
-
-        if (tmp[0] == "game") {
-            // Move to different directory to prevent Save file collisions in IDBFS
-            if (tmp.length > 1) {
-                tmp[1] = tmp[1].toLowerCase();
-                FS.mkdir(tmp[1]);
-                FS.chdir(tmp[1]);
-            }
-        }
-        ret.push("--" + tmp[0]);
-        if (tmp.length > 1) {
-            var arg = decodeURI(tmp[1]);
-            // split except if it's a string
-            if (arg.length > 0) {
-                if (arg.slice(0) == "\"" && arg.slice(-1) == "\"") {
-                    ret.push(arg.slice(1, -1));
-                } else {
-                    var spl = arg.split(" ");
-                    ret = ret.concat(spl);
-                }
-            }
-        }
-    }
-    return ret;
+// Move to different directory to prevent Save file collisions in IDBFS
+FS.mkdir("easyrpg");
+FS.chdir("easyrpg");
+if (Module.EASYRPG_GAME.length > 0) {
+    FS.mkdir(Module.EASYRPG_GAME);
+    FS.chdir(Module.EASYRPG_GAME);
 }
-
-Module.arguments.push("easyrpg-player");
-Module.arguments = Module.arguments.concat(parseargs());
 
 // Use IDBFS for Save storage when the filesystem was not
 // overwritten by a custom emscripten shell file

--- a/resources/emscripten/emscripten-pre.js
+++ b/resources/emscripten/emscripten-pre.js
@@ -1,0 +1,44 @@
+Module.EASYRPG_GAME = ""
+
+function parseargs() {
+    var tmp = [];
+    var ret = [];
+    var items = location.search.substr(1).split("&");
+
+    // Store saves in subdirectory Save
+    ret.push("--save-path");
+    ret.push("Save");
+
+    for (var index = 0; index < items.length; index++) {
+        tmp = items[index].split("=");
+
+        if (tmp[0] == "project-path" || tmp[0] == "save-path") {
+            // Filter arguments that are set by us
+            continue;
+        }
+
+        if (tmp[0] == "game") {
+            // Filesystem is not ready when processing arguments, store path to game
+            if (tmp.length > 1) {
+                Module.EASYRPG_GAME = tmp[1].toLowerCase();
+            }
+        }
+        ret.push("--" + tmp[0]);
+        if (tmp.length > 1) {
+            var arg = decodeURI(tmp[1]);
+            // split except if it's a string
+            if (arg.length > 0) {
+                if (arg.slice(0) == "\"" && arg.slice(-1) == "\"") {
+                    ret.push(arg.slice(1, -1));
+                } else {
+                    var spl = arg.split(" ");
+                    ret = ret.concat(spl);
+                }
+            }
+        }
+    }
+    return ret;
+}
+
+Module.arguments = ["easyrpg-player"];
+Module.arguments = Module.arguments.concat(parseargs());

--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include "async_handler.h"
+#include "cache.h"
 #include "filefinder.h"
 #include "memory_management.h"
 #include "output.h"
@@ -156,6 +157,12 @@ void FileRequestAsync::SetGraphicFile(bool graphic) {
 }
 
 void FileRequestAsync::Start() {
+	if (file == CACHE_DEFAULT_BITMAP) {
+		// Embedded asset -> Fire immediately
+		DownloadDone(true);
+		return;
+	}
+
 	if (state == State_Pending) {
 		return;
 	}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -203,11 +203,8 @@ void Player::Run() {
 	FrameReset();
 
 	// Main loop
-#ifdef EMSCRIPTEN
-	emscripten_set_main_loop(Player::MainLoop, 0, 0);
-#elif defined(USE_LIBRETRO)
-	// Do nothing
-#else
+	// libretro invokes the MainLoop through a retro_run-callback
+#ifndef USE_LIBRETRO
 	while (Graphics::IsTransitionPending() || Scene::instance->type != Scene::Null) {
 #  if defined(_3DS)
 		if (!aptMainLoop())
@@ -332,9 +329,6 @@ void Player::Update(bool update_scene) {
 
 	BitmapRef disp = DisplayUi->GetDisplaySurface();
 
-#ifdef EMSCRIPTEN
-	Graphics::Draw(*disp);
-#else
 	cur_time = (double)DisplayUi->GetTicks();
 	if (cur_time < next_frame) {
 		Graphics::Draw(*disp);
@@ -343,11 +337,10 @@ void Player::Update(bool update_scene) {
 #if !defined(USE_LIBRETRO)
 		// Still time after graphic update? Yield until it's time for next one.
 		if (cur_time < next_frame) {
-			DisplayUi->Sleep((uint32_t)(next_frame - cur_time));
+			DisplayUi->Sleep(static_cast<uint32_t>(next_frame - cur_time));
 		}
 #endif
 	}
-#endif
 }
 
 void Player::IncFrame() {
@@ -376,8 +369,6 @@ int Player::GetFrames() {
 
 void Player::Exit() {
 #ifdef EMSCRIPTEN
-	emscripten_cancel_main_loop();
-
 	BitmapRef surface = DisplayUi->GetDisplaySurface();
 	std::string message = "It's now safe to turn off\n      your browser.";
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -168,10 +168,6 @@ void Player::Init(int argc, char *argv[]) {
 	// Create initial directory structure in our private area
 	// Retrieve save directory from persistent storage
 	EM_ASM(({
-
-		FS.mkdir("easyrpg");
-		FS.chdir("easyrpg");
-
 		var dirs = ['Backdrop', 'Battle', 'Battle2', 'BattleCharSet', 'BattleWeapon', 'CharSet', 'ChipSet', 'FaceSet', 'Frame', 'GameOver', 'Monster', 'Movie', 'Music', 'Panorama', 'Picture', 'Sound', 'System', 'System2', 'Title', 'Save'];
 		dirs.forEach(function(dir) { FS.mkdir(dir) });
 

--- a/src/scene.h
+++ b/src/scene.h
@@ -76,7 +76,7 @@ public:
 	 * executes the scene that is currently on the top of
 	 * the stack.
 	 */
-	virtual void MainFunction();
+	void MainFunction();
 
 	/**
 	 * Start processing.

--- a/src/sdl2_ui.cpp
+++ b/src/sdl2_ui.cpp
@@ -216,9 +216,7 @@ uint32_t Sdl2Ui::GetTicks() const {
 }
 
 void Sdl2Ui::Sleep(uint32_t time) {
-#ifndef EMSCRIPTEN
 	SDL_Delay(time);
-#endif
 }
 
 bool Sdl2Ui::RequestVideoMode(int width, int height, int zoom) {


### PR DESCRIPTION
New build line is:
```
emcc -g0 -O2 -v --llvm-lto 1 -s ASSERTIONS=0 -s NO_EXIT_RUNTIME=1 \
    -s ALLOW_MEMORY_GROWTH=1 -s DEMANGLE_SUPPORT=1 \
    -s ASYNCIFY \
    -lidbfs.js \
    easyrpg-player.bc \
    -o player-js/index.html \
    --pre-js resources/emscripten/emscripten-pre.js \
    --post-js resources/emscripten/emscripten-post.js \
    --shell-file resources/emscripten/emscripten-shell.html
```

Needed to split the argument handling because the generated code changes:
Arguments must be prepared after the pre-js-file was executed.

Currently not added because of problems with the instrumentation (?): "-s ASYNCIFY_IGNORE_INDIRECT"

sleep_for: ``_ZNSt11this_thread9sleep_forIlSt5ratioILl1ELl1EEEEvRKNSt6chrono8durationIT_T0_EE``