### PR TITLE
pixel_format.h - Fix compile errors with DynamicAlpha formats

### DIFF
--- a/src/pixel_format.h
+++ b/src/pixel_format.h
@@ -300,7 +300,7 @@ struct alpha_type_traits<TPF, PF::StaticAlpha, _alpha_type> {
 template<class TPF, PF::AlphaType _alpha_type>
 struct alpha_type_traits<TPF, PF::DynamicAlpha, _alpha_type> {
 	static inline PF::AlphaType alpha_type(const TPF* pf) {
-		return pf->format.alpha_type;
+		return pf->format().alpha_type;
 	}
 };
 
@@ -320,7 +320,7 @@ struct opacity_type_traits<TPF, PF::StaticAlpha, _opacity_type> {
 template<class TPF, PF::OpacityType _opacity_type>
 struct opacity_type_traits<TPF, PF::DynamicAlpha, _opacity_type> {
 	static inline PF::OpacityType opacity_type(const TPF* pf) {
-		return pf->format.opacity_type;
+		return pf->format().opacity_type;
 	}
 };
 


### PR DESCRIPTION
You will get a compile error if you try to instantiate some of the dynamic pixel formats in `pixel_format.h`. This fixes it.

I don't think we use these anywhere, so the error is hidden.