### PR TITLE
Fix lag when loading large SE files

### DIFF
--- a/src/audio_decoder.cpp
+++ b/src/audio_decoder.cpp
@@ -99,40 +99,6 @@ std::vector<uint8_t> AudioDecoder::DecodeAll() {
 	return buffer;
 }
 
-int AudioDecoder::DecodeAsMono(uint8_t* left, uint8_t* right, int size) {
-	int freq; Format format; int channels;
-	GetFormat(freq, format, channels);
-
-	if (channels == 1) {
-		return Decode(left, size);
-	}
-
-	if ((int)mono_buffer.size() < size * 2) {
-		mono_buffer.resize(size * 2);
-	}
-
-	int read = Decode(mono_buffer.data(), size * 2);
-	if (read < 0) {
-		memset(left, '\0', size);
-		memset(right, '\0', size);
-		return -1;
-	}
-
-	int sample_size = GetSamplesizeForFormat(format);
-
-	for (int i = 0; i <= read / 2; i += sample_size) {
-		memcpy(&left[i], &mono_buffer.data()[i * channels], sample_size);
-		memcpy(&right[i], &mono_buffer.data()[i * channels + sample_size], sample_size);
-	}
-
-	if (read < size / 2) {
-		memset(&left[read / 2], '\0', size);
-		memset(&right[read / 2], '\0', size);
-	}
-
-	return read / 2;
-}
-
 class WMAUnsupportedFormatDecoder : public AudioDecoder {
 public:
 	WMAUnsupportedFormatDecoder() {

--- a/src/audio_decoder.cpp
+++ b/src/audio_decoder.cpp
@@ -80,6 +80,25 @@ int AudioDecoder::Decode(uint8_t* buffer, int length, int recursion_depth) {
 	return res;
 }
 
+std::vector<uint8_t> AudioDecoder::DecodeAll() {
+	const int buffer_size = 8192;
+
+	std::vector<uint8_t> buffer;
+	buffer.resize(buffer_size);
+
+	while (!IsFinished()) {
+		int read = Decode(buffer.data() + buffer.size() - buffer_size, buffer_size);
+		if (read < buffer_size) {
+			buffer.resize(buffer.size() - (buffer_size - read));
+			break;
+		}
+
+		buffer.resize(buffer.size() + buffer_size);
+	}
+
+	return buffer;
+}
+
 int AudioDecoder::DecodeAsMono(uint8_t* left, uint8_t* right, int size) {
 	int freq; Format format; int channels;
 	GetFormat(freq, format, channels);

--- a/src/audio_decoder.h
+++ b/src/audio_decoder.h
@@ -73,21 +73,6 @@ public:
 	std::vector<uint8_t> DecodeAll();
 
 	/**
-	 * Splits stereo into mono and Writes 'size' bytes in each of the buffers.
-	 * The data matches the format reported by GetFormat, except that both
-	 * buffers will contain Mono audio. When the source format was already mono
-	 * the 'right' buffer is ignored (and not cleared)
-	 * When size is is smaller then the amount of written bytes or an error occurs
-	 * the remaining buffer space is cleared.
-	 *
-	 * @param left Output buffer of the left channel
-	 * @param right Output buffer of the right channel (or nothing if source is mono)
-	 * @param size Size of each of the buffers
-	 * @return Number of bytes written in one of the buffers or -1 on error
-	 */
-	int DecodeAsMono(uint8_t* left, uint8_t* right, int size);
-
-	/**
 	 * Parses the specified file handle and open a proper audio decoder to handle
 	 * the audio file.
 	 * Upon success the file handle is owned by the audio decoder and further

--- a/src/audio_decoder.h
+++ b/src/audio_decoder.h
@@ -65,6 +65,14 @@ public:
 	int Decode(uint8_t* buffer, int size);
 
 	/**
+	 * Decodes the whole audio sample. The data matches the format reported by
+	 * GetFormat.
+	 *
+	 * @return output buffer
+	 */
+	std::vector<uint8_t> DecodeAll();
+
+	/**
 	 * Splits stereo into mono and Writes 'size' bytes in each of the buffers.
 	 * The data matches the format reported by GetFormat, except that both
 	 * buffers will contain Mono audio. When the source format was already mono

--- a/src/audio_decoder.h
+++ b/src/audio_decoder.h
@@ -90,9 +90,10 @@ public:
 	 *
 	 * @param file File handle to parse
 	 * @param filename Path to the file handle
+	 * @param resample Whether the decoder shall be wrapped into a resampler (if supported)
 	 * @return An audio decoder instance when the format was detected, otherwise null
 	 */
-	static std::unique_ptr<AudioDecoder> Create(FILE* file, const std::string& filename);
+	static std::unique_ptr<AudioDecoder> Create(FILE* file, const std::string& filename, bool resample = true);
 
 	/**
 	 * Updates the volume for the fade in/out effect.

--- a/src/audio_generic.cpp
+++ b/src/audio_generic.cpp
@@ -310,6 +310,12 @@ void GenericAudio::Decode(uint8_t* output_buffer, int buffer_length) {
 
 					read_bytes = currently_mixed_channel.decoder->Decode(scrap_buffer.data(), bytes_to_read);
 
+					if (read_bytes < 0) {
+						// An error occured when reading - the channel is faulty - discard
+						currently_mixed_channel.decoder.reset();
+						continue; // skip this loop run - there is nothing to mix
+					}
+
 					// Now decide what to do when a channel has reached its end
 					if (currently_mixed_channel.decoder->IsFinished()) {
 						// SE are only played once so free the se if finished

--- a/src/audio_generic.h
+++ b/src/audio_generic.h
@@ -69,12 +69,10 @@ private:
 		bool stopped;
 	};
 	struct SeChannel {
-		AudioSeRef se;
-		size_t buffer_pos;
+		std::unique_ptr<AudioDecoder> decoder;
 		int volume;
 		bool paused;
 		bool stopped;
-		bool finished;
 	};
 	struct Format {
 		int frequency;
@@ -100,4 +98,4 @@ private:
 	static std::vector<float> mixer_buffer;
 };
 
-#endif //EASYRPG_AUDIOGENERIC_H_
+#endif

--- a/src/audio_resampler.cpp
+++ b/src/audio_resampler.cpp
@@ -377,24 +377,27 @@ int AudioResampler::FillBuffer(uint8_t* buffer, int length) {
 		}
 	}
 
+	if (amount_filled < 0) {
+		return amount_filled;
+	}
+
 	if (mono_to_stereo_resample) {
 		int sample_size = AudioDecoder::GetSamplesizeForFormat(output_format);
 
 		// Duplicate data from the back, allows writing to the buffer directly
 		for (size_t i = amount_filled - sample_size; i > 0; i -= sample_size) {
 			// left channel
-			memcpy(&buffer[i * 2 - sample_size * 2], &buffer[i], sample_size);
+			memcpy(&buffer[i * 2], &buffer[i], sample_size);
 			// right channel
-			memcpy(&buffer[i * 2 - sample_size], &buffer[i], sample_size);
+			memcpy(&buffer[i * 2 + sample_size], &buffer[i], sample_size);
 		}
 
 		amount_filled *= 2;
 	}
 
 	// Clear the remaining buffer as specified in audio_decoder.h
-	for (int i = (amount_filled > 0) ? amount_filled : 0; i < length; i++) {
-		buffer[i] = 0;
-	}
+	memset(buffer + amount_filled, '\0', length - amount_filled);
+
 	return amount_filled;
 }
 

--- a/src/audio_resampler.h
+++ b/src/audio_resampler.h
@@ -201,6 +201,8 @@ private:
 	 * (In the cpp file sizeof is used therefore it can be adjusted to fit the available memory)
 	 */
 	uint8_t internal_buffer[256*sizeof(float)];
+
+	bool mono_to_stereo_resample = false;
 };
 
 #endif

--- a/src/audio_resampler.h
+++ b/src/audio_resampler.h
@@ -51,7 +51,7 @@ public:
 	 * @param[in] pitch_handled Defines whether the decoder handles pitch changes by itself or not. 
 	 * @param[in] quality Sets the quality rting of the resampler - higher quality implies slower filtering
 	 */
-	AudioResampler(std::unique_ptr<AudioDecoder> decoder, bool pitch_handled=false, Quality quality=Quality::Medium);
+	AudioResampler(std::unique_ptr<AudioDecoder> decoder, bool pitch_handled=false, Quality quality=Quality::Low);
 	
 	/**
 	 * Destroys the resampler as well as its owned ressources

--- a/src/audio_sdl_mixer.cpp
+++ b/src/audio_sdl_mixer.cpp
@@ -629,8 +629,8 @@ void SdlMixerAudio::SE_Play(std::string const& file, int volume, int pitch) {
 }
 
 void SdlMixerAudio::SE_Stop() {
-	for (sounds_type::iterator i = sounds.begin(); i != sounds.end(); ++i) {
-		if (Mix_Playing(i->first)) Mix_HaltChannel(i->first);
+	for (auto& sound : sounds) {
+		if (Mix_Playing(sound.first)) Mix_HaltChannel(sound.first);
 	}
 	sounds.clear();
 }

--- a/src/audio_sdl_mixer.h
+++ b/src/audio_sdl_mixer.h
@@ -72,7 +72,13 @@ private:
 	bool bgs_stop = true;
 	bool played_once = false;
 
-	typedef std::map<int, std::pair<std::shared_ptr<Mix_Chunk>, AudioSeRef>> sounds_type;
+	struct sound_data {
+		std::shared_ptr<Mix_Chunk> chunk;
+		AudioSeRef se_ref;
+		std::vector<uint8_t> buffer;
+	};
+
+	typedef std::map<int, sound_data> sounds_type;
 	sounds_type sounds;
 
 	std::unique_ptr<AudioDecoder> audio_decoder;

--- a/src/audio_secache.cpp
+++ b/src/audio_secache.cpp
@@ -156,19 +156,7 @@ std::unique_ptr<AudioDecoder> AudioSeCache::CreateSeDecoder() {
 	assert(audio_decoder);
 
 	audio_decoder->GetFormat(se->frequency, se->format, se->channels);
-
-	const int buffer_size = 8192;
-	se->buffer.resize(buffer_size);
-
-	while (!audio_decoder->IsFinished()) {
-		int read = audio_decoder->Decode(se->buffer.data() + se->buffer.size() - buffer_size, buffer_size);
-		if (read < 8192) {
-			se->buffer.resize(se->buffer.size() - (buffer_size - read));
-			break;
-		}
-
-		se->buffer.resize(se->buffer.size() + buffer_size);
-	}
+	se->buffer = audio_decoder->DecodeAll();
 
 	cache.insert(std::make_pair(filename, se));
 
@@ -187,6 +175,12 @@ std::unique_ptr<AudioDecoder> AudioSeCache::CreateSeDecoder() {
 	dec->Open(nullptr);
 	return dec;
 }
+
+AudioSeRef AudioSeCache::GetSeData() const {
+    assert(IsCached());
+
+    return cache.find(filename)->second;
+};
 
 void AudioSeCache::Clear() {
 	cache_size = 0;

--- a/src/audio_secache.cpp
+++ b/src/audio_secache.cpp
@@ -85,7 +85,7 @@ std::unique_ptr<AudioSeCache> AudioSeCache::Create(const std::string& filename) 
 			return se;
 		}
 
-		se->audio_decoder = AudioDecoder::Create(f, filename);
+		se->audio_decoder = AudioDecoder::Create(f, filename, false);
 
 		if (se->audio_decoder) {
 			if (!se->audio_decoder->Open(f)) {
@@ -105,61 +105,13 @@ std::unique_ptr<AudioSeCache> AudioSeCache::Create(const std::string& filename) 
 void AudioSeCache::GetFormat(int& frequency, AudioDecoder::Format& format, int& channels) const {
 	if (!audio_decoder) {
 		if (!GetCachedFormat(frequency, format, channels)) {
-			frequency = 0;
-			channels = 0;
-			format = AudioDecoder::Format::S16;
+			assert(false);
 		}
 
 		return;
 	}
 
 	audio_decoder->GetFormat(frequency, format, channels);
-
-	if (mono_to_stereo_resample) {
-		channels = 2;
-	}
-}
-
-bool AudioSeCache::SetFormat(int frequency, AudioDecoder::Format format, int channels) {
-	int cfrequency;
-	AudioDecoder::Format cformat;
-	int cchannels;
-
-	if (!audio_decoder) {
-		// This file is already cached, don't allow uncached format changes
-		if (GetCachedFormat(cfrequency, cformat, cchannels)) {
-			return frequency == cfrequency &&
-					format == cformat &&
-					channels == cchannels;
-		}
-	}
-
-	bool success = audio_decoder->SetFormat(frequency, format, channels);
-
-	if (!success) {
-		audio_decoder->GetFormat(cfrequency, cformat, cchannels);
-		// Handle Mono->Stereo conversion, is quite common for SE
-		if (cfrequency == frequency && cformat == format && cchannels == 1 && channels == 2) {
-			mono_to_stereo_resample = true;
-			return true;
-		}
-	}
-
-	return success;
-}
-
-int AudioSeCache::GetPitch() const {
-	return pitch;
-}
-
-bool AudioSeCache::SetPitch(int pitch) {
-#ifdef USE_AUDIO_RESAMPLER
-	this->pitch = pitch;
-
-	return pitch > 0;
-#else
-	return pitch == 100;
-#endif
 }
 
 bool AudioSeCache::IsCached() const {
@@ -180,88 +132,30 @@ bool AudioSeCache::GetCachedFormat(int& frequency, AudioDecoder::Format& format,
 	return false;
 }
 
-class MemoryPitchResampler : public AudioDecoder {
-public:
-	MemoryPitchResampler(const AudioSeRef se) :
-		se(se) {
-		// no-op
-	}
-
-	bool Open(FILE*) {
-		// No file operations needed
-		return true;
-	}
-
-	bool IsFinished() const {
-		return offset >= se->buffer.size();
-	}
-
-	void GetFormat(int& frequency, Format& format, int& channels) const {
-		frequency = se->frequency;
-		format = se->format;
-		channels = se->channels;
-	}
-
-private:
-	int FillBuffer(uint8_t* buffer, int size) {
-		int real_size = size;
-
-		if (offset + size > se->buffer.size()) {
-			real_size = se->buffer.size() - offset;
-		}
-
-		memcpy(buffer, se->buffer.data() + offset, real_size);
-		offset += real_size;
-
-		return real_size;
-	}
-
-	const AudioSeRef se;
-	size_t offset = 0;
-};
-
-AudioSeRef AudioSeCache::Decode() {
-	// Writes a SE with pitch = 100 to the cache if it is not cached yet,
-	// otherwise returns the cached result
-	// For pitch != 100 the cached result is pitch-adjusted and returned.
-
+std::unique_ptr<AudioDecoder> AudioSeCache::CreateSeDecoder() {
 	AudioSeRef se;
 
 	if (IsCached()) {
 		se = cache.find(filename)->second;
 		se->last_access = Game_Clock::GetFrameTime();
 
-		if (GetPitch() == 100) {
-			// Nothing extra to do
-			return se;
-		}
-
+		std::unique_ptr<AudioDecoder> dec = std::unique_ptr<AudioDecoder>(new AudioSeDecoder(se));
 #ifdef USE_AUDIO_RESAMPLER
-		// Code path is only taken with a resampler, otherwise pitch is always 100 here
-		// Falls through to the decoding logic but does not overwrite the cache
-
-		// Don't overwrite our real cached entry
-		se.reset(new AudioSeData());
-		GetCachedFormat(se->frequency, se->format, se->channels);
-
-		audio_decoder.reset(new AudioResampler(std::unique_ptr<AudioDecoder>(new MemoryPitchResampler(cache.find(filename)->second))));
-		audio_decoder->Open(nullptr);
-#else
-		assert(false && "SeCache: Unexpected code path taken");
+		dec = std::unique_ptr<AudioDecoder>(new AudioResampler(std::move(dec)));
 #endif
+		dec->Open(nullptr);
+		return dec;
 	}
+
+	// Not cached yet: Decode the sample without any resampling
 
 	if (!se) {
 		se.reset(new AudioSeData());
 	}
 
-	GetFormat(se->frequency, se->format, se->channels);
+	assert(audio_decoder);
 
-	if (IsCached()) {
-		audio_decoder->SetPitch(GetPitch());
-	} else {
-		audio_decoder->SetPitch(100);
-	}
+	audio_decoder->GetFormat(se->frequency, se->format, se->channels);
 
 	const int buffer_size = 8192;
 	se->buffer.resize(buffer_size);
@@ -276,47 +170,57 @@ AudioSeRef AudioSeCache::Decode() {
 		se->buffer.resize(se->buffer.size() + buffer_size);
 	}
 
-	if (mono_to_stereo_resample) {
-		se->buffer.resize(se->buffer.size() * 2);
+	cache.insert(std::make_pair(filename, se));
 
-		int sample_size = AudioDecoder::GetSamplesizeForFormat(se->format);
-
-		// Duplicate data from the back, allows writing to the buffer directly
-		for (size_t i = se->buffer.size() / 2 - sample_size; i > 0; i -= sample_size) {
-			// left channel
-			memcpy(&se->buffer[i * 2 - sample_size * 2], &se->buffer[i], sample_size);
-			// right channel
-			memcpy(&se->buffer[i * 2 - sample_size], &se->buffer[i], sample_size);
-		}
-	}
-
-	if (!IsCached()) {
-		// Write normal pitched sample to cache
-		// This codepath is only taken the first time upon cache miss
-		cache.insert(std::make_pair(filename, se));
-
-		se->last_access = Game_Clock::GetFrameTime();
-
-		cache_size += se->buffer.size();
+	cache_size += se->buffer.size();
 
 #ifdef CACHE_DEBUG
-		Output::Debug("SE cache size (Add): %f", cache_size / 1024.0 / 1024.0);
+	Output::Debug("SE cache size (Add): %f", cache_size / 1024.0 / 1024.0);
 #endif
 
-		FreeCacheMemory();
+	FreeCacheMemory();
 
-		if (GetPitch() != 100) {
-			// Also handle a requested resampling
-			// Takes the "IsCached" codepath now
-			mono_to_stereo_resample = false;
-			return Decode();
-		}
-	}
-
-	return se;
+	std::unique_ptr<AudioDecoder> dec = std::unique_ptr<AudioDecoder>(new AudioSeDecoder(se));
+#ifdef USE_AUDIO_RESAMPLER
+	dec = std::unique_ptr<AudioDecoder>(new AudioResampler(std::move(dec)));
+#endif
+	dec->Open(nullptr);
+	return dec;
 }
 
 void AudioSeCache::Clear() {
 	cache_size = 0;
 	cache.clear();
+}
+
+AudioSeDecoder::AudioSeDecoder(AudioSeRef se) :
+	se(se) {
+	se->last_access = Game_Clock::GetFrameTime();
+}
+
+bool AudioSeDecoder::IsFinished() const {
+	return offset >= se->buffer.size();
+}
+
+void AudioSeDecoder::GetFormat(int &frequency, AudioDecoder::Format &format, int &channels) const {
+	frequency = se->frequency;
+	format = se->format;
+	channels = se->channels;
+}
+
+int AudioSeDecoder::FillBuffer(uint8_t *buffer, int size) {
+	int real_size = size;
+
+	if (offset + size > se->buffer.size()) {
+		real_size = se->buffer.size() - offset;
+	}
+
+	memcpy(buffer, se->buffer.data() + offset, real_size);
+	offset += real_size;
+
+	return real_size;
+}
+
+int AudioSeDecoder::GetPitch() const {
+	return 100;
 }

--- a/src/audio_secache.h
+++ b/src/audio_secache.h
@@ -122,6 +122,13 @@ public:
 	 */
 	std::unique_ptr<AudioDecoder> CreateSeDecoder();
 
+	/**
+	 * Returns the SE sample data handled by this SeCache.
+	 *
+	 * @return sample data
+	 */
+	AudioSeRef GetSeData() const;
+
 	static void Clear();
 private:
 	std::unique_ptr<AudioDecoder> audio_decoder;

--- a/src/audio_secache.h
+++ b/src/audio_secache.h
@@ -28,9 +28,10 @@
 #include "audio_decoder.h"
 #include "game_clock.h"
 
+class AudioSeCache;
+
 /**
- * AudioSeData is the decoded sample of AudioSeCache.
- * Format changes and pitch are already applied to the buffer.
+ * AudioSeData contains the decoded sample of AudioSeCache.
  */
 class AudioSeData {
 public:
@@ -42,6 +43,26 @@ public:
 };
 
 typedef std::shared_ptr<AudioSeData> AudioSeRef;
+
+/**
+ * AudioSeDecoder operates on supplied AudioSeData and does format
+ * conversions through the resamplers.
+ */
+class AudioSeDecoder : public AudioDecoder {
+public:
+	AudioSeDecoder(AudioSeRef se);
+
+	bool Open(FILE*) override { return true; };
+	bool IsFinished() const override;
+	void GetFormat(int& frequency, Format& format, int& channels) const override;
+	int GetPitch() const override;
+
+private:
+	int FillBuffer(uint8_t* buffer, int size) override;
+
+	AudioSeRef se;
+	size_t offset = 0;
+};
 
 /**
  * AudioSeCache provides an interface for accessing sound effects.
@@ -72,37 +93,6 @@ public:
 	void GetFormat(int& frequency, AudioDecoder::Format& format, int& channels) const;
 
 	/**
-	 * Requests a prefered format from the internal audio decoder. Not all decoders
-	 * support everything and it's recommended to use the audio hardware
-	 * for audio processing.
-	 * When false is returned use GetFormat to get the real format of the
-	 * output data.
-	 *
-	 * @param frequency Audio frequency
-	 * @param format Audio format
-	 * @param channels Number of channels
-	 * @return true when all settings were set, otherwise false (use GetFormat)
-	 */
-	bool SetFormat(int frequency, AudioDecoder::Format format, int channels);
-
-	/**
-	 * Gets the pitch multiplier of the internal audio decoder.
-	 *
-	 * @return pitch multiplier
-	 */
-	int GetPitch() const;
-
-	/**
-	 * Sets the pitch multiplier of the internal audio decoder.
-	 * 100 = normal speed
-	 * 200 = double speed and so on
-	 * 
-	 * @param pitch Pitch multiplier to use
-	 * @return true if pitch was set, false otherwise
-	 */
-	bool SetPitch(int pitch);
-
-	/**
 	 * Tells if Decode will have a cache hit when executed.
 	 * SetFormat will fail when this returns true.
 	 *
@@ -124,24 +114,19 @@ public:
 	bool GetCachedFormat(int& frequency, AudioDecoder::Format& format, int& channels) const;
 
 	/**
-	 * Decodes the whole sample with the settings specified by SetFormat and
-	 * SetPitch (uses default settings of the audio file if not used).
-	 * In case of a cache hit the decoding is skipped.
-	 * Calling Decode multiple times with different settings is supported.
+	 * Decodes the whole sample without doing any resampling and caches it.
+	 * When cached the decoding step is skipped.
+	 * The returned AudioDecoder contains the SE sample.
 	 *
 	 * @return Decoded sound effect
 	 */
-	AudioSeRef Decode();
+	std::unique_ptr<AudioDecoder> CreateSeDecoder();
 
 	static void Clear();
 private:
-	int pitch = 100;
-
 	std::unique_ptr<AudioDecoder> audio_decoder;
 
 	std::string filename;
-
-	bool mono_to_stereo_resample = false;
 };
 
 #endif

--- a/src/decoder_libsndfile.cpp
+++ b/src/decoder_libsndfile.cpp
@@ -79,7 +79,7 @@ bool LibsndfileDecoder::Open(FILE* file) {
 	file_=file;
 	soundfile=sf_open_virtual(&vio,SFM_READ,&soundinfo,file);
 	sf_command(soundfile, SFC_SET_SCALE_FLOAT_INT_READ, NULL, SF_TRUE);
-	output_format=Format::F32;
+	output_format=Format::S16;
 	finished=false;
 	return soundfile!=0;
 }


### PR DESCRIPTION
**a)** When playing a SE for the first time we
1. load the entire file
2. resample the entire file
3. cache it
The intention was to help slow hardware when many SE are played at once.

**b)** With the new code it is:
1. load the entire file
2. cache it

Resample/Pitch is now done in the Audio thread. So this is a trade-off where we pay the CPU time, at least the IO part is still only once.

For Witch's Heart (Limes game) the load time of SE is reduced from 90ms (with Medium resample quality 140ms) to 6ms.

Refactor: Instead of a buffer+length the SeCache returns now a real AudioDecoder. This gives us more flexibility later, e.g. short samples (TODO: What is short) could be handled as **a)** and longer samples could be handled as **b)**. This patch handles everything as **b)**.

Unfortunately the SDL2 mixer API is fire-and-forget for SE samples so we can't use the optimisation there :(. Everything else using the generic API (SDL2 [Android], Vita, libretro) works. We should really deprecate this API, get FluidSynth working and fix our embarassing Midi support on Windows.

Todo:
- [x] Fix 3DS build
- [x] 3DS Hardware test
- [x] Fix audio glitches when playing some SEs
- [x] NO REPRO. Fix latency when first sample is played