### PR TITLE
Flatten Bitmap formats_map into an array

### DIFF
--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <algorithm>
 #include <iostream>
+#include <unordered_map>
 
 #include "utils.h"
 #include "cache.h"
@@ -385,58 +386,45 @@ Rect Bitmap::TransformRectangle(const Transform& xform, const Rect& rect) {
 	return Rect(bounds.x1, bounds.y1, bounds.x2 - bounds.x1, bounds.y2 - bounds.y1);
 }
 
-bool Bitmap::formats_initialized = false;
-std::map<int, pixman_format_code_t> Bitmap::formats_map;
-
-void Bitmap::add_pair(pixman_format_code_t pcode, const DynamicFormat& format) {
-	int dcode = format.code_alpha();
-	formats_map[dcode] = pcode;
-}
-
-void Bitmap::initialize_formats() {
-	if (formats_initialized)
-		return;
-
-	add_pair(PIXMAN_a8r8g8b8, DynamicFormat(32,8,16,8,8,8,0,8,24,PF::Alpha));
-	add_pair(PIXMAN_x8r8g8b8, DynamicFormat(32,8,16,8,8,8,0,0,0,PF::NoAlpha));
-	add_pair(PIXMAN_a8b8g8r8, DynamicFormat(32,8,0,8,8,8,16,8,24,PF::Alpha));
-	add_pair(PIXMAN_x8b8g8r8, DynamicFormat(32,8,0,8,8,8,16,0,0,PF::NoAlpha));
-	add_pair(PIXMAN_b8g8r8a8, DynamicFormat(32,8,8,8,16,8,24,8,0,PF::Alpha));
-	add_pair(PIXMAN_b8g8r8x8, DynamicFormat(32,8,8,8,16,8,24,0,0,PF::NoAlpha));
-
-	add_pair(PIXMAN_x14r6g6b6, DynamicFormat(32,6,12,6,6,6,0,0,0,PF::NoAlpha));
-	add_pair(PIXMAN_x2r10g10b10, DynamicFormat(32,10,20,10,10,10,0,0,0,PF::NoAlpha));
-	add_pair(PIXMAN_a2r10g10b10, DynamicFormat(32,10,20,10,10,10,0,2,30,PF::Alpha));
-	add_pair(PIXMAN_x2b10g10r10, DynamicFormat(32,10,0,10,10,10,20,0,0,PF::NoAlpha));
-	add_pair(PIXMAN_a2b10g10r10, DynamicFormat(32,10,0,10,10,10,20,2,30,PF::Alpha));
-
-	add_pair(PIXMAN_r8g8b8a8, DynamicFormat(32,8,24,8,16,8,8,8,0,PF::Alpha));
-	add_pair(PIXMAN_r8g8b8x8, DynamicFormat(32,8,24,8,16,8,8,8,0,PF::NoAlpha));
-
-	add_pair(PIXMAN_r8g8b8, DynamicFormat(24,8,16,8,8,8,0,0,0,PF::NoAlpha));
-	add_pair(PIXMAN_b8g8r8, DynamicFormat(24,8,0,8,8,8,16,0,0,PF::NoAlpha));
-
-	add_pair(PIXMAN_r5g6b5, DynamicFormat(16,5,11,6,5,5,0,0,0,PF::NoAlpha));
-	add_pair(PIXMAN_b5g6r5, DynamicFormat(16,5,0,6,5,5,11,0,0,PF::NoAlpha));
-	add_pair(PIXMAN_a1r5g5b5, DynamicFormat(16,5,10,5,5,5,0,1,15,PF::Alpha));
-	add_pair(PIXMAN_x1r5g5b5, DynamicFormat(16,5,10,5,5,5,0,0,0,PF::NoAlpha));
-	add_pair(PIXMAN_a1b5g5r5, DynamicFormat(16,5,0,5,5,5,10,1,15,PF::Alpha));
-	add_pair(PIXMAN_x1b5g5r5, DynamicFormat(16,5,0,5,5,5,10,0,0,PF::NoAlpha));
-	add_pair(PIXMAN_a4r4g4b4, DynamicFormat(16,4,8,4,4,4,0,4,12,PF::Alpha));
-	add_pair(PIXMAN_x4r4g4b4, DynamicFormat(16,4,8,4,4,4,0,0,0,PF::NoAlpha));
-	add_pair(PIXMAN_a4b4g4r4, DynamicFormat(16,4,0,4,4,4,8,4,12,PF::Alpha));
-	add_pair(PIXMAN_x4b4g4r4, DynamicFormat(16,4,0,4,4,4,8,0,0,PF::NoAlpha));
-	add_pair(PIXMAN_g8, DynamicFormat(8,8,0,8,0,8,0,8,0,PF::Alpha));
-	add_pair(PIXMAN_g8, DynamicFormat(8,8,0,8,0,8,0,0,0,PF::NoAlpha));
-
-	formats_initialized = true;
-}
 
 pixman_format_code_t Bitmap::find_format(const DynamicFormat& format) {
-	initialize_formats();
-	int dcode = format.code_alpha();
-	int pcode = formats_map[dcode];
-	if (pcode == 0) {
+	static std::array<std::pair<int,pixman_format_code_t>, 27> formats_map = {{
+			{ DynamicFormat(32,8,24,8,16,8,8,8,0,PF::Alpha).code_alpha(), PIXMAN_r8g8b8a8 },
+			{ DynamicFormat(32,8,24,8,16,8,8,8,0,PF::NoAlpha).code_alpha(), PIXMAN_r8g8b8x8 },
+
+			{ DynamicFormat(32,8,16,8,8,8,0,8,24,PF::Alpha).code_alpha(), PIXMAN_a8r8g8b8 },
+			{ DynamicFormat(32,8,16,8,8,8,0,0,0,PF::NoAlpha).code_alpha(), PIXMAN_x8r8g8b8 },
+			{ DynamicFormat(32,8,0,8,8,8,16,8,24,PF::Alpha).code_alpha(), PIXMAN_a8b8g8r8 },
+			{ DynamicFormat(32,8,0,8,8,8,16,0,0,PF::NoAlpha).code_alpha(), PIXMAN_x8b8g8r8 },
+			{ DynamicFormat(32,8,8,8,16,8,24,8,0,PF::Alpha).code_alpha(), PIXMAN_b8g8r8a8 },
+			{ DynamicFormat(32,8,8,8,16,8,24,0,0,PF::NoAlpha).code_alpha(), PIXMAN_b8g8r8x8 },
+
+			{ DynamicFormat(32,6,12,6,6,6,0,0,0,PF::NoAlpha).code_alpha(), PIXMAN_x14r6g6b6 },
+			{ DynamicFormat(32,10,20,10,10,10,0,0,0,PF::NoAlpha).code_alpha(), PIXMAN_x2r10g10b10 },
+			{ DynamicFormat(32,10,20,10,10,10,0,2,30,PF::Alpha).code_alpha(), PIXMAN_a2r10g10b10 },
+			{ DynamicFormat(32,10,0,10,10,10,20,0,0,PF::NoAlpha).code_alpha(), PIXMAN_x2b10g10r10 },
+			{ DynamicFormat(32,10,0,10,10,10,20,2,30,PF::Alpha).code_alpha(), PIXMAN_a2b10g10r10 },
+
+			{ DynamicFormat(24,8,16,8,8,8,0,0,0,PF::NoAlpha).code_alpha(), PIXMAN_r8g8b8 },
+			{ DynamicFormat(24,8,0,8,8,8,16,0,0,PF::NoAlpha).code_alpha(), PIXMAN_b8g8r8 },
+
+			{ DynamicFormat(16,5,11,6,5,5,0,0,0,PF::NoAlpha).code_alpha(), PIXMAN_r5g6b5 },
+			{ DynamicFormat(16,5,0,6,5,5,11,0,0,PF::NoAlpha).code_alpha(), PIXMAN_b5g6r5 },
+			{ DynamicFormat(16,5,10,5,5,5,0,1,15,PF::Alpha).code_alpha(), PIXMAN_a1r5g5b5 },
+			{ DynamicFormat(16,5,10,5,5,5,0,0,0,PF::NoAlpha).code_alpha(), PIXMAN_x1r5g5b5 },
+			{ DynamicFormat(16,5,0,5,5,5,10,1,15,PF::Alpha).code_alpha(), PIXMAN_a1b5g5r5 },
+			{ DynamicFormat(16,5,0,5,5,5,10,0,0,PF::NoAlpha).code_alpha(), PIXMAN_x1b5g5r5 },
+			{ DynamicFormat(16,4,8,4,4,4,0,4,12,PF::Alpha).code_alpha(), PIXMAN_a4r4g4b4 },
+			{ DynamicFormat(16,4,8,4,4,4,0,0,0,PF::NoAlpha).code_alpha(), PIXMAN_x4r4g4b4 },
+			{ DynamicFormat(16,4,0,4,4,4,8,4,12,PF::Alpha).code_alpha(), PIXMAN_a4b4g4r4 },
+			{ DynamicFormat(16,4,0,4,4,4,8,0,0,PF::NoAlpha).code_alpha(), PIXMAN_x4b4g4r4 },
+			{ DynamicFormat(8,8,0,8,0,8,0,8,0,PF::Alpha).code_alpha(), PIXMAN_g8 },
+			{ DynamicFormat(8,8,0,8,0,8,0,0,0,PF::NoAlpha).code_alpha(), PIXMAN_g8 }
+	}};
+
+	auto dcode = format.code_alpha();
+	auto iter = std::find_if(formats_map.begin(), formats_map.end(), [dcode](const auto& p) { return p.first == dcode; });
+	if (iter == formats_map.end()) {
 		// To fix add a pair to initialize_formats that maps the outputted
 		// DynamicFormat to a pixman format
 		Output::Error("%s\nDynamicFormat(%d, %d, %d, %d, %d, %d, %d, %d, %d, %s)",
@@ -448,7 +436,7 @@ pixman_format_code_t Bitmap::find_format(const DynamicFormat& format) {
 		format.a.bits, format.a.shift,
 		format.alpha_type == PF::Alpha ? "PF::Alpha" : "PF::NoAlpha");
 	}
-	return (pixman_format_code_t) pcode;
+	return iter->second;
 }
 
 DynamicFormat Bitmap::pixel_format;

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -579,12 +579,6 @@ protected:
 		}
 	}
 
