### PR TITLE
Bitmap Improvements: PixmanImagePtr and Opacity - Bitmaps 1 of N

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ add_library(${PROJECT_NAME}
 	src/message_overlay.h
 	src/meta.cpp
 	src/meta.h
+	src/opacity.h
 	src/options.h
 	src/output.cpp
 	src/output.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ add_library(${PROJECT_NAME}
 	src/pending_message.cpp
 	src/picojson.h
 	src/pixel_format.h
+	src/pixman_image_ptr.h
 	src/plane.cpp
 	src/plane.h
 	src/player.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -182,6 +182,7 @@ libeasyrpg_player_a_SOURCES = \
 	src/pending_message.cpp \
 	src/picojson.h \
 	src/pixel_format.h \
+	src/pixman_image_ptr.h \
 	src/plane.cpp \
 	src/plane.h \
 	src/player.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -175,6 +175,7 @@ libeasyrpg_player_a_SOURCES = \
 	src/message_overlay.h \
 	src/meta.cpp \
 	src/meta.h \
+	src/opacity.h \
 	src/options.h \
 	src/output.cpp \
 	src/output.h \

--- a/bench/bitmap.cpp
+++ b/bench/bitmap.cpp
@@ -6,6 +6,13 @@
 #include <pixel_format.h>
 #include <transform.h>
 
+constexpr auto opacity_opaque = Opacity::Opaque();
+constexpr auto opacity_0 = Opacity(0);
+constexpr auto opacity_50 = Opacity(128);
+constexpr auto opacity_75_25 = Opacity(192, 64, 1);
+
+auto opacity = opacity_opaque;
+
 struct BitmapAccess : public Bitmap {
 	static pixman_format_code_t find_format(const DynamicFormat& format) {
 		return Bitmap::find_format(format);
@@ -48,7 +55,7 @@ static void BM_Blit(benchmark::State& state) {
 	auto src = Bitmap::Create(320, 240);
 	auto rect = src->GetRect();
 	for (auto _: state) {
-		dest->Blit(0, 0, *src, rect, Opacity::opaque);
+		dest->Blit(0, 0, *src, rect, opacity);
 	}
 }
 
@@ -60,7 +67,7 @@ static void BM_BlitFast(benchmark::State& state) {
 	auto src = Bitmap::Create(320, 240);
 	auto rect = src->GetRect();
 	for (auto _: state) {
-		dest->BlitFast(0, 0, *src, rect, Opacity::opaque);
+		dest->BlitFast(0, 0, *src, rect, opacity);
 	}
 }
 
@@ -72,7 +79,7 @@ static void BM_TiledBlit(benchmark::State& state) {
 	auto src = Bitmap::Create(320, 240);
 	auto rect = src->GetRect();
 	for (auto _: state) {
-		dest->TiledBlit(rect, *src, rect, Opacity::opaque);
+		dest->TiledBlit(rect, *src, rect, opacity);
 	}
 }
 
@@ -84,7 +91,7 @@ static void BM_TiledBlitOffset(benchmark::State& state) {
 	auto src = Bitmap::Create(320, 240);
 	auto rect = src->GetRect();
 	for (auto _: state) {
-		dest->TiledBlit(0, 0, rect, *src, rect, Opacity::opaque);
+		dest->TiledBlit(0, 0, rect, *src, rect, opacity);
 	}
 }
 
@@ -96,7 +103,7 @@ static void BM_StretchBlit(benchmark::State& state) {
 	auto src = Bitmap::Create(20, 20);
 	auto rect = src->GetRect();
 	for (auto _: state) {
-		dest->StretchBlit(*src, rect, Opacity::opaque);
+		dest->StretchBlit(*src, rect, opacity);
 	}
 }
 
@@ -109,7 +116,7 @@ static void BM_StretchBlitRect(benchmark::State& state) {
 	auto src = Bitmap::Create(20, 20);
 	auto rect = src->GetRect();
 	for (auto _: state) {
-		dest->StretchBlit(dst_rect, *src, rect, Opacity::opaque);
+		dest->StretchBlit(dst_rect, *src, rect, opacity);
 	}
 }
 
@@ -121,7 +128,7 @@ static void BM_FlipBlit(benchmark::State& state) {
 	auto src = Bitmap::Create(320, 240);
 	auto rect = src->GetRect();
 	for (auto _: state) {
-		dest->FlipBlit(0, 0, *src, rect, true, true, Opacity::opaque);
+		dest->FlipBlit(0, 0, *src, rect, true, true, opacity);
 	}
 }
 
@@ -135,7 +142,7 @@ static void BM_TransformBlit(benchmark::State& state) {
 	auto rect = src->GetRect();
 	auto xform = Transform::Rotation(2 * M_PI);
 	for (auto _: state) {
-		dest->TransformBlit(dst_rect, *src, rect, xform, Opacity::opaque);
+		dest->TransformBlit(dst_rect, *src, rect, xform, opacity);
 	}
 }
 
@@ -151,7 +158,7 @@ static void BM_WaverBlit(benchmark::State& state) {
 	int depth = 2;
 	double phase = M_PI;
 	for (auto _: state) {
-		dest->WaverBlit(0, 0, zoom_x, zoom_y, *src, rect, depth, phase, Opacity::opaque);
+		dest->WaverBlit(0, 0, zoom_x, zoom_y, *src, rect, depth, phase, opacity);
 	}
 }
 
@@ -221,7 +228,7 @@ static void BM_ToneBlit(benchmark::State& state) {
 	auto rect = src->GetRect();
 	auto tone = Tone();
 	for (auto _: state) {
-		dest->ToneBlit(0, 0, *src, rect, tone, Opacity::opaque, false);
+		dest->ToneBlit(0, 0, *src, rect, tone, opacity, false);
 	}
 }
 
@@ -234,7 +241,7 @@ static void BM_BlendBlit(benchmark::State& state) {
 	auto rect = src->GetRect();
 	auto color = Color(255, 255, 255, 255);
 	for (auto _: state) {
-		dest->BlendBlit(0, 0, *src, rect, color, Opacity::opaque);
+		dest->BlendBlit(0, 0, *src, rect, color, opacity);
 	}
 }
 
@@ -317,7 +324,7 @@ static void BM_EffectsBlit(benchmark::State& state) {
 	for (auto _: state) {
 		dest->EffectsBlit(0, 0, 0, 0,
 				*src, rect,
-				Opacity::opaque,
+				opacity,
 				zoom_x, zoom_y,
 				angle,
 				waver_depth,

--- a/src/background.cpp
+++ b/src/background.cpp
@@ -129,6 +129,6 @@ void Background::Draw(Bitmap& dst) {
 		dst.TiledBlit(-Scale(fg_x), -Scale(fg_y), fg_bitmap->GetRect(), *fg_bitmap, dst_rect, 255);
 
 	if (tone_effect != Tone()) {
-		dst.ToneBlit(0, 0, dst, dst.GetRect(), tone_effect, Opacity::opaque);
+		dst.ToneBlit(0, 0, dst, dst.GetRect(), tone_effect, Opacity::Opaque());
 	}
 }

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -40,8 +40,6 @@
 #include "util_macro.h"
 #include "bitmap_hslrgb.h"
 
-const Opacity Opacity::opaque;
-
 BitmapRef Bitmap::Create(int width, int height, const Color& color) {
 	BitmapRef surface = Bitmap::Create(width, height, true);
 	surface->Fill(color);
@@ -173,7 +171,7 @@ Bitmap::Bitmap(Bitmap const& source, Rect const& src_rect, bool transparent) {
 
 	Init(src_rect.width, src_rect.height, (void *) NULL);
 
-	Blit(0, 0, source, src_rect, Opacity::opaque);
+	Blit(0, 0, source, src_rect, Opacity::Opaque());
 }
 
 bool Bitmap::WritePNG(std::ostream& os) const {
@@ -221,7 +219,7 @@ Bitmap::TileOpacity Bitmap::CheckOpacity(const Rect& rect) {
 	std::vector<uint32_t> pixels;
 	pixels.resize(rect.width * rect.height);
 	Bitmap bmp(reinterpret_cast<void*>(&pixels.front()), rect.width, rect.height, rect.width*4, format);
-	bmp.Blit(0, 0, *this, rect, Opacity::opaque);
+	bmp.Blit(0, 0, *this, rect, Opacity::Opaque());
 
 	for (std::vector<uint32_t>::const_iterator p = pixels.begin(); p != pixels.end(); ++p) {
 		if ((*p & 0xFF) != 0)
@@ -304,7 +302,7 @@ void Bitmap::HueChangeBlit(int x, int y, Bitmap const& src, Rect const& src_rect
 	std::vector<uint32_t> pixels;
 	pixels.resize(src_rect.width * src_rect.height);
 	Bitmap bmp(reinterpret_cast<void*>(&pixels.front()), src_rect.width, src_rect.height, src_rect.width * 4, format);
-	bmp.Blit(0, 0, src, src_rect, Opacity::opaque);
+	bmp.Blit(0, 0, src, src_rect, Opacity::Opaque());
 
 	for (std::vector<uint32_t>::iterator p = pixels.begin(); p != pixels.end(); ++p) {
 		uint32_t pixel = *p;
@@ -317,7 +315,7 @@ void Bitmap::HueChangeBlit(int x, int y, Bitmap const& src, Rect const& src_rect
 		*p = ((uint32_t) r << 24) | ((uint32_t) g << 16) | ((uint32_t) b << 8) | (uint32_t) a;
 	}
 
-	Blit(dst_rect.x, dst_rect.y, bmp, bmp.GetRect(), Opacity::opaque);
+	Blit(dst_rect.x, dst_rect.y, bmp, bmp.GetRect(), Opacity::Opaque());
 }
 
 void Bitmap::TextDraw(Rect const& rect, int color, std::string const& text, Text::Alignment align) {
@@ -519,7 +517,7 @@ void Bitmap::ConvertImage(int& width, int& height, void*& pixels, bool transpare
 
 	Bitmap src(pixels, width, height, 0, img_format);
 	Clear();
-	Blit(0, 0, src, src.GetRect(), Opacity::opaque);
+	Blit(0, 0, src, src.GetRect(), Opacity::Opaque());
 	free(pixels);
 }
 
@@ -994,7 +992,7 @@ void Bitmap::Flip(const Rect& dst_rect, bool horizontal, bool vertical) {
 
 	BitmapRef resampled(new Bitmap(dst_rect.width, dst_rect.height, GetTransparent()));
 
-	resampled->FlipBlit(0, 0, *this, dst_rect, horizontal, vertical, Opacity::opaque);
+	resampled->FlipBlit(0, 0, *this, dst_rect, horizontal, vertical, Opacity::Opaque());
 
 	pixman_image_composite32(GetOperator(),
 							 resampled->bitmap.get(), nullptr, bitmap.get(),

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -32,46 +32,9 @@
 #include "tone.h"
 #include "text.h"
 #include "pixman_image_ptr.h"
+#include "opacity.h"
 
 struct Transform;
-
-/**
- * Opacity class.
- */
-class Opacity {
-public:
-	int top;
-	int bottom;
-	int split;
-
-	static const Opacity opaque;
-
-	Opacity() :
-		top(255), bottom(255), split(0) {}
-
-	Opacity(int opacity) :
-		top(opacity), bottom(opacity), split(0) {}
-
-	Opacity(int top_opacity, int bottom_opacity, int opacity_split) :
-		top(top_opacity), bottom(bottom_opacity), split(opacity_split) {}
-
-	int Value() const {
-		assert(!IsSplit());
-		return top;
-	}
-
-	bool IsSplit() const {
-		return split > 0 && top != bottom;
-	}
-
-	bool IsTransparent() const {
-		return IsSplit() ? top <= 0 && bottom <= 0 : top <= 0;
-	}
-
-	bool IsOpaque() const {
-		return IsSplit() ? top >= 255 && bottom >= 255 : top >= 255;
-	}
-};
 
 /**
  * Base Bitmap class.

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -548,10 +548,6 @@ protected:
 
 	friend void Text::Draw(Bitmap& dest, int x, int y, int color, FontRef font, std::string const& text, Text::Alignment align);
 
-#ifdef USE_SDL
-	friend class SdlUi;
-#endif
-
 	/** Bitmap data. */
 	PixmanImagePtr bitmap;
 	pixman_format_code_t pixman_format;

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -31,6 +31,7 @@
 #include "pixel_format.h"
 #include "tone.h"
 #include "text.h"
+#include "pixman_image_ptr.h"
 
 struct Transform;
 
@@ -140,11 +141,6 @@ public:
 	Bitmap(const uint8_t* data, unsigned bytes, bool transparent, uint32_t flags);
 	Bitmap(Bitmap const& source, Rect const& src_rect, bool transparent);
 	Bitmap(void *pixels, int width, int height, int pitch, const DynamicFormat& format);
-
-	/**
-	 * Destructor.
-	 */
-	~Bitmap();
 
 	/**
 	 * Gets the bitmap width.
@@ -557,13 +553,13 @@ protected:
 #endif
 
 	/** Bitmap data. */
-	pixman_image_t *bitmap = nullptr;
+	PixmanImagePtr bitmap;
 	pixman_format_code_t pixman_format;
 
 	void Init(int width, int height, void* data, int pitch = 0, bool destroy = true);
 	void ConvertImage(int& width, int& height, void*& pixels, bool transparent);
 
-	static pixman_image_t* GetSubimage(Bitmap const& src, const Rect& src_rect);
+	static PixmanImagePtr GetSubimage(Bitmap const& src, const Rect& src_rect);
 	static inline void MultiplyAlpha(uint8_t &r, uint8_t &g, uint8_t &b, const uint8_t &a) {
 		r = (uint8_t)((int)r * a / 0xFF);
 		g = (uint8_t)((int)g * a / 0xFF);

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -470,16 +470,16 @@ BitmapRef Cache::SpriteEffect(const BitmapRef& src_bitmap, const Rect& rect, boo
 
 		if (tone != Tone()) {
 			bitmap_effects = create();
-			bitmap_effects->ToneBlit(0, 0, *src_bitmap, rect, tone, Opacity::opaque);
+			bitmap_effects->ToneBlit(0, 0, *src_bitmap, rect, tone, Opacity::Opaque());
 		}
 
 		if (blend != Color()) {
 			if (bitmap_effects) {
 				// Tone blit was applied
-				bitmap_effects->BlendBlit(0, 0, *bitmap_effects, bitmap_effects->GetRect(), blend, Opacity::opaque);
+				bitmap_effects->BlendBlit(0, 0, *bitmap_effects, bitmap_effects->GetRect(), blend, Opacity::Opaque());
 			} else {
 				bitmap_effects = create();
-				bitmap_effects->BlendBlit(0, 0, *src_bitmap, rect, blend, Opacity::opaque);
+				bitmap_effects->BlendBlit(0, 0, *src_bitmap, rect, blend, Opacity::Opaque());
 			}
 		}
 
@@ -489,7 +489,7 @@ BitmapRef Cache::SpriteEffect(const BitmapRef& src_bitmap, const Rect& rect, boo
 				bitmap_effects->Flip(bitmap_effects->GetRect(), flip_x, flip_y);
 			} else {
 				bitmap_effects = create();
-				bitmap_effects->FlipBlit(rect.x, rect.y, *src_bitmap, rect, flip_x, flip_y, Opacity::opaque);
+				bitmap_effects->FlipBlit(rect.x, rect.y, *src_bitmap, rect, flip_x, flip_y, Opacity::Opaque());
 			}
 		}
 

--- a/src/game_picture.cpp
+++ b/src/game_picture.cpp
@@ -67,7 +67,7 @@ void Game_Picture::UpdateSprite() {
 		sheet_bitmap->Clear();
 
 		if (last_spritesheet_frame >= 0 && last_spritesheet_frame < NumSpriteSheetFrames()) {
-			sheet_bitmap->Blit(0, 0, *whole_bitmap, r, Opacity::opaque);
+			sheet_bitmap->Blit(0, 0, *whole_bitmap, r, Opacity::Opaque());
 		}
 
 		sprite->SetBitmap(sheet_bitmap);

--- a/src/opacity.h
+++ b/src/opacity.h
@@ -1,0 +1,59 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_OPACITY_H
+#define EP_OPACITY_H
+
+#include <cassert>
+
+/** Opacity class.  */
+struct Opacity {
+	static constexpr Opacity Opaque() { return Opacity(); }
+
+	int top = 255;
+	int bottom = 255;
+	int split = 0;
+
+	constexpr Opacity() = default;
+
+	constexpr Opacity(int opacity) :
+		Opacity(opacity, opacity, 0) {}
+
+	constexpr Opacity(int top_opacity, int bottom_opacity, int split) :
+		top(top_opacity), bottom(bottom_opacity), split(split) {}
+
+	int Value() const {
+		assert(!IsSplit());
+		return top;
+	}
+
+	constexpr bool IsSplit() const {
+		return split > 0 && top != bottom;
+	}
+
+	constexpr bool IsTransparent() const {
+		return IsSplit() ? top <= 0 && bottom <= 0 : top <= 0;
+	}
+
+	constexpr bool IsOpaque() const {
+		return IsSplit() ? top >= 255 && bottom >= 255 : top >= 255;
+	}
+
+	private:
+};
+
+#endif

--- a/src/pixman_image_ptr.h
+++ b/src/pixman_image_ptr.h
@@ -1,0 +1,145 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_PIXMAN_IMAGE_PTR_H
+#define EP_PIXMAN_IMAGE_PTR_H
+
+#include <functional>
+#include <pixman.h>
+
+class PixmanImagePtr {
+	public:
+		/** Construct with nullptr */
+		constexpr PixmanImagePtr() = default;
+
+		/** Construct with nullptr */
+		constexpr PixmanImagePtr(std::nullptr_t);
+
+		/** Take ownership of img */
+		explicit constexpr PixmanImagePtr(pixman_image_t* img);
+
+		/** Increment ref count and share img with other */
+		PixmanImagePtr(const PixmanImagePtr&);
+
+		/** Increment ref count and share img with other */
+		PixmanImagePtr& operator=(const PixmanImagePtr&);
+
+		/** Take img from other */
+		PixmanImagePtr(PixmanImagePtr&&);
+
+		/** Take img from other */
+		PixmanImagePtr& operator=(PixmanImagePtr&&);
+
+		/** Unreference and possibly destroy image */
+		~PixmanImagePtr();
+
+		/** @return pointer to image */
+		pixman_image_t* get() const;
+
+		/** @return reference to image */
+		pixman_image_t& operator*() const;
+
+		/** @return pointer to image */
+		pixman_image_t* operator->() const;
+
+		/** @return true if image is not nullptr */
+		explicit operator bool() const;
+
+		/** 
+		 * Release current image (if any) and take ownership of img
+		 *
+		 * @param img new image to take ownership of
+		 */
+		void reset(pixman_image_t* img = nullptr);
+	private:
+		pixman_image_t* _img = nullptr;
+};
+
+inline bool operator==(const PixmanImagePtr& l, const PixmanImagePtr& r) { return l.get() == r.get(); }
+inline bool operator!=(const PixmanImagePtr& l, const PixmanImagePtr& r) { return l.get() != r.get(); }
+inline bool operator<(const PixmanImagePtr& l, const PixmanImagePtr& r) { return l.get() < r.get(); }
+inline bool operator<=(const PixmanImagePtr& l, const PixmanImagePtr& r) { return l.get() <= r.get(); }
+inline bool operator>(const PixmanImagePtr& l, const PixmanImagePtr& r) { return l.get() > r.get(); }
+inline bool operator>=(const PixmanImagePtr& l, const PixmanImagePtr& r) { return l.get() >= r.get(); }
+
+namespace std {
+template <> struct hash<PixmanImagePtr> {
+	size_t operator()(const PixmanImagePtr& p) {
+		return std::hash<void*>()(p.get());
+	}
+};
+}
+
+inline constexpr PixmanImagePtr::PixmanImagePtr(std::nullptr_t) {}
+
+inline constexpr PixmanImagePtr::PixmanImagePtr(pixman_image_t* img)
+	: _img(img) {}
+
+inline PixmanImagePtr::PixmanImagePtr(const PixmanImagePtr& o)
+	: _img(o._img ? ::pixman_image_ref(o._img) : nullptr)
+{ }
+
+inline PixmanImagePtr& PixmanImagePtr::operator=(const PixmanImagePtr& o) {
+	if (this != &o) {
+		reset();
+		_img = o._img ? ::pixman_image_ref(o._img) : nullptr;
+	}
+	return *this;
+}
+inline PixmanImagePtr::PixmanImagePtr(PixmanImagePtr&& o)
+	:_img(o._img)
+{
+	o._img = nullptr;
+}
+
+inline PixmanImagePtr& PixmanImagePtr::operator=(PixmanImagePtr&& o) {
+	if (this != &o) {
+		reset();
+		_img = o._img;
+		o._img = nullptr;
+	}
+	return *this;
+}
+
+inline PixmanImagePtr::~PixmanImagePtr() {
+	reset();
+}
+
+inline pixman_image_t* PixmanImagePtr::get() const {
+	return _img;
+}
+
+inline pixman_image_t& PixmanImagePtr::operator*() const {
+	return *_img;
+}
+
+inline pixman_image_t* PixmanImagePtr::operator->() const {
+	return _img;
+}
+
+inline PixmanImagePtr::operator bool() const {
+	return get() != nullptr;
+}
+
+inline void PixmanImagePtr::reset(pixman_image_t* img) {
+	if (_img) {
+		::pixman_image_unref(_img);
+	}
+	_img = img;
+}
+
+#endif

--- a/src/pixman_image_ptr.h
+++ b/src/pixman_image_ptr.h
@@ -27,10 +27,10 @@ class PixmanImagePtr {
 		constexpr PixmanImagePtr() = default;
 
 		/** Construct with nullptr */
-		constexpr PixmanImagePtr(std::nullptr_t);
+		constexpr PixmanImagePtr(std::nullptr_t) noexcept;
 
 		/** Take ownership of img */
-		explicit constexpr PixmanImagePtr(pixman_image_t* img);
+		explicit constexpr PixmanImagePtr(pixman_image_t* img) noexcept;
 
 		/** Increment ref count and share img with other */
 		PixmanImagePtr(const PixmanImagePtr&);
@@ -39,32 +39,32 @@ class PixmanImagePtr {
 		PixmanImagePtr& operator=(const PixmanImagePtr&);
 
 		/** Take img from other */
-		PixmanImagePtr(PixmanImagePtr&&);
+		PixmanImagePtr(PixmanImagePtr&&) noexcept;
 
 		/** Take img from other */
-		PixmanImagePtr& operator=(PixmanImagePtr&&);
+		PixmanImagePtr& operator=(PixmanImagePtr&&) noexcept;
 
 		/** Unreference and possibly destroy image */
 		~PixmanImagePtr();
 
 		/** @return pointer to image */
-		pixman_image_t* get() const;
+		pixman_image_t* get() const noexcept;
 
 		/** @return reference to image */
-		pixman_image_t& operator*() const;
+		pixman_image_t& operator*() const noexcept;
 
 		/** @return pointer to image */
-		pixman_image_t* operator->() const;
+		pixman_image_t* operator->() const noexcept;
 
 		/** @return true if image is not nullptr */
-		explicit operator bool() const;
+		explicit operator bool() const noexcept;
 
 		/** 
 		 * Release current image (if any) and take ownership of img
 		 *
 		 * @param img new image to take ownership of
 		 */
-		void reset(pixman_image_t* img = nullptr);
+		void reset(pixman_image_t* img = nullptr) noexcept;
 	private:
 		pixman_image_t* _img = nullptr;
 };
@@ -84,9 +84,9 @@ template <> struct hash<PixmanImagePtr> {
 };
 }
 
-inline constexpr PixmanImagePtr::PixmanImagePtr(std::nullptr_t) {}
+inline constexpr PixmanImagePtr::PixmanImagePtr(std::nullptr_t) noexcept {}
 
-inline constexpr PixmanImagePtr::PixmanImagePtr(pixman_image_t* img)
+inline constexpr PixmanImagePtr::PixmanImagePtr(pixman_image_t* img) noexcept
 	: _img(img) {}
 
 inline PixmanImagePtr::PixmanImagePtr(const PixmanImagePtr& o)
@@ -100,13 +100,13 @@ inline PixmanImagePtr& PixmanImagePtr::operator=(const PixmanImagePtr& o) {
 	}
 	return *this;
 }
-inline PixmanImagePtr::PixmanImagePtr(PixmanImagePtr&& o)
+inline PixmanImagePtr::PixmanImagePtr(PixmanImagePtr&& o) noexcept
 	:_img(o._img)
 {
 	o._img = nullptr;
 }
 
-inline PixmanImagePtr& PixmanImagePtr::operator=(PixmanImagePtr&& o) {
+inline PixmanImagePtr& PixmanImagePtr::operator=(PixmanImagePtr&& o) noexcept {
 	if (this != &o) {
 		reset();
 		_img = o._img;
@@ -119,23 +119,23 @@ inline PixmanImagePtr::~PixmanImagePtr() {
 	reset();
 }
 
-inline pixman_image_t* PixmanImagePtr::get() const {
+inline pixman_image_t* PixmanImagePtr::get() const noexcept {
 	return _img;
 }
 
-inline pixman_image_t& PixmanImagePtr::operator*() const {
+inline pixman_image_t& PixmanImagePtr::operator*() const noexcept {
 	return *_img;
 }
 
-inline pixman_image_t* PixmanImagePtr::operator->() const {
+inline pixman_image_t* PixmanImagePtr::operator->() const noexcept {
 	return _img;
 }
 
-inline PixmanImagePtr::operator bool() const {
+inline PixmanImagePtr::operator bool() const noexcept {
 	return get() != nullptr;
 }
 
-inline void PixmanImagePtr::reset(pixman_image_t* img) {
+inline void PixmanImagePtr::reset(pixman_image_t* img) noexcept {
 	if (_img) {
 		::pixman_image_unref(_img);
 	}

--- a/src/plane.cpp
+++ b/src/plane.cpp
@@ -40,7 +40,7 @@ void Plane::Draw(Bitmap& dst) {
 			tone_bitmap = Bitmap::Create(bitmap->GetWidth(), bitmap->GetHeight());
 		}
 		tone_bitmap->Clear();
-		tone_bitmap->ToneBlit(0, 0, *bitmap, bitmap->GetRect(), tone_effect, Opacity::opaque);
+		tone_bitmap->ToneBlit(0, 0, *bitmap, bitmap->GetRect(), tone_effect, Opacity::Opaque());
 	}
 
 	BitmapRef source = tone_effect == Tone() ? bitmap : tone_bitmap;

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -59,18 +59,17 @@ void Sprite::BlitScreen(Bitmap& dst) {
 			rect.y %= bitmap_effects->GetHeight();
 		}
 
-		BlitScreenIntern(dst, *draw_bitmap, rect, bush_effect);
+		BlitScreenIntern(dst, *draw_bitmap, rect);
 	}
 }
 
-void Sprite::BlitScreenIntern(Bitmap& dst, Bitmap const& draw_bitmap,
-								Rect const& src_rect, int opacity_split) const {
-
+void Sprite::BlitScreenIntern(Bitmap& dst, Bitmap const& draw_bitmap, Rect const& src_rect) const
+{
 	double zoom_x = zoom_x_effect;
 	double zoom_y = zoom_y_effect;
 
 	dst.EffectsBlit(x, y, ox, oy, draw_bitmap, src_rect,
-					 Opacity(opacity_top_effect, opacity_bottom_effect, opacity_split),
+					 Opacity(opacity_top_effect, opacity_bottom_effect, bush_effect),
 					 zoom_x, zoom_y, angle_effect,
 					 waver_effect_depth, waver_effect_phase);
 }

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -150,7 +150,7 @@ private:
 
 	void BlitScreen(Bitmap& dst);
 	void BlitScreenIntern(Bitmap& dst, Bitmap const& draw_bitmap,
-							Rect const& src_rect, int opacity_split) const;
+							Rect const& src_rect) const;
 	BitmapRef Refresh(Rect& rect);
 	void SetFlashEffect(const Color &color);
 };

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -244,7 +244,7 @@ void TilemapLayer::Draw(Bitmap& dst, int z_order) {
 						// Create tone changed tile
 						if (chipset_tone_tiles.find(id) == chipset_tone_tiles.end()) {
 							Rect r(col * TILE_SIZE, row * TILE_SIZE, TILE_SIZE, TILE_SIZE);
-							chipset_effect->ToneBlit(col * TILE_SIZE, row * TILE_SIZE, *chipset, r, tone, Opacity::opaque);
+							chipset_effect->ToneBlit(col * TILE_SIZE, row * TILE_SIZE, *chipset, r, tone, Opacity::Opaque());
 							chipset_tone_tiles.insert(id);
 						}
 
@@ -259,7 +259,7 @@ void TilemapLayer::Draw(Bitmap& dst, int z_order) {
 						// Create tone changed tile
 						if (chipset_tone_tiles.find(tile.ID + (animation_step_c << 12)) == chipset_tone_tiles.end()) {
 							Rect r(col * TILE_SIZE, row * TILE_SIZE, TILE_SIZE, TILE_SIZE);
-							chipset_effect->ToneBlit(col * TILE_SIZE, row * TILE_SIZE, *chipset, r, tone, Opacity::opaque);
+							chipset_effect->ToneBlit(col * TILE_SIZE, row * TILE_SIZE, *chipset, r, tone, Opacity::Opaque());
 							chipset_tone_tiles.insert(tile.ID + (animation_step_c << 12));
 						}
 
@@ -274,7 +274,7 @@ void TilemapLayer::Draw(Bitmap& dst, int z_order) {
 						// Create tone changed tile
 						if (autotiles_ab_screen_tone_tiles.find(tile.ID + (animation_step_ab << 12)) == autotiles_ab_screen_tone_tiles.end()) {
 							Rect r(pos.x * TILE_SIZE, pos.y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
-							autotiles_ab_screen_effect->ToneBlit(pos.x * TILE_SIZE, pos.y * TILE_SIZE, *autotiles_ab_screen, r, tone, Opacity::opaque);
+							autotiles_ab_screen_effect->ToneBlit(pos.x * TILE_SIZE, pos.y * TILE_SIZE, *autotiles_ab_screen, r, tone, Opacity::Opaque());
 							autotiles_ab_screen_tone_tiles.insert(tile.ID + (animation_step_ab << 12));
 						}
 
@@ -288,7 +288,7 @@ void TilemapLayer::Draw(Bitmap& dst, int z_order) {
 						// Create tone changed tile
 						if (autotiles_d_screen_tone_tiles.find(tile.ID) == autotiles_d_screen_tone_tiles.end()) {
 							Rect r(pos.x * TILE_SIZE, pos.y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
-							autotiles_d_screen_effect->ToneBlit(pos.x * TILE_SIZE, pos.y * TILE_SIZE, *autotiles_d_screen, r, tone, Opacity::opaque);
+							autotiles_d_screen_effect->ToneBlit(pos.x * TILE_SIZE, pos.y * TILE_SIZE, *autotiles_d_screen, r, tone, Opacity::Opaque());
 							autotiles_d_screen_tone_tiles.insert(tile.ID);
 						}
 
@@ -316,7 +316,7 @@ void TilemapLayer::Draw(Bitmap& dst, int z_order) {
 						// Create tone changed tile
 						if (chipset_tone_tiles.find(id) == chipset_tone_tiles.end()) {
 							Rect r(col * TILE_SIZE, row * TILE_SIZE, TILE_SIZE, TILE_SIZE);
-							chipset_effect->ToneBlit(col * TILE_SIZE, row * TILE_SIZE, *chipset, r, tone, Opacity::opaque);
+							chipset_effect->ToneBlit(col * TILE_SIZE, row * TILE_SIZE, *chipset, r, tone, Opacity::Opaque());
 							chipset_tone_tiles.insert(id);
 						}
 

--- a/src/transition.cpp
+++ b/src/transition.cpp
@@ -172,10 +172,10 @@ void Transition::Draw(Bitmap& dst) {
 			random_block_transition->Blit(random_blocks[i] % (w / size_random_blocks) * size_random_blocks,
 				random_blocks[i] / (w / size_random_blocks) * size_random_blocks, *screen2,
 				Rect(random_blocks[i] % (w / size_random_blocks) * size_random_blocks, random_blocks[i] / (w / size_random_blocks) * size_random_blocks,
-					size_random_blocks, size_random_blocks), Opacity::opaque);
+					size_random_blocks, size_random_blocks), Opacity::Opaque());
 		}
-		dst.Blit(0, 0, *screen1, screen1->GetRect(), Opacity::opaque);
-		dst.Blit(0, 0, *random_block_transition, random_block_transition->GetRect(), Opacity::opaque);
+		dst.Blit(0, 0, *screen1, screen1->GetRect(), Opacity::Opaque());
+		dst.Blit(0, 0, *random_block_transition, random_block_transition->GetRect(), Opacity::Opaque());
 		current_blocks_print = blocks_to_print;
 		break;
 	case TransitionBlindOpen:

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -121,7 +121,7 @@ void Weather::DrawRain(Bitmap& dst) {
 	if (!rain_bitmap) {
 		rain_bitmap = Bitmap::Create(rain_image, sizeof(rain_image));
 		if (tone_effect != Tone()) {
-			rain_bitmap->ToneBlit(0, 0, *rain_bitmap, rain_bitmap->GetRect(), tone_effect, Opacity::opaque, true);
+			rain_bitmap->ToneBlit(0, 0, *rain_bitmap, rain_bitmap->GetRect(), tone_effect, Opacity::Opaque(), true);
 		}
 	}
 
@@ -141,7 +141,7 @@ void Weather::DrawSnow(Bitmap& dst) {
 	if (!snow_bitmap) {
 		snow_bitmap = Bitmap::Create(snow_image, sizeof(snow_image));
 		if (tone_effect != Tone()) {
-			snow_bitmap->ToneBlit(0, 0, *snow_bitmap, snow_bitmap->GetRect(), tone_effect, Opacity::opaque, true);
+			snow_bitmap->ToneBlit(0, 0, *snow_bitmap, snow_bitmap->GetRect(), tone_effect, Opacity::Opaque(), true);
 		}
 	}
 
@@ -223,7 +223,7 @@ void Weather::DrawFogOverlay(Bitmap& dst, const Bitmap& overlay, BitmapRef& tone
 			tone_overlay = Bitmap::Create(overlay, sr);
 		}
 		if (tone_dirty) {
-			tone_overlay->ToneBlit(0, 0, overlay, sr, tone_effect, Opacity::opaque, false);
+			tone_overlay->ToneBlit(0, 0, overlay, sr, tone_effect, Opacity::Opaque(), false);
 		}
 		src = tone_overlay.get();
 	}

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -84,7 +84,7 @@ void Window_Base::OnFaceReady(FileRequestResult* result, int face_index, int cx,
 		);
 
 	if (flip) {
-		contents->FlipBlit(cx, cy, *faceset, src_rect, true, false, Opacity::opaque);
+		contents->FlipBlit(cx, cy, *faceset, src_rect, true, false, Opacity::Opaque());
 	}
 	else {
 		contents->Blit(cx, cy, *faceset, src_rect, 255);

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -121,7 +121,7 @@ void Window_BattleStatus::RefreshGauge() {
 					DrawActorFace(*static_cast<const Game_Actor*>(actor), 80 * i, 24);
 
 					// Background
-					contents->StretchBlit(Rect(32 + i * 80, 24, 57, 48), *system2, Rect(0, 32, 48, 48), Opacity::opaque);
+					contents->StretchBlit(Rect(32 + i * 80, 24, 57, 48), *system2, Rect(0, 32, 48, 48), Opacity::Opaque());
 
 					// HP
 					DrawGaugeSystem2(48 + i * 80, 24, actor->GetHp(), actor->GetMaxHp(), 0);
@@ -165,7 +165,7 @@ void Window_BattleStatus::DrawGaugeSystem2(int x, int y, int cur_value, int max_
 		gauge_width = 25 * cur_value / max_value;
 	}
 
-	contents->StretchBlit(Rect(x, y, gauge_width, 16), *system2, Rect(48 + gauge_x, 32 + 16 * which, 16, 16), Opacity::opaque);
+	contents->StretchBlit(Rect(x, y, gauge_width, 16), *system2, Rect(48 + gauge_x, 32 + 16 * which, 16, 16), Opacity::Opaque());
 }
 
 void Window_BattleStatus::DrawNumberSystem2(int x, int y, int value) {
@@ -175,7 +175,7 @@ void Window_BattleStatus::DrawNumberSystem2(int x, int y, int value) {
 	bool handle_zero = false;
 
 	if (value >= 1000) {
-		contents->Blit(x, y, *system2, Rect((value / 1000) * 8, 80, 8, 16), Opacity::opaque);
+		contents->Blit(x, y, *system2, Rect((value / 1000) * 8, 80, 8, 16), Opacity::Opaque());
 		value %= 1000;
 		if (value < 100) {
 			handle_zero = true;
@@ -183,18 +183,18 @@ void Window_BattleStatus::DrawNumberSystem2(int x, int y, int value) {
 	}
 	if (handle_zero || value >= 100) {
 		handle_zero = false;
-		contents->Blit(x + 8, y, *system2, Rect((value / 100) * 8, 80, 8, 16), Opacity::opaque);
+		contents->Blit(x + 8, y, *system2, Rect((value / 100) * 8, 80, 8, 16), Opacity::Opaque());
 		value %= 100;
 		if (value < 10) {
 			handle_zero = true;
 		}
 	}
 	if (handle_zero || value >= 10) {
-		contents->Blit(x + 8 * 2, y, *system2, Rect((value / 10) * 8, 80, 8, 16), Opacity::opaque);
+		contents->Blit(x + 8 * 2, y, *system2, Rect((value / 10) * 8, 80, 8, 16), Opacity::Opaque());
 		value %= 10;
 	}
 
-	contents->Blit(x + 8 * 3, y, *system2, Rect(value * 8, 80, 8, 16), Opacity::opaque);
+	contents->Blit(x + 8 * 3, y, *system2, Rect(value * 8, 80, 8, 16), Opacity::Opaque());
 }
 
 int Window_BattleStatus::ChooseActiveCharacter() {

--- a/src/window_shopparty.cpp
+++ b/src/window_shopparty.cpp
@@ -175,7 +175,7 @@ void Window_ShopParty::OnCharsetSpriteReady(FileRequestResult* /* result */, int
 			bm2->Clear();
 			bm2->Blit(0, 0, *bm, src, 255);
 			if (k == 0)
-				bm2->ToneBlit(0, 0, *bm2, bm2->GetRect(), Tone(128, 128, 128, 0), Opacity::opaque);
+				bm2->ToneBlit(0, 0, *bm2, bm2->GetRect(), Tone(128, 128, 128, 0), Opacity::Opaque());
 			bitmaps[party_index][j][k] = bm2;
 		}
 	}


### PR DESCRIPTION
This creates a simple RAII wrapper around pixman images which uses pixman's reference counting and provides a `shared_ptr` like interface.

No material change other than code cleanup. But this will be used later to optimize Bitmap and remove the need for `BitmapRef`

Tested this by playing Frozen triggers and everything works.