### PR TITLE
Introduce PoolAllocator for Graphics Stack - Drawables 4 of N

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 add_library(${PROJECT_NAME}
 	src/3ds_ui.cpp
 	src/3ds_ui.h
+	src/align.h
 	src/async_handler.cpp
 	src/async_handler.h
 	src/async_op.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,9 @@ add_library(${PROJECT_NAME}
 	src/platform.h
 	src/player.cpp
 	src/player.h
+	src/pool_allocator.h
+	src/pool_allocator_base.h
+	src/pool_allocator_base.cpp
 	src/psp2_ui.cpp
 	src/psp2_ui.h
 	src/rect.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -194,6 +194,9 @@ libeasyrpg_player_a_SOURCES = \
 	src/platform.h \
 	src/player.cpp \
 	src/player.h \
+	src/pool_allocator.h \
+	src/pool_allocator_base.h \
+	src/pool_allocator_base.cpp \
 	src/psp2_ui.cpp \
 	src/psp2_ui.h \
 	src/game_quit.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,7 @@ noinst_LIBRARIES = libeasyrpg-player.a
 libeasyrpg_player_a_SOURCES = \
 	src/3ds_ui.cpp \
 	src/3ds_ui.h \
+	src/align.h \
 	src/async_handler.cpp \
 	src/async_handler.h \
 	src/async_op.h \

--- a/src/align.h
+++ b/src/align.h
@@ -1,0 +1,85 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_ALIGN_H
+#define EP_ALIGN_H
+
+#include <type_traits>
+#include <cstdint>
+#include <cstddef>
+
+/**
+ * @return true if t is aligned to a
+ * @pre If a is not a power of 2, the result is undefined.
+ */
+template <typename T,
+         typename = std::enable_if_t<std::is_integral<T>::value>>
+constexpr bool IsAligned(T t, size_t a) noexcept {
+  return ((t & (a-1)) == 0);
+}
+
+/**
+ * @return true if p is aligned to a
+ * @pre If a is not a power of 2, the result is undefined.
+ */
+inline bool IsAligned(void* p, size_t a) noexcept {
+  return IsAligned(uintptr_t(p), a);
+}
+
+/*
+ * @return the smallest number n when n >= val && is_aligned(n, align).
+ * @pre If a is not a power of 2, the result is undefined.
+ */
+template <typename T,
+         typename = std::enable_if_t<std::is_integral<T>::value>>
+constexpr T AlignUp(T val, size_t a) noexcept {
+  return ((val + (a -1)) & -a);
+}
+
+/**
+ * @return the closest pointer p' where p' >= p && is_aligned(p, align).
+ * @pre If a is not a power of 2, the result is undefined.
+ */
+inline void* AlignUp(void* val, size_t a) noexcept {
+  return (void*)AlignUp(uintptr_t(val), a);
+}
+
+/**
+ * @return the largest number n when n <= val && is_aligned(n, align).
+ * @pre If a is not a power of 2, the result is undefined.
+ */
+template <typename T,
+         typename = std::enable_if_t<std::is_integral<T>::value>>
+constexpr T AlignDown(T val, size_t a) noexcept {
+  return val & -a;
+}
+
+/**
+ * @return the closest pointer p' where p' <= val && is_aligned(p, align).
+ * @pre If a is not a power of 2, the result is undefined.
+ */
+inline void* AlignDown(void* val, size_t a) noexcept {
+  return (void*)AlignDown(uintptr_t(val), a);
+}
+
+/** @return true if val is a power of 2 */
+template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
+constexpr bool IsPow2(T val) noexcept {
+	return (val & (val - 1)) == 0;
+}
+
+#endif

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -33,14 +33,34 @@
 #include "text.h"
 #include "pixman_image_ptr.h"
 #include "opacity.h"
+#include "pool_allocator.h"
 
 struct Transform;
+
+
+class BitmapAllocator : public PoolAllocator<Bitmap> {
+	public:
+		static BitmapAllocator& instance() {
+			static BitmapAllocator alloc(1024);
+			return alloc;
+		}
+	private:
+		using PoolAllocator<Bitmap>::PoolAllocator;
+};
 
 /**
  * Base Bitmap class.
  */
 class Bitmap {
 public:
+	static void* operator new(size_t /* sz */) {
+		return BitmapAllocator::instance().AllocUninitialized();
+	}
+
+	static void operator delete(void* ptr) {
+		BitmapAllocator::instance().FreeUninitialized(static_cast<Bitmap*>(ptr));
+	}
+
 	/**
 	 * Creates bitmap with empty surface.
 	 *

--- a/src/drawable.h
+++ b/src/drawable.h
@@ -69,8 +69,6 @@ enum Priority {
  */
 class Drawable {
 public:
-	Drawable(DrawableType type, int z, bool is_global);
-
 	Drawable(const Drawable&) = delete;
 	Drawable& operator=(const Drawable&) = delete;
 
@@ -99,6 +97,10 @@ public:
 	 * @return Priority or 0 when not found
 	 */
 	static int GetPriorityForBattleLayer(int which);
+
+protected:
+	Drawable(DrawableType type, int z, bool is_global);
+
 private:
 	int _z = 0;
 	uint16_t _type = TypeDefault;

--- a/src/pool_allocator.h
+++ b/src/pool_allocator.h
@@ -1,0 +1,238 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_POOL_ALLOCATOR_H
+#define EP_POOL_ALLOCATOR_H
+
+#include <cstddef>
+#include <utility>
+#include <memory>
+#include "compiler.h"
+#include "pool_allocator_base.h"
+#include "scope_guard.h"
+
+/** A paged pool based allocator for untyped data. Initialized at runtime with the size and alignment
+ * requirements of the underlying objects. */
+class PoolAllocatorUntyped : public PoolAllocatorBase {
+	public:
+		using size_type = PoolAllocatorBase::size_type;
+
+		/**
+		 * Create the pool with given arguments
+		 *
+		 * @param nobjs_per_page the number of objects we'll allocate in each page.
+		 * @param obj_size The size of each object.
+		 * @param obj_align The alignment requirements of each object.
+		 */
+		constexpr PoolAllocatorUntyped(size_type nobjs_per_page, size_type obj_size, size_type obj_align = alignof(std::max_align_t));
+
+		/** Destroys the pool.  */
+		~PoolAllocatorUntyped();
+
+		/** Allocate an object with ObjectSize() size and ObjectAlign() alignment */
+		void* Alloc() noexcept;
+
+		/** 
+		 * Free an object allocated by this pool.
+		 *
+		 * @param p pointer allocated by this pool.
+		 */
+		void Free(void* p) noexcept;
+
+		/** @return size of each object allocated by this pool */
+		size_type ObjectSize() const;
+
+		/** @return alignment of each object allocated by this pool */
+		size_type ObjectAlign() const;
+	private:
+		void Reset() noexcept;
+	private:
+		size_type _obj_size = 0;
+		size_type _obj_align = 0;
+};
+
+template <typename T> class PoolAllocator;
+
+/** The Deleter class for PoolUniquePtr */
+template <typename T> class PoolAllocatorDeleter {
+	public:
+		PoolAllocatorDeleter(PoolAllocator<T>* alloc);
+
+		void operator()(T* p) const;
+	private:
+		PoolAllocator<T>* _alloc = nullptr;
+};
+
+/** Wrapper around unique_ptr for PoolAllocator<T> */
+template <typename T>
+using PoolUniquePtr = std::unique_ptr<T, PoolAllocatorDeleter<T>>;
+
+template <typename T>
+class PoolAllocator : public PoolAllocatorBase {
+	public:
+		using size_type = PoolAllocatorBase::size_type;
+		using UniquePtr = PoolUniquePtr<T>;
+
+		/**
+		 * Construct with given number of objects per page
+		 *
+		 * @param nobjs_per_page the number of objects will be storable on each page.
+		 *
+		 * @note For optimal performance, we want nobjs_per_page to match our maximum
+		 * number of expected objects, so they all get allocated on a single page
+		 */
+		explicit constexpr PoolAllocator(size_t nobjs_per_page);
+
+		/**
+		 * Destroy the allocator
+		 *
+		 * @pre If all allocated objects haven't been freed, the result is undefined.
+		 */
+		~PoolAllocator();
+
+		/**
+		 * Allocate a single object of type T.
+		 *
+		 * @return pointer to *uninitialized* memory big enough to store a T.
+		 * @post This pointer be must freed by being passed to FreeUninitialized().
+		 */
+		T* AllocUninitialized();
+
+		/**
+		 * Free a single object of type T which was allocated by this.
+		 *
+		 * @return pointer to uninitialized memory allocated by this.
+		 * @note The destructor of T is not called!
+		 */
+		void FreeUninitialized(T* p) noexcept;
+
+		/**
+		 * Destroy and then free a single object of type T which was allocated by this.
+		 *
+		 * @return pointer to initialized memory allocated by this.
+		 * @note The destructor of T is called!
+		 */
+		void Destroy(T* p) noexcept;
+
+		/**
+		 * Allocates and constructs a T by forwarding args and returns it.
+		 *
+		 * @param args... parameters to be forwarded to T constructor.
+		 * @return a PoolUniquePtr<T> which will automatically call Destroy() when it goes out of scope.
+		 */
+		template <typename... Args>
+			PoolUniquePtr<T> MakeUnique(Args&&... args);
+
+		/** @return size of each object allocated by this pool */
+		static constexpr size_type ObjectSize();
+
+		/** @return alignment of each object allocated by this pool */
+		static constexpr size_type ObjectAlign();
+	private:
+		void Reset() noexcept;
+};
+
+constexpr PoolAllocatorUntyped::PoolAllocatorUntyped(size_type nobjs_per_page, size_type obj_size, size_type obj_align)
+	: PoolAllocatorBase(nobjs_per_page), _obj_size(obj_size), _obj_align(obj_align) {}
+
+	inline PoolAllocatorUntyped::~PoolAllocatorUntyped() {
+		Reset();
+	}
+
+inline void* PoolAllocatorUntyped::Alloc() noexcept {
+	return PoolAllocatorBase::Alloc(ObjectSize(), ObjectAlign());
+}
+
+inline void PoolAllocatorUntyped::Free(void* p) noexcept {
+	return PoolAllocatorBase::Free(p, ObjectSize(), ObjectAlign());
+}
+
+inline void PoolAllocatorUntyped::Reset() noexcept {
+	return PoolAllocatorBase::Reset(ObjectSize(), ObjectAlign());
+}
+
+inline PoolAllocatorUntyped::size_type PoolAllocatorUntyped::ObjectSize() const {
+	return _obj_size;
+}
+
+inline PoolAllocatorUntyped::size_type PoolAllocatorUntyped::ObjectAlign() const {
+	return _obj_align;
+}
+
+	template <typename T>
+constexpr PoolAllocator<T>::PoolAllocator(size_t nobjs_per_page)
+	: PoolAllocatorBase(nobjs_per_page) {}
+
+	template <typename T>
+	PoolAllocator<T>::~PoolAllocator() {
+		Reset();
+	}
+
+template <typename T>
+T* PoolAllocator<T>::AllocUninitialized() {
+	return static_cast<T*>(PoolAllocatorBase::Alloc(ObjectSize(), ObjectAlign()));
+}
+
+template <typename T>
+void PoolAllocator<T>::FreeUninitialized(T* obj) noexcept {
+	PoolAllocatorBase::Free(obj, ObjectSize(), ObjectAlign());
+}
+
+template <typename T>
+void PoolAllocator<T>::Destroy(T* obj) noexcept {
+	obj->~T();
+	FreeUninitialized(obj);
+}
+
+template <typename T>
+void PoolAllocator<T>::Reset() noexcept {
+	PoolAllocatorBase::Reset(ObjectSize(), ObjectAlign());
+}
+
+template <typename T>
+constexpr typename PoolAllocator<T>::size_type PoolAllocator<T>::ObjectSize() {
+	return sizeof(T);
+}
+
+template <typename T>
+constexpr typename PoolAllocator<T>::size_type PoolAllocator<T>::ObjectAlign() {
+	return alignof(T);
+}
+
+template <typename T>
+template <typename... Args>
+inline PoolUniquePtr<T> PoolAllocator<T>::MakeUnique(Args&&... args) {
+	auto* p = this->AllocUninitialized();
+
+	auto sg = makeScopeGuard([&]() { this->FreeUninitialized(p); });
+	auto* t = new (p) T(std::forward<Args>(args)...);
+	sg.Dismiss();
+
+	return PoolUniquePtr<T>(t, PoolAllocatorDeleter<T>(this));
+}
+
+
+	template <typename T>
+PoolAllocatorDeleter<T>::PoolAllocatorDeleter(PoolAllocator<T>* alloc)
+	: _alloc(alloc) {}
+
+	template <typename T>
+	void PoolAllocatorDeleter<T>::operator()(T* p) const {
+		_alloc->Destroy(p);
+	}
+
+#endif

--- a/src/pool_allocator_base.cpp
+++ b/src/pool_allocator_base.cpp
@@ -1,0 +1,67 @@
+#include "pool_allocator_base.h"
+#include "align.h"
+#include <algorithm>
+#include <cassert>
+
+PoolAllocatorBase::Slot* PoolAllocatorBase::FirstSlot(Page* page, size_type obj_align) {
+	auto off = reinterpret_cast<uintptr_t>(page);
+	off += PageHeaderSize(obj_align);
+	return reinterpret_cast<Slot*>(off);
+}
+
+PoolAllocatorBase::Slot* PoolAllocatorBase::NextSlot(Slot* s, size_type n, size_type obj_size, size_type obj_align) {
+	auto off = reinterpret_cast<uintptr_t>(s);
+	off += SlotSize(obj_size, obj_align) * n;
+	return reinterpret_cast<Slot*>(off);
+}
+
+void PoolAllocatorBase::AllocNewPage(size_type obj_size, size_type obj_align) {
+	assert(_nobjs_per_page > 0);
+	const auto page_size = PageSize(_nobjs_per_page, obj_size, obj_align);
+	const auto page_align = PageAlign(obj_align);
+#ifdef __cpp_aligned_new
+	auto* raw_page = operator new(page_size, std::align_val_t(page_align));
+#else
+	auto* raw_page = operator new(page_size);
+	(void)page_align;
+#endif
+	auto* page = reinterpret_cast<Page*>(raw_page);
+	page->next = nullptr;
+
+	auto* slots = FirstSlot(page, obj_align);
+	auto* last_slot = NextSlot(slots, _nobjs_per_page -1, obj_size, obj_align);
+
+	last_slot->freenext = _freehead;
+	auto* prev = last_slot;
+	for(size_t i = _nobjs_per_page-1; i > 0;) {
+		--i;
+		auto* slot = NextSlot(slots, i, obj_size, obj_align);
+		slot->freenext = prev;
+		prev = slot;
+	}
+
+	_freehead = prev;
+	page->next = _pagehead;
+	_pagehead = page;
+}
+
+void PoolAllocatorBase::Reset(size_type obj_size, size_type obj_align) noexcept {
+	assert(_nobjs_per_page > 0);
+	const auto page_size = PageSize(_nobjs_per_page, obj_size, obj_align);
+	const auto page_align = PageAlign(obj_align);
+
+	for(auto* page = _pagehead; page != nullptr;) {
+		auto* nextpage = page->next;
+#ifdef __cpp_aligned_new
+		operator delete(page, page_size, std::align_val_t(page_align));
+#elif defined(__cpp_sized_deallocation)
+		operator delete(page, page_size);
+#else
+		operator delete(page);
+#endif
+		page = nextpage;
+	}
+	_pagehead = nullptr;
+	_freehead = nullptr;
+}
+

--- a/src/pool_allocator_base.h
+++ b/src/pool_allocator_base.h
@@ -1,0 +1,115 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_POOL_ALLOCATOR_BASE_H
+#define EP_POOL_ALLOCATOR_BASE_H
+
+#include <cstddef>
+#include <utility>
+#include <memory>
+#include <algorithm>
+#include "compiler.h"
+#include "align.h"
+
+/** This is an implementation base class for PoolAllocatorUntyped and PoolAllocator<T>
+ * @note Not meant to be used directly, as the same size and alignment must be passed to every method.
+ * @note Destructor does not cleanup! Implementing child class must do this!
+ */
+class PoolAllocatorBase {
+	public:
+		using size_type = size_t;
+
+		static constexpr size_type SlotAlign(size_type obj_align);
+		static constexpr size_type SlotSize(size_type obj_size, size_type obj_align);
+		static constexpr size_type PageAlign(size_type obj_align);
+		static constexpr size_type PageHeaderSize(size_type obj_align);
+		static constexpr size_type PageSize(size_type n_objs_per_page, size_type obj_size, size_type obj_align);
+
+		PoolAllocatorBase(const PoolAllocatorBase&) = delete;
+		PoolAllocatorBase& operator=(const PoolAllocatorBase&) = delete;
+		PoolAllocatorBase(PoolAllocatorBase&&) = delete;
+		PoolAllocatorBase& operator=(PoolAllocatorBase&&) = delete;
+
+	protected:
+		constexpr PoolAllocatorBase(size_type nobjs_per_page);
+
+		// Note: Doesn't cleanup!
+		~PoolAllocatorBase() {}
+
+		void* Alloc(size_type obj_size, size_type obj_align);
+
+		void Free(void* p, size_type obj_size, size_type obj_align) noexcept;
+
+		void Reset(size_type obj_size, size_type obj_align) noexcept;
+	private:
+		union Slot {
+			Slot* freenext;
+		};
+		struct Page {
+			Page* next;
+		};
+	private:
+		static Slot* FirstSlot(Page* page, size_type obj_align);
+		static Slot* NextSlot(Slot* s, size_type n, size_type obj_size, size_type obj_align);
+		void AllocNewPage(size_type obj_size, size_type obj_align);
+	private:
+		Page* _pagehead = nullptr;
+		Slot* _freehead = nullptr;
+		size_type _nobjs_per_page = 0;
+};
+
+
+constexpr PoolAllocatorBase::PoolAllocatorBase(size_type nobjs_per_page)
+	: _nobjs_per_page(nobjs_per_page) { }
+
+	constexpr PoolAllocatorBase::size_type PoolAllocatorBase::SlotAlign(size_type obj_align) {
+		return std::max(static_cast<size_type>(alignof(Slot)), obj_align);
+	}
+
+constexpr PoolAllocatorBase::size_type PoolAllocatorBase::SlotSize(size_type obj_size, size_type obj_align) {
+	return AlignUp(std::max(static_cast<size_type>(sizeof(Slot)), obj_size), SlotAlign(obj_align));
+}
+
+constexpr PoolAllocatorBase::size_type PoolAllocatorBase::PageAlign(size_type obj_align) {
+	return std::max(static_cast<size_type>(alignof(Page)), SlotAlign(obj_align));
+}
+
+constexpr PoolAllocatorBase::size_type PoolAllocatorBase::PageHeaderSize(size_type obj_align) {
+	return AlignUp(sizeof(Page), SlotAlign(obj_align));
+}
+
+constexpr PoolAllocatorBase::size_type PoolAllocatorBase::PageSize(size_type n_objs_per_page, size_type obj_size, size_type obj_align) {
+	return PageHeaderSize(obj_align) + n_objs_per_page * SlotSize(obj_size, obj_align);
+}
+
+inline void* PoolAllocatorBase::Alloc(size_type obj_size, size_type obj_align) {
+	if(EP_UNLIKELY(_freehead == nullptr)) {
+		AllocNewPage(obj_size, obj_align);
+	}
+
+	auto* slot = _freehead;
+	_freehead = slot->freenext;
+	return reinterpret_cast<void*>(slot);
+}
+
+inline void PoolAllocatorBase::Free(void* obj, size_type obj_size, size_type obj_align) noexcept {
+	auto* slot = reinterpret_cast<Slot*>(obj);
+	slot->freenext = _freehead;
+	_freehead = slot;
+}
+
+#endif

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -24,12 +24,33 @@
 #include "memory_management.h"
 #include "rect.h"
 #include "tone.h"
+#include "pool_allocator.h"
+
+class Sprite;
+
+class SpriteAllocator : public PoolAllocator<Sprite> {
+	public:
+		static SpriteAllocator& instance() {
+			static SpriteAllocator alloc(1024);
+			return alloc;
+		}
+	private:
+		using PoolAllocator<Sprite>::PoolAllocator;
+};
 
 /**
  * Sprite class.
  */
 class Sprite : public Drawable {
 public:
+	static void* operator new(size_t sz) {
+		return SpriteAllocator::instance().AllocUninitialized();
+	}
+
+	static void operator delete(void* ptr) {
+		SpriteAllocator::instance().FreeUninitialized(static_cast<Sprite*>(ptr));
+	}
+
 	Sprite();
 
 	void Draw(Bitmap& dst) override;

--- a/tests/align.cpp
+++ b/tests/align.cpp
@@ -1,0 +1,71 @@
+#include "align.h"
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+static_assert(IsPow2(1), "IsPow2 broken");
+static_assert(IsPow2(2), "IsPow2 broken");
+static_assert(!IsPow2(3), "IsPow2 broken");
+static_assert(IsPow2(4), "IsPow2 broken");
+static_assert(!IsPow2(5), "IsPow2 broken");
+static_assert(!IsPow2(6), "IsPow2 broken");
+static_assert(!IsPow2(7), "IsPow2 broken");
+static_assert(IsPow2(8), "IsPow2 broken");
+
+TEST_CASE("IsPow2") {
+	REQUIRE(IsPow2(0));
+	int next = 1;
+	for (int i = 1; i < 1000; ++i) {
+		INFO("val=" << i << " next=" << next);
+		if (i == next) {
+			REQUIRE(IsPow2(i));
+			next *= 2;
+		} else {
+			REQUIRE_FALSE(IsPow2(i));
+		}
+	}
+}
+
+TEST_CASE("AlignUp") {
+	for(int a = 1; a < 64; a *= 2) {
+		INFO("val=0 align=" << a);
+		REQUIRE_EQ(AlignUp(0, a), 0);
+	}
+	for (int i = 1; i < 64; ++i) {
+		for(int a = 1; a < 64; a *= 2) {
+			INFO("val=" << i << " align=" << a);
+			REQUIRE_EQ(AlignUp(i, a), (i % a) == 0 ? i : (i - (i % a) + a));
+		}
+	}
+}
+
+TEST_CASE("AlignDown") {
+	for(int a = 1; a < 64; a *= 2) {
+		INFO("val=0 align=" << a);
+		REQUIRE_EQ(AlignDown(0, a), 0);
+	}
+	for (int i = 1; i < 64; ++i) {
+		for(int a = 1; a < 64; a *= 2) {
+			INFO("val=" << i << " align=" << a);
+			REQUIRE_EQ(AlignDown(i, a), (i - (i % a)));
+		}
+	}
+}
+
+TEST_CASE("IsAligned") {
+	for(int a = 1; a < 64; a *= 2) {
+		INFO("val=0 align=" << a);
+		REQUIRE(IsAligned(0, a));
+	}
+	for (int i = 1; i < 64; ++i) {
+		for(int a = 1; a < 64; a *= 2) {
+			INFO("val=" << i << " align=" << a);
+			if ((i % a) == 0) {
+				REQUIRE(IsAligned(i, a));
+			} else {
+				REQUIRE(!IsAligned(i, a));
+			}
+		}
+	}
+}
+

--- a/tests/pool_allocator.cpp
+++ b/tests/pool_allocator.cpp
@@ -1,0 +1,153 @@
+#include "pool_allocator.h"
+#include <iostream>
+#include <cstdio>
+#include <array>
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+constexpr auto ws = sizeof(void*);
+constexpr auto wa = alignof(void*);
+
+struct alignas(wa / 2) A1P2 {};
+struct alignas(wa) A1P {};
+struct alignas(2 * wa) A2P {};
+struct alignas(4 * wa) A4P {};
+
+static_assert(PoolAllocatorBase::SlotAlign(alignof(A1P2)) == wa, "SlotAlign is broken");
+static_assert(PoolAllocatorBase::SlotAlign(alignof(A1P)) == wa, "SlotAlign is broken");
+static_assert(PoolAllocatorBase::SlotAlign(alignof(A2P)) == 2 * wa, "SlotAlign is broken");
+static_assert(PoolAllocatorBase::SlotAlign(alignof(A4P)) == 4 * wa, "SlotAlign is broken");
+
+static_assert(PoolAllocatorBase::SlotSize(sizeof(A1P2), alignof(A1P2)) == std::max(ws, wa), "SlotSize is broken");
+static_assert(PoolAllocatorBase::SlotSize(sizeof(A1P), alignof(A1P)) == std::max(ws, wa), "SlotSize is broken");
+static_assert(PoolAllocatorBase::SlotSize(sizeof(A2P), alignof(A2P)) == std::max(ws, wa * 2), "SlotSize is broken");
+static_assert(PoolAllocatorBase::SlotSize(sizeof(A4P), alignof(A4P)) == std::max(ws, wa * 4), "SlotSize is broken");
+
+struct SE {};
+struct SP { int* p[1]; };
+struct S2P { int* p[2]; };
+struct S4P { int* p[4]; };
+
+static_assert(PoolAllocatorBase::SlotSize(sizeof(SE), alignof(SE)) == std::max(ws, wa), "SlotSize is broken");
+static_assert(PoolAllocatorBase::SlotSize(sizeof(SP), alignof(SP)) == std::max(ws, wa), "SlotSize is broken");
+static_assert(PoolAllocatorBase::SlotSize(sizeof(S2P), alignof(S2P)) == std::max(ws * 2, wa), "SlotSize is broken");
+static_assert(PoolAllocatorBase::SlotSize(sizeof(S4P), alignof(S4P)) == std::max(ws * 4, wa), "SlotSize is broken");
+
+struct alignas(2 * wa) S1A2P { int* p[2]; };
+struct alignas(2 * wa) S2A2P { int* p[2]; };
+struct alignas(4 * wa) S2A4P { int* p[2]; };
+struct alignas(2 * wa) S4A2P { int* p[4]; };
+struct alignas(4 * wa) S4A4P { int* p[4]; };
+
+static_assert(PoolAllocatorBase::SlotSize(sizeof(S1A2P), alignof(S1A2P)) == std::max(ws, 2 * wa), "SlotSize is broken");
+static_assert(PoolAllocatorBase::SlotSize(sizeof(S2A2P), alignof(S2A2P)) == std::max(2 * ws, 2 * wa), "SlotSize is broken");
+static_assert(PoolAllocatorBase::SlotSize(sizeof(S2A4P), alignof(S2A4P)) == std::max(2 * ws, 4 * wa), "SlotSize is broken");
+static_assert(PoolAllocatorBase::SlotSize(sizeof(S4A2P), alignof(S4A2P)) == std::max(4 * ws, 2 * wa), "SlotSize is broken");
+static_assert(PoolAllocatorBase::SlotSize(sizeof(S4A2P), alignof(S4A2P)) == std::max(4 * ws, 4 * wa), "SlotSize is broken");
+
+static_assert(PoolAllocatorBase::PageHeaderSize(alignof(A1P2)) == wa, "PageHeaderSize is broken");
+static_assert(PoolAllocatorBase::PageHeaderSize(alignof(A1P)) == wa, "PageHeaderSize is broken");
+static_assert(PoolAllocatorBase::PageHeaderSize(alignof(A2P)) == 2 * wa, "PageHeaderSize is broken");
+static_assert(PoolAllocatorBase::PageHeaderSize(alignof(A4P)) == 4 * wa, "PageHeaderSize is broken");
+
+TEST_CASE("PageSize") {
+}
+
+TEST_CASE("Untyped") {
+	PoolAllocatorUntyped p(5, 8, 8);
+}
+
+template <size_t N, size_t A = 1>
+struct alignas(A * alignof(int32_t)) SI : public std::array<int32_t,N> {
+	SI(int32_t value) { this->fill(value); }
+};
+
+template <size_t N, size_t A>
+bool operator==(SI<N,A> l, int32_t r) {
+	return l == SI<N,A>(r);
+}
+
+template <size_t N, size_t A>
+bool operator==(int32_t l, SI<N,A> r) {
+	return SI<N,A>(l) == r;
+}
+
+template <size_t N, size_t A>
+std::ostream& operator<<(std::ostream& os, const SI<N,A>& s) {
+	os << "SI<" << N << ", " << A << ">{";
+	for (auto& v: s) {
+		os << v << ", ";
+	}
+	os << "}";
+	return os;
+}
+
+
+
+template <typename T>
+void testAllocator(int nobjs_per_page, int nobjs) {
+	PoolAllocator<T> alloc(nobjs_per_page);
+
+	constexpr auto size = sizeof(T);
+	constexpr auto align = alignof(T);
+
+	std::cout << "SIZE: " << size <<  " ALIGN: " << alignof(T) << std::endl;
+
+	const char* tname = typeid(T).name();
+
+	REQUIRE_EQ(alloc.ObjectSize(), size);
+	REQUIRE_EQ(alloc.ObjectAlign(), align);
+
+	srand(42);
+
+	std::vector<PoolUniquePtr<T>> vec;
+	for (int i = 0; i < nobjs; ++i) {
+		vec.push_back(PoolUniquePtr<T>(nullptr, &alloc));
+
+		bool add = (rand() % 2);
+		if (add) {
+			auto ptr = alloc.MakeUnique(i);
+			auto* p = ptr.get();
+			INFO("Alignment type=" << tname << " ptr=" << p << " align=" << align);
+			REQUIRE(IsAligned(p, align));
+			vec.back() = std::move(ptr);
+		} else {
+			int index = (rand() % vec.size());
+			vec[index].reset();
+		}
+
+		for (int j = 0; j < i; ++j) {
+			if (vec[j] != nullptr) {
+				INFO("Mem Corruption type=" << tname << " npp=" << nobjs_per_page << " nobjs=" << nobjs << " j=" << j << " i=" << i);
+				REQUIRE_EQ(*vec[j], j);
+			}
+		}
+	}
+}
+
+TEST_CASE("Typed") {
+	testAllocator<SI<1>>(5, 500);
+	testAllocator<SI<1>>(12, 127);
+	testAllocator<SI<1>>(17, 83);
+
+	testAllocator<SI<2>>(5, 200);
+	testAllocator<SI<2>>(12, 301);
+	testAllocator<SI<2>>(17, 83);
+
+	testAllocator<SI<4>>(5, 37);
+	testAllocator<SI<4>>(12, 152);
+	testAllocator<SI<4>>(17, 83);
+
+	testAllocator<SI<1, 2>>(5, 111);
+	testAllocator<SI<2, 2>>(5, 112);
+	testAllocator<SI<4, 2>>(5, 143);
+
+	testAllocator<SI<1, 4>>(5, 99);
+	testAllocator<SI<2, 4>>(5, 85);
+	testAllocator<SI<4, 4>>(5, 82);
+
+	testAllocator<SI<8, 8>>(5, 82);
+	testAllocator<SI<16, 16>>(5, 82);
+}
+


### PR DESCRIPTION
This PR adds a pool based memory allocator to improve the memory performance of small objects, of which many are allocated and they are often used together.

The benefits are:
* Improved cache locality because the objects are stored closer together in physical memory
* Extremely fast alloc()
* Extremely fast free()

TBD:
- [ ] Detailed Benchmarks showing performance differences
- [ ] Ability to tune the page size using INI file for games with different workloads.
- [ ] Logging and metrics on number of objects allocated, max memory usage, page size fit, etc..
- [ ] Figure out licensing. I would like a more liberal license for this allocator class so it can be reused more freely.