### PR TITLE
Cleanup Shake and Flash logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(${PROJECT_NAME}
 	src/exfont.h
 	src/filefinder.cpp
 	src/filefinder.h
+	src/flash.h
 	src/font.cpp
 	src/font.h
 	src/fps_overlay.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,7 @@ add_library(${PROJECT_NAME}
 	src/scene_title.h
 	src/screen.cpp
 	src/screen.h
+	src/shake.h
 	src/shinonome_gothic.h
 	src/shinonome_mincho.h
 	src/sprite_airshipshadow.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -255,6 +255,7 @@ libeasyrpg_player_a_SOURCES = \
 	src/scene_title.h \
 	src/screen.cpp \
 	src/screen.h \
+	src/shake.h \
 	src/sdl2_ui.cpp \
 	src/sdl2_ui.h \
 	src/sdl_ui.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -84,6 +84,7 @@ libeasyrpg_player_a_SOURCES = \
 	src/exfont.h \
 	src/filefinder.cpp \
 	src/filefinder.h \
+	src/flash.h \
 	src/font.cpp \
 	src/font.h \
 	src/fps_overlay.cpp \

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -31,7 +31,6 @@
 #include "game_temp.h"
 #include "options.h"
 #include "drawable_mgr.h"
-#include "flash.h"
 
 BattleAnimation::BattleAnimation(const RPG::Animation& anim, bool only_sound, int cutoff) :
 	Sprite(TypeDefault),
@@ -311,11 +310,8 @@ void BattleAnimationBattle::Draw(Bitmap& dst) {
 	}
 }
 void BattleAnimationBattle::FlashTargets(int r, int g, int b, int p) {
-	auto color = Flash::MakeColor(r, g, b, p);
 	for (auto& battler: battlers) {
-		Sprite_Battler* sprite = Game_Battle::GetSpriteset().FindBattler(battler);
-		if (sprite)
-			sprite->Flash(color, 0);
+		battler->Flash(r, g, b, p, 0);
 	}
 }
 

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -74,14 +74,7 @@ void BattleAnimation::Update() {
 	UpdateScreenFlash();
 	UpdateTargetFlash();
 
-	auto flash_color = Main_Data::game_screen->GetFlashColor();
-	if (flash_color.alpha > 0) {
-		Sprite::Flash(flash_color, 0);
-	} else {
-		Sprite::Flash(Color(), 0);
-	}
-
-	Sprite::Update();
+	SetFlashEffect(Main_Data::game_screen->GetFlashColor());
 
 	frame++;
 }

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -31,6 +31,7 @@
 #include "game_temp.h"
 #include "options.h"
 #include "drawable_mgr.h"
+#include "flash.h"
 
 BattleAnimation::BattleAnimation(const RPG::Animation& anim, bool only_sound, int cutoff) :
 	Sprite(TypeDefault),
@@ -310,7 +311,7 @@ void BattleAnimationBattle::Draw(Bitmap& dst) {
 	}
 }
 void BattleAnimationBattle::FlashTargets(int r, int g, int b, int p) {
-	auto color = MakeFlashColor(r, g, b, p);
+	auto color = Flash::MakeColor(r, g, b, p);
 	for (auto& battler: battlers) {
 		Sprite_Battler* sprite = Game_Battle::GetSpriteset().FindBattler(battler);
 		if (sprite)

--- a/src/color.h
+++ b/src/color.h
@@ -55,18 +55,6 @@ public:
 	uint8_t alpha = 0;
 };
 
-/**
- * Create a Color object from RPG_RT flash values [0,31]
- *
- * @param r red color
- * @param g green color
- * @param b blue color
- * @param current_level strength of flash
- */
-inline Color MakeFlashColor(int r, int g, int b, double current_level) {
-	return Color(r * 8, g * 8, b * 8, current_level * 8);
-}
-
 inline bool operator==(const Color &l, const Color& r) {
 	return l.red == r.red
 		   && l.green == r.green

--- a/src/flash.h
+++ b/src/flash.h
@@ -1,0 +1,76 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_FLASH_H
+#define EP_FLASH_H
+
+#include "color.h"
+
+/** Contains helper functions for flash effect */
+namespace Flash {
+/**
+ * Perform one time step of flash data animation
+ *
+ * @param current_level flash level
+ * @param time_left amount of flash time left
+ * @param continuous true if continuous flash
+ * @param period original flash period
+ * @param sat original flash saturation
+ */
+inline void Update(double& current_level, int32_t& time_left, bool continuous, int32_t period, int32_t sat)
+{
+	if (current_level > 0 || continuous) {
+		if (time_left > 0) {
+			current_level = current_level - (current_level / time_left);
+			--time_left;
+		}
+		if (time_left <= 0) {
+			time_left = 0;
+			current_level = 0;
+			if (continuous) {
+				time_left = period;
+				current_level = sat;
+			}
+		}
+	}
+}
+
+/**
+ * Perform one time step of flash data animation
+ *
+ * @param current_level flash level
+ * @param time_left amount of flash time left
+ */
+inline void Update(double& current_level, int32_t& time_left) {
+	Update(current_level, time_left, false, 0, 0);
+}
+
+/**
+ * Create a Color object from RPG_RT flash values [0,31]
+ *
+ * @param r red color
+ * @param g green color
+ * @param b blue color
+ * @param current_level strength of flash
+ */
+constexpr Color MakeColor(int r, int g, int b, double current_level) {
+	return current_level > 0.0 ? Color(r * 8, g * 8, b * 8, current_level * 8) : Color();
+}
+
+} //namespace Flash
+
+#endif

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -125,32 +125,31 @@ void Game_Battle::Quit() {
 	Main_Data::game_party->ResetBattle();
 }
 
-void Game_Battle::Update() {
+void Game_Battle::RunEvents() {
 	interpreter->Update();
 	if (interpreter->IsAsyncPending()) {
 		terminate = true;
 		return;
 	}
+}
 
-	Main_Data::game_screen->Update();
-
-	spriteset->Update();
+void Game_Battle::UpdateAnimation() {
 	if (animation) {
 		animation->Update();
 		if (animation->IsDone()) {
 			animation.reset();
 		}
 	}
+}
 
-	std::vector<Game_Battler*> battlers;
-	(*Main_Data::game_party).GetBattlers(battlers);
-	(*Main_Data::game_enemyparty).GetBattlers(battlers);
-	for (Game_Battler* b : battlers) {
-		b->UpdateBattle();
-	}
+void Game_Battle::UpdateGraphics() {
+	spriteset->Update();
 
 	if (need_refresh) {
 		need_refresh = false;
+		std::vector<Game_Battler*> battlers;
+		Main_Data::game_party->GetBattlers(battlers);
+		Main_Data::game_enemyparty->GetBattlers(battlers);
 		for (Game_Battler* b : battlers) {
 			Sprite_Battler* spr = spriteset->FindBattler(b);
 			if (spr) {

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -192,6 +192,7 @@ bool Game_Battle::CheckLose() {
 }
 
 Spriteset_Battle& Game_Battle::GetSpriteset() {
+	assert(spriteset);
 	return *spriteset;
 }
 

--- a/src/game_battle.h
+++ b/src/game_battle.h
@@ -42,9 +42,19 @@ namespace Game_Battle {
 	void Quit();
 
 	/**
-	 * Updates the battle state.
+	 * Updates the battle animation
 	 */
-	void Update();
+	void UpdateAnimation();
+
+	/**
+	 * Runs the interpreter
+	 */
+	void RunEvents();
+
+	/**
+	 * Updates spriteset graphics
+	 */
+	void UpdateGraphics();
 
 	void Terminate();
 

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -739,6 +739,8 @@ void Game_Battler::UpdateBattle() {
 			shake_time_left = 0;
 		}
 	}
+
+	UpdateFlash();
 }
 
 const BattleAlgorithmRef Game_Battler::GetBattleAlgorithm() const {
@@ -886,5 +888,17 @@ void Game_Battler::ShakeOnce(int strength, int speed, int frames) {
 	shake_speed = speed;
 	shake_time_left = frames;
 	// FIXME: RPG_RT doesn't reset position for screen shake. So we guess? it doesn't do so here either.
+}
+
+void Game_Battler::Flash(int r, int g, int b, int power, int frames) {
+	flash.red = r;
+	flash.green = g;
+	flash.blue = b;
+	flash.current_level = power;
+	flash.time_left = frames;
+}
+
+void Game_Battler::UpdateFlash() {
+	Flash::Update(flash.current_level, flash.time_left);
 }
 

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -16,6 +16,7 @@
  */
 
 // Headers
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <cassert>
 #include <cmath>
@@ -36,6 +37,7 @@
 #include "reader_util.h"
 #include "game_battlealgorithm.h"
 #include "state.h"
+#include "shake.h"
 
 Game_Battler::Game_Battler() {
 	ResetBattle();
@@ -670,7 +672,7 @@ int Game_Battler::GetAgi() const {
 }
 
 int Game_Battler::GetDisplayX() const {
-	int shake_pos = Main_Data::game_screen->GetShakeOffsetX() + shake_position;
+	int shake_pos = Main_Data::game_screen->GetShakeOffsetX() + shake.position;
 	return GetBattleX() + shake_pos;
 }
 
@@ -730,17 +732,8 @@ int Game_Battler::GetFlyingOffset() const {
 }
 
 void Game_Battler::UpdateBattle() {
-	if (shake_time_left > 0) {
-		--shake_time_left;
-		if (shake_time_left > 0) {
-			shake_position = Game_Screen::AnimateShake(shake_strength, shake_speed, shake_time_left, shake_position);
-		} else {
-			shake_position = 0;
-			shake_time_left = 0;
-		}
-	}
-
-	UpdateFlash();
+	Shake::Update(shake.position, shake.time_left, shake.strength, shake.speed, false);
+	Flash::Update(flash.current_level, flash.time_left);
 }
 
 const BattleAlgorithmRef Game_Battler::GetBattleAlgorithm() const {
@@ -884,9 +877,9 @@ int Game_Battler::GetHitChanceModifierFromStates() const {
 }
 
 void Game_Battler::ShakeOnce(int strength, int speed, int frames) {
-	shake_strength = strength;
-	shake_speed = speed;
-	shake_time_left = frames;
+	shake.strength = strength;
+	shake.speed = speed;
+	shake.time_left = frames;
 	// FIXME: RPG_RT doesn't reset position for screen shake. So we guess? it doesn't do so here either.
 }
 
@@ -896,9 +889,5 @@ void Game_Battler::Flash(int r, int g, int b, int power, int frames) {
 	flash.blue = b;
 	flash.current_level = power;
 	flash.time_left = frames;
-}
-
-void Game_Battler::UpdateFlash() {
-	Flash::Update(flash.current_level, flash.time_left);
 }
 

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -681,8 +681,6 @@ public:
 	/** @return current flash color */
 	Color GetFlashColor() const;
 
-private:
-	void UpdateFlash();
 protected:
 	/** Gauge for RPG2k3 Battle */
 	int gauge;
@@ -705,10 +703,13 @@ protected:
 
 	int battle_order = 0;
 
-	int shake_position = 0;
-	int shake_time_left = 0;
-	int shake_strength = 0;
-	int shake_speed = 0;
+	struct ShakeData {
+		int32_t position = 0;
+		int32_t time_left = 0;
+		int32_t strength = 0;
+		int32_t speed = 0;
+	};
+	ShakeData shake;
 
 	struct FlashData {
 		int32_t red = 0;

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -24,6 +24,8 @@
 #include "rpg_state.h"
 #include "system.h"
 #include "state.h"
+#include "color.h"
+#include "flash.h"
 
 class Game_Actor;
 class Game_Party_Base;
@@ -665,6 +667,22 @@ public:
 	 */
 	void ShakeOnce(int strength, int speed, int frames);
 
+	/**
+	 * Begins a flash.
+	 *
+	 * @param r red color
+	 * @param g blue color
+	 * @param b green color
+	 * @param power power of the flash
+	 * @param frames Duration of the flash in frames
+	 */
+	void Flash(int r, int g, int b, int power, int frames);
+
+	/** @return current flash color */
+	Color GetFlashColor() const;
+
+private:
+	void UpdateFlash();
 protected:
 	/** Gauge for RPG2k3 Battle */
 	int gauge;
@@ -691,6 +709,19 @@ protected:
 	int shake_time_left = 0;
 	int shake_strength = 0;
 	int shake_speed = 0;
+
+	struct FlashData {
+		int32_t red = 0;
+		int32_t green = 0;
+		int32_t blue = 0;
+		int32_t time_left = 0;
+		double current_level = 0.0;
+	};
+	FlashData flash;
 };
+
+inline Color Game_Battler::GetFlashColor() const {
+	return Flash::MakeColor(flash.red, flash.green, flash.blue, flash.current_level);
+}
 
 #endif

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -213,15 +213,7 @@ void Game_Character::UpdateAnimation(bool was_moving) {
 }
 
 void Game_Character::UpdateFlash() {
-	if (data()->flash_current_level > 0) {
-		if (data()->flash_time_left > 0) {
-			data()->flash_current_level = data()->flash_current_level - (data()->flash_current_level / data()->flash_time_left);
-			--data()->flash_time_left;
-		} else {
-			data()->flash_current_level = 0.0;
-			data()->flash_time_left = 0;
-		}
-	}
+	Flash::Update(data()->flash_current_level, data()->flash_time_left);
 }
 
 void Game_Character::UpdateJump() {

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -21,6 +21,7 @@
 // Headers
 #include <string>
 #include "color.h"
+#include "flash.h"
 #include "rpg_moveroute.h"
 #include "rpg_eventpage.h"
 #include "rpg_savemapeventbase.h"
@@ -1000,7 +1001,7 @@ inline void Game_Character::SetAnimPaused(bool value) {
 }
 
 inline Color Game_Character::GetFlashColor() const {
-	return MakeFlashColor(data()->flash_red, data()->flash_green, data()->flash_blue, data()->flash_current_level);
+	return Flash::MakeColor(data()->flash_red, data()->flash_green, data()->flash_blue, data()->flash_current_level);
 }
 
 inline double Game_Character::GetFlashLevel() const {

--- a/src/game_picture.cpp
+++ b/src/game_picture.cpp
@@ -113,12 +113,7 @@ void Game_Picture::UpdateSprite() {
 	sprite->SetTone(tone);
 
 	if (data.flags.affected_by_flash) {
-		auto flash_color = Main_Data::game_screen->GetFlashColor();
-		if (flash_color.alpha > 0) {
-			sprite->Flash(flash_color, 0);
-		} else {
-			sprite->Flash(Color(), 0);
-		}
+		sprite->SetFlashEffect(Main_Data::game_screen->GetFlashColor());
 	}
 }
 

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -17,6 +17,7 @@
 
 // Headers
 #define _USE_MATH_DEFINES
+#include <cmath>
 #include "bitmap.h"
 #include "data.h"
 #include "player.h"
@@ -33,7 +34,7 @@
 #include "reader_util.h"
 #include "scene.h"
 #include "weather.h"
-#include <cmath>
+#include "flash.h"
 
 static constexpr int kShakeContinuousTimeStart = 65535;
 
@@ -384,20 +385,11 @@ void Game_Screen::UpdateScreenEffects() {
 		data.tint_time_left = data.tint_time_left - 1;
 	}
 
-	if (data.flash_current_level > 0 || data.flash_continuous) {
-		if (data.flash_time_left > 0) {
-			data.flash_current_level = data.flash_current_level - (data.flash_current_level / data.flash_time_left);
-			--data.flash_time_left;
-		}
-		if (data.flash_time_left <= 0) {
-			data.flash_time_left = 0;
-			data.flash_current_level = 0;
-			if (data.flash_continuous) {
-				data.flash_time_left = flash_period;
-				data.flash_current_level = flash_sat;
-			}
-		}
-	}
+	Flash::Update(data.flash_current_level,
+			data.flash_time_left,
+			data.flash_continuous,
+			flash_period,
+			flash_sat);
 
 	if (data.shake_time_left > 0) {
 		--data.shake_time_left;

--- a/src/game_screen.h
+++ b/src/game_screen.h
@@ -134,18 +134,6 @@ public:
 	 */
 	bool IsBattleAnimationWaiting();
 
-	/**
-	 * Animates the screen shake algorithm given the parameters
-	 *
-	 * @param strength the strength of the shake
-	 * @param speed of the shake
-	 * @param time_left how much time is left in frames
-	 * @param position current shake displacement
-	 *
-	 * @return next shake displacement
-	 */
-	static int AnimateShake(int strength, int speed, int time_left, int position);
-
 	/** @return current pan_x offset for screen effects in 1/16 pixels */
 	int GetPanX() const;
 

--- a/src/game_screen.h
+++ b/src/game_screen.h
@@ -26,6 +26,7 @@
 #include "game_picture.h"
 #include "game_character.h"
 #include "battle_animation.h"
+#include "flash.h"
 
 class Game_Battler;
 class Screen;
@@ -235,7 +236,7 @@ inline Tone Game_Screen::GetTone() {
 }
 
 inline Color Game_Screen::GetFlashColor() const {
-	return MakeFlashColor(data.flash_red, data.flash_green, data.flash_blue, data.flash_current_level);
+	return Flash::MakeColor(data.flash_red, data.flash_green, data.flash_blue, data.flash_current_level);
 }
 
 inline int Game_Screen::GetWeatherType() {

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -204,6 +204,7 @@ void Scene_Battle::Update() {
 		ProcessActions();
 		ProcessInput();
 	}
+	UpdateCursors();
 
 	auto& interp = Game_Battle::GetInterpreter();
 

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -168,13 +168,26 @@ void Scene_Battle::Update() {
 	item_window->Update();
 	skill_window->Update();
 	target_window->Update();
+
+	const int timer1 = Main_Data::game_party->GetTimerSeconds(Game_Party::Timer1);
+	const int timer2 = Main_Data::game_party->GetTimerSeconds(Game_Party::Timer2);
+
+	// Update Battlers
+	std::vector<Game_Battler*> battlers;
+	Main_Data::game_party->GetBattlers(battlers);
+	Main_Data::game_enemyparty->GetBattlers(battlers);
+	for (auto* b : battlers) {
+		b->UpdateBattle();
+	}
+
+	// Screen Effects
 	Game_Message::Update();
+	Main_Data::game_party->UpdateTimers();
+	Main_Data::game_screen->Update();
+	Game_Battle::UpdateAnimation();
 
 	// Query Timer before and after update.
 	// If it reached zero during update was a running battle timer.
-	int timer1 = Main_Data::game_party->GetTimerSeconds(Game_Party::Timer1);
-	int timer2 = Main_Data::game_party->GetTimerSeconds(Game_Party::Timer2);
-	Main_Data::game_party->UpdateTimers();
 	if ((Main_Data::game_party->GetTimerSeconds(Game_Party::Timer1) == 0 && timer1 > 0) ||
 		(Main_Data::game_party->GetTimerSeconds(Game_Party::Timer2) == 0 && timer2 > 0)) {
 		Scene::Pop();
@@ -195,7 +208,8 @@ void Scene_Battle::Update() {
 	auto& interp = Game_Battle::GetInterpreter();
 
 	bool events_running = interp.IsRunning();
-	Game_Battle::Update();
+	Game_Battle::RunEvents();
+	Game_Battle::UpdateGraphics();
 	if (events_running && !interp.IsRunning()) {
 		// If an event that changed status finishes without displaying a message window,
 		// we need this so it can update automatically the status_window

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -629,7 +629,6 @@ void Scene_Battle::CallDebug() {
 
 void Scene_Battle::SelectionFlash(Game_Battler* battler) {
 	if (battler) {
-		// FIXME: Verify this color and time
-		battler->Flash(31, 31, 31, 12, 15);
+		battler->Flash(31, 31, 31, 24, 16);
 	}
 }

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -627,3 +627,9 @@ void Scene_Battle::CallDebug() {
 	}
 }
 
+void Scene_Battle::SelectionFlash(Game_Battler* battler) {
+	if (battler) {
+		// FIXME: Verify this color and time
+		battler->Flash(31, 31, 31, 12, 15);
+	}
+}

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -97,6 +97,8 @@ public:
 		State_Escape
 	};
 
+	static void SelectionFlash(Game_Battler* battler);
+
 protected:
 	Scene_Battle();
 

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -110,6 +110,7 @@ protected:
 
 	virtual void ProcessActions() = 0;
 	virtual void ProcessInput() = 0;
+	virtual void UpdateCursors() {}
 
 	virtual void SetState(Scene_Battle::State new_state) = 0;
 

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -349,14 +349,11 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 		Main_Data::game_enemyparty->GetActiveBattlers(enemies);
 
 		Game_Enemy* target = static_cast<Game_Enemy*>(enemies[target_window->GetIndex()]);
-		Sprite_Battler* sprite = Game_Battle::GetSpriteset().FindBattler(target);
-		if (sprite) {
-			++select_target_flash_count;
+		++select_target_flash_count;
 
-			if (select_target_flash_count == 60) {
-				sprite->Flash(Color(255, 255, 255, 100), 15);
-				select_target_flash_count = 0;
-			}
+		if (select_target_flash_count == 60) {
+			SelectionFlash(target);
+			select_target_flash_count = 0;
 		}
 		break;
 	}
@@ -510,10 +507,7 @@ bool Scene_Battle_Rpg2k::ProcessActionBegin(Game_BattleAlgorithm::AlgorithmBase*
 		}
 
 		if (action->GetType() != Game_BattleAlgorithm::Type::Null || show_message) {
-			auto* source_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetSource());
-			if (source_sprite) {
-				source_sprite->Flash(Color(255, 255, 255, 100), 15);
-			}
+			SelectionFlash(action->GetSource());
 		}
 
 		if (show_message) {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -202,7 +202,7 @@ void Scene_Battle_Rpg2k3::UpdateCursors() {
 			int frame = frames[(cycle / 15) % 4];
 			ally_cursor->SetSrcRect(Rect(frame * 16, 16, 16, 16));
 
-			if (cycle % 60 == 0) {
+			if (cycle % 30 == 0) {
 				SelectionFlash(actor);
 			}
 		}

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -194,7 +194,7 @@ void Scene_Battle_Rpg2k3::UpdateCursors() {
 		if (ally_index >= 0 && Data::battlecommands.battle_type != RPG::BattleCommands::BattleType_traditional) {
 			ally_cursor->SetVisible(true);
 			Main_Data::game_party->GetBattlers(actors);
-			const Game_Battler* actor = actors[ally_index];
+			Game_Battler* actor = actors[ally_index];
 			Sprite_Battler* sprite = Game_Battle::GetSpriteset().FindBattler(actor);
 			ally_cursor->SetX(actor->GetBattleX());
 			ally_cursor->SetY(actor->GetBattleY() - sprite->GetHeight() / 2);
@@ -203,7 +203,7 @@ void Scene_Battle_Rpg2k3::UpdateCursors() {
 			ally_cursor->SetSrcRect(Rect(frame * 16, 16, 16, 16));
 
 			if (cycle % 60 == 0) {
-				sprite->Flash(Color(255, 255, 255, 100), 15);
+				SelectionFlash(actor);
 			}
 		}
 
@@ -587,14 +587,11 @@ void Scene_Battle_Rpg2k3::ProcessActions() {
 			Main_Data::game_enemyparty->GetActiveBattlers(enemies);
 
 			Game_Enemy* target = static_cast<Game_Enemy*>(enemies[target_window->GetIndex()]);
-			Sprite_Battler* sprite = Game_Battle::GetSpriteset().FindBattler(target);
-			if (sprite) {
-				++select_target_flash_count;
+			++select_target_flash_count;
 
-				if (select_target_flash_count == 60) {
-					sprite->Flash(Color(255, 255, 255, 100), 15);
-					select_target_flash_count = 0;
-				}
+			if (select_target_flash_count == 60) {
+				SelectionFlash(target);
+				select_target_flash_count = 0;
 			}
 			break;
 		}
@@ -697,7 +694,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 		action->Execute();
 
 		if (source_sprite) {
-			source_sprite->Flash(Color(255, 255, 255, 100), 15);
+			SelectionFlash(action->GetSource());
 			source_sprite->SetAnimationState(
 				action->GetSourceAnimationState(),
 				Sprite_Battler::LoopState_WaitAfterFinish);

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -101,7 +101,6 @@ void Scene_Battle_Rpg2k3::Update() {
 	}
 
 	Scene_Battle::Update();
-	UpdateCursors();
 
 	//enemy_status_window->Update();
 }

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -84,7 +84,7 @@ protected:
 	void CreateBattleTargetWindow();
 	void CreateBattleCommandWindow();
 
-	void UpdateCursors();
+	void UpdateCursors() override;
 	void DrawFloatText(int x, int y, int color, const std::string& text);
 
 	void RefreshCommandWindow();

--- a/src/shake.h
+++ b/src/shake.h
@@ -1,0 +1,76 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_SHAKE_H
+#define EP_SHAKE_H
+
+#define _USE_MATH_DEFINES
+#include <cmath>
+#include "utils.h"
+
+/** Contains helper functions for flash effect */
+namespace Shake {
+static constexpr int kShakeContinuousTimeStart = 65535;
+
+/**
+ * Computes new shake position from inputs
+ *
+ * @param strength strength of shake effect
+ * @param speed speed of shake effect
+ * @param time_left amount of time left for shake effect
+ * @param position current shake position
+ */
+inline int NextPosition(int strength, int speed, int time_left, int position) {
+	int amplitude = 1 + 2 * strength;
+	int newpos = amplitude * sin((time_left * 4 * (speed + 2)) % 256 * M_PI / 128);
+	int cutoff = (speed * amplitude / 8) + 1;
+
+	return Utils::Clamp<int>(newpos, position - cutoff, position + cutoff);
+}
+
+/**
+ * Perform one time step of shake animation
+ *
+ * @param position shake position
+ * @param time_left amount of time left for shake effect
+ * @param strength strength of shake effect
+ * @param speed speed of shake effect
+ * @param continous whether this is a continuous shake
+ */
+inline void Update(int32_t& position, int32_t& time_left, int32_t strength, int32_t speed, bool continuous)
+{
+	if (time_left > 0) {
+		--time_left;
+
+		// This fixes a bug in RPG_RT where continuous shake would actually stop after
+		// 18m12s of gameplay.
+		if (time_left <= 0 && continuous) {
+			time_left = kShakeContinuousTimeStart;
+		}
+
+		if (time_left > 0) {
+			position = NextPosition(strength, speed, time_left, position);
+		} else {
+			position = 0;
+			time_left = 0;
+		}
+	}
+}
+
+} //namespace Shake
+
+#endif

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -117,34 +117,6 @@ BitmapRef Sprite::Refresh(Rect& rect) {
 	}
 }
 
-void Sprite::Update() {
-	if (flash_duration != 0) {
-		flash_frame += 1;
-		if (flash_duration == flash_frame) {
-			flash_duration = 0;
-			SetFlashEffect(Color());
-		} else {
-			Color flash_effect = flash_color;
-			flash_effect.alpha = flash_duration == 0 || flash_frame >= flash_duration
-				? 0
-				: flash_effect.alpha * (flash_duration - flash_frame) / flash_duration;
-			SetFlashEffect(flash_effect);
-		}
-	}
-}
-
-void Sprite::Flash(int duration){
-	SetFlashEffect(flash_color);
-	flash_duration = duration;
-	flash_frame = 0;
-}
-void Sprite::Flash(Color color, int duration){
-	flash_color = color;
-	flash_duration = duration;
-	flash_frame = 0;
-	SetFlashEffect(color);
-}
-
 void Sprite::SetFlashEffect(const Color &color) {
 	if (flash_effect != color) {
 		flash_effect = color;

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -34,10 +34,6 @@ public:
 
 	void Draw(Bitmap& dst) override;
 
-	virtual void Flash(int duration);
-	virtual void Flash(Color color, int duration);
-	void Update();
-
 	virtual int GetWidth() const;
 	virtual int GetHeight() const;
 
@@ -103,6 +99,11 @@ public:
 	 */
 	void SetWaverPhase(double phase);
 
+	/**
+	 * Set the flash effect color
+	 */
+	void SetFlashEffect(const Color &color);
+
 protected:
 	Sprite(DrawableType type);
 
@@ -114,11 +115,6 @@ private:
 	int y = 0;
 	int ox = 0;
 	int oy = 0;
-
-	Color flash_color;
-	int flash_duration = 0;
-	int flash_frame = 0;
-
 
 	Rect src_rect_effect;
 	int opacity_top_effect = 255;
@@ -152,7 +148,6 @@ private:
 	void BlitScreenIntern(Bitmap& dst, Bitmap const& draw_bitmap,
 							Rect const& src_rect) const;
 	BitmapRef Refresh(Rect& rect);
-	void SetFlashEffect(const Color &color);
 };
 
 inline int Sprite::GetWidth() const {

--- a/src/sprite_airshipshadow.cpp
+++ b/src/sprite_airshipshadow.cpp
@@ -57,8 +57,6 @@ void Sprite_AirshipShadow::RecreateShadow() {
 }
 
 void Sprite_AirshipShadow::Update() {
-	Sprite::Update();
-
 	if (!Main_Data::game_player->InAirship()) {
 		SetVisible(false);
 		return;

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -59,8 +59,6 @@ void Sprite_Battler::Update() {
 
 	old_hidden = battler->IsHidden();
 
-	Sprite::Update();
-
 	++cycle;
 
 	if (battler->GetBattleAnimationId() <= 0) {
@@ -181,15 +179,7 @@ void Sprite_Battler::Update() {
 	// needed for flying enemies
 	SetY(battler->GetDisplayY());
 
-	auto color = battler->GetFlashColor();
-	if (color.alpha == 0) {
-		color = {};
-	}
-	if (animation) {
-		animation->Flash(color, 0);
-	} else {
-		Sprite::Flash(color, 0);
-	}
+	SetFlashEffect(battler->GetFlashColor());
 }
 
 void Sprite_Battler::SetAnimationState(int state, LoopState loop) {

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -180,6 +180,16 @@ void Sprite_Battler::Update() {
 	SetX(battler->GetDisplayX());
 	// needed for flying enemies
 	SetY(battler->GetDisplayY());
+
+	auto color = battler->GetFlashColor();
+	if (color.alpha == 0) {
+		color = {};
+	}
+	if (animation) {
+		animation->Flash(color, 0);
+	} else {
+		Sprite::Flash(color, 0);
+	}
 }
 
 void Sprite_Battler::SetAnimationState(int state, LoopState loop) {
@@ -251,22 +261,6 @@ void Sprite_Battler::DetectStateChange() {
 
 bool Sprite_Battler::IsIdling() {
 	return idling;
-}
-
-void Sprite_Battler::Flash(int duration) {
-	if (animation) {
-		animation->Flash(duration);
-	} else {
-		Sprite::Flash(duration);
-	}
-}
-
-void Sprite_Battler::Flash(Color color, int duration) {
-	if (animation) {
-		animation->Flash(color, duration);
-	} else {
-		Sprite::Flash(color, duration);
-	}
 }
 
 bool Sprite_Battler::GetVisible() const {

--- a/src/sprite_battler.h
+++ b/src/sprite_battler.h
@@ -88,9 +88,6 @@ public:
 	 */
 	bool IsIdling();
 
-	void Flash(int duration) override;
-	void Flash(Color color, int duration) override;
-
 	bool GetVisible() const override;
 	void SetVisible(bool visible) override;
 

--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -35,7 +35,6 @@ Sprite_Character::Sprite_Character(Game_Character* character, CloneType type) :
 }
 
 void Sprite_Character::Update() {
-	Sprite::Update();
 	if (tile_id != character->GetTileId() ||
 		character_name != character->GetSpriteName() ||
 		character_index != character->GetSpriteIndex() ||
@@ -66,11 +65,7 @@ void Sprite_Character::Update() {
 		SetSrcRect({frame * chara_width, row * chara_height, chara_width, chara_height});
 	}
 
-	if (character->GetFlashLevel() > 0) {
-		Flash(character->GetFlashColor(), 0);
-	} else {
-		Flash(Color(), 0);
-	}
+	SetFlashEffect(character->GetFlashColor());
 
 	SetVisible(character->GetVisible());
 	if (GetVisible()) {


### PR DESCRIPTION
This moves shake and flash animation logic to their own headers so they can be reused. It also eliminates the flash animation capability from `Sprite` and instead relies on game objects to do animation. This is important for timing as there is no guarantee of when sprites are updated vs game objects. It also makes `sizeof(Sprite)` smaller.

Finally, this fixes a bug I discovered in battle where some battle animations with flash effects would cause the flash to stick on the battler sprite and not fade away until another flash replaced it.