### PR TITLE
Transition Random blocks up/down were down/up

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -434,7 +434,7 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 		// increment the old frame and not the new one we just pushed.
 		frame = &_state.stack[current_frame_idx];
 
-		// Only do auto increment if the command didn't manually 
+		// Only do auto increment if the command didn't manually
 		// change the index.
 		if (index_before_exec == frame->current_command) {
 			frame->current_command++;
@@ -2051,10 +2051,10 @@ bool Game_Interpreter::CommandEraseScreen(RPG::EventCommand const& com) { // cod
 		tt = Transition::TransitionRandomBlocks;
 		break;
 	case 2:
-		tt = Transition::TransitionRandomBlocksUp;
+		tt = Transition::TransitionRandomBlocksDown;
 		break;
 	case 3:
-		tt = Transition::TransitionRandomBlocksDown;
+		tt = Transition::TransitionRandomBlocksUp;
 		break;
 	case 4:
 		tt = Transition::TransitionBlindClose;
@@ -2133,10 +2133,10 @@ bool Game_Interpreter::CommandShowScreen(RPG::EventCommand const& com) { // code
 		tt = Transition::TransitionRandomBlocks;
 		break;
 	case 2:
-		tt = Transition::TransitionRandomBlocksUp;
+		tt = Transition::TransitionRandomBlocksDown;
 		break;
 	case 3:
-		tt = Transition::TransitionRandomBlocksDown;
+		tt = Transition::TransitionRandomBlocksUp;
 		break;
 	case 4:
 		tt = Transition::TransitionBlindOpen;

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -369,8 +369,8 @@ int Game_System::GetTransition(int which) {
 		{
 			Transition::TransitionFadeOut,
 			Transition::TransitionRandomBlocks,
-			Transition::TransitionRandomBlocksUp,
 			Transition::TransitionRandomBlocksDown,
+			Transition::TransitionRandomBlocksUp,
 			Transition::TransitionBlindClose,
 			Transition::TransitionVerticalStripesOut,
 			Transition::TransitionHorizontalStripesOut,
@@ -392,8 +392,8 @@ int Game_System::GetTransition(int which) {
 		{
 			Transition::TransitionFadeIn,
 			Transition::TransitionRandomBlocks,
-			Transition::TransitionRandomBlocksUp,
 			Transition::TransitionRandomBlocksDown,
+			Transition::TransitionRandomBlocksUp,
 			Transition::TransitionBlindOpen,
 			Transition::TransitionVerticalStripesIn,
 			Transition::TransitionHorizontalStripesIn,

--- a/src/transition.h
+++ b/src/transition.h
@@ -36,8 +36,8 @@ public:
 		TransitionFadeIn,
 		TransitionFadeOut,
 		TransitionRandomBlocks,
-		TransitionRandomBlocksUp,
 		TransitionRandomBlocksDown,
+		TransitionRandomBlocksUp,
 		TransitionBlindOpen,
 		TransitionBlindClose,
 		TransitionVerticalStripesIn,
@@ -77,7 +77,7 @@ public:
 
 	int GetZ() const override;
 	DrawableType GetType() const override;
-	
+
 	/**
 	 * Defines a screen transition.
 	 *


### PR DESCRIPTION
Found a while ago (iirc it was smivan) in a Yume Nikki comparison video.

Not sure if other transitions have the same problem, but here it was obvious because the menu items were named "Random blocks from above/below" but we did "Random block Up/down" (Up/Down as in "upwards/downwards").

Tested with:
 - [x] Transition predefined in the database and teleporting
 - [x] Changing transition through an event command and teleporting
 - [x] Show/Hide Screen event command
