### PR TITLE
Fix Inputs being lost when the game lags.

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -238,8 +238,13 @@ void Player::MainLoop() {
 
 	int num_updates = 0;
 	while (Game_Clock::NextGameTimeStep()) {
+		if (num_updates > 0) {
+			Player::UpdateInput();
+		}
+
 		Scene::old_instances.clear();
 		Scene::instance->MainFunction();
+
 		++num_updates;
 	}
 


### PR DESCRIPTION
Input events were only processed once per frame. When the user only briefly presses a key this would queue a key-up and a key-down event. Both are processed at the same time, nullifying them.
Now they are polled in every Update.

Fix #2094