### PR TITLE
Add git version hash to sources and log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ stamp-h1
 /output
 /utils
 /directorytree
+src/git_version.cpp
 
 # cmake
 CMakeFiles/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,6 +383,21 @@ include(CMakeDependentOption)
 # Include directories
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
+# Git version file
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
+	# If we're building within the git repo, auto generate the version
+	include(GetGitRevisionDescription)
+	get_git_head_revision(GIT_REFSPEC GIT_VERSION)
+
+	set(GIT_VERSION_SRC ${CMAKE_CURRENT_BINARY_DIR}/src/git_version.cpp)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/git_version.cpp.in ${GIT_VERSION_SRC})
+else()
+	# This is a source distribution tarball, assume the file is already generated and packaged.
+	set(GIT_VERSION_SRC src/git_version.cpp)
+endif()
+
+target_sources(${PROJECT_NAME} PRIVATE ${GIT_VERSION_SRC})
+
 # Platform setup
 set(PLAYER_TARGET_PLATFORM "SDL2" CACHE STRING "Platform to compile for. Options: SDL2 libretro")
 set_property(CACHE PLAYER_TARGET_PLATFORM PROPERTY STRINGS SDL2 libretro)

--- a/Makefile.am
+++ b/Makefile.am
@@ -143,6 +143,7 @@ libeasyrpg_player_a_SOURCES = \
 	src/game_variables.h \
 	src/game_vehicle.cpp \
 	src/game_vehicle.h \
+	src/git_version.cpp \
 	src/graphics.cpp \
 	src/graphics.h \
 	src/hslrgb.cpp \
@@ -476,6 +477,8 @@ test_runner_LDADD = \
 
 check-local:
 	$(AM_V_at)./test_runner
+
+include builds/git_version.mk
 
 # Some tests will create this file
 # make distcheck will fail if it is not cleaned after running these tests

--- a/builds/3ds/Makefile
+++ b/builds/3ds/Makefile
@@ -18,6 +18,9 @@ endif
 TOPDIR ?= $(CURDIR)
 include $(DEVKITARM)/3ds_rules
 
+# Default Target
+all:
+
 #---------------------------------------------------------------------------------
 # TARGET is the name of the output
 # BUILD is the directory where object files & intermediate files will be placed

