### PR TITLE
Switch to ctest and fix conflicts with liblcf tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -744,11 +744,10 @@ if(PLAYER_ENABLE_TESTS)
 	endif()
 
 	file(GLOB TEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp)
-	add_executable(test_runner EXCLUDE_FROM_ALL ${TEST_FILES})
+	add_executable(test_runner ${TEST_FILES})
 	target_compile_definitions(test_runner PUBLIC EP_TEST_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/tests\")
 	target_link_libraries(test_runner ${PROJECT_NAME})
-	add_custom_target(check COMMAND ${PROJECT_BINARY_DIR}/test_runner)
-	add_dependencies(check test_runner)
+	add_test(player_test test_runner)
 endif()
 
 # Benchmarks

--- a/src/game_variables.h
+++ b/src/game_variables.h
@@ -69,7 +69,7 @@ private:
 	bool ShouldWarn(int first_id, int last_id) const;
 	void WarnGet(int variable_id) const;
 	template <typename F>
-		int SetOp(int variable_id, Var_t value, F&& op, const char* warn);
+		Var_t SetOp(int variable_id, Var_t value, F&& op, const char* warn);
 	template <typename F>
 		void SetOpRange(int first_id, int last_id, Var_t value, F&& op, const char* warn);
 private:

--- a/tests/switches.cpp
+++ b/tests/switches.cpp
@@ -1,11 +1,11 @@
 #include "game_switches.h"
-
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
+
+TEST_SUITE_BEGIN("Switches");
 
 constexpr int max_switches = 5;
 
-Game_Switches make() {
+static Game_Switches make() {
 	Data::switches.resize(max_switches);
 	Game_Switches s;
 	s.SetWarning(0);
@@ -138,3 +138,5 @@ TEST_CASE("IsValid") {
 
 	REQUIRE_FALSE(s.IsValid(max_switches + 1));
 }
+
+TEST_SUITE_END();

--- a/tests/variables.cpp
+++ b/tests/variables.cpp
@@ -1,13 +1,13 @@
 #include "game_variables.h"
-
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
+
+TEST_SUITE_BEGIN("Variables");
 
 constexpr int max_vars = 5;
 constexpr int minval = Game_Variables::min_2k3;
 constexpr int maxval = Game_Variables::max_2k3;
 
-Game_Variables make() {
+static Game_Variables make() {
 	Data::variables.resize(max_vars);
 	Game_Variables v(minval, maxval);
 	v.SetWarning(0);
@@ -176,3 +176,4 @@ TEST_CASE("Mod") {
 	REQUIRE_EQ(s.Get(2), 0);
 }
 
+TEST_SUITE_END();


### PR DESCRIPTION
This fixes build errors with tests with liblcf and Player when compiled with -DPLAYER_BUILD_LIBLCF=ON

Also fixes errors in tests recently merged from other PRs