### PR TITLE
window_equipstatus: Draw fullwidth arrow in Japanese games

### DIFF
--- a/src/window_equipstatus.cpp
+++ b/src/window_equipstatus.cpp
@@ -22,6 +22,7 @@
 #include "window_equipstatus.h"
 #include "bitmap.h"
 #include "font.h"
+#include "player.h"
 
 Window_EquipStatus::Window_EquipStatus(int ix, int iy, int iwidth, int iheight, int actor_id) :
 	Window_Base(ix, iy, iwidth, iheight),
@@ -120,8 +121,13 @@ void Window_EquipStatus::DrawParameter(int cx, int cy, int type) {
 	contents->TextDraw(cx, cy, Font::ColorDefault, std::to_string(value), Text::AlignRight);
 
 	if (draw_params) {
-		// Draw arrow (+3 for center between the two numbers)
-		contents->TextDraw(cx + 3, cy, 1, ">");
+		if (Player::IsCP932()) {
+			// Draw fullwidth arrow
+			contents->TextDraw(cx, cy, 1, "→");
+		} else {
+			// Draw arrow (+3 for center between the two numbers)
+			contents->TextDraw(cx + 3, cy, 1, ">");
+		}
 
 		// Draw New Value
 		cx += 6 * 2 + 6 * 3;


### PR DESCRIPTION
See screenshots.

RPG_RT on Windows:
![equip_arrow_rpgrt](https://user-images.githubusercontent.com/10556453/66049998-5ca1a380-e567-11e9-92f9-a6380f7c1267.png)
EasyRPG Player (Unpatched):
![equip_arrow_unpatched](https://user-images.githubusercontent.com/10556453/66049999-5d3a3a00-e567-11e9-8604-60786ecd5a96.png)
EasyRPG Player (Patched):
![equip_arrow_patched](https://user-images.githubusercontent.com/10556453/66049997-5ca1a380-e567-11e9-8fda-4856e0e7758f.png)