### PR TITLE
Don't call Scene_File::Update from Start()

### DIFF
--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -109,7 +109,10 @@ void Scene_File::Start() {
 	top_index = std::max(0, index - 2);
 
 	Refresh();
-	Update();
+
+	for (auto& fw: file_windows) {
+		fw->Update();
+	}
 }
 
 void Scene_File::Refresh() {


### PR DESCRIPTION
This behavior triggers a rare bug:
From map, open the debug menu, then open save menu.

The debug menu has a instant CutOut transition, which mean there is no
frame between exiting debug and starting save menu. Because of this,
Input::Update() is never called and so Scene_File::Update() immediately
saves and then pops the scene from Start(), which breaks the scene
stack.

Fixes second issue in #2080