### PR TITLE
Refactor param parsing methods + use utf8 + level up msg fix - Messages 4 of N

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -457,6 +457,7 @@ test_runner_SOURCES = \
 	tests/drawable_mgr.cpp \
 	tests/filefinder.cpp \
 	tests/output.cpp \
+	tests/parse.cpp \
 	tests/platform.cpp \
 	tests/rtp.cpp \
 	tests/switches.cpp \

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -21,7 +21,7 @@
 // Headers
 #include <string>
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 #include "rpg_saveactor.h"
 #include "rpg_learning.h"
 #include "game_battler.h"
@@ -33,6 +33,8 @@ namespace RPG {
 	class Item;
 	class Class;
 }
+
+class PendingMessage;
 
 /**
  * Game_Actor class.
@@ -371,18 +373,18 @@ public:
 	 * experience.
 	 *
 	 * @param exp new exp.
-	 * @param level_up_message Whether to show level up message and learned skills.
+	 * @param pm If non-null, will push the level up message and learned skills.
 	 */
-	void ChangeExp(int exp, bool level_up_message);
+	void ChangeExp(int exp, PendingMessage* pm);
 
 	/**
 	 * Changes level of actor and handles experience changes, skill
 	 * learning and other attributes based on the new level.
 	 *
 	 * @param level new level.
-	 * @param level_up_message Whether to show level up message and learned skills.
+	 * @param pm If non-null, will push the level up message and learned skills.
 	 */
-	void ChangeLevel(int level, bool level_up_message);
+	void ChangeLevel(int level, PendingMessage* pm);
 
 	/**
 	 * Sets level of actor.

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -163,8 +163,10 @@ protected:
 
 	/**
 	 * Triggers a game over when all party members are dead.
+	 *
+	 * @return true if game over was started.
 	 */
-	void CheckGameOver();
+	bool CheckGameOver();
 
 	bool CommandOptionGeneric(RPG::EventCommand const& com, int option_sub_idx, std::initializer_list<int> next);
 

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -204,6 +204,69 @@ namespace Game_Message {
 	bool IsMessageVisible();
 	/** @return true if IsMessagePending() || IsMessageVisible() */
 	bool IsMessageActive();
+
+	// EasyRPG extension allowing more recursive variables \v[\v[...]]
+	static constexpr int easyrpg_default_max_recursion = 8;
+	// RPG_RT only allows 1 level of recursion.
+	static constexpr int rpg_rt_default_max_recursion = 1;
+	// Which one we'll use by default.
+	static constexpr int default_max_recursion = easyrpg_default_max_recursion;
+
+	/** Struct returned by parameter parsing methods */
+	struct ParseParamResult {
+		/** iterator to the next character after parsed content */
+		const char* next = nullptr;
+		/** value that was parsed */
+		int value = 0;
+	};
+
+	/** Parse a \v[] variable string
+	 *
+	 * @param iter start of utf8 string
+	 * @param end end of utf8 string
+	 * @param escape_char the escape character to use
+	 * @param skip_prefix if true, assume prefix was already parsed and iter starts at the first left bracket.
+	 * @param max_recursion How many times to allow recursive variable lookups.
+	 *
+	 * @return \refer ParseParamResult
+	 */
+	ParseParamResult ParseVariable(const char* iter, const char* end, uint32_t escape_char, bool skip_prefix = false, int max_recursion = default_max_recursion);
+
+	/** Parse a \c[] color string
+	 *
+	 * @param iter start of utf8 string
+	 * @param end end of utf8 string
+	 * @param escape_char the escape character to use
+	 * @param skip_prefix if true, assume prefix was already parsed and iter starts at the first left bracket.
+	 * @param max_recursion How many times to allow recursive variable lookups.
+	 *
+	 * @return \refer ParseParamResult
+	 */
+	ParseParamResult ParseColor(const char* iter, const char* end, uint32_t escape_char, bool skip_prefix = false, int max_recursion = default_max_recursion);
+
+	/** Parse a \s[] speed string
+	 *
+	 * @param iter start of utf8 string
+	 * @param end end of utf8 string
+	 * @param escape_char the escape character to use
+	 * @param skip_prefix if true, assume prefix was already parsed and iter starts at the first left bracket.
+	 * @param max_recursion How many times to allow recursive variable lookups.
+	 *
+	 * @return \refer ParseParamResult
+	 */
+	ParseParamResult ParseSpeed(const char* iter, const char* end, uint32_t escape_char, bool skip_prefix = false, int max_recursion = default_max_recursion);
+
+	/** Parse a \n[] actor name string
+	 *
+	 * @param iter start of utf8 string
+	 * @param end end of utf8 string
+	 * @param escape_char the escape character to use
+	 * @param skip_prefix if true, assume prefix was already parsed and iter starts at the first left bracket.
+	 * @param max_recursion How many times to allow recursive variable lookups.
+	 *
+	 * @return \refer ParseParamResult
+	 */
+	ParseParamResult ParseActor(const char* iter, const char* end, uint32_t escape_char, bool skip_prefix = false, int max_recursion = default_max_recursion);
 }
 
 

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -108,7 +108,7 @@ void Game_Party::SetupBattleTestMembers() {
 		actor->SetEquipment(RPG::Item::Type_armor, ids[2]);
 		actor->SetEquipment(RPG::Item::Type_helmet, ids[3]);
 		actor->SetEquipment(RPG::Item::Type_accessory, ids[4]);
-		actor->ChangeLevel(btdata.level, false);
+		actor->ChangeLevel(btdata.level, nullptr);
 		actor->SetHp(actor->GetMaxHp());
 		actor->SetSp(actor->GetMaxSp());
 	}

