### PR TITLE
Battle 2k3: Fix BattleAnim-Battlers being invisible before first action

### DIFF
--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -317,9 +317,9 @@ void Sprite_Battler::CreateSprite() {
 	else { // animated
 		SetOx(24);
 		SetOy(24);
+		ResetZ();
 		SetAnimationState(anim_state);
 		idling = true;
-		ResetZ();
 	}
 
 	SetVisible(!battler->IsHidden());


### PR DESCRIPTION
Call ResetZ before SetAnimationState is called. Otherwise BattleAnimation-Battlers will be invisible at the beginning of the battle.

Just a cosmetic thing.

~~Is there an open issue about this?~~ (Yes there is #1826). Was mentioned in the VD discord.