### PR TITLE
Fix save window when party members have no face graphic

### DIFF
--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -53,35 +53,7 @@ void Scene_File::CreateHelpWindow() {
 }
 
 void Scene_File::PopulatePartyFaces(Window_SaveFile& win, int /* id */, RPG::Save& savegame) {
-	std::vector<std::pair<int, std::string> > party;
-
-	// When a face_name is empty the party list ends
-	int party_size =
-		savegame.title.face1_name.empty() ? 0 :
-		savegame.title.face2_name.empty() ? 1 :
-		savegame.title.face3_name.empty() ? 2 :
-		savegame.title.face4_name.empty() ? 3 : 4;
-
-	party.resize(party_size);
-
-	if (party_size > 3) {
-		party[3].first = savegame.title.face4_id;
-		party[3].second = savegame.title.face4_name;
-	}
-	if (party_size > 2) {
-		party[2].first = savegame.title.face3_id;
-		party[2].second = savegame.title.face3_name;
-	}
-	if (party_size > 1) {
-		party[1].first = savegame.title.face2_id;
-		party[1].second = savegame.title.face2_name;
-	}
-	if (party_size > 0) {
-		party[0].first = savegame.title.face1_id;
-		party[0].second = savegame.title.face1_name;
-	}
-
-	win.SetParty(party, savegame.title.hero_name, savegame.title.hero_hp, savegame.title.hero_level);
+	win.SetParty(savegame.title);
 	win.SetHasSave(true);
 }
 

--- a/src/window_savefile.cpp
+++ b/src/window_savefile.cpp
@@ -49,7 +49,7 @@ void Window_SaveFile::UpdateCursorRect() {
 std::string Window_SaveFile::GetSaveFileName() const {
 	std::ostringstream out;
 	if (!override_name.empty()) {
-		if (override_name.size() > 14 && !party.empty()) {
+		if (override_name.size() > 14 && has_party) {
 			out << override_name.substr(0, 11) << "...";
 		} else {
 			out << override_name;
@@ -69,12 +69,9 @@ void Window_SaveFile::SetDisplayOverride(const std::string& name, int index) {
 	override_index = index;
 }
 
-void Window_SaveFile::SetParty(const std::vector<std::pair<int, std::string> >& actors,
-	std::string name, int hp, int level) {
-	party = actors;
-	hero_name = name;
-	hero_hp = hp;
-	hero_level = level;
+void Window_SaveFile::SetParty(RPG::SaveTitle title) {
+	data = std::move(title);
+	has_party = true;
 }
 
 void Window_SaveFile::SetCorrupted(bool corrupted) {
@@ -101,16 +98,16 @@ void Window_SaveFile::Refresh() {
 		return;
 	}
 
-	if (party.empty())
+	if (!has_party) {
 		return;
-
+	}
 
 	std::stringstream out;
 	if (override_index > 0) {
 		out << Data::terms.file << std::setw(2) << std::setfill(' ') << override_index;
 		contents->TextDraw(4, 16+2, fc, out.str());
 	} else {
-		contents->TextDraw(4, 16 + 2, fc, hero_name);
+		contents->TextDraw(4, 16 + 2, fc, data.hero_name);
 	}
 
 	auto lvl_short = Data::terms.lvl_short;
@@ -122,7 +119,7 @@ void Window_SaveFile::Refresh() {
 
 	int lx = Font::Default()->GetSize(lvl_short).width;
 	out.str("");
-	out << std::setw(2) << std::setfill(' ') << hero_level;
+	out << std::setw(2) << std::setfill(' ') << data.hero_level;
 	contents->TextDraw(4 + lx, 32 + 2, fc, out.str());
 
 	auto hp_short = Data::terms.hp_short;
@@ -134,12 +131,14 @@ void Window_SaveFile::Refresh() {
 
 	int hx = Font::Default()->GetSize(hp_short).width;
 	out.str("");
-	out << std::setw(Player::IsRPG2k3() ? 4 : 3) << std::setfill(' ') << hero_hp;
+	out << std::setw(Player::IsRPG2k3() ? 4 : 3) << std::setfill(' ') << data.hero_hp;
 	contents->TextDraw(46 + hx, 32 + 2, fc, out.str());
 
-	for (int i = 0; i < 4 && (size_t) i < party.size(); i++) {
-		DrawFace(party[i].second, party[i].first, 92 + i * 56, 0, false);
-	}
+	int i = 0;
+	DrawFace(data.face1_name, data.face1_id, 92 + i++ * 56, 0, false);
+	DrawFace(data.face2_name, data.face2_id, 92 + i++ * 56, 0, false);
+	DrawFace(data.face3_name, data.face3_id, 92 + i++ * 56, 0, false);
+	DrawFace(data.face4_name, data.face4_id, 92 + i++ * 56, 0, false);
 }
 
 void Window_SaveFile::Update() {

--- a/src/window_savefile.h
+++ b/src/window_savefile.h
@@ -55,15 +55,11 @@ public:
 	void SetDisplayOverride(const std::string& name, int index);
 
 	/**
-	 * Party data displayed in the savegame slot.
+	 * Set party data displayed in the savegame slot.
 	 *
-	 * @param actors face_id and face_name of all party members.
-	 * @param name name of the First party member.
-	 * @param hp HP of the first party member.
-	 * @param level level of the First party member.
+	 * @param title the savegame party data to set.
 	 */
-	void SetParty(const std::vector<std::pair<int, std::string> >& actors,
-		std::string name, int hp, int level);
+	void SetParty(RPG::SaveTitle title);
 
 	/**
 	 * Gets if the slot holds a valid save.
@@ -94,12 +90,10 @@ protected:
 	int index = 0;
 	std::string override_name;
 	int override_index = 0;
-	std::vector<std::pair<int, std::string> > party;
-	std::string hero_name;
-	int hero_hp = 0;
-	int hero_level = 0;
+	RPG::SaveTitle data;
 	bool corrupted = false;
 	bool has_save = false;
+	bool has_party = false;
 };
 
 #endif


### PR DESCRIPTION
Save window would not display name, level, or hp when the first actor has no face graphic.