--- a/src/pending_message.cpp
+++ b/src/pending_message.cpp
@@ -110,7 +110,7 @@ std::string PendingMessage::ApplyTextInsertingCommands(std::string input, uint32
 
 			const auto* actor = ReaderUtil::GetElement(Data::actors, value);
 			if (!actor) {
-				Output::Error("Invalid Actor Id %d in message text", value);
+				Output::Warning("Invalid Actor Id %d in message text", value);
 			} else{
 				output.append(actor->name);
 			}

--- a/src/pending_message.cpp
+++ b/src/pending_message.cpp
@@ -1,4 +1,12 @@
 #include "pending_message.h"
+#include "game_variables.h"
+#include "game_message.h"
+#include "data.h"
+#include "reader_util.h"
+#include "output.h"
+#include "utils.h"
+#include "player.h"
+#include "main_data.h"
 #include <cassert>
 #include <cctype>
 #include <algorithm>
@@ -11,6 +19,7 @@ static void RemoveControlChars(std::string& s) {
 
 int PendingMessage::PushLineImpl(std::string msg) {
 	RemoveControlChars(msg);
+	msg = ApplyTextInsertingCommands(std::move(msg), Player::escape_char);
 	texts.push_back(std::move(msg));
 	return texts.size();
 }
@@ -59,4 +68,74 @@ void PendingMessage::SetChoiceCancelType(int value) {
 void PendingMessage::SetChoiceResetColors(bool value) {
 	choice_reset_color = value;
 }
+
+std::string PendingMessage::ApplyTextInsertingCommands(std::string input, uint32_t escape_char) {
+	if (input.empty()) {
+		return std::move(input);
+	}
+
+	std::string output;
+
+	auto iter = input.data();
+	const auto end = input.data() + input.size();
+
+	auto start_copy = iter;
+	while (iter != end) {
+		auto ret = Utils::UTF8Next(iter, end);
+		if (ret.ch != escape_char) {
+			iter = ret.iter;
+			continue;
+		}
+
+		// utf8 parsing failed
+		if (ret.ch == 0) {
+			break;
+		}
+
+		output.append(start_copy, iter);
+		start_copy = iter;
+
+		iter = ret.iter;
+		if (iter == end) {
+			break;
+		}
+
+		const auto ch = *iter;
+		++iter;
+
+		if (ch == 'N' || ch == 'n') {
+			auto parse_ret = Game_Message::ParseActor(iter, end, escape_char, true);
+			iter = parse_ret.next;
+			int value = parse_ret.value;
+
+			const auto* actor = ReaderUtil::GetElement(Data::actors, value);
+			if (!actor) {
+				Output::Error("Invalid Actor Id %d in message text", value);
+			} else{
+				output.append(actor->name);
+			}
+
+			start_copy = iter;
+		} else if (ch == 'V' || ch == 'v') {
+			auto parse_ret = Game_Message::ParseVariable(iter, end, escape_char, true);
+			iter = parse_ret.next;
+			int value = parse_ret.value;
+
+			int variable_value = Main_Data::game_variables->Get(value);
+			output.append(std::to_string(variable_value));
+
+			start_copy = iter;
+		}
+	}
+
+	if (start_copy == input.data()) {
+		// Fast path - no substitutions occured, so just move the input into the return value.
+		output = std::move(input);
+	} else {
+		output.append(start_copy, end);
+	}
+
+	return output;
+}
+
 

--- a/src/pending_message.h
+++ b/src/pending_message.h
@@ -56,8 +56,12 @@ class PendingMessage {
 		int GetNumberInputDigits() const { return num_input_digits; }
 		int GetNumberInputVariable() const { return num_input_variable; }
 		int GetNumberInputStartLine() const { return NumLines(); }
+
 	private:
 		int PushLineImpl(std::string msg);
+
+		std::string ApplyTextInsertingCommands(std::string input, uint32_t escape_char);
+
 	private:
 		ChoiceContinuation choice_continuation;
 		std::vector<std::string> texts;

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -1556,10 +1556,11 @@ bool Scene_Battle_Rpg2k::CheckWin() {
 		std::vector<Game_Battler*> ally_battlers;
 		Main_Data::game_party->GetActiveBattlers(ally_battlers);
 
-		for (std::vector<Game_Battler*>::iterator it = ally_battlers.begin();
-			it != ally_battlers.end(); ++it) {
-				Game_Actor* actor = static_cast<Game_Actor*>(*it);
-				actor->ChangeExp(actor->GetExp() + exp, true);
+		pm.PushPageEnd();
+
+		for (auto& ally: ally_battlers) {
+			Game_Actor* actor = static_cast<Game_Actor*>(ally);
+			actor->ChangeExp(actor->GetExp() + exp, &pm);
 		}
 		Main_Data::game_party->GainGold(money);
 		for (std::vector<int>::iterator it = drops.begin(); it != drops.end(); ++it) {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1120,10 +1120,12 @@ bool Scene_Battle_Rpg2k3::CheckWin() {
 		std::vector<Game_Battler*> ally_battlers;
 		Main_Data::game_party->GetActiveBattlers(ally_battlers);
 
+		pm.PushPageEnd();
+
 		for (std::vector<Game_Battler*>::iterator it = ally_battlers.begin();
 			it != ally_battlers.end(); ++it) {
 				Game_Actor* actor = static_cast<Game_Actor*>(*it);
-				actor->ChangeExp(actor->GetExp() + exp, true);
+				actor->ChangeExp(actor->GetExp() + exp, &pm);
 		}
 
 		Main_Data::game_party->GainGold(money);

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -89,21 +89,26 @@ void Window_Message::StartMessageProcessing(PendingMessage pm) {
 	}
 
 	text.clear();
+	auto append = [&](const std::string& line) {
+		text.append(line);
+		if (text.empty() || (text.back() != '\n' && text.back() != '\f')) {
+			text.append(1, '\n');
+		}
+	};
 	if (pending_message.IsWordWrapped()) {
 		for (const std::string& line : lines) {
 			/* TODO: don't take commands like \> \< into account when word-wrapping */
 			Game_Message::WordWrap(
 					line,
 					width - 24,
-					[this](const std::string& wrapped_line) {
-						text.append(wrapped_line).append(1, '\n');
+					[&](const std::string& wrapped_line) {
+						append(wrapped_line);
 					}
 			);
 		}
-	}
-	else {
+	} else {
 		for (const std::string& line : lines) {
-			text.append(line).append(1, U'\n');
+			append(line);
 		}
 	}
 	item_max = min(4, pending_message.GetNumChoices());
@@ -389,11 +394,6 @@ void Window_Message::UpdateMessage() {
 			// Used by our code to inject form feeds.
 			instant_speed = false;
 
-			auto res = Utils::UTF8Next(text_index, end);
-			const auto next_ch = res.ch;
-			if (next_ch == '\n') {
-				text_index = res.iter;
-			}
 			if (text_index != end) {
 				SetPause(true);
 				new_page_after_pause = true;

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -113,7 +113,6 @@ void Window_Message::StartMessageProcessing(PendingMessage pm) {
 	item_max = min(4, pending_message.GetNumChoices());
 
 	text_index = text.begin();
-	end = text.end();
 
 	// If we're displaying a new message, reset the closing animation.
 	if (closing) {
@@ -136,7 +135,6 @@ void Window_Message::FinishMessageProcessing() {
 
 	text.clear();
 	text_index = text.begin();
-	end = text.end();
 }
 
 void Window_Message::StartChoiceProcessing() {
@@ -336,7 +334,7 @@ void Window_Message::UpdateMessage() {
 			break;
 		}
 
-		if (text_index == end) {
+		if (text_index == text.end()) {
 			if (!instant_speed) {
 				SetWaitForPage();
 			}
@@ -365,7 +363,7 @@ void Window_Message::UpdateMessage() {
 		}
 
 		if (*text_index == '\n') {
-			if (text_index + 1 != end) {
+			if (text_index + 1 != text.end()) {
 				if (!instant_speed && line_char_counter == 0) {
 					// RPG_RT will always wait 1 frame for each empty line.
 					SetWait(1);
@@ -388,7 +386,7 @@ void Window_Message::UpdateMessage() {
 			if (*text_index == '\n') {
 				++text_index;
 			}
-			if (text_index != end) {
+			if (text_index != text.end()) {
 				SetPause(true);
 				new_page_after_pause = true;
 			}
@@ -396,7 +394,7 @@ void Window_Message::UpdateMessage() {
 			break;
 		}
 
-		if (*text_index == Player::escape_char && std::distance(text_index, end) > 1) {
+		if (*text_index == Player::escape_char && std::distance(text_index, text.end()) > 1) {
 			// Special message codes
 			++text_index;
 
@@ -479,7 +477,7 @@ void Window_Message::UpdateMessage() {
 		}
 
 		if (*text_index == '$'
-				   && std::distance(text_index, end) > 1
+				   && std::distance(text_index, text.end()) > 1
 				   && std::isalpha(*std::next(text_index))) {
 			// ExFont
 			DrawGlyph(Utils::EncodeUTF(std::u32string(text_index, std::next(text_index, 2))), instant_speed);
@@ -524,7 +522,7 @@ void Window_Message::IncrementLineCharCounter(int width) {
 int Window_Message::ParseParameter(bool& is_valid) {
 	++text_index;
 
-	if (text_index == end ||
+	if (text_index == text.end() ||
 		*text_index != '[') {
 		--text_index;
 		is_valid = false;
@@ -536,7 +534,7 @@ int Window_Message::ParseParameter(bool& is_valid) {
 	bool null_at_start = false;
 	std::stringstream ss;
 	for (;;) {
-		if (text_index == end) {
+		if (text_index == text.end()) {
 			break;
 		} else if (*text_index == '\n') {
 			--text_index;
@@ -558,7 +556,7 @@ int Window_Message::ParseParameter(bool& is_valid) {
 		} else {
 			// End of number
 			// Search for ] or line break
-			while (text_index != end) {
+			while (text_index != text.end()) {
 					if (*text_index == '\n') {
 						--text_index;
 						break;
@@ -656,7 +654,7 @@ void Window_Message::WaitForInput() {
 
 		if (text.empty()) {
 			TerminateMessage();
-		} else if (text_index != end && new_page_after_pause) {
+		} else if (text_index != text.end() && new_page_after_pause) {
 			new_page_after_pause = false;
 			InsertNewPage();
 		}

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -88,31 +88,27 @@ void Window_Message::StartMessageProcessing(PendingMessage pm) {
 		return;
 	}
 
+	text.clear();
 	if (pending_message.IsWordWrapped()) {
-		std::u32string wrapped_text;
 		for (const std::string& line : lines) {
 			/* TODO: don't take commands like \> \< into account when word-wrapping */
-			if (pending_message.IsWordWrapped()) {
-				Game_Message::WordWrap(
-						line,
-						width - 24,
-						[&wrapped_text](const std::string& wrapped_line) {
-							wrapped_text.append(Utils::DecodeUTF32(wrapped_line)).append(1, U'\n');
-						}
-				);
-				text = wrapped_text;
-			}
+			Game_Message::WordWrap(
+					line,
+					width - 24,
+					[this](const std::string& wrapped_line) {
+						text.append(wrapped_line).append(1, '\n');
+					}
+			);
 		}
 	}
 	else {
-		text.clear();
 		for (const std::string& line : lines) {
-			text.append(Utils::DecodeUTF32(line)).append(1, U'\n');
+			text.append(line).append(1, U'\n');
 		}
 	}
 	item_max = min(4, pending_message.GetNumChoices());
 
-	text_index = text.begin();
+	text_index = text.data();
 
 	// If we're displaying a new message, reset the closing animation.
 	if (closing) {
@@ -134,7 +130,7 @@ void Window_Message::FinishMessageProcessing() {
 	}
 
 	text.clear();
-	text_index = text.begin();
+	text_index = text.data();
 }
 
 void Window_Message::StartChoiceProcessing() {
@@ -283,10 +279,10 @@ void Window_Message::Update() {
 				SetOpenAnimation(0);
 			} else {
 				//Handled after base class updates.
-				if (text_index != text.end()) {
+				if (text_index != &*text.end()) {
 					update_message_processing = true;
 				}
-				if (text_index == text.end() && wait_count <= 0) {
+				if (text_index == &*text.end() && wait_count <= 0) {
 					FinishMessageProcessing();
 				}
 			}
@@ -329,12 +325,14 @@ void Window_Message::UpdateMessage() {
 	}
 
 	while (true) {
+		const auto* end = &*text.end();
+
 		if (wait_count > 0) {
 			--wait_count;
 			break;
 		}
 
-		if (text_index == text.end()) {
+		if (text_index == end) {
 			if (!instant_speed) {
 				SetWaitForPage();
 			}
@@ -356,14 +354,23 @@ void Window_Message::UpdateMessage() {
 			break;
 		}
 
-		if (*text_index == '\r') {
-			// Not handled
-			++text_index;
+		const auto start_index = text_index;
+
+		auto res = Utils::UTF8Next(text_index, end);
+		text_index = res.iter;
+		auto ch = res.ch;
+
+		if (ch == 0) {
 			continue;
 		}
 
-		if (*text_index == '\n') {
-			if (text_index + 1 != text.end()) {
+		if (ch == '\r') {
+			// Not handled
+			continue;
+		}
+
+		if (ch == '\n') {
+			if (text_index != end) {
 				if (!instant_speed && line_char_counter == 0) {
 					// RPG_RT will always wait 1 frame for each empty line.
 					SetWait(1);
@@ -375,18 +382,19 @@ void Window_Message::UpdateMessage() {
 				}
 			}
 			InsertNewLine();
-			++text_index;
 			continue;
 		}
 
-		if (*text_index == '\f') {
+		if (ch == '\f') {
 			// Used by our code to inject form feeds.
 			instant_speed = false;
-			++text_index;
-			if (*text_index == '\n') {
-				++text_index;
+
+			auto res = Utils::UTF8Next(text_index, end);
+			const auto next_ch = res.ch;
+			if (next_ch == '\n') {
+				text_index = res.iter;
 			}
-			if (text_index != text.end()) {
+			if (text_index != end) {
 				SetPause(true);
 				new_page_after_pause = true;
 			}
@@ -394,22 +402,33 @@ void Window_Message::UpdateMessage() {
 			break;
 		}
 
-		if (*text_index == Player::escape_char && std::distance(text_index, text.end()) > 1) {
+		if (ch == Player::escape_char && text_index != end) {
 			// Special message codes
-			++text_index;
+			const auto prev_index = text_index;
 
-			int parameter;
-			bool is_valid;
-			switch (tolower(*text_index)) {
+			auto res = Utils::UTF8Next(text_index, end);
+			ch = res.ch;
+			text_index = res.iter;
+
+			switch (ch) {
 			case 'c':
-				// Color
-				parameter = ParseParameter(is_valid);
-				text_color = parameter > 19 ? 0 : parameter;
+			case 'C':
+				{
+					// Color
+					auto pres = Game_Message::ParseColor(text_index, end, Player::escape_char, true);
+					auto value = pres.value;
+					text_color = value > 19 ? 0 : value;
+					text_index = pres.next;
+				}
 				break;
 			case 's':
-				// Speed modifier
-				parameter = ParseParameter(is_valid);
-				speed = Utils::Clamp(parameter, 1, 20);
+			case 'S':
+				{
+					// Speed modifier
+					auto pres = Game_Message::ParseSpeed(text_index, end, Player::escape_char, true);
+					speed = Utils::Clamp(pres.value, 1, 20);
+					text_index = pres.next;
+				}
 				break;
 			case '_':
 				// Insert half size space
@@ -464,29 +483,31 @@ void Window_Message::UpdateMessage() {
 			case '\n':
 			case '\f':
 				// \ followed by linebreak, don't skip them
-				--text_index;
+				text_index = prev_index;
 				break;
 			default:
-				if (*text_index == Player::escape_char) {
+				if (ch == Player::escape_char) {
 					DrawGlyph(Player::escape_symbol, instant_speed);
 				}
 				break;
 			}
-			++text_index;
 			continue;
 		}
 
-		if (*text_index == '$'
-				   && std::distance(text_index, text.end()) > 1
-				   && std::isalpha(*std::next(text_index))) {
-			// ExFont
-			DrawGlyph(Utils::EncodeUTF(std::u32string(text_index, std::next(text_index, 2))), instant_speed);
-			text_index += 2;
-			continue;
+		if (ch == '$' && text_index != end) {
+			auto res = Utils::UTF8Next(text_index, end);
+			ch = res.ch;
+
+			if (ch < 128 && std::isalpha(static_cast<char>(ch))) {
+				text_index = res.iter;
+
+				// ExFont
+				DrawGlyph(std::string(start_index, text_index), instant_speed);
+				continue;
+			}
 		}
 
-		DrawGlyph(Utils::EncodeUTF(std::u32string(text_index, std::next(text_index))), instant_speed);
-		++text_index;
+		DrawGlyph(std::string(start_index, text_index), instant_speed);
 	}
 }
 
@@ -519,113 +540,6 @@ void Window_Message::IncrementLineCharCounter(int width) {
 	}
 }
 
-int Window_Message::ParseParameter(bool& is_valid) {
-	++text_index;
-
-	if (text_index == text.end() ||
-		*text_index != '[') {
-		--text_index;
-		is_valid = false;
-		return 0;
-	}
-
-	++text_index; // Skip the [
-
-	bool null_at_start = false;
-	std::stringstream ss;
-	for (;;) {
-		if (text_index == text.end()) {
-			break;
-		} else if (*text_index == '\n') {
-			--text_index;
-			break;
-		}
-		else if (*text_index == '0') {
-			// Truncate 0 at the start
-			if (!ss.str().empty()) {
-				ss << "0";
-			} else {
-				null_at_start = true;
-			}
-		}
-		else if (*text_index >= '1' &&
-			*text_index <= '9') {
-			ss << std::string(text_index, std::next(text_index));
-		} else if (*text_index == ']') {
-			break;
-		} else {
-			// End of number
-			// Search for ] or line break
-			while (text_index != text.end()) {
-					if (*text_index == '\n') {
-						--text_index;
-						break;
-					} else if (*text_index == ']') {
-						break;
-					}
-					++text_index;
-			}
-			break;
-		}
-		++text_index;
-	}
-
-	if (ss.str().empty()) {
-		if (null_at_start) {
-			ss << "0";
-		} else {
-			is_valid = false;
-			return 0;
-		}
-	}
-
-	int num;
-	ss >> num;
-	is_valid = true;
-	return num;
-}
-
-std::string Window_Message::ParseCommandCode(bool& success, int& parameter) {
-	bool is_valid;
-	uint32_t cmd_char = *text_index;
-	success = true;
-	parameter = -1;
-
-	switch (tolower(cmd_char)) {
-	case 'n':
-		// Output Hero name
-		parameter = ParseParameter(is_valid);
-		if (is_valid) {
-			Game_Actor* actor = NULL;
-			if (parameter == 0) {
-				// Party hero
-				if (Main_Data::game_party->GetBattlerCount() > 0) {
-					actor = Main_Data::game_party->GetActors()[0];
-				}
-			} else {
-				actor = Game_Actors::GetActor(parameter);
-			}
-			if (actor != NULL) {
-				return actor->GetName();
-			}
-		}
-		break;
-	case 'v':
-		// Show Variable value
-		parameter = ParseParameter(is_valid);
-		if (is_valid) {
-			return std::to_string(Main_Data::game_variables->Get(parameter));
-		} else {
-			// Invalid Var is always 0
-			return "0";
-		}
-	default:;
-		// When this happens text_index was not on a \ during calling
-	}
-	success = false;
-	return "";
-}
-
 void Window_Message::UpdateCursorRect() {
 	if (index >= 0) {
 		int x_pos = 2;
@@ -654,7 +568,7 @@ void Window_Message::WaitForInput() {
 
 		if (text.empty()) {
 			TerminateMessage();
-		} else if (text_index != text.end() && new_page_after_pause) {
+		} else if (text_index != &*text.end() && new_page_after_pause) {
 			new_page_after_pause = false;
 			InsertNewPage();
 		}

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -122,15 +122,6 @@ public:
 	std::string ParseCommandCode(bool& success, int& value);
 
 	/**
-	 * Updates the text variable, replacing the commands
-	 * \N[x] and \V[x] in it.
-	 *
-	 * Doesn't return anything. The result is stored into
-	 * the text variable.
-	 */
-	void ApplyTextInsertingCommands();
-
-	/**
 	 * Stub. For choice.
 	 */
 	void UpdateCursorRect() override;

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -156,7 +156,7 @@ protected:
 	/** Current number of lines on this page. */
 	int line_count = 0;
 	/** Index of the next char in text that will be output. */
-	std::u32string::iterator text_index, end;
+	std::u32string::iterator text_index;
 	/** text message that will be displayed. */
 	std::u32string text;
 	/** Used by Message kill command \^. */

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -99,29 +99,6 @@ public:
 	virtual void UpdateMessage();
 
 	/**
-	 * Parses the parameter part of a \-message-command.
-	 * It starts parsing after the [ and stops after
-	 * encountering ], a non-number or a line break.
-	 *
-	 * @param is_valid contains if a number was read
-	 * @return the read number.
-	 */
-	int ParseParameter(bool& is_valid);
-
-	/**
-	 * Parses a message command code (\ followed by a char).
-	 * This should only be used for codes that accept
-	 * parameters!
-	 * The text_index must be on the char following \ when
-	 * calling.
-	 *
-	 * @param[out] success If parsing was successful.
-	 * @param[out] value The extracted value if parsing was successful
-	 * @return the final text output of the code.
-	 */
-	std::string ParseCommandCode(bool& success, int& value);
-
-	/**
 	 * Stub. For choice.
 	 */
 	void UpdateCursorRect() override;
@@ -156,9 +133,9 @@ protected:
 	/** Current number of lines on this page. */
 	int line_count = 0;
 	/** Index of the next char in text that will be output. */
-	std::u32string::iterator text_index;
+	const char* text_index = nullptr;
 	/** text message that will be displayed. */
-	std::u32string text;
+	std::string text;
 	/** Used by Message kill command \^. */
 	bool kill_message = false;
 	/** Text color. */

--- a/tests/parse.cpp
+++ b/tests/parse.cpp
@@ -1,0 +1,468 @@
+#include "game_message.h"
+#include "options.h"
+#include "data.h"
+#include "game_variables.h"
+#include "main_data.h"
+#include <iostream>
+#include "doctest.h"
+
+TEST_SUITE_BEGIN("Parse");
+
+constexpr char escape = '\\';
+
+struct DataInit {
+	DataInit() {
+		Data::actors.push_back({});
+		Data::actors.back().name = "Alex";
+		Data::actors.push_back({});
+		Data::actors.back().name = "Brian";
+		Data::actors.push_back({});
+		Data::actors.back().name = "Carol";
+		Data::actors.push_back({});
+		Data::actors.back().name = "Daisy";
+		Data::actors.push_back({});
+
+		Main_Data::game_variables = std::make_unique<Game_Variables>(Game_Variables::min_2k3, Game_Variables::max_2k3);
+	}
+	~DataInit() {
+		Data::actors.clear();
+		Main_Data::game_variables.reset();
+	}
+};
+
+TEST_CASE("Actors") {
+	DataInit init;
+
+	std::string msg;
+	Game_Message::ParseParamResult ret;
+
+	msg = u8"\\n[0]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 1);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\n[1]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 1);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\n[2]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 2);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\n[3]HelloWorld";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 3);
+	REQUIRE_EQ(ret.next, msg.data() + 5);
+
+	msg = u8"\\n[55]HelloWorld";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 55);
+	REQUIRE_EQ(ret.next, msg.data() + 6);
+
+	msg = u8"\\N[55]HelloWorld";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 55);
+	REQUIRE_EQ(ret.next, msg.data() + 6);
+
+	msg = u8"\\C[55]HelloWorld";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, msg.data());
+}
+
+TEST_CASE("BadActors") {
+	DataInit init;
+
+	std::string msg;
+	Game_Message::ParseParamResult ret;
+
+	msg = u8"\\n[A]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\n[2A]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 2);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\n[A2]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\n[2A2]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 2);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\n[]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\n[";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\n[2";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 2);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\n";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\n";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\n[01]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 1);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\n[000]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 1);
+	REQUIRE_EQ(ret.next, &*msg.end());
+}
+
+TEST_CASE("ActorVars") {
+	DataInit init;
+
+	std::string msg;
+	Game_Message::ParseParamResult ret;
+
+	msg = u8"\\n[\\v[0]]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 1);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	Main_Data::game_variables->Set(1, 0);
+	msg = u8"\\n[\\v[1]]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 1);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	Main_Data::game_variables->Set(1, 1);
+	msg = u8"\\n[\\v[1]]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 1);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	Main_Data::game_variables->Set(1, 5);
+	msg = u8"\\n[\\v[1]]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 5);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	Main_Data::game_variables->Set(1, 2);
+	Main_Data::game_variables->Set(2, 3);
+	msg = u8"\\n[\\v[2]\\v[1]]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 32);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	Main_Data::game_variables->Set(1, 2);
+	Main_Data::game_variables->Set(2, 3);
+	msg = u8"\\n[\\v[1]\\v[0]]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 20);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\n[\\v[0]\\v[0]]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 1);
+	REQUIRE_EQ(ret.next, &*msg.end());
+}
+
+TEST_CASE("ActorVarsRecurse") {
+	DataInit init;
+
+	std::string msg;
+	Game_Message::ParseParamResult ret;
+
+	Main_Data::game_variables->Set(1, 2);
+	Main_Data::game_variables->Set(2, 50);
+	msg = u8"\\n[\\v[\\v[1]]]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape, false, Game_Message::easyrpg_default_max_recursion);
+	REQUIRE_EQ(ret.value, 50);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	Main_Data::game_variables->Set(1, 2);
+	Main_Data::game_variables->Set(2, 50);
+	msg = u8"\\n[\\v[\\v[1]]]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape, false, Game_Message::rpg_rt_default_max_recursion);
+	REQUIRE_EQ(ret.value, 1);
+	REQUIRE_EQ(ret.next, &*msg.end() - 1);
+}
+
+TEST_CASE("ActorsUnicode") {
+	DataInit init;
+
+	// Hack for MSVC. Complains with error C2015 when we try to use U'σ'
+	const uint32_t esc = U"σ"[0];
+	std::string msg;
+	Game_Message::ParseParamResult ret;
+
+	msg = u8"σn[1]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), esc);
+	REQUIRE_EQ(ret.value, 1);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	Main_Data::game_variables->Set(1, 25);
+	msg = u8"σn[σv[1]]";
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), esc);
+	REQUIRE_EQ(ret.value, 25);
+	REQUIRE_EQ(ret.next, &*msg.end());
+}
+
+TEST_CASE("Variables") {
+	DataInit init;
+
+	std::string msg;
+	Game_Message::ParseParamResult ret;
+
+	msg = u8"\\v[0]";
+	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\v[1]";
+	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 1);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\v[A]";
+	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\v[999]";
+	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 999);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\v[1]HelloWorld";
+	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 1);
+	REQUIRE_EQ(ret.next, &*msg.data() + 5);
+}
+
+TEST_CASE("VarsRecurse") {
+	DataInit init;
+
+	std::string msg;
+	Game_Message::ParseParamResult ret;
+
+	Main_Data::game_variables->Set(1, 2);
+	msg = u8"\\v[\\v[1]]";
+	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape, false, Game_Message::easyrpg_default_max_recursion);
+	REQUIRE_EQ(ret.value, 2);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	Main_Data::game_variables->Set(1, 2);
+	msg = u8"\\v[\\v[1]]";
+	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape, false, Game_Message::rpg_rt_default_max_recursion);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.end() - 1);
+}
+
+TEST_CASE("Colors") {
+	DataInit init;
+
+	std::string msg;
+	Game_Message::ParseParamResult ret;
+
+	msg = u8"\\c[0]";
+	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\c[1]";
+	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 1);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\c[A]";
+	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\c[999]";
+	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 999);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\c[1]HelloWorld";
+	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 1);
+	REQUIRE_EQ(ret.next, &*msg.data() + 5);
+}
+
+TEST_CASE("ColorVarsRecurse") {
+	DataInit init;
+
+	std::string msg;
+	Game_Message::ParseParamResult ret;
+
+	Main_Data::game_variables->Set(1, 2);
+	Main_Data::game_variables->Set(2, 50);
+	msg = u8"\\c[\\v[\\v[1]]]";
+	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape, false, Game_Message::easyrpg_default_max_recursion);
+	REQUIRE_EQ(ret.value, 50);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	Main_Data::game_variables->Set(1, 2);
+	Main_Data::game_variables->Set(2, 50);
+	msg = u8"\\c[\\v[\\v[1]]]";
+	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape, false, Game_Message::rpg_rt_default_max_recursion);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.end() - 1);
+}
+
+TEST_CASE("Speed") {
+	DataInit init;
+
+	std::string msg;
+	Game_Message::ParseParamResult ret;
+
+	msg = u8"\\s[0]";
+	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\s[1]";
+	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 1);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\s[A]";
+	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\s[999]";
+	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 999);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	msg = u8"\\s[1]HelloWorld";
+	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 1);
+	REQUIRE_EQ(ret.next, &*msg.data() + 5);
+}
+
+TEST_CASE("SpeedVarsRecurse") {
+	DataInit init;
+
+	std::string msg;
+	Game_Message::ParseParamResult ret;
+
+	Main_Data::game_variables->Set(1, 2);
+	Main_Data::game_variables->Set(2, 50);
+	msg = u8"\\s[\\v[\\v[1]]]";
+	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape, false, Game_Message::easyrpg_default_max_recursion);
+	REQUIRE_EQ(ret.value, 50);
+	REQUIRE_EQ(ret.next, &*msg.end());
+
+	Main_Data::game_variables->Set(1, 2);
+	Main_Data::game_variables->Set(2, 50);
+	msg = u8"\\s[\\v[\\v[1]]]";
+	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape, false, Game_Message::rpg_rt_default_max_recursion);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.end() - 1);
+}
+
+TEST_CASE("BadActor") {
+	DataInit init;
+
+	std::string msg;
+	Game_Message::ParseParamResult ret;
+
+	msg = u8"\\n[3]";
+
+	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.begin());
+
+	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.begin());
+
+	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.begin());
+}
+
+TEST_CASE("BadVariable") {
+	DataInit init;
+
+	std::string msg;
+	Game_Message::ParseParamResult ret;
+
+	msg = u8"\\v[3]";
+
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.begin());
+
+	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.begin());
+
+	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.begin());
+}
+
+TEST_CASE("BadColor") {
+	DataInit init;
+
+	std::string msg;
+	Game_Message::ParseParamResult ret;
+
+	msg = u8"\\c[3]";
+
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.begin());
+
+	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.begin());
+
+	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.begin());
+}
+
+TEST_CASE("BadSpeed") {
+	DataInit init;
+
+	std::string msg;
+	Game_Message::ParseParamResult ret;
+
+	msg = u8"\\s[3]";
+
+	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.begin());
+
+	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.begin());
+
+	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape);
+	REQUIRE_EQ(ret.value, 0);
+	REQUIRE_EQ(ret.next, &*msg.begin());
+}
+
+TEST_SUITE_END();


### PR DESCRIPTION
Depends on #1909 

Moves param parsing methods to `Game_Message` so they can be used generically. Adds unit tests. It also changes `Window_Message::text` to be utf8 and uses `UTF8Next` to iterate the text. 

This optimizes our message processing by removing roundtrips between utf8 -> utf32 -> utf8. It reduces the memory footprint of the text and also spreads the cost of utf8 parsing over the frames of message rendering instead of doing it upfront.

In later PR's we'll eliminate `Window_Message::text` entirely and do everything from `PendingMessage`, removing the additional memory copies.

Fixes test cases of #1706:
- [x] Test cases 12 - includes supporting recursive variables
- [x] Test cases 39
- [x] Tests 28 & 29 for level up