### PR TITLE
Cleanup main loop - MainLoop 3 of N

### DIFF
--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -101,7 +101,6 @@ void Graphics::Update() {
 	fps_overlay->Update();
 	fps_overlay->AddUpdate();
 	message_overlay->Update();
-	Transition::instance().Update();
 }
 
 void Graphics::UpdateTitle() {

--- a/src/player.h
+++ b/src/player.h
@@ -75,6 +75,11 @@ namespace Player {
 	void Update(bool update_scene = true);
 
 	/**
+	 * Renders EasyRPG Player state to the screen
+	 */
+	void Draw();
+
+	/**
 	 * Returns executed game frames since player start.
 	 * Should be 60 fps when game ran fast enough.
 	 *

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -95,6 +95,8 @@ void Scene::MainFunction() {
 	// it could have changed the scene.
 	if (!IsAsyncPending() && Scene::instance.get() == this) {
 		if (!init) {
+			Graphics::UpdateSceneCallback();
+
 			auto prev_scene_type = prev_scene ? prev_scene->type : Null;
 			TransferDrawablesFrom(prev_scene.get());
 			// Destroy the previous scene here, before any initialization logic / transition in occurs.
@@ -140,9 +142,6 @@ void Scene::MainFunction() {
 		auto next_scene = instance ? instance->type : Null;
 		Suspend(next_scene);
 		TransitionOut(next_scene);
-
-		// TransitionOut stored a screenshot of the last scene
-		Graphics::UpdateSceneCallback();
 
 		prev_scene = this->shared_from_this();
 		init = false;


### PR DESCRIPTION
Depends on #1973 

This pulls the first set of commits out of #2017 which just cleans up our current main loop without doing a major refactor. The main purpose of this is to move the time keeping and loop management all into `Player::MainLoop`. 

We also do drawing *after* suspending scenes, which is necessary for visual correctness of transitions initiated by `Scene::TransitionOut()`. It also makes sure transitions are updated with the rest of the game logic, so that they animate properly even under fast forward or frameskip. With respect to transitions, this PR has all the dependencies needed for #2019 

This also ensures sleep caused by vsync happens at near the same time as mandatory sleep.

Finally, this also fixes the framerate histogram in vtune.

This should be mergable sooner, while we test #2017 further.




