### PR TITLE
Improve Window_Message timing accuracy - Messages 6 of N

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -321,7 +321,7 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 			if (Game_Message::IsMessagePending())
 				break;
 		} else {
-			if ((Game_Message::IsMessageActive()) && _state.show_message) {
+			if (Game_Message::IsMessageActive() && _state.show_message) {
 				break;
 			}
 		}

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -198,22 +198,6 @@ int Game_Message::WordWrap(const std::string& line, const int limit, const std::
 	return line_count;
 }
 
-bool Game_Message::CanShowMessage(bool foreground) {
-	// If there's a text already, return immediately
-	if (IsMessagePending())
-		return false;
-
-	// Forground interpreters: If the message box already started animating we wait for it to finish.
-	if (foreground && IsMessageVisible() && !window->GetAllowNextMessage())
-		return false;
-
-	// Parallel interpreters must wait until the message window is closed
-	if (!foreground && IsMessageVisible())
-		return false;
-
-	return true;
-}
-
 AsyncOp Game_Message::Update() {
 	if (window) {
 		window->Update();
@@ -229,16 +213,17 @@ void Game_Message::SetPendingMessage(PendingMessage&& pm) {
 }
 
 bool Game_Message::IsMessagePending() {
-	return window ? window->GetPendingMessage().IsActive() : false;
-}
-
-bool Game_Message::IsMessageVisible() {
-	return window ? window->IsVisible() : false;
+	return window ? window->IsMessagePending() : false;
 }
 
 bool Game_Message::IsMessageActive() {
-	return IsMessagePending() || IsMessageVisible();
+	return window ? !window->GetAllowNextMessage(false) : false;
 }
+
+bool Game_Message::CanShowMessage(bool foreground) {
+	return window ? window->GetAllowNextMessage(foreground) : false;
+}
+
 
 static Game_Message::ParseParamResult ParseParamImpl(
 		const char upper,

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -201,9 +201,7 @@ namespace Game_Message {
 
 	/** @return true if there is message text pending */
 	bool IsMessagePending();
-	/** @return true if the message window is visible */
-	bool IsMessageVisible();
-	/** @return true if IsMessagePending() || IsMessageVisible() */
+	/** @return true if message window is running */
 	bool IsMessageActive();
 
 	// EasyRPG extension allowing more recursive variables \v[\v[...]]

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -211,7 +211,7 @@ void Scene_Battle::Update() {
 		Scene::Push(std::move(call));
 	}
 
-	if (!Game_Message::IsMessageVisible() && events_finished) {
+	if (!Game_Message::IsMessageActive() && events_finished) {
 		ProcessActions();
 		ProcessInput();
 	}

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -485,7 +485,7 @@ void Scene_Map::FinishInn() {
 
 void Scene_Map::UpdateInn() {
 	// Allow message box to render during inn sequence.
-	if (Game_Message::IsMessageVisible()) {
+	if (Game_Message::IsMessageActive()) {
 		Game_Message::Update();
 		return;
 	}

--- a/src/sprite_timer.cpp
+++ b/src/sprite_timer.cpp
@@ -87,7 +87,7 @@ void Sprite_Timer::Update() {
 	if (Game_Battle::IsBattleRunning()) {
 		SetY(SCREEN_TARGET_HEIGHT / 3 * 2 - 20);
 	}
-	else if (Game_Message::IsMessageVisible() && Game_Message::GetRealPosition() == 0) {
+	else if (Game_Message::IsMessageActive() && Game_Message::GetRealPosition() == 0) {
 		SetY(SCREEN_TARGET_HEIGHT - 20);
 	}
 	else {

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -125,22 +125,20 @@ Window_Message::~Window_Message() {
 }
 
 void Window_Message::StartMessageProcessing(PendingMessage pm) {
-	contents->Clear();
+	text.clear();
 	pending_message = std::move(pm);
-	SetIndex(-1);
-	kill_page = false;
 
 	if (!IsVisible()) {
 		DebugLogResetFrameCounter();
 	}
 	DebugLog("{}: MSG START");
 
-	const auto& lines = pending_message.GetLines();
-	if (!(pending_message.NumLines() > 0 || pending_message.HasNumberInput())) {
+	if (!pending_message.IsActive()) {
 		return;
 	}
 
-	text.clear();
+	const auto& lines = pending_message.GetLines();
+
 	int num_lines = 0;
 	auto append = [&](const std::string& line) {
 		bool force_page_break = (!line.empty() && line.back() == '\f');
@@ -181,6 +179,8 @@ void Window_Message::StartMessageProcessing(PendingMessage pm) {
 	item_max = min(4, pending_message.GetNumChoices());
 
 	text_index = text.data();
+
+	DebugLog("%d: MSG TEXT \n%s", text.c_str());
 
 	auto open_frames = (!IsVisible() && !Game_Battle::IsBattleRunning()) ? message_animation_frames : 0;
 	SetOpenAnimation(open_frames);
@@ -245,6 +245,18 @@ void Window_Message::InsertNewPage() {
 	face_request_ids.clear();
 
 	contents->Clear();
+	SetIndex(-1);
+	SetPause(false);
+	number_input_window->SetActive(false);
+	number_input_window->SetVisible(false);
+	kill_page = false;
+	line_count = 0;
+	text_color = Font::ColorDefault;
+	speed = 1;
+	kill_page = false;
+	instant_speed = false;
+	prev_char_printable = false;
+	prev_char_waited = true;
 
 	y = Game_Message::GetRealPosition() * 80;
 
@@ -273,13 +285,6 @@ void Window_Message::InsertNewPage() {
 	}
 
 	contents_y = 2;
-	line_count = 0;
-	text_color = Font::ColorDefault;
-	speed = 1;
-	kill_page = false;
-	instant_speed = false;
-	prev_char_printable = false;
-	prev_char_waited = true;
 
 	if (pending_message.GetNumberInputStartLine() == 0 && pending_message.HasNumberInput()) {
 		// If there is an input window on the first line

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -296,7 +296,7 @@ void Window_Message::InsertNewPage() {
 		ShowGoldWindow();
 	} else {
 		// If first character is gold, the gold window appears immediately and animates open with the main window.
-		auto tret = Utils::TextNext(text_index, &*text.end(), Player::escape_char);
+		auto tret = Utils::TextNext(text_index, (text.data() + text.size()), Player::escape_char);
 		if (tret && tret.is_escape && tret.ch == '$') {
 			ShowGoldWindow();
 		}

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -379,12 +379,6 @@ void Window_Message::Update() {
 	close_started_this_frame = false;
 	close_finished_this_frame = false;
 
-#if 0
-	if (IsVisible() && text.empty() && !IsClosing()) {
-		TerminateMessage();
-	}
-#endif
-
 	const bool was_closing = IsClosing();
 
 	Window_Selectable::Update();

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -186,11 +186,6 @@ void Window_Message::StartMessageProcessing(PendingMessage pm) {
 	SetOpenAnimation(open_frames);
 	DebugLog("{}: MSG START OPEN {}", open_frames);
 
-	if (pending_message.ShowGoldWindow()) {
-		//GOld window on multiple pages? Does it stay up?
-		ShowGoldWindow();
-	}
-
 	InsertNewPage();
 }
 
@@ -231,11 +226,16 @@ void Window_Message::StartNumberInputProcessing() {
 }
 
 void Window_Message::ShowGoldWindow() {
-	if (!gold_window->IsVisible() && !Game_Battle::IsBattleRunning()) {
-		gold_window->SetY(y == 0 ? SCREEN_TARGET_HEIGHT - 32 : 0);
-		gold_window->Refresh();
-		gold_window->SetOpenAnimation(message_animation_frames);
+	if (Game_Battle::IsBattleRunning()) {
+		return;
 	}
+	if (!gold_window->IsVisible()) {
+		gold_window->SetY(y == 0 ? SCREEN_TARGET_HEIGHT - 32 : 0);
+		gold_window->SetOpenAnimation(message_animation_frames);
+	} else if (gold_window->IsClosing()) {
+		gold_window->SetOpenAnimation(0);
+	}
+	gold_window->Refresh();
 }
 
 void Window_Message::InsertNewPage() {
@@ -285,6 +285,17 @@ void Window_Message::InsertNewPage() {
 		StartNumberInputProcessing();
 	}
 	line_char_counter = 0;
+
+	if (pending_message.ShowGoldWindow()) {
+		ShowGoldWindow();
+	} else {
+		// If first character is gold, the gold window appears immediately and animates open with the main window.
+		auto tret = Utils::TextNext(text_index, &*text.end(), Player::escape_char);
+		if (tret && tret.is_escape && tret.ch == '$') {
+			ShowGoldWindow();
+		}
+	}
+
 }
 
 void Window_Message::InsertNewLine() {

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -566,7 +566,8 @@ void Window_Message::UpdateMessage() {
 			case '.':
 				// 1/4 second sleep
 				// Despite documentation saying 1/4 second, RPG_RT waits for 16 frames.
-				SetWaitForNonPrintable(16);
+				// RPG_RT also has a bug(??) where speeds >= 17 slow this down by 1 more frame per speed.
+				SetWaitForNonPrintable(16 + Utils::Clamp(speed - 16, 0, 4));
 				DebugLogText("{}: MSG Quick Sleep \\.");
 				break;
 			case '|':

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -38,7 +38,44 @@
 #include "cache.h"
 #include "text.h"
 
-constexpr int message_animation_frames = 8;
+// FIXME: Off by 1 bug in window base class
+constexpr int message_animation_frames = 7;
+
+namespace {
+#if defined(EP_DEBUG_MESSAGE) || defined(EP_DEBUG_MESSAGE_TEXT)
+static int frame_offset = 0;
+
+void DebugLogResetFrameCounter() {
+	frame_offset = Game_System::GetFrameCounter();
+}
+#else
+void DebugLogResetFrameCounter() { }
+#endif
+
+#ifdef EP_DEBUG_MESSAGE
+template <typename... Args>
+void DebugLog(const char* fmt, Args&&... args) {
+	int frames = Game_System::GetFrameCounter() - frame_offset;
+	Output::Debug(fmt, frames, std::forward<Args>(args)...);
+}
+#else
+
+template <typename... Args>
+void DebugLog(const char*, Args&&...) { }
+#endif
+
+#ifdef EP_DEBUG_MESSAGE_TEXT
+template <typename... Args>
+void DebugLogText(const char* fmt, Args&&... args) {
+	int frames = Game_System::GetFrameCounter() - frame_offset;
+	Output::Debug(fmt, frames, std::forward<Args>(args)...);
+}
+#else
+
+template <typename... Args>
+void DebugLogText(const char*, Args&&...) { }
+#endif
+} //namespace
 
 // C4428 is nonsense
 #ifdef _MSC_VER
@@ -69,8 +106,8 @@ Window_Message::Window_Message(int ix, int iy, int iwidth, int iheight) :
 	// Above other windows
 	SetZ(Priority_Window + 100);
 
-	active = false;
-	index = -1;
+	active = true;
+	SetIndex(-1);
 	text_color = Font::ColorDefault;
 
 	number_input_window->SetVisible(false);
@@ -82,7 +119,6 @@ Window_Message::Window_Message(int ix, int iy, int iwidth, int iheight) :
 }
 
 Window_Message::~Window_Message() {
-	TerminateMessage();
 	if (Game_Message::GetWindow() == this) {
 		Game_Message::SetWindow(nullptr);
 	}
@@ -91,7 +127,13 @@ Window_Message::~Window_Message() {
 void Window_Message::StartMessageProcessing(PendingMessage pm) {
 	contents->Clear();
 	pending_message = std::move(pm);
-	allow_next_message = false;
+	SetIndex(-1);
+	kill_page = false;
+
+	if (!IsVisible()) {
+		DebugLogResetFrameCounter();
+	}
+	DebugLog("{}: MSG START");
 
 	const auto& lines = pending_message.GetLines();
 	if (!(pending_message.NumLines() > 0 || pending_message.HasNumberInput())) {
@@ -99,12 +141,22 @@ void Window_Message::StartMessageProcessing(PendingMessage pm) {
 	}
 
 	text.clear();
+	int num_lines = 0;
 	auto append = [&](const std::string& line) {
-		text.append(line);
-		if (line.empty() || (text.back() != '\n' && text.back() != '\f')) {
-			text.append(1, '\n');
+		bool force_page_break = (!line.empty() && line.back() == '\f');
+
+		text.append(line, 0, line.size() - force_page_break);
+		if (!line.empty() && text.back() != '\n') {
+			text.push_back('\n');
+		}
+		++num_lines;
+
+		if (num_lines == 4 || force_page_break) {
+			text.push_back('\f');
+			num_lines = 0;
 		}
 	};
+
 	if (pending_message.IsWordWrapped()) {
 		for (const std::string& line : lines) {
 			/* TODO: don't take commands like \> \< into account when word-wrapping */
@@ -121,36 +173,46 @@ void Window_Message::StartMessageProcessing(PendingMessage pm) {
 			append(line);
 		}
 	}
+
+	if (text.empty() || text.back() != '\f') {
+		text.push_back('\f');
+	}
+
 	item_max = min(4, pending_message.GetNumChoices());
 
 	text_index = text.data();
 
-	// If we're displaying a new message, reset the closing animation.
-	if (closing) {
-		SetCloseAnimation(Game_Battle::IsBattleRunning() ? 0 : message_animation_frames);
+	auto open_frames = (!IsVisible() && !Game_Battle::IsBattleRunning()) ? message_animation_frames : 0;
+	SetOpenAnimation(open_frames);
+	DebugLog("{}: MSG START OPEN {}", open_frames);
+
+	if (pending_message.ShowGoldWindow()) {
+		//GOld window on multiple pages? Does it stay up?
+		ShowGoldWindow();
 	}
 
 	InsertNewPage();
 }
 
-void Window_Message::FinishMessageProcessing() {
+void Window_Message::OnFinishPage() {
+	DebugLog("{}: FINISH PAGE");
+
 	if (pending_message.GetNumChoices() > 0) {
 		StartChoiceProcessing();
 	} else if (pending_message.HasNumberInput()) {
 		StartNumberInputProcessing();
-	} else if (kill_message) {
-		TerminateMessage();
-	} else {
+	} else if (!kill_page) {
+		DebugLog("{}: SET PAUSE");
 		SetPause(true);
 	}
 
-	text.clear();
-	text_index = text.data();
+	line_count = 0;
+	kill_page = false;
+	line_char_counter = 0;
 }
 
 void Window_Message::StartChoiceProcessing() {
-	active = true;
-	index = 0;
+	SetIndex(0);
 }
 
 void Window_Message::StartNumberInputProcessing() {
@@ -175,6 +237,7 @@ void Window_Message::ShowGoldWindow() {
 }
 
 void Window_Message::InsertNewPage() {
+	DebugLog("{}: MSG NEW PAGE");
 	// Cancel pending face requests for async
 	// Otherwise they render on the wrong page
 	face_request_ids.clear();
@@ -211,6 +274,7 @@ void Window_Message::InsertNewPage() {
 	line_count = 0;
 	text_color = Font::ColorDefault;
 	speed = 1;
+	kill_page = false;
 
 	if (pending_message.GetNumberInputStartLine() == 0 && pending_message.HasNumberInput()) {
 		// If there is an input window on the first line
@@ -220,6 +284,7 @@ void Window_Message::InsertNewPage() {
 }
 
 void Window_Message::InsertNewLine() {
+	DebugLog("{}: MSG NEW LINE");
 	if (IsFaceEnabled() && !Game_Message::IsFaceRightPosition()) {
 		contents_x = LeftMargin + FaceSize + RightFaceMargin;
 	} else {
@@ -245,24 +310,38 @@ void Window_Message::InsertNewLine() {
 	line_char_counter = 0;
 }
 
-void Window_Message::TerminateMessage() {
-	active = false;
+void Window_Message::FinishMessageProcessing() {
+	DebugLog("{}: FINISH MSG");
+	text.clear();
+	text_index = text.data();
+
 	SetPause(false);
-	kill_message = false;
+	kill_page = false;
 	line_char_counter = 0;
-	index = -1;
+	SetIndex(-1);
+
+	pending_message = {};
+
+	auto close_frames = Game_Battle::IsBattleRunning() ? 0 : message_animation_frames;
 
 	if (number_input_window->IsVisible()) {
 		number_input_window->SetActive(false);
 		number_input_window->SetVisible(false);
 	}
 
-	if (gold_window->IsVisible()) {
-		gold_window->SetCloseAnimation(message_animation_frames);
-	}
+	SetCloseAnimation(close_frames);
+	close_started_this_frame = true;
+	DebugLog("{}: MSG START CLOSE {}", close_frames);
 
-	// This clears the active flag.
-	pending_message = {};
+	// RPG_RT updates window open/close at the end of the main loop.
+	// To simulate this timing, we run base class Update() again once
+	// to animate the closing by 1 frame.
+	Window::Update();
+
+	if (gold_window->IsVisible()) {
+		gold_window->SetCloseAnimation(close_frames);
+		gold_window->Update();
+	}
 }
 
 void Window_Message::ResetWindow() {
@@ -270,67 +349,73 @@ void Window_Message::ResetWindow() {
 }
 
 void Window_Message::Update() {
-	bool update_message_processing = false;
-	allow_next_message = false;
 	aop = {};
+	if (IsOpening()) { DebugLog("{}: MSG OPENING"); }
+	if (IsClosing()) { DebugLog("{}: MSG CLOSING"); }
 
-	if (pending_message.ShowGoldWindow()) {
-		ShowGoldWindow();
+	close_started_this_frame = false;
+	close_finished_this_frame = false;
+
+#if 0
+	if (IsVisible() && text.empty() && !IsClosing()) {
+		TerminateMessage();
 	}
+#endif
 
-	if (wait_count == 0) {
-		if (GetPause()) {
-			WaitForInput();
-		} else if (active) {
-			InputChoice();
-		} else if (number_input_window->IsVisible()) {
-			InputNumber();
-		} else if (!text.empty()) {
-			if (!IsVisible()) {
-				// The MessageBox is not open yet but text output is needed
-				// Open and Close Animations are skipped in battle
-				SetOpenAnimation(Game_Battle::IsBattleRunning() ? 0 : message_animation_frames);
-			} else if (closing) {
-				// If a message was requested while closing, cancel it and display the message immediately.
-				SetOpenAnimation(0);
-			} else {
-				//Handled after base class updates.
-				if (text_index != (text.data() + text.size())) {
-					update_message_processing = true;
-				}
-				if (text_index == (text.data() + text.size()) && wait_count <= 0) {
-					FinishMessageProcessing();
-				}
-			}
-		}
-
-		if (!Game_Message::IsMessagePending() && IsVisible() && !closing) {
-			// Start the closing animation
-			SetCloseAnimation(Game_Battle::IsBattleRunning() ? 0 : message_animation_frames);
-			// This frame a foreground event may push a new message and interupt the close animation.
-			allow_next_message = true;
-		}
-	}
+	const bool was_closing = IsClosing();
 
 	Window_Selectable::Update();
 	number_input_window->Update();
 	gold_window->Update();
 
-	if (wait_count > 0) {
-		--wait_count;
+	if (was_closing && !IsClosing()) {
+		close_finished_this_frame = true;
+	}
+
+	if (!IsVisible()) {
 		return;
 	}
 
-	if (update_message_processing) {
-		UpdateMessage();
-	}
-}
-
-void Window_Message::UpdateMessage() {
 	if (IsOpeningOrClosing()) {
 		return;
 	}
 
+	if (wait_count > 0) {
+		DebugLog("{}: MSG WAIT {}", wait_count);
+		--wait_count;
+		return;
+	}
+
+	if (GetPause()) {
+		DebugLog("{}: MSG PAUSE");
+		WaitForInput();
+
+		if (GetPause()) {
+			return;
+		}
+	}
+
+	if (GetIndex() >= 0) {
+		DebugLog("{}: MSG CHOICE");
+		InputChoice();
+		if (GetIndex() >= 0) {
+			return;
+		}
+	}
+
+	if (number_input_window->GetActive()) {
+		DebugLog("{}: MSG NUMBER");
+		InputNumber();
+		if (number_input_window->GetActive()) {
+			return;
+		}
+	}
+
+	DebugLog("{}: MSG UPD");
+	UpdateMessage();
+}
+
+void Window_Message::UpdateMessage() {
 	// Message Box Show Message rendering loop
 	bool instant_speed = false;
 	bool instant_speed_forced = false;
@@ -347,30 +432,22 @@ void Window_Message::UpdateMessage() {
 		const auto* end = text.data() + text.size();
 
 		if (wait_count > 0) {
+			DebugLog("{}: MSG WAIT LOOP {}", wait_count);
 			--wait_count;
-			break;
-		}
-
-		if (text_index == end) {
-			if (!instant_speed) {
-				SetWaitForPage();
-			}
-			break;
-		}
-
-		if (line_count == 4) {
-			// FIXME: Unify pause logic
-			SetPause(true);
-			new_page_after_pause = true;
-			if (!instant_speed) {
-				//FIXME: Does this wait happen when pause is enabled?
-				SetWaitForPage();
-			}
 			break;
 		}
 
 		if (GetPause()) {
 			break;
+		}
+
+		if (text_index == end) {
+			FinishMessageProcessing();
+			break;
+		}
+
+		if (text_index != &*text.begin() && *(text_index - 1) == '\f') {
+			InsertNewPage();
 		}
 
 		auto tret = Utils::TextNext(text_index, end, Player::escape_char);
@@ -387,31 +464,26 @@ void Window_Message::UpdateMessage() {
 		}
 
 		if (ch == '\n') {
-			if (text_index != end) {
-				if (!instant_speed && line_char_counter == 0) {
-					// RPG_RT will always wait 1 frame for each empty line.
-					SetWait(1);
-				}
-				if (instant_speed && !instant_speed_forced) {
-					// instant_speed stops at the end of the line
-					// unless it was triggered by the shift key.
-					instant_speed = false;
-				}
-			}
 			InsertNewLine();
-			continue;
-		}
 
-		if (ch == '\f') {
-			// Used by our code to inject form feeds.
-			instant_speed = false;
+			if (*text_index == '\f') {
+				++text_index;
 
-			if (text_index != end) {
-				SetPause(true);
-				new_page_after_pause = true;
+				OnFinishPage();
+
+				if (instant_speed) {
+					// When the page ends and speed is instant, RPG_RT always waits 2 frames.
+					SetWait(2);
+				}
+
 			}
-			//FIXME: Delays formfeed?
-			break;
+
+			if (instant_speed && !instant_speed_forced) {
+				// instant_speed stops at the end of the line
+				// unless it was triggered by the shift key.
+				instant_speed = false;
+			}
+			continue;
 		}
 
 		if (Utils::IsControlCharacter(ch)) {
@@ -430,6 +502,8 @@ void Window_Message::UpdateMessage() {
 					auto value = pres.value;
 					text_color = value > 19 ? 0 : value;
 					text_index = pres.next;
+					DebugLogText("{}: MSG Color \\c[{}]", text_color);
+					SetWaitForNonPrintable(0, instant_speed);
 				}
 				break;
 			case 's':
@@ -439,56 +513,61 @@ void Window_Message::UpdateMessage() {
 					auto pres = Game_Message::ParseSpeed(text_index, end, Player::escape_char, true);
 					speed = Utils::Clamp(pres.value, 1, 20);
 					text_index = pres.next;
+					DebugLogText("{}: MSG Speed \\s[{}]", speed);
+					SetWaitForNonPrintable(0, instant_speed);
 				}
 				break;
 			case '_':
 				// Insert half size space
 				contents_x += Font::Default()->GetSize(" ").width / 2;
-				if (!instant_speed) {
-					SetWaitForCharacter(1);
-				}
-				IncrementLineCharCounter(1);
+				DebugLogText("{}: MSG HalfWait \\_");
+				SetWaitForCharacter(1, instant_speed);
 				break;
 			case '$':
 				// Show Gold Window
 				ShowGoldWindow();
-				if (!instant_speed) {
-					SetWait(speed);
-				}
+				DebugLogText("{}: MSG Gold \\$");
+				SetWaitForNonPrintable(speed, instant_speed);
 				break;
 			case '!':
 				// Text pause
+				// FIXME Timing this? When is arrow?
+				DebugLogText("{}: MSG Pause \\!");
 				SetPause(true);
 				break;
 			case '^':
 				// Force message close
 				// The close happens at the end of the message, not where
 				// the ^ is encountered
-				kill_message = true;
+				DebugLogText("{}: MSG Kill Page \\^");
+				kill_page = true;
+				SetWaitForNonPrintable(speed, instant_speed);
 				break;
 			case '>':
 				// Instant speed start
+				DebugLogText("{}: MSG Instant Speed Start \\>");
+				// FIXME: Support this.
+				//SetWaitForNonPrintable(0, instant_speed);
 				instant_speed = true;
 				break;
 			case '<':
 				// Instant speed stop - also cancels shift key and forces a delay.
 				instant_speed = false;
 				instant_speed_forced = false;
-				SetWait(speed);
+				DebugLogText("{}: MSG Instant Speed Stop \\<");
+				SetWaitForNonPrintable(speed, instant_speed);
 				break;
 			case '.':
 				// 1/4 second sleep
-				if (!instant_speed) {
-					// Despite documentation saying 1/4 second, RPG_RT waits for 20 frames.
-					SetWait(20);
-				}
+				// Despite documentation saying 1/4 second, RPG_RT waits for 16 frames.
+				SetWaitForNonPrintable(16, instant_speed);
+				DebugLogText("{}: MSG Quick Sleep \\.");
 				break;
 			case '|':
 				// Second sleep
-				if (!instant_speed) {
-					// Despite documentation saying 1 second, RPG_RT waits for 61 frames.
-					SetWait(61);
-				}
+				// Despite documentation saying 1 second, RPG_RT waits for 61 frames.
+				SetWaitForNonPrintable(61, instant_speed);
+				DebugLogText("{}: MSG Sleep \\|");
 				break;
 			default:
 				break;
@@ -501,20 +580,24 @@ void Window_Message::UpdateMessage() {
 }
 
 void Window_Message::DrawGlyph(Font& font, const Bitmap& system, char32_t glyph, bool instant_speed, bool is_exfont) {
-#ifdef EP_DEBUG_MESSAGE
-	Output::Debug("Msg Draw Glyph {:#x} {}", uint32_t(glyph), instant_speed);
-#endif
+	if (is_exfont) {
+		DebugLogText("{}: MSG DrawGlyph Exfont {}", static_cast<uint32_t>(glyph));
+	} else {
+		if (glyph < 128) {
+			DebugLogText("{}: MSG DrawGlyph ASCII {}", static_cast<char>(glyph));
+		} else {
+			DebugLogText("{}: MSG DrawGlyph UTF32 {#:X}", static_cast<uint32_t>(glyph));
+		}
+	}
+
 	auto rect = Text::Draw(*contents, contents_x, contents_y, font, system, text_color, glyph, is_exfont);
 
 	int glyph_width = rect.width;
 	contents_x += glyph_width;
-	int width = (glyph_width - 1) / 6 + 1;
-	if (!instant_speed && glyph_width > 0) {
-		// RPG_RT compatible for half-width (6) and full-width (12)
-		// generalizes the algo for even bigger glyphs
-		SetWaitForCharacter(width);
-	}
-	IncrementLineCharCounter(width);
+	int width = (glyph_width > 0) ? (glyph_width - 1) / 6 + 1 : 0;
+	// RPG_RT compatible for half-width (6) and full-width (12)
+	// generalizes the algo for even bigger glyphs
+	SetWaitForCharacter(width, instant_speed);
 }
 
 void Window_Message::IncrementLineCharCounter(int width) {
@@ -550,30 +633,19 @@ void Window_Message::UpdateCursorRect() {
 }
 
 void Window_Message::WaitForInput() {
-	active = true; // Enables the Pause arrow
 	if (Input::IsTriggered(Input::DECISION) ||
 			Input::IsTriggered(Input::CANCEL)) {
-		active = false;
 		SetPause(false);
-
-		if (text.empty()) {
-			TerminateMessage();
-		} else if (text_index != (text.data() + text.size()) && new_page_after_pause) {
-			new_page_after_pause = false;
-			InsertNewPage();
-		}
 	}
 }
 
 void Window_Message::InputChoice() {
-	bool do_terminate = false;
 	int choice_result = -1;
 
 	if (Input::IsTriggered(Input::CANCEL)) {
 		if (pending_message.GetChoiceCancelType() > 0) {
 			Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cancel));
 			choice_result = pending_message.GetChoiceCancelType() - 1; // Cancel
-			do_terminate = true;
 		}
 	} else if (Input::IsTriggered(Input::DECISION)) {
 		if (!pending_message.IsChoiceEnabled(index)) {
@@ -583,17 +655,15 @@ void Window_Message::InputChoice() {
 
 		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 		choice_result = index;
-		do_terminate = true;
 	}
 
-	if (do_terminate) {
-		if (choice_result >= 0) {
-			auto& continuation = pending_message.GetChoiceContinuation();
-			if (continuation) {
-				aop = continuation(choice_result);
-			}
+	if (choice_result >= 0) {
+		auto& continuation = pending_message.GetChoiceContinuation();
+		if (continuation) {
+			aop = continuation(choice_result);
 		}
-		TerminateMessage();
+		// This disables choices
+		index = -1;
 	}
 }
 
@@ -602,37 +672,64 @@ void Window_Message::InputNumber() {
 		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 		Main_Data::game_variables->Set(pending_message.GetNumberInputVariable(), number_input_window->GetNumber());
 		Game_Map::SetNeedRefresh(true);
-		TerminateMessage();
 		number_input_window->SetNumber(0);
+		number_input_window->SetActive(false);
 	}
 }
 
-void Window_Message::SetWaitForCharacter(int width) {
+void Window_Message::SetWaitForNonPrintable(int frames, bool instant_speed) {
+	if (!instant_speed) {
+		bool is_last_for_page = (text.data() + text.size() - text_index) < 2 || (*text_index == '\n' && *(text_index + 1) == '\f');
+		if (is_last_for_page) {
+			// If the page ends with a non-printable, RPG_RT waits 2 extra frames.
+			frames += 2;
+		} else if (*text_index == '\n') {
+			// If the line ends with a non-printable, RPG_RT waits 1 extra frame.
+			frames += 1;
+		}
+
+		if (speed <= 1) {
+			frames += (line_char_counter & 1);
+		}
+		SetWait(frames);
+	}
+	// Non printables only contribute to character count after the first printable..
+	if (line_char_counter > 0) {
+		IncrementLineCharCounter(1);
+	}
+}
+
+void Window_Message::SetWaitForCharacter(int width, bool instant_speed) {
 	int frames = 0;
-	if (width > 0) {
-		if (speed > 1) {
-			frames = speed * width / 2 + 1;
+	if (!instant_speed && width > 0) {
+		bool is_last_for_page = (text.data() + text.size() - text_index) < 2 || (*text_index == '\n' && *(text_index + 1) == '\f');
+
+		if (is_last_for_page) {
+			// RPG_RT always waits 2 frames for last character on the page.
+			// FIXME: Exfonts / wide last on page?
+			frames = 2;
 		} else {
-			frames = width / 2;
-			if (width & 1) {
-				// For odd widths, speed 1 adds a 1 frame delay for every odd character printed.
-				// This logic assumes num chars is incremented after the wait.
-				frames += !(line_char_counter & 1);
+			if (speed > 1) {
+				frames = speed * width / 2 + 1;
+			} else {
+				frames = width / 2;
+				if (width & 1) {
+					bool is_last_for_line = (*text_index == '\n');
+
+					// RPG_RT waits for every even character. Also always waits
+					// for the last character.
+					frames += (line_char_counter & 1) || is_last_for_line;
+				}
 			}
 		}
 	}
 	SetWait(frames);
-}
-
-void Window_Message::SetWaitForPage() {
-	SetWait(speed);
+	IncrementLineCharCounter(width);
 }
 
 void Window_Message::SetWait(int frames) {
 	assert(speed >= 1 && speed <= 20);
-#ifdef EP_DEBUG_MESSAGE
-	Output::Debug("Msg Wait {}", frames);
-#endif
+	DebugLogText("{}: MSG SetWait {}", frames);
 	wait_count = frames;
 }
 

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -597,6 +597,8 @@ void Window_Message::UpdateMessage() {
 				DebugLogText("{}: MSG Sleep \\|");
 				break;
 			default:
+				// Unknown characters will not display anything but do wait.
+				SetWaitForNonPrintable(speed);
 				break;
 			}
 			continue;

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -224,7 +224,9 @@ void Window_Message::StartNumberInputProcessing() {
 	}
 	number_input_window->SetY(y + contents_y - 2);
 	number_input_window->SetActive(true);
-	number_input_window->SetVisible(true);
+	if (visible && !IsOpeningOrClosing()) {
+		number_input_window->SetVisible(true);
+	}
 	number_input_window->Update();
 }
 
@@ -437,7 +439,7 @@ void Window_Message::UpdateMessage() {
 			break;
 		}
 
-		if (GetPause()) {
+		if (GetPause() || GetIndex() >= 0 || number_input_window->GetActive()) {
 			break;
 		}
 
@@ -668,6 +670,7 @@ void Window_Message::InputChoice() {
 }
 
 void Window_Message::InputNumber() {
+	number_input_window->SetVisible(true);
 	if (Input::IsTriggered(Input::DECISION)) {
 		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 		Main_Data::game_variables->Set(pending_message.GetNumberInputVariable(), number_input_window->GetNumber());

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -468,10 +468,6 @@ void Window_Message::UpdateMessage() {
 			break;
 		}
 
-		if (text_index != &*text.begin() && *(text_index - 1) == '\f') {
-			InsertNewPage();
-		}
-
 		auto tret = Utils::TextNext(text_index, end, Player::escape_char);
 		auto text_prev = text_index;
 		text_index = tret.next;
@@ -484,6 +480,14 @@ void Window_Message::UpdateMessage() {
 		if (tret.is_exfont) {
 			if (!DrawGlyph(*font, *system, ch, true)) {
 				text_index = text_prev;
+			}
+			continue;
+		}
+
+		if (ch == '\f') {
+			if (text_index != end) {
+				InsertNewPage();
+				SetWait(1);
 			}
 			continue;
 		}
@@ -503,9 +507,7 @@ void Window_Message::UpdateMessage() {
 
 			InsertNewLine();
 
-			if (*text_index == '\f') {
-				++text_index;
-
+			if (end_page) {
 				OnFinishPage();
 			}
 			SetWait(wait_frames);

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -278,6 +278,7 @@ void Window_Message::InsertNewPage() {
 	speed = 1;
 	kill_page = false;
 	instant_speed = false;
+	printable_did_not_wait = false;
 
 	if (pending_message.GetNumberInputStartLine() == 0 && pending_message.HasNumberInput()) {
 		// If there is an input window on the first line
@@ -311,6 +312,7 @@ void Window_Message::InsertNewLine() {
 		contents_x += 12;
 	}
 	line_char_counter = 0;
+	printable_did_not_wait = false;
 }
 
 void Window_Message::FinishMessageProcessing() {
@@ -453,6 +455,7 @@ void Window_Message::UpdateMessage() {
 		}
 
 		auto tret = Utils::TextNext(text_index, end, Player::escape_char);
+		auto text_prev = text_index;
 		text_index = tret.next;
 
 		if (EP_UNLIKELY(!tret)) {
@@ -461,7 +464,9 @@ void Window_Message::UpdateMessage() {
 
 		const auto ch = tret.ch;
 		if (tret.is_exfont) {
-			DrawGlyph(*font, *system, ch, true);
+			if (!DrawGlyph(*font, *system, ch, true)) {
+				text_index = text_prev;
+			}
 			continue;
 		}
 
@@ -576,11 +581,14 @@ void Window_Message::UpdateMessage() {
 			continue;
 		}
 
-		DrawGlyph(*font, *system, ch, false);
+		if (!DrawGlyph(*font, *system, ch, false)) {
+			text_index = text_prev;
+			continue;
+		}
 	}
 }
 
-void Window_Message::DrawGlyph(Font& font, const Bitmap& system, char32_t glyph, bool is_exfont) {
+bool Window_Message::DrawGlyph(Font& font, const Bitmap& system, char32_t glyph, bool is_exfont) {
 	if (is_exfont) {
 		DebugLogText("{}: MSG DrawGlyph Exfont {}", static_cast<uint32_t>(glyph));
 	} else {
@@ -591,20 +599,39 @@ void Window_Message::DrawGlyph(Font& font, const Bitmap& system, char32_t glyph,
 		}
 	}
 
+	// RPG_RT compatible for half-width (6) and full-width (12)
+	// generalizes the algo for even bigger glyphs
+	auto get_width = [](int w) {
+		return (w > 0) ? (w - 1) / 6 + 1 : 0;
+	};
+
+	// Wide characters cause an extra wait if the last printed character did not wait.
+	if (printable_did_not_wait) {
+		auto& wide_font = is_exfont ? *Font::exfont : font;
+		auto rect = wide_font.GetSize(glyph);
+		auto width = get_width(rect.width);
+		if (width >= 2) {
+			printable_did_not_wait = false;
+			++line_char_counter;
+			SetWait(1);
+			return false;
+		}
+	}
+
 	auto rect = Text::Draw(*contents, contents_x, contents_y, font, system, text_color, glyph, is_exfont);
 
 	int glyph_width = rect.width;
 	contents_x += glyph_width;
-	int width = (glyph_width > 0) ? (glyph_width - 1) / 6 + 1 : 0;
-	// RPG_RT compatible for half-width (6) and full-width (12)
-	// generalizes the algo for even bigger glyphs
+	int width = get_width(glyph_width);
 	SetWaitForCharacter(width);
+
+	return true;
 }
 
 void Window_Message::IncrementLineCharCounter(int width) {
-	// For speed 1, RPG_RT prints 2 half width chars every frame. This 
+	// For speed 1, RPG_RT prints 2 half width chars every frame. This
 	// resets anytime we print a full width character or another
-	// character with a different speed. 
+	// character with a different speed.
 	// To emulate this, we increment by 2 and clear the low bit anytime
 	// we're not a speed 1 half width char.
 	if (width == 1 && speed <= 1) {
@@ -727,6 +754,7 @@ void Window_Message::SetWaitForCharacter(int width) {
 			}
 		}
 	}
+	printable_did_not_wait = (!instant_speed && frames == 0);
 	SetWait(frames);
 	IncrementLineCharCounter(width);
 }

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -518,10 +518,10 @@ void Window_Message::UpdateMessage() {
 					// Color
 					auto pres = Game_Message::ParseColor(text_index, end, Player::escape_char, true);
 					auto value = pres.value;
-					text_color = value > 19 ? 0 : value;
 					text_index = pres.next;
-					DebugLogText("{}: MSG Color \\c[{}]", text_color);
+					DebugLogText("{}: MSG Color \\c[{}]", value);
 					SetWaitForNonPrintable(0);
+					text_color = value > 19 ? 0 : value;
 				}
 				break;
 			case 's':
@@ -529,10 +529,10 @@ void Window_Message::UpdateMessage() {
 				{
 					// Speed modifier
 					auto pres = Game_Message::ParseSpeed(text_index, end, Player::escape_char, true);
-					speed = Utils::Clamp(pres.value, 1, 20);
 					text_index = pres.next;
-					DebugLogText("{}: MSG Speed \\s[{}]", speed);
+					DebugLogText("{}: MSG Speed \\s[{}]", pres.value);
 					SetWaitForNonPrintable(0);
+					speed = Utils::Clamp(pres.value, 1, 20);
 				}
 				break;
 			case '_':

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -565,8 +565,8 @@ void Window_Message::UpdateMessage() {
 				break;
 			case '!':
 				// Text pause
-				// FIXME Timing this? When is arrow?
 				DebugLogText("{}: MSG Pause \\!");
+				SetWaitForNonPrintable(0);
 				SetPause(true);
 				break;
 			case '^':

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -163,8 +163,10 @@ protected:
 	 * or by 2 for any other character */
 	int line_char_counter = 0;
 
-	/** Did the last printable character wait? */
-	bool printable_did_not_wait = false;
+	/** Did we wait for the prev character */
+	bool prev_char_waited = true;
+	/** Was the previous character printable? */
+	bool prev_char_printable = false;
 
 	/** Used by the number input event. */
 	std::unique_ptr<Window_NumberInput> number_input_window;
@@ -176,7 +178,7 @@ protected:
 	void IncrementLineCharCounter(int width);
 
 	void SetWaitForCharacter(int width);
-	void SetWaitForNonPrintable(int frames, bool check_end = true);
+	void SetWaitForNonPrintable(int frames);
 	void SetWait(int frames);
 
 	bool IsFaceEnabled() const;

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -163,13 +163,16 @@ protected:
 	 * or by 2 for any other character */
 	int line_char_counter = 0;
 
+	/** Did the last printable character wait? */
+	bool printable_did_not_wait = false;
+
 	/** Used by the number input event. */
 	std::unique_ptr<Window_NumberInput> number_input_window;
 	std::unique_ptr<Window_Gold> gold_window;
 
 	PendingMessage pending_message;
 
-	void DrawGlyph(Font& font, const Bitmap& system, char32_t glyph, bool is_exfont);
+	bool DrawGlyph(Font& font, const Bitmap& system, char32_t glyph, bool is_exfont);
 	void IncrementLineCharCounter(int width);
 
 	void SetWaitForCharacter(int width);

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -141,12 +141,14 @@ protected:
 	const char* text_index = nullptr;
 	/** text message that will be displayed. */
 	std::string text;
-	/** Used by Message kill command \^. */
-	bool kill_page = false;
 	/** Text color. */
 	int text_color = 0;
 	/** Current speed modifier. */
 	int speed = 1;
+	/** Used by Message kill command \^. */
+	bool kill_page = false;
+	/** If instant speed is enabled */
+	bool instant_speed = false;
 
 	// FIXME: This hacky flags exist because RPG_RT likely animates the message window
 	// after the game loop finishes. Our code isn't structured that way, so we must hack
@@ -167,11 +169,11 @@ protected:
 
 	PendingMessage pending_message;
 
-	void DrawGlyph(Font& font, const Bitmap& system, char32_t glyph, bool instant_speed, bool is_exfont);
+	void DrawGlyph(Font& font, const Bitmap& system, char32_t glyph, bool is_exfont);
 	void IncrementLineCharCounter(int width);
 
-	void SetWaitForCharacter(int width, bool instant_speed);
-	void SetWaitForNonPrintable(int frames, bool instant_speed);
+	void SetWaitForCharacter(int width);
+	void SetWaitForNonPrintable(int frames, bool check_end = true);
 	void SetWait(int frames);
 
 	bool IsFaceEnabled() const;

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -80,11 +80,7 @@ public:
 	 */
 	void InsertNewLine();
 
-	/**
-	 * Closes the Messagebox and clears the waiting-flag
-	 * (allows the interpreter to continue).
-	 */
-	void TerminateMessage();
+	void OnFinishPage();
 
 	/**
 	 * Stub.
@@ -123,8 +119,11 @@ public:
 	/** @return the stored PendingMessage */
 	const PendingMessage& GetPendingMessage() const;
 
+	/** @return true if there is still text pending */
+	bool IsMessagePending() const;
+
 	/** @return true if we can push a new message this frame */
-	bool GetAllowNextMessage() const;
+	bool GetAllowNextMessage(bool foreground) const;
 
 	/** @return the last async operation */
 	AsyncOp GetAsyncOp() const;
@@ -143,15 +142,17 @@ protected:
 	/** text message that will be displayed. */
 	std::string text;
 	/** Used by Message kill command \^. */
-	bool kill_message = false;
+	bool kill_page = false;
 	/** Text color. */
 	int text_color = 0;
 	/** Current speed modifier. */
 	int speed = 1;
-	/** If true inserts a new page after pause ended */
-	bool new_page_after_pause = false;
-	/** If true, we allow a new message to be pushed this frame */
-	bool allow_next_message = false;
+
+	// FIXME: This hacky flags exist because RPG_RT likely animates the message window
+	// after the game loop finishes. Our code isn't structured that way, so we must hack
+	// around it.
+	bool close_started_this_frame = false;
+	bool close_finished_this_frame = false;
 
 	/** Frames to wait when a message wait command was used */
 	int wait_count = 0;
@@ -169,8 +170,8 @@ protected:
 	void DrawGlyph(Font& font, const Bitmap& system, char32_t glyph, bool instant_speed, bool is_exfont);
 	void IncrementLineCharCounter(int width);
 
-	void SetWaitForCharacter(int width);
-	void SetWaitForPage();
+	void SetWaitForCharacter(int width, bool instant_speed);
+	void SetWaitForNonPrintable(int frames, bool instant_speed);
 	void SetWait(int frames);
 
 	bool IsFaceEnabled() const;
@@ -180,12 +181,17 @@ inline const PendingMessage& Window_Message::GetPendingMessage() const {
 	return pending_message;
 }
 
-inline bool Window_Message::GetAllowNextMessage() const {
-	return allow_next_message;
+inline bool Window_Message::IsMessagePending() const {
+	return IsVisible() && !IsClosing();
 }
 
 inline AsyncOp Window_Message::GetAsyncOp() const {
 	return aop;
+}
+
+inline bool Window_Message::GetAllowNextMessage(bool foreground) const {
+	bool is_active = (IsVisible() || close_finished_this_frame);
+	return foreground ? !is_active || close_started_this_frame : !is_active;
 }
 
 #endif


### PR DESCRIPTION
Depends on #1964 

Fixes more cases of #1706

This is yet another refactor of Window_Message. I've tried to clean up the Update loop to make it more understandable.

Unfortunately the number of edge cases here is just insane. So making this code readable is a real challenge.

There are a number of notable issues
* RPG_RT animates open/close after the main loop. Since we don't do this, I had to put in hacks to emulate the timing.
* I've finally nailed down the exact timing (and the rationale for why it works this way) for window open, close, and the interpreter blocking. 
* There are many, many subtle edge cases previously unknown with character timing. Even more-so with speed=1. Many have been discovered and added.

For this PR I have a much improved workflow to measure accuracy. To time any message, you can setup the following:

Foreground Event:
```
Msg: \^
FlashScreen 31,31,31,31 0.0s (no wait)
Var1 = 0
Msg: MESSAGE TO TEST
Msg: Time \v[1]
```

Parallel event
```
Var1+=1
```

To get individual character timings within a message, you have to do screen captures. I am doing this with `simplescreenrecorder` on linux by recording RPG_RT at 60fps. Then I use `ffmpeg -i vid.mkv frames%0004d.png` to dump the frames to png files and look at them.

The flash command in the above event helps identify exactly the frame where the message event command is executed and pushed into the messaging system.
The above construct will measure the exact number of frames the message takes to render.

Instead of writing page after page of test cases in issues. I have a test game with lots of message tests.

The test game is here. 

https://github.com/fmatthew5876/EasyRPG-InterpreterTestGame

All maps under the "Messages" Map tree have the #1706 test cases.
In particular the map `Messages / MESSAGE CRAZY` has a lot of NPCs with different text timing edge cases. Just talk to each NPC in RPG_RT and Player and compare.

#1706 Retested:
- [x] 1 - 16 Pass
- [x] 19 -24 Pass
- [x] 25 Timers retested - still working
- [x] 28-30 Pass
- [x] 31 We don't emulate system graphic corruption and shouldn't
- [x] 32-39 Pass

#1706 Newly fixed:
- [x] 26 Inn interruption tested with text, choices, and number input. 

- [x] 40 - tested and working
- [x] 41 - Timings match


#1706 Still broken:
- [ ] 17 & 18 Pushed to later PR
- [ ] 27 Test 1 - Pushed to later PR
- [ ] 27 Test 2 - box doesn't close.
- [ ] 42 - We don't interrupt the message
- [ ] 43 - Currently off by 1 frame.
- [ ] 44 - We set `show_message` chunk but it gets cleared every frame due to `Game_Map::UpdateForegroundEvents()` always calling `Game_Interpreter::Clear()` even when no events run.
- [ ] 45 Don't match