--- a/builds/3ds/Makefile
+++ b/builds/3ds/Makefile
@@ -115,6 +115,9 @@ SHLISTFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.shlist)))
 GFXFILES	:=	$(foreach dir,$(GRAPHICS),$(notdir $(wildcard $(dir)/*.t3s)))
 BINFILES	:=	$(foreach dir,$(DATA),$(notdir $(wildcard $(dir)/*.*)))
 
+include ../../builds/git_version.mk
+CPPFILES	+= $(GIT_VERSION_OUT)
+
 #---------------------------------------------------------------------------------
 # use CXX for linking C++ projects, CC for standard C
 #---------------------------------------------------------------------------------

--- a/builds/amiga/Makefile
+++ b/builds/amiga/Makefile
@@ -1,3 +1,6 @@
+# Default Target
+all:
+
 TARGET  := EasyRPG
 BUILD   := build
 SOURCES := ../../src

--- a/builds/amiga/Makefile
+++ b/builds/amiga/Makefile
@@ -10,6 +10,9 @@ CFILES   := $(foreach dir,$(SOURCES), $(wildcard $(dir)/*.c))
 CPPFILES := $(foreach dir,$(SOURCES), $(wildcard $(dir)/*.cpp))
 OBJS     := $(CFILES:.c=.o) $(CPPFILES:.cpp=.o)
 
+include ../../builds/git_version.mk
+CPPFILES	+= $(GIT_VERSION_OUT)
+
 ifeq ($(OSTYPE), MorphOS)
 PREFIX  = ppc-morphos
 CC      = $(PREFIX)-gcc -noixemul

--- a/builds/android/app/src/main/jni/src/Android.mk
+++ b/builds/android/app/src/main/jni/src/Android.mk
@@ -17,6 +17,9 @@ LOCAL_SRC_FILES := \
 	org_easyrpg_player_player_EasyRpgPlayerActivity.cpp \
 	$(patsubst $(LOCAL_PATH)/%, %, $(wildcard $(LOCAL_PATH)/$(PLAYER_PATH)/src/*.cpp))
 
+include $(LOCAL_PATH)/$(PLAYER_PATH)/builds/git_version.mk
+LOCAL_SRC_FILES	+= $(patsubst $(LOCAL_PATH)/%, %, $(GIT_VERSION_OUT))
+
 LOCAL_SHARED_LIBRARIES := SDL2 hidapi
 
 LOCAL_STATIC_LIBRARIES := \

--- a/builds/cmake/Modules/GetGitRevisionDescription.cmake
+++ b/builds/cmake/Modules/GetGitRevisionDescription.cmake
@@ -1,0 +1,172 @@
+# - Returns a version string from Git
+#
+# These functions force a re-configure on each git commit so that you can
+# trust the values of the variables in your build system.
+#
+#  get_git_head_revision(<refspecvar> <hashvar> [<additional arguments to git describe> ...])
+#
+# Returns the refspec and sha hash of the current head revision
+#
+#  git_describe(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe on the source tree, and adjusting
+# the output so that it tests false if an error occurs.
+#
+#  git_get_exact_tag(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe --exact-match on the source tree,
+# and adjusting the output so that it tests false if there was no exact
+# matching tag.
+#
+#  git_local_changes(<var>)
+#
+# Returns either "CLEAN" or "DIRTY" with respect to uncommitted changes.
+# Uses the return code of "git diff-index --quiet HEAD --".
+# Does not regard untracked files.
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+if(__get_git_revision_description)
+	return()
+endif()
+set(__get_git_revision_description YES)
+
+# We must run the following at "include" time, not at function call time,
+# to find the path to this module rather than the path to a calling list file
+get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
+
+function(get_git_head_revision _refspecvar _hashvar)
+	set(GIT_PARENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+	set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+	while(NOT EXISTS "${GIT_DIR}")	# .git dir not found, search parent directories
+		set(GIT_PREVIOUS_PARENT "${GIT_PARENT_DIR}")
+		get_filename_component(GIT_PARENT_DIR ${GIT_PARENT_DIR} PATH)
+		if(GIT_PARENT_DIR STREQUAL GIT_PREVIOUS_PARENT)
+			# We have reached the root directory, we are not in git
+			set(${_refspecvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+			set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+			return()
+		endif()
+		set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+	endwhile()
+	# check if this is a submodule
+	if(NOT IS_DIRECTORY ${GIT_DIR})
+		file(READ ${GIT_DIR} submodule)
+		string(REGEX REPLACE "gitdir: (.*)\n$" "\\1" GIT_DIR_RELATIVE ${submodule})
+		get_filename_component(SUBMODULE_DIR ${GIT_DIR} PATH)
+		get_filename_component(GIT_DIR ${SUBMODULE_DIR}/${GIT_DIR_RELATIVE} ABSOLUTE)
+	endif()
+	if(NOT IS_DIRECTORY "${GIT_DIR}")
+		file(READ ${GIT_DIR} worktree)
+ 		string(REGEX REPLACE "gitdir: (.*)worktrees(.*)\n$" "\\1" GIT_DIR ${worktree})
+ 	endif()
+	set(GIT_DATA "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/git-data")
+	if(NOT EXISTS "${GIT_DATA}")
+		file(MAKE_DIRECTORY "${GIT_DATA}")
+	endif()
+
+	if(NOT EXISTS "${GIT_DIR}/HEAD")
+		return()
+	endif()
+	set(HEAD_FILE "${GIT_DATA}/HEAD")
+	configure_file("${GIT_DIR}/HEAD" "${HEAD_FILE}" COPYONLY)
+
+	configure_file("${_gitdescmoddir}/GetGitRevisionDescription.cmake.in"
+		"${GIT_DATA}/grabRef.cmake"
+		@ONLY)
+	include("${GIT_DATA}/grabRef.cmake")
+
+	set(${_refspecvar} "${HEAD_REF}" PARENT_SCOPE)
+	set(${_hashvar} "${HEAD_HASH}" PARENT_SCOPE)
+endfunction()
+
+function(git_describe _var)
+	if(NOT GIT_FOUND)
+		find_package(Git QUIET)
+	endif()
+	get_git_head_revision(refspec hash)
+	if(NOT GIT_FOUND)
+		set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+	if(NOT hash)
+		set(${_var} "HEAD-HASH-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+
+	# TODO sanitize
+	#if((${ARGN}" MATCHES "&&") OR
+	#	(ARGN MATCHES "||") OR
+	#	(ARGN MATCHES "\\;"))
+	#	message("Please report the following error to the project!")
+	#	message(FATAL_ERROR "Looks like someone's doing something nefarious with git_describe! Passed arguments ${ARGN}")
+	#endif()
+
+	#message(STATUS "Arguments to execute_process: ${ARGN}")
+
+	execute_process(COMMAND
+		"${GIT_EXECUTABLE}"
+		describe
+		${hash}
+		${ARGN}
+		WORKING_DIRECTORY
+		"${CMAKE_CURRENT_SOURCE_DIR}"
+		RESULT_VARIABLE
+		res
+		OUTPUT_VARIABLE
+		out
+		ERROR_QUIET
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if(NOT res EQUAL 0)
+		set(out "${out}-${res}-NOTFOUND")
+	endif()
+
+	set(${_var} "${out}" PARENT_SCOPE)
+endfunction()
+
+function(git_get_exact_tag _var)
+	git_describe(out --exact-match ${ARGN})
+	set(${_var} "${out}" PARENT_SCOPE)
+endfunction()
+
+function(git_local_changes _var)
+	if(NOT GIT_FOUND)
+		find_package(Git QUIET)
+	endif()
+	get_git_head_revision(refspec hash)
+	if(NOT GIT_FOUND)
+		set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+	if(NOT hash)
+		set(${_var} "HEAD-HASH-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+
+	execute_process(COMMAND
+		"${GIT_EXECUTABLE}"
+		diff-index --quiet HEAD --
+		WORKING_DIRECTORY
+		"${CMAKE_CURRENT_SOURCE_DIR}"
+		RESULT_VARIABLE
+		res
+		OUTPUT_VARIABLE
+		out
+		ERROR_QUIET
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if(res EQUAL 0)
+		set(${_var} "CLEAN" PARENT_SCOPE)
+	else()
+		set(${_var} "DIRTY" PARENT_SCOPE)
+	endif()
+endfunction()

--- a/builds/cmake/Modules/GetGitRevisionDescription.cmake.in
+++ b/builds/cmake/Modules/GetGitRevisionDescription.cmake.in
@@ -1,0 +1,41 @@
+#
+# Internal file for GetGitRevisionDescription.cmake
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+set(HEAD_HASH)
+
+file(READ "@HEAD_FILE@" HEAD_CONTENTS LIMIT 1024)
+
+string(STRIP "${HEAD_CONTENTS}" HEAD_CONTENTS)
+if(HEAD_CONTENTS MATCHES "ref")
+	# named branch
+	string(REPLACE "ref: " "" HEAD_REF "${HEAD_CONTENTS}")
+	if(EXISTS "@GIT_DIR@/${HEAD_REF}")
+		configure_file("@GIT_DIR@/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
+	else()
+		configure_file("@GIT_DIR@/packed-refs" "@GIT_DATA@/packed-refs" COPYONLY)
+		file(READ "@GIT_DATA@/packed-refs" PACKED_REFS)
+		if(${PACKED_REFS} MATCHES "([0-9a-z]*) ${HEAD_REF}")
+			set(HEAD_HASH "${CMAKE_MATCH_1}")
+		endif()
+	endif()
+else()
+	# detached HEAD
+	configure_file("@GIT_DIR@/HEAD" "@GIT_DATA@/head-ref" COPYONLY)
+endif()
+
+if(NOT HEAD_HASH)
+	file(READ "@GIT_DATA@/head-ref" HEAD_HASH LIMIT 1024)
+	string(STRIP "${HEAD_HASH}" HEAD_HASH)
+endif()

--- a/builds/git_version.mk
+++ b/builds/git_version.mk
@@ -1,0 +1,16 @@
+GIT_ROOT = $(git rev-parse --absolute-git-dir)
+GIT_HEAD_FILE = HEAD
+GIT_REF_FILE = $(shell git symbolic-ref -q HEAD)
+ifeq ($(strip $(GIT_REF_FILE)),)
+	GIT_REV_FILE=$(GIT_ROOT)/$(GIT_HEAD_FILE)
+else
+	GIT_REV_FILE=$(GIT_ROOT)/$(GIT_REF_FILE)
+endif
+
+
+GIT_VERSION_IN = $(GIT_ROOT)/../src/git_version.cpp.in
+GIT_VERSION_OUT =$(GIT_ROOT)/../src/git_version.cpp
+
+$(GIT_VERSION_OUT): $(GIT_VERSION_IN) $(GIT_REV_FILE)
+	sed "s/@GIT_VERSION@/`cat $(GIT_REV_FILE)`/" $(GIT_VERSION_IN) > $@
+

--- a/builds/opendingux/Makefile
+++ b/builds/opendingux/Makefile
@@ -4,6 +4,9 @@
 #                     - Based on Rikku2000's -                   #
 ##################################################################
 
+# Default Target
+all:
+
 # Compiler Device option
 BUILD_TARGET ?= gcwzero
 

--- a/builds/opendingux/Makefile
+++ b/builds/opendingux/Makefile
@@ -71,6 +71,9 @@ CPPFILES = $(foreach dir, $(SOURCES), $(wildcard $(dir)/*.cpp))
 BINFILES = $(foreach dir, $(DATA), $(wildcard $(dir)/*.*))
 OBJS = $(addsuffix .o, $(BINFILES)) $(CPPFILES:.cpp=.o)
 
+include ../../builds/git_version.mk
+CPPFILES	+= $(GIT_VERSION_OUT)
+
 # Compiler flags
 CFLAGS += -Wall -DNDEBUG -DUSE_SDL=$(SDL_TARGET) -DHAVE_SDL_MIXER -DSUPPORT_AUDIO `$(SDL_CONFIG) --cflags` $(PIXMAN_CFLAGS) $(FREETYPE_CFLAGS) $(ICU_CFLAGS) $(LIBMPG123_CFLAGS) $(LIBSNDFILE_CFLAGS)
 CXXFLAGS += $(CFLAGS) -fno-rtti -fno-exceptions

--- a/builds/psvita/Makefile
+++ b/builds/psvita/Makefile
@@ -22,6 +22,9 @@ LIBS = -llcf -lexpat -lvita2d \
 	-lvitashaders -lSceSysmodule_stub -lSceCtrl_stub -lSceTouch_stub \
 	-lScePgf_stub -lScePower_stub -lSceCommonDialog_stub -lSceAudio_stub
 
+include ../../builds/git_version.mk
+CPPFILES	+= $(GIT_VERSION_OUT)
+
 ifeq ($(strip $(LIBLCF_DIR)),)
 LIBLCF_DIR := $(TOOLCHAIN_DIR)
 endif

--- a/builds/psvita/Makefile
+++ b/builds/psvita/Makefile
@@ -1,3 +1,6 @@
+# Default Target
+all:
+
 TARGET  := EasyRPG
 BUILD   := build
 SOURCES := ../../src

--- a/builds/switch/Makefile
+++ b/builds/switch/Makefile
@@ -114,6 +114,9 @@ CPPFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.cpp)))
 SFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.s)))
 BINFILES	:=	$(foreach dir,$(DATA),$(notdir $(wildcard $(dir)/*.*)))
 
+include ../../builds/git_version.mk
+CPPFILES	+= $(GIT_VERSION_OUT)
+
 #---------------------------------------------------------------------------------
 # use CXX for linking C++ projects, CC for standard C
 #---------------------------------------------------------------------------------

--- a/builds/switch/Makefile
+++ b/builds/switch/Makefile
@@ -18,6 +18,9 @@ endif
 TOPDIR ?= $(CURDIR)
 include $(DEVKITPRO)/libnx/switch_rules
 
+# Default Target
+all:
+
 #---------------------------------------------------------------------------------
 # TARGET is the name of the output
 # BUILD is the directory where object files & intermediate files will be placed

--- a/builds/wii/Makefile
+++ b/builds/wii/Makefile
@@ -18,6 +18,9 @@ endif
 
 include $(DEVKITPPC)/wii_rules
 
+# Default Target
+all:
+
 #---------------------------------------------------------------------------------
 # TARGET is the name of the output
 # BUILD is the directory where object files & intermediate files will be placed

--- a/builds/wii/Makefile
+++ b/builds/wii/Makefile
@@ -92,6 +92,9 @@ sFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(TOPDIR)/$(dir)/*.s)))
 SFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(TOPDIR)/$(dir)/*.S)))
 BINFILES	:=	$(foreach dir,$(DATA),$(notdir $(wildcard $(dir)/*.*)))
 
+include $(TOPDIR)/builds/git_version.mk
+CPPFILES	+= $(GIT_VERSION_OUT)
+
 #---------------------------------------------------------------------------------
 # use CXX for linking C++ projects, CC for standard C
 #---------------------------------------------------------------------------------

--- a/src/git_version.cpp.in
+++ b/src/git_version.cpp.in
@@ -1,0 +1,20 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "version.h"
+
+const char PLAYER_GIT_VERSION[] = "@GIT_VERSION@";

--- a/src/main_data.cpp
+++ b/src/main_data.cpp
@@ -79,7 +79,7 @@ void Main_Data::Init() {
 			// first set to current directory for all platforms
 			project_path = ".";
 
-#if defined(GEKKO) || defined(SWITCH) || defined(__MORPHOS__) || defined(__amigaos4__) || defined(__AROS__) 
+#if defined(GEKKO) || defined(__SWITCH__) || defined(__MORPHOS__) || defined(__amigaos4__) || defined(__AROS__) 
 			// Working directory not correctly handled
 			char working_dir[256];
 			getcwd(working_dir, 255);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -142,18 +142,13 @@ void Player::Init(int argc, char *argv[]) {
 	Graphics::Init();
 
 	// Display a nice version string
-	std::stringstream header;
-	std::string addtl_ver(PLAYER_ADDTL);
-	header << "EasyRPG Player " << PLAYER_VERSION;
-	if (!addtl_ver.empty())
-		header << " " << addtl_ver;
-	header << " started";
-	Output::Debug(header.str().c_str());
+	auto header = GetFullVersionString() + " started";
+	Output::Debug(header.c_str());
 
-	unsigned int header_width = header.str().length();
-	header.str("");
-	header << std::setfill('=') << std::setw(header_width) << "=";
-	Output::Debug(header.str().c_str());
+	for (auto& c: header) {
+		c = '=';
+	}
+	Output::Debug(header.c_str());
 
 #ifdef GEKKO
 	// Init libfat (Mount SD/USB)
@@ -1075,16 +1070,18 @@ int Player::GetSpeedModifier() {
 	return 1;
 }
 
-void Player::PrintVersion() {
-	std::string additional(PLAYER_ADDTL);
+std::string Player::GetFullVersionString() {
 	std::stringstream version;
+	version << "EasyRPG PLayer " << PLAYER_VERSION;
+	if (std::strlen(PLAYER_ADDTL) > 0) {
+		version << " " << PLAYER_ADDTL;
+	}
+	version << " " << PLAYER_GIT_VERSION;
+	return version.str();
+}
 
-	version << PLAYER_VERSION;
-
-	if (!additional.empty())
-		version << " " << additional;
-
-	std::cout << "EasyRPG Player " << version.str() << std::endl;
+void Player::PrintVersion() {
+	std::cout << GetFullVersionString() << std::endl;
 }
 
 void Player::PrintUsage() {

--- a/src/player.h
+++ b/src/player.h
@@ -236,6 +236,9 @@ namespace Player {
 	 */
 	int GetSpeedModifier();
 
+	/** @return full version string for player */
+	std::string GetFullVersionString();
+
 	/** Output program version on stdout */
 	void PrintVersion();
 

--- a/src/system.h
+++ b/src/system.h
@@ -79,7 +79,7 @@
 #  define SUPPORT_JOYSTICK
 #  define SUPPORT_JOYSTICK_HAT
 #  define SUPPORT_JOYSTICK_AXIS
-#elif defined(SWITCH)
+#elif defined(__SWITCH__)
 #elif defined(__MORPHOS__) || defined(__amigaos4__)
 #  define SUPPORT_ZOOM
 #  define WORDS_BIGENDIAN

--- a/src/version.h
+++ b/src/version.h
@@ -38,4 +38,6 @@
  */
 #define PLAYER_SAVEGAME_VERSION (PLAYER_MAJOR * 1000 + PLAYER_MINOR * 100 + PLAYER_PATCH * 10 + 0)
 
+extern const char PLAYER_GIT_VERSION[];
+
 #endif /* EP_VERSION_H */


### PR DESCRIPTION
Fix: #87

This logs the git commit hash in the output log. Should help with bug reports.

For cmake this uses some cmakefiles from here: https://github.com/rpavlik/cmake-modules/blob/master/GetGitRevisionDescription.cmake

These will correctly rebuild the `git_version.cpp` each time the git hash changes.

Plaforms:
- [x] cmake
- [x] autotools
- [x] Android
- [x] 3ds
- [ ] switch
- [x] gcw0
- [x] wii
- [x] vita

Features
- [x] Detects git version correctly
- [x] Reacts to git HEAD changes and rebuilds
- [x] Builds from source tarball without `.git` - `make distcheck` in autotools

Todo:
- [ ] Remove PLAYER_ADDTL_VERSION hacks from jenkins build scripts (not part of the codebase)