### PR TITLE
Fix spritesheet regression

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2433,7 +2433,8 @@ bool Game_Interpreter::CommandShowPicture(RPG::EventCommand const& com) { // cod
 		if (com.parameters[24] == 2) {
 			params.spritesheet_speed = com.parameters[25];
 		} else {
-			params.spritesheet_frame = ValueOrVariable(com.parameters[24], com.parameters[25]);
+			// Picture data / LSD data frame number is 0 based, while event parameter counts from 1.
+			params.spritesheet_frame = ValueOrVariable(com.parameters[24], com.parameters[25]) - 1;
 		}
 
 		params.spritesheet_play_once = com.parameters[26];

--- a/src/game_picture.cpp
+++ b/src/game_picture.cpp
@@ -44,7 +44,10 @@ void Game_Picture::UpdateSprite() {
 	}
 
 	// RPG Maker 2k3 1.12: Spritesheets
-	if (HasSpritesheet() && (data.spritesheet_frame != last_spritesheet_frame || !sheet_bitmap)) {
+	if (Player::IsRPG2k3E()
+			&& NumSpriteSheetFrames() > 1
+			&& (data.spritesheet_frame != last_spritesheet_frame || !sheet_bitmap))
+	{
 		// Usage of an additional bitmap instead of Subrect is necessary because the Subrect
 		// approach will fail while the bitmap is rotated because the outer parts will be
 		// visible for degrees != 90 * n
@@ -268,16 +271,6 @@ void Game_Picture::OnPictureSpriteReady(FileRequestResult*) {
 		sprite.reset(new Sprite());
 	}
 	sprite->SetBitmap(whole_bitmap);
-}
-
-bool Game_Picture::HasSpritesheet() const {
-	RPG::SavePicture& data = GetData();
-
-	if (data.spritesheet_rows < 1 || data.spritesheet_cols < 1) {
-		return false;
-	}
-
-	return data.spritesheet_rows > 1 || data.spritesheet_cols > 1;
 }
 
 void Game_Picture::Update() {

--- a/src/game_picture.h
+++ b/src/game_picture.h
@@ -86,6 +86,7 @@ private:
 	void RequestPictureSprite();
 	void OnPictureSpriteReady(FileRequestResult*);
 	bool HasSpritesheet() const;
+	int NumSpriteSheetFrames() const;
 	/**
 	 * Compared to other classes picture doesn't hold a direct reference.
 	 * Resizing the picture vector when the ID is larger then the vector can

--- a/src/game_picture.h
+++ b/src/game_picture.h
@@ -85,7 +85,6 @@ private:
 	void SyncCurrentToFinish();
 	void RequestPictureSprite();
 	void OnPictureSpriteReady(FileRequestResult*);
-	bool HasSpritesheet() const;
 	int NumSpriteSheetFrames() const;
 	/**
 	 * Compared to other classes picture doesn't hold a direct reference.


### PR DESCRIPTION
* spritesheet_frame from command starts with 1, but save data starts 0
* Optimize case for invalid frames, which can be caused by code
  which uses variables to set the frame id

The bug can be noticed in Frozen Triggers. Right at the beginning the are visual glitches with the weapons.