### PR TITLE
Implement Ticks for: libsndfile, FmMidi, Wildmidi (kinda)

### DIFF
--- a/src/decoder_fmmidi.h
+++ b/src/decoder_fmmidi.h
@@ -59,6 +59,11 @@ private:
 	float pitch = 1.0f;
 	int frequency = 44100;
 	bool begin = true;
+	uint32_t tempo = 500000;
+
+	float ticks_per_sec = 0.0f;
+	float mtime_last_tempo_change = 0.0f;
+	int ticks_last_tempo_change = 0;
 
 	// midisequencer::output interface
 	int synthesize(int_least16_t* output, std::size_t samples, float rate);

--- a/src/decoder_libsndfile.h
+++ b/src/decoder_libsndfile.h
@@ -45,11 +45,14 @@ public:
 
 	bool SetFormat(int frequency, AudioDecoder::Format format, int channels) override;
 
+	int GetTicks() const override;
+
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 	Format output_format;
 	FILE * file_;
 	bool finished;
+	int decoded_samples = 0;
 #ifdef HAVE_LIBSNDFILE
 	SNDFILE *soundfile;
 	SF_INFO soundinfo;

--- a/src/decoder_wav.h
+++ b/src/decoder_wav.h
@@ -42,6 +42,8 @@ public:
 
 	bool SetFormat(int frequency, AudioDecoder::Format format, int channels) override;
 
+	int GetTicks() const override;
+
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 	Format output_format;
@@ -52,6 +54,7 @@ private:
 	uint32_t audiobuf_offset;
 	uint32_t chunk_size;
 	uint32_t cur_pos;
+	int decoded_samples = 0;
 };
 
 #endif

--- a/src/decoder_wildmidi.h
+++ b/src/decoder_wildmidi.h
@@ -42,6 +42,8 @@ public:
 
 	bool Seek(size_t offset, Origin origin) override;
 
+	int GetTicks() const override;
+
 	bool IsFinished() const override;
 
 	void GetFormat(int& frequency, AudioDecoder::Format& format, int& channels) const override;
@@ -51,6 +53,7 @@ private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 
 	std::string filename;
+	uint32_t division = 96;
 #ifdef HAVE_WILDMIDI
 	midi* handle = NULL;
 #endif

--- a/src/midisequencer.cpp
+++ b/src/midisequencer.cpp
@@ -260,7 +260,7 @@ namespace midisequencer{
         unsigned num_tracks = (t0 << 8) | t1;
         int d0 = fgetc(fp);
         int d1 = fgetc(fp);
-        unsigned division = (d0 << 8) | d1;
+        division = (d0 << 8) | d1;
         for(unsigned track = 0; track < num_tracks; ++track){
             if(fgetc(fp) != 0x4D || fgetc(fp) != 0x54 || fgetc(fp) != 0x72 || fgetc(fp) != 0x6B){
                 Output::Warning("Midi sequencer: invalid track header");
@@ -439,6 +439,10 @@ namespace midisequencer{
             }
         }
     }
+
+	uint32_t sequencer::get_division() const {
+		return division;
+	}
 }
 
 #endif

--- a/src/midisequencer.h
+++ b/src/midisequencer.h
@@ -76,12 +76,14 @@ namespace midisequencer{
         std::string get_title()const;
         std::string get_copyright()const;
         std::string get_song()const;
+        uint32_t get_division()const;
         void play(float time, output* out);
         void set_time(float time, output* out);
     private:
         std::vector<midi_message> messages;
         std::vector<midi_message>::iterator position;
         std::vector<std::string> long_messages;
+        uint32_t division = 0;
         void load_smf(void* fp, int(*fgetc)(void*));
     };
 }


### PR DESCRIPTION
_libsndfile_ and our bad _wave decoder for slow platforms (FASTWAV)_ have no way to query the position. I added sample counting to get the position. This is hard to get right when "Seek" is used, so I kept this as a FIXME.

In _FmMidi_ I added the current tick count to the midi message. The value matches the harmony value with some margin of error (is a bit higher/lower, harmony somehow keeps the value constant). No idea yet how to make it match better.

_WildMidi_: This is problematic. Will probably create a PR to there library someday to export the values through there API. They only offer the samplerate (How many samples were created based on the Midi file, so this is indirectly calculated through tempo + division).
When the Midi has no tempo changes just knowing the current tempo is enough to get a quite good value but for a perfect value we need all tempo informations (thats why the midi library has to calculate it).
There is no API to get the current tempo. Assume a fixed tempo (default tempo of WildMidi) and parse the division manually from the Midi header. This makes the error small enough to fix #2106 (the tick reaches the required value before the track ends), fix #1733 and fix #2241.

The Ticks are not implemented for Midis that state that there timing is FPS based. WildMidi rejects such files and because we are not aware of any bug reports this format is very unpopular I guess.

Test for MIDI. Autorun event. Outputs the delta since the last Midi Tick call
```
@> Play BGM: 'Battle1', 100, 100, 50
@> Control Variables: [0001:Variable 0001] = MIDI Play Location (Tick)
@> Control Variables: [0003:Variable 0003] = Variable [0001]
@> Control Variables: [0001:Variable 0001] -= Variable [0002]
@> Text: \V[1]\|\^
@> Control Variables: [0002:Variable 0002] = Variable [0003]
```

