### PR TITLE
Use custom implementation instead of iscntrl

### DIFF
--- a/src/font.cpp
+++ b/src/font.cpp
@@ -179,7 +179,7 @@ BitmapFont::BitmapFont(const std::string& name, function_type func)
 
 Rect BitmapFont::GetSize(char32_t ch) const {
 	size_t units = 0;
-	if (EP_LIKELY(!std::iscntrl(static_cast<unsigned char>(ch)))) {
+	if (EP_LIKELY(!Utils::IsControlCharacter(ch))) {
 		auto glyph = func(ch);
 		units += glyph->is_full? 2 : 1;
 	}
@@ -194,7 +194,7 @@ Rect BitmapFont::GetSize(std::string const& txt) const {
 		auto resp = Utils::UTF8Next(iter, end);
 		auto ch = resp.ch;
 		iter = resp.next;
-		if (EP_LIKELY(!std::iscntrl(static_cast<unsigned char>(resp.ch)))) {
+		if (EP_LIKELY(!Utils::IsControlCharacter(resp.ch))) {
 			auto glyph = func(ch);
 			units += glyph->is_full? 2 : 1;
 		}
@@ -206,7 +206,7 @@ Font::GlyphRet BitmapFont::Glyph(char32_t code) {
 	if (EP_UNLIKELY(!glyph_bm)) {
 		glyph_bm = Bitmap::Create(nullptr, FULL_WIDTH, HEIGHT, 0, DynamicFormat(8,8,0,8,0,8,0,8,0,PF::Alpha));
 	}
-	if (EP_UNLIKELY(std::iscntrl(static_cast<unsigned char>(code)))) {
+	if (EP_UNLIKELY(Utils::IsControlCharacter(code))) {
 		return { glyph_bm, Rect(0, 0, 0, HEIGHT) };
 	}
 	auto glyph = func(code);

--- a/src/pending_message.cpp
+++ b/src/pending_message.cpp
@@ -13,7 +13,7 @@
 
 static void RemoveControlChars(std::string& s) {
 	// RPG_RT ignores any control characters within messages.
-	auto iter = std::remove_if(s.begin(), s.end(), [](const char c) { return std::iscntrl(c); });
+	auto iter = std::remove_if(s.begin(), s.end(), [](const char c) { return Utils::IsControlCharacter(c); });
 	s.erase(iter, s.end());
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -322,7 +322,14 @@ namespace Utils {
 	 * @return value clamped between min and max
 	 */
 	template <typename T>
-		constexpr T Clamp(T value, const T& minv, const T& maxv);
+	constexpr T Clamp(T value, const T& minv, const T& maxv);
+
+	/**
+	 * Determines if a char is a control character (0x00-0x1F and 0x7F)
+	 * @return true when ch is a control character
+	 */
+	template <typename T>
+	bool IsControlCharacter(T ch);
 
 } // namespace Utils
 
@@ -351,6 +358,11 @@ inline void Utils::ForEachLine(const std::string& line, F&& f) {
 		f(line.substr(next, idx - next));
 		next = idx + 1;
 	} while(next < line.size());
+}
+
+template <typename T>
+inline bool Utils::IsControlCharacter(T ch) {
+	return (ch >= 0x0 && ch <= 0x1F) || ch == 0x7F;
 }
 
 #endif

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -413,7 +413,7 @@ void Window_Message::UpdateMessage() {
 			break;
 		}
 
-		if (std::iscntrl(static_cast<unsigned char>(ch))) {
+		if (Utils::IsControlCharacter(ch)) {
 			// control characters not handled
 			continue;
 		}

--- a/tests/font.cpp
+++ b/tests/font.cpp
@@ -23,6 +23,7 @@ TEST_CASE("FontSizeStr") {
 	REQUIRE_EQ(font->GetSize("\n"), Rect(0, 0, 0, ch));
 	REQUIRE_EQ(font->GetSize("$A"), Rect(0, 0, cwh * 2, ch));
 	REQUIRE_EQ(font->GetSize("X\nX"), Rect(0, 0, cwh * 2, ch));
+	REQUIRE_EQ(font->GetSize("下"), Rect(0, 0, cwf, ch));
 }
 
 TEST_CASE("FontSizeChar") {
@@ -33,6 +34,7 @@ TEST_CASE("FontSizeChar") {
 	REQUIRE_EQ(font->GetSize(U'\n'), Rect(0, 0, 0, ch));
 	REQUIRE_EQ(font->GetSize(U'X'), Rect(0, 0, cwh, ch));
 	REQUIRE_EQ(font->GetSize(U'ぽ'), Rect(0, 0, cwf, ch));
+	REQUIRE_EQ(font->GetSize(U'下'), Rect(0, 0, cwf, ch));
 }
 
 TEST_CASE("FontSizeStrEx") {
@@ -65,6 +67,7 @@ TEST_CASE("FontGlyphChar") {
 	check(U'\n', Rect(0, 0, 0, ch));
 	check(U'X', Rect(0, 0, cwh, ch));
 	check(U'ぽ', Rect(0, 0, cwf, ch));
+	check(U'下', Rect(0, 0, cwf, ch));
 }
 
 TEST_CASE("FontGlyphCharEx") {
@@ -93,6 +96,7 @@ TEST_CASE("FontGlyphChar") {
 	check(U'\n', Rect(0, 0, 0, ch));
 	check(U'X', Rect(0, 0, cwh, ch));
 	check(U'ぽ', Rect(0, 0, cwf, ch));
+	check(U'下', Rect(0, 0, cwf, ch));
 }
 
 TEST_CASE("FontGlyphCharEx") {


### PR DESCRIPTION
Fix #2090

Unfortunately @fmatthew5876 was unlucky with the glyph he picked for the unit test, otherwise this would have been catched by it :(

iscntrl takes a int but the docs say "Like all other functions from cctype, the behavior of std::iscntrl is undefined if the argument's value is neither representable as unsigned char nor equal to EOF" Nice API