### PR TITLE
Refactor Time and Sleep - MainLoop 2 of N

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,8 @@ add_library(${PROJECT_NAME}
 	src/game_battler.h
 	src/game_character.cpp
 	src/game_character.h
+	src/game_clock.cpp
+	src/game_clock.h
 	src/game_commonevent.cpp
 	src/game_commonevent.h
 	src/game_enemy.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -103,6 +103,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/game_battler.h \
 	src/game_character.cpp \
 	src/game_character.h \
+	src/game_clock.cpp \
+	src/game_clock.h \
 	src/game_commonevent.cpp \
 	src/game_commonevent.h \
 	src/game_enemy.cpp \

--- a/src/3ds_ui.cpp
+++ b/src/3ds_ui.cpp
@@ -147,11 +147,6 @@ CtrUi::~CtrUi() {
 	}
 }
 
-void CtrUi::Sleep(uint32_t time) {
-	u64 nsecs = time * 1000000;
-	svcSleepThread(nsecs);
-}
-
 static inline double u64_to_double(u64 value) {
 	return (((double)(u32)(value >> 32)) * 0x100000000ULL + (u32)value);
 }

--- a/src/3ds_ui.cpp
+++ b/src/3ds_ui.cpp
@@ -147,10 +147,6 @@ CtrUi::~CtrUi() {
 	}
 }
 
-static inline double u64_to_double(u64 value) {
-	return (((double)(u32)(value >> 32)) * 0x100000000ULL + (u32)value);
-}
-
 void CtrUi::BeginDisplayModeChange() {
 	// no-op
 }

--- a/src/3ds_ui.cpp
+++ b/src/3ds_ui.cpp
@@ -156,11 +156,6 @@ static inline double u64_to_double(u64 value) {
 	return (((double)(u32)(value >> 32)) * 0x100000000ULL + (u32)value);
 }
 
-uint32_t CtrUi::GetTicks() const {
-	double ticks = u64_to_double(svcGetSystemTick());
-	u64 usecs = (u64)(ticks / ticks_per_msec);
-	return usecs;
-}
 void CtrUi::BeginDisplayModeChange() {
 	// no-op
 }

--- a/src/3ds_ui.h
+++ b/src/3ds_ui.h
@@ -66,8 +66,6 @@ public:
 
 	bool IsFullscreen();
 
-	void Sleep(uint32_t time_milli);
-
 #ifdef SUPPORT_AUDIO
 	AudioInterface& GetAudio();
 #endif

--- a/src/3ds_ui.h
+++ b/src/3ds_ui.h
@@ -66,7 +66,6 @@ public:
 
 	bool IsFullscreen();
 
-	uint32_t GetTicks() const;
 	void Sleep(uint32_t time_milli);
 
 #ifdef SUPPORT_AUDIO

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -40,7 +40,7 @@ void EmptyAudio::BGM_Stop() {
 	playing = false;
 }
 
