### PR TITLE
Refactor Pictures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,8 +130,8 @@ add_library(${PROJECT_NAME}
 	src/game_party_base.h
 	src/game_party.cpp
 	src/game_party.h
-	src/game_picture.cpp
-	src/game_picture.h
+	src/game_pictures.cpp
+	src/game_pictures.h
 	src/game_player.cpp
 	src/game_player.h
 	src/game_quit.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -127,8 +127,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/game_party.h \
 	src/game_party_base.cpp \
 	src/game_party_base.h \
-	src/game_picture.cpp \
-	src/game_picture.h \
+	src/game_pictures.cpp \
+	src/game_pictures.h \
 	src/game_player.cpp \
 	src/game_player.h \
 	src/game_screen.cpp \

--- a/src/background.cpp
+++ b/src/background.cpp
@@ -26,6 +26,7 @@
 #include "reader_util.h"
 #include "output.h"
 #include "drawable_mgr.h"
+#include "game_screen.h"
 
 Background::Background(const std::string& name) : Drawable(Priority_Background)
 {

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -20,6 +20,7 @@
 #include "output.h"
 #include "game_battle.h"
 #include "game_system.h"
+#include "game_screen.h"
 #include "game_map.h"
 #include "main_data.h"
 #include "filefinder.h"

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -28,6 +28,8 @@
 #include "game_system.h"
 #include "game_variables.h"
 #include "game_interpreter_battle.h"
+#include "game_screen.h"
+#include "game_pictures.h"
 #include "battle_animation.h"
 #include "game_battle.h"
 #include "reader_util.h"
@@ -128,7 +130,7 @@ void Game_Battle::Quit() {
 	page_can_run.clear();
 
 	Main_Data::game_party->ResetBattle();
-	Main_Data::game_screen->OnBattleEnd();
+	Main_Data::game_pictures->OnBattleEnd();
 }
 
 void Game_Battle::RunEvents() {
@@ -150,7 +152,8 @@ void Game_Battle::UpdateAnimation() {
 
 void Game_Battle::UpdateGraphics() {
 	spriteset->Update();
-	Main_Data::game_screen->UpdateGraphics(true);
+	Main_Data::game_screen->UpdateGraphics();
+	Main_Data::game_pictures->UpdateGraphics(true);
 
 	if (need_refresh) {
 		need_refresh = false;

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -31,6 +31,7 @@
 #include "game_system.h"
 #include "game_temp.h"
 #include "game_targets.h"
+#include "game_screen.h"
 #include "util_macro.h"
 #include "main_data.h"
 #include "utils.h"

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -25,6 +25,7 @@
 #include "input.h"
 #include "main_data.h"
 #include "game_message.h"
+#include "drawable.h"
 #include "player.h"
 #include "utils.h"
 #include "util_macro.h"

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -35,7 +35,8 @@
 #include "game_actors.h"
 #include "game_system.h"
 #include "game_message.h"
-#include "game_picture.h"
+#include "game_pictures.h"
+#include "game_screen.h"
 #include "spriteset_map.h"
 #include "sprite_character.h"
 #include "scene_gameover.h"
@@ -2330,7 +2331,7 @@ namespace PicPointerPatch {
 		}
 	}
 
-	static void AdjustParams(Game_Picture::Params& params) {
+	static void AdjustParams(Game_Pictures::Params& params) {
 		if (params.magnify > 10000) {
 			int new_magnify = Main_Data::game_variables->Get(params.magnify - 10000);
 			Output::Debug("PicPointer: Zoom %d replaced with %d", params.magnify, new_magnify);
@@ -2376,7 +2377,7 @@ namespace PicPointerPatch {
 		return new_pic_name;
 	}
 
-	static void AdjustShowParams(int& pic_id, Game_Picture::ShowParams& params) {
+	static void AdjustShowParams(int& pic_id, Game_Pictures::ShowParams& params) {
 		// Adjust name
 		if (pic_id >= 50000) {
 			// Name substitution is pic_id + 1
@@ -2391,7 +2392,7 @@ namespace PicPointerPatch {
 		AdjustParams(params);
 	}
 
-	static void AdjustMoveParams(int& pic_id, Game_Picture::MoveParams& params) {
+	static void AdjustMoveParams(int& pic_id, Game_Pictures::MoveParams& params) {
 		AdjustId(pic_id);
 		AdjustParams(params);
 
@@ -2412,7 +2413,7 @@ bool Game_Interpreter::CommandShowPicture(RPG::EventCommand const& com) { // cod
 
 	int pic_id = com.parameters[0];
 
-	Game_Picture::ShowParams params = {};
+	Game_Pictures::ShowParams params = {};
 	params.name = com.string;
 	params.position_x = ValueOrVariable(com.parameters[1], com.parameters[2]);
 	params.position_y = ValueOrVariable(com.parameters[1], com.parameters[3]);
@@ -2479,8 +2480,7 @@ bool Game_Interpreter::CommandShowPicture(RPG::EventCommand const& com) { // cod
 	// RPG_RT will crash if you ask for a picture id greater than the limit that
 	// version of the engine allows. We allow an arbitrary number of pictures in Player.
 
-	auto& picture = Main_Data::game_screen->GetPicture(pic_id);
-	picture.Show(params);
+	Main_Data::game_pictures->Show(pic_id, params);
 
 	return true;
 }
@@ -2493,7 +2493,7 @@ bool Game_Interpreter::CommandMovePicture(RPG::EventCommand const& com) { // cod
 
 	int pic_id = com.parameters[0];
 
-	Game_Picture::MoveParams params;
+	Game_Pictures::MoveParams params;
 	params.position_x = ValueOrVariable(com.parameters[1], com.parameters[2]);
 	params.position_y = ValueOrVariable(com.parameters[1], com.parameters[3]);
 	params.magnify = com.parameters[5];
@@ -2540,8 +2540,7 @@ bool Game_Interpreter::CommandMovePicture(RPG::EventCommand const& com) { // cod
 		Output::Error("MovePicture: Requested invalid picture id (%d)", pic_id);
 	}
 
-	Game_Picture& picture = Main_Data::game_screen->GetPicture(pic_id);
-	picture.Move(params);
+	Main_Data::game_pictures->Move(pic_id, params);
 
 	if (wait)
 		SetupWait(params.duration);
@@ -2574,8 +2573,7 @@ bool Game_Interpreter::CommandErasePicture(RPG::EventCommand const& com) { // co
 				Output::Error("ErasePicture: Requested invalid picture id (%d)", i);
 			}
 
-			auto& picture = Main_Data::game_screen->GetPicture(i);
-			picture.Erase();
+			Main_Data::game_pictures->Erase(i);
 		}
 	} else {
 		PicPointerPatch::AdjustId(pic_id);
@@ -2584,8 +2582,7 @@ bool Game_Interpreter::CommandErasePicture(RPG::EventCommand const& com) { // co
 			Output::Error("ErasePicture: Requested invalid picture id (%d)", pic_id);
 		}
 
-		auto& picture = Main_Data::game_screen->GetPicture(pic_id);
-		picture.Erase();
+		Main_Data::game_pictures->Erase(pic_id);
 	}
 
 	return true;

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -34,7 +34,7 @@
 #include "game_actors.h"
 #include "game_system.h"
 #include "game_message.h"
-#include "game_picture.h"
+#include "game_screen.h"
 #include "spriteset_map.h"
 #include "sprite_character.h"
 #include "scene_map.h"

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -33,6 +33,8 @@
 #include "game_player.h"
 #include "game_party.h"
 #include "game_message.h"
+#include "game_screen.h"
+#include "game_pictures.h"
 #include "lmu_reader.h"
 #include "reader_lcf.h"
 #include "map_data.h"
@@ -155,6 +157,7 @@ void Game_Map::Setup(int _id, TeleportTarget::Type tt) {
 	Dispose();
 	if (tt != TeleportTarget::eAsyncQuickTeleport) {
 		Main_Data::game_screen->OnMapChange();
+		Main_Data::game_pictures->OnMapChange();
 	}
 	SetupCommon(_id, false);
 	map_info.encounter_rate = GetMapInfo().encounter_steps;
@@ -976,7 +979,8 @@ void Game_Map::Update(MapUpdateAsyncContext& actx, bool is_preupdate) {
 
 		Game_Message::Update();
 		Main_Data::game_party->UpdateTimers();
-		Main_Data::game_screen->Update(false);
+		Main_Data::game_screen->Update();
+		Main_Data::game_pictures->Update(false);
 	}
 
 	if (!actx.IsActive() || actx.IsForegroundEvent()) {

--- a/src/game_pictures.cpp
+++ b/src/game_pictures.cpp
@@ -376,9 +376,6 @@ void Game_Pictures::RequestPictureSprite(Picture& pic) {
 
 	int pic_id = pic.data.ID;
 
-	// FIXME: This lambda is here because it's possible the picture vector can be
-	// resized before the async call of onPictureSpriteReady().
-	// Pictures should be refactored so this ugly hack is not needed.
 	pic.request_id = request->Bind([this, pic_id](FileRequestResult*) {
 			OnPictureSpriteReady(pic_id);
 			});

--- a/src/game_pictures.cpp
+++ b/src/game_pictures.cpp
@@ -45,13 +45,17 @@ Game_Pictures::Picture::Picture(RPG::SavePicture save)
 	needs_update = !UpdateWouldBeNop();
 }
 
-Game_Pictures::Game_Pictures(std::vector<RPG::SavePicture> save)
+void Game_Pictures::SetSaveData(std::vector<RPG::SavePicture> save)
 {
+	pictures.clear();
+
 	pictures.reserve(save.size());
 	for (auto& d: save) {
 		pictures.emplace_back(std::move(d));
 	}
+}
 
+void Game_Pictures::InitGraphics() {
 	for (auto& pic: pictures) {
 		RequestPictureSprite(pic);
 	}

--- a/src/game_pictures.cpp
+++ b/src/game_pictures.cpp
@@ -22,7 +22,7 @@
 #include "cache.h"
 #include "output.h"
 #include "game_map.h"
-#include "game_picture.h"
+#include "game_pictures.h"
 #include "game_screen.h"
 #include "player.h"
 #include "main_data.h"
@@ -32,16 +32,74 @@
 // Applied to ensure that all pictures are above "normal" objects on this layer
 constexpr int z_mask = (1 << 16);
 
-void Game_Picture::SetupFromSave(RPG::SavePicture sp)
-{
-	// FIXME: This should be a constructor. But we can't change it until we can remove the lambda hack from RequestPictureSprite().
-	data = std::move(sp);
-	needs_update = !UpdateWouldBeNop();
-	RequestPictureSprite();
+Game_Pictures::Game_Pictures() {
+	// RPG_RT Save game data always has a constant number of pictures.
+	// FIXME: Do this resize when we write save data instead of doing it here
+	// because calling Update() on all the empty pictures is slow.
+	GetPicture(GetDefaultNumberOfPictures());
 }
 
+Game_Pictures::Picture::Picture(RPG::SavePicture save)
+	: data(std::move(save))
+{
+	needs_update = !UpdateWouldBeNop();
+}
 
-void Game_Picture::UpdateSprite(bool is_battle) {
+Game_Pictures::Game_Pictures(std::vector<RPG::SavePicture> save)
+{
+	pictures.reserve(save.size());
+	for (auto& d: save) {
+		pictures.emplace_back(std::move(d));
+	}
+
+	for (auto& pic: pictures) {
+		RequestPictureSprite(pic);
+	}
+}
+
+std::vector<RPG::SavePicture> Game_Pictures::GetSaveData() const {
+	std::vector<RPG::SavePicture> save;
+
+	save.reserve(pictures.size());
+	for (auto& pic: pictures) {
+		save.push_back(pic.data);
+	}
+
+	return save;
+}
+
+int Game_Pictures::GetDefaultNumberOfPictures() {
+	if (Player::IsEnglish()) {
+		return 1000;
+	}
+	else if (Player::IsMajorUpdatedVersion()) {
+		return 50;
+	}
+	else if (Player::IsRPG2k3Legacy()) {
+		return 40;
+	}
+	else if (Player::IsRPG2kLegacy()) {
+		return 20;
+	}
+	return 0;
+}
+
+Game_Pictures::Picture& Game_Pictures::GetPicture(int id) {
+	if (EP_UNLIKELY(id > static_cast<int>(pictures.size()))) {
+		pictures.reserve(id);
+		while (static_cast<int>(pictures.size()) < id) {
+			pictures.emplace_back(pictures.size() + 1);
+		}
+	}
+	return pictures[id - 1];
+}
+
+Game_Pictures::Picture* Game_Pictures::GetPicturePtr(int id) {
+	return id <= static_cast<int>(pictures.size())
+		? &pictures[id - 1] : nullptr;
+}
+
+void Game_Pictures::Picture::UpdateGraphics(bool is_battle) {
 	if (!sprite || !sprite->GetBitmap() || data.name.empty()) {
 		return;
 	}
@@ -53,8 +111,8 @@ void Game_Picture::UpdateSprite(bool is_battle) {
 	{
 		last_spritesheet_frame = data.spritesheet_frame;
 
-		const int sw = bitmap->GetWidth() / data.spritesheet_cols;
-		const int sh = bitmap->GetHeight() / data.spritesheet_rows;
+		const int sw = sprite->GetBitmap()->GetWidth() / data.spritesheet_cols;
+		const int sh = sprite->GetBitmap()->GetHeight() / data.spritesheet_rows;
 		const int sx = sw * ((last_spritesheet_frame) % data.spritesheet_cols);
 		const int sy = sh * ((last_spritesheet_frame) / data.spritesheet_cols % data.spritesheet_rows);
 
@@ -127,37 +185,29 @@ void Game_Picture::UpdateSprite(bool is_battle) {
 	}
 }
 
-void Game_Picture::UpdateSprite(std::vector<Game_Picture>& pictures, bool is_battle) {
+void Game_Pictures::UpdateGraphics(bool is_battle) {
 	for (auto& pic: pictures) {
-		pic.UpdateSprite(is_battle);
+		pic.UpdateGraphics(is_battle);
 	}
 }
 
-void Game_Picture::OnMapChange() {
-	if (data.flags.erase_on_map_change) {
-		Erase();
-	}
-}
-
-void Game_Picture::OnMapChange(std::vector<Game_Picture>& pictures) {
+void Game_Pictures::OnMapChange() {
 	for (auto& pic: pictures) {
-		pic.OnMapChange();
+		if (pic.data.flags.erase_on_map_change) {
+			pic.Erase();
+		}
 	}
 }
 
-void Game_Picture::OnBattleEnd() {
-	if (data.flags.erase_on_battle_end) {
-		Erase();
-	}
-}
-
-void Game_Picture::OnBattleEnd(std::vector<Game_Picture>& pictures) {
+void Game_Pictures::OnBattleEnd() {
 	for (auto& pic: pictures) {
-		pic.OnBattleEnd();
+		if (pic.data.flags.erase_on_battle_end) {
+			pic.Erase();
+		}
 	}
 }
 
-void Game_Picture::Show(const ShowParams& params) {
+bool Game_Pictures::Picture::Show(const ShowParams& params) {
 	needs_update = true;
 
 	data.name = params.name;
@@ -206,13 +256,20 @@ void Game_Picture::Show(const ShowParams& params) {
 		if (sprite) {
 			sprite->SetBitmap(nullptr);
 		}
-		return;
+		return false;
 	}
 
-	RequestPictureSprite();
+	return true;
 }
 
-void Game_Picture::Move(const MoveParams& params) {
+void Game_Pictures::Show(int id, const ShowParams& params) {
+	auto& pic = GetPicture(id);
+	if (pic.Show(params)) {
+		RequestPictureSprite(pic);
+	}
+}
+
+void Game_Pictures::Picture::Move(const MoveParams& params) {
 	const bool ignore_position = Player::IsLegacy() && data.fixed_to_map;
 
 	SetNonEffectParams(params, !ignore_position);
@@ -255,36 +312,45 @@ void Game_Picture::Move(const MoveParams& params) {
 	}
 }
 
-void Game_Picture::Erase() {
+void Game_Pictures::Move(int id, const MoveParams& params) {
+	auto& pic = GetPicture(id);
+	pic.Move(params);
+}
+
+void Game_Pictures::Picture::Erase() {
 	request_id = {};
 	data.name.clear();
 	sprite.reset();
-	bitmap.reset();
 }
 
-void Game_Picture::RequestPictureSprite() {
-	const std::string& name = data.name;
+void Game_Pictures::Erase(int id) {
+	auto* pic = GetPicturePtr(id);
+	if (EP_LIKELY(pic)) {
+		pic->Erase();
+	}
+}
+
+void Game_Pictures::RequestPictureSprite(Picture& pic) {
+	const auto& name = pic.data.name;
 	if (name.empty()) return;
 
 	FileRequestAsync* request = AsyncHandler::RequestFile("Picture", name);
 	request->SetGraphicFile(true);
 
-	int pic_id = data.ID;
+	int pic_id = pic.data.ID;
 
 	// FIXME: This lambda is here because it's possible the picture vector can be
 	// resized before the async call of onPictureSpriteReady().
 	// Pictures should be refactored so this ugly hack is not needed.
-	request_id = request->Bind([pic_id](FileRequestResult* res) {
-			if (Main_Data::game_screen) {
-				auto& pic = Main_Data::game_screen->GetPicture(pic_id);
-				pic.OnPictureSpriteReady(res);
-			}
+	pic.request_id = request->Bind([this, pic_id](FileRequestResult*) {
+			OnPictureSpriteReady(pic_id);
 			});
 	request->Start();
 }
 
-void Game_Picture::OnPictureSpriteReady(FileRequestResult*) {
-	bitmap = Cache::Picture(data.name, data.use_transparent_color);
+
+void Game_Pictures::Picture::OnPictureSpriteReady() {
+	auto bitmap = Cache::Picture(data.name, data.use_transparent_color);
 
 	if (!sprite) {
 		sprite.reset(new Sprite(Drawable::Flags::Shared));
@@ -292,7 +358,14 @@ void Game_Picture::OnPictureSpriteReady(FileRequestResult*) {
 	sprite->SetBitmap(bitmap);
 }
 
-bool Game_Picture::UpdateWouldBeNop() const {
+void Game_Pictures::OnPictureSpriteReady(int id) {
+	auto* pic = GetPicturePtr(id);
+	if (EP_LIKELY(pic)) {
+		pic->OnPictureSpriteReady();
+	}
+}
+
+bool Game_Pictures::Picture::UpdateWouldBeNop() const {
 	// FIXME: Make this more accurate by checking all animating chunks values to see if they all will remain stable.
 	// Write unit tests to ensure it's correct.
 	// Then add it to ErasePicture()
@@ -303,8 +376,7 @@ bool Game_Picture::UpdateWouldBeNop() const {
 	return data == empty;
 }
 
-
-void Game_Picture::Update(bool is_battle) {
+void Game_Pictures::Picture::Update(bool is_battle) {
 	if ((is_battle && !IsOnBattle()) || (!is_battle && !IsOnMap())) {
 		return;
 	}
@@ -404,13 +476,13 @@ void Game_Picture::Update(bool is_battle) {
 	}
 }
 
-void Game_Picture::Update(std::vector<Game_Picture>& pictures, bool is_battle) {
+void Game_Pictures::Update(bool is_battle) {
 	for (auto& pic: pictures) {
 		pic.Update(is_battle);
 	}
 }
 
-void Game_Picture::SetNonEffectParams(const Params& params, bool set_positions) {
+void Game_Pictures::Picture::SetNonEffectParams(const Params& params, bool set_positions) {
 	if (set_positions) {
 		data.finish_x = params.position_x;
 		data.finish_y = params.position_y;
@@ -424,7 +496,7 @@ void Game_Picture::SetNonEffectParams(const Params& params, bool set_positions) 
 	data.finish_sat = params.saturation;
 }
 
-void Game_Picture::SyncCurrentToFinish() {
+void Game_Pictures::Picture::SyncCurrentToFinish() {
 	data.current_x = data.finish_x;
 	data.current_y = data.finish_y;
 	data.current_red = data.finish_red;
@@ -437,6 +509,6 @@ void Game_Picture::SyncCurrentToFinish() {
 	data.current_effect_power = data.finish_effect_power;
 }
 
-inline int Game_Picture::NumSpriteSheetFrames() const {
+inline int Game_Pictures::Picture::NumSpriteSheetFrames() const {
 	return data.spritesheet_cols * data.spritesheet_rows;
 }

--- a/src/game_pictures.h
+++ b/src/game_pictures.h
@@ -33,9 +33,11 @@ class Scene;
 class Game_Pictures {
 public:
 	Game_Pictures();
-	explicit Game_Pictures(std::vector<RPG::SavePicture> save);
 
+	void SetSaveData(std::vector<RPG::SavePicture> save);
 	std::vector<RPG::SavePicture> GetSaveData() const;
+
+	void InitGraphics();
 
 	static int GetDefaultNumberOfPictures();
 

--- a/src/game_pictures.h
+++ b/src/game_pictures.h
@@ -28,15 +28,16 @@ class Sprite;
 class Scene;
 
 /**
- * Picture class.
+ * Pictures class.
  */
-class Game_Picture {
+class Game_Pictures {
 public:
-	explicit Game_Picture(int ID);
+	Game_Pictures();
+	explicit Game_Pictures(std::vector<RPG::SavePicture> save);
 
-	void SetupFromSave(RPG::SavePicture sp);
+	std::vector<RPG::SavePicture> GetSaveData() const;
 
-	const RPG::SavePicture& GetSaveData() const;
+	static int GetDefaultNumberOfPictures();
 
 	struct Params {
 		int position_x;
@@ -71,57 +72,58 @@ public:
 		int duration;
 	};
 
-	bool IsOnMap() const;
-	bool IsOnBattle() const;
-
-	void Show(const ShowParams& params);
-	void Move(const MoveParams& params);
-	void Erase();
+	void Show(int id, const ShowParams& params);
+	void Move(int id, const MoveParams& params);
+	void Erase(int id);
 
 	void Update(bool is_battle);
-	void UpdateSprite(bool is_battle);
-
-	static void Update(std::vector<Game_Picture>& pictures, bool is_battle);
-	static void UpdateSprite(std::vector<Game_Picture>& pictures, bool is_battle);
+	void UpdateGraphics(bool is_battle);
 
 	void OnMapChange();
 	void OnBattleEnd();
 
-	static void OnMapChange(std::vector<Game_Picture>& pictures);
-	static void OnBattleEnd(std::vector<Game_Picture>& pictures);
-
 private:
-	RPG::SavePicture data;
-	std::unique_ptr<Sprite> sprite;
-	BitmapRef bitmap;
-	FileRequestBinding request_id;
-	int last_spritesheet_frame = 0;
-	bool needs_update = false;
+	struct Picture {
+		Picture(int id) { data.ID = id; }
+		Picture(RPG::SavePicture data);
 
-	void SetNonEffectParams(const Params& params, bool set_positions);
-	void SyncCurrentToFinish();
-	void RequestPictureSprite();
-	void OnPictureSpriteReady(FileRequestResult*);
-	int NumSpriteSheetFrames() const;
+		RPG::SavePicture data;
+		std::unique_ptr<Sprite> sprite;
+		FileRequestBinding request_id;
+		int last_spritesheet_frame = 0;
+		bool needs_update = false;
 
-	bool UpdateWouldBeNop() const;
+		void Update(bool is_battle);
+		void UpdateGraphics(bool is_battle);
 
+		bool IsOnMap() const;
+		bool IsOnBattle() const;
+		bool UpdateWouldBeNop() const;
+		int NumSpriteSheetFrames() const;
+
+		void SetNonEffectParams(const Params& params, bool set_positions);
+		void SyncCurrentToFinish();
+
+		bool Show(const ShowParams& params);
+		void Move(const MoveParams& params);
+		void Erase();
+
+		void OnPictureSpriteReady();
+	};
+
+	Picture& GetPicture(int id);
+	Picture* GetPicturePtr(int id);
+	void RequestPictureSprite(Picture& pic);
+	void OnPictureSpriteReady(int id);
+
+	std::vector<Picture> pictures;
 };
 
-inline Game_Picture::Game_Picture(int id) {
-	data.ID = id;
-	needs_update = false;
-}
-
-inline const RPG::SavePicture& Game_Picture::GetSaveData() const {
-	return data;
-}
-
-inline bool Game_Picture::IsOnMap() const {
+inline bool Game_Pictures::Picture::IsOnMap() const {
 	return data.map_layer > 0;
 }
 
-inline bool Game_Picture::IsOnBattle() const {
+inline bool Game_Pictures::Picture::IsOnBattle() const {
 	return data.battle_layer > 0;
 }
 

--- a/src/game_pictures.h
+++ b/src/game_pictures.h
@@ -32,7 +32,7 @@ class Scene;
  */
 class Game_Pictures {
 public:
-	Game_Pictures();
+	Game_Pictures() = default;
 
 	void SetSaveData(std::vector<RPG::SavePicture> save);
 	std::vector<RPG::SavePicture> GetSaveData() const;
@@ -100,7 +100,6 @@ private:
 
 		bool IsOnMap() const;
 		bool IsOnBattle() const;
-		bool UpdateWouldBeNop() const;
 		int NumSpriteSheetFrames() const;
 
 		void SetNonEffectParams(const Params& params, bool set_positions);
@@ -119,6 +118,7 @@ private:
 	void OnPictureSpriteReady(int id);
 
 	std::vector<Picture> pictures;
+	int frame_counter = 0;
 };
 
 inline bool Game_Pictures::Picture::IsOnMap() const {

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -23,6 +23,7 @@
 #include "game_message.h"
 #include "game_party.h"
 #include "game_system.h"
+#include "game_screen.h"
 #include "input.h"
 #include "main_data.h"
 #include "player.h"

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -276,7 +276,7 @@ void Game_Screen::InitSand() {
 
 			p.x = std::round(std::cos(p.angle) * dist) + w / 2;
 			p.y = std::round(std::sin(p.angle) * dist);
-			p.life = Utils::GetRandomNumber(sand_min_alpha, sand_min_alpha);
+			p.life = Utils::GetRandomNumber(sand_min_alpha, sand_max_alpha);
 		}
 	}
 }

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -43,15 +43,13 @@ Game_Screen::Game_Screen()
 Game_Screen::~Game_Screen() {
 }
 
-void Game_Screen::SetupNewGame() {
-	data = {};
-	weather = std::make_unique<Weather>();
-	OnWeatherChanged();
+void Game_Screen::SetSaveData(RPG::SaveScreen screen)
+{
+	data = std::move(screen);
 }
 
-void Game_Screen::SetupFromSave(RPG::SaveScreen screen) {
-	data = std::move(screen);
 
+void Game_Screen::InitGraphics() {
 	weather = std::make_unique<Weather>();
 	OnWeatherChanged();
 

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -36,22 +36,6 @@
 #include "flash.h"
 #include "shake.h"
 
-static int GetDefaultNumberOfPictures() {
-	if (Player::IsEnglish()) {
-		return 1000;
-	}
-	else if (Player::IsMajorUpdatedVersion()) {
-		return 50;
-	}
-	else if (Player::IsRPG2k3Legacy()) {
-		return 40;
-	}
-	else if (Player::IsRPG2kLegacy()) {
-		return 20;
-	}
-	return 0;
-}
-
 Game_Screen::Game_Screen()
 {
 }
@@ -63,27 +47,13 @@ void Game_Screen::SetupNewGame() {
 	data = {};
 	weather = std::make_unique<Weather>();
 	OnWeatherChanged();
-
-	// Pre-allocate pictures depending on detected game version.
-	// This makes our savegames match RPG_RT.
-	PreallocatePictureData(GetDefaultNumberOfPictures());
 }
 
-void Game_Screen::SetupFromSave(RPG::SaveScreen screen, std::vector<RPG::SavePicture> save_pics) {
+void Game_Screen::SetupFromSave(RPG::SaveScreen screen) {
 	data = std::move(screen);
 
 	weather = std::make_unique<Weather>();
-
-	pictures.clear();
-	pictures.reserve(save_pics.size());
-
-	weather = std::make_unique<Weather>();
 	OnWeatherChanged();
-
-	for (auto& sp: save_pics) {
-		pictures.emplace_back(sp.ID);
-		pictures.back().SetupFromSave(std::move(sp));
-	}
 
 	if (data.battleanim_active) {
 		ShowBattleAnimation(data.battleanim_id,
@@ -93,18 +63,7 @@ void Game_Screen::SetupFromSave(RPG::SaveScreen screen, std::vector<RPG::SavePic
 	}
 }
 
-std::vector<RPG::SavePicture> Game_Screen::GetPictureSaveData() const {
-	std::vector<RPG::SavePicture> save_pics;
-	save_pics.reserve(pictures.size());
-	for (auto& pic: pictures) {
-		save_pics.push_back(pic.GetSaveData());
-	}
-	return save_pics;
-}
-
 void Game_Screen::OnMapChange() {
-	Game_Picture::OnMapChange(pictures);
-
 	data.flash_red = 0;
 	data.flash_green = 0;
 	data.flash_blue = 0;
@@ -130,17 +89,6 @@ void Game_Screen::OnMapChange() {
 	movie_res_y = 0;
 
 	animation.reset();
-}
-
-void Game_Screen::OnBattleEnd() {
-	Game_Picture::OnBattleEnd(pictures);
-}
-
-void Game_Screen::DoPreallocatePictureData(int id) {
-	pictures.reserve(id);
-	while (static_cast<int>(pictures.size()) < id) {
-		pictures.emplace_back(pictures.size() + 1);
-	}
 }
 
 void Game_Screen::TintScreen(int r, int g, int b, int s, int tenths) {
@@ -417,9 +365,8 @@ void Game_Screen::UpdateWeather() {
 	}
 }
 
-void Game_Screen::Update(bool is_battle) {
+void Game_Screen::Update() {
 	UpdateScreenEffects();
-	Game_Picture::Update(pictures, is_battle);
 	UpdateMovie();
 	UpdateWeather();
 	UpdateBattleAnimation();
@@ -468,7 +415,6 @@ void Game_Screen::CancelBattleAnimation() {
 	animation.reset();
 }
 
-void Game_Screen::UpdateGraphics(bool is_battle) {
-	Game_Picture::UpdateSprite(pictures, is_battle);
+void Game_Screen::UpdateGraphics() {
 	weather->SetTone(GetTone());
 }

--- a/src/game_screen.h
+++ b/src/game_screen.h
@@ -38,9 +38,9 @@ public:
 	Game_Screen();
 	~Game_Screen();
 
-	void SetupNewGame();
-	void SetupFromSave(RPG::SaveScreen screen);
+	void InitGraphics();
 
+	void SetSaveData(RPG::SaveScreen screen);
 	const RPG::SaveScreen& GetSaveData() const;
 
 	void TintScreen(int r, int g, int b, int s, int tenths);

--- a/src/game_screen.h
+++ b/src/game_screen.h
@@ -23,7 +23,6 @@
 #include "system.h"
 #include "options.h"
 #include "compiler.h"
-#include "game_picture.h"
 #include "game_character.h"
 #include "battle_animation.h"
 #include "flash.h"
@@ -40,12 +39,9 @@ public:
 	~Game_Screen();
 
 	void SetupNewGame();
-	void SetupFromSave(RPG::SaveScreen screen, std::vector<RPG::SavePicture> pictures);
+	void SetupFromSave(RPG::SaveScreen screen);
 
-	const RPG::SaveScreen& GetScreenSaveData() const;
-	std::vector<RPG::SavePicture> GetPictureSaveData() const;
-
-	Game_Picture& GetPicture(int id);
+	const RPG::SaveScreen& GetSaveData() const;
 
 	void TintScreen(int r, int g, int b, int s, int tenths);
 	void FlashOnce(int r, int g, int b, int s, int frames);
@@ -58,8 +54,8 @@ public:
 	void SetWeatherEffect(int type, int strength);
 	void PlayMovie(const std::string& filename,
 				   int pos_x, int pos_y, int res_x, int res_y);
-	void Update(bool is_battle);
-	void UpdateGraphics(bool is_battle);
+	void Update();
+	void UpdateGraphics();
 
 	/**
 	 * Returns the current screen tone.
@@ -163,7 +159,6 @@ public:
 	void OnBattleEnd();
 
 private:
-	std::vector<Game_Picture> pictures;
 	std::unique_ptr<BattleAnimation> animation;
 	std::unique_ptr<Weather> weather;
 
@@ -191,8 +186,6 @@ protected:
 	void OnWeatherChanged();
 	void InitRainSnow(int lifetime);
 	void InitSand();
-	void PreallocatePictureData(int id);
-	void DoPreallocatePictureData(int id);
 };
 
 inline int Game_Screen::GetPanX() const {
@@ -250,22 +243,7 @@ inline bool Game_Screen::IsBattleAnimationWaiting() {
 	return (bool)animation;
 }
 
-inline Game_Picture& Game_Screen::GetPicture(int id) {
-	assert(id >= 0);
-
-	PreallocatePictureData(id);
-
-	return pictures[id - 1];
-}
-
-inline void Game_Screen::PreallocatePictureData(int id) {
-	if (EP_UNLIKELY(id > (int)pictures.size())) {
-		DoPreallocatePictureData(id);
-		return;
-	}
-}
-
-inline const RPG::SaveScreen& Game_Screen::GetScreenSaveData() const {
+inline const RPG::SaveScreen& Game_Screen::GetSaveData() const {
 	return data;
 }
 

--- a/src/main_data.cpp
+++ b/src/main_data.cpp
@@ -23,6 +23,7 @@
 #include "game_enemyparty.h"
 #include "game_player.h"
 #include "game_screen.h"
+#include "game_pictures.h"
 #include "game_map.h"
 #include "game_variables.h"
 #include "game_switches.h"
@@ -57,6 +58,7 @@ namespace Main_Data {
 	std::unique_ptr<Game_Switches> game_switches;
 	std::unique_ptr<Game_Variables> game_variables;
 	std::unique_ptr<Game_Screen> game_screen;
+	std::unique_ptr<Game_Pictures> game_pictures;
 	std::unique_ptr<Game_Player> game_player;
 	std::unique_ptr<Game_Party> game_party;
 	std::unique_ptr<Game_EnemyParty> game_enemyparty;
@@ -161,6 +163,7 @@ void Main_Data::Cleanup() {
 
 	game_switches.reset();
 	game_screen.reset();
+	game_pictures.reset();
 	game_player.reset();
 	game_party.reset();
 	game_enemyparty.reset();

--- a/src/main_data.h
+++ b/src/main_data.h
@@ -21,14 +21,15 @@
 // Headers
 #include "data.h"
 #include "rpg_save.h"
-#include "game_screen.h"
 #include <string>
+#include <memory>
 
 /**
  * Main Data namespace.
  */
 class Game_Player;
 class Game_Screen;
+class Game_Pictures;
 class Game_Party;
 class Game_EnemyParty;
 class Game_Switches;
@@ -41,6 +42,7 @@ namespace Main_Data {
 	extern std::unique_ptr<Game_Switches> game_switches;
 	extern std::unique_ptr<Game_Variables> game_variables;
 	extern std::unique_ptr<Game_Screen> game_screen;
+	extern std::unique_ptr<Game_Pictures> game_pictures;
 	extern std::unique_ptr<Game_Player> game_player;
 	extern std::unique_ptr<Game_Party> game_party;
 	extern std::unique_ptr<Game_EnemyParty> game_enemyparty;

--- a/src/meta.cpp
+++ b/src/meta.cpp
@@ -20,6 +20,7 @@
 // Headers
 #include <fstream>
 #include <iomanip>
+#include <sstream>
 #include <zlib.h>
 #include "data.h"
 #include "filefinder.h"

--- a/src/plane.cpp
+++ b/src/plane.cpp
@@ -22,6 +22,7 @@
 #include "main_data.h"
 #include "game_map.h"
 #include "drawable_mgr.h"
+#include "game_screen.h"
 
 Plane::Plane() : Drawable(0)
 {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -72,6 +72,7 @@
 #include "reader_util.h"
 #include "scene_battle.h"
 #include "scene_logo.h"
+#include "scene_map.h"
 #include "utils.h"
 #include "version.h"
 #include "game_quit.h"
@@ -929,6 +930,11 @@ void Player::LoadSavegame(const std::string& save_name) {
 
 	Game_Actors::Fixup();
 	Main_Data::game_party->SetupFromSave(std::move(Main_Data::game_data.inventory));
+	Main_Data::game_switches->SetData(std::move(Main_Data::game_data.system.switches));
+	Main_Data::game_variables->SetData(std::move(Main_Data::game_data.system.variables));
+	Main_Data::game_screen->SetSaveData(std::move(Main_Data::game_data.screen));
+	Main_Data::game_pictures->SetSaveData(std::move(Main_Data::game_data.pictures));
+	Main_Data::game_targets->SetSaveData(std::move(Main_Data::game_data.targets));
 
 	int map_id = save->party_location.map_id;
 
@@ -936,13 +942,10 @@ void Player::LoadSavegame(const std::string& save_name) {
 	save_request_id = map->Bind(&OnMapSaveFileReady);
 	map->SetImportantFile(true);
 
-	Main_Data::game_switches->SetData(std::move(Main_Data::game_data.system.switches));
-	Main_Data::game_variables->SetData(std::move(Main_Data::game_data.system.variables));
-	Main_Data::game_targets->SetSaveData(std::move(Main_Data::game_data.targets));
-
 	Game_System::ReloadSystemGraphic();
 
 	map->Start();
+	Scene::Push(std::make_shared<Scene_Map>(true));
 }
 
 static void OnMapFileReady(FileRequestResult*) {
@@ -975,6 +978,7 @@ void Player::SetupNewGame() {
 
 	Main_Data::game_party->SetupNewGame();
 	SetupPlayerSpawn();
+	Scene::Push(std::make_shared<Scene_Map>(false));
 }
 
 void Player::SetupPlayerSpawn() {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -53,6 +53,8 @@
 #include "game_party.h"
 #include "game_player.h"
 #include "game_switches.h"
+#include "game_screen.h"
+#include "game_pictures.h"
 #include "game_system.h"
 #include "game_temp.h"
 #include "game_variables.h"
@@ -794,6 +796,7 @@ void Player::ResetGameObjects() {
 	// Prevent a crash when Game_Map wants to reset the screen content
 	// because Setup() modified pictures array
 	Main_Data::game_screen = std::make_unique<Game_Screen>();
+	Main_Data::game_pictures = std::make_unique<Game_Pictures>();
 
 	Game_Actors::Init();
 	Game_Map::Init();

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -32,6 +32,8 @@
 #include "game_enemy.h"
 #include "game_enemyparty.h"
 #include "game_battle.h"
+#include "game_screen.h"
+#include "game_pictures.h"
 #include "battle_animation.h"
 #include "reader_util.h"
 #include "scene_battle.h"
@@ -185,7 +187,8 @@ void Scene_Battle::Update() {
 	// Screen Effects
 	Game_Message::Update();
 	Main_Data::game_party->UpdateTimers();
-	Main_Data::game_screen->Update(true);
+	Main_Data::game_screen->Update();
+	Main_Data::game_pictures->Update(true);
 	Game_Battle::UpdateAnimation();
 
 	// Query Timer before and after update.

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -29,6 +29,7 @@
 #include "game_message.h"
 #include "game_battle.h"
 #include "game_battlealgorithm.h"
+#include "game_screen.h"
 #include "battle_animation.h"
 #include "reader_util.h"
 #include "scene_battle_rpg2k.h"

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -30,6 +30,7 @@
 #include "game_message.h"
 #include "game_battle.h"
 #include "game_battlealgorithm.h"
+#include "game_screen.h"
 #include "reader_util.h"
 #include "scene_gameover.h"
 #include "utils.h"

--- a/src/scene_equip.cpp
+++ b/src/scene_equip.cpp
@@ -20,6 +20,7 @@
 #include "game_actors.h"
 #include "game_party.h"
 #include "game_system.h"
+#include "game_screen.h"
 #include "input.h"
 #include "player.h"
 #include "reader_util.h"

--- a/src/scene_file.h
+++ b/src/scene_file.h
@@ -25,6 +25,7 @@
 #include "scene.h"
 #include "window_help.h"
 #include "window_savefile.h"
+#include "sprite.h"
 
 
 /**

--- a/src/scene_import.cpp
+++ b/src/scene_import.cpp
@@ -25,7 +25,6 @@
 #include "player.h"
 #include "scene_file.h"
 #include "scene_import.h"
-#include "scene_map.h"
 
 Scene_Import::Scene_Import() :
 	Scene_File(Player::meta->GetExVocabImportSaveHelpText()) {
@@ -138,8 +137,6 @@ void Scene_Import::FinishScan() {
 
 void Scene_Import::Action(int index) {
 	Player::LoadSavegame(files[index].full_path);
-
-	Scene::Push(std::make_shared<Scene_Map>(true));
 }
 
 bool Scene_Import::IsSlotValid(int index) {

--- a/src/scene_load.cpp
+++ b/src/scene_load.cpp
@@ -36,8 +36,6 @@ void Scene_Load::Action(int index) {
 	std::string save_name = FileFinder::FindDefault(*tree, ss.str());
 
 	Player::LoadSavegame(save_name);
-
-	Scene::Push(std::make_shared<Scene_Map>(true));
 }
 
 bool Scene_Load::IsSlotValid(int index) {

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -23,7 +23,6 @@
 #include "game_battle.h"
 #include "input.h"
 #include "player.h"
-#include "scene_map.h"
 #include "scene_title.h"
 #include "scene_gamebrowser.h"
 #include "output.h"
@@ -95,7 +94,6 @@ void Scene_Logo::Update() {
 
 				std::string save_name = FileFinder::FindDefault(*tree, ss.str());
 				Player::LoadSavegame(save_name);
-				Scene::Push(std::make_shared<Scene_Map>(true));
 			}
 		}
 		else {

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -55,8 +55,9 @@ static bool GetRunForegroundEvents(TeleportTarget::Type tt) {
 	return false;
 }
 
-Scene_Map::Scene_Map(bool from_save) :
-	from_save(from_save) {
+Scene_Map::Scene_Map(bool from_save)
+	: from_save(from_save)
+{
 	type = Scene::Map;
 
 	SetUseSharedDrawables(true);
@@ -78,17 +79,15 @@ void Scene_Map::Start() {
 	// Called here instead of Scene Load, otherwise wrong graphic stack
 	// is used.
 	if (from_save) {
-		Main_Data::game_screen->SetupFromSave(std::move(Main_Data::game_data.screen));
-		Main_Data::game_pictures = std::make_unique<Game_Pictures>(std::move(Main_Data::game_data.pictures));
 		auto current_music = Game_System::GetCurrentBGM();
 		Game_System::BgmStop();
 		Game_System::BgmPlay(current_music);
 	} else {
-		Main_Data::game_screen->SetupNewGame();
-		Main_Data::game_pictures = std::make_unique<Game_Pictures>();
 		Game_Map::PlayBgm();
 	}
 
+	Main_Data::game_screen->InitGraphics();
+	Main_Data::game_pictures->InitGraphics();
 	Player::FrameReset(Game_Clock::now());
 
 	Start2(MapUpdateAsyncContext());

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -33,6 +33,7 @@
 #include "game_player.h"
 #include "game_system.h"
 #include "game_screen.h"
+#include "game_pictures.h"
 #include "rpg_system.h"
 #include "player.h"
 #include "transition.h"
@@ -77,12 +78,14 @@ void Scene_Map::Start() {
 	// Called here instead of Scene Load, otherwise wrong graphic stack
 	// is used.
 	if (from_save) {
-		Main_Data::game_screen->SetupFromSave(std::move(Main_Data::game_data.screen), std::move(Main_Data::game_data.pictures));
+		Main_Data::game_screen->SetupFromSave(std::move(Main_Data::game_data.screen));
+		Main_Data::game_pictures = std::make_unique<Game_Pictures>(std::move(Main_Data::game_data.pictures));
 		auto current_music = Game_System::GetCurrentBGM();
 		Game_System::BgmStop();
 		Game_System::BgmPlay(current_music);
 	} else {
 		Main_Data::game_screen->SetupNewGame();
+		Main_Data::game_pictures = std::make_unique<Game_Pictures>();
 		Game_Map::PlayBgm();
 	}
 
@@ -137,7 +140,8 @@ void Scene_Map::Continue(SceneType prev_scene) {
 
 void Scene_Map::UpdateGraphics() {
 	spriteset->Update();
-	Main_Data::game_screen->UpdateGraphics(false);
+	Main_Data::game_screen->UpdateGraphics();
+	Main_Data::game_pictures->UpdateGraphics(false);
 }
 
 static bool IsMenuScene(Scene::SceneType scene) {

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -33,7 +33,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Scene_Map(bool from_save = false);
+	explicit Scene_Map(bool from_save);
 
 	~Scene_Map();
 
@@ -92,7 +92,7 @@ private:
 	std::unique_ptr<Window_Message> message_window;
 
 	int debug_menuoverwrite_counter = 0;
-	bool from_save;
+	bool from_save = false;
 	bool screen_erased_by_event = false;
 
 	AsyncContinuation map_async_continuation = {};

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -32,6 +32,8 @@
 #include "game_party.h"
 #include "game_system.h"
 #include "game_targets.h"
+#include "game_screen.h"
+#include "game_pictures.h"
 #include "lsd_reader.h"
 #include "output.h"
 #include "player.h"
@@ -120,8 +122,8 @@ void Scene_Save::Action(int index) {
 	data_copy.system.variables = Main_Data::game_variables->GetData();
 	data_copy.inventory = Main_Data::game_party->GetSaveData();
 
-	data_copy.screen = Main_Data::game_screen->GetScreenSaveData();
-	data_copy.pictures = Main_Data::game_screen->GetPictureSaveData();
+	data_copy.screen = Main_Data::game_screen->GetSaveData();
+	data_copy.pictures = Main_Data::game_pictures->GetSaveData();
 
 	// RPG_RT saves always have the scene set to this.
 	data_copy.system.scene = RPG::SaveSystem::Scene_file;

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -35,7 +35,6 @@
 #include "scene_battle.h"
 #include "scene_import.h"
 #include "scene_load.h"
-#include "scene_map.h"
 #include "window_command.h"
 #include "baseui.h"
 
@@ -103,7 +102,6 @@ void Scene_Title::Update() {
 
 	if (!Data::system.show_title || Player::new_game_flag) {
 		Player::SetupNewGame();
-		Scene::Push(std::make_shared<Scene_Map>());
 		if (Player::debug_flag && Player::hide_title_flag) {
 			Scene::Push(std::make_shared<Scene_Load>());
 		}
@@ -212,7 +210,6 @@ void Scene_Title::CommandNewGame() {
 		Output::Debug("Starting new game");
 		Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Decision));
 		Player::SetupNewGame();
-		Scene::Push(std::make_shared<Scene_Map>());
 	}
 }
 

--- a/src/spriteset_battle.cpp
+++ b/src/spriteset_battle.cpp
@@ -25,6 +25,7 @@
 #include "game_enemyparty.h"
 #include "game_party.h"
 #include "game_temp.h"
+#include "game_screen.h"
 #include "main_data.h"
 #include "player.h"
 #include "sprite_battler.h"

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -25,6 +25,7 @@
 #include "game_character.h"
 #include "game_player.h"
 #include "game_vehicle.h"
+#include "game_screen.h"
 #include "bitmap.h"
 #include "player.h"
 #include "drawable_list.h"


### PR DESCRIPTION
Depends on #2052 

This refactors the picture data. Now we have one `Game_Pictures` class which manages all the pictures and detaches them from `Game_Screen`. This fixes all the recent picture loading issues #2051 and #2053. It also cleans up initialization and provides some optimizations.