### PR TITLE
Fix use-after-free in Audio SDL Mixer

### DIFF
--- a/src/audio_sdl_mixer.cpp
+++ b/src/audio_sdl_mixer.cpp
@@ -625,7 +625,7 @@ void SdlMixerAudio::SE_Play(std::string const& file, int volume, int pitch) {
 		Output::Warning("Couldn't play %s SE. %s", FileFinder::GetPathInsideGamePath(file).c_str(), Mix_GetError());
 		return;
 	}
-	sounds[channel] = snd_data;
+	sounds[channel] = std::move(snd_data);
 }
 
 void SdlMixerAudio::SE_Stop() {

--- a/src/audio_sdl_mixer.h
+++ b/src/audio_sdl_mixer.h
@@ -73,6 +73,12 @@ private:
 	bool played_once = false;
 
 	struct sound_data {
+		sound_data() = default;
+		sound_data(const sound_data&) = delete;
+		sound_data(sound_data&&) = default;
+		sound_data& operator=(const sound_data&) = delete;
+		sound_data& operator=(sound_data&&) = default;
+
 		std::shared_ptr<Mix_Chunk> chunk;
 		AudioSeRef se_ref;
 		std::vector<uint8_t> buffer;


### PR DESCRIPTION
The SE playback buffer was copied and not moved. The buffer used by SDL2 was invalid after returning from the function.

Not detected by ASAN because it happened in SDL :(

Fix #2130