### PR TITLE
Refactor and optimize Game_Picture + Wave fix - Bitmaps 2 of N

### DIFF
--- a/bench/bitmap.cpp
+++ b/bench/bitmap.cpp
@@ -11,7 +11,15 @@ constexpr auto opacity_0 = Opacity(0);
 constexpr auto opacity_50 = Opacity(128);
 constexpr auto opacity_75_25 = Opacity(192, 64, 1);
 
-auto opacity = opacity_opaque;
+constexpr auto opacity = opacity_opaque;
+
+const auto fmt_rgba = format_R8G8B8A8_a().format();
+const auto fmt_bgra = format_B8G8R8A8_a().format();
+const auto fmt_argb = format_A8R8G8B8_a().format();
+const auto fmt_abgr = format_A8B8G8R8_a().format();
+
+const DynamicFormat formats[] = { fmt_rgba, fmt_bgra, fmt_argb, fmt_abgr };
+const auto format = fmt_rgba;
 
 struct BitmapAccess : public Bitmap {
 	static pixman_format_code_t find_format(const DynamicFormat& format) {
@@ -20,9 +28,8 @@ struct BitmapAccess : public Bitmap {
 };
 
 static void BM_FindFormatSingle(benchmark::State& state) {
-	const auto fmt = format_R8G8B8A8_a().format();
 	for (auto _: state) {
-		BitmapAccess::find_format(fmt);
+		BitmapAccess::find_format(format);
 	}
 }
 
@@ -30,17 +37,16 @@ BENCHMARK(BM_FindFormatSingle);
 
 static void BM_FindFormat(benchmark::State& state) {
 	for (auto _: state) {
-		BitmapAccess::find_format(format_R8G8B8A8_a().format());
-		BitmapAccess::find_format(format_B8G8R8A8_a().format());
-		BitmapAccess::find_format(format_A8B8G8R8_n().format());
-		BitmapAccess::find_format(format_B8G8R8A8_n().format());
+		for (auto& f: formats) {
+			BitmapAccess::find_format(f);
+		}
 	}
 }
 
 BENCHMARK(BM_FindFormat);
 
 static void BM_Create(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	for (auto _: state) {
 		auto bm = Bitmap::Create(320, 240);
 		(void)bm;
@@ -50,7 +56,7 @@ static void BM_Create(benchmark::State& state) {
 BENCHMARK(BM_Create);
 
 static void BM_Blit(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto src = Bitmap::Create(320, 240);
 	auto rect = src->GetRect();
@@ -62,7 +68,7 @@ static void BM_Blit(benchmark::State& state) {
 BENCHMARK(BM_Blit);
 
 static void BM_BlitFast(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto src = Bitmap::Create(320, 240);
 	auto rect = src->GetRect();
@@ -74,7 +80,7 @@ static void BM_BlitFast(benchmark::State& state) {
 BENCHMARK(BM_BlitFast);
 
 static void BM_TiledBlit(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto src = Bitmap::Create(320, 240);
 	auto rect = src->GetRect();
@@ -86,7 +92,7 @@ static void BM_TiledBlit(benchmark::State& state) {
 BENCHMARK(BM_TiledBlit);
 
 static void BM_TiledBlitOffset(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto src = Bitmap::Create(320, 240);
 	auto rect = src->GetRect();
@@ -98,7 +104,7 @@ static void BM_TiledBlitOffset(benchmark::State& state) {
 BENCHMARK(BM_TiledBlitOffset);
 
 static void BM_StretchBlit(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto src = Bitmap::Create(20, 20);
 	auto rect = src->GetRect();
@@ -110,7 +116,7 @@ static void BM_StretchBlit(benchmark::State& state) {
 BENCHMARK(BM_StretchBlit);
 
 static void BM_StretchBlitRect(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto dst_rect = dest->GetRect();
 	auto src = Bitmap::Create(20, 20);
@@ -123,7 +129,7 @@ static void BM_StretchBlitRect(benchmark::State& state) {
 BENCHMARK(BM_StretchBlitRect);
 
 static void BM_FlipBlit(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto src = Bitmap::Create(320, 240);
 	auto rect = src->GetRect();
@@ -134,22 +140,32 @@ static void BM_FlipBlit(benchmark::State& state) {
 
 BENCHMARK(BM_FlipBlit);
 
-static void BM_TransformBlit(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+static void BM_ZoomOpacityBlit(benchmark::State& state) {
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
-	auto dst_rect = dest->GetRect();
-	auto src = Bitmap::Create(320, 240);
+	auto src = Bitmap::Create(60, 60);
 	auto rect = src->GetRect();
-	auto xform = Transform::Rotation(2 * M_PI);
 	for (auto _: state) {
-		dest->TransformBlit(dst_rect, *src, rect, xform, opacity);
+		dest->ZoomOpacityBlit(0, 0, 30, 30, *src, rect, 2.0, 2.0, opacity);
 	}
 }
 
-BENCHMARK(BM_TransformBlit);
+BENCHMARK(BM_ZoomOpacityBlit);
+
+static void BM_RotateZoomOpacityBlit(benchmark::State& state) {
+	Bitmap::SetFormat(format);
+	auto dest = Bitmap::Create(320, 240);
+	auto src = Bitmap::Create(60, 60);
+	auto rect = src->GetRect();
+	for (auto _: state) {
+		dest->RotateZoomOpacityBlit(0, 0, 30, 30, *src, rect, M_PI, 2.0, 2.0, opacity);
+	}
+}
+
+BENCHMARK(BM_RotateZoomOpacityBlit);
 
 static void BM_WaverBlit(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto src = Bitmap::Create(320, 240);
 	auto rect = src->GetRect();
@@ -165,7 +181,7 @@ static void BM_WaverBlit(benchmark::State& state) {
 BENCHMARK(BM_WaverBlit);
 
 static void BM_Fill(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto color = Color(255, 255, 255, 255);
 	for (auto _: state) {
@@ -176,7 +192,7 @@ static void BM_Fill(benchmark::State& state) {
 BENCHMARK(BM_Fill);
 
 static void BM_FillRect(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto rect = dest->GetRect();
 	auto color = Color(255, 255, 255, 255);
@@ -188,7 +204,7 @@ static void BM_FillRect(benchmark::State& state) {
 BENCHMARK(BM_FillRect);
 
 static void BM_Clear(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	for (auto _: state) {
 		dest->Clear();
@@ -198,7 +214,7 @@ static void BM_Clear(benchmark::State& state) {
 BENCHMARK(BM_Clear);
 
 static void BM_ClearRect(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto rect = dest->GetRect();
 	for (auto _: state) {
@@ -209,7 +225,7 @@ static void BM_ClearRect(benchmark::State& state) {
 BENCHMARK(BM_ClearRect);
 
 static void BM_HueChangeBlit(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto src = Bitmap::Create(320, 240);
 	auto rect = src->GetRect();
@@ -222,7 +238,7 @@ static void BM_HueChangeBlit(benchmark::State& state) {
 BENCHMARK(BM_HueChangeBlit);
 
 static void BM_ToneBlit(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto src = Bitmap::Create(320, 240);
 	auto rect = src->GetRect();
@@ -235,7 +251,7 @@ static void BM_ToneBlit(benchmark::State& state) {
 BENCHMARK(BM_ToneBlit);
 
 static void BM_BlendBlit(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto src = Bitmap::Create(320, 240);
 	auto rect = src->GetRect();
@@ -248,7 +264,7 @@ static void BM_BlendBlit(benchmark::State& state) {
 BENCHMARK(BM_BlendBlit);
 
 static void BM_Flip(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto rect = dest->GetRect();
 	for (auto _: state) {
@@ -259,7 +275,7 @@ static void BM_Flip(benchmark::State& state) {
 BENCHMARK(BM_Flip);
 
 static void BM_MaskedBlit(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto dst_rect = dest->GetRect();
 	auto src = Bitmap::Create(320, 240);
@@ -272,7 +288,7 @@ static void BM_MaskedBlit(benchmark::State& state) {
 BENCHMARK(BM_MaskedBlit);
 
 static void BM_MaskedColorBlit(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto dst_rect = dest->GetRect();
 	auto mask = Bitmap::Create(320, 240);
@@ -285,7 +301,7 @@ static void BM_MaskedColorBlit(benchmark::State& state) {
 BENCHMARK(BM_MaskedColorBlit);
 
 static void BM_Blit2x(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto dst_rect = dest->GetRect();
 	auto src = Bitmap::Create(320, 240);
@@ -298,7 +314,7 @@ static void BM_Blit2x(benchmark::State& state) {
 BENCHMARK(BM_Blit2x);
 
 static void BM_TransformRectangle(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto rect = dest->GetRect();
 	auto xform = Transform::Rotation(M_PI);
@@ -310,7 +326,7 @@ static void BM_TransformRectangle(benchmark::State& state) {
 BENCHMARK(BM_TransformRectangle);
 
 static void BM_EffectsBlit(benchmark::State& state) {
-	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	Bitmap::SetFormat(format);
 	auto dest = Bitmap::Create(320, 240);
 	auto src = Bitmap::Create(320, 240);
 	auto rect = src->GetRect();

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -698,6 +698,8 @@ void Bitmap::WaverBlit(int x, int y, double zoom_x, double zoom_y, Bitmap const&
 
 	int height = static_cast<int>(std::floor(src_rect.height * zoom_y));
 	int width  = static_cast<int>(std::floor(src_rect.width * zoom_x));
+	const auto xoff = src_rect.x * zoom_x;
+	const auto yoff = src_rect.y * zoom_y;
 	const auto yclip = y < 0 ? -y : 0;
 	const auto yend = std::min(height, this->height() - y);
 	for (int i = yclip; i < yend; i++) {
@@ -710,8 +712,8 @@ void Bitmap::WaverBlit(int x, int y, double zoom_x, double zoom_y, Bitmap const&
 
 		pixman_image_composite32(src.GetOperator(mask.get()),
 								 src.bitmap.get(), mask.get(), bitmap.get(),
-								 src_rect.x, i,
-								 src_rect.x, i,
+								 xoff, yoff + i,
+								 0, i,
 								 x + offset, dy,
 								 width, 1);
 	}

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -336,7 +336,7 @@ public:
 	void FlipBlit(int x, int y, Bitmap const& src, Rect const& src_rect, bool horizontal, bool vertical, Opacity const& opacity);
 
 	/**
-	 * Blits source bitmap with waver effect.
+	 * Blits source bitmap with waver, zoom, and opacity effects.
 	 *
 	 * @param x x position.
 	 * @param y y position.
@@ -351,11 +351,17 @@ public:
 	void WaverBlit(int x, int y, double zoom_x, double zoom_y, Bitmap const& src, Rect const& src_rect, int depth, double phase, Opacity const& opacity);
 
 	/**
-	 * Blits source bitmap with transformation and opacity scaling.
+	 * Blits source bitmap with rotation, zoom, and opacity effects.
 	 *
-	 * @param fwd forward (src->dst) transformation matrix.
+	 * @param x x position.
+	 * @param y y position.
+	 * @param ox source origin x.
+	 * @param oy source origin y.
 	 * @param src source bitmap.
-	 * @param src_rect source bitmap rectangle.
+	 * @param src_rect source bitmap rect.
+	 * @param angle rotation angle in radians.
+	 * @param zoom_x x scale factor.
+	 * @param zoom_y y scale factor.
 	 * @param opacity opacity.
 	 */
 	void RotateZoomOpacityBlit(int x, int y, int ox, int oy,

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -336,18 +336,6 @@ public:
 	void FlipBlit(int x, int y, Bitmap const& src, Rect const& src_rect, bool horizontal, bool vertical, Opacity const& opacity);
 
 	/**
-	 * Blits source bitmap scaled, rotated and translated.
-	 *
-	 * @param dst_rect destination rect.
-	 * @param src source bitmap.
-	 * @param src_rect source bitmap rect.
-	 * @param inv transformation matrix from destination coordinates
-	 *            to source coordinates.
-	 * @param opacity opacity for blending with bitmap.
-	 */
-	void TransformBlit(Rect const& dst_rect, Bitmap const& src, Rect const& src_rect, const Transform& inv, Opacity const& opacity);
-
-	/**
 	 * Blits source bitmap with waver effect.
 	 *
 	 * @param x x position.
@@ -361,6 +349,37 @@ public:
 	 * @param opacity opacity.
 	 */
 	void WaverBlit(int x, int y, double zoom_x, double zoom_y, Bitmap const& src, Rect const& src_rect, int depth, double phase, Opacity const& opacity);
+
+	/**
+	 * Blits source bitmap with transformation and opacity scaling.
+	 *
+	 * @param fwd forward (src->dst) transformation matrix.
+	 * @param src source bitmap.
+	 * @param src_rect source bitmap rectangle.
+	 * @param opacity opacity.
+	 */
+	void RotateZoomOpacityBlit(int x, int y, int ox, int oy,
+			Bitmap const& src, Rect const& src_rect,
+			double angle, double zoom_x, double zoom_y, Opacity const& opacity);
+
+	/**
+	 * Blits source bitmap with zoom and opacity scaling.
+	 *
+	 * @param x x position.
+	 * @param y y position.
+	 * @param ox source origin x.
+	 * @param oy source origin y.
+	 * @param src source bitmap.
+	 * @param src_rect source bitmap rectangle.
+	 * @param zoom_x x scale factor.
+	 * @param zoom_y y scale factor.
+	 * @param opacity opacity.
+	 */
+	void ZoomOpacityBlit(int x, int y, int ox, int oy,
+						 Bitmap const& src, Rect const& src_rect,
+						 double zoom_x, double zoom_y,
+						 Opacity const& opacity);
+
 
 	/**
 	 * Fills entire bitmap with color.
@@ -551,36 +570,6 @@ protected:
 
 	pixman_op_t GetOperator(pixman_image_t* mask = nullptr) const;
 	bool read_only = false;
-
-private:
-	/**
-	 * Blits source bitmap with transformation and opacity scaling.
-	 *
-	 * @param fwd forward (src->dst) transformation matrix.
-	 * @param src source bitmap.
-	 * @param src_rect source bitmap rectangle.
-	 * @param opacity opacity.
-	 */
-	void RotateZoomOpacityBlit(const Transform &fwd, Bitmap const& src, Rect const& src_rect,
-							   Opacity const& opacity);
-
-	/**
-	 * Blits source bitmap with zoom and opacity scaling.
-	 *
-	 * @param x x position.
-	 * @param y y position.
-	 * @param ox source origin x.
-	 * @param oy source origin y.
-	 * @param src source bitmap.
-	 * @param src_rect source bitmap rectangle.
-	 * @param zoom_x x scale factor.
-	 * @param zoom_y y scale factor.
-	 * @param opacity opacity.
-	 */
-	void ZoomOpacityBlit(int x, int y, int ox, int oy,
-						 Bitmap const& src, Rect const& src_rect,
-						 double zoom_x, double zoom_y,
-						 Opacity const& opacity);
 };
 
 #endif

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2490,8 +2490,15 @@ bool Game_Interpreter::CommandShowPicture(RPG::EventCommand const& com) { // cod
 	params.top_trans = std::max(0, std::min(params.top_trans, 100));
 	params.bottom_trans = std::max(0, std::min(params.bottom_trans, 100));
 
-	Game_Picture* picture = Main_Data::game_screen->GetPicture(pic_id);
-	picture->Show(params);
+	if (pic_id <= 0) {
+		Output::Error("ShowPicture: Requested invalid picture id (%d)", pic_id);
+	}
+
+	// RPG_RT will crash if you ask for a picture id greater than the limit that
+	// version of the engine allows. We allow an arbitrary number of pictures in Player.
+
+	auto& picture = Main_Data::game_screen->GetPicture(pic_id);
+	picture.Show(params);
 
 	return true;
 }
@@ -2552,8 +2559,12 @@ bool Game_Interpreter::CommandMovePicture(RPG::EventCommand const& com) { // cod
 	params.bottom_trans = std::max(0, std::min(params.bottom_trans, 100));
 	params.duration = std::max(0, std::min(params.duration, 10000));
 
-	Game_Picture* picture = Main_Data::game_screen->GetPicture(pic_id);
-	picture->Move(params);
+	if (pic_id <= 0) {
+		Output::Error("MovePicture: Requested invalid picture id (%d)", pic_id);
+	}
+
+	Game_Picture& picture = Main_Data::game_screen->GetPicture(pic_id);
+	picture.Move(params);
 
 	if (wait)
 		SetupWait(params.duration);
@@ -2587,14 +2598,22 @@ bool Game_Interpreter::CommandErasePicture(RPG::EventCommand const& com) { // co
 		}
 
 		for (int i = pic_id; i <= max; ++i) {
-			Game_Picture *picture = Main_Data::game_screen->GetPicture(i);
-			picture->Erase(true);
+			if (i <= 0) {
+				Output::Error("ErasePicture: Requested invalid picture id (%d)", i);
+			}
+
+			auto& picture = Main_Data::game_screen->GetPicture(i);
+			picture.Erase(true);
 		}
 	} else {
 		PicPointerPatch::AdjustId(pic_id);
 
-		Game_Picture *picture = Main_Data::game_screen->GetPicture(pic_id);
-		picture->Erase(true);
+		if (pic_id <= 0) {
+			Output::Error("ErasePicture: Requested invalid picture id (%d)", pic_id);
+		}
+
+		auto& picture = Main_Data::game_screen->GetPicture(pic_id);
+		picture.Erase(true);
 	}
 
 	return true;

--- a/src/game_picture.cpp
+++ b/src/game_picture.cpp
@@ -25,20 +25,11 @@
 #include "game_picture.h"
 #include "player.h"
 #include "main_data.h"
-#include "reader_util.h"
 
 // Applied to ensure that all pictures are above "normal" objects on this layer
 constexpr int z_mask = (1 << 16);
 
-Game_Picture::Game_Picture(int ID) :
-	id(ID)
-{
-	RequestPictureSprite();
-}
-
 void Game_Picture::UpdateSprite() {
-	RPG::SavePicture& data = GetData();
-
 	if (!sprite || !sprite->GetBitmap() || data.name.empty()) {
 		return;
 	}
@@ -124,8 +115,6 @@ void Game_Picture::UpdateSprite() {
 }
 
 void Game_Picture::Show(const ShowParams& params) {
-	RPG::SavePicture& data = GetData();
-
 	data.name = params.name;
 	data.use_transparent_color = params.use_transparent_color;
 	data.fixed_to_map = params.fixed_to_map;
@@ -179,8 +168,6 @@ void Game_Picture::Show(const ShowParams& params) {
 }
 
 void Game_Picture::Move(const MoveParams& params) {
-	RPG::SavePicture& data = GetData();
-
 	const bool ignore_position = Player::IsLegacy() && data.fixed_to_map;
 
 	SetNonEffectParams(params, !ignore_position);
@@ -224,8 +211,6 @@ void Game_Picture::Move(const MoveParams& params) {
 }
 
 void Game_Picture::Erase(bool force_erase) {
-	RPG::SavePicture& data = GetData();
-
 	if (!(force_erase || data.flags.erase_on_map_change)) {
 		return;
 	}
@@ -238,7 +223,7 @@ void Game_Picture::Erase(bool force_erase) {
 }
 
 void Game_Picture::RequestPictureSprite() {
-	const std::string& name = GetData().name;
+	const std::string& name = data.name;
 	if (name.empty()) return;
 
 	FileRequestAsync* request = AsyncHandler::RequestFile("Picture", name);
@@ -248,8 +233,6 @@ void Game_Picture::RequestPictureSprite() {
 }
 
 void Game_Picture::OnPictureSpriteReady(FileRequestResult*) {
-	RPG::SavePicture& data = GetData();
-
 	bitmap = Cache::Picture(data.name, data.use_transparent_color);
 
 	if (!sprite) {
@@ -259,8 +242,6 @@ void Game_Picture::OnPictureSpriteReady(FileRequestResult*) {
 }
 
 void Game_Picture::Update() {
-	RPG::SavePicture& data = GetData();
-
 	if (data.fixed_to_map) {
 		// Instead of modifying the Ox/Oy offset the real position is altered
 		// based on map scroll because of savegame compatibility with RPG_RT
@@ -352,8 +333,6 @@ void Game_Picture::Update() {
 }
 
 void Game_Picture::SetNonEffectParams(const Params& params, bool set_positions) {
-	RPG::SavePicture& data = GetData();
-
 	if (set_positions) {
 		data.finish_x = params.position_x;
 		data.finish_y = params.position_y;
@@ -368,8 +347,6 @@ void Game_Picture::SetNonEffectParams(const Params& params, bool set_positions) 
 }
 
 void Game_Picture::SyncCurrentToFinish() {
-	RPG::SavePicture& data = GetData();
-
 	data.current_x = data.finish_x;
 	data.current_y = data.finish_y;
 	data.current_red = data.finish_red;
@@ -382,12 +359,6 @@ void Game_Picture::SyncCurrentToFinish() {
 	data.current_effect_power = data.finish_effect_power;
 }
 
-RPG::SavePicture& Game_Picture::GetData() const {
-	// Save: Picture array is guaranteed to be of correct size
-	return *ReaderUtil::GetElement(Main_Data::game_data.pictures, id);
-}
-
 inline int Game_Picture::NumSpriteSheetFrames() const {
-	auto& data = GetData();
 	return data.spritesheet_cols * data.spritesheet_rows;
 }

--- a/src/game_picture.h
+++ b/src/game_picture.h
@@ -73,6 +73,11 @@ public:
 	void Move(const MoveParams& params);
 	void Erase(bool force_erase);
 
+	// FIXME: Use C++20 span
+	static void Update(std::vector<Game_Picture>& pictures);
+	// FIXME: Use C++20 span
+	static void UpdateSprite(std::vector<Game_Picture>& pictures);
+
 	void Update();
 	void UpdateSprite();
 
@@ -80,24 +85,23 @@ private:
 	RPG::SavePicture data;
 	std::unique_ptr<Sprite> sprite;
 	BitmapRef bitmap;
-	int last_spritesheet_frame = 0;
 	FileRequestBinding request_id;
+	int last_spritesheet_frame = 0;
+	bool needs_update = false;
 
 	void SetNonEffectParams(const Params& params, bool set_positions);
 	void SyncCurrentToFinish();
 	void RequestPictureSprite();
 	void OnPictureSpriteReady(FileRequestResult*);
 	int NumSpriteSheetFrames() const;
+
+	bool UpdateWouldBeNop() const;
+
 };
 
 inline Game_Picture::Game_Picture(int id) {
 	data.ID = id;
-}
-
-inline Game_Picture::Game_Picture(RPG::SavePicture sp)
-	: data(std::move(sp))
-{
-	RequestPictureSprite();
+	needs_update = false;
 }
 
 inline const RPG::SavePicture& Game_Picture::GetSaveData() const {

--- a/src/game_picture.h
+++ b/src/game_picture.h
@@ -73,9 +73,7 @@ public:
 	void Move(const MoveParams& params);
 	void Erase(bool force_erase);
 
-	// FIXME: Use C++20 span
 	static void Update(std::vector<Game_Picture>& pictures);
-	// FIXME: Use C++20 span
 	static void UpdateSprite(std::vector<Game_Picture>& pictures);
 
 	void Update();

--- a/src/game_picture.h
+++ b/src/game_picture.h
@@ -32,6 +32,9 @@ class Sprite;
 class Game_Picture {
 public:
 	explicit Game_Picture(int ID);
+	explicit Game_Picture(RPG::SavePicture sp);
+
+	const RPG::SavePicture& GetSaveData() const;
 
 	struct Params {
 		int position_x;
@@ -74,7 +77,7 @@ public:
 	void UpdateSprite();
 
 private:
-	int id;
+	RPG::SavePicture data;
 	std::unique_ptr<Sprite> sprite;
 	BitmapRef bitmap;
 	int last_spritesheet_frame = 0;
@@ -85,15 +88,20 @@ private:
 	void RequestPictureSprite();
 	void OnPictureSpriteReady(FileRequestResult*);
 	int NumSpriteSheetFrames() const;
-	/**
-	 * Compared to other classes picture doesn't hold a direct reference.
-	 * Resizing the picture vector when the ID is larger then the vector can
-	 * result in a memmove on resize, resulting in data pointers pointing into
-	 * garbage.
-	 *
-	 * @return Reference to the SavePicture data
-	 */
-	RPG::SavePicture& GetData() const;
 };
+
+inline Game_Picture::Game_Picture(int id) {
+	data.ID = id;
+}
+
+inline Game_Picture::Game_Picture(RPG::SavePicture sp)
+	: data(std::move(sp))
+{
+	RequestPictureSprite();
+}
+
+inline const RPG::SavePicture& Game_Picture::GetSaveData() const {
+	return data;
+}
 
 #endif

--- a/src/game_picture.h
+++ b/src/game_picture.h
@@ -76,8 +76,7 @@ public:
 private:
 	int id;
 	std::unique_ptr<Sprite> sprite;
-	BitmapRef whole_bitmap;
-	BitmapRef sheet_bitmap;
+	BitmapRef bitmap;
 	int last_spritesheet_frame = 0;
 	FileRequestBinding request_id;
 

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -369,7 +369,7 @@ int Game_Screen::AnimateShake(int strength, int speed, int time_left, int positi
 	return Utils::Clamp<int>(newpos, position - cutoff, position + cutoff);
 }
 
-void Game_Screen::Update() {
+void Game_Screen::UpdateScreenEffects() {
 	constexpr auto pan_limit_x = GetPanLimitX();
 	constexpr auto pan_limit_y = GetPanLimitY();
 
@@ -415,15 +415,15 @@ void Game_Screen::Update() {
 			data.shake_time_left = 0;
 		}
 	}
+}
 
-	for (auto& picture : pictures) {
-		picture.Update();
-	}
-
+void Game_Screen::UpdateMovie() {
 	if (!movie_filename.empty()) {
 		/* update movie */
 	}
+}
 
+void Game_Screen::UpdateWeather() {
 	switch (data.weather) {
 		case Weather_None:
 			break;
@@ -439,7 +439,13 @@ void Game_Screen::Update() {
 			UpdateSand();
 			break;
 	}
+}
 
+void Game_Screen::Update() {
+	UpdateScreenEffects();
+	Game_Picture::Update(pictures);
+	UpdateMovie();
+	UpdateWeather();
 	UpdateBattleAnimation();
 }
 
@@ -487,8 +493,6 @@ void Game_Screen::CancelBattleAnimation() {
 }
 
 void Game_Screen::UpdateGraphics() {
-	for (auto& picture: pictures) {
-		picture.UpdateSprite();
-	}
+	Game_Picture::UpdateSprite(pictures);
 	weather->SetTone(GetTone());
 }

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -131,25 +131,11 @@ void Game_Screen::Reset() {
 	animation.reset();
 }
 
-void Game_Screen::PreallocatePictureData(int id) {
-	if (EP_LIKELY(id <= (int)pictures.size())) {
-		return;
-	}
-
+void Game_Screen::DoPreallocatePictureData(int id) {
 	pictures.reserve(id);
 	while (static_cast<int>(pictures.size()) < id) {
 		pictures.emplace_back(pictures.size() + 1);
 	}
-}
-
-Game_Picture* Game_Screen::GetPicture(int id) {
-	if (EP_UNLIKELY(id <= 0)) {
-		return NULL;
-	}
-
-	PreallocatePictureData(id);
-
-	return &pictures[id - 1];
 }
 
 void Game_Screen::TintScreen(int r, int g, int b, int s, int tenths) {

--- a/src/game_screen.h
+++ b/src/game_screen.h
@@ -19,8 +19,10 @@
 #define EP_GAME_SCREEN_H
 
 #include <vector>
+#include <cassert>
 #include "system.h"
 #include "options.h"
+#include "compiler.h"
 #include "game_picture.h"
 #include "game_character.h"
 #include "battle_animation.h"
@@ -40,7 +42,7 @@ public:
 
 	std::vector<RPG::SavePicture> GetPictureSaveData() const;
 
-	Game_Picture* GetPicture(int id);
+	Game_Picture& GetPicture(int id);
 
 	void Reset();
 	void TintScreen(int r, int g, int b, int s, int tenths);
@@ -190,6 +192,7 @@ protected:
 	void InitRainSnow(int lifetime);
 	void InitSand();
 	void PreallocatePictureData(int id);
+	void DoPreallocatePictureData(int id);
 };
 
 inline int Game_Screen::GetPanX() const {
@@ -245,6 +248,21 @@ inline const std::vector<Game_Screen::Particle>& Game_Screen::GetParticles() {
 
 inline bool Game_Screen::IsBattleAnimationWaiting() {
 	return (bool)animation;
+}
+
+inline Game_Picture& Game_Screen::GetPicture(int id) {
+	assert(id >= 0);
+
+	PreallocatePictureData(id);
+
+	return pictures[id - 1];
+}
+
+inline void Game_Screen::PreallocatePictureData(int id) {
+	if (EP_UNLIKELY(id > (int)pictures.size())) {
+		DoPreallocatePictureData(id);
+		return;
+	}
 }
 
 #endif

--- a/src/game_screen.h
+++ b/src/game_screen.h
@@ -188,6 +188,10 @@ protected:
 	void UpdateRain();
 	void UpdateSnow();
 	void UpdateSand();
+	void UpdateScreenEffects();
+	void UpdateMovie();
+	void UpdateWeather();
+	void UpdateFog(int dx, int dy);
 	void OnWeatherChanged();
 	void InitRainSnow(int lifetime);
 	void InitSand();

--- a/src/game_screen.h
+++ b/src/game_screen.h
@@ -36,7 +36,9 @@ public:
 	~Game_Screen();
 
 	void SetupNewGame();
-	void SetupFromSave();
+	void SetupFromSave(std::vector<RPG::SavePicture> pictures);
+
+	std::vector<RPG::SavePicture> GetPictureSaveData() const;
 
 	Game_Picture* GetPicture(int id);
 
@@ -187,7 +189,6 @@ protected:
 	void OnWeatherChanged();
 	void InitRainSnow(int lifetime);
 	void InitSand();
-	void CreatePicturesFromSave();
 	void PreallocatePictureData(int id);
 };
 

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -76,7 +76,7 @@ void Scene_Map::Start() {
 	// Called here instead of Scene Load, otherwise wrong graphic stack
 	// is used.
 	if (from_save) {
-		Main_Data::game_screen->SetupFromSave();
+		Main_Data::game_screen->SetupFromSave(std::move(Main_Data::game_data.pictures));
 	} else {
 		Main_Data::game_screen->SetupNewGame();
 	}

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -118,6 +118,8 @@ void Scene_Save::Action(int index) {
 	data_copy.system.variables = Main_Data::game_variables->GetData();
 	data_copy.inventory = Main_Data::game_party->GetSaveData();
 
+	data_copy.pictures = Main_Data::game_screen->GetPictureSaveData();
+
 	// RPG_RT saves always have the scene set to this.
 	data_copy.system.scene = RPG::SaveSystem::Scene_file;
 	// 2k RPG_RT always stores SaveMapEvent with map_id == 0.


### PR DESCRIPTION
Fix #1093
Fix #1883 

 * Remove sheet bitmap
 * Fix Effect's blit to properly handle src_rect for rotations in pixman

Tests with normal picture

For these tests I created several pictures with different sprite sheet frames of the actor1 charset. I also created a picture without a spritesheet.

For the 75% / 25% test, you have to hack player code because top/bottom trans are not supported in 2k3e.

Test Cases
- [x] No effects
- [x]  50% trans
- [x] 100% trans
- [x] 75% / 25% trans
- [x] 50% zoom
- [x] 50% zoom, 50% trans
- [x] 50% zoom, 100% trans
- [x] 50% zoom, 75% / 25% trans
- [x] 200% zoom
- [x] 200% zoom, 50% trans
- [x] 200% zoom, 100% trans
- [x] 200% zoom, 75% / 25% trans
- [x] Rotate
- [x] Rotate, 50% trans
- [x] Rotate, 100% trans
- [x] Rotate, 75% / 25% trans
- [x] Rotate, 50% zoom
- [x] Rotate, 50% zoom, 50% trans
- [x] Rotate, 50% zoom, 100% trans
- [x] Rotate, 50% zoom, 75% / 25% trans
- [x] Rotate, 200% zoom
- [x] Rotate, 200% zoom, 50% trans
- [x] Rotate, 200% zoom, 100% trans
- [x] Rotate, 200% zoom, 75% / 25% trans
- [x] Wave
- [x] Wave, 50% trans
- [x] Wave, 100% trans
- [x] Wave, 75% / 25% trans
- [x] Wave, 50% zoom
- [x] Wave, 50% zoom, 50% trans
- [x] Wave, 50% zoom, 100% trans
- [x] Wave, 50% zoom, 75% / 25% trans
- [x] Wave, 200% zoom
- [x] Wave, 200% zoom, 50% trans
- [x] Wave, 200% zoom, 100% trans
- [x] Wave, 200% zoom, 75% / 25% trans