### PR TITLE
Refactor Text Rendering stack - Messages 5 of N

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -468,6 +468,7 @@ test_runner_SOURCES = \
 	tests/platform.cpp \
 	tests/rtp.cpp \
 	tests/switches.cpp \
+	tests/text.cpp \
 	tests/utils.cpp \
 	tests/utf.cpp \
 	tests/variables.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -462,6 +462,7 @@ test_runner_SOURCES = \
 	tests/drawable_list.cpp \
 	tests/drawable_mgr.cpp \
 	tests/filefinder.cpp \
+	tests/font.cpp \
 	tests/output.cpp \
 	tests/parse.cpp \
 	tests/platform.cpp \

--- a/bench/font.cpp
+++ b/bench/font.cpp
@@ -20,6 +20,16 @@ static void BM_FontSizeStr(benchmark::State& state) {
 
 BENCHMARK(BM_FontSizeStr);
 
+static void BM_FontSizeChar(benchmark::State& state) {
+	auto font = Font::Default();
+	for (auto _: state) {
+		auto rect = font->GetSize(symbol);
+		(void)rect;
+	}
+}
+
+BENCHMARK(BM_FontSizeChar);
+
 static void BM_Glyph(benchmark::State& state) {
 	auto font = Font::Default();
 	for (auto _: state) {

--- a/bench/text.cpp
+++ b/bench/text.cpp
@@ -4,36 +4,81 @@
 #include <bitmap.h>
 #include <text.h>
 #include <pixel_format.h>
+#include <cache.h>
 
-const std::string text = "Alex landed a critical hit on Slime!";
+const std::string text = "Alex $A landed a critical hit on Slime $B!";
 char32_t symbol = '\\';
 constexpr int width = 240;
 constexpr int height = 80;
 
-static void BM_TextDrawStr(benchmark::State& state) {
+static void BM_TextDrawStrSystem(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto font = Font::Default();
+	auto surface = Bitmap::Create(width, height);
+	auto system = Cache::SysBlack();
+
+	for (auto _: state) {
+		Text::Draw(*surface, 0, 0, *font, *system, 0, text, Text::AlignLeft);
+	}
+}
+
+BENCHMARK(BM_TextDrawStrSystem);
+
+static void BM_TextDrawStrColor(benchmark::State& state) {
 	Bitmap::SetFormat(format_R8G8B8A8_a().format());
 	auto font = Font::Default();
 	auto surface = Bitmap::Create(width, height);
 
 	for (auto _: state) {
-		Text::Draw(*surface, 0, 0, 0, font, text, Text::AlignLeft);
+		Text::Draw(*surface, 0, 0, *font, Color(255,255,255,255), text);
 	}
 }
 
-BENCHMARK(BM_TextDrawStr);
+BENCHMARK(BM_TextDrawStrColor);
 
-static void BM_TextDrawStrRaw(benchmark::State& state) {
+void DrawCharSystemWrap(benchmark::State& state, char32_t ch, bool is_exfont) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto font = Font::Default();
+	auto surface = Bitmap::Create(width, height);
+	auto system = Cache::SysBlack();
+
+	for (auto _: state) {
+		Text::Draw(*surface, 0, 0, *font, *system, 0, ch, is_exfont);
+	}
+}
+
+static void BM_TextDrawCharSystem(benchmark::State& state) {
+	DrawCharSystemWrap(state, 'X', false);
+}
+
+BENCHMARK(BM_TextDrawCharSystem);
+
+static void BM_TextDrawCharSystemEx(benchmark::State& state) {
+	DrawCharSystemWrap(state, 0, true);
+}
+
+BENCHMARK(BM_TextDrawCharSystemEx);
+
+void DrawCharColorWrap(benchmark::State& state, char32_t ch, bool is_exfont) {
 	Bitmap::SetFormat(format_R8G8B8A8_a().format());
 	auto font = Font::Default();
 	auto surface = Bitmap::Create(width, height);
 
 	for (auto _: state) {
-		Text::Draw(*surface, 0, 0, Color(255,255,255,255), font, text);
+		Text::Draw(*surface, 0, 0, *font, Color(255,255,255,255), ch, is_exfont);
 	}
 }
 
-BENCHMARK(BM_TextDrawStrRaw);
+static void BM_TextDrawCharColor(benchmark::State& state) {
+	DrawCharColorWrap(state, 'X', false);
+}
 
+BENCHMARK(BM_TextDrawCharColor);
 
+static void BM_TextDrawCharColorEx(benchmark::State& state) {
+	DrawCharColorWrap(state, 0, true);
+}
+
+BENCHMARK(BM_TextDrawCharColorEx);
 
 BENCHMARK_MAIN();

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -188,28 +188,12 @@ bool Bitmap::WritePNG(std::ostream& os) const {
 	return ImagePNG::WritePNG(os, width, height, &data.front());
 }
 
-int Bitmap::GetWidth() const {
-	return width();
-}
-
-int Bitmap::GetHeight() const {
-	return height();
-}
-
-Rect Bitmap::GetRect() const {
-	return Rect(0, 0, width(), height());
-}
-
 size_t Bitmap::GetSize() const {
 	if (!bitmap) {
 		return 0;
 	}
 
 	return pitch() * height();
-}
-
-bool Bitmap::GetTransparent() const {
-	return format.alpha_type != PF::NoAlpha;
 }
 
 ImageOpacity Bitmap::ComputeImageOpacity() const {

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -331,7 +331,9 @@ void Bitmap::TextDraw(Rect const& rect, int color, std::string const& text, Text
 }
 
 void Bitmap::TextDraw(int x, int y, int color, std::string const& text, Text::Alignment align) {
-	Text::Draw(*this, x, y, color, Font::Default(), text, align);
+	auto font = Font::Default();
+	auto system = Cache::SystemOrBlack();
+	Text::Draw(*this, x, y, *font, *system, color, text, align);
 }
 
 void Bitmap::TextDraw(Rect const& rect, Color color, std::string const& text, Text::Alignment align) {
@@ -354,7 +356,8 @@ void Bitmap::TextDraw(Rect const& rect, Color color, std::string const& text, Te
 }
 
 void Bitmap::TextDraw(int x, int y, Color color, std::string const& text) {
-	Text::Draw(*this, x, y, color, Font::Default(), text);
+	auto font = Font::Default();
+	Text::Draw(*this, x, y, *font, color, text);
 }
 
 Rect Bitmap::TransformRectangle(const Transform& xform, const Rect& rect) {

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -586,4 +586,20 @@ inline Color Bitmap::GetShadowColor() const {
 	return sh_color;
 }
 
+inline int Bitmap::GetWidth() const {
+	return width();
+}
+
+inline int Bitmap::GetHeight() const {
+	return height();
+}
+
+inline Rect Bitmap::GetRect() const {
+	return Rect(0, 0, width(), height());
+}
+
+inline bool Bitmap::GetTransparent() const {
+	return format.alpha_type != PF::NoAlpha;
+}
+
 #endif

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -539,8 +539,6 @@ protected:
 	TileOpacity tile_opacity;
 	Color bg_color, sh_color;
 
-	friend void Text::Draw(Bitmap& dest, int x, int y, int color, FontRef font, std::string const& text, Text::Alignment align);
-
 	/** Bitmap data. */
 	PixmanImagePtr bitmap;
 	pixman_format_code_t pixman_format;

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -41,6 +41,7 @@
 #include "utils.h"
 #include "cache.h"
 #include "player.h"
+#include "compiler.h"
 
 // Static variables.
 namespace {
@@ -100,12 +101,14 @@ namespace {
 
 		BitmapFont(const std::string& name, function_type func);
 
-		Rect GetSize(std::u32string const& txt) const override;
+		Rect GetSize(std::string const& txt) const override;
+		Rect GetSize(char32_t ch) const override;
 
-		BitmapRef Glyph(char32_t code) override;
+		GlyphRet Glyph(char32_t code) override;
 
 	private:
-		function_type const func_;
+		function_type func;
+		BitmapRef glyph_bm;
 	}; // class BitmapFont
 
 #ifdef HAVE_FREETYPE
@@ -127,9 +130,10 @@ namespace {
 	struct FTFont : public Font  {
 		FTFont(const std::string& name, int size, bool bold, bool italic);
 
-		Rect GetSize(std::u32string const& txt) const override;
+		Rect GetSize(std::string const& txt) const override;
+		Rect GetSize(char32_t ch) const override;
 
-		BitmapRef Glyph(char32_t code) override;
+		GlyphRet Glyph(char32_t code) override;
 
 	private:
 		static std::weak_ptr<std::remove_pointer<FT_Library>::type> library_checker_;
@@ -158,38 +162,64 @@ namespace {
 	FontRef const ttyp0 = std::make_shared<BitmapFont>("ttyp0", &find_ttyp0_glyph);
 
 	struct ExFont : public Font {
-		ExFont();
-		Rect GetSize(std::u32string const& txt) const override;
-		BitmapRef Glyph(char32_t code) override;
+		public:
+			enum { HEIGHT = 12, WIDTH = 12 };
+			ExFont();
+			Rect GetSize(std::string const& txt) const override;
+			Rect GetSize(char32_t ch) const override;
+			GlyphRet Glyph(char32_t code) override;
+		private:
+			BitmapRef bm;
 	};
 } // anonymous namespace
 
-BitmapFont::BitmapFont(const std::string& name, BitmapFont::function_type func)
-	: Font(name, HEIGHT, false, false), func_(func) {}
+BitmapFont::BitmapFont(const std::string& name, function_type func)
+	: Font(name, HEIGHT, false, false), func(func)
+{}
 
-Rect BitmapFont::GetSize(std::u32string const& txt) const {
+Rect BitmapFont::GetSize(char32_t ch) const {
 	size_t units = 0;
-	for (char32_t c : txt) {
-		BitmapFontGlyph const* const glyph = func_(c);
-		assert(glyph);
+	if (EP_LIKELY(!std::iscntrl(static_cast<unsigned char>(ch)))) {
+		auto glyph = func(ch);
 		units += glyph->is_full? 2 : 1;
 	}
 	return Rect(0, 0, units * HALF_WIDTH, HEIGHT);
 }
 
-BitmapRef BitmapFont::Glyph(char32_t code) {
-	BitmapFontGlyph const* const glyph = func_(code);
-	assert(glyph);
-	size_t const width = glyph->is_full? FULL_WIDTH : HALF_WIDTH;
+Rect BitmapFont::GetSize(std::string const& txt) const {
+	size_t units = 0;
+	const auto* iter = txt.data();
+	const auto* end = txt.data() + txt.size();
+	while (iter != end) {
+		auto resp = Utils::UTF8Next(iter, end);
+		auto ch = resp.ch;
+		iter = resp.next;
+		if (EP_LIKELY(!std::iscntrl(static_cast<unsigned char>(resp.ch)))) {
+			auto glyph = func(ch);
+			units += glyph->is_full? 2 : 1;
+		}
+	}
+	return Rect(0, 0, units * HALF_WIDTH, HEIGHT);
+}
 
-	BitmapRef bm = Bitmap::Create(nullptr, width, HEIGHT, 0, DynamicFormat(8,8,0,8,0,8,0,8,0,PF::Alpha));
-	uint8_t* data = reinterpret_cast<uint8_t*>(bm->pixels());
-	int pitch = bm->pitch();
+Font::GlyphRet BitmapFont::Glyph(char32_t code) {
+	if (EP_UNLIKELY(!glyph_bm)) {
+		glyph_bm = Bitmap::Create(nullptr, FULL_WIDTH, HEIGHT, 0, DynamicFormat(8,8,0,8,0,8,0,8,0,PF::Alpha));
+	}
+	if (EP_UNLIKELY(std::iscntrl(static_cast<unsigned char>(code)))) {
+		return { glyph_bm, Rect(0, 0, 0, HEIGHT) };
+	}
+	auto glyph = func(code);
+	auto width = glyph->is_full? FULL_WIDTH : HALF_WIDTH;
+
+	glyph_bm->Clear();
+	uint8_t* data = reinterpret_cast<uint8_t*>(glyph_bm->pixels());
+	int pitch = glyph_bm->pitch();
 	for(size_t y_ = 0; y_ < HEIGHT; ++y_)
 		for(size_t x_ = 0; x_ < width; ++x_)
 			data[y_*pitch+x_] = (glyph->data[y_] & (0x1 << x_)) ? 255 : 0;
 
-	return bm;
+	return { glyph_bm, Rect(0, 0, width, HEIGHT) };
 }
 
 #ifdef HAVE_FREETYPE
@@ -198,7 +228,7 @@ std::weak_ptr<std::remove_pointer<FT_Library>::type> FTFont::library_checker_;
 FTFont::FTFont(const std::string& name, int size, bool bold, bool italic)
 	: Font(name, size, bold, italic), current_size_(0) {}
 
-Rect FTFont::GetSize(std::u32string const& txt) const {
+Rect FTFont::GetSize(std::string const& txt) const {
 	int const s = Font::Default()->GetSize(txt).width;
 
 	if (s == -1) {
@@ -210,7 +240,21 @@ Rect FTFont::GetSize(std::u32string const& txt) const {
 	}
 }
 
-BitmapRef FTFont::Glyph(char32_t glyph) {
+Rect FTFont::GetSize(char32_t ch) const {
+	int const s = Font::Default()->GetSize(ch).width;
+
+	if (s == -1) {
+		Output::Warning("Text contains invalid chars. Is the encoding correct?");
+
+		return Rect(0, 0, pixel_size() / 2, pixel_size());
+	} else {
+		return Rect(0, 0, s, pixel_size());
+	}
+}
+
+
+
+Font::GlyphRet FTFont::Glyph(char32_t glyph) {
 	if(!check_face()) {
 		return Font::Default()->Glyph(glyph);
 	}
@@ -242,7 +286,7 @@ BitmapRef FTFont::Glyph(char32_t glyph) {
 		}
 	}
 
-	return bm;
+	return { bm, Rect(0, 0, width, height) };
 }
 
 bool FTFont::check_face() {
@@ -352,28 +396,36 @@ Font::Font(const std::string& name, int size, bool bold, bool italic)
 {
 }
 
-Rect Font::GetSize(std::string const& txt) const {
-	return GetSize(Utils::DecodeUTF32(txt));
-}
+Rect Font::Render(Bitmap& dest, int const x, int const y, const Bitmap& sys, int color, char32_t code) {
+	auto gret = Glyph(code);
 
-void Font::Render(Bitmap& bmp, int const x, int const y, Bitmap const& sys, int color, char32_t code) {
-	if(color != ColorShadow) {
-		Render(bmp, x + 1, y + 1, sys.GetShadowColor(), code);
+	auto rect = Rect(x, y, gret.rect.width, gret.rect.height);
+	if (EP_UNLIKELY(rect.width == 0)) {
+		return rect;
 	}
 
-	BitmapRef bm = Glyph(code);
+	if(color != ColorShadow) {
+		auto shadow_rect = Rect(x + 1, y + 1, rect.width, rect.height);
+		dest.MaskedBlit(shadow_rect, *gret.bitmap, 0, 0, sys, 16, 32);
+	}
 
 	unsigned const
 		src_x = color == ColorShadow? 16 : color % 10 * 16 + 2,
-		src_y = color == ColorShadow? 32 : color / 10 * 16 + 48 + 16 - bm->height();
+		src_y = color == ColorShadow? 32 : color / 10 * 16 + 48 + 16 - gret.bitmap->height();
 
-	bmp.MaskedBlit(Rect(x, y, bm->width(), bm->height()), *bm, 0, 0, sys, src_x, src_y);
+
+	dest.MaskedBlit(rect, *gret.bitmap, 0, 0, sys, src_x, src_y);
+
+	return rect;
 }
 
-void Font::Render(Bitmap& bmp, int x, int y, Color const& color, char32_t code) {
-	BitmapRef bm = Glyph(code);
+Rect Font::Render(Bitmap& dest, int x, int y, Color const& color, char32_t code) {
+	auto gret = Glyph(code);
 
-	bmp.MaskedBlit(Rect(x, y, bm->width(), bm->height()), *bm, 0, 0, color);
+	auto rect = Rect(x, y, gret.rect.width, gret.rect.height);
+	dest.MaskedBlit(rect, *gret.bitmap, 0, 0, color);
+
+	return rect;
 }
 
 ExFont::ExFont() : Font("exfont", 12, false, false) {
@@ -381,12 +433,20 @@ ExFont::ExFont() : Font("exfont", 12, false, false) {
 
 FontRef Font::exfont = std::make_shared<ExFont>();
 
-BitmapRef ExFont::Glyph(char32_t code) {
-	BitmapRef exfont = Cache::Exfont();
-	Rect const rect((code % 13) * 12, (code / 13) * 12, 12, 12);
-	return Bitmap::Create(*exfont, rect, true);
+Font::GlyphRet ExFont::Glyph(char32_t code) {
+	if (EP_UNLIKELY(!bm)) { bm = Bitmap::Create(WIDTH, HEIGHT, true); }
+	auto exfont = Cache::Exfont();
+
+	Rect const rect((code % 13) * WIDTH, (code / 13) * HEIGHT, WIDTH, HEIGHT);
+	bm->Clear();
+	bm->Blit(0, 0, *exfont, rect, Opacity::Opaque());
+	return { bm, Rect(0, 0, WIDTH, HEIGHT) };
 }
 
-Rect ExFont::GetSize(std::u32string const& /* txt */) const {
+Rect ExFont::GetSize(std::string const&) const {
+	return Rect(0, 0, 12, 12);
+}
+
+Rect ExFont::GetSize(char32_t) const {
 	return Rect(0, 0, 12, 12);
 }

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -358,10 +358,7 @@ Rect Font::GetSize(std::string const& txt) const {
 
 void Font::Render(Bitmap& bmp, int const x, int const y, Bitmap const& sys, int color, char32_t code) {
 	if(color != ColorShadow) {
-		BitmapRef system = Cache::System();
-		if (system) {
-			Render(bmp, x + 1, y + 1, system->GetShadowColor(), code);
-		}
+		Render(bmp, x + 1, y + 1, sys.GetShadowColor(), code);
 	}
 
 	BitmapRef bm = Glyph(code);

--- a/src/font.h
+++ b/src/font.h
@@ -20,6 +20,8 @@
 
 // Headers
 #include "system.h"
+#include "memory_management.h"
+#include "rect.h"
 #include <string>
 
 class Color;
@@ -32,13 +34,64 @@ class Font {
  public:
 	virtual ~Font() {}
 
-	Rect GetSize(std::string const& txt) const;
-	virtual Rect GetSize(std::u32string const& txt) const = 0;
+	/**
+	 * Returns the size of the rendered string, not including shadows.
+	 *
+	 * @param txt the string to measure
+	 * @return Rect describing the rendered string boundary
+	 */
+	virtual Rect GetSize(std::string const& txt) const = 0;
+	/**
+	 * Returns the size of the rendered utf32 character, not including shadows.
+	 *
+	 * @param ch the character to measure
+	 * @return Rect describing the rendered character boundary
+	 */
+	virtual Rect GetSize(char32_t ch) const = 0;
 
-	virtual BitmapRef Glyph(char32_t code) = 0;
+	struct GlyphRet {
+		/* bitmap which the glyph pixels are located within */
+		BitmapRef bitmap;
+		/* sub-rect of the bitmap which contains glyph pixels */
+		Rect rect;
+	};
 
-	void Render(Bitmap& bmp, int x, int y, Bitmap const& sys, int color, char32_t glyph);
-	void Render(Bitmap& bmp, int x, int y, Color const& color, char32_t glyph);
+	/* Returns a bitmap and rect containing the pixels of the glyph.
+	 * The bitmap may be larger than the size of the glyph, and so the
+	 * rect must be used to get the pixels out of the bitmap
+	 *
+	 * @param code which utf32 glyph to return.
+	 * @return @refer GlyphRet
+	 */
+	virtual GlyphRet Glyph(char32_t code) = 0;
+
+	/**
+	 * Renders the glyph onto bitmap at the given position with system graphic and color
+	 *
+	 * @param dest the bitmap to render to
+	 * @param x X offset to render glyph
+	 * @param y Y offset to render glyph
+	 * @param sys system graphic to use
+	 * @param color which color in the system graphic
+	 * @param glyph which utf32 glyph to render
+	 *
+	 * @return Rect containing the x offset, y offset, width, and height of the subrect that was blitted onto dest. Not including text shadow!
+	 */
+	Rect Render(Bitmap& dest, int x, int y, const Bitmap& sys, int color, char32_t glyph);
+
+	/**
+	 * Renders the glyph onto bitmap at the given position with system graphic and color
+	 *
+	 * @param dest the bitmap to render to
+	 * @param x X offset to render glyph
+	 * @param y Y offset to render glyph
+	 * @param sys system graphic to use
+	 * @param color which color in the system graphic
+	 * @param glyph which utf32 glyph to render
+	 *
+	 * @return Rect containing the x offset, y offset, width, and height of the subrect that was blitted onto dest.
+	 */
+	Rect Render(Bitmap& dest, int x, int y, Color const& color, char32_t glyph);
 
 	static FontRef Create(const std::string& name, int size, bool bold, bool italic);
 	static FontRef Default();

--- a/src/font.h
+++ b/src/font.h
@@ -85,7 +85,6 @@ class Font {
 	 * @param dest the bitmap to render to
 	 * @param x X offset to render glyph
 	 * @param y Y offset to render glyph
-	 * @param sys system graphic to use
 	 * @param color which color in the system graphic
 	 * @param glyph which utf32 glyph to render
 	 *

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -255,7 +255,7 @@ static Game_Message::ParseParamResult ParseParamImpl(
 		if (ret.ch != escape_char) {
 			return { begin, 0 };
 		}
-		iter = ret.iter;
+		iter = ret.next;
 		if (iter == end || (*iter != upper && *iter != lower)) {
 			return { begin, 0 };
 		}
@@ -290,7 +290,7 @@ static Game_Message::ParseParamResult ParseParamImpl(
 		if (max_recursion > 0) {
 			auto ret = Utils::UTF8Next(iter, end);
 			auto ch = ret.ch;
-			iter = ret.iter;
+			iter = ret.next;
 
 			// Recursive variable case.
 			if (ch == escape_char) {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -191,8 +191,8 @@ static void HandleErrorOutput(const std::string& err) {
 
 	error += "\n\nEasyRPG Player will close now.\nPress [ENTER] key to exit...";
 
-	Text::Draw(*surface, 11, 11, Color(0, 0, 0, 255), Font::Default(), error);
-	Text::Draw(*surface, 10, 10, Color(255, 255, 255, 255), Font::Default(), error);
+	Text::Draw(*surface, 11, 11, *Font::Default(), Color(0, 0, 0, 255), error);
+	Text::Draw(*surface, 10, 10, *Font::Default(), Color(255, 255, 255, 255), error);
 	DisplayUi->UpdateDisplay();
 
 	if (ignore_pause) { return; }

--- a/src/pending_message.cpp
+++ b/src/pending_message.cpp
@@ -83,7 +83,7 @@ std::string PendingMessage::ApplyTextInsertingCommands(std::string input, uint32
 	while (iter != end) {
 		auto ret = Utils::UTF8Next(iter, end);
 		if (ret.ch != escape_char) {
-			iter = ret.iter;
+			iter = ret.next;
 			continue;
 		}
 
@@ -95,7 +95,7 @@ std::string PendingMessage::ApplyTextInsertingCommands(std::string input, uint32
 		output.append(start_copy, iter);
 		start_copy = iter;
 
-		iter = ret.iter;
+		iter = ret.next;
 		if (iter == end) {
 			break;
 		}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -390,7 +390,7 @@ void Player::Exit() {
 	BitmapRef surface = DisplayUi->GetDisplaySurface();
 	std::string message = "It's now safe to turn off\n      your browser.";
 
-	Text::Draw(*surface, 84, DisplayUi->GetHeight() / 2 - 30, Color(221, 123, 64, 255), Font::Default(), message);
+	Text::Draw(*surface, 84, DisplayUi->GetHeight() / 2 - 30, *Font::Default(), Color(221, 123, 64, 255), message);
 	DisplayUi->UpdateDisplay();
 #endif
 

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -90,7 +90,7 @@ void Text::Draw(Bitmap& dest, int x, int y, int color, FontRef font, std::string
 			// Skip the next character
 			++c;
 		} else {
-			next_glyph_pos += font->GetSize(std::u32string(1, *c)).width;
+			next_glyph_pos += font->GetSize(*c).width;
 		}
 	}
 
@@ -112,16 +112,15 @@ void Text::Draw(Bitmap& dest, int x, int y, Color color, FontRef font, std::stri
 	int next_glyph_pos = 0;
 
 	for (char32_t c : Utils::DecodeUTF32(text)) {
-		std::u32string const glyph = std::u32string(1, c);
 		if (c == U'\n') {
-			y += font->GetSize(glyph).height;
+			y += font->GetSize(c).height;
 			next_glyph_pos = 0;
 			continue;
 		}
 		Rect next_glyph_rect(x + next_glyph_pos, y, 0, 0);
 
 		font->Render(dest, next_glyph_rect.x, next_glyph_rect.y, color, c);
-		
-		next_glyph_pos += font->GetSize(glyph).width;
+
+		next_glyph_pos += font->GetSize(c).width;
 	}
 }

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -23,15 +23,33 @@
 #include "bitmap.h"
 #include "font.h"
 #include "text.h"
-#include "game_system.h"
+#include "compiler.h"
 
 #include <cctype>
 #include <iterator>
 
-void Text::Draw(Bitmap& dest, int x, int y, int color, FontRef font, std::string const& text, Text::Alignment align) {
-	if (text.length() == 0) return;
+Rect Text::Draw(Bitmap& dest, int x, int y, Font& font, const Bitmap& system, int color, char32_t ch, bool is_exfont) {
+	if (is_exfont) {
+		return Font::exfont->Render(dest, x, y, system, color, ch);
+	} else {
+		return font.Render(dest, x, y, system, color, ch);
+	}
+}
 
-	Rect dst_rect = font->GetSize(text);
+Rect Text::Draw(Bitmap& dest, int x, int y, Font& font, Color color, char32_t ch, bool is_exfont) {
+	if (is_exfont) {
+		return Font::exfont->Render(dest, x, y, color, ch);
+	} else {
+		return font.Render(dest, x, y, color, ch);
+	}
+}
+
+Rect Text::Draw(Bitmap& dest, const int x, const int y, Font& font, const Bitmap& system, const int color, const std::string& text, const Text::Alignment align) {
+	if (text.length() == 0) return { x, y, 0, 0 };
+
+	Rect dst_rect = font.GetSize(text);
+
+	const int ih = dst_rect.height;
 
 	switch (align) {
 	case Text::AlignCenter:
@@ -45,82 +63,69 @@ void Text::Draw(Bitmap& dest, int x, int y, int color, FontRef font, std::string
 
 	dst_rect.y = y;
 	dst_rect.width += 1; dst_rect.height += 1; // Need place for shadow
-	if (dst_rect.IsOutOfBounds(dest.GetWidth(), dest.GetHeight())) return;
+	if (dst_rect.IsOutOfBounds(dest.GetWidth(), dest.GetHeight())) return { x, y, 0, 0 };
 
-	BitmapRef text_surface; // Complete text will be on this surface
-	text_surface = Bitmap::Create(dst_rect.width, dst_rect.height, true);
-	text_surface->Clear();
-
-	BitmapRef system = Cache::SystemOrBlack();
+	const int iy = dst_rect.y;
+	const int ix = dst_rect.x;
 
 	// Where to draw the next glyph (x pos)
 	int next_glyph_pos = 0;
 
-	// The current char is an exfont
-	bool is_exfont = false;
-
 	// This loops always renders a single char, color blends it and then puts
 	// it onto the text_surface (including the drop shadow)
-	std::u32string u32text = Utils::DecodeUTF32(text);
-	for (auto c = u32text.begin(), end = u32text.end(); c != end; ++c) {
-		Rect next_glyph_rect(next_glyph_pos, 0, 0, 0);
+	auto iter = &*text.begin();
+	const auto end = &*text.end();
+	while (iter != end) {
+		auto ret = Utils::TextNext(iter, end, 0);
 
-		char32_t const next_c = std::distance(c, end) > 1? *std::next(c) : 0;
-
-		// ExFont-Detection: Check for A-Z or a-z behind the $
-		if (*c == '$' && std::isalpha(next_c)) {
-			int exfont_value = -1;
-			// Calculate which exfont shall be rendered
-			if (islower(next_c)) {
-				exfont_value = 26 + next_c - 'a';
-			} else if (isupper(next_c)) {
-				exfont_value = next_c - 'A';
-			} else { assert(false); }
-			is_exfont = true;
-
-			Font::exfont->Render(*text_surface, next_glyph_rect.x, next_glyph_rect.y, *system, color, exfont_value);
-		} else { // Not ExFont, draw normal text
-			font->Render(*text_surface, next_glyph_rect.x, next_glyph_rect.y, *system, color, *c);
-		}
-
-		// If it's a full size glyph, add the size of a half-size glyph twice
-		if (is_exfont) {
-			is_exfont = false;
-			next_glyph_pos += 12;
-			// Skip the next character
-			++c;
-		} else {
-			next_glyph_pos += font->GetSize(*c).width;
-		}
-	}
-
-	BitmapRef text_bmp = Bitmap::Create(*text_surface, text_surface->GetRect());
-
-	Rect src_rect(0, 0, dst_rect.width, dst_rect.height);
-	int iy = dst_rect.y;
-	if (dst_rect.height > text_bmp->GetHeight()) {
-		iy += ((dst_rect.height - text_bmp->GetHeight()) / 2);
-	}
-	int ix = dst_rect.x;
-
-	dest.Blit(ix, iy, *text_bmp, src_rect, 255);
-}
-
-void Text::Draw(Bitmap& dest, int x, int y, Color color, FontRef font, std::string const& text) {
-	if (text.length() == 0) return;
-
-	int next_glyph_pos = 0;
-
-	for (char32_t c : Utils::DecodeUTF32(text)) {
-		if (c == U'\n') {
-			y += font->GetSize(c).height;
-			next_glyph_pos = 0;
+		iter = ret.next;
+		if (EP_UNLIKELY(!ret)) {
 			continue;
 		}
-		Rect next_glyph_rect(x + next_glyph_pos, y, 0, 0);
-
-		font->Render(dest, next_glyph_rect.x, next_glyph_rect.y, color, c);
-
-		next_glyph_pos += font->GetSize(c).width;
+		next_glyph_pos += Text::Draw(dest, ix + next_glyph_pos, iy, font, system, color, ret.ch, ret.is_exfont).width;
 	}
+	return { x, y, next_glyph_pos, ih };
 }
+
+Rect Text::Draw(Bitmap& dest, const int x, const int y, Font& font, const Color color, const std::string& text) {
+	if (text.length() == 0) return { x, y, 0, 0 };
+
+	int dx = x;
+	int mx = x;
+
+	int dy = y;
+	int ny = 0;
+
+	auto iter = &*text.begin();
+	const auto end = &*text.end();
+	while (iter != end) {
+		auto ret = Utils::UTF8Next(iter, end);
+
+		iter = ret.next;
+		if (EP_UNLIKELY(!ret)) {
+			continue;
+		}
+
+		if (ret.ch == U'\n') {
+			if (ny == 0) {
+				ny = font.GetSize(ret.ch).height;
+			}
+			dy += ny;
+			mx = std::max(mx, dx);
+			dx = x;
+			ny = 0;
+			continue;
+		}
+
+		auto rect = font.Render(dest, dx, dy, color, ret.ch);
+		dx += rect.width;
+		assert(ny == 0 || ny == rect.height);
+		ny = rect.height;
+	}
+	dy += ny;
+	mx = std::max(mx, dx);
+
+	return Rect(x, y, mx - x , dy - y);
+}
+
+

--- a/src/text.h
+++ b/src/text.h
@@ -19,22 +19,86 @@
 #define EP_TEXT_H
 
 #include "system.h"
-#include "font.h"
+#include "memory_management.h"
+#include "rect.h"
+#include "color.h"
 #include <string>
+
+class Font;
+class Bitmap;
 
 namespace Text {
 	/** TextDraw alignment options. */
 	enum Alignment {
+		/** Align text to the left. */
 		AlignLeft,
+		/** Align text to the center. */
 		AlignCenter,
+		/** Align text to the right. */
 		AlignRight
 	};
 
-	void Draw(Bitmap& dest, int x, int y, int color, FontRef font, std::string const& text, Text::Alignment align = Text::AlignLeft);
+	/**
+	 * Draws the text onto dest bitmap with given parameters.
+	 *
+	 * @param dest the bitmap to render to.
+	 * @param x X offset to render text.
+	 * @param y Y offset to render text.
+	 * @param font the font used to render.
+	 * @param system the system graphic to use to render.
+	 * @param color which color from the system graphic to use.
+	 * @param text the utf8 / exfont text to render.
+	 * @param align the text alignment to use
+	 *
+	 * @return Rect describing the sub-rect of dest that was rendered to. Does *not* include shadow pixels.
+	 */
+	Rect Draw(Bitmap& dest, int x, int y, Font& font, const Bitmap& system, int color, const std::string& text, Text::Alignment align = Text::AlignLeft);
 
 	/**
-	 * Draws text using the specified color on dest
+	 * Draws the text onto dest bitmap with given parameters. Does not draw a shadow.
+	 *
+	 * @param dest the bitmap to render to.
+	 * @param x X offset to render text.
+	 * @param y Y offset to render text.
+	 * @param font the font used to render.
+	 * @param color which color to use.
+	 * @param text the utf8 / exfont text to render.
+	 *
+	 * @return Rect describing the sub-rect of dest that was rendered to. Does *not* include shadow pixels.
 	 */
-	void Draw(Bitmap& dest, int x, int y, Color color, FontRef font, std::string const& text);
+	Rect Draw(Bitmap& dest, int x, int y, Font& font, Color color, const std::string& text);
+
+	/**
+	 * Draws the character onto dest bitmap with given parameters.
+	 *
+	 * @param dest the bitmap to render to.
+	 * @param x X offset to render text.
+	 * @param y Y offset to render text.
+	 * @param font the font used to render.
+	 * @param system the system graphic to use to render.
+	 * @param color which color from the system graphic to use.
+	 * @param ch the character to render.
+	 * @param is_exfont if true, treat ch as an exfont character. Otherwise, a utf32 character. 
+	 *
+	 * @return Rect describing the sub-rect of dest that was rendered to. Does *not* include shadow pixels.
+	 */
+	Rect Draw(Bitmap& dest, int x, int y, Font& font, const Bitmap& system, int color, char32_t ch, bool is_exfont);
+
+
+	/**
+	 * Draws the character onto dest bitmap with given parameters. does not draw a shadow.
+	 *
+	 * @param dest the bitmap to render to.
+	 * @param x X offset to render text.
+	 * @param y Y offset to render text.
+	 * @param font the font used to render.
+	 * @param system the system graphic to use to render.
+	 * @param color which color from the system graphic to use.
+	 * @param ch the character to render.
+	 * @param is_exfont if true, treat ch as an exfont character. Otherwise, a utf32 character. 
+	 *
+	 * @return Rect describing the sub-rect of dest that was rendered to. Does *not* include shadow pixels.
+	 */
+	Rect Draw(Bitmap& dest, int x, int y, Font& font, Color color, char32_t ch, bool is_exfont);
 }
 #endif

--- a/src/text.h
+++ b/src/text.h
@@ -86,14 +86,13 @@ namespace Text {
 
 
 	/**
-	 * Draws the character onto dest bitmap with given parameters. does not draw a shadow.
+	 * Draws the character onto dest bitmap with given parameters. Does not draw a shadow.
 	 *
 	 * @param dest the bitmap to render to.
 	 * @param x X offset to render text.
 	 * @param y Y offset to render text.
 	 * @param font the font used to render.
-	 * @param system the system graphic to use to render.
-	 * @param color which color from the system graphic to use.
+	 * @param color which color to use.
 	 * @param ch the character to render.
 	 * @param is_exfont if true, treat ch as an exfont character. Otherwise, a utf32 character. 
 	 *

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -377,11 +377,12 @@ Utils::TextRet Utils::TextNext(const char* iter, const char* end, char32_t escap
 	ret.ch = utf8_ret.ch;
 
 	if (escape != 0 && ret.ch == escape && ret.next != end) {
-		auto eret = UTF8Next(iter, end);
+		auto eret = UTF8Next(ret.next, end);
 		ret.next = eret.next;
 		ret.ch = eret.ch;
 		ret.is_escape = true;
 	}
+	ret.is_exfont = false;
 
 	return ret;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -272,7 +272,7 @@ Utils::UtfNextResult Utils::UTF8Next(const char* iter, const char* const end) {
 		uint8_t c1 = *iter;
 		++iter;
 		if (c1 < 0x80) {
-			return { static_cast<uint32_t>(c1), iter };
+			return { iter, static_cast<uint32_t>(c1) };
 		}
 		if (c1 < 0xC2) {
 			continue;
@@ -286,7 +286,7 @@ Utils::UtfNextResult Utils::UTF8Next(const char* iter, const char* const end) {
 			if ((c2 & 0xC0) != 0x80)
 				continue;
 			auto ch = (static_cast<uint32_t>(((c1 & 0x1F) << 6) | (c2 & 0x3F)));
-			return { ch, iter };
+			return { iter, ch };
 		}
 		if (iter == end) {
 			break;
@@ -309,7 +309,7 @@ Utils::UtfNextResult Utils::UTF8Next(const char* iter, const char* const end) {
 			auto ch = (static_cast<uint32_t>(((c1 & 0x0F) << 12)
 						| ((c2 & 0x3F) << 6)
 						|  (c3 & 0x3F)));
-			return { ch, iter };
+			return { iter, ch };
 		}
 		if (iter == end) {
 			break;
@@ -333,10 +333,10 @@ Utils::UtfNextResult Utils::UTF8Next(const char* iter, const char* const end) {
 				| ((c2 & 0x3F) << 12)
 				| ((c3 & 0x3F) << 6)
 				|  (c4 & 0x3F));
-		return { ch, iter };
+		return { iter, ch };
 		}
 	}
-	return { 0, iter };
+	return { iter, 0 };
 }
 
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -125,6 +125,48 @@ namespace Utils {
 	std::string FromWideString(const std::wstring& str);
 #endif
 
+	struct ExFontRet {
+		const char* next = nullptr;
+		char value = '\0';
+		bool is_valid = false;
+
+		explicit operator bool() const { return is_valid; }
+	};
+
+	/**
+	 * Determine if the next character is an exfont character (example: $A)
+	 *
+	 * @param iter pointer to next character
+	 * @param end pointer to end of string.
+	 * @return if this is an exfont char, returns a pointer to the next character after.
+	 *         Otherwise, returns iter.
+	 */
+	ExFontRet ExFontNext(const char* iter, const char* end);
+
+	struct TextRet {
+		/* Pointer to next character */
+		const char* next = nullptr;
+		/* Next UTF8 character or exfont ascii character parsed. If no character was parsed, is 0. */
+		uint32_t ch = '\0';
+		/* true if this is an exfont character. */
+		bool is_exfont = false;
+		/* true if this is an escaped character. */
+		bool is_escape = false;
+		/* @return true if a valid character was parsed */
+		explicit operator bool() const { return ch != 0 || is_exfont; }
+	};
+
+	/**
+	 * Parses the next character out of the given text range.
+	 * Assumes UTF8 and supports exfont.
+	 *
+	 * @param iter pointer to beginning of UTF8 string.
+	 * @param end pointer to end of UTF8 string.
+	 * @param escape the escape character for escape sequences. Ignored if set to 0.
+	 * @return TextRet object, @refer TextRet.
+	 */
+	TextRet TextNext(const char* iter, const char* end, char32_t escape);
+
 	/**
 	 * Calculates the modulo of number i ensuring the result is non-negative
 	 * for all values of i when m > 0.

--- a/src/utils.h
+++ b/src/utils.h
@@ -93,8 +93,9 @@ namespace Utils {
 	std::string EncodeUTF(const std::u32string& str);
 
 	struct UtfNextResult {
-		uint32_t ch;
-		const char* iter;
+		const char* next = nullptr;
+		uint32_t ch = 0;
+		explicit operator bool() const { return ch != 0; }
 	};
 
 	/**

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -26,6 +26,7 @@
 #include "game_system.h"
 #include "game_battle.h"
 #include "player.h"
+#include "font.h"
 #include "window_battlestatus.h"
 
 Window_BattleStatus::Window_BattleStatus(int ix, int iy, int iwidth, int iheight, bool enemy) :

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -362,10 +362,10 @@ void Window_Message::UpdateMessage() {
 		const auto start_index = text_index;
 
 		auto res = Utils::UTF8Next(text_index, end);
-		text_index = res.iter;
+		text_index = res.next;
 		auto ch = res.ch;
 
-		if (ch == 0) {
+		if (!res) {
 			continue;
 		}
 
@@ -408,7 +408,7 @@ void Window_Message::UpdateMessage() {
 
 			auto res = Utils::UTF8Next(text_index, end);
 			ch = res.ch;
-			text_index = res.iter;
+			text_index = res.next;
 
 			switch (ch) {
 			case 'c':
@@ -499,7 +499,7 @@ void Window_Message::UpdateMessage() {
 			ch = res.ch;
 
 			if (ch < 128 && std::isalpha(static_cast<char>(ch))) {
-				text_index = res.iter;
+				text_index = res.next;
 
 				// ExFont
 				DrawGlyph(std::string(start_index, text_index), instant_speed);

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <iterator>
 
+#include "compiler.h"
 #include "window_message.h"
 #include "game_actors.h"
 #include "game_map.h"
@@ -34,6 +35,8 @@
 #include "game_battle.h"
 #include "bitmap.h"
 #include "font.h"
+#include "cache.h"
+#include "text.h"
 
 constexpr int message_animation_frames = 8;
 
@@ -329,6 +332,9 @@ void Window_Message::UpdateMessage() {
 		instant_speed_forced = true;
 	}
 
+	auto system = Cache::SystemOrBlack();
+	auto font = Font::Default();
+
 	while (true) {
 		const auto* end = &*text.end();
 
@@ -359,18 +365,16 @@ void Window_Message::UpdateMessage() {
 			break;
 		}
 
-		const auto start_index = text_index;
+		auto tret = Utils::TextNext(text_index, end, Player::escape_char);
+		text_index = tret.next;
 
-		auto res = Utils::UTF8Next(text_index, end);
-		text_index = res.next;
-		auto ch = res.ch;
-
-		if (!res) {
+		if (EP_UNLIKELY(!tret)) {
 			continue;
 		}
 
-		if (ch == '\r') {
-			// Not handled
+		const auto ch = tret.ch;
+		if (tret.is_exfont) {
+			DrawGlyph(*font, *system, ch, instant_speed, true);
 			continue;
 		}
 
@@ -402,14 +406,13 @@ void Window_Message::UpdateMessage() {
 			break;
 		}
 
-		if (ch == Player::escape_char && text_index != end) {
+		if (std::iscntrl(static_cast<unsigned char>(ch))) {
+			// Not handled
+			continue;
+		}
+
+		if (tret.is_escape && ch != Player::escape_char) {
 			// Special message codes
-			const auto prev_index = text_index;
-
-			auto res = Utils::UTF8Next(text_index, end);
-			ch = res.ch;
-			text_index = res.next;
-
 			switch (ch) {
 			case 'c':
 			case 'C':
@@ -479,44 +482,23 @@ void Window_Message::UpdateMessage() {
 					SetWait(61);
 				}
 				break;
-			case '\r':
-			case '\n':
-			case '\f':
-				// \ followed by linebreak, don't skip them
-				text_index = prev_index;
-				break;
 			default:
-				if (ch == Player::escape_char) {
-					DrawGlyph(Player::escape_symbol, instant_speed);
-				}
 				break;
 			}
 			continue;
 		}
 
-		if (ch == '$' && text_index != end) {
-			auto res = Utils::UTF8Next(text_index, end);
-			ch = res.ch;
-
-			if (ch < 128 && std::isalpha(static_cast<char>(ch))) {
-				text_index = res.next;
-
-				// ExFont
-				DrawGlyph(std::string(start_index, text_index), instant_speed);
-				continue;
-			}
-		}
-
-		DrawGlyph(std::string(start_index, text_index), instant_speed);
+		DrawGlyph(*font, *system, ch, instant_speed, false);
 	}
 }
 
-void Window_Message::DrawGlyph(const std::string& glyph, bool instant_speed) {
+void Window_Message::DrawGlyph(Font& font, const Bitmap& system, char32_t glyph, bool instant_speed, bool is_exfont) {
 #ifdef EP_DEBUG_MESSAGE
-	Output::Debug("Msg Draw Glyph %s %d", glyph.c_str(), instant_speed);
+	Output::Debug("Msg Draw Glyph %d %d", glyph, instant_speed);
 #endif
-	contents->TextDraw(contents_x, contents_y, text_color, glyph);
-	int glyph_width = Font::Default()->GetSize(glyph).width;
+	auto rect = Text::Draw(*contents, contents_x, contents_y, font, system, text_color, glyph, is_exfont);
+
+	int glyph_width = rect.width;
 	contents_x += glyph_width;
 	int width = (glyph_width - 1) / 6 + 1;
 	if (!instant_speed && glyph_width > 0) {

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -407,7 +407,7 @@ void Window_Message::UpdateMessage() {
 		}
 
 		if (std::iscntrl(static_cast<unsigned char>(ch))) {
-			// Not handled
+			// control characters not handled
 			continue;
 		}
 

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -160,7 +160,7 @@ protected:
 
 	PendingMessage pending_message;
 
-	void DrawGlyph(const std::string& glyph, bool instant_speed);
+	void DrawGlyph(Font& font, const Bitmap& system, char32_t glyph, bool instant_speed, bool is_exfont);
 	void IncrementLineCharCounter(int width);
 
 	void SetWaitForCharacter(int width);

--- a/tests/font.cpp
+++ b/tests/font.cpp
@@ -1,0 +1,110 @@
+#include "text.h"
+#include "pixel_format.h"
+#include "cache.h"
+#include "bitmap.h"
+#include "font.h"
+#include <iostream>
+#include "doctest.h"
+
+TEST_SUITE_BEGIN("Font");
+
+constexpr char32_t escape = '\\';
+constexpr int width = 240;
+constexpr int height = 80;
+constexpr int ch = 12;
+constexpr int cwh = 6;
+constexpr int cwf = 12;
+
+TEST_CASE("FontSizeStr") {
+	auto font = Font::Default();
+
+	REQUIRE_EQ(font->GetSize(""), Rect(0, 0, 0, ch));
+	REQUIRE_EQ(font->GetSize(" "), Rect(0, 0, cwh, ch));
+	REQUIRE_EQ(font->GetSize("\n"), Rect(0, 0, 0, ch));
+	REQUIRE_EQ(font->GetSize("$A"), Rect(0, 0, cwh * 2, ch));
+	REQUIRE_EQ(font->GetSize("X\nX"), Rect(0, 0, cwh * 2, ch));
+}
+
+TEST_CASE("FontSizeChar") {
+	auto font = Font::Default();
+
+	REQUIRE_EQ(font->GetSize(0), Rect(0, 0, 0, ch));
+	REQUIRE_EQ(font->GetSize(U' '), Rect(0, 0, cwh, ch));
+	REQUIRE_EQ(font->GetSize(U'\n'), Rect(0, 0, 0, ch));
+	REQUIRE_EQ(font->GetSize(U'X'), Rect(0, 0, cwh, ch));
+	REQUIRE_EQ(font->GetSize(U'ぽ'), Rect(0, 0, cwf, ch));
+}
+
+TEST_CASE("FontSizeStrEx") {
+	auto font = Font::exfont;
+
+	for (char i = 0; i < 52; ++i) {
+		REQUIRE_EQ(font->GetSize(std::string(1,i)), Rect(0, 0, cwf, cwf));
+	}
+}
+
+TEST_CASE("FontSizeCharEx") {
+	auto font = Font::exfont;
+
+	for (char32_t i = 0; i < 52; ++i) {
+		REQUIRE_EQ(font->GetSize(i), Rect(0, 0, cwf, cwf));
+	}
+}
+
+TEST_CASE("FontGlyphChar") {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto font = Font::Default();
+	auto check = [&](char32_t ch, Rect r) {
+		auto ret = font->Glyph(ch);
+		REQUIRE(ret.bitmap != nullptr);
+		REQUIRE_EQ(ret.rect, r);
+	};
+
+	check(0, Rect(0, 0, 0, ch));
+	check(U' ', Rect(0, 0, cwh, ch));
+	check(U'\n', Rect(0, 0, 0, ch));
+	check(U'X', Rect(0, 0, cwh, ch));
+	check(U'ぽ', Rect(0, 0, cwf, ch));
+}
+
+TEST_CASE("FontGlyphCharEx") {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto font = Font::exfont;
+
+	for (char32_t i = 0; i < 52; ++i) {
+		auto ret = font->Glyph(i);
+		REQUIRE(ret.bitmap != nullptr);
+		REQUIRE_EQ(ret.rect, Rect(0, 0, cwf, ch));
+	}
+}
+
+TEST_CASE("FontGlyphChar") {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto font = Font::Default();
+	auto system = Cache::SysBlack();
+	auto surface = Bitmap::Create(width, height);
+	int color = 0;
+	auto check = [&](char32_t ch, Rect r) {
+		REQUIRE_EQ(font->Render(*surface, 0, 0, *system, color, ch), r);
+	};
+
+	check(0, Rect(0, 0, 0, ch));
+	check(U' ', Rect(0, 0, cwh, ch));
+	check(U'\n', Rect(0, 0, 0, ch));
+	check(U'X', Rect(0, 0, cwh, ch));
+	check(U'ぽ', Rect(0, 0, cwf, ch));
+}
+
+TEST_CASE("FontGlyphCharEx") {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto font = Font::exfont;
+	auto system = Cache::SysBlack();
+	auto surface = Bitmap::Create(width, height);
+	int color = 0;
+
+	for (char32_t i = 0; i < 52; ++i) {
+		REQUIRE_EQ(font->Render(*surface, 0, 0, *system, color, ch), Rect(0, 0, cwf, ch));
+	}
+}
+
+TEST_SUITE_END();

--- a/tests/text.cpp
+++ b/tests/text.cpp
@@ -1,0 +1,51 @@
+#include "text.h"
+#include "pixel_format.h"
+#include "cache.h"
+#include "bitmap.h"
+#include "font.h"
+#include <iostream>
+#include "doctest.h"
+
+TEST_SUITE_BEGIN("Text");
+
+constexpr char32_t escape = '\\';
+constexpr int width = 240;
+constexpr int height = 80;
+constexpr int ch = 12;
+constexpr int cwh = 6;
+constexpr int cwf = 12;
+
+TEST_CASE("TextDrawSystemStrReturn") {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto font = Font::Default();
+	auto surface = Bitmap::Create(width, height);
+	auto system = Cache::SysBlack();
+
+	auto draw = [&](int x, int y, const auto& text) {
+		return Text::Draw(*surface, x, y, *font, *system, 0, text);
+	};
+
+	REQUIRE_EQ(draw(0, 0, ""), Rect(0, 0, 0, 0));
+	REQUIRE_EQ(draw(0, 0, "abc"), Rect(0, 0, cwh * 3, ch));
+	REQUIRE_EQ(draw(3, 17, "$A"), Rect(3, 17, cwf, ch));
+	REQUIRE_EQ(draw(3, 17, "$A $B"), Rect(3, 17, cwf * 2 + cwh, ch));
+}
+
+TEST_CASE("TextDrawColorStrReturn") {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto font = Font::Default();
+	auto surface = Bitmap::Create(width, height);
+	auto color = Color(255,255,255,255);
+
+	auto draw = [&](int x, int y, const auto& text) {
+		return Text::Draw(*surface, x, y, *font, color, text);
+	};
+
+	REQUIRE_EQ(draw(0, 0, ""), Rect(0, 0, 0, 0));
+	REQUIRE_EQ(draw(0, 0, "abc"), Rect(0, 0, cwh * 3, ch));
+	REQUIRE_EQ(draw(3, 17, "\n"), Rect(3, 17, 0, ch));
+	REQUIRE_EQ(draw(3, 17, "x\nyz"), Rect(3, 17, cwh * 2, ch *2));
+	REQUIRE_EQ(draw(10, 0, "xy\nz"), Rect(10, 0, cwh * 2, ch *2));
+}
+
+TEST_SUITE_END();

--- a/tests/utf.cpp
+++ b/tests/utf.cpp
@@ -79,7 +79,7 @@ TEST_CASE("next") {
 		while (iter < e) {
 			auto ret = Utils::UTF8Next(iter, e);
 			REQUIRE_EQ(ret.ch, ts.u32[i]);
-			iter = ret.iter;
+			iter = ret.next;
 			++i;
 		}
 	}

--- a/tests/utf.cpp
+++ b/tests/utf.cpp
@@ -3,6 +3,7 @@
 #include "utils.h"
 #include "doctest.h"
 
+constexpr char32_t escape = '\\';
 // Correct Tests
 TEST_SUITE_BEGIN("UTF");
 
@@ -83,6 +84,98 @@ TEST_CASE("next") {
 			++i;
 		}
 	}
+}
+
+TEST_CASE("TextNext") {
+	std::string text = u8"H $A$B\\\\\\^\\n\nぽ";
+	const auto* iter = &*text.begin();
+	const auto* end = &*text.end();
+
+	Utils::TextRet ret;
+	ret = Utils::TextNext(iter, end, escape);
+	REQUIRE_EQ(ret.ch, 'H');
+	REQUIRE_NE(ret.next, end);
+	REQUIRE_FALSE(ret.is_exfont);
+	REQUIRE_FALSE(ret.is_escape);
+	iter = ret.next;
+
+	ret = Utils::TextNext(iter, end, escape);
+	REQUIRE_EQ(ret.ch, ' ');
+	REQUIRE_NE(ret.next, end);
+	REQUIRE_FALSE(ret.is_exfont);
+	REQUIRE_FALSE(ret.is_escape);
+	iter = ret.next;
+
+	ret = Utils::TextNext(iter, end, escape);
+	REQUIRE_EQ(ret.ch, 0);
+	REQUIRE_NE(ret.next, end);
+	REQUIRE(ret.is_exfont);
+	REQUIRE_FALSE(ret.is_escape);
+	iter = ret.next;
+
+	ret = Utils::TextNext(iter, end, escape);
+	REQUIRE_EQ(ret.ch, 1);
+	REQUIRE_NE(ret.next, end);
+	REQUIRE(ret.is_exfont);
+	REQUIRE_FALSE(ret.is_escape);
+	iter = ret.next;
+
+	ret = Utils::TextNext(iter, end, escape);
+	REQUIRE_EQ(ret.ch, '\\');
+	REQUIRE_NE(ret.next, end);
+	REQUIRE_FALSE(ret.is_exfont);
+	REQUIRE(ret.is_escape);
+	iter = ret.next;
+
+	ret = Utils::TextNext(iter, end, escape);
+	REQUIRE_EQ(ret.ch, '^');
+	REQUIRE_NE(ret.next, end);
+	REQUIRE_FALSE(ret.is_exfont);
+	REQUIRE(ret.is_escape);
+	iter = ret.next;
+
+	ret = Utils::TextNext(iter, end, escape);
+	REQUIRE_EQ(ret.ch, 'n');
+	REQUIRE_NE(ret.next, end);
+	REQUIRE_FALSE(ret.is_exfont);
+	REQUIRE(ret.is_escape);
+	iter = ret.next;
+
+	ret = Utils::TextNext(iter, end, escape);
+	REQUIRE_EQ(ret.ch, '\n');
+	REQUIRE_NE(ret.next, end);
+	REQUIRE_FALSE(ret.is_exfont);
+	REQUIRE_FALSE(ret.is_escape);
+	iter = ret.next;
+
+	ret = Utils::TextNext(iter, end, escape);
+	REQUIRE_EQ(ret.ch, U'ぽ');
+	REQUIRE_EQ(ret.next, end);
+	REQUIRE_FALSE(ret.is_exfont);
+	REQUIRE_FALSE(ret.is_escape);
+	iter = ret.next;
+}
+
+TEST_CASE("TextNextNoEscape") {
+	std::string text = u8"\\$";
+	const auto* iter = &*text.begin();
+	const auto* end = &*text.end();
+
+	Utils::TextRet ret;
+
+	ret = Utils::TextNext(iter, end, 0);
+	REQUIRE_EQ(ret.ch, '\\');
+	REQUIRE_NE(ret.next, end);
+	REQUIRE_FALSE(ret.is_exfont);
+	REQUIRE_FALSE(ret.is_escape);
+	iter = ret.next;
+
+	ret = Utils::TextNext(iter, end, 0);
+	REQUIRE_EQ(ret.ch, '$');
+	REQUIRE_EQ(ret.next, end);
+	REQUIRE_FALSE(ret.is_exfont);
+	REQUIRE_FALSE(ret.is_escape);
+	iter = ret.next;
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
~~Depend on: #1956~~

This PR refactors the underlying `Font` and `Text` interfaces to be more streamlined and efficient.

Current Test Results
--------------------------

After "Font::Render - remove query for system"

Font:
```
------------------------------------------------------
Benchmark               Time           CPU Iterations
------------------------------------------------------
BM_FontSizeStr        637 ns        637 ns    1107660
BM_Glyph              171 ns        171 ns    4005735
BM_Render            2481 ns       2480 ns     282438
```
Text:
```
---------------------------------------------------------
Benchmark                  Time           CPU Iterations
---------------------------------------------------------
BM_TextDrawStr         94971 ns      94971 ns       7365
BM_TextDrawStrRaw      42719 ns      42718 ns      16451
```

HEAD of PR:

Font:
```
-------------------------------------------------------
Benchmark                Time           CPU Iterations
-------------------------------------------------------
BM_FontSizeStr         636 ns        632 ns    1116692
BM_FontSizeChar         21 ns         21 ns   34673138
BM_Glyph                67 ns         67 ns   10619258
BM_Render             2182 ns       2182 ns     320334
```
Text:
```
---------------------------------------------------------------
Benchmark                        Time           CPU Iterations
---------------------------------------------------------------
BM_TextDrawStrSystem         86675 ns      86676 ns       7963
BM_TextDrawStrColor          41405 ns      41405 ns      17102
BM_TextDrawCharSystem         2210 ns       2211 ns     316856
BM_TextDrawCharSystemEx       3046 ns       3046 ns     230286
BM_TextDrawCharColor           965 ns        965 ns     733548
BM_TextDrawCharColorEx        1971 ns       1971 ns     355208
```

