### PR TITLE
Add F12 Quit window.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,8 @@ add_library(${PROJECT_NAME}
 	src/game_picture.h
 	src/game_player.cpp
 	src/game_player.h
+	src/game_quit.cpp
+	src/game_quit.h
 	src/game_screen.cpp
 	src/game_screen.h
 	src/game_switches.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -190,6 +190,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/player.h \
 	src/psp2_ui.cpp \
 	src/psp2_ui.h \
+	src/game_quit.cpp \
+	src/game_quit.h \
 	src/rect.cpp \
 	src/rect.h \
 	src/registry.cpp \

--- a/src/game_quit.cpp
+++ b/src/game_quit.cpp
@@ -1,0 +1,60 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "game_quit.h"
+#include "options.h"
+#include "input.h"
+#include "scene.h"
+
+constexpr int num_seconds = 2;
+constexpr int start_time = num_seconds * DEFAULT_FPS;
+
+constexpr int window_height = 32;
+
+Game_Quit::Game_Quit()
+	: window(SCREEN_TARGET_WIDTH / 4, SCREEN_TARGET_HEIGHT / 2 - window_height / 2, SCREEN_TARGET_WIDTH / 2, window_height, true)
+{
+	window.SetBackOpacity(128);
+	window.SetZ(Priority_Overlay - 20);
+	Reset();
+}
+
+void Game_Quit::Update() {
+	if (Scene::instance == nullptr || Scene::instance->type == Scene::Title || !Input::IsPressed(Input::RESET)) {
+		if (time_left != start_time) {
+			Reset();
+		}
+		return;
+	}
+
+	window.SetVisible(true);
+
+	if (time_left > 0) {
+		--time_left;
+	}
+
+	// FIXME Need to write the text every frame in case system graphic changes..
+	auto s = (time_left + DEFAULT_FPS - 1) / DEFAULT_FPS;
+	window.SetText("Restarting in " + std::to_string(s) + " sec ...");
+	window.Update();
+}
+
+void Game_Quit::Reset() {
+	window.SetVisible(false);
+	time_left = DEFAULT_FPS * num_seconds;
+}
+

--- a/src/game_quit.h
+++ b/src/game_quit.h
@@ -15,43 +15,26 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef EP_WINDOW_HELP_H
-#define EP_WINDOW_HELP_H
+#ifndef EP_GAME_QUIT_H
+#define EP_GAME_QUIT_H
 
-// Headers
-#include "window_base.h"
-#include "text.h"
+#include "window_help.h"
 
-/**
- * Window_Help class.
- * Shows skill and item explanations.
- */
-class Window_Help : public Window_Base {
-
+class Game_Quit {
 public:
-	/**
-	 * Constructor.
-	 */
-	Window_Help(int ix, int iy, int iwidth, int iheight, bool is_global = false);
+	Game_Quit();
+	void Update();
 
-	/**
-	 * Sets the text that will be shown.
-	 *
-	 * @param text text to show.
-	 * @param align text alignment.
-	 */
-	void SetText(std::string text, Text::Alignment align = Text::AlignLeft);
-
-	/**
-	 * Clears the window
-	 */
-	void Clear();
-
+	bool ShouldQuit() const;
 private:
-	/** Text to draw. */
-	std::string text;
-	/** Alignment of text. */
-	Text::Alignment align;
+	void Reset();
+
+	Window_Help window;
+	int time_left = 0;
 };
+
+inline bool Game_Quit::ShouldQuit() const {
+	return time_left == 0;
+}
 
 #endif

--- a/src/main_data.cpp
+++ b/src/main_data.cpp
@@ -26,6 +26,7 @@
 #include "game_map.h"
 #include "game_variables.h"
 #include "game_switches.h"
+#include "game_quit.h"
 #include "font.h"
 #include "player.h"
 
@@ -58,6 +59,7 @@ namespace Main_Data {
 	std::unique_ptr<Game_Player> game_player;
 	std::unique_ptr<Game_Party> game_party;
 	std::unique_ptr<Game_EnemyParty> game_enemyparty;
+	std::unique_ptr<Game_Quit> game_quit;
 
 	RPG::Save game_data;
 }
@@ -160,6 +162,7 @@ void Main_Data::Cleanup() {
 	game_player.reset();
 	game_party.reset();
 	game_enemyparty.reset();
+	game_quit.reset();
 
 	game_data = RPG::Save();
 }

--- a/src/main_data.h
+++ b/src/main_data.h
@@ -33,6 +33,7 @@ class Game_Party;
 class Game_EnemyParty;
 class Game_Switches;
 class Game_Variables;
+class Game_Quit;
 
 namespace Main_Data {
 	// Dynamic Game Data
@@ -42,6 +43,7 @@ namespace Main_Data {
 	extern std::unique_ptr<Game_Player> game_player;
 	extern std::unique_ptr<Game_Party> game_party;
 	extern std::unique_ptr<Game_EnemyParty> game_enemyparty;
+	extern std::unique_ptr<Game_Quit> game_quit;
 	extern RPG::Save game_data;
 
 	void Init();
@@ -49,7 +51,7 @@ namespace Main_Data {
 
 	const std::string& GetProjectPath();
 	void SetProjectPath(const std::string& path);
-	
+
 	const std::string& GetSavePath();
 	void SetSavePath(const std::string& path);
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -70,6 +70,7 @@
 #include "scene_logo.h"
 #include "utils.h"
 #include "version.h"
+#include "game_quit.h"
 
 #ifndef EMSCRIPTEN
 // This is not used on Emscripten.
@@ -271,9 +272,6 @@ void Player::Update(bool update_scene) {
 	if (Input::IsTriggered(Input::SHOW_LOG)) {
 		Output::ToggleLog();
 	}
-	if (Input::IsTriggered(Input::RESET)) {
-		reset_flag = true;
-	}
 	if (Input::IsTriggered(Input::TOGGLE_ZOOM)) {
 		DisplayUi->ToggleZoom();
 	}
@@ -281,8 +279,15 @@ void Player::Update(bool update_scene) {
 		DisplayUi->ToggleFullscreen();
 	}
 
+	if (Main_Data::game_quit) {
+		Main_Data::game_quit->Update();
+		reset_flag |= Main_Data::game_quit->ShouldQuit();
+	}
+
 	// Update Logic:
 	DisplayUi->ProcessEvents();
+
+	std::shared_ptr<Scene> old_instance = Scene::instance;
 
 	if (exit_flag) {
 		Scene::PopUntil(Scene::Null);
@@ -299,8 +304,6 @@ void Player::Update(bool update_scene) {
 
 	Audio().Update();
 	Input::Update();
-
-	std::shared_ptr<Scene> old_instance = Scene::instance;
 
 	int speed_modifier = GetSpeedModifier();
 
@@ -796,6 +799,7 @@ void Player::ResetGameObjects() {
 	Main_Data::game_enemyparty = std::make_unique<Game_EnemyParty>();
 	Main_Data::game_party = std::make_unique<Game_Party>();
 	Main_Data::game_player = std::make_unique<Game_Player>();
+	Main_Data::game_quit = std::make_unique<Game_Quit>();
 
 	FrameReset();
 }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -27,7 +27,7 @@
 
 constexpr int pause_animation_frames = 20;
 
-Window::Window(): Drawable(TypeWindow, Priority_Window, false)
+Window::Window(bool is_global): Drawable(TypeWindow, Priority_Window, is_global)
 {
 	DrawableMgr::Register(this);
 }

--- a/src/window.h
+++ b/src/window.h
@@ -28,7 +28,7 @@
  */
 class Window : public Drawable {
 public:
-	Window();
+	Window(bool is_global = false);
 
 	void Draw(Bitmap& dst) override;
 

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -26,7 +26,9 @@
 #include "font.h"
 #include "player.h"
 
-Window_Base::Window_Base(int x, int y, int width, int height) {
+Window_Base::Window_Base(int x, int y, int width, int height, bool is_global)
+	: Window(is_global)
+{
 	SetWindowskin(Cache::SystemOrBlack());
 
 	SetX(x);

--- a/src/window_base.h
+++ b/src/window_base.h
@@ -39,8 +39,9 @@ public:
 	 * @param y window y position.
 	 * @param width window width.
 	 * @param height window height.
+	 * @param is_global if this is global drawable
 	 */
-	Window_Base(int x, int y, int width, int height);
+	Window_Base(int x, int y, int width, int height, bool is_global = false);
 
 	/**
 	 * Updates the window.

--- a/src/window_help.cpp
+++ b/src/window_help.cpp
@@ -20,8 +20,8 @@
 #include "bitmap.h"
 #include "font.h"
 
-Window_Help::Window_Help(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight),
+Window_Help::Window_Help(int ix, int iy, int iwidth, int iheight, bool is_global) :
+	Window_Base(ix, iy, iwidth, iheight, is_global),
 	align(Text::AlignLeft) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));


### PR DESCRIPTION
When you hold F12 a window appears and counts down. Once
countdown is complete, we reset to title screen.

Replaces 2k3e Alt+F12 feature. Enabled for all versions of the engine.

Also fixes a crash with F12, we capture old_scene before
checking for reset.