-unsigned EmptyAudio::BGM_GetTicks() const {
+int EmptyAudio::BGM_GetTicks() const {
 	if (!playing) {
 		return 0;
 	}

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -20,7 +20,7 @@
 #include "system.h"
 #include "baseui.h"
 #include "player.h"
-#include "graphics.h"
+#include "game_clock.h"
 
 AudioInterface& Audio() {
 	static EmptyAudio default_;
@@ -46,10 +46,10 @@ unsigned EmptyAudio::BGM_GetTicks() const {
 	}
 
 	// Time since BGM_Play was called, works for everything except MIDI
-	return (Player::GetFrames() - bgm_starttick + 1) / Graphics::GetDefaultFps();
+	return (Player::GetFrames() - bgm_starttick + 1) / Game_Clock::GetSimulationFps();
 }
 
 bool EmptyAudio::BGM_PlayedOnce() const {
 	// 5 seconds, arbitrary
-	return BGM_GetTicks() > (Graphics::GetDefaultFps() * 5);
+	return BGM_GetTicks() > (Game_Clock::GetSimulationFps() * 5);
 }

--- a/src/audio.h
+++ b/src/audio.h
@@ -63,7 +63,7 @@ struct AudioInterface {
 	 * Returns the current MIDI tick of the background music.
 	 * Only useful when the BGM is a MIDI track.
 	 */
-	virtual unsigned BGM_GetTicks() const = 0;
+	virtual int BGM_GetTicks() const = 0;
 
 	/**
 	 * Does a fade out of the background music.
@@ -119,7 +119,7 @@ public:
 	void BGM_Stop() override;
 	bool BGM_PlayedOnce() const override;
 	bool BGM_IsPlaying() const override { return false; }
-	unsigned BGM_GetTicks() const override;
+	int BGM_GetTicks() const override;
 	void BGM_Fade(int) override {}
 	void BGM_Volume(int) override {}
 	void BGM_Pitch(int) override {};

--- a/src/audio_3ds.cpp
+++ b/src/audio_3ds.cpp
@@ -110,7 +110,7 @@ void CtrAudio::BGM_Resume()  {
 	if (!dsp_inited)
 		return;
 
-	bgm_starttick = Game_Clock::GetTicks();
+	bgm_starttick = Game_Clock::now();
 	ndspChnSetPaused(bgm_channel, false);
 }
 
@@ -147,7 +147,7 @@ unsigned CtrAudio::BGM_GetTicks() const {
 
 void CtrAudio::BGM_Fade(int fade) {
 	if (bgm_decoder) {
-		bgm_starttick = Game_Clock::GetTicks();
+		bgm_starttick = Game_Clock::now();
 		bgm_decoder->SetFade(bgm_decoder->GetVolume(),0,fade);
 	}
 }
@@ -233,8 +233,9 @@ void CtrAudio::SE_Stop() {
 
 void CtrAudio::Update() {
 	if (bgm_decoder) {
-		int t = Game_Clock::GetTicks();
-		bgm_decoder->Update(t - bgm_starttick);
+		auto t = Game_Clock::now();
+		auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t - bgm_starttick);
+		bgm_decoder->Update(ms.count());
 		bgm_starttick = t;
 	}
 }

--- a/src/audio_3ds.cpp
+++ b/src/audio_3ds.cpp
@@ -21,7 +21,7 @@
 
 #include "audio_3ds.h"
 #include "filefinder.h"
-#include "baseui.h"
+#include "game_clock.h"
 #include "output.h"
 #include "audio_secache.h"
 
@@ -110,7 +110,7 @@ void CtrAudio::BGM_Resume()  {
 	if (!dsp_inited)
 		return;
 
-	bgm_starttick = DisplayUi->GetTicks();
+	bgm_starttick = Game_Clock::GetTicks();
 	ndspChnSetPaused(bgm_channel, false);
 }
 
@@ -147,7 +147,7 @@ unsigned CtrAudio::BGM_GetTicks() const {
 
 void CtrAudio::BGM_Fade(int fade) {
 	if (bgm_decoder) {
-		bgm_starttick = DisplayUi->GetTicks();
+		bgm_starttick = Game_Clock::GetTicks();
 		bgm_decoder->SetFade(bgm_decoder->GetVolume(),0,fade);
 	}
 }
@@ -233,7 +233,7 @@ void CtrAudio::SE_Stop() {
 
 void CtrAudio::Update() {
 	if (bgm_decoder) {
-		int t = DisplayUi->GetTicks();
+		int t = Game_Clock::GetTicks();
 		bgm_decoder->Update(t - bgm_starttick);
 		bgm_starttick = t;
 	}

--- a/src/audio_3ds.cpp
+++ b/src/audio_3ds.cpp
@@ -137,7 +137,7 @@ bool CtrAudio::BGM_IsPlaying() const {
 	return res;
 }
 
-unsigned CtrAudio::BGM_GetTicks() const {
+int CtrAudio::BGM_GetTicks() const {
 	if (bgm_decoder) {
 		return bgm_decoder->GetTicks();
 	}

--- a/src/audio_3ds.h
+++ b/src/audio_3ds.h
@@ -26,6 +26,7 @@
 #include <memory>
 
 #include "audio_decoder.h"
+#include "game_clock.h"
 
 class CtrAudio : public AudioInterface {
 public:
@@ -59,7 +60,7 @@ private:
 	mutable LightLock audio_mutex;
 
 	ndspWaveBuf se_buf[23];
-	unsigned bgm_starttick = 0;
+	Game_Clock::time_point bgm_starttick;
 	uint32_t* bgm_audio_buffer;
 }; // class CtrAudio
 

--- a/src/audio_3ds.h
+++ b/src/audio_3ds.h
@@ -39,7 +39,7 @@ public:
 	void BGM_Stop() override;
 	bool BGM_PlayedOnce() const override;
 	bool BGM_IsPlaying() const override;
-	unsigned BGM_GetTicks() const override;
+	int BGM_GetTicks() const override;
 	void BGM_Fade(int fade) override;
 	void BGM_Volume(int volume) override;
 	void BGM_Pitch(int pitch) override;

--- a/src/audio_al.cpp
+++ b/src/audio_al.cpp
@@ -539,7 +539,7 @@ bool ALAudio::BGM_IsPlaying() const {
 	return (state == AL_PLAYING);
 }
 
-unsigned ALAudio::BGM_GetTicks() const {
+int ALAudio::BGM_GetTicks() const {
 	SET_CONTEXT(ctx_);
 	return bgm_src_->midi_ticks();
 }

--- a/src/audio_al.h
+++ b/src/audio_al.h
@@ -42,7 +42,7 @@ struct ALAudio : public AudioInterface {
 	void BGM_Stop() override;
 	bool BGM_PlayedOnce() const override;
 	bool BGM_IsPlaying() const override;
-	unsigned BGM_GetTicks() const override;
+	int BGM_GetTicks() const override;
 	void BGM_Fade(int) override;
 	void BGM_Volume(int) override;
 	void BGM_Pitch(int) override;

--- a/src/audio_generic.cpp
+++ b/src/audio_generic.cpp
@@ -107,7 +107,7 @@ bool GenericAudio::BGM_IsPlaying() const {
 	return false;
 }
 
-unsigned GenericAudio::BGM_GetTicks() const {
+int GenericAudio::BGM_GetTicks() const {
 	unsigned ticks = 0;
 	LockMutex();
 	for (unsigned i = 0; i < nr_of_bgm_channels; i++) {

--- a/src/audio_generic.h
+++ b/src/audio_generic.h
@@ -47,7 +47,7 @@ public:
 	void BGM_Stop() override;
 	bool BGM_PlayedOnce() const override;
 	bool BGM_IsPlaying() const override;
-	unsigned BGM_GetTicks() const override;
+	int BGM_GetTicks() const override;
 	void BGM_Fade(int fade) override;
 	void BGM_Volume(int volume) override;
 	void BGM_Pitch(int pitch) override;

--- a/src/audio_libretro.cpp
+++ b/src/audio_libretro.cpp
@@ -18,7 +18,7 @@
 #if defined(USE_LIBRETRO) && defined(SUPPORT_AUDIO)
 #include "audio_libretro.h"
 #include "output.h"
-#include "graphics.h"
+#include "game_clock.h"
 
 #include <vector>
 #include <cstdlib>
@@ -64,7 +64,7 @@ LibretroAudio::LibretroAudio() :
 
 	SetFormat(AUDIO_SAMPLERATE, AudioDecoder::Format::S16, 2);
 
-	samples_per_frame = AUDIO_SAMPLERATE / Graphics::GetDefaultFps();
+	samples_per_frame = AUDIO_SAMPLERATE / Game_Clock::GetSimulationFps();
 }
 
 LibretroAudio::~LibretroAudio() {

--- a/src/audio_sdl_mixer.cpp
+++ b/src/audio_sdl_mixer.cpp
@@ -462,7 +462,7 @@ bool SdlMixerAudio::BGM_IsPlaying() const {
 	return audio_decoder || !bgm_stop || !bgs_stop;
 }
 
-unsigned SdlMixerAudio::BGM_GetTicks() const {
+int SdlMixerAudio::BGM_GetTicks() const {
 	if (!BGM_IsPlaying()) {
 		return 0;
 	}

--- a/src/audio_sdl_mixer.cpp
+++ b/src/audio_sdl_mixer.cpp
@@ -27,6 +27,7 @@
 #include "baseui.h"
 #include "filefinder.h"
 #include "output.h"
+#include "game_clock.h"
 
 #ifdef EMSCRIPTEN
 #  include <emscripten.h>
@@ -42,12 +43,14 @@
 
 namespace {
 	void bgm_played_once() {
+		// FIXME: Can we break this reference to DisplayUi?
 		if (DisplayUi)
 			static_cast<SdlMixerAudio&>(Audio()).BGM_OnPlayedOnce();
 	}
 
 #if SDL_MAJOR_VERSION>1
 	void bgs_played_once(int channel) {
+		// FIXME: Can we break this reference to DisplayUi?
 		if (DisplayUi && channel == BGS_CHANNEL_NUM)
 			bgm_played_once();
 	}
@@ -316,7 +319,7 @@ void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int
 		return;
 	}
 
-	bgm_starttick = SDL_GetTicks();
+	bgm_starttick = Game_Clock::GetTicks();
 
 #if SDL_MAJOR_VERSION>1
 	Mix_MusicType mtype = Mix_GetMusicType(bgm.get());
@@ -363,7 +366,7 @@ void SdlMixerAudio::SetupAudioDecoder(FILE* handle, const std::string& file, int
 #endif
 
 	audio_decoder->SetLooping(true);
-	bgm_starttick = SDL_GetTicks();
+	bgm_starttick = Game_Clock::GetTicks();
 
 	int audio_rate;
 	Uint16 sdl_format;
@@ -415,7 +418,7 @@ void SdlMixerAudio::BGM_Pause() {
 
 void SdlMixerAudio::BGM_Resume() {
 	if (audio_decoder) {
-		bgm_starttick = SDL_GetTicks();
+		bgm_starttick = Game_Clock::GetTicks();
 		audio_decoder->Resume();
 		return;
 	}
@@ -467,7 +470,7 @@ unsigned SdlMixerAudio::BGM_GetTicks() const {
 	}
 
 	// Should work for everything except MIDI
-	return SDL_GetTicks() + 1 - bgm_starttick;
+	return Game_Clock::GetTicks() + 1 - bgm_starttick;
 }
 
 void SdlMixerAudio::BGM_Volume(int volume) {
@@ -498,7 +501,7 @@ void SdlMixerAudio::BGM_Pitch(int pitch) {
 
 void SdlMixerAudio::BGM_Fade(int fade) {
 	if (audio_decoder) {
-		bgm_starttick = DisplayUi->GetTicks();
+		bgm_starttick = Game_Clock::GetTicks();
 		audio_decoder->SetFade(audio_decoder->GetVolume(), 0, fade);
 		return;
 	}
@@ -632,7 +635,7 @@ void SdlMixerAudio::SE_Stop() {
 
 void SdlMixerAudio::Update() {
 	if (audio_decoder && bgm_starttick > 0) {
-		int t = DisplayUi->GetTicks();
+		int t = Game_Clock::GetTicks();
 		audio_decoder->Update(t - bgm_starttick);
 		bgm_starttick = t;
 	}

--- a/src/audio_sdl_mixer.h
+++ b/src/audio_sdl_mixer.h
@@ -24,6 +24,7 @@
 #include "audio.h"
 #include "audio_decoder.h"
 #include "audio_secache.h"
+#include "game_clock.h"
 
 #include <map>
 
@@ -64,7 +65,7 @@ private:
 
 	std::shared_ptr<Mix_Music> bgm;
 	int bgm_volume;
-	unsigned bgm_starttick = 0;
+	Game_Clock::time_point bgm_starttick;
 	bool bgm_stop = true;
 	std::shared_ptr<Mix_Chunk> bgs;
 	bool bgs_playing = false;

--- a/src/audio_sdl_mixer.h
+++ b/src/audio_sdl_mixer.h
@@ -42,7 +42,7 @@ public:
 	void BGM_Stop() override;
 	bool BGM_PlayedOnce() const override;
 	bool BGM_IsPlaying() const override;
-	unsigned BGM_GetTicks() const override;
+	int BGM_GetTicks() const override;
 	void BGM_Fade(int) override;
 	void BGM_Volume(int) override;
 	void BGM_Pitch(int) override;

--- a/src/audio_secache.cpp
+++ b/src/audio_secache.cpp
@@ -26,6 +26,8 @@
 #include "filefinder.h"
 #include "output.h"
 
+using namespace std::chrono_literals;
+
 namespace {
 	typedef std::map<std::string, AudioSeRef> cache_type;
 
@@ -35,7 +37,7 @@ namespace {
 	int cache_size = 0;
 
 	void FreeCacheMemory() {
-		int32_t cur_ticks = Game_Clock::GetTicks();
+		auto cur_time = Game_Clock::now();
 
 		for (auto it = cache.begin(); it != cache.end(); ) {
 			if (it->second.use_count() > 1) {
@@ -44,7 +46,7 @@ namespace {
 				continue;
 			}
 
-			if (cache_size <= cache_limit && cur_ticks - it->second->last_access < 3000) {
+			if (cache_size <= cache_limit && cur_time - it->second->last_access < 3s) {
 				// Below memory limit and last access < 3s
 				++it;
 				continue;
@@ -227,7 +229,7 @@ AudioSeRef AudioSeCache::Decode() {
 
 	if (IsCached()) {
 		se = cache.find(filename)->second;
-		se->last_access = Game_Clock::GetTicks();
+		se->last_access = Game_Clock::now();
 
 		if (GetPitch() == 100) {
 			// Nothing extra to do
@@ -293,7 +295,7 @@ AudioSeRef AudioSeCache::Decode() {
 		// This codepath is only taken the first time upon cache miss
 		cache.insert(std::make_pair(filename, se));
 
-		se->last_access = Game_Clock::GetTicks();
+		se->last_access = Game_Clock::now();
 
 		cache_size += se->buffer.size();
 

--- a/src/audio_secache.cpp
+++ b/src/audio_secache.cpp
@@ -22,7 +22,7 @@
 #include <set>
 #include "audio_resampler.h"
 #include "audio_secache.h"
-#include "baseui.h"
+#include "game_clock.h"
 #include "filefinder.h"
 #include "output.h"
 
@@ -35,7 +35,7 @@ namespace {
 	int cache_size = 0;
 
 	void FreeCacheMemory() {
-		int32_t cur_ticks = DisplayUi->GetTicks();
+		int32_t cur_ticks = Game_Clock::GetTicks();
 
 		for (auto it = cache.begin(); it != cache.end(); ) {
 			if (it->second.use_count() > 1) {
@@ -227,7 +227,7 @@ AudioSeRef AudioSeCache::Decode() {
 
 	if (IsCached()) {
 		se = cache.find(filename)->second;
-		se->last_access = DisplayUi->GetTicks();
+		se->last_access = Game_Clock::GetTicks();
 
 		if (GetPitch() == 100) {
 			// Nothing extra to do
@@ -293,7 +293,7 @@ AudioSeRef AudioSeCache::Decode() {
 		// This codepath is only taken the first time upon cache miss
 		cache.insert(std::make_pair(filename, se));
 
-		se->last_access = DisplayUi->GetTicks();
+		se->last_access = Game_Clock::GetTicks();
 
 		cache_size += se->buffer.size();
 

--- a/src/audio_secache.h
+++ b/src/audio_secache.h
@@ -26,6 +26,7 @@
 #include <map>
 
 #include "audio_decoder.h"
+#include "game_clock.h"
 
 /**
  * AudioSeData is the decoded sample of AudioSeCache.
@@ -34,10 +35,10 @@
 class AudioSeData {
 public:
 	std::vector<uint8_t> buffer;
+	Game_Clock::time_point last_access;
 	int frequency;
 	AudioDecoder::Format format;
 	int channels;
-	int last_access;
 };
 
 typedef std::shared_ptr<AudioSeData> AudioSeRef;

--- a/src/baseui.h
+++ b/src/baseui.h
@@ -125,13 +125,6 @@ public:
 	virtual bool IsFullscreen() = 0;
 
 	/**
-	 * Gets ticks in ms for time measurement.
-	 *
-	 * @return time in ms.
-	 */
-	virtual uint32_t GetTicks() const = 0;
-
-	/**
 	 * Sleeps some time.
 	 *
 	 * @param time_milli ms to sleep.

--- a/src/baseui.h
+++ b/src/baseui.h
@@ -124,13 +124,6 @@ public:
 	 */
 	virtual bool IsFullscreen() = 0;
 
-	/**
-	 * Sleeps some time.
-	 *
-	 * @param time_milli ms to sleep.
-	 */
-	virtual void Sleep(uint32_t time_milli) = 0;
-
 #ifdef SUPPORT_AUDIO
 	/**
 	 * Returns audio instance.

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -34,6 +34,7 @@
 #include "output.h"
 #include "player.h"
 #include "data.h"
+#include "game_clock.h"
 
 using namespace std::chrono_literals;
 
@@ -67,11 +68,10 @@ namespace {
 		}
 		return key.data() + offset;
 	}
-	using clock = std::chrono::steady_clock;
 
 	struct CacheItem {
 		BitmapRef bitmap;
-		clock::time_point last_access;
+		Game_Clock::time_point last_access;
 	};
 
 	using key_type = std::string;
@@ -92,7 +92,7 @@ namespace {
 	size_t cache_size = 0;
 
 	void FreeBitmapMemory() {
-		auto cur_ticks = clock::now();
+		auto cur_ticks = Game_Clock::now();
 
 		for (auto& i : cache) {
 			if (i.second.bitmap.use_count() != 1) {
@@ -127,7 +127,7 @@ namespace {
 #endif
 		}
 
-		return (cache[key] = {bmp, clock::now()}).bitmap;
+		return (cache[key] = {bmp, Game_Clock::now()}).bitmap;
 	}
 
 	BitmapRef LoadBitmap(const std::string& folder_name, const std::string& filename,
@@ -154,7 +154,7 @@ namespace {
 
 			return AddToCache(key, bmp);
 		} else {
-			it->second.last_access = clock::now();
+			it->second.last_access = Game_Clock::now();
 			return it->second.bitmap;
 		}
 	}
@@ -260,7 +260,7 @@ namespace {
 
 			return AddToCache(key, bitmap);
 		} else {
-			it->second.last_access = clock::now();
+			it->second.last_access = Game_Clock::now();
 			return it->second.bitmap;
 		}
 	}
@@ -411,7 +411,7 @@ BitmapRef Cache::Exfont() {
 
 		return AddToCache(key, exfont_img);
 	} else {
-		it->second.last_access = clock::now();
+		it->second.last_access = Game_Clock::now();
 		return it->second.bitmap;
 	}
 }

--- a/src/game_clock.cpp
+++ b/src/game_clock.cpp
@@ -18,8 +18,4 @@
 #include "game_clock.h"
 
 constexpr bool Game_Clock::is_steady;
-Game_Clock::time_point Game_Clock::init_ticks;
 
-void Game_Clock::InitTicks() {
-	init_ticks = now();
-}

--- a/src/game_clock.cpp
+++ b/src/game_clock.cpp
@@ -19,23 +19,18 @@
 
 #include <thread>
 
-// FIXME: For platform specific sleep functions. Can we remove these?
 #if defined(PSP2)
 #include <psp2/kernel/threadmgr.h>
 #elif defined(_3DS)
 #include <3ds/svc.h>
-#elif defined(__SWITCH__)
-#include <switch/kernel/svc.h>
 #endif
 
 constexpr bool Game_Clock::is_steady;
 
 void Game_Clock::SleepFor(std::chrono::nanoseconds ns) {
-#if defined(_3DS) || defined(__SWITCH__)
-	// FIXME: Can we use std::this_thread::sleep_for() for 3ds and switch?
+#if defined(_3DS)
 	svcSleepThread(ns.count());
 #elif defined(PSP2)
-	// FIXME: Can we use std::this_thread::sleep_for() for psp?
 	auto us = std::chrono::duration_cast<std::chrono::microseconds>(ns);
 	sceKernelDelayThread(us.count());
 #else

--- a/src/game_clock.cpp
+++ b/src/game_clock.cpp
@@ -1,0 +1,25 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "game_clock.h"
+
+constexpr bool Game_Clock::is_steady;
+Game_Clock::time_point Game_Clock::init_ticks;
+
+void Game_Clock::InitTicks() {
+	init_ticks = now();
+}

--- a/src/game_clock.cpp
+++ b/src/game_clock.cpp
@@ -17,5 +17,28 @@
 
 #include "game_clock.h"
 
+#include <thread>
+
+// FIXME: For platform specific sleep functions. Can we remove these?
+#if defined(PSP2)
+#include <psp2/kernel/threadmgr.h>
+#elif defined(_3DS)
+#include <3ds/svc.h>
+#elif defined(__SWITCH__)
+#include <switch/kernel/svc.h>
+#endif
+
 constexpr bool Game_Clock::is_steady;
 
+void Game_Clock::SleepFor(std::chrono::nanoseconds ns) {
+#if defined(_3DS) || defined(__SWITCH__)
+	// FIXME: Can we use std::this_thread::sleep_for() for 3ds and switch?
+	svcSleepThread(ns.count());
+#elif defined(PSP2)
+	// FIXME: Can we use std::this_thread::sleep_for() for psp?
+	auto us = std::chrono::duration_cast<std::chrono::microseconds>(ns);
+	sceKernelDelayThread(us.count());
+#else
+	std::this_thread::sleep_for(ns);
+#endif
+}

--- a/src/game_clock.h
+++ b/src/game_clock.h
@@ -42,6 +42,9 @@ public:
 	/** Get current time */
 	static time_point now();
 
+	/** Sleep for the specified duration */
+	static void SleepFor(std::chrono::nanoseconds ns);
+
 	/** Get the target frames per second for the game simulation */
 	static constexpr int GetSimulationFps();
 

--- a/src/game_clock.h
+++ b/src/game_clock.h
@@ -50,23 +50,10 @@ public:
 
 	/** Get the timestep for a given frames per second value */
 	static constexpr duration TimeStepFromFps(int fps);
-
-	// FIXME: Remove this and use now() everywhere.
-	static uint32_t GetTicks();
-	// FIXME: Remove this and use now() everywhere.
-	static void InitTicks();
-private:
-	static time_point init_ticks;
 };
 
 inline Game_Clock::time_point Game_Clock::now() {
 	return clock::now();
-}
-
-inline uint32_t Game_Clock::GetTicks() {
-	auto d = now() - init_ticks;
-	auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(d);
-	return ms.count();
 }
 
 constexpr int Game_Clock::GetSimulationFps() {

--- a/src/game_clock.h
+++ b/src/game_clock.h
@@ -18,6 +18,7 @@
 #ifndef EP_GAME_CLOCK_H
 #define EP_GAME_CLOCK_H
 
+#include "options.h"
 #include <chrono>
 #include <type_traits>
 
@@ -41,6 +42,15 @@ public:
 	/** Get current time */
 	static time_point now();
 
+	/** Get the target frames per second for the game simulation */
+	static constexpr int GetSimulationFps();
+
+	/** Get the amount of time each logical frame should take */
+	static constexpr duration GetSimulationTimeStep();
+
+	/** Get the timestep for a given frames per second value */
+	static constexpr duration TimeStepFromFps(int fps);
+
 	// FIXME: Remove this and use now() everywhere.
 	static uint32_t GetTicks();
 	// FIXME: Remove this and use now() everywhere.
@@ -48,7 +58,6 @@ public:
 private:
 	static time_point init_ticks;
 };
-
 
 inline Game_Clock::time_point Game_Clock::now() {
 	return clock::now();
@@ -58,6 +67,20 @@ inline uint32_t Game_Clock::GetTicks() {
 	auto d = now() - init_ticks;
 	auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(d);
 	return ms.count();
+}
+
+constexpr int Game_Clock::GetSimulationFps() {
+	return DEFAULT_FPS;
+}
+
+/** Get the amount of time each logical frame should take */
+constexpr Game_Clock::duration Game_Clock::GetSimulationTimeStep() {
+	return TimeStepFromFps(GetSimulationFps());
+}
+
+constexpr Game_Clock::duration Game_Clock::TimeStepFromFps(int fps) {
+	auto ns = std::chrono::nanoseconds(std::chrono::seconds(1)) / fps;
+	return std::chrono::duration_cast<Game_Clock::duration>(ns);
 }
 
 #endif

--- a/src/game_clock.h
+++ b/src/game_clock.h
@@ -63,7 +63,6 @@ constexpr int Game_Clock::GetSimulationFps() {
 	return DEFAULT_FPS;
 }
 
-/** Get the amount of time each logical frame should take */
 constexpr Game_Clock::duration Game_Clock::GetSimulationTimeStep() {
 	return TimeStepFromFps(GetSimulationFps());
 }

--- a/src/game_clock.h
+++ b/src/game_clock.h
@@ -1,0 +1,63 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_GAME_CLOCK_H
+#define EP_GAME_CLOCK_H
+
+#include <chrono>
+#include <type_traits>
+
+/**
+ * Used for time keeping in Player
+ */
+class Game_Clock {
+public:
+	using clock = std::conditional_t<
+		std::chrono::high_resolution_clock::is_steady,
+		std::chrono::high_resolution_clock,
+		std::chrono::steady_clock>;
+
+	using rep = clock::rep;
+	using period = clock::period;
+	using duration = clock::duration;
+	using time_point = clock::time_point;
+
+	static constexpr bool is_steady = clock::is_steady;
+
+	/** Get current time */
+	static time_point now();
+
+	// FIXME: Remove this and use now() everywhere.
+	static uint32_t GetTicks();
+	// FIXME: Remove this and use now() everywhere.
+	static void InitTicks();
+private:
+	static time_point init_ticks;
+};
+
+
+inline Game_Clock::time_point Game_Clock::now() {
+	return clock::now();
+}
+
+inline uint32_t Game_Clock::GetTicks() {
+	auto d = now() - init_ticks;
+	auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(d);
+	return ms.count();
+}
+
+#endif

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -41,7 +41,7 @@
 #include "scene_gameover.h"
 #include "scene_map.h"
 #include "scene.h"
-#include "graphics.h"
+#include "game_clock.h"
 #include "input.h"
 #include "main_data.h"
 #include "output.h"
@@ -363,7 +363,7 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 			if (_keyinput.timed) {
 				// 10 per second
 				Main_Data::game_variables->Set(_keyinput.time_variable,
-						(_keyinput.wait_frames * 10) / Graphics::GetDefaultFps());
+						(_keyinput.wait_frames * 10) / Game_Clock::GetSimulationFps());
 			}
 			_keyinput.wait = false;
 		}

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -30,6 +30,7 @@
 #include "drawable.h"
 #include "drawable_mgr.h"
 #include "baseui.h"
+#include "game_clock.h"
 
 namespace Graphics {
 	void UpdateTitle();
@@ -72,12 +73,12 @@ void Graphics::Quit() {
 void Graphics::Update() {
 	//FPS:
 	if (next_fps_time == 0) {
-		next_fps_time = DisplayUi->GetTicks() + 1000;
+		next_fps_time = Game_Clock::GetTicks() + 1000;
 	}
 
 	BitmapRef disp = DisplayUi->GetDisplaySurface();
 
-	uint32_t current_time = DisplayUi->GetTicks();
+	uint32_t current_time = Game_Clock::GetTicks();
 	if (current_time >= next_fps_time) {
 		next_fps_time += 1000;
 

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -66,13 +66,6 @@ namespace Graphics {
 	void UpdateSceneCallback();
 
 	/**
-	 * Gets target frame rate.
-	 *
-	 * @return target frame rate
-	 */
-	constexpr int GetDefaultFps() { return DEFAULT_FPS; }
-
-	/**
 	 * Returns a handle to the message overlay.
 	 * Only used by Output to put messages.
 	 *

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -23,6 +23,7 @@
 #include "bitmap.h"
 #include "drawable.h"
 #include "drawable_list.h"
+#include "game_clock.h"
 
 class MessageOverlay;
 class Scene;
@@ -51,9 +52,9 @@ namespace Graphics {
 	 * Resets the fps count.
 	 * Don't call this. Use Player::FrameReset instead.
 	 *
-	 * @param start_ticks time in ticks
+	 * @param now the current time.
 	 */
-	void FrameReset(uint32_t start_ticks);
+	void FrameReset(Game_Clock::time_point now);
 
 	/**
 	 * Gets a bitmap with the actual contents of the screen.

--- a/src/libretro_ui.cpp
+++ b/src/libretro_ui.cpp
@@ -206,10 +206,6 @@ bool LibretroUi::IsFullscreen() {
 	return false;
 }
 
-uint32_t LibretroUi::GetTicks() const {
-	return (uint32_t)(time_in_microseconds/1000);
-}
-
 void LibretroUi::Sleep(uint32_t) {
 	// Sleep is not needed libretro will ensure 60 fps
 }

--- a/src/libretro_ui.cpp
+++ b/src/libretro_ui.cpp
@@ -469,7 +469,7 @@ RETRO_API void retro_set_environment(retro_environment_t cb) {
 
 	static retro_frame_time_callback frame_time_definition = {
 		retro_time_update,
-		1000000 / Graphics::GetDefaultFps()
+		1000000 / Game_Clock::GetSimulationFps()
 	};
 
 	static retro_audio_callback audio_callback_definition = {
@@ -581,7 +581,7 @@ RETRO_API void retro_get_system_av_info(struct retro_system_av_info* info) {
 	info->geometry.max_width = SCREEN_TARGET_WIDTH;
 	info->geometry.max_height = SCREEN_TARGET_HEIGHT;
 	info->geometry.aspect_ratio = 0.0f;
-	info->timing.fps = Graphics::GetDefaultFps();
+	info->timing.fps = Game_Clock::GetSimulationFps();
 	info->timing.sample_rate = AUDIO_SAMPLERATE;
 }
 

--- a/src/libretro_ui.cpp
+++ b/src/libretro_ui.cpp
@@ -206,10 +206,6 @@ bool LibretroUi::IsFullscreen() {
 	return false;
 }
 
-void LibretroUi::Sleep(uint32_t) {
-	// Sleep is not needed libretro will ensure 60 fps
-}
-
 retro_video_refresh_t LibretroUi::UpdateWindow = nullptr;
 void LibretroUi::SetRetroVideoCallback(retro_video_refresh_t cb) {
 	UpdateWindow = cb;

--- a/src/libretro_ui.h
+++ b/src/libretro_ui.h
@@ -59,8 +59,6 @@ public:
 
 	bool IsFullscreen() override;
 
-	void Sleep(uint32_t time_milli) override;
-
 #ifdef SUPPORT_AUDIO
 	AudioInterface& GetAudio() override;
 	std::unique_ptr<AudioInterface> audio_;

--- a/src/libretro_ui.h
+++ b/src/libretro_ui.h
@@ -59,7 +59,6 @@ public:
 
 	bool IsFullscreen() override;
 
-	uint32_t GetTicks() const override;
 	void Sleep(uint32_t time_milli) override;
 
 #ifdef SUPPORT_AUDIO

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -23,6 +23,8 @@
 
 #include <iostream>
 #include <fstream>
+#include <thread>
+#include <chrono>
 
 #include "graphics.h"
 
@@ -49,6 +51,8 @@
 #include "utils.h"
 #include "font.h"
 #include "baseui.h"
+
+using namespace std::chrono_literals;
 
 namespace {
 	std::ofstream LOG_FILE;
@@ -195,7 +199,9 @@ static void HandleErrorOutput(const std::string& err) {
 
 	Input::ResetKeys();
 	while (!Input::IsAnyPressed()) {
-		DisplayUi->Sleep(1);
+#if !defined(USE_LIBRETRO)
+		Game_Clock::SleepFor(1ms);
+#endif
 		DisplayUi->ProcessEvents();
 
 		if (Player::exit_flag) break;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -208,7 +208,6 @@ bool did_sleep_this_frame = false;
 void Player::Run() {
 	Instrumentation::Init("EasyRPG-Player");
 	Scene::Push(std::make_shared<Scene_Logo>());
-	Game_Clock::InitTicks();
 	Graphics::UpdateSceneCallback();
 
 	reset_flag = false;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <iomanip>
 #include <fstream>
+#include <thread>
 
 #ifdef _WIN32
 #  include "util_win.h"
@@ -358,8 +359,7 @@ void Player::Update(bool update_scene) {
 		if (cur_time < next_frame) {
 			iframe_scope.End();
 			did_sleep_this_frame = true;
-			auto dt = std::chrono::duration_cast<std::chrono::milliseconds>(next_frame - cur_time);
-			DisplayUi->Sleep(dt.count());
+			Game_Clock::SleepFor(next_frame - cur_time);
 			iframe_scope.Begin();
 		}
 #endif

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -264,7 +264,7 @@ void Player::Update(bool update_scene) {
 	static const double framerate_interval = 1000.0 / Graphics::GetDefaultFps();
 	next_frame = start_time + framerate_interval;
 
-	double cur_time = (double)DisplayUi->GetTicks();
+	double cur_time = (double)Game_Clock::GetTicks();
 
 #if !defined(USE_LIBRETRO)
 	// libretro: The frontend handles this, cores should not do rate
@@ -350,10 +350,10 @@ void Player::Update(bool update_scene) {
 
 	BitmapRef disp = DisplayUi->GetDisplaySurface();
 
-	cur_time = (double)DisplayUi->GetTicks();
+	cur_time = (double)Game_Clock::GetTicks();
 	if (cur_time < next_frame) {
 		Graphics::Draw(*disp);
-		cur_time = (double)DisplayUi->GetTicks();
+		cur_time = (double)Game_Clock::GetTicks();
 		// Don't use sleep when the port uses an external timing source
 #if !defined(USE_LIBRETRO)
 		// Still time after graphic update? Yield until it's time for next one.
@@ -374,7 +374,7 @@ void Player::IncFrame() {
 
 void Player::FrameReset() {
 	// When update started
-	FrameReset(DisplayUi->GetTicks());
+	FrameReset(Game_Clock::GetTicks());
 }
 
 void Player::FrameReset(uint32_t start_ticks) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -261,8 +261,7 @@ void Player::Resume() {
 
 void Player::Update(bool update_scene) {
 	// available ms per frame, game logic expects 60 fps
-	static const double framerate_interval = 1000.0 / Graphics::GetDefaultFps();
-	next_frame = start_time + framerate_interval;
+	next_frame = start_time + std::chrono::duration_cast<std::chrono::milliseconds>(Game_Clock::GetSimulationTimeStep()).count();
 
 	double cur_time = (double)Game_Clock::GetTicks();
 
@@ -378,11 +377,8 @@ void Player::FrameReset() {
 }
 
 void Player::FrameReset(uint32_t start_ticks) {
-	// available ms per frame, game logic expects 60 fps
-	static const double framerate_interval = 1000.0 / Graphics::GetDefaultFps();
-
 	// When next frame is expected
-	next_frame = start_ticks + framerate_interval;
+	next_frame = start_ticks + std::chrono::duration_cast<std::chrono::milliseconds>(Game_Clock::GetSimulationTimeStep()).count();
 
 	Graphics::FrameReset(start_ticks);
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -76,6 +76,7 @@
 #include "instrumentation.h"
 #include "scope_guard.h"
 #include "baseui.h"
+#include "game_clock.h"
 
 #ifndef EMSCRIPTEN
 // This is not used on Emscripten.
@@ -206,7 +207,8 @@ bool did_sleep_this_frame = false;
 
 void Player::Run() {
 	Instrumentation::Init("EasyRPG-Player");
-	Scene::Push(std::shared_ptr<Scene>(static_cast<Scene*>(new Scene_Logo())));
+	Scene::Push(std::make_shared<Scene_Logo>());
+	Game_Clock::InitTicks();
 	Graphics::UpdateSceneCallback();
 
 	reset_flag = false;

--- a/src/player.h
+++ b/src/player.h
@@ -20,6 +20,7 @@
 
 // Headers
 #include "meta.h"
+#include "game_clock.h"
 #include <vector>
 #include <memory>
 
@@ -84,18 +85,10 @@ namespace Player {
 	/**
 	 * Resets the fps count (both updates and frames per second).
 	 * Should be called after an expensive operation.
-	 */
-	void FrameReset();
-
-	/**
-	 * Resets the fps count (both updates and frames per second).
-	 * Should be called after an expensive operation.
-	 * Instead of using DisplayUi->GetTicks uses the start_ticks arg which
-	 * saves a system call.
 	 *
-	 * @param start_ticks time in ticks when this function was called
+	 * @param now the current time
 	 */
-	void FrameReset(uint32_t start_ticks);
+	void FrameReset(Game_Clock::time_point now);
 
 	/**
 	 * Increment the frame counters.

--- a/src/psp2_ui.cpp
+++ b/src/psp2_ui.cpp
@@ -200,9 +200,6 @@ void Psp2Ui::Sleep(uint32_t time) {
 	sceKernelDelayThread(usecs);
 }
 
-uint32_t Psp2Ui::GetTicks() const {
-	return (sceKernelGetProcessTimeWide() / 1000 - starttick);
-}
 void Psp2Ui::BeginDisplayModeChange() {
 	// no-op
 }

--- a/src/psp2_ui.cpp
+++ b/src/psp2_ui.cpp
@@ -195,11 +195,6 @@ Psp2Ui::~Psp2Ui() {
 	vita2d_fini();
 }
 
-void Psp2Ui::Sleep(uint32_t time) {
-	uint64_t usecs = time*1000;
-	sceKernelDelayThread(usecs);
-}
-
 void Psp2Ui::BeginDisplayModeChange() {
 	// no-op
 }

--- a/src/psp2_ui.h
+++ b/src/psp2_ui.h
@@ -66,7 +66,6 @@ public:
 
 	bool IsFullscreen();
 
-	void Sleep(uint32_t time_milli);
 #ifdef SUPPORT_AUDIO
 	AudioInterface& GetAudio();
 	std::unique_ptr<AudioInterface> audio_;

--- a/src/psp2_ui.h
+++ b/src/psp2_ui.h
@@ -66,7 +66,6 @@ public:
 
 	bool IsFullscreen();
 
-	uint32_t GetTicks() const;
 	void Sleep(uint32_t time_milli);
 #ifdef SUPPORT_AUDIO
 	AudioInterface& GetAudio();

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -41,7 +41,7 @@ Scene_GameBrowser::Scene_GameBrowser() {
 void Scene_GameBrowser::Start() {
 	Game_System::SetSystemGraphic(CACHE_DEFAULT_BITMAP, RPG::System::Stretch_stretch, RPG::System::Font_gothic);
 	CreateWindows();
-	Player::FrameReset();
+	Player::FrameReset(Game_Clock::now());
 }
 
 void Scene_GameBrowser::Continue(SceneType /* prev_scene */) {

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -86,7 +86,7 @@ void Scene_Map::Start() {
 		Game_Map::PlayBgm();
 	}
 
-	Player::FrameReset();
+	Player::FrameReset(Game_Clock::now());
 
 	Start2(MapUpdateAsyncContext());
 }

--- a/src/sdl2_ui.cpp
+++ b/src/sdl2_ui.cpp
@@ -211,10 +211,6 @@ Sdl2Ui::~Sdl2Ui() {
 	SDL_Quit();
 }
 
-void Sdl2Ui::Sleep(uint32_t time) {
-	SDL_Delay(time);
-}
-
 bool Sdl2Ui::RequestVideoMode(int width, int height, int zoom) {
 	// SDL2 documentation says that resolution dependent code should not be used
 	// anymore. The library takes care of it now.

--- a/src/sdl2_ui.cpp
+++ b/src/sdl2_ui.cpp
@@ -211,10 +211,6 @@ Sdl2Ui::~Sdl2Ui() {
 	SDL_Quit();
 }
 
-uint32_t Sdl2Ui::GetTicks() const {
-	return SDL_GetTicks();
-}
-
 void Sdl2Ui::Sleep(uint32_t time) {
 	SDL_Delay(time);
 }

--- a/src/sdl2_ui.h
+++ b/src/sdl2_ui.h
@@ -73,8 +73,6 @@ public:
 
 	bool IsFullscreen() override;
 
-	void Sleep(uint32_t time_milli) override;
-
 #ifdef SUPPORT_AUDIO
 	AudioInterface& GetAudio() override;
 #endif

--- a/src/sdl2_ui.h
+++ b/src/sdl2_ui.h
@@ -73,7 +73,6 @@ public:
 
 	bool IsFullscreen() override;
 
-	uint32_t GetTicks() const override;
 	void Sleep(uint32_t time_milli) override;
 
 #ifdef SUPPORT_AUDIO

--- a/src/sdl_ui.cpp
+++ b/src/sdl_ui.cpp
@@ -149,10 +149,6 @@ SdlUi::~SdlUi() {
 	SDL_Quit();
 }
 
-uint32_t SdlUi::GetTicks() const {
-	return SDL_GetTicks();
-}
-
 void SdlUi::Sleep(uint32_t time) {
 	SDL_Delay(time);
 }

--- a/src/sdl_ui.cpp
+++ b/src/sdl_ui.cpp
@@ -149,10 +149,6 @@ SdlUi::~SdlUi() {
 	SDL_Quit();
 }
 
-void SdlUi::Sleep(uint32_t time) {
-	SDL_Delay(time);
-}
-
 bool SdlUi::RequestVideoMode(int width, int height, bool fullscreen) {
 	// FIXME: Split method into submethods, really, this method isn't nice.
 	// Note to Zhek, don't delete this fixme again.

--- a/src/sdl_ui.h
+++ b/src/sdl_ui.h
@@ -70,8 +70,6 @@ public:
 
 	bool IsFullscreen() override;
 
-	void Sleep(uint32_t time_milli) override;
-
 #ifdef SUPPORT_AUDIO
 	AudioInterface& GetAudio() override;
 #endif

--- a/src/sdl_ui.h
+++ b/src/sdl_ui.h
@@ -70,7 +70,6 @@ public:
 
 	bool IsFullscreen() override;
 
-	uint32_t GetTicks() const override;
 	void Sleep(uint32_t time_milli) override;
 
 #ifdef SUPPORT_AUDIO

--- a/src/switch_ui.cpp
+++ b/src/switch_ui.cpp
@@ -326,11 +326,6 @@ NxUi::~NxUi() {
 	deinitEgl();
 }
 
-void NxUi::Sleep(uint32_t time) {
-	u64 nsecs = time * 1000000;
-	svcSleepThread(nsecs);
-}
-
 static inline double u64_to_double(u64 value) {
 	return (((double)(u32)(value >> 32)) * 0x100000000ULL + (u32)value);
 }

--- a/src/switch_ui.cpp
+++ b/src/switch_ui.cpp
@@ -326,10 +326,6 @@ NxUi::~NxUi() {
 	deinitEgl();
 }
 
-static inline double u64_to_double(u64 value) {
-	return (((double)(u32)(value >> 32)) * 0x100000000ULL + (u32)value);
-}
-
 void NxUi::BeginDisplayModeChange() {
 	// no-op
 }

--- a/src/switch_ui.cpp
+++ b/src/switch_ui.cpp
@@ -335,12 +335,6 @@ static inline double u64_to_double(u64 value) {
 	return (((double)(u32)(value >> 32)) * 0x100000000ULL + (u32)value);
 }
 
-uint32_t NxUi::GetTicks() const {
-	double ticks = u64_to_double(armGetSystemTick());
-	u64 msecs = (u64)(ticks / ticks_per_msec);
-	return msecs;
-}
-
 void NxUi::BeginDisplayModeChange() {
 	// no-op
 }

--- a/src/switch_ui.h
+++ b/src/switch_ui.h
@@ -64,7 +64,6 @@ public:
 
 	bool IsFullscreen();
 
-	uint32_t GetTicks() const;
 	void Sleep(uint32_t time_milli);
 
 #ifdef SUPPORT_AUDIO

--- a/src/switch_ui.h
+++ b/src/switch_ui.h
@@ -64,8 +64,6 @@ public:
 
 	bool IsFullscreen();
 
-	void Sleep(uint32_t time_milli);
-
 #ifdef SUPPORT_AUDIO
 	AudioInterface& GetAudio();
 #endif


### PR DESCRIPTION
Depends on #2021 

This adds `Game_Clock` for getting the current time and and sleeping. 

- [x] Remove dependency on Ui for time keeping
- [x] Use highest precision time available on system
- [x] Prefer standard time functions over platform specific ones wherever possible

TBD:
- [x] Check if we can use `std::this_thread::sleep_for()` on 3ds
- [x] Check if we can use `std::this_thread::sleep_for()` on switch
- [x] Check if we can use `std::this_thread::sleep_for()` on vita