### PR TITLE
Optimize SDL2 Renderer

### DIFF
--- a/bench/pixel_format.cpp
+++ b/bench/pixel_format.cpp
@@ -1,0 +1,67 @@
+#define _USE_MATH_DEFINES
+#include <cmath>
+#include <benchmark/benchmark.h>
+#include <rect.h>
+#include <bitmap.h>
+#include <pixel_format.h>
+#include <transform.h>
+
+static void BlitTest(benchmark::State& state, DynamicFormat fmt) {
+	Bitmap::SetFormat(fmt);
+	auto dest = Bitmap::Create(320, 240);
+	auto src = Bitmap::Create(320, 240);
+	auto rect = src->GetRect();
+	for (auto _: state) {
+		dest->Blit(0, 0, *src, rect, Opacity::Opaque());
+	}
+}
+
+static void BM_BlitBGRA_a(benchmark::State& state) {
+	BlitTest(state, format_B8G8R8A8_a().format());
+}
+
+BENCHMARK(BM_BlitBGRA_a);
+
+static void BM_BlitRGBA_a(benchmark::State& state) {
+	BlitTest(state, format_R8G8B8A8_a().format());
+}
+
+BENCHMARK(BM_BlitRGBA_a);
+
+static void BM_BlitABGR_a(benchmark::State& state) {
+	BlitTest(state, format_A8B8G8R8_a().format());
+}
+
+BENCHMARK(BM_BlitABGR_a);
+
+static void BM_BlitARGB_a(benchmark::State& state) {
+	BlitTest(state, format_A8R8G8B8_a().format());
+}
+
+BENCHMARK(BM_BlitARGB_a);
+
+static void BM_BlitBGRA_n(benchmark::State& state) {
+	BlitTest(state, format_B8G8R8A8_n().format());
+}
+
+BENCHMARK(BM_BlitBGRA_n);
+
+static void BM_BlitRGBA_n(benchmark::State& state) {
+	BlitTest(state, format_R8G8B8A8_n().format());
+}
+
+BENCHMARK(BM_BlitRGBA_n);
+
+static void BM_BlitABGR_n(benchmark::State& state) {
+	BlitTest(state, format_A8B8G8R8_n().format());
+}
+
+BENCHMARK(BM_BlitABGR_n);
+
+static void BM_BlitARGB_n(benchmark::State& state) {
+	BlitTest(state, format_A8R8G8B8_n().format());
+}
+
+BENCHMARK(BM_BlitARGB_n);
+
+BENCHMARK_MAIN();

--- a/src/baseui.h
+++ b/src/baseui.h
@@ -223,13 +223,12 @@ protected:
 	 * Display mode data struct.
 	 */
 	struct DisplayMode {
-		DisplayMode() : effective(false), zoom(0), width(0), height(0), bpp(0), flags(0) {}
-		bool effective;
-		int zoom;
-		int width;
-		int height;
-		uint8_t bpp;
-		uint32_t flags;
+		bool effective = false;
+		int zoom = 0;
+		int width = 0;
+		int height = 0;
+		uint8_t bpp = 0;
+		uint32_t flags = 0;
 	};
 
 	/** Current display mode. */


### PR DESCRIPTION
~~In our SDL rendering code we call `SDL_UpdateTexture` which is documented to be a very slow function and not intended for streaming textures.~~

~~https://wiki.libsdl.org/SDL_UpdateTexture~~

~~This PR uses the recommended Lock/Unlock methods instead.~~

Further testing shows at least on my machine despite what the docs say, `SDL_UpdateTexture` is faster on my machine.
