### PR TITLE
 Optimization: Devirtualize Drawable attributes - Drawables 1 of N

### DIFF
--- a/bench/draw.cpp
+++ b/bench/draw.cpp
@@ -1,0 +1,49 @@
+#include <benchmark/benchmark.h>
+#include <font.h>
+#include <rect.h>
+#include <bitmap.h>
+#include <sprite.h>
+#include <graphics.h>
+
+constexpr int num_sprites = 5000;
+
+class TestSprite : public Drawable {
+	public:
+		void Draw() override {}
+		int GetZ() const override { return 0; }
+		DrawableType GetType() const override { return TypeDefault; }
+		bool IsGlobal() const override { return true; }
+};
+
+static void BM_DrawSort(benchmark::State& state) {
+	std::vector<std::unique_ptr<TestSprite>> sprites;
+	for (int i = 0; i < num_sprites; ++i) {
+		sprites.push_back(std::make_unique<TestSprite>());
+	}
+	Graphics::DrawableList list;
+	for (auto& s: sprites) {
+		list.push_back(s.get());
+	}
+
+	for (auto _: state) {
+		Graphics::SortDrawableList(list);
+	}
+}
+
+BENCHMARK(BM_DrawSort);
+
+static void BM_DrawSortLocality(benchmark::State& state) {
+	std::array<TestSprite,num_sprites> sprites;
+	Graphics::DrawableList list;
+	for (auto& s: sprites) {
+		list.push_back(&s);
+	}
+
+	for (auto _: state) {
+		Graphics::SortDrawableList(list);
+	}
+}
+
+BENCHMARK(BM_DrawSortLocality);
+
+BENCHMARK_MAIN();

