### PR TITLE
Handle teleports run by foreground events in preupdate

### DIFF
--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -377,6 +377,17 @@ void Scene_Map::FinishPendingTeleport3(MapUpdateAsyncContext actx, TeleportParam
 			OnAsyncSuspend([=] { FinishPendingTeleport3(actx, tp); }, actx.GetAsyncOp(), true);
 			return;
 		}
+
+		if (!tp.defer_recursive_teleports) {
+			// See comments about defer_recursive_teleports in FinishPendingTeleport2
+			// Deferring in this block can actually never occur, since an Escape/Teleport won't ever
+			// also trigger foreground events to run in pre-update. We leave the check in here for symmetry.
+			if (Main_Data::game_player->IsPendingTeleport()) {
+				tp.erase_screen = false;
+				StartPendingTeleport(tp);
+				return;
+			}
+		}
 	}
 
 	// Call any requested scenes when transition is done.


### PR DESCRIPTION
When a foreground event causes a teleport, foreground
events run during pre-update. If then during that preupdate
the fg event triggers another teleport, we need to handle it.

Fix: #2038

Leaving this as a draft as I want to do more testing around this scenario.