### PR TITLE
Add micro benchmark framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -757,6 +757,22 @@ if(PLAYER_ENABLE_TESTS)
 	endforeach()
 endif()
 
+# Benchmarks
+option(PLAYER_ENABLE_BENCHMARKS "Build benchmarks" OFF)
+
+if(PLAYER_ENABLE_BENCHMARKS)
+	find_package(benchmark REQUIRED)
+	file(GLOB BENCH_FILES ${CMAKE_CURRENT_SOURCE_DIR}/bench/*.cpp)
+	foreach(i ${BENCH_FILES})
+		get_filename_component(name "${i}" NAME_WE)
+		add_executable(bench_${name} ${i})
+		target_link_libraries(bench_${name} ${PROJECT_NAME})
+		target_link_libraries(bench_${name} benchmark)
+	endforeach()
+endif()
+
+
+
 # Print summary
 message(STATUS "")
 message(STATUS "Target system: ${PLAYER_TARGET_PLATFORM}")

--- a/bench/bitmap.cpp
+++ b/bench/bitmap.cpp
@@ -1,0 +1,44 @@
+#include <benchmark/benchmark.h>
+#include <rect.h>
+#include <bitmap.h>
+#include <pixel_format.h>
+
+struct BitmapAccess : public Bitmap {
+	static pixman_format_code_t find_format(const DynamicFormat& format) {
+		return Bitmap::find_format(format);
+	}
+};
+
+static void BM_FindFormatSingle(benchmark::State& state) {
+	const auto fmt = format_R8G8B8A8_a().format();
+	for (auto _: state) {
+		BitmapAccess::find_format(fmt);
+	}
+}
+
+BENCHMARK(BM_FindFormatSingle);
+
+static void BM_FindFormat(benchmark::State& state) {
+	for (auto _: state) {
+		BitmapAccess::find_format(format_R8G8B8A8_a().format());
+		BitmapAccess::find_format(format_B8G8R8A8_a().format());
+		BitmapAccess::find_format(format_A8B8G8R8_n().format());
+		BitmapAccess::find_format(format_B8G8R8A8_n().format());
+	}
+}
+
+BENCHMARK(BM_FindFormat);
+
+static void BM_Create(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	for (auto _: state) {
+		auto bm = Bitmap::Create(320, 240);
+		(void)bm;
+	}
+}
+
+BENCHMARK(BM_Create);
+
+BENCHMARK_MAIN();
+
+

--- a/bench/bitmap.cpp
+++ b/bench/bitmap.cpp
@@ -1,7 +1,10 @@
+#define _USE_MATH_DEFINES
+#include <cmath>
 #include <benchmark/benchmark.h>
 #include <rect.h>
 #include <bitmap.h>
 #include <pixel_format.h>
+#include <transform.h>
 
 struct BitmapAccess : public Bitmap {
 	static pixman_format_code_t find_format(const DynamicFormat& format) {
@@ -38,6 +41,293 @@ static void BM_Create(benchmark::State& state) {
 }
 
 BENCHMARK(BM_Create);
+
+static void BM_Blit(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto src = Bitmap::Create(320, 240);
+	auto rect = src->GetRect();
+	for (auto _: state) {
+		dest->Blit(0, 0, *src, rect, Opacity::opaque);
+	}
+}
+
+BENCHMARK(BM_Blit);
+
+static void BM_BlitFast(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto src = Bitmap::Create(320, 240);
+	auto rect = src->GetRect();
+	for (auto _: state) {
+		dest->BlitFast(0, 0, *src, rect, Opacity::opaque);
+	}
+}
+
+BENCHMARK(BM_BlitFast);
+
+static void BM_TiledBlit(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto src = Bitmap::Create(320, 240);
+	auto rect = src->GetRect();
+	for (auto _: state) {
+		dest->TiledBlit(rect, *src, rect, Opacity::opaque);
+	}
+}
+
+BENCHMARK(BM_TiledBlit);
+
+static void BM_TiledBlitOffset(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto src = Bitmap::Create(320, 240);
+	auto rect = src->GetRect();
+	for (auto _: state) {
+		dest->TiledBlit(0, 0, rect, *src, rect, Opacity::opaque);
+	}
+}
+
+BENCHMARK(BM_TiledBlitOffset);
+
+static void BM_StretchBlit(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto src = Bitmap::Create(20, 20);
+	auto rect = src->GetRect();
+	for (auto _: state) {
+		dest->StretchBlit(*src, rect, Opacity::opaque);
+	}
+}
+
+BENCHMARK(BM_StretchBlit);
+
+static void BM_StretchBlitRect(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto dst_rect = dest->GetRect();
+	auto src = Bitmap::Create(20, 20);
+	auto rect = src->GetRect();
+	for (auto _: state) {
+		dest->StretchBlit(dst_rect, *src, rect, Opacity::opaque);
+	}
+}
+
+BENCHMARK(BM_StretchBlitRect);
+
+static void BM_FlipBlit(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto src = Bitmap::Create(320, 240);
+	auto rect = src->GetRect();
+	for (auto _: state) {
+		dest->FlipBlit(0, 0, *src, rect, true, true, Opacity::opaque);
+	}
+}
+
+BENCHMARK(BM_FlipBlit);
+
+static void BM_TransformBlit(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto dst_rect = dest->GetRect();
+	auto src = Bitmap::Create(320, 240);
+	auto rect = src->GetRect();
+	auto xform = Transform::Rotation(2 * M_PI);
+	for (auto _: state) {
+		dest->TransformBlit(dst_rect, *src, rect, xform, Opacity::opaque);
+	}
+}
+
+BENCHMARK(BM_TransformBlit);
+
+static void BM_WaverBlit(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto src = Bitmap::Create(320, 240);
+	auto rect = src->GetRect();
+	auto zoom_x = 2.0;
+	auto zoom_y = 2.0;
+	int depth = 2;
+	double phase = M_PI;
+	for (auto _: state) {
+		dest->WaverBlit(0, 0, zoom_x, zoom_y, *src, rect, depth, phase, Opacity::opaque);
+	}
+}
+
+BENCHMARK(BM_WaverBlit);
+
+static void BM_Fill(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto color = Color(255, 255, 255, 255);
+	for (auto _: state) {
+		dest->Fill(color);
+	}
+}
+
+BENCHMARK(BM_Fill);
+
+static void BM_FillRect(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto rect = dest->GetRect();
+	auto color = Color(255, 255, 255, 255);
+	for (auto _: state) {
+		dest->FillRect(rect, color);
+	}
+}
+
+BENCHMARK(BM_FillRect);
+
+static void BM_Clear(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	for (auto _: state) {
+		dest->Clear();
+	}
+}
+
+BENCHMARK(BM_Clear);
+
+static void BM_ClearRect(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto rect = dest->GetRect();
+	for (auto _: state) {
+		dest->ClearRect(rect);
+	}
+}
+
+BENCHMARK(BM_ClearRect);
+
+static void BM_HueChangeBlit(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto src = Bitmap::Create(320, 240);
+	auto rect = src->GetRect();
+	double hue = 1.0;
+	for (auto _: state) {
+		dest->HueChangeBlit(0, 0, *src, rect, hue);
+	}
+}
+
+BENCHMARK(BM_HueChangeBlit);
+
+static void BM_ToneBlit(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto src = Bitmap::Create(320, 240);
+	auto rect = src->GetRect();
+	auto tone = Tone();
+	for (auto _: state) {
+		dest->ToneBlit(0, 0, *src, rect, tone, Opacity::opaque, false);
+	}
+}
+
+BENCHMARK(BM_ToneBlit);
+
+static void BM_BlendBlit(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto src = Bitmap::Create(320, 240);
+	auto rect = src->GetRect();
+	auto color = Color(255, 255, 255, 255);
+	for (auto _: state) {
+		dest->BlendBlit(0, 0, *src, rect, color, Opacity::opaque);
+	}
+}
+
+BENCHMARK(BM_BlendBlit);
+
+static void BM_Flip(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto rect = dest->GetRect();
+	for (auto _: state) {
+		dest->Flip(rect, true, true);
+	}
+}
+
+BENCHMARK(BM_Flip);
+
+static void BM_MaskedBlit(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto dst_rect = dest->GetRect();
+	auto src = Bitmap::Create(320, 240);
+	auto mask = Bitmap::Create(320, 240);
+	auto color = Color(255, 255, 255, 255);
+	for (auto _: state) {
+		dest->MaskedBlit(dst_rect, *mask, 0, 0, *src, 0, 0);
+	}
+}
+
+BENCHMARK(BM_MaskedBlit);
+
+static void BM_MaskedColorBlit(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto dst_rect = dest->GetRect();
+	auto mask = Bitmap::Create(320, 240);
+	auto color = Color(255, 255, 255, 255);
+	for (auto _: state) {
+		dest->MaskedBlit(dst_rect, *mask, 0, 0, color);
+	}
+}
+
+BENCHMARK(BM_MaskedColorBlit);
+
+static void BM_Blit2x(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto dst_rect = dest->GetRect();
+	auto src = Bitmap::Create(320, 240);
+	auto rect = src->GetRect();
+	for (auto _: state) {
+		dest->Blit2x(dst_rect, *src, rect);
+	}
+}
+
+BENCHMARK(BM_Blit2x);
+
+static void BM_TransformRectangle(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto rect = dest->GetRect();
+	auto xform = Transform::Rotation(M_PI);
+	for (auto _: state) {
+		dest->TransformRectangle(xform, rect);
+	}
+}
+
+BENCHMARK(BM_TransformRectangle);
+
+static void BM_EffectsBlit(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto dest = Bitmap::Create(320, 240);
+	auto dst_rect = dest->GetRect();
+	auto src = Bitmap::Create(320, 240);
+	auto rect = src->GetRect();
+	auto zoom_x = 2.0;
+	auto zoom_y = 2.0;
+	auto angle = M_PI;
+	int waver_depth = 2;
+	double waver_phase = M_PI;
+	for (auto _: state) {
+		dest->EffectsBlit(0, 0, 0, 0,
+				*src, rect,
+				Opacity::opaque,
+				zoom_x, zoom_y,
+				angle,
+				waver_depth,
+				waver_phase);
+	}
+}
+
+BENCHMARK(BM_EffectsBlit);
+
+
 
 BENCHMARK_MAIN();
 

--- a/bench/font.cpp
+++ b/bench/font.cpp
@@ -1,0 +1,46 @@
+#include <benchmark/benchmark.h>
+#include <font.h>
+#include <rect.h>
+#include <bitmap.h>
+#include <pixel_format.h>
+#include <cache.h>
+
+const std::string text = "Alex landed a critical hit on Slime!";
+char32_t symbol = '\\';
+constexpr int width = 240;
+constexpr int height = 80;
+
+static void BM_FontSizeStr(benchmark::State& state) {
+	auto font = Font::Default();
+	for (auto _: state) {
+		auto rect = font->GetSize(text);
+		(void)rect;
+	}
+}
+
+BENCHMARK(BM_FontSizeStr);
+
+static void BM_Glyph(benchmark::State& state) {
+	auto font = Font::Default();
+	for (auto _: state) {
+		auto bm = font->Glyph(symbol);
+		(void)bm;
+	}
+}
+
+BENCHMARK(BM_Glyph);
+
+static void BM_Render(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto surface = Bitmap::Create(width, height);
+	auto system = Cache::SystemOrBlack();
+
+	auto font = Font::Default();
+	for (auto _: state) {
+		font->Render(*surface, 0, 0, *system, 0, symbol);
+	}
+}
+
+BENCHMARK(BM_Render);
+
+BENCHMARK_MAIN();

--- a/bench/text.cpp
+++ b/bench/text.cpp
@@ -1,0 +1,39 @@
+#include <benchmark/benchmark.h>
+#include <font.h>
+#include <rect.h>
+#include <bitmap.h>
+#include <text.h>
+#include <pixel_format.h>
+
+const std::string text = "Alex landed a critical hit on Slime!";
+char32_t symbol = '\\';
+constexpr int width = 240;
+constexpr int height = 80;
+
+static void BM_TextDrawStr(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto font = Font::Default();
+	auto surface = Bitmap::Create(width, height);
+
+	for (auto _: state) {
+		Text::Draw(*surface, 0, 0, 0, font, text, Text::AlignLeft);
+	}
+}
+
+BENCHMARK(BM_TextDrawStr);
+
+static void BM_TextDrawStrRaw(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto font = Font::Default();
+	auto surface = Bitmap::Create(width, height);
+
+	for (auto _: state) {
+		Text::Draw(*surface, 0, 0, Color(255,255,255,255), font, text);
+	}
+}
+
+BENCHMARK(BM_TextDrawStrRaw);
+
+
+
+BENCHMARK_MAIN();

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -55,7 +55,6 @@ namespace {
 	cache_effect_type cache_effects;
 
 	std::string system_name;
-	BitmapRef default_system;
 
 	std::string system2_name;
 
@@ -513,15 +512,17 @@ BitmapRef Cache::System() {
 	}
 }
 
+BitmapRef Cache::SysBlack() {
+	static auto system_black = Bitmap::Create(160, 80, false);
+	return system_black;
+}
+
 BitmapRef Cache::SystemOrBlack() {
 	auto system = Cache::System();
 	if (system) {
 		return system;
 	}
-	if (!default_system) {
-		default_system = Bitmap::Create(160, 80, false);
-	}
-	return default_system;
+	return SysBlack();
 }
 
 BitmapRef Cache::System2() {

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -22,6 +22,7 @@
 
 #include <map>
 #include <tuple>
+#include <chrono>
 
 #include "async_handler.h"
 #include "cache.h"
@@ -33,12 +34,15 @@
 #include "player.h"
 #include "data.h"
 
+using namespace std::chrono_literals;
+
 namespace {
 	using key_type = std::tuple<std::string,std::string,bool>;
+	using clock = std::chrono::steady_clock;
 
 	struct CacheItem {
 		BitmapRef bitmap;
-		uint32_t last_access;
+		clock::time_point last_access;
 	};
 
 	using tile_pair = std::pair<std::string, int>;
@@ -62,7 +66,7 @@ namespace {
 	size_t cache_size = 0;
 
 	void FreeBitmapMemory() {
-		int32_t cur_ticks = DisplayUi->GetTicks();
+		auto cur_ticks = clock::now();
 
 		for (auto& i : cache) {
 			if (i.second.bitmap.use_count() != 1) {
@@ -70,14 +74,14 @@ namespace {
 				continue;
 			}
 
-			if (cache_size <= cache_limit && cur_ticks - i.second.last_access < 3000) {
+			if (cache_size <= cache_limit && cur_ticks - i.second.last_access < 3s) {
 				// Below memory limit and last access < 3s
 				continue;
 			}
 
 #ifdef CACHE_DEBUG
-			Output::Debug("Freeing memory of %s/%s %d %d",
-						  std::get<0>(i.first).c_str(), std::get<1>(i.first).c_str(), i.second.last_access, cur_ticks);
+			Output::Debug("Freeing memory of %s/%s",
+						  std::get<0>(i.first).c_str(), std::get<1>(i.first).c_str());
 #endif
 
 			cache_size -= i.second.bitmap->GetSize();
@@ -97,7 +101,7 @@ namespace {
 #endif
 		}
 
-		return (cache[key] = {bmp, DisplayUi->GetTicks()}).bitmap;
+		return (cache[key] = {bmp, clock::now()}).bitmap;
 	}
 
 	BitmapRef LoadBitmap(const std::string& folder_name, const std::string& filename,
@@ -124,7 +128,7 @@ namespace {
 
 			return AddToCache(key, bmp);
 		} else {
-			it->second.last_access = DisplayUi->GetTicks();
+			it->second.last_access = clock::now();
 			return it->second.bitmap;
 		}
 	}
@@ -243,7 +247,7 @@ namespace {
 
 			return AddToCache(key, bitmap);
 		} else {
-			it->second.last_access = DisplayUi->GetTicks();
+			it->second.last_access = clock::now();
 			return it->second.bitmap;
 		}
 	}
@@ -394,7 +398,7 @@ BitmapRef Cache::Exfont() {
 
 		return AddToCache(hash, exfont_img);
 	} else {
-		it->second.last_access = DisplayUi->GetTicks();
+		it->second.last_access = clock::now();
 		return it->second.bitmap;
 	}
 }

--- a/src/cache.h
+++ b/src/cache.h
@@ -61,6 +61,9 @@ namespace Cache {
 	/** @return the configured system bitmap, or nullptr if there is no system */
 	BitmapRef System();
 
+	/** @return a black system graphic bitmap */
+	BitmapRef SysBlack();
+
 	/** @return the configured system bitmap, or a default black bitmap if there is no system */
 	BitmapRef SystemOrBlack();
 

--- a/src/color.h
+++ b/src/color.h
@@ -20,6 +20,7 @@
 
 #include <cstdint>
 #include <tuple>
+#include <ostream>
 
 /**
  * Color class.
@@ -92,6 +93,15 @@ inline bool operator<(const Color &l, const Color& r) {
 	return
 		std::tie(l.red, l.green, l.blue, l.alpha) <
 		std::tie(r.red, r.green, r.blue, r.alpha);
+}
+
+inline std::ostream& operator<<(std::ostream& os, const Color& c) {
+	os << "Color{"
+		<< static_cast<int>(c.red) << ", "
+		<< static_cast<int>(c.green) << ", "
+		<< static_cast<int>(c.blue) << ", "
+		<< static_cast<int>(c.alpha) << "}";
+	return os;
 }
 
 #endif

--- a/src/rect.h
+++ b/src/rect.h
@@ -19,6 +19,7 @@
 #define EP_RECT_H
 
 #include <tuple>
+#include <ostream>
 
 /**
  * Rect.
@@ -149,6 +150,11 @@ inline bool operator<(const Rect &l, const Rect& r) {
 	return
 		std::tie(l.x, l.y, l.width, l.height) <
 		std::tie(r.x, r.y, r.width, r.height);
+}
+
+inline std::ostream& operator<<(std::ostream& os, Rect r) {
+	os << "Rect{" << r.x << "," << r.y << "," << r.width << "," << r.height << "}";
+	return os;
 }
 
 #endif

--- a/src/tone.h
+++ b/src/tone.h
@@ -19,6 +19,7 @@
 #define EP_TONE_H
 
 #include <tuple>
+#include <ostream>
 
 /**
  * Tone class.
@@ -85,6 +86,11 @@ inline bool operator<(const Tone &l, const Tone& r) {
 	return
 		std::tie(l.red, l.green, l.blue, l.gray) <
 		std::tie(r.red, r.green, r.blue, r.gray);
+}
+
+inline std::ostream& operator<<(std::ostream& os, const Tone& t) {
+	os << "Tone{" << t.red << ", " << t.green << ", " << t.blue << ", " << t.gray << "}";
+	return os;
 }
 
 #endif


### PR DESCRIPTION
https://github.com/google/benchmark

Enabled by `-DPLAYER_ENABLE_BENCHMARKS=ON` in cmake. Turned off by default.

Only when build is enabled, we pull in the libbenchmark dependency.

I used this to get the numbers in #1959

Also adds a bunch of smaller changes to make it easier to write automated tests