--- a/bench/draw.cpp
+++ b/bench/draw.cpp
@@ -9,10 +9,8 @@ constexpr int num_sprites = 5000;
 
 class TestSprite : public Drawable {
 	public:
+		TestSprite() : Drawable(TypeDefault, 0, true) {}
 		void Draw() override {}
-		int GetZ() const override { return 0; }
-		DrawableType GetType() const override { return TypeDefault; }
-		bool IsGlobal() const override { return true; }
 };
 
 static void BM_DrawSort(benchmark::State& state) {

--- a/src/background.cpp
+++ b/src/background.cpp
@@ -29,6 +29,7 @@
 #include "output.h"
 
 Background::Background(const std::string& name) :
+	Drawable(TypeBackground, Priority_Background, false),
 	visible(true), tone_effect(Tone()),
 	bg_hscroll(0), bg_vscroll(0), bg_x(0), bg_y(0),
 	fg_hscroll(0), fg_vscroll(0), fg_x(0), fg_y(0) {
@@ -44,6 +45,7 @@ Background::Background(const std::string& name) :
 }
 
 Background::Background(int terrain_id) :
+	Drawable(TypeBackground, Priority_Background, false),
 	visible(true), tone_effect(Tone()),
 	bg_hscroll(0), bg_vscroll(0), bg_x(0), bg_y(0),
 	fg_hscroll(0), fg_vscroll(0), fg_x(0), fg_y(0) {
@@ -103,14 +105,6 @@ void Background::OnForegroundFrameGraphicReady(FileRequestResult* result) {
 
 Background::~Background() {
 	Graphics::RemoveDrawable(this);
-}
-
-int Background::GetZ() const {
-	return z;
-}
-
-DrawableType Background::GetType() const {
-	return type;
 }
 
 Tone Background::GetTone() const {

--- a/src/background.cpp
+++ b/src/background.cpp
@@ -103,10 +103,6 @@ void Background::OnForegroundFrameGraphicReady(FileRequestResult* result) {
 	fg_bitmap = Cache::Frame(result->file);
 }
 
-Background::~Background() {
-	Graphics::RemoveDrawable(this);
-}
-
 Tone Background::GetTone() const {
 	return tone_effect;
 }

--- a/src/background.h
+++ b/src/background.h
@@ -29,7 +29,6 @@ class Background : public Drawable {
 public:
 	Background(const std::string& name);
 	Background(int terrain_id);
-	~Background() override;
 
 	void Draw() override;
 	void Update();

--- a/src/background.h
+++ b/src/background.h
@@ -36,13 +36,7 @@ public:
 	Tone GetTone() const;
 	void SetTone(Tone tone);
 
-	int GetZ() const override;
-	DrawableType GetType() const override;
-
 private:
-	static const int z = Priority_Background;
-	static const DrawableType type = TypeBackground;
-
 	static void Update(int& rate, int& value);
 	static int Scale(int x);
 

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -241,9 +241,7 @@ BattleAnimationMap::BattleAnimationMap(const RPG::Animation& anim, Game_Characte
 {
 	Graphics::RegisterDrawable(this);
 }
-BattleAnimationMap::~BattleAnimationMap() {
-	Graphics::RemoveDrawable(this);
-}
+
 void BattleAnimationMap::Draw() {
 	if (IsOnlySound()) {
 		return;
@@ -296,9 +294,7 @@ BattleAnimationBattle::BattleAnimationBattle(const RPG::Animation& anim, std::ve
 {
 	Graphics::RegisterDrawable(this);
 }
-BattleAnimationBattle::~BattleAnimationBattle() {
-	Graphics::RemoveDrawable(this);
-}
+
 void BattleAnimationBattle::Draw() {
 	if (IsOnlySound())
 		return;

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -32,6 +32,7 @@
 #include "game_temp.h"
 
 BattleAnimation::BattleAnimation(const RPG::Animation& anim, bool only_sound, int cutoff) :
+	Sprite(TypeDefault),
 	animation(anim), frame(0), only_sound(only_sound)
 {
 	num_frames = GetRealFrames() * 2;
@@ -57,10 +58,6 @@ BattleAnimation::BattleAnimation(const RPG::Animation& anim, bool only_sound, in
 		request_id = request->Bind(&BattleAnimation::OnBattleSpriteReady, this);
 		request->Start();
 	}
-}
-
-DrawableType BattleAnimation::GetType() const {
-	return TypeDefault;
 }
 
 void BattleAnimation::Update() {

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -34,8 +34,6 @@ struct FileRequestResult;
 
 class BattleAnimation : public Sprite {
 public:
-	DrawableType GetType() const override;
-
 	/** Update the animation to the next animation **/
 	void Update();
 

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -90,7 +90,6 @@ protected:
 class BattleAnimationMap : public BattleAnimation {
 public:
 	BattleAnimationMap(const RPG::Animation& anim, Game_Character& target, bool global);
-	~BattleAnimationMap() override;
 	void Draw() override;
 protected:
 	void FlashTargets(int r, int g, int b, int p) override;
@@ -106,7 +105,6 @@ protected:
 class BattleAnimationBattle : public BattleAnimation {
 public:
 	BattleAnimationBattle(const RPG::Animation& anim, std::vector<Game_Battler*> battlers, bool only_sound = false, int cutoff_frame = -1);
-	~BattleAnimationBattle() override;
 	void Draw() override;
 protected:
 	void FlashTargets(int r, int g, int b, int p) override;

--- a/src/drawable.cpp
+++ b/src/drawable.cpp
@@ -17,6 +17,19 @@
 
 #include "drawable.h"
 #include "rpg_savepicture.h"
+#include "graphics.h"
+
+Drawable::Drawable(DrawableType type, int z, bool is_global)
+	: _z(z),
+	_type(static_cast<decltype(_type)>(type)),
+	_is_global(is_global)
+{
+}
+
+void Drawable::SetZ(int nz) {
+	if (_z != nz) Graphics::UpdateZCallback();
+	_z = nz;
+}
 
 int Drawable::GetPriorityForMapLayer(int which) {
 	switch (which) {

--- a/src/drawable.cpp
+++ b/src/drawable.cpp
@@ -26,6 +26,10 @@ Drawable::Drawable(DrawableType type, int z, bool is_global)
 {
 }
 
+Drawable::~Drawable() {
+	Graphics::RemoveDrawable(this);
+}
+
 void Drawable::SetZ(int nz) {
 	if (_z != nz) Graphics::UpdateZCallback();
 	_z = nz;

--- a/src/drawable.h
+++ b/src/drawable.h
@@ -67,7 +67,7 @@ public:
 	Drawable(const Drawable&) = delete;
 	Drawable& operator=(const Drawable&) = delete;
 
-	virtual ~Drawable() {};
+	virtual ~Drawable();
 
 	virtual void Draw() = 0;
 

--- a/src/drawable.h
+++ b/src/drawable.h
@@ -18,6 +18,8 @@
 #ifndef EP_DRAWABLE_H
 #define EP_DRAWABLE_H
 
+#include <cstdint>
+
 // What kind of drawable is the current one?
 enum DrawableType {
 	TypeWindow,
@@ -60,15 +62,22 @@ enum Priority {
  */
 class Drawable {
 public:
+	Drawable(DrawableType type, int z, bool is_global);
+
+	Drawable(const Drawable&) = delete;
+	Drawable& operator=(const Drawable&) = delete;
+
 	virtual ~Drawable() {};
 
 	virtual void Draw() = 0;
 
-	virtual int GetZ() const = 0;
+	int GetZ() const;
 
-	virtual DrawableType GetType() const = 0;
+	void SetZ(int z);
 
-	virtual bool IsGlobal() const { return false; }
+	DrawableType GetType() const;
+
+	bool IsGlobal() const;
 
 	/**
 	 * Converts a RPG Maker map layer value into a EasyRPG priority value.
@@ -83,6 +92,23 @@ public:
 	 * @return Priority or 0 when not found
 	 */
 	static int GetPriorityForBattleLayer(int which);
+private:
+	int _z = 0;
+	uint16_t _type = TypeDefault;
+	bool _is_global = false;
 };
+
+inline int Drawable::GetZ() const {
+	return _z;
+}
+
+inline DrawableType Drawable::GetType() const {
+	return static_cast<DrawableType>(_type);
+}
+
+inline bool Drawable::IsGlobal() const {
+	return _is_global;
+}
+
 
 #endif

--- a/src/fps_overlay.cpp
+++ b/src/fps_overlay.cpp
@@ -25,18 +25,13 @@
 #include "font.h"
 
 FpsOverlay::FpsOverlay() :
-	type(TypeOverlay),
-	z(Priority_Overlay + 100) {
-
+	Drawable(TypeOverlay, Priority_Overlay + 100, true)
+{
 	Graphics::RegisterDrawable(this);
 }
 
 FpsOverlay::~FpsOverlay() {
 	Graphics::RemoveDrawable(this);
-}
-
-bool FpsOverlay::IsGlobal() const {
-	return true;
 }
 
 void FpsOverlay::Update() {
@@ -99,14 +94,6 @@ void FpsOverlay::Draw() {
 		int dwidth = DisplayUi->GetDisplaySurface()->GetWidth();
 		DisplayUi->GetDisplaySurface()->Blit(dwidth - speedup_rect.width - 1, 2, *speedup_bitmap, speedup_rect, 255);
 	}
-}
-
-int FpsOverlay::GetZ() const {
-	return z;
-}
-
-DrawableType FpsOverlay::GetType() const {
-	return type;
 }
 
 int FpsOverlay::GetFps() const {

--- a/src/fps_overlay.cpp
+++ b/src/fps_overlay.cpp
@@ -30,10 +30,6 @@ FpsOverlay::FpsOverlay() :
 	Graphics::RegisterDrawable(this);
 }
 
-FpsOverlay::~FpsOverlay() {
-	Graphics::RemoveDrawable(this);
-}
-
 void FpsOverlay::Update() {
 	int mod = Player::GetSpeedModifier();
 

--- a/src/fps_overlay.h
+++ b/src/fps_overlay.h
@@ -31,7 +31,6 @@
 class FpsOverlay : public Drawable {
 public:
 	FpsOverlay();
-	~FpsOverlay() override;
 
 	void Draw() override;
 

--- a/src/fps_overlay.h
+++ b/src/fps_overlay.h
@@ -35,12 +35,6 @@ public:
 
 	void Draw() override;
 
-	int GetZ() const override;
-
-	DrawableType GetType() const override;
-
-	bool IsGlobal() const override;
-
 	void Update();
 
 	/**
@@ -80,12 +74,8 @@ public:
 	std::string GetFpsString() const;
 
 private:
-	DrawableType type;
-
 	BitmapRef fps_bitmap;
 	BitmapRef speedup_bitmap;
-
-	int z;
 
 	bool fps_dirty = false;
 	bool speedup_dirty = false;

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -25,7 +25,9 @@
 #include "main_data.h"
 #include "frame.h"
 
-Frame::Frame() {
+Frame::Frame() :
+	Drawable(TypeFrame, Priority_Frame, false)
+{
 	if (!Data::system.frame_name.empty() && Data::system.show_frame) {
 		FileRequestAsync* request = AsyncHandler::RequestFile("Frame", Data::system.frame_name);
 		request->SetGraphicFile(true);
@@ -38,14 +40,6 @@ Frame::Frame() {
 
 Frame::~Frame() {
 	Graphics::RemoveDrawable(this);
-}
-
-int Frame::GetZ() const {
-	return z;
-}
-
-DrawableType Frame::GetType() const {
-	return type;
 }
 
 void Frame::Update() {

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -38,10 +38,6 @@ Frame::Frame() :
 	Graphics::RegisterDrawable(this);
 }
 
-Frame::~Frame() {
-	Graphics::RemoveDrawable(this);
-}
-
 void Frame::Update() {
 	// no-op
 }

--- a/src/frame.h
+++ b/src/frame.h
@@ -34,14 +34,7 @@ public:
 	void Draw() override;
 	void Update();
 
-	int GetZ() const override;
-	DrawableType GetType() const override;
-
 private:
-
-	static const int z = Priority_Frame;
-	static const DrawableType type = TypeFrame;
-
 	void OnFrameGraphicReady(FileRequestResult* result);
 
 	BitmapRef frame_bitmap;

--- a/src/frame.h
+++ b/src/frame.h
@@ -22,6 +22,7 @@
 #include <string>
 #include "drawable.h"
 #include "system.h"
+#include "async_handler.h"
 
 /**
  * Renders the frame overlay.
@@ -29,7 +30,6 @@
 class Frame : public Drawable {
 public:
 	Frame();
-	~Frame() override;
 
 	void Draw() override;
 	void Update();

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -104,6 +104,11 @@ namespace Graphics {
 	MessageOverlay& GetMessageOverlay();
 
 	Transition& GetTransition();
+
+	/**
+	 * Sort the list of drawables in Z order
+	 */
+	void SortDrawableList(DrawableList& list);
 }
 
 #endif

--- a/src/message_overlay.cpp
+++ b/src/message_overlay.cpp
@@ -24,8 +24,7 @@
 #include "game_message.h"
 
 MessageOverlay::MessageOverlay() :
-	type(TypeOverlay),
-	z(Priority_Overlay),
+	Drawable(TypeOverlay, Priority_Overlay, true),
 	ox(0),
 	oy(0),
 	text_height(12),
@@ -38,10 +37,6 @@ MessageOverlay::MessageOverlay() :
 
 MessageOverlay::~MessageOverlay() {
 	Graphics::RemoveDrawable(this);
-}
-
-bool MessageOverlay::IsGlobal() const {
-	return true;
 }
 
 void MessageOverlay::Draw() {
@@ -78,14 +73,6 @@ void MessageOverlay::Draw() {
 	}
 
 	dirty = false;
-}
-
-int MessageOverlay::GetZ() const {
-	return z;
-}
-
-DrawableType MessageOverlay::GetType() const {
-	return type;
 }
 
 void MessageOverlay::AddMessage(const std::string& message, Color color) {

--- a/src/message_overlay.cpp
+++ b/src/message_overlay.cpp
@@ -35,10 +35,6 @@ MessageOverlay::MessageOverlay() :
 	// Graphics::RegisterDrawable is in the Update function
 }
 
-MessageOverlay::~MessageOverlay() {
-	Graphics::RemoveDrawable(this);
-}
-
 void MessageOverlay::Draw() {
 	if (!IsAnyMessageVisible() && !show_all) {
 		// Don't render overlay when no message visible

--- a/src/message_overlay.h
+++ b/src/message_overlay.h
@@ -42,7 +42,6 @@ public:
 class MessageOverlay : public Drawable {
 public:
 	MessageOverlay();
-	~MessageOverlay() override;
 
 	void Draw() override;
 

--- a/src/message_overlay.h
+++ b/src/message_overlay.h
@@ -46,12 +46,6 @@ public:
 
 	void Draw() override;
 
-	int GetZ() const override;
-
-	DrawableType GetType() const override;
-
-	bool IsGlobal() const override;
-
 	void Update();
 
 	void AddMessage(const std::string& message, Color color);
@@ -61,12 +55,9 @@ public:
 private:
 	bool IsAnyMessageVisible() const;
 
-	DrawableType type;
-
 	BitmapRef bitmap;
 	BitmapRef black;
 
-	int z;
 	int ox;
 	int oy;
 

--- a/src/plane.cpp
+++ b/src/plane.cpp
@@ -32,10 +32,6 @@ Plane::Plane() :
 	Graphics::RegisterDrawable(this);
 }
 
-Plane::~Plane() {
-	Graphics::RemoveDrawable(this);
-}
-
 void Plane::Draw() {
 	if (!visible || !bitmap) return;
 

--- a/src/plane.cpp
+++ b/src/plane.cpp
@@ -24,9 +24,8 @@
 #include "game_map.h"
 
 Plane::Plane() :
-	type(TypePlane),
+	Drawable(TypePlane, 0, false),
 	visible(true),
-	z(0),
 	ox(0),
 	oy(0) {
 
@@ -111,13 +110,6 @@ bool Plane::GetVisible() const {
 void Plane::SetVisible(bool nvisible) {
 	visible = nvisible;
 }
-int Plane::GetZ() const {
-	return z;
-}
-void Plane::SetZ(int nz) {
-	if (z != nz) Graphics::UpdateZCallback();
-	z = nz;
-}
 int Plane::GetOx() const {
 	return ox;
 }
@@ -142,6 +134,3 @@ void Plane::SetTone(Tone tone) {
 	}
 }
 
-DrawableType Plane::GetType() const {
-	return type;
-}

--- a/src/plane.h
+++ b/src/plane.h
@@ -38,8 +38,6 @@ public:
 	void SetBitmap(BitmapRef const& bitmap);
 	bool GetVisible() const;
 	void SetVisible(bool visible);
-	int GetZ() const override;
-	void SetZ(int z);
 	int GetOx() const;
 	void SetOx(int ox);
 	int GetOy() const;
@@ -47,18 +45,13 @@ public:
 	Tone GetTone() const;
 	void SetTone(Tone tone);
 
-	DrawableType GetType() const override;
-
 private:
-	DrawableType type;
-
 	BitmapRef bitmap;
 	BitmapRef tone_bitmap;
 
 	Tone tone_effect;
 
 	bool visible;
-	int z;
 	int ox;
 	int oy;
 

--- a/src/plane.h
+++ b/src/plane.h
@@ -30,7 +30,6 @@
 class Plane : public Drawable {
 public:
 	Plane();
-	~Plane() override;
 
 	void Draw() override;
 

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -31,10 +31,6 @@ Screen::Screen() :
 	Graphics::RegisterDrawable(this);
 }
 
-Screen::~Screen() {
-	Graphics::RemoveDrawable(this);
-}
-
 void Screen::Update() {
 }
 

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -25,20 +25,14 @@
 #include "main_data.h"
 #include "screen.h"
 
-Screen::Screen() {
+Screen::Screen() :
+	Drawable(TypeScreen, Priority_Screen, false)
+{
 	Graphics::RegisterDrawable(this);
 }
 
 Screen::~Screen() {
 	Graphics::RemoveDrawable(this);
-}
-
-int Screen::GetZ() const {
-	return z;
-}
-
-DrawableType Screen::GetType() const {
-	return type;
 }
 
 void Screen::Update() {

--- a/src/screen.h
+++ b/src/screen.h
@@ -40,16 +40,10 @@ public:
 	void Draw() override;
 	void Update();
 
-	int GetZ() const override;
-	DrawableType GetType() const override;
-
 	Tone GetTone() const;
 	void SetTone(Tone tone);
 
 private:
-	static const int z = Priority_Screen;
-	static const DrawableType type = TypeScreen;
-
 	BitmapRef flash;
 
 	Tone tone_effect;

--- a/src/screen.h
+++ b/src/screen.h
@@ -35,7 +35,6 @@
 class Screen : public Drawable {
 public:
 	Screen();
-	~Screen() override;
 
 	void Draw() override;
 	void Update();

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -63,11 +63,6 @@ Sprite::Sprite(const DrawableType type) :
 	Graphics::RegisterDrawable(this);
 }
 
-// Destructor
-Sprite::~Sprite() {
-	Graphics::RemoveDrawable(this);
-}
-
 // Draw
 void Sprite::Draw() {
 	if (!visible) return;

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -25,12 +25,13 @@
 #include "cache.h"
 
 // Constructor
-Sprite::Sprite() :
-	type(TypeSprite),
+Sprite::Sprite() : Sprite(TypeSprite) {}
+
+Sprite::Sprite(const DrawableType type) :
+	Drawable(type, 0, false),
 	visible(true),
 	x(0),
 	y(0),
-	z(0),
 	ox(0),
 	oy(0),
 	flash_duration(0),
@@ -249,14 +250,6 @@ void Sprite::SetY(int ny) {
 	y = ny;
 }
 
-int Sprite::GetZ() const {
-	return z;
-}
-void Sprite::SetZ(int nz) {
-	if (z != nz) Graphics::UpdateZCallback();
-	z = nz;
-}
-
 int Sprite::GetOx() const {
 	return ox;
 }
@@ -392,6 +385,3 @@ void Sprite::SetWaverPhase(double phase) {
 	}
 }
 
-DrawableType Sprite::GetType() const {
-	return type;
-}

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -53,8 +53,6 @@ public:
 	void SetX(int x);
 	int GetY() const;
 	void SetY(int y);
-	int GetZ() const override;
-	void SetZ(int z);
 	int GetOx() const;
 	void SetOx(int ox);
 	int GetOy() const;
@@ -106,18 +104,16 @@ public:
 	 */
 	void SetWaverPhase(double phase);
 
-	DrawableType GetType() const override;
+protected:
+	Sprite(DrawableType type);
 
 private:
-	DrawableType type;
-
 	BitmapRef bitmap;
 
 	Rect src_rect;
 	bool visible;
 	int x;
 	int y;
-	int z;
 	int ox;
 	int oy;
 

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -31,7 +31,6 @@
 class Sprite : public Drawable {
 public:
 	Sprite();
-	~Sprite() override;
 
 	void Draw() override;
 

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -758,9 +758,8 @@ void TilemapLayer::SetFastBlit(bool fast) {
 }
 
 TilemapSubLayer::TilemapSubLayer(TilemapLayer* tilemap, int z) :
-	type(TypeTilemap),
-	tilemap(tilemap),
-	z(z)
+	Drawable(TypeTilemap, z, false),
+	tilemap(tilemap)
 {
 	Graphics::RegisterDrawable(this);
 }
@@ -775,14 +774,6 @@ void TilemapSubLayer::Draw() {
 	}
 
 	tilemap->Draw(GetZ());
-}
-
-int TilemapSubLayer::GetZ() const {
-	return z;
-}
-
-DrawableType TilemapSubLayer::GetType() const {
-	return type;
 }
 
 void TilemapLayer::SetTone(Tone tone) {

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -764,10 +764,6 @@ TilemapSubLayer::TilemapSubLayer(TilemapLayer* tilemap, int z) :
 	Graphics::RegisterDrawable(this);
 }
 
-TilemapSubLayer::~TilemapSubLayer() {
-	Graphics::RemoveDrawable(this);
-}
-
 void TilemapSubLayer::Draw() {
 	if (!tilemap->GetChipset()) {
 		return;

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -38,14 +38,8 @@ public:
 
 	void Draw() override;
 
-	int GetZ() const override;
-
-	DrawableType GetType() const override;
-
 private:
-	DrawableType type;
 	TilemapLayer* tilemap;
-	int z;
 };
 
 /**

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -34,7 +34,6 @@ class TilemapLayer;
 class TilemapSubLayer : public Drawable {
 public:
 	TilemapSubLayer(TilemapLayer* tilemap, int z);
-	~TilemapSubLayer() override;
 
 	void Draw() override;
 

--- a/src/transition.cpp
+++ b/src/transition.cpp
@@ -29,7 +29,9 @@
 #include "scene.h"
 #include "drawable.h"
 
-Transition::Transition() {
+Transition::Transition() :
+	Drawable(TypeTransition, Priority_Transition, true)
+{
 	flash_iterations = 0;
 	flash_duration = 0;
 	current_frame = -1;
@@ -39,14 +41,6 @@ Transition::Transition() {
 
 Transition::~Transition() {
 	Graphics::RemoveDrawable(this);
-}
-
-int Transition::GetZ() const {
-	return z;
-}
-
-DrawableType Transition::GetType() const {
-	return type;
 }
 
 void Transition::AppendBefore(Color color, int duration, int iterations) {
@@ -67,7 +61,7 @@ void Transition::Init(TransitionType type, Scene *linked_scene, int duration, bo
 	}
 
 	if (erase && type == TransitionNone) {
-		old_frozen_screen = Graphics::SnapToBitmap(z);
+		old_frozen_screen = Graphics::SnapToBitmap(GetZ());
 		screen1 = old_frozen_screen;
 		return;
 	}
@@ -75,7 +69,7 @@ void Transition::Init(TransitionType type, Scene *linked_scene, int duration, bo
 		return;
 	}
 
-	frozen_screen = Graphics::SnapToBitmap(z);
+	frozen_screen = Graphics::SnapToBitmap(GetZ());
 	screen1 = erase ? frozen_screen : old_frozen_screen? old_frozen_screen : black_screen;
 	screen2 = erase ? black_screen : frozen_screen;
 
@@ -368,10 +362,6 @@ void Transition::Update() {
 		frozen_screen.reset();
 		frozen_screen = nullptr;
 	}
-}
-
-bool Transition::IsGlobal() const {
-	return true;
 }
 
 bool Transition::IsActive() {

--- a/src/transition.cpp
+++ b/src/transition.cpp
@@ -39,10 +39,6 @@ Transition::Transition() :
 	black_screen = nullptr;
 }
 
-Transition::~Transition() {
-	Graphics::RemoveDrawable(this);
-}
-
 void Transition::AppendBefore(Color color, int duration, int iterations) {
 	if (!IsActive()) {
 		current_frame = 0;

--- a/src/transition.h
+++ b/src/transition.h
@@ -75,9 +75,6 @@ public:
 	Transition();
 	~Transition() override;
 
-	int GetZ() const override;
-	DrawableType GetType() const override;
-
 	/**
 	 * Defines a screen transition.
 	 *
@@ -92,15 +89,11 @@ public:
 
 	void Draw() override;
 	void Update();
-	bool IsGlobal() const override;
 
 	bool IsActive();
 	bool IsErased();
 
 private:
-
-	static const int z = Priority_Transition;
-	static const DrawableType type = TypeTransition;
 	const uint32_t size_random_blocks = 4;
 
 	BitmapRef black_screen;

--- a/src/transition.h
+++ b/src/transition.h
@@ -73,7 +73,6 @@ public:
 	};
 
 	Transition();
-	~Transition() override;
 
 	/**
 	 * Defines a screen transition.

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -27,21 +27,13 @@
 #include "weather.h"
 
 Weather::Weather() :
-	dirty(false) {
-
+	Drawable(TypeWeather, Priority_Weather, false)
+{
 	Graphics::RegisterDrawable(this);
 }
 
 Weather::~Weather() {
 	Graphics::RemoveDrawable(this);
-}
-
-int Weather::GetZ() const {
-	return z;
-}
-
-DrawableType Weather::GetType() const {
-	return type;
 }
 
 void Weather::Update() {

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -32,10 +32,6 @@ Weather::Weather() :
 	Graphics::RegisterDrawable(this);
 }
 
-Weather::~Weather() {
-	Graphics::RemoveDrawable(this);
-}
-
 void Weather::Update() {
 }
 

--- a/src/weather.h
+++ b/src/weather.h
@@ -22,6 +22,7 @@
 #include <string>
 #include "drawable.h"
 #include "system.h"
+#include "tone.h"
 
 /**
  * Renders the weather effects.
@@ -34,9 +35,6 @@ public:
 	void Draw() override;
 	void Update();
 
-	int GetZ() const override;
-	DrawableType GetType() const override;
-
 	Tone GetTone() const;
 	void SetTone(Tone tone);
 
@@ -46,16 +44,13 @@ private:
 	void DrawFog();
 	void DrawSandstorm();
 
-	static const int z = Priority_Weather;
-	static const DrawableType type = TypeWeather;
-
 	BitmapRef weather_surface;
 	BitmapRef snow_bitmap;
 	BitmapRef rain_bitmap;
 
 	Tone tone_effect;
 
-	bool dirty;
+	bool dirty = false;
 };
 
 #endif

--- a/src/weather.h
+++ b/src/weather.h
@@ -30,7 +30,6 @@
 class Weather : public Drawable {
 public:
 	Weather();
-	~Weather() override;
 
 	void Draw() override;
 	void Update();

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -28,7 +28,7 @@
 constexpr int pause_animation_frames = 20;
 
 Window::Window():
-	type(TypeWindow),
+	Drawable(TypeWindow, Priority_Window, false),
 	stretch(true),
 	active(true),
 	visible(true),
@@ -39,7 +39,6 @@ Window::Window():
 	y(0),
 	width(0),
 	height(0),
-	z(Priority_Window),
 	ox(0),
 	oy(0),
 	border_x(8),
@@ -442,14 +441,6 @@ void Window::SetHeight(int nheight) {
 	height = nheight;
 }
 
-int Window::GetZ() const {
-	return z;
-}
-void Window::SetZ(int nz) {
-	if (z != nz) Graphics::UpdateZCallback();
-	z = nz;
-}
-
 int Window::GetOx() const {
 	return ox;
 }
@@ -495,10 +486,8 @@ void Window::SetBackOpacity(int nback_opacity) {
 int Window::GetContentsOpacity() const {
 	return contents_opacity;
 }
+
 void Window::SetContentsOpacity(int ncontents_opacity) {
 	contents_opacity = ncontents_opacity;
 }
 
-DrawableType Window::GetType() const {
-	return type;
-}

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -60,10 +60,6 @@ Window::Window():
 	cursor2 = BitmapRef();
 }
 
-Window::~Window() {
-	Graphics::RemoveDrawable(this);
-}
-
 void Window::SetOpenAnimation(int frames) {
 	closing = false;
 	visible = true;

--- a/src/window.h
+++ b/src/window.h
@@ -60,8 +60,6 @@ public:
 	void SetWidth(int nwidth);
 	int GetHeight() const;
 	void SetHeight(int nheight);
-	int GetZ() const override;
-	void SetZ(int nz);
 	int GetOx() const;
 	void SetOx(int nox);
 	int GetOy() const;
@@ -83,10 +81,7 @@ public:
 	bool IsClosing() const;
 	bool IsOpeningOrClosing() const;
 
-	DrawableType GetType() const override;
-
 protected:
-	DrawableType type;
 	unsigned long ID;
 	BitmapRef windowskin, contents;
 	bool stretch;
@@ -100,7 +95,6 @@ protected:
 	int y;
 	int width;
 	int height;
-	int z;
 	int ox;
 	int oy;
 	int border_x;

--- a/src/window.h
+++ b/src/window.h
@@ -29,7 +29,6 @@
 class Window : public Drawable {
 public:
 	Window();
-	~Window() override;
 
 	void Draw() override;
 


### PR DESCRIPTION
This devirtualizes `Drawable::GetZ()` resulting in 3x speed up when we sort the drawables.

Benchmark results on a Surface Go Tablet running Windows 10 / WSL.

Before:
```
---------------------------------------------------
Benchmark            Time           CPU Iterations
---------------------------------------------------
BM_DrawSort     320284 ns     313895 ns       2240
```

After:
```
---------------------------------------------------
Benchmark            Time           CPU Iterations
---------------------------------------------------
BM_DrawSort     103358 ns     104627 ns       7467
```

And for fun, if we keep `GetZ()` as non-virtual but don't inline it:
```
---------------------------------------------------
Benchmark            Time           CPU Iterations
---------------------------------------------------
BM_DrawSort     269318 ns     272770 ns       2635
```