### PR TITLE
Fix battle event battle animation crash

### DIFF
--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -65,6 +65,7 @@ namespace {
 void Game_Battle::Init() {
 	interpreter.reset(new Game_Interpreter_Battle());
 	spriteset.reset(new Spriteset_Battle());
+	spriteset->Update();
 	animation.reset();
 
 	Game_Temp::battle_running = true;

--- a/src/spriteset_battle.cpp
+++ b/src/spriteset_battle.cpp
@@ -65,8 +65,6 @@ Spriteset_Battle::Spriteset_Battle() {
 	timer2.reset(new Sprite_Timer(1));
 
 	screen.reset(new Screen());
-
-	Update();
 }
 
 void Spriteset_Battle::Update() {


### PR DESCRIPTION
When a battle event does an animation as the first command, which
also triggers a flash effect on the first frame the game crashes.

This happens because SpriteSet_Battle::Update() is called within
it's constructor before the spriteset unique_ptr is set within
Game_Battle.

Fix: #1929