### PR TITLE
Remove global drawable list - Main Loop 5 of N

### DIFF
--- a/src/drawable_mgr.cpp
+++ b/src/drawable_mgr.cpp
@@ -34,18 +34,10 @@ void DrawableMgr::SetLocalList(DrawableList* list) {
 }
 
 void DrawableMgr::Register(Drawable* drawable) {
-	if (drawable->IsGlobal()) {
-		GetGlobalList().Append(drawable);
-	} else {
-		GetLocalList().Append(drawable);
-	}
+	GetLocalList().Append(drawable);
 }
 
 void DrawableMgr::Remove(Drawable* drawable) {
-	if (drawable->IsGlobal()) {
-		GetGlobalList().Take(drawable);
-	} else {
-		GetLocalList().Take(drawable);
-	}
+	GetLocalList().Take(drawable);
 }
 

--- a/src/drawable_mgr.h
+++ b/src/drawable_mgr.h
@@ -24,7 +24,6 @@
 
 struct DrawableMgr {
 	public:
-		static DrawableList& GetGlobalList();
 		static DrawableList& GetLocalList();
 		static DrawableList* GetLocalListPtr();
 
@@ -38,12 +37,6 @@ struct DrawableMgr {
 };
 
 
-inline DrawableList& DrawableMgr::GetGlobalList() {
-	// FIXME: Make DrawableList constructor constexpr to optimize this.
-	static DrawableList _global;
-	return _global;
-}
-
 inline DrawableList& DrawableMgr::GetLocalList() {
 	auto* local = GetLocalListPtr();
 	assert(local != nullptr);
@@ -54,12 +47,8 @@ inline DrawableList* DrawableMgr::GetLocalListPtr() {
 	return _local;
 }
 
-inline void DrawableMgr::OnUpdateZ(Drawable* drawable) {
-	if (drawable->IsGlobal()) {
-		GetGlobalList().SetDirty();
-	} else {
-		GetLocalList().SetDirty();
-	}
+inline void DrawableMgr::OnUpdateZ(Drawable* /* drawable */) {
+	GetLocalList().SetDirty();
 }
 
 #endif

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -59,9 +59,8 @@ namespace Graphics {
 	void Draw(Bitmap& dst);
 
 	void LocalDraw(Bitmap& dst, int min_z, int max_z);
-	void GlobalDraw(Bitmap& dst, int min_z, int max_z);
 
-	void UpdateSceneCallback();
+	std::shared_ptr<Scene> UpdateSceneCallback();
 
 	/**
 	 * Returns a handle to the message overlay.

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -348,6 +348,7 @@ void Player::Draw() {
 	auto cur_time = Game_Clock::now();
 	if (cur_time < next_frame) {
 		Graphics::Draw(*DisplayUi->GetDisplaySurface());
+		DisplayUi->UpdateDisplay();
 	}
 }
 

--- a/src/scene.h
+++ b/src/scene.h
@@ -28,7 +28,7 @@
 /**
  * Scene virtual class.
  */
-class Scene : public std::enable_shared_from_this<Scene> {
+class Scene {
 public:
 	/** Scene types. */
 	enum SceneType {
@@ -259,9 +259,9 @@ public:
 	 * Transfer drawables from the previous scene. This is called
 	 * when we do a scene change.
 	 *
-	 * @param prev_scene can be nullptr if this is the first scene.
+	 * @param prev_scene the scene to take from.
 	 */
-	void TransferDrawablesFrom(Scene* prev_scene);
+	void TransferDrawablesFrom(Scene& prev_scene);
 
 protected:
 	using AsyncContinuation = std::function<void(void)>;

--- a/src/transition.cpp
+++ b/src/transition.cpp
@@ -93,7 +93,6 @@ void Transition::Init(Type type, Scene *linked_scene, int duration, bool erase) 
 		if (erase) {
 			screen1 =  Bitmap::Create(DisplayUi->GetWidth(), DisplayUi->GetHeight(), true);
 			Graphics::LocalDraw(*screen1, std::numeric_limits<int>::min(), GetZ() - 1);
-			Graphics::GlobalDraw(*screen1, std::numeric_limits<int>::min(), GetZ() - 1);
 		} else {
 			screen1 = DisplayUi->CaptureScreen();
 		}
@@ -103,7 +102,6 @@ void Transition::Init(Type type, Scene *linked_scene, int duration, bool erase) 
 	} else {
 		screen2 =  Bitmap::Create(DisplayUi->GetWidth(), DisplayUi->GetHeight(), true);
 		Graphics::LocalDraw(*screen2, std::numeric_limits<int>::min(), GetZ() - 1);
-		Graphics::GlobalDraw(*screen2, std::numeric_limits<int>::min(), GetZ() - 1);
 	}
 
 	// Total frames and erased have to be set *after* the above drawing code.

--- a/tests/drawable_list.cpp
+++ b/tests/drawable_list.cpp
@@ -2,6 +2,7 @@
 #include <cstdlib>
 #include "utils.h"
 #include "drawable_list.h"
+#include "drawable_mgr.h"
 #include "bitmap.h"
 #include "doctest.h"
 
@@ -56,6 +57,9 @@ TEST_CASE("DirtyDraw") {
 
 template <typename F>
 void testAppend(F&& f) {
+	DrawableList default_list;
+	DrawableMgr::SetLocalList(&default_list);
+
 	DrawableList list;
 
 	TestSprite s1(5);
@@ -107,6 +111,9 @@ TEST_CASE("AppendDraw") {
 }
 
 TEST_CASE("AppendUnSorted") {
+	DrawableList default_list;
+	DrawableMgr::SetLocalList(&default_list);
+
 	DrawableList list;
 
 	TestSprite s1(2);
@@ -130,6 +137,9 @@ TEST_CASE("AppendUnSorted") {
 }
 
 TEST_CASE("AppendSorted") {
+	DrawableList default_list;
+	DrawableMgr::SetLocalList(&default_list);
+
 	DrawableList list;
 
 	TestSprite s1(1);
@@ -153,6 +163,9 @@ TEST_CASE("AppendSorted") {
 }
 
 TEST_CASE("AppendSame") {
+	DrawableList default_list;
+	DrawableMgr::SetLocalList(&default_list);
+
 	DrawableList list;
 
 	TestSprite s1;
@@ -176,6 +189,9 @@ TEST_CASE("AppendSame") {
 }
 
 TEST_CASE("TakeSorted") {
+	DrawableList default_list;
+	DrawableMgr::SetLocalList(&default_list);
+
 	DrawableList list;
 
 	TestSprite s1(1);
@@ -209,6 +225,9 @@ TEST_CASE("TakeSorted") {
 }
 
 TEST_CASE("TakeNotSorted") {
+	DrawableList default_list;
+	DrawableMgr::SetLocalList(&default_list);
+
 	DrawableList list;
 
 	TestSprite s1(3);
@@ -242,6 +261,9 @@ TEST_CASE("TakeNotSorted") {
 }
 
 TEST_CASE("TakeFromAll") {
+	DrawableList default_list;
+	DrawableMgr::SetLocalList(&default_list);
+
 	TestSprite s1;
 	TestSprite s2;
 	TestFrame f1;
@@ -277,6 +299,9 @@ TEST_CASE("TakeFromAll") {
 }
 
 TEST_CASE("TakeFromPred") {
+	DrawableList default_list;
+	DrawableMgr::SetLocalList(&default_list);
+
 	TestSprite s1;
 	TestSprite s2;
 	TestFrame f1;

--- a/tests/drawable_mgr.cpp
+++ b/tests/drawable_mgr.cpp
@@ -29,7 +29,6 @@ TEST_CASE("LocalSet") {
 
 		REQUIRE_EQ(DrawableMgr::GetLocalListPtr(), &list);
 		REQUIRE_EQ(&DrawableMgr::GetLocalList(), &list);
-		REQUIRE_NE(&DrawableMgr::GetGlobalList(), &list);
 	}
 	REQUIRE_EQ(DrawableMgr::GetLocalListPtr(), nullptr);
 }
@@ -42,44 +41,17 @@ TEST_CASE("Drawables") {
 	list.Sort();
 	REQUIRE_FALSE(list.IsDirty());
 
-	auto& glist = DrawableMgr::GetGlobalList();
-
-	auto global = std::make_unique<TestSprite>(Drawable::Flags::Global);
-
-	REQUIRE_EQ(glist.size(), 1L);
-	REQUIRE_EQ(*glist.begin(), global.get());
-	REQUIRE_FALSE(glist.IsDirty());
-	REQUIRE_FALSE(list.IsDirty());
-
-	REQUIRE_EQ(list.size(), 0L);
-
 	auto local = std::make_unique<TestSprite>(Drawable::Flags::Default);
 
-	REQUIRE_EQ(glist.size(), 1L);
-	REQUIRE_EQ(*glist.begin(), global.get());
-	REQUIRE_FALSE(glist.IsDirty());
-	REQUIRE_FALSE(list.IsDirty());
-
-	global->SetZ(10);
-
-	REQUIRE(glist.IsDirty());
 	REQUIRE_FALSE(list.IsDirty());
 
 	local->SetZ(10);
-
-	REQUIRE(glist.IsDirty());
 	REQUIRE(list.IsDirty());
-
-	global.reset();
-
-	REQUIRE_EQ(glist.size(), 0L);
 
 	REQUIRE_EQ(list.size(), 1L);
 	REQUIRE_EQ(*list.begin(), local.get());
 
 	local.reset();
-
-	REQUIRE_EQ(glist.size(), 0L);
 
 	REQUIRE_EQ(list.size(), 0L);
 }


### PR DESCRIPTION
Depends on #2019

This PR removes the global drawable list. Now all drawables can be sorted and rendered in a cohesive way. The `TakeFrom` mechanism is used to transfer the globals between scenes during scene change.

Drawing still works as before, because all the global drawables also have higher Z values than local drawables.