-	typedef std::pair<int, pixman_format_code_t> format_pair;
-	static std::map<int, pixman_format_code_t> formats_map;
-	static bool formats_initialized;
-
-	static void initialize_formats();
-	static void add_pair(pixman_format_code_t pcode, const DynamicFormat& format);
 	static pixman_format_code_t find_format(const DynamicFormat& format);
 
 	pixman_op_t GetOperator(pixman_image_t* mask = nullptr) const;


### PR DESCRIPTION
Put most common formats first and do a linear scan.

Shown to be faster than map, unordered_map, and
lower_bound on sorted array.

I have a google bench setup in another branch which is part of the message PR queue. I wanted to present this one earlier since it's standalone.

```
static void BM_FindFormatSingle(benchmark::State& state) {
    const auto fmt = format_R8G8B8A8_a().format();
    for (auto _: state) {
        BitmapAccess::find_format(fmt);
    }
}

BENCHMARK(BM_FindFormatSingle);

static void BM_FindFormat(benchmark::State& state) {
    for (auto _: state) {
        BitmapAccess::find_format(format_R8G8B8A8_a().format());
        BitmapAccess::find_format(format_B8G8R8A8_a().format());
        BitmapAccess::find_format(format_A8B8G8R8_n().format());
        BitmapAccess::find_format(format_B8G8R8A8_n().format());
    }
}

BENCHMARK(BM_FindFormat);
```

Master:
```
BM_FindFormatSingle         19 ns         18 ns   38761196
BM_FindFormat               59 ns         58 ns   11620732
```

This PR:
```
BM_FindFormatSingle          3 ns          3 ns  227203497
BM_FindFormat               13 ns         13 ns   54225434
```

