### PR TITLE
Optimize Tilemap

### DIFF
--- a/bench/bitmap.cpp
+++ b/bench/bitmap.cpp
@@ -48,9 +48,8 @@ BENCHMARK(BM_FindFormat);
 static void BM_ComputeImageOpacity(benchmark::State& state) {
 	Bitmap::SetFormat(format_R8G8B8A8_a().format());
 	auto bm = Bitmap::Create(320, 240);
-	auto rect = bm->GetRect();
 	for (auto _: state) {
-		bm->ComputeImageOpacity(rect);
+		bm->ComputeImageOpacity();
 	}
 }
 

--- a/bench/bitmap.cpp
+++ b/bench/bitmap.cpp
@@ -45,6 +45,35 @@ static void BM_FindFormat(benchmark::State& state) {
 
 BENCHMARK(BM_FindFormat);
 
+static void BM_ComputeImageOpacity(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	auto bm = Bitmap::Create(320, 240);
+	auto rect = bm->GetRect();
+	for (auto _: state) {
+		bm->ComputeImageOpacity(rect);
+	}
+}
+
+BENCHMARK(BM_ComputeImageOpacity);
+
+static void BM_ComputeImageOpacityChipset(benchmark::State& state) {
+	Bitmap::SetFormat(format_R8G8B8A8_a().format());
+	const int w = 480;
+	const int h = 256;
+	const int dx = 16;
+	const int dy = 16;
+	auto bm = Bitmap::Create(w, h);
+	for (auto _: state) {
+		for (int y = 0; y < h; y += dy) {
+			for (int x = 0; x < w; x += dx) {
+				bm->ComputeImageOpacity(Rect{ x, y, dx, dy });
+			}
+		}
+	}
+}
+
+BENCHMARK(BM_ComputeImageOpacityChipset);
+
 static void BM_Create(benchmark::State& state) {
 	Bitmap::SetFormat(format);
 	for (auto _: state) {

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -273,13 +273,15 @@ void Bitmap::CheckPixels(uint32_t flags) {
 	}
 
 	if (flags & Flag_Chipset) {
-		tile_opacity.clear();
-		tile_opacity.resize(height() / 16);
-		for (int row = 0; row < height() / 16; row++) {
-			tile_opacity[row].resize(width() / 16);
-			for (int col = 0; col < width() / 16; col++) {
-				Rect rect(col * 16, row * 16, 16, 16);
-				tile_opacity[row][col] = ComputeImageOpacity(rect);
+		const int h = height() / TILE_SIZE;
+		const int w = width() / TILE_SIZE;
+		tile_opacity = TileOpacity(w, h);
+
+		for (int ty = 0; ty < h; ++ty) {
+			for (int tx = 0; tx < w; ++tx) {
+				Rect rect(tx * TILE_SIZE, ty * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+				auto op = ComputeImageOpacity(rect);
+				tile_opacity.Set(tx, ty, op);
 			}
 		}
 	}

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -164,12 +164,12 @@ public:
 	 * Provides opacity information about a tile on a tilemap.
 	 * This influences the selected operator when blitting a tile.
 	 *
-	 * @param row tile row
-	 * @param col tile col
+	 * @param x tile x coordinate
+	 * @param y tile y coordinate
 	 *
 	 * @return opacity information
 	 */
-	ImageOpacity GetTileOpacity(int row, int col) const;
+	ImageOpacity GetTileOpacity(int x, int y) const;
 
 	/**
 	 * Writes PNG converted bitmap to output stream.
@@ -575,8 +575,8 @@ inline ImageOpacity Bitmap::GetImageOpacity() const {
 	return image_opacity;
 }
 
-inline ImageOpacity Bitmap::GetTileOpacity(int row, int col) const {
-	return !tile_opacity.Empty() ? tile_opacity.Get(row, col) : ImageOpacity::Partial;
+inline ImageOpacity Bitmap::GetTileOpacity(int x, int y) const {
+	return !tile_opacity.Empty() ? tile_opacity.Get(x, y) : ImageOpacity::Partial;
 }
 
 inline Color Bitmap::GetBackgroundColor() const {

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -151,14 +151,6 @@ public:
 		Flag_ReadOnly = 1 << 16
 	};
 
-	enum TileOpacity {
-		// Image is full opaque and can be blitted fast
-		Opaque,
-		// Image has alpha and needs an alpha blit
-		Partial,
-		// Image is complately transparent
-		Transparent
-	};
 
 	/**
 	 * Provides opacity information about the image.
@@ -166,7 +158,7 @@ public:
 	 *
 	 * @return opacity information
 	 */
-	TileOpacity GetOpacity() const;
+	ImageOpacity GetImageOpacity() const;
 
 	/**
 	 * Provides opacity information about a tile on a tilemap.
@@ -177,7 +169,7 @@ public:
 	 *
 	 * @return opacity information
 	 */
-	TileOpacity GetTileOpacity(int row, int col) const;
+	ImageOpacity GetTileOpacity(int row, int col) const;
 
 	/**
 	 * Writes PNG converted bitmap to output stream.
@@ -538,13 +530,13 @@ public:
 	int bpp() const;
 	int pitch() const;
 
-protected:
-	TileOpacity CheckOpacity(Rect const& rect);
+	ImageOpacity ComputeImageOpacity(Rect rect) const;
 
+protected:
 	DynamicFormat format;
 
-	std::vector<std::vector<TileOpacity>> tile_opacity;
-	TileOpacity opacity = Partial;
+	std::vector<std::vector<ImageOpacity>> tile_opacity;
+	ImageOpacity image_opacity = ImageOpacity::Partial;
 	Color bg_color, sh_color;
 
 	friend void Text::Draw(Bitmap& dest, int x, int y, int color, FontRef font, std::string const& text, Text::Alignment align);
@@ -577,5 +569,21 @@ protected:
 	pixman_op_t GetOperator(pixman_image_t* mask = nullptr) const;
 	bool read_only = false;
 };
+
+inline ImageOpacity Bitmap::GetImageOpacity() const {
+	return image_opacity;
+}
+
+inline ImageOpacity Bitmap::GetTileOpacity(int row, int col) const {
+	return !tile_opacity.empty() ? tile_opacity[row][col] : ImageOpacity::Partial;
+}
+
+inline Color Bitmap::GetBackgroundColor() const {
+	return bg_color;
+}
+
+inline Color Bitmap::GetShadowColor() const {
+	return sh_color;
+}
 
 #endif

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -536,8 +536,8 @@ public:
 protected:
 	DynamicFormat format;
 
-	std::vector<std::vector<ImageOpacity>> tile_opacity;
 	ImageOpacity image_opacity = ImageOpacity::Partial;
+	TileOpacity tile_opacity;
 	Color bg_color, sh_color;
 
 	friend void Text::Draw(Bitmap& dest, int x, int y, int color, FontRef font, std::string const& text, Text::Alignment align);
@@ -576,7 +576,7 @@ inline ImageOpacity Bitmap::GetImageOpacity() const {
 }
 
 inline ImageOpacity Bitmap::GetTileOpacity(int row, int col) const {
-	return !tile_opacity.empty() ? tile_opacity[row][col] : ImageOpacity::Partial;
+	return !tile_opacity.Empty() ? tile_opacity.Get(row, col) : ImageOpacity::Partial;
 }
 
 inline Color Bitmap::GetBackgroundColor() const {

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -530,6 +530,7 @@ public:
 	int bpp() const;
 	int pitch() const;
 
+	ImageOpacity ComputeImageOpacity() const;
 	ImageOpacity ComputeImageOpacity(Rect rect) const;
 
 protected:

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -21,10 +21,27 @@
 #ifdef __GNUC__
 #define EP_LIKELY(x) __builtin_expect(!!(x), 1)
 #define EP_UNLIKELY(x) __builtin_expect(!!(x), 0)
+
 #define EP_FALLTHROUGH __attribute__((fallthrough))
-#else
+
+#define EP_ALWAYS_INLINE __attribute__((always_inline)) inline
+
+#elif _MSC_VER
+
 #define EP_LIKELY(x) (x)
 #define EP_UNLIKELY(x) (x)
+
+#define EP_FALLTHROUGH do {} while (false)
+
+#define EP_ALWAYS_INLINE __forceinline
+
+#else
+
+#define EP_LIKELY(x) (x)
+#define EP_UNLIKELY(x) (x)
+
+#define EP_ALWAYS_INLINE inline
+
 #define EP_FALLTHROUGH do {} while (false)
 #endif
 

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -19,10 +19,9 @@
 #define EP_COMPILER_H
 
 #ifdef __GNUC__
+
 #define EP_LIKELY(x) __builtin_expect(!!(x), 1)
 #define EP_UNLIKELY(x) __builtin_expect(!!(x), 0)
-
-#define EP_FALLTHROUGH __attribute__((fallthrough))
 
 #define EP_ALWAYS_INLINE __attribute__((always_inline)) inline
 
@@ -30,8 +29,6 @@
 
 #define EP_LIKELY(x) (x)
 #define EP_UNLIKELY(x) (x)
-
-#define EP_FALLTHROUGH do {} while (false)
 
 #define EP_ALWAYS_INLINE __forceinline
 
@@ -42,7 +39,6 @@
 
 #define EP_ALWAYS_INLINE inline
 
-#define EP_FALLTHROUGH do {} while (false)
 #endif
 
 #endif

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1230,7 +1230,7 @@ void Game_Actor::ChangeClass(int new_class_id,
 		case eSkillReset:
 			// RPG_RT has a bug where if (new_level == 1 && new_class_id == prev_class_id) no skills are removed.
 			UnlearnAllSkills();
-			EP_FALLTHROUGH;
+			// fall through
 		case eSkillAdd:
 			// RPG_RT has a bug where if (new_class_id == prev_class_id) level 1 skills are not learned.
 			LearnLevelSkills(1, new_level, pm);

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -335,7 +335,6 @@ void Game_Screen::InitSand() {
 	particles.resize(num_particles);
 
 	const int w = SCREEN_TARGET_WIDTH * 16;
-	const int h = SCREEN_TARGET_HEIGHT * 16;
 	for (auto& p: particles) {
 		auto angle = Utils::GetRandomNumber(0, 360);
 		if (angle <= 180) {

--- a/src/opacity.h
+++ b/src/opacity.h
@@ -68,7 +68,7 @@ enum class ImageOpacity {
 	Partial,
 	/** Image is full opaque and can be blitted fast */
 	Opaque,
-	/** Image is complately transparent and blitting can be skipped entirely */
+	/** Image is completely transparent and blitting can be skipped entirely */
 	Transparent
 };
 

--- a/src/opacity.h
+++ b/src/opacity.h
@@ -96,10 +96,6 @@ class TileOpacity {
 		std::unique_ptr<uint8_t[]> _p;
 		int _w = 0;
 		int _h = 0;
-
-		/** Must be enough bits to store all valid ImageOpacity values */
-		static constexpr int tile_bit = 2;
-		static constexpr int tile_mask = (1 << tile_bit) - 1;
 };
 
 inline TileOpacity::TileOpacity(int w, int h)

--- a/src/opacity.h
+++ b/src/opacity.h
@@ -56,4 +56,18 @@ struct Opacity {
 	private:
 };
 
+/**
+ * Enum used to describe the opacity of an entire image.
+ * This is used to decide whether we can shortcut fast blit
+ * operations
+ */
+enum class ImageOpacity {
+	/** Image has alpha and needs an alpha blit */
+	Partial,
+	/** Image is full opaque and can be blitted fast */
+	Opaque,
+	/** Image is complately transparent and blitting can be skipped entirely */
+	Transparent
+};
+
 #endif

--- a/src/pending_message.cpp
+++ b/src/pending_message.cpp
@@ -71,7 +71,7 @@ void PendingMessage::SetChoiceResetColors(bool value) {
 
 std::string PendingMessage::ApplyTextInsertingCommands(std::string input, uint32_t escape_char) {
 	if (input.empty()) {
-		return std::move(input);
+		return input;
 	}
 
 	std::string output;

--- a/src/rect.cpp
+++ b/src/rect.cpp
@@ -69,7 +69,7 @@ bool Rect::IsOutOfBounds(const Rect &src_rect) const {
 	return false;
 }
 
-Rect Rect::GetSubRect(const Rect &src_rect) {
+Rect Rect::GetSubRect(const Rect src_rect) const {
 	Rect rect = src_rect;
 
 	rect.x += x;

--- a/src/rect.h
+++ b/src/rect.h
@@ -87,7 +87,7 @@ public:
 	 *
 	 * @param rect rect.
 	 */
-	Rect GetSubRect(Rect const& rect);
+	Rect GetSubRect(Rect rect) const;
 
 	/** X coordinate. */
 	int x = 0;

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -201,7 +201,7 @@ void Scene_Map::TransitionOut(SceneType next_scene) {
 }
 
 void Scene_Map::DrawBackground(Bitmap& dst) {
-	if (spriteset->RequireBackground(GetDrawableList())) {
+	if (spriteset->RequireClear(GetDrawableList())) {
 		dst.Clear();
 	}
 }

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -159,7 +159,11 @@ void Spriteset_Map::SubstituteUp(int old_id, int new_id) {
 	}
 }
 
-bool Spriteset_Map::RequireBackground(const DrawableList& drawable_list) {
+bool Spriteset_Map::RequireClear(DrawableList& drawable_list) {
+	if (drawable_list.empty()) {
+		return true;
+	}
+
 	// Speed optimisation:
 	// When there is nothing below the tilemap it can be drawn opaque (faster)
 	tilemap->SetFastBlitDown(false);
@@ -170,20 +174,16 @@ bool Spriteset_Map::RequireBackground(const DrawableList& drawable_list) {
 		return false;
 	}
 
-	for (const Drawable* d : drawable_list) {
-		if (d->GetZ() > Priority_Background) {
-			if (d->GetZ() < Priority_TilesetBelow) {
-				// There is a picture below the tilemap -> No opaque tilemap blit possible
-				return true;
-			} else {
-				tilemap->SetFastBlitDown(true);
-				return true;
-			}
-		}
+	// The list is about to be drawn, so we can just sort it now if needed.
+	if (drawable_list.IsDirty()) {
+		drawable_list.Sort();
 	}
 
-	// shouldn't happen
-	assert(false);
+	// Only if there is nothing below the tileset, can we do fast blitting.
+	if ((*drawable_list.begin())->GetZ() >= Priority_TilesetBelow) {
+		tilemap->SetFastBlitDown(true);
+	}
+
 	return true;
 }
 

--- a/src/spriteset_map.h
+++ b/src/spriteset_map.h
@@ -69,7 +69,10 @@ public:
 	 */
 	void SubstituteUp(int old_id, int new_id);
 
-	bool RequireBackground(const DrawableList& drawable_list);
+	/**
+	 * @return true if we should clear the screen before drawing the map
+	 */
+	bool RequireClear(DrawableList& drawable_list);
 
 protected:
 	std::unique_ptr<Tilemap> tilemap;

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -156,15 +156,15 @@ TilemapLayer::TilemapLayer(int ilayer) :
 }
 
 void TilemapLayer::DrawTile(Bitmap& dst, Bitmap& screen, int x, int y, int row, int col, bool allow_fast_blit) {
-	Bitmap::TileOpacity op = screen.GetTileOpacity(row, col);
+	auto op = screen.GetTileOpacity(row, col);
 
-	if (op == Bitmap::Transparent)
+	if (op == ImageOpacity::Transparent)
 		return;
 
 	Rect rect(col * TILE_SIZE, row * TILE_SIZE, TILE_SIZE, TILE_SIZE);
 
 	bool use_fast_blit = fast_blit && allow_fast_blit;
-	if (op == Bitmap::Opaque || use_fast_blit) {
+	if (op == ImageOpacity::Opaque || use_fast_blit) {
 		dst.BlitFast(x, y, screen, rect, 255);
 	} else {
 		dst.Blit(x, y, screen, rect, 255);

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -560,7 +560,7 @@ BitmapRef TilemapLayer::GenerateAutotiles(int count, const std::unordered_map<ui
 				rect.x = (x * 2 + i) * (TILE_SIZE/2);
 				rect.y = (y * 2 + j) * (TILE_SIZE/2);
 
-				tiles->Blit((dst.x * 2 + i) * (TILE_SIZE / 2), (dst.y * 2 + j) * (TILE_SIZE / 2), *chipset, rect, 255);
+				tiles->BlitFast((dst.x * 2 + i) * (TILE_SIZE / 2), (dst.y * 2 + j) * (TILE_SIZE / 2), *chipset, rect, 255);
 			}
 		}
 	}

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -217,26 +217,32 @@ void TilemapLayer::Draw(Bitmap& dst, int z_order) {
 	const bool loop_h = Game_Map::LoopHorizontal();
 	const bool loop_v = Game_Map::LoopVertical();
 
+	auto div_rounding_down = [](int n, int m) {
+		if (n >= 0) return n / m;
+		return (n - m + 1) / m;
+	};
+	auto mod = [](int n, int m) {
+		int rem = n % m;
+		return rem >= 0 ? rem : m + rem;
+	};
+
+	const int div_ox = div_rounding_down(ox, TILE_SIZE);
+	const int div_oy = div_rounding_down(oy, TILE_SIZE);
+
+	const int mod_ox = mod(ox, TILE_SIZE);
+	const int mod_oy = mod(oy, TILE_SIZE);
+
 	for (int y = 0; y < tiles_y; y++) {
 		for (int x = 0; x < tiles_x; x++) {
 
-			auto div_rounding_down = [](int n, int m) {
-				if (n >= 0) return n / m;
-				return (n - m + 1) / m;
-			};
-			auto mod = [](int n, int m) {
-				int rem = n % m;
-				return rem >= 0 ? rem : m + rem;
-			};
-
 			// Get the real maps tile coordinates
-			int map_x = div_rounding_down(ox, TILE_SIZE) + x;
-			int map_y = div_rounding_down(oy, TILE_SIZE) + y;
+			int map_x = div_ox + x;
+			int map_y = div_oy + y;
 			if (loop_h) map_x = mod(map_x, width);
 			if (loop_v) map_y = mod(map_y, height);
 
-			int map_draw_x = x * TILE_SIZE - mod(ox, TILE_SIZE);
-			int map_draw_y = y * TILE_SIZE - mod(oy, TILE_SIZE);
+			int map_draw_x = x * TILE_SIZE - mod_ox;
+			int map_draw_y = y * TILE_SIZE - mod_oy;
 
 			bool out_of_bounds =
 				map_x < 0 || map_x >= width ||

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -214,6 +214,9 @@ void TilemapLayer::Draw(Bitmap& dst, int z_order) {
 		++tiles_y;
 	}
 
+	const bool loop_h = Game_Map::LoopHorizontal();
+	const bool loop_v = Game_Map::LoopVertical();
+
 	for (int y = 0; y < tiles_y; y++) {
 		for (int x = 0; x < tiles_x; x++) {
 
@@ -229,8 +232,8 @@ void TilemapLayer::Draw(Bitmap& dst, int z_order) {
 			// Get the real maps tile coordinates
 			int map_x = div_rounding_down(ox, TILE_SIZE) + x;
 			int map_y = div_rounding_down(oy, TILE_SIZE) + y;
-			if (Game_Map::LoopHorizontal()) map_x = mod(map_x, width);
-			if (Game_Map::LoopVertical()) map_y = mod(map_y, height);
+			if (loop_h) map_x = mod(map_x, width);
+			if (loop_v) map_y = mod(map_y, height);
 
 			int map_draw_x = x * TILE_SIZE - mod(ox, TILE_SIZE);
 			int map_draw_y = y * TILE_SIZE - mod(oy, TILE_SIZE);

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -142,14 +142,14 @@ TilemapLayer::TilemapLayer(int ilayer) :
 	substitutions(ilayer >= 1
 			? Main_Data::game_data.map_info.upper_tiles
 			: Main_Data::game_data.map_info.lower_tiles),
-	layer(ilayer) {
-
-	// SubLayer for the tiles with Wall or Above passability
-	// Its z-value should be between the z of the events in the upper layer and the hero
-	sublayers.push_back(std::make_shared<TilemapSubLayer>(this, Priority_TilesetAbove + layer));
+	layer(ilayer),
 	// SubLayer for the tiles without Wall or Above passability
 	// Its z-value should be under z of the events in the lower layer
-	sublayers.push_back(std::make_shared<TilemapSubLayer>(this, Priority_TilesetBelow + layer));
+	lower_layer(this, Priority_TilesetBelow + layer),
+	// SubLayer for the tiles with Wall or Above passability
+	// Its z-value should be between the z of the events in the upper layer and the hero
+	upper_layer(this, Priority_TilesetAbove + layer)
+{
 }
 
 void TilemapLayer::DrawTile(Bitmap& dst, Bitmap& screen, int x, int y, int row, int col, bool allow_fast_blit) {

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -184,8 +184,8 @@ void TilemapLayer::Draw(Bitmap& dst, int z_order) {
 		++tiles_y;
 	}
 
-	for (int x = 0; x < tiles_x; x++) {
-		for (int y = 0; y < tiles_y; y++) {
+	for (int y = 0; y < tiles_y; y++) {
+		for (int x = 0; x < tiles_x; x++) {
 
 			auto div_rounding_down = [](int n, int m) {
 				if (n >= 0) return n / m;
@@ -214,7 +214,7 @@ void TilemapLayer::Draw(Bitmap& dst, int z_order) {
 			}
 
 			// Get the tile data
-			TileData &tile = data_cache[map_x][map_y];
+			TileData &tile = GetDataCache(map_x, map_y);
 
 			// Draw the sublayer if its z is being draw now
 			if (z_order == tile.z) {
@@ -341,9 +341,8 @@ TilemapLayer::TileXY TilemapLayer::GetCachedAutotileD(short ID) {
 }
 
 void TilemapLayer::CreateTileCache(const std::vector<short>& nmap_data) {
-	data_cache.resize(width);
+	data_cache_vec.resize(width * height);
 	for (int x = 0; x < width; x++) {
-		data_cache[x].resize(height);
 		for (int y = 0; y < height; y++) {
 			TileData tile;
 
@@ -373,7 +372,7 @@ void TilemapLayer::CreateTileCache(const std::vector<short>& nmap_data) {
 
 				}
 			}
-			data_cache[x][y] = tile;
+			GetDataCache(x, y) = tile;
 		}
 	}
 }
@@ -630,16 +629,16 @@ void TilemapLayer::SetMapData(std::vector<short> nmap_data) {
 		for (int y = 0; y < height; y++) {
 			for (int x = 0; x < width; x++) {
 
-				if (data_cache[x][y].ID < BLOCK_C) {
+				if (GetDataCache(x, y).ID < BLOCK_C) {
 					// If blocks A and B
 
-					GenerateAutotileAB(data_cache[x][y].ID, 0);
-					GenerateAutotileAB(data_cache[x][y].ID, 1);
-					GenerateAutotileAB(data_cache[x][y].ID, 2);
-				} else if (data_cache[x][y].ID >= BLOCK_D && data_cache[x][y].ID < BLOCK_E) {
+					GenerateAutotileAB(GetDataCache(x, y).ID, 0);
+					GenerateAutotileAB(GetDataCache(x, y).ID, 1);
+					GenerateAutotileAB(GetDataCache(x, y).ID, 2);
+				} else if (GetDataCache(x, y).ID >= BLOCK_D && GetDataCache(x, y).ID < BLOCK_E) {
 					// If block D
 
-					GenerateAutotileD(data_cache[x][y].ID);
+					GenerateAutotileD(GetDataCache(x, y).ID);
 				}
 			}
 		}

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -153,7 +153,7 @@ TilemapLayer::TilemapLayer(int ilayer) :
 }
 
 void TilemapLayer::DrawTile(Bitmap& dst, Bitmap& tileset, Bitmap& tone_tileset, int x, int y, int row, int col, uint32_t tone_hash, bool allow_fast_blit) {
-	auto op = tileset.GetTileOpacity(row, col);
+	auto op = tileset.GetTileOpacity(col, row);
 
 	if (op == ImageOpacity::Transparent)
 		return;

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -23,6 +23,7 @@
 #include "player.h"
 #include "map_data.h"
 #include "bitmap.h"
+#include "compiler.h"
 #include "game_map.h"
 #include "main_data.h"
 #include "drawable_mgr.h"
@@ -152,11 +153,15 @@ TilemapLayer::TilemapLayer(int ilayer) :
 {
 }
 
+EP_ALWAYS_INLINE
 void TilemapLayer::DrawTile(Bitmap& dst, Bitmap& tileset, Bitmap& tone_tileset, int x, int y, int row, int col, uint32_t tone_hash, bool allow_fast_blit) {
 	auto op = tileset.GetTileOpacity(col, row);
+	if (op != ImageOpacity::Transparent) {
+		DrawTileImpl(dst, tileset, tone_tileset, x, y, row, col, tone_hash, op, allow_fast_blit);
+	}
+}
 
-	if (op == ImageOpacity::Transparent)
-		return;
+void TilemapLayer::DrawTileImpl(Bitmap& dst, Bitmap& tileset, Bitmap& tone_tileset, int x, int y, int row, int col, uint32_t tone_hash, ImageOpacity op, bool allow_fast_blit) {
 
 	auto rect = Rect{ col * TILE_SIZE, row * TILE_SIZE, TILE_SIZE, TILE_SIZE };
 

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -153,6 +153,9 @@ TilemapLayer::TilemapLayer(int ilayer) :
 {
 }
 
+// This setup of having an always inlined DrawTile() which dispatches to DrawTileImpl()
+// was created intentionally. Inlining the transparency check was measured and shown
+// to provide a performance improvement
 EP_ALWAYS_INLINE
 void TilemapLayer::DrawTile(Bitmap& dst, Bitmap& tileset, Bitmap& tone_tileset, int x, int y, int row, int col, uint32_t tone_hash, bool allow_fast_blit) {
 	auto op = tileset.GetTileOpacity(col, row);

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -144,9 +144,6 @@ TilemapLayer::TilemapLayer(int ilayer) :
 			: Main_Data::game_data.map_info.lower_tiles),
 	layer(ilayer) {
 
-	memset(autotiles_ab, 0, sizeof(autotiles_ab));
-	memset(autotiles_d, 0, sizeof(autotiles_d));
-
 	// SubLayer for the tiles with Wall or Above passability
 	// Its z-value should be between the z of the events in the upper layer and the hero
 	sublayers.push_back(std::make_shared<TilemapSubLayer>(this, Priority_TilesetAbove + layer));
@@ -464,8 +461,7 @@ void TilemapLayer::GenerateAutotileAB(short ID, short animID) {
 			}
 
 	// check whether we have already generated this tile
-	std::map<uint32_t, TileXY>::iterator it;
-	it = autotiles_ab_map.find(quarters_hash);
+	auto it = autotiles_ab_map.find(quarters_hash);
 	if (it != autotiles_ab_map.end()) {
 		autotiles_ab[animID][block][b_subtile][a_subtile] = it->second;
 		return;
@@ -528,8 +524,7 @@ void TilemapLayer::GenerateAutotileD(short ID) {
 			}
 
 	// check whether we have already generated this tile
-	std::map<uint32_t, TileXY>::iterator it;
-	it = autotiles_d_map.find(quarters_hash);
+	auto it = autotiles_d_map.find(quarters_hash);
 	if (it != autotiles_d_map.end()) {
 		autotiles_d[block][subtile] = it->second;
 		return;
@@ -544,16 +539,15 @@ void TilemapLayer::GenerateAutotileD(short ID) {
 	autotiles_d[block][subtile] = tile_xy;
 }
 
-BitmapRef TilemapLayer::GenerateAutotiles(int count, const std::map<uint32_t, TileXY>& map) {
+BitmapRef TilemapLayer::GenerateAutotiles(int count, const std::unordered_map<uint32_t, TileXY>& map) {
 	int rows = (count + TILES_PER_ROW - 1) / TILES_PER_ROW;
 	BitmapRef tiles = Bitmap::Create(TILES_PER_ROW * TILE_SIZE, rows * TILE_SIZE);
 	tiles->Clear();
 	Rect rect(0, 0, TILE_SIZE/2, TILE_SIZE/2);
 
-	std::map<uint32_t, TileXY>::const_iterator it;
-	for (it = map.begin(); it != map.end(); ++it) {
-		uint32_t quarters_hash = it->first;
-		TileXY dst = it->second;
+	for (auto& p: map) {
+		uint32_t quarters_hash = p.first;
+		TileXY dst = p.second;
 
 		// unpack the quarters data
 		for (int j = 0; j < 2; j++) {

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -147,7 +147,9 @@ private:
 		int z;
 	};
 	std::vector<std::vector<TileData> > data_cache;
-	std::vector<std::shared_ptr<TilemapSubLayer> > sublayers;
+
+	TilemapSubLayer lower_layer;
+	TilemapSubLayer upper_layer;
 
 	Tone tone;
 };

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -89,8 +89,7 @@ public:
 private:
 	BitmapRef chipset;
 	BitmapRef chipset_effect;
-	std::unordered_set<short> chipset_tone_tiles;
-
+	std::unordered_set<uint32_t> chipset_tone_tiles;
 	std::vector<short> map_data;
 	std::vector<uint8_t> passable;
 	// FIXME Should be span<uint8_t>
@@ -128,10 +127,8 @@ private:
 	TileXY GetCachedAutotileD(short ID);
 	BitmapRef autotiles_ab_screen;
 	BitmapRef autotiles_ab_screen_effect;
-	std::unordered_set<short> autotiles_ab_screen_tone_tiles;
 	BitmapRef autotiles_d_screen;
 	BitmapRef autotiles_d_screen_effect;
-	std::unordered_set<short> autotiles_d_screen_tone_tiles;
 
 	int autotiles_ab_next = -1;
 	int autotiles_d_next = -1;

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -26,6 +26,7 @@
 #include "system.h"
 #include "drawable.h"
 #include "tone.h"
+#include "opacity.h"
 
 class TilemapLayer;
 
@@ -49,7 +50,6 @@ class TilemapLayer {
 public:
 	TilemapLayer(int ilayer);
 
-	void DrawTile(Bitmap& dst, Bitmap& tile, Bitmap& tone_tile, int x, int y, int row, int col, uint32_t tone_hash, bool allow_fast_blit = true);
 	void Draw(Bitmap& dst, int z_order);
 
 	void Update();
@@ -110,6 +110,8 @@ private:
 	void CreateTileCache(const std::vector<short>& nmap_data);
 	void GenerateAutotileAB(short ID, short animID);
 	void GenerateAutotileD(short ID);
+	void DrawTile(Bitmap& dst, Bitmap& tile, Bitmap& tone_tile, int x, int y, int row, int col, uint32_t tone_hash, bool allow_fast_blit = true);
+	void DrawTileImpl(Bitmap& dst, Bitmap& tile, Bitmap& tone_tile, int x, int y, int row, int col, uint32_t tone_hash, ImageOpacity op, bool allow_fast_blit);
 
 	static const int TILES_PER_ROW = 64;
 

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -49,7 +49,7 @@ class TilemapLayer {
 public:
 	TilemapLayer(int ilayer);
 
-	void DrawTile(Bitmap& dst, Bitmap& screen, int x, int y, int row, int col, bool allow_fast_blit = true);
+	void DrawTile(Bitmap& dst, Bitmap& tile, Bitmap& tone_tile, int x, int y, int row, int col, uint32_t tone_hash, bool allow_fast_blit = true);
 	void Draw(Bitmap& dst, int z_order);
 
 	void Update();

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -21,7 +21,8 @@
 // Headers
 #include <vector>
 #include <map>
-#include <set>
+#include <unordered_set>
+#include <unordered_map>
 #include "system.h"
 #include "drawable.h"
 #include "tone.h"
@@ -88,7 +89,7 @@ public:
 private:
 	BitmapRef chipset;
 	BitmapRef chipset_effect;
-	std::set<short> chipset_tone_tiles;
+	std::unordered_set<short> chipset_tone_tiles;
 
 	std::vector<short> map_data;
 	std::vector<uint8_t> passable;
@@ -121,25 +122,25 @@ private:
 		TileXY(uint8_t x, uint8_t y) : x(x), y(y), valid(true) {}
 	};
 
-	BitmapRef GenerateAutotiles(int count, const std::map<uint32_t, TileXY>& map);
+	BitmapRef GenerateAutotiles(int count, const std::unordered_map<uint32_t, TileXY>& map);
 
 	TileXY GetCachedAutotileAB(short ID, short animID);
 	TileXY GetCachedAutotileD(short ID);
 	BitmapRef autotiles_ab_screen;
 	BitmapRef autotiles_ab_screen_effect;
-	std::set<short> autotiles_ab_screen_tone_tiles;
+	std::unordered_set<short> autotiles_ab_screen_tone_tiles;
 	BitmapRef autotiles_d_screen;
 	BitmapRef autotiles_d_screen_effect;
-	std::set<short> autotiles_d_screen_tone_tiles;
+	std::unordered_set<short> autotiles_d_screen_tone_tiles;
 
 	int autotiles_ab_next = -1;
 	int autotiles_d_next = -1;
 
-	TileXY autotiles_ab[3][3][16][47];
-	TileXY autotiles_d[12][50];
+	TileXY autotiles_ab[3][3][16][47] = {};
+	TileXY autotiles_d[12][50] = {};
 
-	std::map<uint32_t, TileXY> autotiles_ab_map;
-	std::map<uint32_t, TileXY> autotiles_d_map;
+	std::unordered_map<uint32_t, TileXY> autotiles_ab_map;
+	std::unordered_map<uint32_t, TileXY> autotiles_d_map;
 
 	struct TileData {
 		short ID;

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -146,7 +146,10 @@ private:
 		short ID;
 		int z;
 	};
-	std::vector<std::vector<TileData> > data_cache;
+
+	TileData& GetDataCache(int x, int y);
+
+	std::vector<TileData> data_cache_vec;
 
 	TilemapSubLayer lower_layer;
 	TilemapSubLayer upper_layer;
@@ -224,6 +227,10 @@ inline void TilemapLayer::SetAnimationType(int type) {
 
 inline void TilemapLayer::SetFastBlit(bool fast) {
 	fast_blit = fast;
+}
+
+inline TilemapLayer::TileData& TilemapLayer::GetDataCache(int x, int y) {
+	return data_cache_vec[x + y * width];
 }
 
 


### PR DESCRIPTION
Retested #1417 

There was a performance regression introduced into tilemap when tone support was added. Basically we never actually use the `TileOpacity` value, resulting in us rendering every tile, even when they are fully transparent.

This PR fixes that and adds several other optimizations to TilemapLayer. 

The test case is a map with all transparent tiles and no background. Each optimization commit in this PR was measured and shown to have an improvement for this test.

For `ComputeImageOpacity()`

Master:
```
---------------------------------------------------------------------
Benchmark                              Time           CPU Iterations
---------------------------------------------------------------------
BM_ComputeImageOpacity            352849 ns     352851 ns       1969
BM_ComputeImageOpacityChipset     862583 ns     862591 ns        800
```

This PR:
```
---------------------------------------------------------------------
Benchmark                              Time           CPU Iterations
---------------------------------------------------------------------
BM_ComputeImageOpacity             70558 ns      70557 ns       9301
BM_ComputeImageOpacityChipset     116219 ns     116219 ns       5241
```

Master:
![tilemap_master](https://user-images.githubusercontent.com/1198466/71760982-44596180-2e93-11ea-97a9-51da82693c5e.png)
The calls to `operator()` are the div and mod lambdas in `TilemapLayer::Draw()`

This PR:
![tilemap](https://user-images.githubusercontent.com/1198466/71760936-e3318e00-2e92-11ea-9baa-e2e966d3918d.png)

Note in both profiles, the amount of time spent in `Game_picture::Update()` even though there are no pictures. This is fixed in #1989 