### PR TITLE
Fix Vehicle Teleport transition regression

### DIFF
--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -70,6 +70,7 @@ private:
 		bool erase_screen = false;
 		bool use_default_transition_in = false;
 		bool defer_recursive_teleports = false;
+		bool no_transition_in = false;
 	};
 	void StartPendingTeleport(TeleportParams tp);
 	void FinishPendingTeleport(TeleportParams tp);


### PR DESCRIPTION
Previous async refactor caused a regression where screen fade in would
occur for vehicle teleports. Add an extra flag to handle it.