### PR TITLE
Allow global drawables to be destroyed when there is no list + windows crash fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -664,11 +664,6 @@ if(${PLAYER_AUDIO_BACKEND} MATCHES "^(SDL.*|libretro)$")
 	endif()
 endif()
 
-# MSVC: Set UTF-8 encoding for all files (important for rtp table)
-if(MSVC)
-	target_compile_options(${PROJECT_NAME} PRIVATE "/utf-8")
-endif()
-
 # Executable
 if (${PLAYER_BUILD_EXECUTABLE})
 	add_executable(${PROJECT_NAME}_exe WIN32 "src/main.cpp")

--- a/builds/cmake/Modules/ConfigureWindows.cmake
+++ b/builds/cmake/Modules/ConfigureWindows.cmake
@@ -43,6 +43,8 @@ if(MSVC)
 
 	option(MSVC_MULTICORE "MSVC: Build using multiple cores (/MP)" ON)
 	if (MSVC_MULTICORE)
-		add_compile_options(/MP)
+		add_compile_options("/MP")
 	endif()
+
+	add_compile_options("/utf-8")
 endif()

--- a/src/drawable_mgr.cpp
+++ b/src/drawable_mgr.cpp
@@ -38,6 +38,13 @@ void DrawableMgr::Register(Drawable* drawable) {
 }
 
 void DrawableMgr::Remove(Drawable* drawable) {
-	GetLocalList().Take(drawable);
+	auto* list = GetLocalListPtr();
+	// Global drawables can be singletons, which may get destroyed after all scenes due
+	// static initialization order. Non-global drawables we assume are all gone before
+	// all lists are destroyed.
+	assert(list || drawable->IsGlobal());
+	if (list) {
+		list->Take(drawable);
+	}
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -668,10 +668,10 @@ void Player::ParseCommandLine(int argc, char *argv[]) {
 void Player::CreateGameObjects() {
 	GetEncoding();
 	escape_symbol = ReaderUtil::Recode("\\", encoding);
-	escape_char = Utils::DecodeUTF32(Player::escape_symbol).front();
 	if (escape_symbol.empty()) {
 		Output::Error("Invalid encoding: %s.", encoding.c_str());
 	}
+	escape_char = Utils::DecodeUTF32(Player::escape_symbol).front();
 
 	std::string game_path = Main_Data::GetProjectPath();
 	std::string save_path = Main_Data::GetSavePath();

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -73,8 +73,8 @@ Rect Text::Draw(Bitmap& dest, const int x, const int y, Font& font, const Bitmap
 
 	// This loops always renders a single char, color blends it and then puts
 	// it onto the text_surface (including the drop shadow)
-	auto iter = &*text.begin();
-	const auto end = &*text.end();
+	auto iter = text.data();
+	const auto end = iter + text.size();
 	while (iter != end) {
 		auto ret = Utils::TextNext(iter, end, 0);
 
@@ -96,8 +96,8 @@ Rect Text::Draw(Bitmap& dest, const int x, const int y, Font& font, const Color 
 	int dy = y;
 	int ny = 0;
 
-	auto iter = &*text.begin();
-	const auto end = &*text.end();
+	auto iter = text.data();
+	const auto end = iter + text.size();
 	while (iter != end) {
 		auto ret = Utils::UTF8Next(iter, end);
 

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -287,10 +287,10 @@ void Window_Message::Update() {
 				SetOpenAnimation(0);
 			} else {
 				//Handled after base class updates.
-				if (text_index != &*text.end()) {
+				if (text_index != (text.data() + text.size())) {
 					update_message_processing = true;
 				}
-				if (text_index == &*text.end() && wait_count <= 0) {
+				if (text_index == (text.data() + text.size()) && wait_count <= 0) {
 					FinishMessageProcessing();
 				}
 			}
@@ -336,7 +336,7 @@ void Window_Message::UpdateMessage() {
 	auto font = Font::Default();
 
 	while (true) {
-		const auto* end = &*text.end();
+		const auto* end = text.data() + text.size();
 
 		if (wait_count > 0) {
 			--wait_count;
@@ -550,7 +550,7 @@ void Window_Message::WaitForInput() {
 
 		if (text.empty()) {
 			TerminateMessage();
-		} else if (text_index != &*text.end() && new_page_after_pause) {
+		} else if (text_index != (text.data() + text.size()) && new_page_after_pause) {
 			new_page_after_pause = false;
 			InsertNewPage();
 		}

--- a/tests/parse.cpp
+++ b/tests/parse.cpp
@@ -37,37 +37,37 @@ TEST_CASE("Actors") {
 	Game_Message::ParseParamResult ret;
 
 	msg = u8"\\n[0]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 1);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\n[1]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 1);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\n[2]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 2);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\n[3]HelloWorld";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 3);
 	REQUIRE_EQ(ret.next, msg.data() + 5);
 
 	msg = u8"\\n[55]HelloWorld";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 55);
 	REQUIRE_EQ(ret.next, msg.data() + 6);
 
 	msg = u8"\\N[55]HelloWorld";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 55);
 	REQUIRE_EQ(ret.next, msg.data() + 6);
 
 	msg = u8"\\C[55]HelloWorld";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
 	REQUIRE_EQ(ret.next, msg.data());
 }
@@ -79,59 +79,59 @@ TEST_CASE("BadActors") {
 	Game_Message::ParseParamResult ret;
 
 	msg = u8"\\n[A]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\n[2A]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 2);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\n[A2]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\n[2A2]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 2);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\n[]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\n[";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\n[2";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 2);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\n";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\n";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\n[01]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 1);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\n[000]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 1);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 }
 
 TEST_CASE("ActorVars") {
@@ -141,46 +141,46 @@ TEST_CASE("ActorVars") {
 	Game_Message::ParseParamResult ret;
 
 	msg = u8"\\n[\\v[0]]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 1);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	Main_Data::game_variables->Set(1, 0);
 	msg = u8"\\n[\\v[1]]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 1);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	Main_Data::game_variables->Set(1, 1);
 	msg = u8"\\n[\\v[1]]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 1);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	Main_Data::game_variables->Set(1, 5);
 	msg = u8"\\n[\\v[1]]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 5);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	Main_Data::game_variables->Set(1, 2);
 	Main_Data::game_variables->Set(2, 3);
 	msg = u8"\\n[\\v[2]\\v[1]]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 32);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	Main_Data::game_variables->Set(1, 2);
 	Main_Data::game_variables->Set(2, 3);
 	msg = u8"\\n[\\v[1]\\v[0]]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 20);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\n[\\v[0]\\v[0]]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 1);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 }
 
 TEST_CASE("ActorVarsRecurse") {
@@ -192,16 +192,16 @@ TEST_CASE("ActorVarsRecurse") {
 	Main_Data::game_variables->Set(1, 2);
 	Main_Data::game_variables->Set(2, 50);
 	msg = u8"\\n[\\v[\\v[1]]]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape, false, Game_Message::easyrpg_default_max_recursion);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape, false, Game_Message::easyrpg_default_max_recursion);
 	REQUIRE_EQ(ret.value, 50);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	Main_Data::game_variables->Set(1, 2);
 	Main_Data::game_variables->Set(2, 50);
 	msg = u8"\\n[\\v[\\v[1]]]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape, false, Game_Message::rpg_rt_default_max_recursion);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape, false, Game_Message::rpg_rt_default_max_recursion);
 	REQUIRE_EQ(ret.value, 1);
-	REQUIRE_EQ(ret.next, &*msg.end() - 1);
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()) - 1);
 }
 
 TEST_CASE("ActorsUnicode") {
@@ -213,15 +213,15 @@ TEST_CASE("ActorsUnicode") {
 	Game_Message::ParseParamResult ret;
 
 	msg = u8"σn[1]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), esc);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), esc);
 	REQUIRE_EQ(ret.value, 1);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	Main_Data::game_variables->Set(1, 25);
 	msg = u8"σn[σv[1]]";
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), esc);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), esc);
 	REQUIRE_EQ(ret.value, 25);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 }
 
 TEST_CASE("Variables") {
@@ -231,27 +231,27 @@ TEST_CASE("Variables") {
 	Game_Message::ParseParamResult ret;
 
 	msg = u8"\\v[0]";
-	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseVariable(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\v[1]";
-	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseVariable(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 1);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\v[A]";
-	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseVariable(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\v[999]";
-	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseVariable(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 999);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\v[1]HelloWorld";
-	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseVariable(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 1);
 	REQUIRE_EQ(ret.next, &*msg.data() + 5);
 }
@@ -264,15 +264,15 @@ TEST_CASE("VarsRecurse") {
 
 	Main_Data::game_variables->Set(1, 2);
 	msg = u8"\\v[\\v[1]]";
-	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape, false, Game_Message::easyrpg_default_max_recursion);
+	ret = Game_Message::ParseVariable(msg.data(), (msg.data() + msg.size()), escape, false, Game_Message::easyrpg_default_max_recursion);
 	REQUIRE_EQ(ret.value, 2);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	Main_Data::game_variables->Set(1, 2);
 	msg = u8"\\v[\\v[1]]";
-	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape, false, Game_Message::rpg_rt_default_max_recursion);
+	ret = Game_Message::ParseVariable(msg.data(), (msg.data() + msg.size()), escape, false, Game_Message::rpg_rt_default_max_recursion);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.end() - 1);
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()) - 1);
 }
 
 TEST_CASE("Colors") {
@@ -282,27 +282,27 @@ TEST_CASE("Colors") {
 	Game_Message::ParseParamResult ret;
 
 	msg = u8"\\c[0]";
-	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseColor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\c[1]";
-	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseColor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 1);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\c[A]";
-	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseColor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\c[999]";
-	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseColor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 999);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\c[1]HelloWorld";
-	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseColor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 1);
 	REQUIRE_EQ(ret.next, &*msg.data() + 5);
 }
@@ -316,16 +316,16 @@ TEST_CASE("ColorVarsRecurse") {
 	Main_Data::game_variables->Set(1, 2);
 	Main_Data::game_variables->Set(2, 50);
 	msg = u8"\\c[\\v[\\v[1]]]";
-	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape, false, Game_Message::easyrpg_default_max_recursion);
+	ret = Game_Message::ParseColor(msg.data(), (msg.data() + msg.size()), escape, false, Game_Message::easyrpg_default_max_recursion);
 	REQUIRE_EQ(ret.value, 50);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	Main_Data::game_variables->Set(1, 2);
 	Main_Data::game_variables->Set(2, 50);
 	msg = u8"\\c[\\v[\\v[1]]]";
-	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape, false, Game_Message::rpg_rt_default_max_recursion);
+	ret = Game_Message::ParseColor(msg.data(), (msg.data() + msg.size()), escape, false, Game_Message::rpg_rt_default_max_recursion);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.end() - 1);
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()) - 1);
 }
 
 TEST_CASE("Speed") {
@@ -335,27 +335,27 @@ TEST_CASE("Speed") {
 	Game_Message::ParseParamResult ret;
 
 	msg = u8"\\s[0]";
-	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseSpeed(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\s[1]";
-	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseSpeed(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 1);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\s[A]";
-	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseSpeed(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\s[999]";
-	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseSpeed(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 999);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	msg = u8"\\s[1]HelloWorld";
-	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseSpeed(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 1);
 	REQUIRE_EQ(ret.next, &*msg.data() + 5);
 }
@@ -369,16 +369,16 @@ TEST_CASE("SpeedVarsRecurse") {
 	Main_Data::game_variables->Set(1, 2);
 	Main_Data::game_variables->Set(2, 50);
 	msg = u8"\\s[\\v[\\v[1]]]";
-	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape, false, Game_Message::easyrpg_default_max_recursion);
+	ret = Game_Message::ParseSpeed(msg.data(), (msg.data() + msg.size()), escape, false, Game_Message::easyrpg_default_max_recursion);
 	REQUIRE_EQ(ret.value, 50);
-	REQUIRE_EQ(ret.next, &*msg.end());
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()));
 
 	Main_Data::game_variables->Set(1, 2);
 	Main_Data::game_variables->Set(2, 50);
 	msg = u8"\\s[\\v[\\v[1]]]";
-	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape, false, Game_Message::rpg_rt_default_max_recursion);
+	ret = Game_Message::ParseSpeed(msg.data(), (msg.data() + msg.size()), escape, false, Game_Message::rpg_rt_default_max_recursion);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.end() - 1);
+	REQUIRE_EQ(ret.next, (msg.data() + msg.size()) - 1);
 }
 
 TEST_CASE("BadActor") {
@@ -389,17 +389,17 @@ TEST_CASE("BadActor") {
 
 	msg = u8"\\n[3]";
 
-	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseVariable(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.begin());
+	REQUIRE_EQ(ret.next, msg.data());
 
-	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseColor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.begin());
+	REQUIRE_EQ(ret.next, msg.data());
 
-	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseSpeed(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.begin());
+	REQUIRE_EQ(ret.next, msg.data());
 }
 
 TEST_CASE("BadVariable") {
@@ -410,17 +410,17 @@ TEST_CASE("BadVariable") {
 
 	msg = u8"\\v[3]";
 
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.begin());
+	REQUIRE_EQ(ret.next, msg.data());
 
-	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseColor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.begin());
+	REQUIRE_EQ(ret.next, msg.data());
 
