### PR TITLE
Transition bitmap - disable transparency

### DIFF
--- a/src/transition.cpp
+++ b/src/transition.cpp
@@ -91,7 +91,7 @@ void Transition::Init(Type type, Scene *linked_scene, int duration, bool erase) 
 		screen1 = Bitmap::Create(DisplayUi->GetWidth(), DisplayUi->GetHeight(), Color(0, 0, 0, 255));
 	} else {
 		if (erase) {
-			screen1 =  Bitmap::Create(DisplayUi->GetWidth(), DisplayUi->GetHeight(), true);
+			screen1 =  Bitmap::Create(DisplayUi->GetWidth(), DisplayUi->GetHeight(), false);
 			Graphics::LocalDraw(*screen1, std::numeric_limits<int>::min(), GetZ() - 1);
 		} else {
 			screen1 = DisplayUi->CaptureScreen();
@@ -100,7 +100,7 @@ void Transition::Init(Type type, Scene *linked_scene, int duration, bool erase) 
 	if (erase) {
 		screen2 = Bitmap::Create(DisplayUi->GetWidth(), DisplayUi->GetHeight(), Color(0, 0, 0, 255));
 	} else {
-		screen2 =  Bitmap::Create(DisplayUi->GetWidth(), DisplayUi->GetHeight(), true);
+		screen2 =  Bitmap::Create(DisplayUi->GetWidth(), DisplayUi->GetHeight(), false);
 		Graphics::LocalDraw(*screen2, std::numeric_limits<int>::min(), GetZ() - 1);
 	}
 


### PR DESCRIPTION
Transparent pixels blend improperly and cause visual glitches

Fix: #2117