### PR TITLE
Fix picture waver effect

### DIFF
--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -16,6 +16,7 @@
  */
 
 // Headers
+#define _USE_MATH_DEFINES
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -739,8 +740,8 @@ void Bitmap::WaverBlit(int x, int y, double zoom_x, double zoom_y, Bitmap const&
 			continue;
 		if (dy >= this->height())
 			break;
-		int sy = static_cast<int>(std::floor((i+0.5) / zoom_y));
-		int offset = (int) (2 * zoom_x * depth * sin((phase + (src_rect.y + sy) * 11.2) * 3.14159 / 180));
+		double sy = i * 360.0 / (32.0 * zoom_y);
+		int offset = 2 * zoom_x * depth * std::sin((phase + sy) * M_PI / 180);
 
 		pixman_image_composite32(src.GetOperator(mask),
 								 src.bitmap, mask, bitmap,

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -734,14 +734,15 @@ void Bitmap::WaverBlit(int x, int y, double zoom_x, double zoom_y, Bitmap const&
 
 	int height = static_cast<int>(std::floor(src_rect.height * zoom_y));
 	int width  = static_cast<int>(std::floor(src_rect.width * zoom_x));
-	for (int i = 0; i < height; i++) {
+	const auto yclip = y < 0 ? -y : 0;
+	const auto yend = std::min(height, this->height() - y);
+	for (int i = yclip; i < yend; i++) {
 		int dy = y + i;
-		if (dy < 0)
-			continue;
-		if (dy >= this->height())
-			break;
-		double sy = i * 360.0 / (32.0 * zoom_y);
-		int offset = 2 * zoom_x * depth * std::sin((phase + sy) * M_PI / 180);
+		// RPG_RT starts the effect from the top of the screen even if the image is clipped. The result
+		// is that moving images which cross the top of the screen can appear to go too fast or too slow
+		// in RPT_RT. The (i - yclip) is RPG_RT compatible behavior. Just (i) would be more correct.
+		const double sy = (i - yclip) * (2 * M_PI) / (32.0 * zoom_y);
+		const int offset = 2 * zoom_x * depth * std::sin(phase + sy);
 
 		pixman_image_composite32(src.GetOperator(mask),
 								 src.bitmap, mask, bitmap,

--- a/src/game_picture.cpp
+++ b/src/game_picture.cpp
@@ -105,8 +105,9 @@ void Game_Picture::UpdateSprite() {
 	sprite->SetOy(sprite->GetBitmap()->GetHeight() / 2);
 
 	sprite->SetAngle(data.effect_mode != RPG::SavePicture::Effect_wave ? data.current_rotation * 360 / 256 : 0.0);
-	sprite->SetWaverPhase(data.effect_mode == RPG::SavePicture::Effect_wave ? data.current_waver : 0.0);
+	sprite->SetWaverPhase(data.effect_mode == RPG::SavePicture::Effect_wave ? data.current_waver * 360 / 256 : 0.0);
 	sprite->SetWaverDepth(data.effect_mode == RPG::SavePicture::Effect_wave ? data.current_effect_power * 2 : 0);
+
 	sprite->SetOpacity(
 		(int)(255 * (100 - data.current_top_trans) / 100),
 		(int)(255 * (100 - data.current_bot_trans) / 100));
@@ -338,7 +339,7 @@ void Game_Picture::Update() {
 
 	// Update waver phase
 	if (data.effect_mode == RPG::SavePicture::Effect_wave) {
-		data.current_waver = data.current_waver + 10;
+		data.current_waver = data.current_waver + 8;
 	}
 
 	// RPG Maker 2k3 1.12: Spritesheets


### PR DESCRIPTION
* Animate LSD chunks accurately
* Fix visual effect speed, period, and displacement

Fix: #1946 

@Br4ssman please confirm

A good way to test this is with this event:
```
ShowPicture: Wave effect w/ some power
Loop:
  HideScreen Fade Out
  ShowScreen Fade In
  Wait 0.5s
  Wait 0.0s
  Wait 0.0s
```

The screen fades will happen between 1 complete cycle (32 frames), regardless of wave power.

Here are some good images to test the fact that the wave effect period is 32 pixels:
![waver32](https://user-images.githubusercontent.com/1198466/69485150-72b23e80-0e09-11ea-9115-836985eb52fa.png)
![waver64](https://user-images.githubusercontent.com/1198466/69485151-72b23e80-0e09-11ea-8d3e-4b61aee6d260.png)

I tested the following scenarios:

- [x] Wave effect with different powers
- [x] Wave effect with different starting x and y positions
- [x] Wave effect with zoom
- [x] Wave effect during movement