### PR TITLE
Add Game_Data singleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,8 @@ add_library(${PROJECT_NAME}
 	src/game_character.h
 	src/game_commonevent.cpp
 	src/game_commonevent.h
+	src/game_data.cpp
+	src/game_data.h
 	src/game_enemy.cpp
 	src/game_enemy.h
 	src/game_enemyparty.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -104,6 +104,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/game_character.h \
 	src/game_commonevent.cpp \
 	src/game_commonevent.h \
+	src/game_data.cpp \
+	src/game_data.h \
 	src/game_enemy.cpp \
 	src/game_enemy.h \
 	src/game_enemyparty.cpp \

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -279,10 +279,10 @@ void Game_Actor::ChangeEquipment(int equip_type, int item_id) {
 	int prev_item = SetEquipment(equip_type, item_id);
 
 	if (prev_item != 0) {
-		Main_Data::game_party->AddItem(prev_item, 1);
+		Game_Data::GetParty().AddItem(prev_item, 1);
 	}
 	if (item_id != 0) {
-		Main_Data::game_party->RemoveItem(item_id, 1);
+		Game_Data::GetParty().RemoveItem(item_id, 1);
 	}
 
 	// In case you have a two_handed weapon equipped, the other weapon is removed.
@@ -875,8 +875,8 @@ int Game_Actor::GetBattleX() const {
 
 	if (GetActor().battle_x == 0 ||
 		Data::battlecommands.placement == RPG::BattleCommands::Placement_automatic) {
-		int party_pos = Main_Data::game_party->GetActorPositionInParty(actor_id);
-		int party_size = Main_Data::game_party->GetBattlerCount();
+		int party_pos = Game_Data::GetParty().GetActorPositionInParty(actor_id);
+		int party_size = Game_Data::GetParty().GetBattlerCount();
 
 		float left = GetBattleRow() == RowType::RowType_back ? 25.0 : 50.0;
 		float right = left;
@@ -958,8 +958,8 @@ int Game_Actor::GetBattleY() const {
 
 	if (GetActor().battle_y == 0 ||
 		Data::battlecommands.placement == RPG::BattleCommands::Placement_automatic) {
-		int party_pos = Main_Data::game_party->GetActorPositionInParty(actor_id);
-		int party_size = Main_Data::game_party->GetBattlerCount();
+		int party_pos = Game_Data::GetParty().GetActorPositionInParty(actor_id);
+		int party_size = Game_Data::GetParty().GetBattlerCount();
 
 		float top = 0.0f;
 		float bottom = 0.0f;

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -316,13 +316,13 @@ bool Game_Battle::AreConditionsMet(const RPG::TroopPageCondition& condition) {
 		return false;
 	}
 
-	if (condition.flags.switch_a && !Main_Data::game_switches->Get(condition.switch_a_id))
+	if (condition.flags.switch_a && !Game_Data::GetSwitches().Get(condition.switch_a_id))
 		return false;
 
-	if (condition.flags.switch_b && !Main_Data::game_switches->Get(condition.switch_b_id))
+	if (condition.flags.switch_b && !Game_Data::GetSwitches().Get(condition.switch_b_id))
 		return false;
 
-	if (condition.flags.variable && !(Main_Data::game_variables->Get(condition.variable_id) >= condition.variable_value))
+	if (condition.flags.variable && !(Game_Data::GetVariables().Get(condition.variable_id) >= condition.variable_value))
 		return false;
 
 	if (condition.flags.turn && !CheckTurns(GetTurn(), condition.turn_b, condition.turn_a))

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -69,7 +69,7 @@ void Game_Battle::Init() {
 	animation.reset();
 
 	Game_Temp::battle_running = true;
-	Main_Data::game_party->ResetTurns();
+	Game_Data::GetParty().ResetTurns();
 	terminate = false;
 	escape_fail_count = 0;
 	target_enemy_index = 0;
@@ -86,9 +86,9 @@ void Game_Battle::Init() {
 		return false;
 	});
 
-	Main_Data::game_party->ResetBattle();
+	Game_Data::GetParty().ResetBattle();
 
-	for (auto* actor: Main_Data::game_party->GetActors()) {
+	for (auto* actor: Game_Data::GetParty().GetActors()) {
 		actor->ResetEquipmentStates(true);
 	}
 }
@@ -103,7 +103,7 @@ void Game_Battle::Quit() {
 	SetTerrainId(0);
 
 	std::vector<Game_Battler*> allies;
-	Main_Data::game_party->GetBattlers(allies);
+	Game_Data::GetParty().GetBattlers(allies);
 
 	// Remove conditions which end after battle
 	for (std::vector<Game_Battler*>::iterator it = allies.begin(); it != allies.end(); it++) {
@@ -111,18 +111,18 @@ void Game_Battle::Quit() {
 		(*it)->SetBattleAlgorithm(BattleAlgorithmRef());
 	}
 
-	Main_Data::game_party->IncBattleCount();
+	Game_Data::GetParty().IncBattleCount();
 	switch (Game_Temp::battle_result) {
-		case Game_Temp::BattleVictory: Main_Data::game_party->IncWinCount(); break;
-		case Game_Temp::BattleEscape: Main_Data::game_party->IncRunCount(); break;
-		case Game_Temp::BattleDefeat: Main_Data::game_party->IncDefeatCount(); break;
+		case Game_Temp::BattleVictory: Game_Data::GetParty().IncWinCount(); break;
+		case Game_Temp::BattleEscape: Game_Data::GetParty().IncRunCount(); break;
+		case Game_Temp::BattleDefeat: Game_Data::GetParty().IncDefeatCount(); break;
 		case Game_Temp::BattleAbort: break;
 	}
 
 	page_executed.clear();
 	page_can_run.clear();
 
-	Main_Data::game_party->ResetBattle();
+	Game_Data::GetParty().ResetBattle();
 }
 
 void Game_Battle::Update() {
@@ -143,7 +143,7 @@ void Game_Battle::Update() {
 	}
 
 	std::vector<Game_Battler*> battlers;
-	(*Main_Data::game_party).GetBattlers(battlers);
+	(Game_Data::GetParty()).GetBattlers(battlers);
 	(*Main_Data::game_enemyparty).GetBattlers(battlers);
 	for (Game_Battler* b : battlers) {
 		b->UpdateBattle();
@@ -170,7 +170,7 @@ bool Game_Battle::CheckWin() {
 }
 
 bool Game_Battle::CheckLose() {
-	if (!Main_Data::game_party->IsAnyActive())
+	if (!Game_Data::GetParty().IsAnyActive())
 		return true;
 
 	// If there are active characters, but all of them are in a state with Restriction "Do Nothing" and 0% recovery probability, it's game over
@@ -178,7 +178,7 @@ bool Game_Battle::CheckLose() {
 	int character_number = 0;
 	std::vector<Game_Battler*> actors;
 
-	Main_Data::game_party->GetActiveBattlers(actors);
+	Game_Data::GetParty().GetActiveBattlers(actors);
 	for (auto actor : actors) {
 		for (auto id_state : actor->GetInflictedStates()) {
 			RPG::State *state = ReaderUtil::GetElement(Data::states, id_state);
@@ -244,13 +244,13 @@ void Game_Battle::NextTurn(Game_Battler* battler) {
 		}
 	}
 
-	Main_Data::game_party->IncTurns();
+	Game_Data::GetParty().IncTurns();
 }
 
 void Game_Battle::UpdateGauges() {
 	std::vector<Game_Battler*> battlers;
 	Main_Data::game_enemyparty->GetActiveBattlers(battlers);
-	Main_Data::game_party->GetActiveBattlers(battlers);
+	Game_Data::GetParty().GetActiveBattlers(battlers);
 
 	int max_agi = 1;
 
@@ -288,7 +288,7 @@ void Game_Battle::IncEscapeFailureCount() {
 
 
 int Game_Battle::GetTurn() {
-	return Main_Data::game_party->GetTurns();
+	return Game_Data::GetParty().GetTurns();
 }
 
 bool Game_Battle::CheckTurns(int turns, int base, int multiple) {
@@ -337,7 +337,7 @@ bool Game_Battle::AreConditionsMet(const RPG::TroopPageCondition& condition) {
 		return false;
 
 	if (condition.flags.fatigue) {
-		int fatigue = Main_Data::game_party->GetFatigue();
+		int fatigue = Game_Data::GetParty().GetFatigue();
 		if (fatigue < condition.fatigue_min || fatigue > condition.fatigue_max)
 			return false;
 	}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1358,7 +1358,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 void Game_BattleAlgorithm::Skill::Apply() {
 	if (IsFirstAttack()) {
 		if (item) {
-			Main_Data::game_party->ConsumeItemUse(item->ID);
+			Game_Data::GetParty().ConsumeItemUse(item->ID);
 		}
 		else {
 			source->ChangeSp(-source->CalculateSkillCost(skill.ID));
@@ -1512,7 +1512,7 @@ bool Game_BattleAlgorithm::Skill::IsReflected() const {
 
 bool Game_BattleAlgorithm::Skill::ActionIsPossible() const {
 	if (item) {
-		int count = Main_Data::game_party->GetItemCount(item->ID);
+		int count = Game_Data::GetParty().GetItemCount(item->ID);
 		if (count == 0) {
 			auto* src = GetSource();
 			if (src && src->GetType() == Game_Battler::Type_Ally) {
@@ -1626,7 +1626,7 @@ void Game_BattleAlgorithm::Item::Apply() {
 	AlgorithmBase::Apply();
 
 	if (first_attack) {
-		Main_Data::game_party->ConsumeItemUse(item.ID);
+		Game_Data::GetParty().ConsumeItemUse(item.ID);
 	}
 }
 
@@ -1665,7 +1665,7 @@ const RPG::Sound* Game_BattleAlgorithm::Item::GetStartSe() const {
 }
 
 bool Game_BattleAlgorithm::Item::ActionIsPossible() const {
-	return Main_Data::game_party->GetItemCount(item.ID) > 0;
+	return Game_Data::GetParty().GetItemCount(item.ID) > 0;
 }
 
 Game_BattleAlgorithm::Defend::Defend(Game_Battler* source) :
@@ -1891,7 +1891,7 @@ bool Game_BattleAlgorithm::Escape::Execute() {
 	this->success = true;
 
 	if (source->GetType() == Game_Battler::Type_Ally && !always_succeed) {
-		int ally_agi = Main_Data::game_party->GetAverageAgility();
+		int ally_agi = Game_Data::GetParty().GetAverageAgility();
 		int enemy_agi = Main_Data::game_enemyparty->GetAverageAgility();
 
 		// flee chance is 0% when ally has less than 70% of enemy agi

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -624,7 +624,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		return;
 
 	if (GetAffectedSwitch() != -1) {
-		Main_Data::game_switches->Set(GetAffectedSwitch(), true);
+		Game_Data::GetSwitches().Set(GetAffectedSwitch(), true);
 	}
 
 	auto* target = GetTarget();
@@ -718,11 +718,11 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 
 void Game_BattleAlgorithm::AlgorithmBase::ApplyActionSwitches() {
 	for (int s : switch_on) {
-		Main_Data::game_switches->Set(s, true);
+		Game_Data::GetSwitches().Set(s, true);
 	}
 
 	for (int s : switch_off) {
-		Main_Data::game_switches->Set(s, false);
+		Game_Data::GetSwitches().Set(s, false);
 	}
 }
 

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -685,7 +685,7 @@ int Game_Battler::GetHue() const {
 
 Game_Party_Base& Game_Battler::GetParty() const {
 	if (GetType() == Type_Ally) {
-		return *Main_Data::game_party;
+		return Game_Data::GetParty();
 	} else {
 		return *Main_Data::game_enemyparty;
 	}

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -364,7 +364,7 @@ bool Game_Battler::UseSkill(int skill_id, const Game_Battler* source) {
 		was_used = true;
 	} else if (skill->type == RPG::Skill::Type_switch) {
 		Game_System::SePlay(skill->sound_effect);
-		Main_Data::game_switches->Set(skill->switch_id, true);
+		Game_Data::GetSwitches().Set(skill->switch_id, true);
 		was_used = true;
 	}
 

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -362,12 +362,12 @@ void Game_Character::UpdateMoveRoute(int32_t& current_index, const RPG::MoveRout
 				SetMoveFrequency(max(GetMoveFrequency() - 1, 1));
 				break;
 			case RPG::MoveCommand::Code::switch_on: // Parameter A: Switch to turn on
-				Main_Data::game_switches->Set(move_command.parameter_a, true);
+				Game_Data::GetSwitches().Set(move_command.parameter_a, true);
 				Game_Map::SetNeedRefresh(Game_Map::Refresh_All);
 				Game_Map::Refresh();
 				break;
 			case RPG::MoveCommand::Code::switch_off: // Parameter A: Switch to turn off
-				Main_Data::game_switches->Set(move_command.parameter_a, false);
+				Game_Data::GetSwitches().Set(move_command.parameter_a, false);
 				Game_Map::SetNeedRefresh(Game_Map::Refresh_All);
 				Game_Map::Refresh();
 				break;

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -104,12 +104,12 @@ RPG::SaveEventExecState Game_CommonEvent::GetSaveData() {
 bool Game_CommonEvent::IsWaitingForegroundExecution() const {
 	auto* ce = ReaderUtil::GetElement(Data::commonevents, common_event_id);
 	return ce->trigger == RPG::EventPage::Trigger_auto_start &&
-		(!ce->switch_flag || Main_Data::game_switches->Get(ce->switch_id))
+		(!ce->switch_flag || Game_Data::GetSwitches().Get(ce->switch_id))
 		&& !ce->event_commands.empty();
 }
 
 bool Game_CommonEvent::IsWaitingBackgroundExecution(bool force_run) const {
 	auto* ce = ReaderUtil::GetElement(Data::commonevents, common_event_id);
 	return ce->trigger == RPG::EventPage::Trigger_parallel &&
-		(force_run || !ce->switch_flag || Main_Data::game_switches->Get(ce->switch_id));
+		(force_run || !ce->switch_flag || Game_Data::GetSwitches().Get(ce->switch_id));
 }

--- a/src/game_data.cpp
+++ b/src/game_data.cpp
@@ -38,5 +38,5 @@ void Game_Data::SetupLoadGame(RPG::Save save) {
 }
 
 void Game_Data::WriteSaveGame(RPG::Save& save) {
-	save.inventory = GetGameParty().GetSaveData();
+	save.inventory = GetParty().GetSaveData();
 }

--- a/src/game_data.cpp
+++ b/src/game_data.cpp
@@ -1,0 +1,42 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "game_data.h"
+#include "game_party.h"
+
+Game_Data::Data Game_Data::data = {};
+
+void Game_Data::Reset() {
+	data = {};
+}
+
+void Game_Data::SetupNewGame() {
+	Reset();
+
+	data.game_party = std::make_unique<Game_Party>();
+}
+
+void Game_Data::SetupLoadGame(RPG::Save save) {
+	Reset();
+
+	data.game_party = std::make_unique<Game_Party>();
+	data.game_party->SetupFromSave(std::move(save.inventory));
+}
+
+void Game_Data::WriteSaveGame(RPG::Save& save) {
+	save.inventory = GetGameParty().GetSaveData();
+}

--- a/src/game_data.h
+++ b/src/game_data.h
@@ -32,7 +32,7 @@ class Game_Variables;
 struct Game_Data {
 	public:
 		/** @return reference to Game_Party object */
-		static Game_Party& GetGameParty();
+		static Game_Party& GetParty();
 
 		/** Construct data for a new game */
 		static void SetupNewGame();
@@ -60,7 +60,7 @@ struct Game_Data {
 		static Data data;
 };
 
-inline Game_Party& Game_Data::GetGameParty() {
+inline Game_Party& Game_Data::GetParty() {
 	assert(data.game_party);
 	return *data.game_party;
 }

--- a/src/game_data.h
+++ b/src/game_data.h
@@ -1,0 +1,69 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_GAME_DATA_H
+#define EP_GAME_DATA_H
+
+#include <memory>
+#include <cassert>
+#include "rpg_save.h"
+
+class Game_Player;
+class Game_Screen;
+class Game_Party;
+class Game_EnemyParty;
+class Game_Switches;
+class Game_Variables;
+
+struct Game_Data {
+	public:
+		/** @return reference to Game_Party object */
+		static Game_Party& GetGameParty();
+
+		/** Construct data for a new game */
+		static void SetupNewGame();
+
+		/**
+		 * Construct data from given save game
+		 *
+		 * @param save the save to load from
+		 */
+		static void SetupLoadGame(RPG::Save save);
+
+		/**
+		 * Serialize state to save game format
+		 *
+		 * @param save the save to write to
+		 */
+		static void WriteSaveGame(RPG::Save& save);
+
+		/** Destroy all data */
+		static void Reset();
+	private:
+		struct Data {
+			std::unique_ptr<Game_Party> game_party;
+		};
+		static Data data;
+};
+
+inline Game_Party& Game_Data::GetGameParty() {
+	assert(data.game_party);
+	return *data.game_party;
+}
+
+#endif
+

--- a/src/game_data.h
+++ b/src/game_data.h
@@ -31,6 +31,12 @@ class Game_Variables;
 
 struct Game_Data {
 	public:
+		/** @return reference to Game_Switches object */
+		static Game_Switches& GetSwitches();
+
+		/** @return reference to Game_Variables object */
+		static Game_Variables& GetVariables();
+
 		/** @return reference to Game_Party object */
 		static Game_Party& GetParty();
 
@@ -55,10 +61,22 @@ struct Game_Data {
 		static void Reset();
 	private:
 		struct Data {
+			std::unique_ptr<Game_Switches> game_switches;
+			std::unique_ptr<Game_Variables> game_variables;
 			std::unique_ptr<Game_Party> game_party;
 		};
 		static Data data;
 };
+
+inline Game_Switches& Game_Data::GetSwitches() {
+	assert(data.game_switches);
+	return *data.game_switches;
+}
+
+inline Game_Variables& Game_Data::GetVariables() {
+	assert(data.game_variables);
+	return *data.game_variables;
+}
 
 inline Game_Party& Game_Data::GetParty() {
 	assert(data.game_party);

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -283,12 +283,12 @@ bool Game_Enemy::IsActionValid(const RPG::EnemyAction& action) {
 		}
 	case RPG::EnemyAction::ConditionType_party_lvl:
 		{
-			int party_lvl = Main_Data::game_party->GetAverageLevel();
+			int party_lvl = Game_Data::GetParty().GetAverageLevel();
 			return party_lvl >= action.condition_param1 && party_lvl <= action.condition_param2;
 		}
 	case RPG::EnemyAction::ConditionType_party_fatigue:
 		{
-			int party_exh = Main_Data::game_party->GetFatigue();
+			int party_exh = Game_Data::GetParty().GetFatigue();
 			return party_exh >= action.condition_param1 && party_exh <= action.condition_param2;
 		}
 	default:

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -258,7 +258,7 @@ bool Game_Enemy::IsActionValid(const RPG::EnemyAction& action) {
 	case RPG::EnemyAction::ConditionType_always:
 		return true;
 	case RPG::EnemyAction::ConditionType_switch:
-		return Main_Data::game_switches->Get(action.switch_id);
+		return Game_Data::GetSwitches().Get(action.switch_id);
 	case RPG::EnemyAction::ConditionType_turn:
 		{
 			int turns = Game_Battle::GetTurn();

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -251,28 +251,28 @@ bool Game_Event::AreConditionsMet(const RPG::EventPage& page) {
 	}
 
 	// Item in possession?
-	if (page.condition.flags.item && !(Main_Data::game_party->GetItemCount(page.condition.item_id)
-		+ Main_Data::game_party->GetEquippedItemCount(page.condition.item_id))) {
+	if (page.condition.flags.item && !(Game_Data::GetParty().GetItemCount(page.condition.item_id)
+		+ Game_Data::GetParty().GetEquippedItemCount(page.condition.item_id))) {
 			return false;
 	}
 
 	// Actor in party?
 	if (page.condition.flags.actor) {
-		if (!Main_Data::game_party->IsActorInParty(page.condition.actor_id)) {
+		if (!Game_Data::GetParty().IsActorInParty(page.condition.actor_id)) {
 			return false;
 		}
 	}
 
 	// Timer
 	if (page.condition.flags.timer) {
-		int secs = Main_Data::game_party->GetTimerSeconds(Main_Data::game_party->Timer1);
+		int secs = Game_Data::GetParty().GetTimerSeconds(Game_Data::GetParty().Timer1);
 		if (secs > page.condition.timer_sec)
 			return false;
 	}
 
 	// Timer2
 	if (page.condition.flags.timer2) {
-		int secs = Main_Data::game_party->GetTimerSeconds(Main_Data::game_party->Timer2);
+		int secs = Game_Data::GetParty().GetTimerSeconds(Game_Data::GetParty().Timer2);
 		if (secs > page.condition.timer2_sec)
 			return false;
 	}

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -205,45 +205,45 @@ void Game_Event::Refresh(bool from_save) {
 
 bool Game_Event::AreConditionsMet(const RPG::EventPage& page) {
 	// First switch (A)
-	if (page.condition.flags.switch_a && !Main_Data::game_switches->Get(page.condition.switch_a_id)) {
+	if (page.condition.flags.switch_a && !Game_Data::GetSwitches().Get(page.condition.switch_a_id)) {
 		return false;
 	}
 
 	// Second switch (B)
-	if (page.condition.flags.switch_b && !Main_Data::game_switches->Get(page.condition.switch_b_id)) {
+	if (page.condition.flags.switch_b && !Game_Data::GetSwitches().Get(page.condition.switch_b_id)) {
 		return false;
 	}
 
 	// Variable
 	if (Player::IsRPG2k()) {
-		if (page.condition.flags.variable && !(Main_Data::game_variables->Get(page.condition.variable_id) >= page.condition.variable_value)) {
+		if (page.condition.flags.variable && !(Game_Data::GetVariables().Get(page.condition.variable_id) >= page.condition.variable_value)) {
 			return false;
 		}
 	} else {
 		if (page.condition.flags.variable) {
 			switch (page.condition.compare_operator) {
 			case 0: // ==
-				if (!(Main_Data::game_variables->Get(page.condition.variable_id) == page.condition.variable_value))
+				if (!(Game_Data::GetVariables().Get(page.condition.variable_id) == page.condition.variable_value))
 					return false;
 				break;
 			case 1: // >=
-				if (!(Main_Data::game_variables->Get(page.condition.variable_id) >= page.condition.variable_value))
+				if (!(Game_Data::GetVariables().Get(page.condition.variable_id) >= page.condition.variable_value))
 					return false;
 				break;
 			case 2: // <=
-				if (!(Main_Data::game_variables->Get(page.condition.variable_id) <= page.condition.variable_value))
+				if (!(Game_Data::GetVariables().Get(page.condition.variable_id) <= page.condition.variable_value))
 					return false;
 				break;
 			case 3: // >
-				if (!(Main_Data::game_variables->Get(page.condition.variable_id) > page.condition.variable_value))
+				if (!(Game_Data::GetVariables().Get(page.condition.variable_id) > page.condition.variable_value))
 					return false;
 				break;
 			case 4: // <
-				if (!(Main_Data::game_variables->Get(page.condition.variable_id) < page.condition.variable_value))
+				if (!(Game_Data::GetVariables().Get(page.condition.variable_id) < page.condition.variable_value))
 					return false;
 				break;
 			case 5: // !=
-				if (!(Main_Data::game_variables->Get(page.condition.variable_id) != page.condition.variable_value))
+				if (!(Game_Data::GetVariables().Get(page.condition.variable_id) != page.condition.variable_value))
 					return false;
 				break;
 			}

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -463,9 +463,9 @@ void Game_Interpreter::Push(Game_CommonEvent* ev) {
 }
 
 bool Game_Interpreter::CheckGameOver() {
-	if (!Game_Temp::battle_running && !Main_Data::game_party->IsAnyActive()) {
+	if (!Game_Temp::battle_running && !Game_Data::GetParty().IsAnyActive()) {
 		// Empty party is allowed
-		if (Main_Data::game_party->GetBattlerCount() > 0) {
+		if (Game_Data::GetParty().GetBattlerCount() > 0) {
 			Scene::instance->SetRequestedScene(Scene::Gameover);
 			return true;
 		}
@@ -1008,11 +1008,11 @@ bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { /
 			switch (com.parameters[6]) {
 				case 0:
 					// Number of items posessed
-					value = Main_Data::game_party->GetItemCount(com.parameters[5]);
+					value = Game_Data::GetParty().GetItemCount(com.parameters[5]);
 					break;
 				case 1:
 					// How often the item is equipped
-					value = Main_Data::game_party->GetEquippedItemCount(com.parameters[5]);
+					value = Game_Data::GetParty().GetEquippedItemCount(com.parameters[5]);
 					break;
 			}
 			break;
@@ -1128,14 +1128,14 @@ bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { /
 			switch (com.parameters[5]) {
 				case 0:
 					// Gold
-					value = Main_Data::game_party->GetGold();
+					value = Game_Data::GetParty().GetGold();
 					break;
 				case 1:
-					value = Main_Data::game_party->GetTimerSeconds(Main_Data::game_party->Timer1);
+					value = Game_Data::GetParty().GetTimerSeconds(Game_Data::GetParty().Timer1);
 					break;
 				case 2:
 					// Number of heroes in party
-					value = Main_Data::game_party->GetActors().size();
+					value = Game_Data::GetParty().GetActors().size();
 					break;
 				case 3:
 					// Number of saves
@@ -1143,26 +1143,26 @@ bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { /
 					break;
 				case 4:
 					// Number of battles
-					value = Main_Data::game_party->GetBattleCount();
+					value = Game_Data::GetParty().GetBattleCount();
 					break;
 				case 5:
 					// Number of wins
-					value = Main_Data::game_party->GetWinCount();
+					value = Game_Data::GetParty().GetWinCount();
 					break;
 				case 6:
 					// Number of defeats
-					value = Main_Data::game_party->GetDefeatCount();
+					value = Game_Data::GetParty().GetDefeatCount();
 					break;
 				case 7:
 					// Number of escapes (aka run away)
-					value = Main_Data::game_party->GetRunCount();
+					value = Game_Data::GetParty().GetRunCount();
 					break;
 				case 8:
 					// MIDI play position
 					value = Audio().BGM_GetTicks();
 					break;
 				case 9:
-					value = Main_Data::game_party->GetTimerSeconds(Main_Data::game_party->Timer2);
+					value = Game_Data::GetParty().GetTimerSeconds(Game_Data::GetParty().Timer2);
 					break;
 			}
 			break;
@@ -1291,7 +1291,7 @@ std::vector<Game_Actor*> Game_Interpreter::GetActors(int mode, int id) {
 	switch (mode) {
 	case 0:
 		// Party
-		actors = Main_Data::game_party->GetActors();
+		actors = Game_Data::GetParty().GetActors();
 		break;
 	case 1:
 		// Hero
@@ -1346,15 +1346,15 @@ bool Game_Interpreter::CommandTimerOperation(RPG::EventCommand const& com) { // 
 	case 0:
 		seconds = ValueOrVariable(com.parameters[1],
 			com.parameters[2]);
-		Main_Data::game_party->SetTimer(timer_id, seconds);
+		Game_Data::GetParty().SetTimer(timer_id, seconds);
 		break;
 	case 1:
 		visible = com.parameters[3] != 0;
 		battle = com.parameters[4] != 0;
-		Main_Data::game_party->StartTimer(timer_id, visible, battle);
+		Game_Data::GetParty().StartTimer(timer_id, visible, battle);
 		break;
 	case 2:
-		Main_Data::game_party->StopTimer(timer_id);
+		Game_Data::GetParty().StopTimer(timer_id);
 		break;
 	default:
 		return false;
@@ -1370,7 +1370,7 @@ bool Game_Interpreter::CommandChangeGold(RPG::EventCommand const& com) { // Code
 		com.parameters[2]
 	);
 
-	Main_Data::game_party->GainGold(value);
+	Game_Data::GetParty().GainGold(value);
 
 	// Continue
 	return true;
@@ -1400,10 +1400,10 @@ bool Game_Interpreter::CommandChangeItems(RPG::EventCommand const& com) { // Cod
 
 	if (com.parameters[1] == 0) {
 		// Item by const number
-		Main_Data::game_party->AddItem(com.parameters[2], value);
+		Game_Data::GetParty().AddItem(com.parameters[2], value);
 	} else {
 		// Item by variable
-		Main_Data::game_party->AddItem(
+		Game_Data::GetParty().AddItem(
 			Main_Data::game_variables->Get(com.parameters[2]),
 			value
 		);
@@ -1432,11 +1432,11 @@ bool Game_Interpreter::CommandChangePartyMember(RPG::EventCommand const& com) { 
 
 	if (com.parameters[0] == 0) {
 		// Add members
-		Main_Data::game_party->AddActor(id);
+		Game_Data::GetParty().AddActor(id);
 
 	} else {
 		// Remove members
-		Main_Data::game_party->RemoveActor(id);
+		Game_Data::GetParty().RemoveActor(id);
 	}
 
 	CheckGameOver();
@@ -1614,8 +1614,8 @@ bool Game_Interpreter::CommandChangeEquipment(RPG::EventCommand const& com) { //
 				continue;
 			}
 
-			if (Main_Data::game_party->GetItemCount(item_id) == 0 && !actor->IsEquipped(item_id)) {
-				Main_Data::game_party->AddItem(item_id, 1);
+			if (Game_Data::GetParty().GetItemCount(item_id) == 0 && !actor->IsEquipped(item_id)) {
+				Game_Data::GetParty().AddItem(item_id, 1);
 			}
 
 			if (actor->HasTwoWeapons() && slot == RPG::Item::Type_weapon && item_id != 0) {
@@ -2906,7 +2906,7 @@ bool Game_Interpreter::CommandConditionalBranch(RPG::EventCommand const& com) { 
 		}
 		break;
 	case 2:
-		value1 = Main_Data::game_party->GetTimerSeconds(Main_Data::game_party->Timer1);
+		value1 = Game_Data::GetParty().GetTimerSeconds(Game_Data::GetParty().Timer1);
 		value2 = com.parameters[1];
 		switch (com.parameters[2]) {
 		case 0:
@@ -2921,22 +2921,22 @@ bool Game_Interpreter::CommandConditionalBranch(RPG::EventCommand const& com) { 
 		// Gold
 		if (com.parameters[2] == 0) {
 			// Greater than or equal
-			result = (Main_Data::game_party->GetGold() >= com.parameters[1]);
+			result = (Game_Data::GetParty().GetGold() >= com.parameters[1]);
 		} else {
 			// Less than or equal
-			result = (Main_Data::game_party->GetGold() <= com.parameters[1]);
+			result = (Game_Data::GetParty().GetGold() <= com.parameters[1]);
 		}
 		break;
 	case 4:
 		// Item
 		if (com.parameters[2] == 0) {
 			// Having
-			result = Main_Data::game_party->GetItemCount(com.parameters[1])
-				+ Main_Data::game_party->GetEquippedItemCount(com.parameters[1]) > 0;
+			result = Game_Data::GetParty().GetItemCount(com.parameters[1])
+				+ Game_Data::GetParty().GetEquippedItemCount(com.parameters[1]) > 0;
 		} else {
 			// Not having
-			result = Main_Data::game_party->GetItemCount(com.parameters[1])
-				+ Main_Data::game_party->GetEquippedItemCount(com.parameters[1]) == 0;
+			result = Game_Data::GetParty().GetItemCount(com.parameters[1])
+				+ Game_Data::GetParty().GetEquippedItemCount(com.parameters[1]) == 0;
 		}
 		break;
 	case 5:
@@ -2955,7 +2955,7 @@ bool Game_Interpreter::CommandConditionalBranch(RPG::EventCommand const& com) { 
 		switch (com.parameters[2]) {
 		case 0:
 			// Is actor in party
-			result = Main_Data::game_party->IsActorInParty(actor_id);
+			result = Game_Data::GetParty().IsActorInParty(actor_id);
 			break;
 		case 1:
 			// Name
@@ -3020,7 +3020,7 @@ bool Game_Interpreter::CommandConditionalBranch(RPG::EventCommand const& com) { 
 		result = Audio().BGM_PlayedOnce();
 		break;
 	case 10:
-		value1 = Main_Data::game_party->GetTimerSeconds(Main_Data::game_party->Timer2);
+		value1 = Game_Data::GetParty().GetTimerSeconds(Game_Data::GetParty().Timer2);
 		value2 = com.parameters[1];
 		switch (com.parameters[2]) {
 		case 0:

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -353,7 +353,7 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 
 		if (_keyinput.wait) {
 			const int key = _keyinput.CheckInput();
-			Main_Data::game_variables->Set(_keyinput.variable, key);
+			Game_Data::GetVariables().Set(_keyinput.variable, key);
 			Game_Map::SetNeedRefresh(Game_Map::Refresh_Map);
 			if (key == 0) {
 				++_keyinput.wait_frames;
@@ -361,7 +361,7 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 			}
 			if (_keyinput.timed) {
 				// 10 per second
-				Main_Data::game_variables->Set(_keyinput.time_variable,
+				Game_Data::GetVariables().Set(_keyinput.time_variable,
 						(_keyinput.wait_frames * 10) / Graphics::GetDefaultFps());
 			}
 			_keyinput.wait = false;
@@ -954,21 +954,21 @@ bool Game_Interpreter::CommandControlSwitches(RPG::EventCommand const& com) { //
 		// Param0: 0: Single, 1: Range, 2: Indirect
 		// For Range set end to param 2, otherwise to start, this way the loop runs exactly once
 
-		int start = com.parameters[0] == 2 ? Main_Data::game_variables->Get(com.parameters[1]) : com.parameters[1];
+		int start = com.parameters[0] == 2 ? Game_Data::GetVariables().Get(com.parameters[1]) : com.parameters[1];
 		int end = com.parameters[0] == 1 ? com.parameters[2] : start;
 		int val = com.parameters[3];
 
 		if (start == end) {
 			if (val < 2) {
-				Main_Data::game_switches->Set(start, val == 0);
+				Game_Data::GetSwitches().Set(start, val == 0);
 			} else {
-				Main_Data::game_switches->Flip(start);
+				Game_Data::GetSwitches().Flip(start);
 			}
 		} else {
 			if (val < 2) {
-				Main_Data::game_switches->SetRange(start, end, val == 0);
+				Game_Data::GetSwitches().SetRange(start, end, val == 0);
 			} else {
-				Main_Data::game_switches->FlipRange(start, end);
+				Game_Data::GetSwitches().FlipRange(start, end);
 			}
 		}
 
@@ -990,11 +990,11 @@ bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { /
 			break;
 		case 1:
 			// Var A ops B
-			value = Main_Data::game_variables->Get(com.parameters[5]);
+			value = Game_Data::GetVariables().Get(com.parameters[5]);
 			break;
 		case 2:
 			// Number of var A ops B
-			value = Main_Data::game_variables->Get(Main_Data::game_variables->Get(com.parameters[5]));
+			value = Game_Data::GetVariables().Get(Game_Data::GetVariables().Get(com.parameters[5]));
 			break;
 		case 3:
 			// Random between range
@@ -1214,49 +1214,49 @@ bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { /
 		// Param0: 0: Single, 1: Range, 2: Indirect
 		// For Range set end to param 2, otherwise to start, this way the loop runs exactly once
 
-		int start = com.parameters[0] == 2 ? Main_Data::game_variables->Get(com.parameters[1]) : com.parameters[1];
+		int start = com.parameters[0] == 2 ? Game_Data::GetVariables().Get(com.parameters[1]) : com.parameters[1];
 		int end = com.parameters[0] == 1 ? com.parameters[2] : start;
 
 		if (start == end) {
 			switch (com.parameters[3]) {
 				case 0:
-					Main_Data::game_variables->Set(start, value);
+					Game_Data::GetVariables().Set(start, value);
 					break;
 				case 1:
-					Main_Data::game_variables->Add(start, value);
+					Game_Data::GetVariables().Add(start, value);
 					break;
 				case 2:
-					Main_Data::game_variables->Sub(start, value);
+					Game_Data::GetVariables().Sub(start, value);
 					break;
 				case 3:
-					Main_Data::game_variables->Mult(start, value);
+					Game_Data::GetVariables().Mult(start, value);
 					break;
 				case 4:
-					Main_Data::game_variables->Div(start, value);
+					Game_Data::GetVariables().Div(start, value);
 					break;
 				case 5:
-					Main_Data::game_variables->Mod(start, value);
+					Game_Data::GetVariables().Mod(start, value);
 					break;
 			}
 		} else {
 			switch (com.parameters[3]) {
 				case 0:
-					Main_Data::game_variables->SetRange(start, end, value);
+					Game_Data::GetVariables().SetRange(start, end, value);
 					break;
 				case 1:
-					Main_Data::game_variables->AddRange(start, end, value);
+					Game_Data::GetVariables().AddRange(start, end, value);
 					break;
 				case 2:
-					Main_Data::game_variables->SubRange(start, end, value);
+					Game_Data::GetVariables().SubRange(start, end, value);
 					break;
 				case 3:
-					Main_Data::game_variables->MultRange(start, end, value);
+					Game_Data::GetVariables().MultRange(start, end, value);
 					break;
 				case 4:
-					Main_Data::game_variables->DivRange(start, end, value);
+					Game_Data::GetVariables().DivRange(start, end, value);
 					break;
 				case 5:
-					Main_Data::game_variables->ModRange(start, end, value);
+					Game_Data::GetVariables().ModRange(start, end, value);
 					break;
 			}
 		}
@@ -1273,7 +1273,7 @@ int Game_Interpreter::OperateValue(int operation, int operand_type, int operand)
 	if (operand_type == 0) {
 		value = operand;
 	} else {
-		value = Main_Data::game_variables->Get(operand);
+		value = Game_Data::GetVariables().Get(operand);
 	}
 
 	// Reverse sign of value if operation is substract
@@ -1306,9 +1306,9 @@ std::vector<Game_Actor*> Game_Interpreter::GetActors(int mode, int id) {
 		break;
 	case 2:
 		// Var hero
-		actor = Game_Actors::GetActor(Main_Data::game_variables->Get(id));
+		actor = Game_Actors::GetActor(Game_Data::GetVariables().Get(id));
 		if (!actor) {
-			Output::Warning("Invalid actor ID %d", Main_Data::game_variables->Get(id));
+			Output::Warning("Invalid actor ID %d", Game_Data::GetVariables().Get(id));
 			return actors;
 		}
 
@@ -1404,7 +1404,7 @@ bool Game_Interpreter::CommandChangeItems(RPG::EventCommand const& com) { // Cod
 	} else {
 		// Item by variable
 		Game_Data::GetParty().AddItem(
-			Main_Data::game_variables->Get(com.parameters[2]),
+			Game_Data::GetVariables().Get(com.parameters[2]),
 			value
 		);
 	}
@@ -1420,7 +1420,7 @@ bool Game_Interpreter::CommandChangePartyMember(RPG::EventCommand const& com) { 
 	if (com.parameters[1] == 0) {
 		id = com.parameters[2];
 	} else {
-		id = Main_Data::game_variables->Get(com.parameters[2]);
+		id = Game_Data::GetVariables().Get(com.parameters[2]);
 	}
 
 	actor = Game_Actors::GetActor(id);
@@ -1508,7 +1508,7 @@ int Game_Interpreter::ValueOrVariable(int mode, int val) {
 		case 0:
 			return val;
 		case 1:
-			return Main_Data::game_variables->Get(val);
+			return Game_Data::GetVariables().Get(val);
 		default:
 			return -1;
 	}
@@ -1736,7 +1736,7 @@ bool Game_Interpreter::CommandSimulatedAttack(RPG::EventCommand const& com) { //
 		actor->ChangeHp(-result);
 
 		if (com.parameters[6] != 0) {
-			Main_Data::game_variables->Set(com.parameters[7], result);
+			Game_Data::GetVariables().Set(com.parameters[7], result);
 			Game_Map::SetNeedRefresh(Game_Map::Refresh_Map);
 		}
 	}
@@ -1931,9 +1931,9 @@ bool Game_Interpreter::CommandMemorizeLocation(RPG::EventCommand const& com) { /
 	int var_map_id = com.parameters[0];
 	int var_x = com.parameters[1];
 	int var_y = com.parameters[2];
-	Main_Data::game_variables->Set(var_map_id, Game_Map::GetMapId());
-	Main_Data::game_variables->Set(var_x, player->GetX());
-	Main_Data::game_variables->Set(var_y, player->GetY());
+	Game_Data::GetVariables().Set(var_map_id, Game_Map::GetMapId());
+	Game_Data::GetVariables().Set(var_x, player->GetX());
+	Game_Data::GetVariables().Set(var_y, player->GetY());
 	Game_Map::SetNeedRefresh(Game_Map::Refresh_Map);
 	return true;
 }
@@ -2048,7 +2048,7 @@ bool Game_Interpreter::CommandStoreTerrainID(RPG::EventCommand const& com) { // 
 	int x = ValueOrVariable(com.parameters[0], com.parameters[1]);
 	int y = ValueOrVariable(com.parameters[0], com.parameters[2]);
 	int var_id = com.parameters[3];
-	Main_Data::game_variables->Set(var_id, Game_Map::GetTerrainTag(x, y));
+	Game_Data::GetVariables().Set(var_id, Game_Map::GetTerrainTag(x, y));
 	Game_Map::SetNeedRefresh(Game_Map::Refresh_Map);
 	return true;
 }
@@ -2058,7 +2058,7 @@ bool Game_Interpreter::CommandStoreEventID(RPG::EventCommand const& com) { // co
 	int y = ValueOrVariable(com.parameters[0], com.parameters[2]);
 	int var_id = com.parameters[3];
 	auto* ev = Game_Map::GetEventAt(x, y, false);
-	Main_Data::game_variables->Set(var_id, ev ? ev->GetId() : 0);
+	Game_Data::GetVariables().Set(var_id, ev ? ev->GetId() : 0);
 	Game_Map::SetNeedRefresh(Game_Map::Refresh_Map);
 	return true;
 }
@@ -2322,9 +2322,9 @@ namespace PicPointerPatch {
 		if (pic_id > 10000) {
 			int new_id;
 			if (pic_id > 50000) {
-				new_id = Main_Data::game_variables->Get(pic_id - 50000);
+				new_id = Game_Data::GetVariables().Get(pic_id - 50000);
 			} else {
-				new_id = Main_Data::game_variables->Get(pic_id - 10000);
+				new_id = Game_Data::GetVariables().Get(pic_id - 10000);
 			}
 
 			if (new_id > 0) {
@@ -2336,19 +2336,19 @@ namespace PicPointerPatch {
 
 	static void AdjustParams(Game_Picture::Params& params) {
 		if (params.magnify > 10000) {
-			int new_magnify = Main_Data::game_variables->Get(params.magnify - 10000);
+			int new_magnify = Game_Data::GetVariables().Get(params.magnify - 10000);
 			Output::Debug("PicPointer: Zoom %d replaced with %d", params.magnify, new_magnify);
 			params.magnify = new_magnify;
 		}
 
 		if (params.top_trans > 10000) {
-			int new_top_trans = Main_Data::game_variables->Get(params.top_trans - 10000);
+			int new_top_trans = Game_Data::GetVariables().Get(params.top_trans - 10000);
 			Output::Debug("PicPointer: Top transparency %d replaced with %d", params.top_trans, new_top_trans);
 			params.top_trans = new_top_trans;
 		}
 
 		if (params.bottom_trans > 10000) {
-			int new_bottom_trans = Main_Data::game_variables->Get(params.bottom_trans - 10000);
+			int new_bottom_trans = Game_Data::GetVariables().Get(params.bottom_trans - 10000);
 			Output::Debug("PicPointer: Bottom transparency %d replaced with %d", params.bottom_trans, new_bottom_trans);
 			params.bottom_trans = new_bottom_trans;
 		}
@@ -2384,7 +2384,7 @@ namespace PicPointerPatch {
 		// Adjust name
 		if (pic_id >= 50000) {
 			// Name substitution is pic_id + 1
-			int pic_num = Main_Data::game_variables->Get(pic_id - 50000 + 1);
+			int pic_num = Game_Data::GetVariables().Get(pic_id - 50000 + 1);
 
 			if (pic_num >= 0) {
 				params.name = ReplaceName(params.name, pic_num, 4);
@@ -2400,7 +2400,7 @@ namespace PicPointerPatch {
 		AdjustParams(params);
 
 		if (params.duration > 10000) {
-			int new_duration = Main_Data::game_variables->Get(params.duration - 10000);
+			int new_duration = Game_Data::GetVariables().Get(params.duration - 10000);
 			Output::Debug("PicPointer: Move duration %d replaced with %d", params.duration, new_duration);
 			params.duration = new_duration;
 		}
@@ -2450,8 +2450,8 @@ bool Game_Interpreter::CommandShowPicture(RPG::EventCommand const& com) { // cod
 		pic_id = ValueOrVariable(com.parameters[17], pic_id);
 		if (com.parameters[19] != 0) {
 			int var = 0;
-			if (Main_Data::game_variables->IsValid(com.parameters[19])) {
-				var = Main_Data::game_variables->Get(com.parameters[19]);
+			if (Game_Data::GetVariables().IsValid(com.parameters[19])) {
+				var = Game_Data::GetVariables().Get(com.parameters[19]);
 			}
 			params.name = PicPointerPatch::ReplaceName(params.name, var, com.parameters[18]);
 		}
@@ -2691,7 +2691,7 @@ bool Game_Interpreter::CommandKeyInputProc(RPG::EventCommand const& com) { // co
 
 	if (wait) {
 		// While waiting the variable is reset to 0 each frame.
-		Main_Data::game_variables->Set(var_id, 0);
+		Game_Data::GetVariables().Set(var_id, 0);
 		Game_Map::SetNeedRefresh(Game_Map::Refresh_Map);
 	}
 
@@ -2745,7 +2745,7 @@ bool Game_Interpreter::CommandKeyInputProc(RPG::EventCommand const& com) { // co
 	}
 
 	int key = _keyinput.CheckInput();
-	Main_Data::game_variables->Set(_keyinput.variable, key);
+	Game_Data::GetVariables().Set(_keyinput.variable, key);
 	Game_Map::SetNeedRefresh(Game_Map::Refresh_Map);
 
 	return true;
@@ -2868,15 +2868,15 @@ bool Game_Interpreter::CommandConditionalBranch(RPG::EventCommand const& com) { 
 	switch (com.parameters[0]) {
 	case 0:
 		// Switch
-		result = Main_Data::game_switches->Get(com.parameters[1]) == (com.parameters[2] == 0);
+		result = Game_Data::GetSwitches().Get(com.parameters[1]) == (com.parameters[2] == 0);
 		break;
 	case 1:
 		// Variable
-		value1 = Main_Data::game_variables->Get(com.parameters[1]);
+		value1 = Game_Data::GetVariables().Get(com.parameters[1]);
 		if (com.parameters[2] == 0) {
 			value2 = com.parameters[3];
 		} else {
-			value2 = Main_Data::game_variables->Get(com.parameters[3]);
+			value2 = Game_Data::GetVariables().Get(com.parameters[3]);
 		}
 		switch (com.parameters[4]) {
 		case 0:
@@ -3195,8 +3195,8 @@ bool Game_Interpreter::CommandCallEvent(RPG::EventCommand const& com) { // code 
 		event_page = com.parameters[2];
 		break;
 	case 2: // Indirect
-		evt_id = Main_Data::game_variables->Get(com.parameters[1]);
-		event_page = Main_Data::game_variables->Get(com.parameters[2]);
+		evt_id = Game_Data::GetVariables().Get(com.parameters[1]);
+		event_page = Game_Data::GetVariables().Get(com.parameters[2]);
 		break;
 	default:
 		return false;

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -174,7 +174,7 @@ bool Game_Interpreter_Battle::CommandChangeMonsterHP(RPG::EventCommand const& co
 		change = com.parameters[3];
 	    break;
 	case 1:
-		change = Main_Data::game_variables->Get(com.parameters[3]);
+		change = Game_Data::GetVariables().Get(com.parameters[3]);
 	    break;
 	case 2:
 		change = com.parameters[3] * hp / 100;
@@ -206,7 +206,7 @@ bool Game_Interpreter_Battle::CommandChangeMonsterMP(RPG::EventCommand const& co
 		change = com.parameters[3];
 	    break;
 	case 1:
-		change = Main_Data::game_variables->Get(com.parameters[3]);
+		change = Game_Data::GetVariables().Get(com.parameters[3]);
 	    break;
 	}
 
@@ -315,15 +315,15 @@ bool Game_Interpreter_Battle::CommandConditionalBranchBattle(RPG::EventCommand c
 	switch (com.parameters[0]) {
 		case 0:
 			// Switch
-			result = Main_Data::game_switches->Get(com.parameters[1]) == (com.parameters[2] == 0);
+			result = Game_Data::GetSwitches().Get(com.parameters[1]) == (com.parameters[2] == 0);
 			break;
 		case 1:
 			// Variable
-			value1 = Main_Data::game_variables->Get(com.parameters[1]);
+			value1 = Game_Data::GetVariables().Get(com.parameters[1]);
 			if (com.parameters[2] == 0) {
 				value2 = com.parameters[3];
 			} else {
-				value2 = Main_Data::game_variables->Get(com.parameters[3]);
+				value2 = Game_Data::GetVariables().Get(com.parameters[3]);
 			}
 			switch (com.parameters[4]) {
 				case 0:

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -140,7 +140,7 @@ bool Game_Interpreter_Battle::CommandForceFlee(RPG::EventCommand const& com) {
 bool Game_Interpreter_Battle::CommandEnableCombo(RPG::EventCommand const& com) {
 	int actor_id = com.parameters[0];
 
-	if (!Main_Data::game_party->IsActorInParty(actor_id)) {
+	if (!Game_Data::GetParty().IsActorInParty(actor_id)) {
 		return true;
 	}
 
@@ -267,7 +267,7 @@ bool Game_Interpreter_Battle::CommandShowBattleAnimation(RPG::EventCommand const
 		std::vector<Game_Battler*> v;
 
 		if (allies) {
-			Main_Data::game_party->GetActiveBattlers(v);
+			Game_Data::GetParty().GetActiveBattlers(v);
 		} else {
 			Main_Data::game_enemyparty->GetActiveBattlers(v);
 		}
@@ -280,8 +280,8 @@ bool Game_Interpreter_Battle::CommandShowBattleAnimation(RPG::EventCommand const
 		if (allies) {
 			// Allies counted from 1
 			target -= 1;
-			if (target >= 0 && target < Main_Data::game_party->GetBattlerCount()) {
-				battler_target = &(*Main_Data::game_party)[target];
+			if (target >= 0 && target < Game_Data::GetParty().GetBattlerCount()) {
+				battler_target = &(Game_Data::GetParty())[target];
 			}
 		}
 		else {

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -167,9 +167,9 @@ bool Game_Interpreter_Map::CommandRecallToLocation(RPG::EventCommand const& com)
 	int var_map_id = com.parameters[0];
 	int var_x = com.parameters[1];
 	int var_y = com.parameters[2];
-	int map_id = Main_Data::game_variables->Get(var_map_id);
-	int x = Main_Data::game_variables->Get(var_x);
-	int y = Main_Data::game_variables->Get(var_y);
+	int map_id = Game_Data::GetVariables().Get(var_map_id);
+	int x = Game_Data::GetVariables().Get(var_x);
+	int y = Game_Data::GetVariables().Get(var_y);
 
 	auto tt = main_flag ? TeleportTarget::eForegroundTeleport : TeleportTarget::eParallelTeleport;
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -433,7 +433,7 @@ bool Game_Interpreter_Map::CommandShowInn(RPG::EventCommand const& com) { // cod
 			return false;
 	}
 
-	bool can_afford = (Main_Data::game_party->GetGold() >= Game_Temp::inn_price);
+	bool can_afford = (Game_Data::GetParty().GetGold() >= Game_Temp::inn_price);
 	pm.SetChoiceResetColors(true);
 
 	switch (inn_type) {
@@ -471,7 +471,7 @@ void Game_Interpreter_Map::ContinuationShowInnStart(int indent, int choice_resul
 	SetSubcommandIndex(indent, inn_stay ? eOptionInnStay : eOptionInnNoStay);
 
 	if (inn_stay) {
-		Main_Data::game_party->GainGold(-Game_Temp::inn_price);
+		Game_Data::GetParty().GainGold(-Game_Temp::inn_price);
 
 		_async_op = AsyncOp::MakeCallInn();
 	}

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -990,7 +990,7 @@ void Game_Map::Update(MapUpdateAsyncContext& actx, bool is_preupdate) {
 		}
 
 		Game_Message::Update();
-		Main_Data::game_party->UpdateTimers();
+		Game_Data::GetParty().UpdateTimers();
 		Main_Data::game_screen->Update();
 	}
 

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -299,7 +299,7 @@ static Game_Message::ParseParamResult ParseParamImpl(
 
 					auto ret = ParseParamImpl('V', 'v', iter, end, escape_char, true, max_recursion - 1);
 					iter = ret.next;
-					int var_val = Main_Data::game_variables->Get(ret.value);
+					int var_val = Game_Data::GetVariables().Get(ret.value);
 
 					got_valid_number = true;
 

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -33,10 +33,6 @@
 #include "output.h"
 
 Game_Party::Game_Party() {
-	SetupNewGame();
-}
-
-void Game_Party::SetupNewGame() {
 	data.Setup();
 	RemoveInvalidData();
 }

--- a/src/game_party.h
+++ b/src/game_party.h
@@ -28,13 +28,8 @@
  */
 class Game_Party : public Game_Party_Base {
 public:
-	/**
-	 * Initializes Game_Party.
-	 */
-	Game_Party();
-
 	/** Initialize for new game */
-	void SetupNewGame();
+	Game_Party();
 
 	/** Initialize from save game */
 	void SetupFromSave(RPG::SaveInventory save);

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -69,7 +69,7 @@ void Game_Player::ReserveTeleport(const RPG::SaveTarget& target) {
 	ReserveTeleport(map_id, target.map_x, target.map_y, Down, TeleportTarget::eSkillTeleport);
 
 	if (target.switch_on) {
-		Main_Data::game_switches->Set(target.switch_id, true);
+		Game_Data::GetSwitches().Set(target.switch_id, true);
 		Game_Map::SetNeedRefresh(Game_Map::Refresh_All);
 	}
 

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -296,11 +296,11 @@ void Game_Player::UpdateSelfMovement() {
 					break;
 			}
 			if (tried_move && !move_failed) {
-				Main_Data::game_party->IncSteps();
+				Game_Data::GetParty().IncSteps();
 				if (Game_Map::UpdateEncounterSteps()) {
 					SetEncounterCalling(true);
 				}
-				if (Main_Data::game_party->ApplyStateDamage()) {
+				if (Game_Data::GetParty().ApplyStateDamage()) {
 					Main_Data::game_screen->FlashMapStepDamage();
 				}
 			}
@@ -444,7 +444,7 @@ bool Game_Player::CheckEventTriggerThere(TriggerSet triggers, int x, int y, bool
 
 void Game_Player::Refresh() {
 
-	auto* actor = Main_Data::game_party->GetActor(0);
+	auto* actor = Game_Data::GetParty().GetActor(0);
 	if (actor == nullptr) {
 		SetSpriteGraphic("", 0);
 		SetTransparency(0);
@@ -576,7 +576,7 @@ void Game_Player::BeginMove() {
 				Game_System::SePlay(terrain->footstep);
 			}
 			if (terrain->damage > 0) {
-				for (auto hero : Main_Data::game_party->GetActors()) {
+				for (auto hero : Game_Data::GetParty().GetActors()) {
 					if (!hero->PreventsTerrainDamage()) {
 						red_flash = true;
 						hero->ChangeHp(-std::max<int>(0, std::min<int>(terrain->damage, hero->GetHp() - 1)));

--- a/src/main_data.cpp
+++ b/src/main_data.cpp
@@ -23,10 +23,7 @@
 #include "game_player.h"
 #include "game_screen.h"
 #include "game_map.h"
-#include "game_variables.h"
-#include "game_switches.h"
 #include "game_quit.h"
-#include "font.h"
 #include "player.h"
 
 #ifndef _WIN32
@@ -52,8 +49,6 @@ std::string save_path;
 
 namespace Main_Data {
 	// Dynamic Game Data
-	std::unique_ptr<Game_Switches> game_switches;
-	std::unique_ptr<Game_Variables> game_variables;
 	std::unique_ptr<Game_Screen> game_screen;
 	std::unique_ptr<Game_Player> game_player;
 	std::unique_ptr<Game_EnemyParty> game_enemyparty;
@@ -155,7 +150,6 @@ void Main_Data::Cleanup() {
 	Game_Map::Quit();
 	Game_Actors::Dispose();
 
-	game_switches.reset();
 	game_screen.reset();
 	game_player.reset();
 	game_enemyparty.reset();

--- a/src/main_data.cpp
+++ b/src/main_data.cpp
@@ -19,7 +19,6 @@
 #include <cstdlib>
 #include "main_data.h"
 #include "game_actors.h"
-#include "game_party.h"
 #include "game_enemyparty.h"
 #include "game_player.h"
 #include "game_screen.h"
@@ -57,7 +56,6 @@ namespace Main_Data {
 	std::unique_ptr<Game_Variables> game_variables;
 	std::unique_ptr<Game_Screen> game_screen;
 	std::unique_ptr<Game_Player> game_player;
-	std::unique_ptr<Game_Party> game_party;
 	std::unique_ptr<Game_EnemyParty> game_enemyparty;
 	std::unique_ptr<Game_Quit> game_quit;
 
@@ -160,7 +158,6 @@ void Main_Data::Cleanup() {
 	game_switches.reset();
 	game_screen.reset();
 	game_player.reset();
-	game_party.reset();
 	game_enemyparty.reset();
 	game_quit.reset();
 

--- a/src/main_data.h
+++ b/src/main_data.h
@@ -31,14 +31,10 @@
 class Game_Player;
 class Game_Screen;
 class Game_EnemyParty;
-class Game_Switches;
-class Game_Variables;
 class Game_Quit;
 
 namespace Main_Data {
 	// Dynamic Game Data
-	extern std::unique_ptr<Game_Switches> game_switches;
-	extern std::unique_ptr<Game_Variables> game_variables;
 	extern std::unique_ptr<Game_Screen> game_screen;
 	extern std::unique_ptr<Game_Player> game_player;
 	extern std::unique_ptr<Game_EnemyParty> game_enemyparty;

--- a/src/main_data.h
+++ b/src/main_data.h
@@ -22,6 +22,7 @@
 #include "data.h"
 #include "rpg_save.h"
 #include "game_screen.h"
+#include "game_data.h"
 #include <string>
 
 /**
@@ -29,7 +30,6 @@
  */
 class Game_Player;
 class Game_Screen;
-class Game_Party;
 class Game_EnemyParty;
 class Game_Switches;
 class Game_Variables;
@@ -41,7 +41,6 @@ namespace Main_Data {
 	extern std::unique_ptr<Game_Variables> game_variables;
 	extern std::unique_ptr<Game_Screen> game_screen;
 	extern std::unique_ptr<Game_Player> game_player;
-	extern std::unique_ptr<Game_Party> game_party;
 	extern std::unique_ptr<Game_EnemyParty> game_enemyparty;
 	extern std::unique_ptr<Game_Quit> game_quit;
 	extern RPG::Save game_data;

--- a/src/pending_message.cpp
+++ b/src/pending_message.cpp
@@ -7,6 +7,7 @@
 #include "utils.h"
 #include "player.h"
 #include "main_data.h"
+#include "game_data.h"
 #include <cassert>
 #include <cctype>
 #include <algorithm>
@@ -121,7 +122,7 @@ std::string PendingMessage::ApplyTextInsertingCommands(std::string input, uint32
 			iter = parse_ret.next;
 			int value = parse_ret.value;
 
-			int variable_value = Main_Data::game_variables->Get(value);
+			int variable_value = Game_Data::GetVariables().Get(value);
 			output.append(std::to_string(variable_value));
 
 			start_copy = iter;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -799,7 +799,6 @@ void Player::ResetGameObjects() {
 	Game_Temp::Init();
 
 	Main_Data::game_enemyparty = std::make_unique<Game_EnemyParty>();
-	Main_Data::game_party = std::make_unique<Game_Party>();
 	Main_Data::game_player = std::make_unique<Game_Player>();
 	Main_Data::game_quit = std::make_unique<Game_Quit>();
 
@@ -924,8 +923,8 @@ void Player::LoadSavegame(const std::string& save_name) {
 	Main_Data::game_data.system.Fixup();
 
 	Game_Actors::Fixup();
+
 	Game_Data::SetupLoadGame(Main_Data::game_data);
-	Main_Data::game_party->SetupFromSave(std::move(Main_Data::game_data.inventory));
 
 	int map_id = save->party_location.map_id;
 
@@ -949,10 +948,10 @@ static void OnMapFileReady(FileRequestResult*) {
 	int y_pos = Player::party_y_position == -1 ?
 		Data::treemap.start.party_y : Player::party_y_position;
 	if (Player::party_members.size() > 0) {
-		Main_Data::game_party->Clear();
+		Game_Data::GetParty().Clear();
 		std::vector<int>::iterator member;
 		for (member = Player::party_members.begin(); member != Player::party_members.end(); ++member) {
-			Main_Data::game_party->AddActor(*member);
+			Game_Data::GetParty().AddActor(*member);
 		}
 	}
 
@@ -970,7 +969,6 @@ void Player::SetupNewGame() {
 	}
 
 	Game_Data::SetupNewGame();
-	Main_Data::game_party->SetupNewGame();
 	SetupPlayerSpawn();
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -51,10 +51,8 @@
 #include "game_enemyparty.h"
 #include "game_party.h"
 #include "game_player.h"
-#include "game_switches.h"
 #include "game_system.h"
 #include "game_temp.h"
-#include "game_variables.h"
 #include "game_data.h"
 #include "graphics.h"
 #include "inireader.h"
@@ -782,12 +780,6 @@ void Player::ResetGameObjects() {
 
 	Main_Data::game_data.Setup();
 
-	Main_Data::game_switches = std::make_unique<Game_Switches>();
-
-	auto min_var = Player::IsRPG2k3() ? Game_Variables::min_2k3 : Game_Variables::min_2k;
-	auto max_var = Player::IsRPG2k3() ? Game_Variables::max_2k3 : Game_Variables::max_2k;
-	Main_Data::game_variables = std::make_unique<Game_Variables>(min_var, max_var);
-
 	// Prevent a crash when Game_Map wants to reset the screen content
 	// because Setup() modified pictures array
 	Main_Data::game_screen = std::make_unique<Game_Screen>();
@@ -931,9 +923,6 @@ void Player::LoadSavegame(const std::string& save_name) {
 	FileRequestAsync* map = Game_Map::RequestMap(map_id);
 	save_request_id = map->Bind(&OnMapSaveFileReady);
 	map->SetImportantFile(true);
-
-	Main_Data::game_switches->SetData(std::move(Main_Data::game_data.system.switches));
-	Main_Data::game_variables->SetData(std::move(Main_Data::game_data.system.variables));
 
 	Game_System::ReloadSystemGraphic();
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -55,6 +55,7 @@
 #include "game_system.h"
 #include "game_temp.h"
 #include "game_variables.h"
+#include "game_data.h"
 #include "graphics.h"
 #include "inireader.h"
 #include "input.h"
@@ -776,6 +777,7 @@ void Player::ResetGameObjects() {
 	Game_System::ResetSystemGraphic();
 
 	// The init order is important
+	Game_Data::Reset();
 	Main_Data::Cleanup();
 
 	Main_Data::game_data.Setup();
@@ -922,6 +924,7 @@ void Player::LoadSavegame(const std::string& save_name) {
 	Main_Data::game_data.system.Fixup();
 
 	Game_Actors::Fixup();
+	Game_Data::SetupLoadGame(Main_Data::game_data);
 	Main_Data::game_party->SetupFromSave(std::move(Main_Data::game_data.inventory));
 
 	int map_id = save->party_location.map_id;
@@ -966,6 +969,7 @@ void Player::SetupNewGame() {
 		static_cast<Scene_Title*>(title.get())->OnGameStart();
 	}
 
+	Game_Data::SetupNewGame();
 	Main_Data::game_party->SetupNewGame();
 	SetupPlayerSpawn();
 }

--- a/src/scene_actortarget.cpp
+++ b/src/scene_actortarget.cpp
@@ -111,11 +111,11 @@ void Scene_ActorTarget::Update() {
 
 void Scene_ActorTarget::UpdateItem() {
 	if (Input::IsTriggered(Input::DECISION)) {
-		if (Main_Data::game_party->GetItemCount(id) <= 0) {
+		if (Game_Data::GetParty().GetItemCount(id) <= 0) {
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Buzzer));
 			return;
 		}
-		if (Main_Data::game_party->UseItem(id, target_window->GetActor())) {
+		if (Game_Data::GetParty().UseItem(id, target_window->GetActor())) {
 			auto* item = ReaderUtil::GetElement(Data::items, id);
 			assert(item);
 
@@ -151,13 +151,13 @@ void Scene_ActorTarget::UpdateItem() {
 
 void Scene_ActorTarget::UpdateSkill() {
 	if (Input::IsTriggered(Input::DECISION)) {
-		Game_Actor* actor = &(*Main_Data::game_party)[actor_index];
+		Game_Actor* actor = &(Game_Data::GetParty())[actor_index];
 
 		if (actor->GetSp() < actor->CalculateSkillCost(id)) {
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Buzzer));
 			return;
 		}
-		if (Main_Data::game_party->UseSkill(id, actor, target_window->GetActor())) {
+		if (Game_Data::GetParty().UseSkill(id, actor, target_window->GetActor())) {
 			RPG::Skill* skill = ReaderUtil::GetElement(Data::skills, id);
 			RPG::Animation* animation = ReaderUtil::GetElement(Data::animations, skill->animation_id);
 			if (animation) {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -284,7 +284,7 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 		break;
 	case State_SelectOption:
 		// No Auto battle/Escape when all actors are sleeping or similar
-		if (!Main_Data::game_party->IsAnyControllable()) {
+		if (!Game_Data::GetParty().IsAnyControllable()) {
 			SelectNextActor();
 		}
 		break;
@@ -337,7 +337,7 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 			}
 
 			// Go right into next turn if no actors controllable.
-			if (!Main_Data::game_party->IsAnyControllable()) {
+			if (!Game_Data::GetParty().IsAnyControllable()) {
 				SelectNextActor();
 			} else {
 				SetState(State_SelectOption);
@@ -1181,7 +1181,7 @@ void Scene_Battle_Rpg2k::Escape() {
 	if (battle_action_substate == eBegin) {
 		battle_message_window->Clear();
 
-		Game_BattleAlgorithm::Escape escape_alg = Game_BattleAlgorithm::Escape(&(*Main_Data::game_party)[0], first_strike);
+		Game_BattleAlgorithm::Escape escape_alg = Game_BattleAlgorithm::Escape(&(Game_Data::GetParty())[0], first_strike);
 
 		auto next_ss = escape_alg.Execute()
 			? eSuccess
@@ -1222,7 +1222,7 @@ void Scene_Battle_Rpg2k::Escape() {
 }
 
 void Scene_Battle_Rpg2k::SelectNextActor() {
-	std::vector<Game_Actor*> allies = Main_Data::game_party->GetActors();
+	std::vector<Game_Actor*> allies = Game_Data::GetParty().GetActors();
 
 	if ((size_t)actor_index == allies.size()) {
 		// All actor actions decided, player turn ends
@@ -1251,7 +1251,7 @@ void Scene_Battle_Rpg2k::SelectNextActor() {
 
 	switch (active_actor->GetSignificantRestriction()) {
 		case RPG::State::Restriction_attack_ally:
-			random_target = Main_Data::game_party->GetRandomActiveBattler();
+			random_target = Game_Data::GetParty().GetRandomActiveBattler();
 			break;
 		case RPG::State::Restriction_attack_enemy:
 			random_target = Main_Data::game_enemyparty->GetRandomActiveBattler();
@@ -1287,7 +1287,7 @@ void Scene_Battle_Rpg2k::SelectNextActor() {
 }
 
 void Scene_Battle_Rpg2k::SelectPreviousActor() {
-	std::vector<Game_Actor*> allies = Main_Data::game_party->GetActors();
+	std::vector<Game_Actor*> allies = Game_Data::GetParty().GetActors();
 
 	if (allies[0] == active_actor) {
 		SetState(State_SelectOption);
@@ -1554,7 +1554,7 @@ bool Scene_Battle_Rpg2k::CheckWin() {
 
 		// Update attributes
 		std::vector<Game_Battler*> ally_battlers;
-		Main_Data::game_party->GetActiveBattlers(ally_battlers);
+		Game_Data::GetParty().GetActiveBattlers(ally_battlers);
 
 		pm.PushPageEnd();
 
@@ -1562,9 +1562,9 @@ bool Scene_Battle_Rpg2k::CheckWin() {
 			Game_Actor* actor = static_cast<Game_Actor*>(ally);
 			actor->ChangeExp(actor->GetExp() + exp, &pm);
 		}
-		Main_Data::game_party->GainGold(money);
+		Game_Data::GetParty().GainGold(money);
 		for (std::vector<int>::iterator it = drops.begin(); it != drops.end(); ++it) {
-			Main_Data::game_party->AddItem(*it, 1);
+			Game_Data::GetParty().AddItem(*it, 1);
 		}
 
 		Game_Message::SetPendingMessage(std::move(pm));

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -193,7 +193,7 @@ void Scene_Battle_Rpg2k3::UpdateCursors() {
 
 		if (ally_index >= 0 && Data::battlecommands.battle_type != RPG::BattleCommands::BattleType_traditional) {
 			ally_cursor->SetVisible(true);
-			Main_Data::game_party->GetBattlers(actors);
+			Game_Data::GetParty().GetBattlers(actors);
 			const Game_Battler* actor = actors[ally_index];
 			Sprite_Battler* sprite = Game_Battle::GetSpriteset().FindBattler(actor);
 			ally_cursor->SetX(actor->GetBattleX());
@@ -299,8 +299,8 @@ void Scene_Battle_Rpg2k3::CreateBattleCommandWindow() {
 
 	Game_Actor* actor;
 
-	if (!active_actor && Main_Data::game_party->GetBattlerCount() > 0) {
-		actor = &(*Main_Data::game_party)[0];
+	if (!active_actor && Game_Data::GetParty().GetBattlerCount() > 0) {
+		actor = &(Game_Data::GetParty())[0];
 	}
 	else {
 		actor = active_actor;
@@ -539,7 +539,7 @@ void Scene_Battle_Rpg2k3::SetState(Scene_Battle::State new_state) {
 }
 
 void Scene_Battle_Rpg2k3::ProcessActions() {
-	if (Main_Data::game_party->GetBattlerCount() == 0) {
+	if (Game_Data::GetParty().GetBattlerCount() == 0) {
 		Game_Temp::battle_result = Game_Temp::BattleVictory;
 		Scene::Pop();
 	}
@@ -650,7 +650,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 
 			// The internal state turn counter increments for all every turn
 			std::vector<Game_Battler*> battler;
-			Main_Data::game_party->GetActiveBattlers(battler);
+			Game_Data::GetParty().GetActiveBattlers(battler);
 			Main_Data::game_enemyparty->GetActiveBattlers(battler);
 
 			for (auto& b : battler) {
@@ -708,7 +708,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 
 		{
 			std::vector<Game_Battler*> battlers;
-			Main_Data::game_party->GetActiveBattlers(battlers);
+			Game_Data::GetParty().GetActiveBattlers(battlers);
 			Main_Data::game_enemyparty->GetActiveBattlers(battlers);
 
 			if (combo_repeat == 1) {
@@ -1065,7 +1065,7 @@ bool Scene_Battle_Rpg2k3::CheckWin() {
 		SetState(State_Victory);
 
 		std::vector<Game_Battler*> battlers;
-		Main_Data::game_party->GetActiveBattlers(battlers);
+		Game_Data::GetParty().GetActiveBattlers(battlers);
 		for (std::vector<Game_Battler*>::const_iterator it = battlers.begin(); it != battlers.end(); ++it) {
 			Sprite_Battler* sprite = Game_Battle::GetSpriteset().FindBattler(*it);
 			if (sprite) {
@@ -1118,7 +1118,7 @@ bool Scene_Battle_Rpg2k3::CheckWin() {
 
 		// Update attributes
 		std::vector<Game_Battler*> ally_battlers;
-		Main_Data::game_party->GetActiveBattlers(ally_battlers);
+		Game_Data::GetParty().GetActiveBattlers(ally_battlers);
 
 		pm.PushPageEnd();
 
@@ -1128,9 +1128,9 @@ bool Scene_Battle_Rpg2k3::CheckWin() {
 				actor->ChangeExp(actor->GetExp() + exp, &pm);
 		}
 
-		Main_Data::game_party->GainGold(money);
+		Game_Data::GetParty().GainGold(money);
 		for (std::vector<int>::iterator it = drops.begin(); it != drops.end(); ++it) {
-			Main_Data::game_party->AddItem(*it, 1);
+			Game_Data::GetParty().AddItem(*it, 1);
 		}
 
 		return true;
@@ -1171,7 +1171,7 @@ bool Scene_Battle_Rpg2k3::CheckResultConditions() {
 
 void Scene_Battle_Rpg2k3::SelectNextActor() {
 	std::vector<Game_Battler*> battler;
-	Main_Data::game_party->GetBattlers(battler);
+	Game_Data::GetParty().GetBattlers(battler);
 
 	int i = 0;
 	for (std::vector<Game_Battler*>::iterator it = battler.begin();
@@ -1187,7 +1187,7 @@ void Scene_Battle_Rpg2k3::SelectNextActor() {
 			if (active_actor->CanAct()) {
 				switch (active_actor->GetSignificantRestriction()) {
 				case RPG::State::Restriction_attack_ally:
-					random_target = Main_Data::game_party->GetRandomActiveBattler();
+					random_target = Game_Data::GetParty().GetRandomActiveBattler();
 					break;
 				case RPG::State::Restriction_attack_enemy:
 					random_target = Main_Data::game_enemyparty->GetRandomActiveBattler();

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -186,7 +186,7 @@ void Scene_Debug::Update() {
 				break;
 			case eItemSelect:
 				if (GetIndex() <= static_cast<int>(Data::items.size())) {
-					EnterFromListOptionToValue(eItemValue, Main_Data::game_party->GetItemCount(GetIndex()), 2, false);
+					EnterFromListOptionToValue(eItemValue, Game_Data::GetParty().GetItemCount(GetIndex()), 2, false);
 				}
 				break;
 			case eItemValue:
@@ -526,7 +526,7 @@ void Scene_Debug::EnterGold() {
 	range_window->SetActive(false);
 	range_index = 0;
 	range_window->SetIndex(range_index);
-	numberinput_window->SetNumber(Main_Data::game_party->GetGold());
+	numberinput_window->SetNumber(Game_Data::GetParty().GetGold());
 	numberinput_window->SetShowOperator(false);
 	numberinput_window->SetVisible(true);
 	numberinput_window->SetActive(true);
@@ -649,15 +649,15 @@ void Scene_Debug::DoVariable() {
 }
 
 void Scene_Debug::DoGold() {
-	auto delta = numberinput_window->GetNumber() - Main_Data::game_party->GetGold();
-	Main_Data::game_party->GainGold(delta);
+	auto delta = numberinput_window->GetNumber() - Game_Data::GetParty().GetGold();
+	Game_Data::GetParty().GainGold(delta);
 
 	ReturnToMain(4);
 }
 
 void Scene_Debug::DoItem() {
-	auto delta = numberinput_window->GetNumber() - Main_Data::game_party->GetItemCount(GetIndex());
-	Main_Data::game_party->AddItem(GetIndex(), delta);
+	auto delta = numberinput_window->GetNumber() - Game_Data::GetParty().GetItemCount(GetIndex());
+	Game_Data::GetParty().AddItem(GetIndex(), delta);
 
 	Game_Map::SetNeedRefresh(Game_Map::Refresh_All);
 
@@ -707,7 +707,7 @@ void Scene_Debug::DoMap() {
 void Scene_Debug::DoFullHeal() {
 	Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_UseItem));
 	int id = GetIndex();
-	auto actors = Main_Data::game_party->GetActors();
+	auto actors = Game_Data::GetParty().GetActors();
 	if (id <= 1) {
 		for (auto& actor: actors) {
 			actor->FullHeal();

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -171,8 +171,8 @@ void Scene_Debug::Update() {
 				EnterFromListOption(eVariableSelect, prev.var);
 				break;
 			case eVariableSelect:
-				if (Main_Data::game_variables->IsValid(GetIndex())) {
-					EnterFromListOptionToValue(eVariableValue, Main_Data::game_variables->Get(GetIndex()), 7, true);
+				if (Game_Data::GetVariables().IsValid(GetIndex())) {
+					EnterFromListOptionToValue(eVariableValue, Game_Data::GetVariables().Get(GetIndex()), 7, true);
 				}
 				break;
 			case eVariableValue:
@@ -401,10 +401,10 @@ int Scene_Debug::GetLastPage() {
 	size_t num_elements = 0;
 	switch (mode) {
 		case eSwitch:
-			num_elements = Main_Data::game_switches->GetSize();
+			num_elements = Game_Data::GetSwitches().GetSize();
 			break;
 		case eVariable:
-			num_elements = Main_Data::game_variables->GetSize();
+			num_elements = Game_Data::GetVariables().GetSize();
 			break;
 		case eItem:
 			num_elements = Data::items.size();
@@ -631,8 +631,8 @@ void Scene_Debug::ReturnToMain(int from_idx) {
 
 
 void Scene_Debug::DoSwitch() {
-	if (Main_Data::game_switches->IsValid(GetIndex())) {
-		Main_Data::game_switches->Flip(GetIndex());
+	if (Game_Data::GetSwitches().IsValid(GetIndex())) {
+		Game_Data::GetSwitches().Flip(GetIndex());
 		Game_Map::SetNeedRefresh(Game_Map::Refresh_All);
 
 		var_window->Refresh();
@@ -640,7 +640,7 @@ void Scene_Debug::DoSwitch() {
 }
 
 void Scene_Debug::DoVariable() {
-	Main_Data::game_variables->Set(GetIndex(), numberinput_window->GetNumber());
+	Game_Data::GetVariables().Set(GetIndex(), numberinput_window->GetNumber());
 	Game_Map::SetNeedRefresh(Game_Map::Refresh_All);
 
 	var_window->Refresh();

--- a/src/scene_equip.cpp
+++ b/src/scene_equip.cpp
@@ -159,16 +159,16 @@ void Scene_Equip::UpdateEquipSelection() {
 		equip_window->SetActive(false);
 		item_window->SetActive(true);
 		item_window->SetIndex(0);
-	} else if (Main_Data::game_party->GetActors().size() > 1 && Input::IsTriggered(Input::RIGHT)) {
+	} else if (Game_Data::GetParty().GetActors().size() > 1 && Input::IsTriggered(Input::RIGHT)) {
 		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cursor));
-		int actor_index = Main_Data::game_party->GetActorPositionInParty(actor.GetId());
-		actor_index = (actor_index + 1) % Main_Data::game_party->GetActors().size();
-		Scene::Push(std::make_shared<Scene_Equip>((*Main_Data::game_party)[actor_index], equip_window->GetIndex()), true);
-	} else if (Main_Data::game_party->GetActors().size() > 1 && Input::IsTriggered(Input::LEFT)) {
+		int actor_index = Game_Data::GetParty().GetActorPositionInParty(actor.GetId());
+		actor_index = (actor_index + 1) % Game_Data::GetParty().GetActors().size();
+		Scene::Push(std::make_shared<Scene_Equip>((Game_Data::GetParty())[actor_index], equip_window->GetIndex()), true);
+	} else if (Game_Data::GetParty().GetActors().size() > 1 && Input::IsTriggered(Input::LEFT)) {
 		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cursor));
-		int actor_index = Main_Data::game_party->GetActorPositionInParty(actor.GetId());
-		actor_index = (actor_index + Main_Data::game_party->GetActors().size() - 1) % Main_Data::game_party->GetActors().size();
-		Scene::Push(std::make_shared<Scene_Equip>((*Main_Data::game_party)[actor_index], equip_window->GetIndex()), true);
+		int actor_index = Game_Data::GetParty().GetActorPositionInParty(actor.GetId());
+		actor_index = (actor_index + Game_Data::GetParty().GetActors().size() - 1) % Game_Data::GetParty().GetActors().size();
+		Scene::Push(std::make_shared<Scene_Equip>((Game_Data::GetParty())[actor_index], equip_window->GetIndex()), true);
 	}
 }
 

--- a/src/scene_item.cpp
+++ b/src/scene_item.cpp
@@ -66,7 +66,7 @@ void Scene_Item::Update() {
 
 			if (item.type == RPG::Item::Type_switch) {
 				Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
-				Main_Data::game_party->ConsumeItemUse(item_id);
+				Game_Data::GetParty().ConsumeItemUse(item_id);
 				Main_Data::game_switches->Set(item.switch_id, true);
 				Scene::PopUntil(Scene::Map);
 				Game_Map::SetNeedRefresh(Game_Map::Refresh_All);
@@ -81,14 +81,14 @@ void Scene_Item::Update() {
 					Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 					Scene::Push(std::make_shared<Scene_Teleport>(item, *skill));
 				} else if (skill->type == RPG::Skill::Type_escape) {
-					Main_Data::game_party->ConsumeItemUse(item_id);
+					Game_Data::GetParty().ConsumeItemUse(item_id);
 					Game_System::SePlay(skill->sound_effect);
 
 					Main_Data::game_player->ReserveTeleport(*Game_Targets::GetEscapeTarget());
 
 					Scene::PopUntil(Scene::Map);
 				} else if (skill->type == RPG::Skill::Type_switch) {
-					Main_Data::game_party->ConsumeItemUse(item_id);
+					Game_Data::GetParty().ConsumeItemUse(item_id);
 					Game_System::SePlay(skill->sound_effect);
 					Main_Data::game_switches->Set(skill->switch_id, true);
 					Scene::PopUntil(Scene::Map);

--- a/src/scene_item.cpp
+++ b/src/scene_item.cpp
@@ -67,7 +67,7 @@ void Scene_Item::Update() {
 			if (item.type == RPG::Item::Type_switch) {
 				Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 				Game_Data::GetParty().ConsumeItemUse(item_id);
-				Main_Data::game_switches->Set(item.switch_id, true);
+				Game_Data::GetSwitches().Set(item.switch_id, true);
 				Scene::PopUntil(Scene::Map);
 				Game_Map::SetNeedRefresh(Game_Map::Refresh_All);
 			} else if (item.type == RPG::Item::Type_special && item.skill_id > 0) {
@@ -90,7 +90,7 @@ void Scene_Item::Update() {
 				} else if (skill->type == RPG::Skill::Type_switch) {
 					Game_Data::GetParty().ConsumeItemUse(item_id);
 					Game_System::SePlay(skill->sound_effect);
-					Main_Data::game_switches->Set(skill->switch_id, true);
+					Game_Data::GetSwitches().Set(skill->switch_id, true);
 					Scene::PopUntil(Scene::Map);
 					Game_Map::SetNeedRefresh(Game_Map::Refresh_All);
 				} else {

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -500,7 +500,7 @@ void Scene_Map::FinishInn() {
 	Game_System::BgmPlay(music_before_inn);
 
 	// Full heal
-	std::vector<Game_Actor*> actors = Main_Data::game_party->GetActors();
+	std::vector<Game_Actor*> actors = Game_Data::GetParty().GetActors();
 	for (Game_Actor* actor : actors) {
 		actor->FullHeal();
 	}

--- a/src/scene_menu.cpp
+++ b/src/scene_menu.cpp
@@ -146,12 +146,12 @@ void Scene_Menu::CreateCommandWindow() {
 		case Debug:
 			break;
 		case Order:
-			if (Main_Data::game_party->GetActors().size() <= 1) {
+			if (Game_Data::GetParty().GetActors().size() <= 1) {
 				command_window->DisableItem(it - command_options.begin());
 			}
 			break;
 		default:
-			if (Main_Data::game_party->GetActors().empty()) {
+			if (Game_Data::GetParty().GetActors().empty()) {
 				command_window->DisableItem(it - command_options.begin());
 			}
 			break;
@@ -168,7 +168,7 @@ void Scene_Menu::UpdateCommand() {
 
 		switch (command_options[menu_index]) {
 		case Item:
-			if (Main_Data::game_party->GetActors().empty()) {
+			if (Game_Data::GetParty().GetActors().empty()) {
 				Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Buzzer));
 			} else {
 				Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
@@ -179,7 +179,7 @@ void Scene_Menu::UpdateCommand() {
 		case Equipment:
 		case Status:
 		case Row:
-			if (Main_Data::game_party->GetActors().empty()) {
+			if (Game_Data::GetParty().GetActors().empty()) {
 				Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Buzzer));
 			} else {
 				Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
@@ -197,7 +197,7 @@ void Scene_Menu::UpdateCommand() {
 			}
 			break;
 		case Order:
-			if (Main_Data::game_party->GetActors().size() <= 1) {
+			if (Game_Data::GetParty().GetActors().size() <= 1) {
 				Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Buzzer));
 			} else {
 				Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
@@ -250,7 +250,7 @@ void Scene_Menu::UpdateActorSelection() {
 		{
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 			// Don't allow entire party in the back row.
-			const auto& actors = Main_Data::game_party->GetActors();
+			const auto& actors = Game_Data::GetParty().GetActors();
 			int num_in_back = 0;
 			for (auto* actor: actors) {
 				if (actor->GetBattleRow() == Game_Actor::RowType::RowType_back) {

--- a/src/scene_order.cpp
+++ b/src/scene_order.cpp
@@ -33,7 +33,7 @@ Scene_Order::Scene_Order() :
 }
 
 void Scene_Order::Start() {
-	actors.resize(Main_Data::game_party->GetActors().size());
+	actors.resize(Game_Data::GetParty().GetActors().size());
 
 	CreateCommandWindow();
 }
@@ -57,7 +57,7 @@ void Scene_Order::UpdateOrder() {
 			Scene::Pop();
 		} else {
 			--actor_counter;
-			window_left->SetItemText(actors[actor_counter] - 1, Main_Data::game_party->GetActors()[actors[actor_counter] - 1]->GetName());
+			window_left->SetItemText(actors[actor_counter] - 1, Game_Data::GetParty().GetActors()[actors[actor_counter] - 1]->GetName());
 			window_right->SetItemText(actor_counter, "");
 			actors[actor_counter] = 0;
 		}
@@ -67,14 +67,14 @@ void Scene_Order::UpdateOrder() {
 		} else {
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 			window_left->SetItemText(window_left->GetIndex(), "");
-			window_right->SetItemText(actor_counter, Main_Data::game_party->GetActors()[window_left->GetIndex()]->GetName());
+			window_right->SetItemText(actor_counter, Game_Data::GetParty().GetActors()[window_left->GetIndex()]->GetName());
 
 			actors[actor_counter] = window_left->GetIndex() + 1;
 
 			++actor_counter;
 
 			// Display Confirm/Redo window
-			if (actor_counter == (int)Main_Data::game_party->GetActors().size()) {
+			if (actor_counter == (int)Game_Data::GetParty().GetActors().size()) {
 				window_left->SetIndex(-1);
 				window_left->SetActive(false);
 				window_confirm->SetIndex(0);
@@ -103,7 +103,7 @@ void Scene_Order::CreateCommandWindow() {
 	std::vector<std::string> options_right;
 	std::vector<std::string> options_confirm;
 
-	std::vector<Game_Actor*> actors = Main_Data::game_party->GetActors();
+	std::vector<Game_Actor*> actors = Game_Data::GetParty().GetActors();
 	for (std::vector<Game_Actor*>::const_iterator it = actors.begin();
 		it != actors.end(); ++it) {
 		options_left.push_back((*it)->GetName());
@@ -135,9 +135,9 @@ void Scene_Order::Redo() {
 	Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cancel));
 
 	actors.clear();
-	actors.resize(Main_Data::game_party->GetActors().size());
+	actors.resize(Game_Data::GetParty().GetActors().size());
 
-	std::vector<Game_Actor*> actors = Main_Data::game_party->GetActors();
+	std::vector<Game_Actor*> actors = Game_Data::GetParty().GetActors();
 	for (std::vector<Game_Actor*>::const_iterator it = actors.begin();
 		it != actors.end(); ++it) {
 		int index = it - actors.begin();
@@ -160,16 +160,16 @@ void Scene_Order::Redo() {
 void Scene_Order::Confirm() {
 	Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 
-	std::vector<Game_Actor*> party_actors = Main_Data::game_party->GetActors();
+	std::vector<Game_Actor*> party_actors = Game_Data::GetParty().GetActors();
 
 	std::vector<int>::const_iterator it;
 
 	for (it = actors.begin(); it != actors.end(); ++it) {
-		Main_Data::game_party->RemoveActor(party_actors[*it - 1]->GetId());
+		Game_Data::GetParty().RemoveActor(party_actors[*it - 1]->GetId());
 	}
 
 	for (it = actors.begin(); it != actors.end(); ++it) {
-		Main_Data::game_party->AddActor(party_actors[*it - 1]->GetId());
+		Game_Data::GetParty().AddActor(party_actors[*it - 1]->GetId());
 	}
 
 	// TODO: Where is the best place to overwrite the character map graphic?

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -26,7 +26,6 @@
 #include "filefinder.h"
 #include "game_actor.h"
 #include "game_map.h"
-#include "game_party.h"
 #include "game_switches.h"
 #include "game_variables.h"
 #include "game_party.h"
@@ -62,26 +61,26 @@ void Scene_Save::Action(int index) {
 	// TODO: Maybe find a better place to setup the save file?
 	RPG::SaveTitle title;
 
-	int size = (int)Main_Data::game_party->GetActors().size();
+	int size = (int)Game_Data::GetParty().GetActors().size();
 	Game_Actor* actor;
 
 	if (size > 3) {
-		actor = Main_Data::game_party->GetActors()[3];
+		actor = Game_Data::GetParty().GetActors()[3];
 		title.face4_id = actor->GetFaceIndex();
 		title.face4_name = actor->GetFaceName();
 	}
 	if (size > 2) {
-		actor = Main_Data::game_party->GetActors()[2];
+		actor = Game_Data::GetParty().GetActors()[2];
 		title.face3_id = actor->GetFaceIndex();
 		title.face3_name = actor->GetFaceName();
 	}
 	if (size > 1) {
-		actor = Main_Data::game_party->GetActors()[1];
+		actor = Game_Data::GetParty().GetActors()[1];
 		title.face2_id = actor->GetFaceIndex();
 		title.face2_name = actor->GetFaceName();
 	}
 	if (size > 0) {
-		actor = Main_Data::game_party->GetActors()[0];
+		actor = Game_Data::GetParty().GetActors()[0];
 		title.face1_id = actor->GetFaceIndex();
 		title.face1_name = actor->GetFaceName();
 		title.hero_hp = actor->GetHp();
@@ -116,7 +115,7 @@ void Scene_Save::Action(int index) {
 
 	data_copy.system.switches = Main_Data::game_switches->GetData();
 	data_copy.system.variables = Main_Data::game_variables->GetData();
-	data_copy.inventory = Main_Data::game_party->GetSaveData();
+	Game_Data::WriteSaveGame(data_copy);
 
 	// RPG_RT saves always have the scene set to this.
 	data_copy.system.scene = RPG::SaveSystem::Scene_file;

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -26,8 +26,6 @@
 #include "filefinder.h"
 #include "game_actor.h"
 #include "game_map.h"
-#include "game_switches.h"
-#include "game_variables.h"
 #include "game_party.h"
 #include "game_system.h"
 #include "lsd_reader.h"
@@ -113,8 +111,6 @@ void Scene_Save::Action(int index) {
 		}
 	}
 
-	data_copy.system.switches = Main_Data::game_switches->GetData();
-	data_copy.system.variables = Main_Data::game_variables->GetData();
 	Game_Data::WriteSaveGame(data_copy);
 
 	// RPG_RT saves always have the scene set to this.

--- a/src/scene_shop.cpp
+++ b/src/scene_shop.cpp
@@ -250,7 +250,7 @@ void Scene_Shop::UpdateBuySelection() {
 			if (item->price == 0) {
 				max = 99;
 			} else {
-				max = Main_Data::game_party->GetGold() / item->price;
+				max = Game_Data::GetParty().GetGold() / item->price;
 			}
 			number_window->SetData(item_id, max, item->price);
 
@@ -278,7 +278,7 @@ void Scene_Shop::UpdateSellSelection() {
 
 		if (item && item->price > 0) {
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
-			number_window->SetData(item->ID, Main_Data::game_party->GetItemCount(item->ID), item->price / 2);
+			number_window->SetData(item->ID, Game_Data::GetParty().GetItemCount(item->ID), item->price / 2);
 			SetMode(SellHowMany);
 		} else {
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Buzzer));
@@ -300,16 +300,16 @@ void Scene_Shop::UpdateNumberInput() {
 		switch (shop_window->GetChoice()) {
 		case Buy:
 			item_id = buy_window->GetItemId();
-			Main_Data::game_party->LoseGold(number_window->GetTotal());
-			Main_Data::game_party->AddItem(item_id, number_window->GetNumber());
+			Game_Data::GetParty().LoseGold(number_window->GetTotal());
+			Game_Data::GetParty().AddItem(item_id, number_window->GetNumber());
 			gold_window->Refresh();
 			buy_window->Refresh();
 			status_window->Refresh();
 			SetMode(Bought); break;
 		case Sell:
 			item_id = sell_window->GetItem() == NULL ? 0 : sell_window->GetItem()->ID;
-			Main_Data::game_party->GainGold(number_window->GetTotal());
-			Main_Data::game_party->RemoveItem(item_id, number_window->GetNumber());
+			Game_Data::GetParty().GainGold(number_window->GetTotal());
+			Game_Data::GetParty().RemoveItem(item_id, number_window->GetNumber());
 			gold_window->Refresh();
 			sell_window->Refresh();
 			status_window->Refresh();

--- a/src/scene_skill.cpp
+++ b/src/scene_skill.cpp
@@ -40,8 +40,8 @@ void Scene_Skill::Start() {
 	skill_window.reset(new Window_Skill(0, 64, SCREEN_TARGET_WIDTH, SCREEN_TARGET_HEIGHT - 64));
 
 	// Assign actors and help to windows
-	skill_window->SetActor(Main_Data::game_party->GetActors()[actor_index]->GetId());
-	skillstatus_window->SetActor(Main_Data::game_party->GetActors()[actor_index]->GetId());
+	skill_window->SetActor(Game_Data::GetParty().GetActors()[actor_index]->GetId());
+	skillstatus_window->SetActor(Game_Data::GetParty().GetActors()[actor_index]->GetId());
 	skill_window->SetIndex(skill_index);
 	skill_window->SetHelpWindow(help_window.get());
 }
@@ -58,12 +58,12 @@ void Scene_Skill::Update() {
 		const RPG::Skill* skill = skill_window->GetSkill();
 		int skill_id = skill ? skill->ID : 0;
 
-		Game_Actor* actor = Main_Data::game_party->GetActors()[actor_index];
+		Game_Actor* actor = Game_Data::GetParty().GetActors()[actor_index];
 
 		if (skill && skill_window->CheckEnable(skill_id)) {
 			if (skill->type == RPG::Skill::Type_switch) {
 				Game_System::SePlay(skill->sound_effect);
-				Main_Data::game_party->UseSkill(skill_id, actor, actor);
+				Game_Data::GetParty().UseSkill(skill_id, actor, actor);
 				Scene::PopUntil(Scene::Map);
 				Game_Map::SetNeedRefresh(Game_Map::Refresh_All);
 			} else if (skill->type == RPG::Skill::Type_normal || skill->type >= RPG::Skill::Type_subskill) {
@@ -75,7 +75,7 @@ void Scene_Skill::Update() {
 				Scene::Push(std::make_shared<Scene_Teleport>(*actor, *skill));
 			} else if (skill->type == RPG::Skill::Type_escape) {
 				Game_System::SePlay(skill->sound_effect);
-				Main_Data::game_party->UseSkill(skill_id, actor, actor);
+				Game_Data::GetParty().UseSkill(skill_id, actor, actor);
 				Main_Data::game_player->ReserveTeleport(*Game_Targets::GetEscapeTarget());
 
 				Scene::PopUntil(Scene::Map);

--- a/src/scene_status.cpp
+++ b/src/scene_status.cpp
@@ -29,7 +29,7 @@ Scene_Status::Scene_Status(int actor_index) :
 }
 
 void Scene_Status::Start() {
-	int actor = Main_Data::game_party->GetActors()[actor_index]->GetId();
+	int actor = Game_Data::GetParty().GetActors()[actor_index]->GetId();
 
 	actorinfo_window.reset(new Window_ActorInfo(0, 0, 124, 208, actor));
 	actorstatus_window.reset(new Window_ActorStatus(124, 0, 196, 64, actor));
@@ -51,13 +51,13 @@ void Scene_Status::Update() {
 	if (Input::IsTriggered(Input::CANCEL)) {
 		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cancel));
 		Scene::Pop();
-	} else if (Main_Data::game_party->GetActors().size() > 1 && Input::IsTriggered(Input::RIGHT)) {
+	} else if (Game_Data::GetParty().GetActors().size() > 1 && Input::IsTriggered(Input::RIGHT)) {
 		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cursor));
-		actor_index = (actor_index + 1) % Main_Data::game_party->GetActors().size();
+		actor_index = (actor_index + 1) % Game_Data::GetParty().GetActors().size();
 		Scene::Push(std::make_shared<Scene_Status>(actor_index), true);
-	} else if (Main_Data::game_party->GetActors().size() > 1 && Input::IsTriggered(Input::LEFT)) {
+	} else if (Game_Data::GetParty().GetActors().size() > 1 && Input::IsTriggered(Input::LEFT)) {
 		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cursor));
-		actor_index = (actor_index + Main_Data::game_party->GetActors().size() - 1) % Main_Data::game_party->GetActors().size();
+		actor_index = (actor_index + Game_Data::GetParty().GetActors().size() - 1) % Game_Data::GetParty().GetActors().size();
 		Scene::Push(std::make_shared<Scene_Status>(actor_index), true);
 	}
 }

--- a/src/scene_teleport.cpp
+++ b/src/scene_teleport.cpp
@@ -46,9 +46,9 @@ void Scene_Teleport::Update() {
 
 	if (Input::IsTriggered(Input::DECISION)) {
 		if (item) {
-			Main_Data::game_party->ConsumeItemUse(item->ID);
+			Game_Data::GetParty().ConsumeItemUse(item->ID);
 		} else {
-			Main_Data::game_party->UseSkill(skill->ID, actor, actor);
+			Game_Data::GetParty().UseSkill(skill->ID, actor, actor);
 		}
 
 		Game_System::SePlay(skill->sound_effect);

--- a/src/sprite_timer.cpp
+++ b/src/sprite_timer.cpp
@@ -52,7 +52,7 @@ void Sprite_Timer::Draw(Bitmap& dst) {
 	GetBitmap()->Clear();
 	for (int i = 0; i < 5; ++i) {
 		if (i == 2) { // :
-			int frames =  Main_Data::game_party->GetTimerFrames(which);
+			int frames =  Game_Data::GetParty().GetTimerFrames(which);
 			if (frames % DEFAULT_FPS < DEFAULT_FPS / 2) {
 				continue;
 			}
@@ -64,7 +64,7 @@ void Sprite_Timer::Draw(Bitmap& dst) {
 }
 
 void Sprite_Timer::Update() {
-	const bool visible = Main_Data::game_party->GetTimerVisible(which, Game_Temp::battle_running);
+	const bool visible = Game_Data::GetParty().GetTimerVisible(which, Game_Temp::battle_running);
 
 	SetVisible(visible);
 
@@ -72,7 +72,7 @@ void Sprite_Timer::Update() {
 		return;
 	}
 
-	const int all_secs = Main_Data::game_party->GetTimerSeconds(which);
+	const int all_secs = Game_Data::GetParty().GetTimerSeconds(which);
 
 	int mins = all_secs / 60;
 	int secs = all_secs % 60;

--- a/src/spriteset_battle.cpp
+++ b/src/spriteset_battle.cpp
@@ -86,7 +86,7 @@ void Spriteset_Battle::Update() {
 	for (auto sprite : sprites) {
 		Game_Battler* battler = sprite->GetBattler();
 		if (battler->GetType() == Game_Battler::Type_Ally) {
-			sprite->SetVisible(Main_Data::game_party->IsActorInParty(battler->GetId()));
+			sprite->SetVisible(Game_Data::GetParty().IsActorInParty(battler->GetId()));
 		}
 
 		sprite->Update();

--- a/src/window_actortarget.cpp
+++ b/src/window_actortarget.cpp
@@ -33,11 +33,11 @@ Window_ActorTarget::Window_ActorTarget(int ix, int iy, int iwidth, int iheight) 
 void Window_ActorTarget::Refresh() {
 	contents->Clear();
 
-	item_max = Main_Data::game_party->GetActors().size();
+	item_max = Game_Data::GetParty().GetActors().size();
 
 	int y = 0;
 	for (int i = 0; i < item_max; ++i) {
-		const Game_Actor& actor = *(Main_Data::game_party->GetActors()[i]);
+		const Game_Actor& actor = *(Game_Data::GetParty().GetActors()[i]);
 
 		DrawActorFace(actor, 0, i * 48 + y);
 		DrawActorName(actor, 48 + 8, i * 48 + 2 + y);
@@ -70,5 +70,5 @@ Game_Actor* Window_ActorTarget::GetActor() {
 		return NULL;
 	}
 
-	return &(*Main_Data::game_party)[ind];
+	return &(Game_Data::GetParty())[ind];
 }

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -57,7 +57,7 @@ void Window_BattleStatus::Refresh() {
 		item_max = Main_Data::game_enemyparty->GetBattlerCount();
 	}
 	else {
-		item_max = Main_Data::game_party->GetBattlerCount();
+		item_max = Game_Data::GetParty().GetBattlerCount();
 	}
 
 	item_max = std::min(item_max, 4);
@@ -69,7 +69,7 @@ void Window_BattleStatus::Refresh() {
 			actor = &(*Main_Data::game_enemyparty)[i];
 		}
 		else {
-			actor = &(*Main_Data::game_party)[i];
+			actor = &(Game_Data::GetParty())[i];
 		}
 
 		if (!enemy && Data::battlecommands.battle_type == RPG::BattleCommands::BattleType_gauge) {
@@ -105,7 +105,7 @@ void Window_BattleStatus::RefreshGauge() {
 				actor = &(*Main_Data::game_enemyparty)[i];
 			}
 			else {
-				actor = &(*Main_Data::game_party)[i];
+				actor = &(Game_Data::GetParty())[i];
 			}
 
 			if (!enemy && Data::battlecommands.battle_type == RPG::BattleCommands::BattleType_gauge) {
@@ -202,7 +202,7 @@ int Window_BattleStatus::ChooseActiveCharacter() {
 	index = -1;
 	for (int i = 0; i < item_max; i++) {
 		int new_index = (old_index + i) % item_max;
-		if ((*Main_Data::game_party)[new_index].IsGaugeFull()) {
+		if ((Game_Data::GetParty())[new_index].IsGaugeFull()) {
 			index = new_index;
 			return index;
 		}
@@ -227,7 +227,7 @@ void Window_BattleStatus::Update() {
 	if (enemy) {
 		item_max = Main_Data::game_enemyparty->GetBattlerCount();
 	} else {
-		item_max = Main_Data::game_party->GetBattlerCount();
+		item_max = Game_Data::GetParty().GetBattlerCount();
 	}
 
 	if (item_max != old_item_max) {
@@ -241,7 +241,7 @@ void Window_BattleStatus::Update() {
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cursor));
 			for (int i = 1; i < item_max; i++) {
 				int new_index = (index + i) % item_max;
-				if (IsChoiceValid((*Main_Data::game_party)[new_index])) {
+				if (IsChoiceValid((Game_Data::GetParty())[new_index])) {
 					index = new_index;
 					break;
 				}
@@ -251,7 +251,7 @@ void Window_BattleStatus::Update() {
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cursor));
 			for (int i = item_max - 1; i > 0; i--) {
 				int new_index = (index + i) % item_max;
-				if (IsChoiceValid((*Main_Data::game_party)[new_index])) {
+				if (IsChoiceValid((Game_Data::GetParty())[new_index])) {
 					index = new_index;
 					break;
 				}

--- a/src/window_equipitem.cpp
+++ b/src/window_equipitem.cpp
@@ -70,7 +70,7 @@ bool Window_EquipItem::CheckInclude(int item_id) {
 
 	if (result) {
 		// Check if the party has the item at least once
-		if (Main_Data::game_party->GetItemCount(item_id) == 0) {
+		if (Game_Data::GetParty().GetItemCount(item_id) == 0) {
 			return false;
 		} else {
 			return Game_Actors::GetActor(actor_id)->IsEquippable(item_id);

--- a/src/window_gold.cpp
+++ b/src/window_gold.cpp
@@ -33,5 +33,5 @@ Window_Gold::Window_Gold(int ix, int iy, int iwidth, int iheight) :
 
 void Window_Gold::Refresh() {
 	contents->Clear();
-	DrawCurrencyValue(Main_Data::game_party->GetGold(), contents->GetWidth(), 2);
+	DrawCurrencyValue(Game_Data::GetParty().GetGold(), contents->GetWidth(), 2);
 }

--- a/src/window_item.cpp
+++ b/src/window_item.cpp
@@ -56,14 +56,14 @@ bool Window_Item::CheckEnable(int item_id) {
 			&& (!Game_Temp::battle_running || !item->occasion_field1)) {
 		return true;
 	}
-	return Main_Data::game_party->IsItemUsable(item_id, actor);
+	return Game_Data::GetParty().IsItemUsable(item_id, actor);
 }
 
 void Window_Item::Refresh() {
 	std::vector<int> party_items;
 
 	data.clear();
-	Main_Data::game_party->GetItems(party_items);
+	Game_Data::GetParty().GetItems(party_items);
 
 	for (size_t i = 0; i < party_items.size(); ++i) {
 		if (this->CheckInclude(party_items[i])) {
@@ -110,7 +110,7 @@ void Window_Item::DrawItem(int index) {
 	int item_id = data[index];
 
 	if (item_id > 0) {
-		int number = Main_Data::game_party->GetItemCount(item_id);
+		int number = Game_Data::GetParty().GetItemCount(item_id);
 
 		// Items are guaranteed to be valid
 		const RPG::Item* item = ReaderUtil::GetElement(Data::items, item_id);

--- a/src/window_menustatus.cpp
+++ b/src/window_menustatus.cpp
@@ -34,12 +34,12 @@ Window_MenuStatus::Window_MenuStatus(int ix, int iy, int iwidth, int iheight) :
 void Window_MenuStatus::Refresh() {
 	contents->Clear();
 
-	item_max = Main_Data::game_party->GetActors().size();
+	item_max = Game_Data::GetParty().GetActors().size();
 
 	int y = 0;
 	for (int i = 0; i < item_max; ++i) {
 		// The party always contains valid battlers
-		const Game_Actor& actor = *(Main_Data::game_party->GetActors()[i]);
+		const Game_Actor& actor = *(Game_Data::GetParty().GetActors()[i]);
 
 		int face_x = 0;
 		if (Player::IsRPG2k3()) {
@@ -69,5 +69,5 @@ void Window_MenuStatus::UpdateCursorRect()
 }
 
 Game_Actor* Window_MenuStatus::GetActor() const {
-	return &(*Main_Data::game_party)[GetIndex()];
+	return &(Game_Data::GetParty())[GetIndex()];
 }

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -610,7 +610,7 @@ void Window_Message::InputChoice() {
 void Window_Message::InputNumber() {
 	if (Input::IsTriggered(Input::DECISION)) {
 		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
-		Main_Data::game_variables->Set(pending_message.GetNumberInputVariable(), number_input_window->GetNumber());
+		Game_Data::GetVariables().Set(pending_message.GetNumberInputVariable(), number_input_window->GetNumber());
 		Game_Map::SetNeedRefresh(Game_Map::Refresh_Map);
 		TerminateMessage();
 		number_input_window->SetNumber(0);

--- a/src/window_shopbuy.cpp
+++ b/src/window_shopbuy.cpp
@@ -68,7 +68,7 @@ void Window_ShopBuy::DrawItem(int index) {
 	if (!item) {
 		Output::Warning("Window ShopBuy: Invalid item ID %d", item_id);
 	} else {
-		enabled = item->price <= Main_Data::game_party->GetGold();
+		enabled = item->price <= Game_Data::GetParty().GetGold();
 		price = item->price;
 	}
 
@@ -100,6 +100,6 @@ bool Window_ShopBuy::CheckEnable(int item_id) {
 		return false;
 	}
 
-	return (item->price <= Main_Data::game_party->GetGold() &&
-		Main_Data::game_party->GetItemCount(item_id) < 99);
+	return (item->price <= Game_Data::GetParty().GetGold() &&
+		Game_Data::GetParty().GetItemCount(item_id) < 99);
 }

--- a/src/window_shopparty.cpp
+++ b/src/window_shopparty.cpp
@@ -34,7 +34,7 @@ Window_ShopParty::Window_ShopParty(int ix, int iy, int iwidth, int iheight) :
 	cycle = 0;
 	item_id = 0;
 
-	const std::vector<Game_Actor*>& actors = Main_Data::game_party->GetActors();
+	const std::vector<Game_Actor*>& actors = Game_Data::GetParty().GetActors();
 	for (size_t i = 0; i < actors.size() && i < 4; i++) {
 		const std::string& sprite_name = actors[i]->GetSpriteName();
 		FileRequestAsync* request = AsyncHandler::RequestFile("CharSet", sprite_name);
@@ -95,7 +95,7 @@ void Window_ShopParty::Refresh() {
 	if (item_id < 0 || item_id > static_cast<int>(Data::items.size()))
 		return;
 
-	const std::vector<Game_Actor*>& actors = Main_Data::game_party->GetActors();
+	const auto& actors = Game_Data::GetParty().GetActors();
 	for (int i = 0; i < static_cast<int>(actors.size()) && i < 4; i++) {
 		Game_Actor *actor = actors[i];
 		int phase = (cycle / anim_rate) % 4;
@@ -159,7 +159,7 @@ void Window_ShopParty::Update() {
 }
 
 void Window_ShopParty::OnCharsetSpriteReady(FileRequestResult* /* result */, int party_index) {
-	Game_Actor *actor = Main_Data::game_party->GetActors()[party_index];
+	Game_Actor *actor = Game_Data::GetParty().GetActors()[party_index];
 	const std::string& sprite_name = actor->GetSpriteName();
 	int sprite_id = actor->GetSpriteIndex();
 	BitmapRef bm = Cache::Charset(sprite_name);

--- a/src/window_shopstatus.cpp
+++ b/src/window_shopstatus.cpp
@@ -38,8 +38,8 @@ void Window_ShopStatus::Refresh() {
 	int equipped = 0;
 
 	if (item_id != 0) {
-		number = Main_Data::game_party->GetItemCount(item_id);
-		equipped = Main_Data::game_party->GetEquippedItemCount(item_id);
+		number = Game_Data::GetParty().GetItemCount(item_id);
+		equipped = Game_Data::GetParty().GetEquippedItemCount(item_id);
 	}
 
 	contents->TextDraw(0, 2, 1, Data::terms.possessed_items);

--- a/src/window_skill.cpp
+++ b/src/window_skill.cpp
@@ -125,7 +125,7 @@ bool Window_Skill::CheckInclude(int skill_id) {
 bool Window_Skill::CheckEnable(int skill_id) {
 	const Game_Actor* actor = Game_Actors::GetActor(actor_id);
 
-	return actor->IsSkillLearned(skill_id) && Main_Data::game_party->IsSkillUsable(skill_id, actor);
+	return actor->IsSkillLearned(skill_id) && Game_Data::GetParty().IsSkillUsable(skill_id, actor);
 }
 
 void Window_Skill::SetSubsetFilter(int subset) {

--- a/src/window_targetstatus.cpp
+++ b/src/window_targetstatus.cpp
@@ -45,9 +45,9 @@ void Window_TargetStatus::Refresh() {
 	// Scene_ActorTarget validates items and skills
 	std::string str;
 	if (use_item) {
-		str = std::to_string(Main_Data::game_party->GetItemCount(id));
+		str = std::to_string(Game_Data::GetParty().GetItemCount(id));
 	} else {
-		str = std::to_string((*Main_Data::game_party)[actor_index].CalculateSkillCost(id));
+		str = std::to_string((Game_Data::GetParty())[actor_index].CalculateSkillCost(id));
 	}
 
 	FontRef font = Font::Default();

--- a/src/window_varlist.cpp
+++ b/src/window_varlist.cpp
@@ -53,7 +53,7 @@ void Window_VarList::DrawItemValue(int index){
 	switch (mode) {
 		case eSwitch:
 			{
-				auto value = Main_Data::game_switches->Get(first_var + index);
+				auto value = Game_Data::GetSwitches().Get(first_var + index);
 				auto font = (!value) ? Font::ColorCritical : Font::ColorDefault;
 				DrawItem(index, Font::ColorDefault);
 				contents->TextDraw(GetWidth() - 16, 16 * index + 2, font, value ? "[ON]" : "[OFF]", Text::AlignRight);
@@ -61,7 +61,7 @@ void Window_VarList::DrawItemValue(int index){
 			break;
 		case eVariable:
 			{
-				auto value = Main_Data::game_variables->Get(first_var + index);
+				auto value = Game_Data::GetVariables().Get(first_var + index);
 				auto font = (value < 0) ? Font::ColorCritical : Font::ColorDefault;
 				DrawItem(index, Font::ColorDefault);
 				contents->TextDraw(GetWidth() - 16, 16 * index + 2, font, std::to_string(value), Text::AlignRight);
@@ -106,10 +106,10 @@ void Window_VarList::UpdateList(int first_value){
 		ss << std::setfill('0') << std::setw(4) << (first_value + i) << ": ";
 		switch (mode) {
 			case eSwitch:
-				ss << Main_Data::game_switches->GetName(first_value + i);
+				ss << Game_Data::GetSwitches().GetName(first_value + i);
 				break;
 			case eVariable:
-				ss << Main_Data::game_variables->GetName(first_value + i);
+				ss << Game_Data::GetVariables().GetName(first_value + i);
 				break;
 			case eItem:
 				ss << ReaderUtil::GetElement(Data::items, first_value+i)->name;
@@ -169,9 +169,9 @@ int Window_VarList::GetIndex() {
 bool Window_VarList::DataIsValid(int range_index) {
 	switch (mode) {
 		case eSwitch:
-			return Main_Data::game_switches->IsValid(range_index);
+			return Game_Data::GetSwitches().IsValid(range_index);
 		case eVariable:
-			return Main_Data::game_variables->IsValid(range_index);
+			return Game_Data::GetVariables().IsValid(range_index);
 		case eItem:
 			return range_index > 0 && range_index <= static_cast<int>(Data::items.size());
 		case eTroop:

--- a/src/window_varlist.cpp
+++ b/src/window_varlist.cpp
@@ -69,7 +69,7 @@ void Window_VarList::DrawItemValue(int index){
 			break;
 		case eItem:
 			{
-				auto value = Main_Data::game_party->GetItemCount(first_var + index);
+				auto value = Game_Data::GetParty().GetItemCount(first_var + index);
 				auto font = (value == 0) ? Font::ColorCritical : Font::ColorDefault;
 				DrawItem(index, Font::ColorDefault);
 				contents->TextDraw(GetWidth() - 16, 16 * index + 2, font, std::to_string(value), Text::AlignRight);
@@ -130,7 +130,7 @@ void Window_VarList::UpdateList(int first_value){
 				if (first_value + i == 1) {
 					ss << "Party";
 				} else {
-					auto* actor = Main_Data::game_party->GetActors()[first_value + i-2];
+					auto* actor = Game_Data::GetParty().GetActors()[first_value + i-2];
 					ss << actor->GetName() << " " << actor->GetHp() << " / " << actor->GetMaxHp();
 				}
 				break;
@@ -179,7 +179,7 @@ bool Window_VarList::DataIsValid(int range_index) {
 		case eMap:
 			return range_index > 0 && range_index <= (Data::treemap.maps.size() > 0 ? Data::treemap.maps.back().ID : 0);
 		case eHeal:
-			return range_index > 0 && range_index <= static_cast<int>(Main_Data::game_party->GetActors().size()) + 1;
+			return range_index > 0 && range_index <= static_cast<int>(Game_Data::GetParty().GetActors().size()) + 1;
 		case eCommonEvent:
 			return range_index > 0 && range_index <= static_cast<int>(Data::commonevents.size());
 		default:


### PR DESCRIPTION
This is a refactor of `Main_Data` to better encapsulate saving and loading.

* Only valid when either a new game or load game is running. 
* Stand up all members on new game and load game
* Tear down all on quit game / back to title
* Eventually contain all `Game_*` objects
* Eventually and saving to and loading from `RPG_Save` objects should be isolated to this class.

Depends on #2003 
Depends on #2004