-	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseSpeed(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.begin());
+	REQUIRE_EQ(ret.next, msg.data());
 }
 
 TEST_CASE("BadColor") {
@@ -431,17 +431,17 @@ TEST_CASE("BadColor") {
 
 	msg = u8"\\c[3]";
 
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.begin());
+	REQUIRE_EQ(ret.next, msg.data());
 
-	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseVariable(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.begin());
+	REQUIRE_EQ(ret.next, msg.data());
 
-	ret = Game_Message::ParseSpeed(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseSpeed(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.begin());
+	REQUIRE_EQ(ret.next, msg.data());
 }
 
 TEST_CASE("BadSpeed") {
@@ -452,17 +452,17 @@ TEST_CASE("BadSpeed") {
 
 	msg = u8"\\s[3]";
 
-	ret = Game_Message::ParseActor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseActor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.begin());
+	REQUIRE_EQ(ret.next, msg.data());
 
-	ret = Game_Message::ParseVariable(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseVariable(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.begin());
+	REQUIRE_EQ(ret.next, msg.data());
 
-	ret = Game_Message::ParseColor(&*msg.begin(), &*msg.end(), escape);
+	ret = Game_Message::ParseColor(msg.data(), (msg.data() + msg.size()), escape);
 	REQUIRE_EQ(ret.value, 0);
-	REQUIRE_EQ(ret.next, &*msg.begin());
+	REQUIRE_EQ(ret.next, msg.data());
 }
 
 TEST_SUITE_END();

--- a/tests/utf.cpp
+++ b/tests/utf.cpp
@@ -88,8 +88,8 @@ TEST_CASE("next") {
 
 TEST_CASE("TextNext") {
 	std::string text = u8"H $A$B\\\\\\^\\n\nぽ";
-	const auto* iter = &*text.begin();
-	const auto* end = &*text.end();
+	const auto* iter = text.data();
+	const auto* end = text.data() + text.size();
 
 	Utils::TextRet ret;
 	ret = Utils::TextNext(iter, end, escape);
@@ -158,8 +158,8 @@ TEST_CASE("TextNext") {
 
 TEST_CASE("TextNextNoEscape") {
 	std::string text = u8"\\$";
-	const auto* iter = &*text.begin();
-	const auto* end = &*text.end();
+	const auto* iter = text.data();
+	const auto* end = text.data() + text.size();
 
 	Utils::TextRet ret;
 


### PR DESCRIPTION
Fix: #2073
Fix: #2061 
Fix: #2045 

@elsemieni can you confirm this fixes the crash you found? I can't reproduce it so while I suspect this is the cause I can't prove it.