### PR TITLE
GenericAudio: Fix a race condition when BGM_Play is called too often

### DIFF
--- a/src/audio_generic.cpp
+++ b/src/audio_generic.cpp
@@ -26,7 +26,6 @@
 GenericAudio::BgmChannel GenericAudio::BGM_Channels[nr_of_bgm_channels];
 GenericAudio::SeChannel GenericAudio::SE_Channels[nr_of_se_channels];
 bool GenericAudio::BGM_PlayedOnceIndicator;
-bool GenericAudio::Muted = false;
 
 std::vector<int16_t> GenericAudio::sample_buffer;
 std::vector<uint8_t> GenericAudio::scrap_buffer;
@@ -85,11 +84,7 @@ void GenericAudio::BGM_Stop() {
 	for (auto& BGM_Channel : BGM_Channels) {
 		BGM_Channel.stopped = true; //Stop all running background music
 		LockMutex();
-		if (Muted) {
-			// If the audio is muted the audio thread doesn't perform the deletion (it isn't running)
-			// Do the cleanup on our own.
-			BGM_Channel.decoder.reset();
-		}
+		BGM_Channel.decoder.reset();
 		UnlockMutex();
 	}
 }
@@ -151,7 +146,6 @@ void GenericAudio::BGM_Pitch(int pitch) {
 }
 
 void GenericAudio::SE_Play(std::string const &file, int volume, int pitch) {
-	if (Muted) return;
 	for (auto& SE_Channel : SE_Channels) {
 		if (!SE_Channel.decoder) {
 			//If there is an unused se channel


### PR DESCRIPTION
This one should be in 0.6.2 because it breaks BGM playback.

GenericAudio: Fix a race condition in BGM_Stop: When BGM_Play is executed too quickly there is no free BGM channel available because the audio thread had no time to destroy the BGM decoder.

Force the decoder deletion in BGM_Stop to ensure that there is always a channel.

Remove "Muted": there is no way to set this variable and all channels support pausing.


That's the first half for #2106.
