### PR TITLE
Do an early transition out before loading save

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -910,6 +910,11 @@ void Player::LoadSavegame(const std::string& save_name) {
 	Output::Debug("Loading Save %s", FileFinder::GetPathInsidePath(Main_Data::GetSavePath(), save_name).c_str());
 	Game_System::BgmStop();
 
+	// We erase the screen now before loading the saved game. This prevents an issue where
+	// if the save game has a different system graphic, the load screen would change before
+	// transitioning out.
+	Transition::instance().InitErase(Transition::TransitionFadeOut, Scene::instance.get(), 6);
+
 	auto title_scene = Scene::Find(Scene::Title);
 	if (title_scene) {
 		static_cast<Scene_Title*>(title_scene.get())->OnGameStart();

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -119,7 +119,10 @@ void Scene::MainFunction() {
 
 			push_pop_operation = 0;
 
-			TransitionIn(prev_scene_type);
+			// Scene could have manually triggered transition earlier
+			if (!Transition::instance().IsActive()) {
+				TransitionIn(prev_scene_type);
+			}
 			Resume(prev_scene_type);
 
 
@@ -139,7 +142,10 @@ void Scene::MainFunction() {
 
 		auto next_scene = instance ? instance->type : Null;
 		Suspend(next_scene);
-		TransitionOut(next_scene);
+		// Scene could have manually triggered transition earlier
+		if (!Transition::instance().IsActive()) {
+			TransitionOut(next_scene);
+		}
 
 		init = false;
 	}

--- a/src/transition.cpp
+++ b/src/transition.cpp
@@ -67,6 +67,9 @@ void Transition::PrependFlashes(int r, int g, int b, int p, int duration, int it
 }
 
 void Transition::Init(Type type, Scene *linked_scene, int duration, bool erase) {
+	// Triggering multiple transitions on a single frame is a bug.
+	assert(!IsActive());
+
 	if (duration < 0) {
 		duration = GetDefaultFrames(type);
 	}


### PR DESCRIPTION
Prevents the load game's state from impacting the
currently visible screen.

Fix: #2111