### PR TITLE
Battle 2k3 2: Implement 2k3 battler placement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ add_library(${PROJECT_NAME}
 	src/platform_clock.h
 	src/player.cpp
 	src/player.h
+	src/point.h
 	src/rect.cpp
 	src/rect.h
 	src/registry.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -179,6 +179,7 @@ libeasyrpg_player_a_SOURCES = \
 	src/platform_clock.h \
 	src/player.cpp \
 	src/player.h \
+	src/point.h \
 	src/game_quit.cpp \
 	src/game_quit.h \
 	src/rect.cpp \

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -287,15 +287,13 @@ void BattleAnimationBattle::Draw(Bitmap& dst) {
 		return;
 	}
 
-	for (std::vector<Game_Battler*>::const_iterator it = battlers.begin();
-	     it != battlers.end(); ++it) {
-		const Game_Battler& battler = **it;
-		const Sprite_Battler* sprite = Game_Battle::GetSpriteset().FindBattler(&battler);
+	for (auto* battler: battlers) {
+		const Sprite_Battler* sprite = Game_Battle::GetSpriteset().FindBattler(battler);
 		int offset = 0;
 		if (sprite && sprite->GetBitmap()) {
 			offset = CalculateOffset(animation.position, sprite->GetHeight());
 		}
-		DrawAt(dst, battler.GetBattleX(), battler.GetBattleY() + offset);
+		DrawAt(dst, battler->GetBattlePosition().x, battler->GetBattlePosition().y + offset);
 	}
 }
 void BattleAnimationBattle::FlashTargets(int r, int g, int b, int p) {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -817,6 +817,11 @@ const lcf::rpg::Skill* Game_Actor::GetRandomSkill() const {
 	return lcf::ReaderUtil::GetElement(lcf::Data::skills, skills[Utils::GetRandomNumber(0, skills.size() - 1)]);
 }
 
+Point Game_Actor::GetOriginalPosition() const {
+	auto& actor = GetActor();
+	return { actor.battle_x, actor.battle_y };
+}
+
 int Game_Actor::GetBattleX() const {
 	float position = 0.0;
 

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -53,10 +53,11 @@ int Game_Actor::MaxStatBaseValue() const {
 }
 
 Game_Actor::Game_Actor(int actor_id) :
-	Game_Battler(),
 	actor_id(actor_id) {
 	GetData().Setup(actor_id);
 	Setup();
+
+	SetBattlePosition(GetOriginalPosition());
 }
 
 void Game_Actor::Setup() {
@@ -820,160 +821,6 @@ const lcf::rpg::Skill* Game_Actor::GetRandomSkill() const {
 Point Game_Actor::GetOriginalPosition() const {
 	auto& actor = GetActor();
 	return { actor.battle_x, actor.battle_y };
-}
-
-int Game_Actor::GetBattleX() const {
-	float position = 0.0;
-
-	if (GetActor().battle_x == 0 ||
-		lcf::Data::battlecommands.placement == lcf::rpg::BattleCommands::Placement_automatic) {
-		int party_pos = Main_Data::game_party->GetActorPositionInParty(actor_id);
-		int party_size = Main_Data::game_party->GetBattlerCount();
-
-		float left = GetBattleRow() == RowType::RowType_back ? 25.0 : 50.0;
-		float right = left;
-
-		const lcf::rpg::Terrain* terrain = lcf::ReaderUtil::GetElement(lcf::Data::terrains, Game_Battle::GetTerrainId());
-		if (terrain) {
-			// No warning, already reported on battle start
-			right = left + terrain->grid_inclination / 1103;
-		}
-
-		switch (party_size) {
-		case 1:
-			position = left + ((right - left) / 2);
-			break;
-		case 2:
-			switch (party_pos) {
-			case 0:
-				position = right;
-				break;
-			case 1:
-				position = left;
-				break;
-			}
-			break;
-		case 3:
-			switch (party_pos) {
-			case 0:
-				position = right;
-				break;
-			case 1:
-				position = left + ((right - left) / 2);
-				break;
-			case 2:
-				position = left;
-				break;
-			}
-			break;
-		case 4:
-			switch (party_pos) {
-			case 0:
-				position = right;
-				break;
-			case 1:
-				position = left + ((right - left) * 2.0/3);
-				break;
-			case 2:
-				position = left + ((right - left) * 1.0/3);
-				break;
-			case 3:
-				position = left;
-				break;
-			}
-			break;
-		}
-
-		switch (Game_Battle::GetBattleCondition()) {
-			case lcf::rpg::System::BattleCondition_none:
-			case lcf::rpg::System::BattleCondition_initiative:
-				return SCREEN_TARGET_WIDTH - position;
-			case lcf::rpg::System::BattleCondition_back:
-				return position;
-			case lcf::rpg::System::BattleCondition_surround:
-			case lcf::rpg::System::BattleCondition_pincers:
-				// ToDo: Correct position
-				return SCREEN_TARGET_WIDTH - position;
-		}
-	}
-	else {
-		// Output::Debug("{} {} {} {}", lcf::Data::terrains[0].grid_top_y, lcf::Data::terrains[0].grid_elongation, lcf::Data::terrains[0].grid_inclination, lcf::Data::terrains[0].grid_location);
-
-		position = GetActor().battle_x * SCREEN_TARGET_WIDTH / 320;
-	}
-
-	return position;
-}
-
-int Game_Actor::GetBattleY() const {
-	float position = 0.0;
-
-	if (GetActor().battle_y == 0 ||
-		lcf::Data::battlecommands.placement == lcf::rpg::BattleCommands::Placement_automatic) {
-		int party_pos = Main_Data::game_party->GetActorPositionInParty(actor_id);
-		int party_size = Main_Data::game_party->GetBattlerCount();
-
-		float top = 0.0f;
-		float bottom = 0.0f;
-		const lcf::rpg::Terrain* terrain = lcf::ReaderUtil::GetElement(lcf::Data::terrains, Game_Battle::GetTerrainId());
-		if (terrain) {
-			// No warning, already reported on battle start
-			top = terrain->grid_top_y;
-			bottom = top + terrain->grid_elongation / 13;
-		}
-
-		switch (party_size) {
-		case 1:
-			position = top + ((bottom - top) / 2);
-			break;
-		case 2:
-			switch (party_pos) {
-			case 0:
-				position = top;
-				break;
-			case 1:
-				position = bottom;
-				break;
-			}
-			break;
-		case 3:
-			switch (party_pos) {
-			case 0:
-				position = top;
-				break;
-			case 1:
-				position = top + ((bottom - top) / 2);
-				break;
-			case 2:
-				position = bottom;
-				break;
-			}
-			break;
-		case 4:
-			switch (party_pos) {
-			case 0:
-				position = top;
-				break;
-			case 1:
-				position = top + ((bottom - top) * 1.0 / 3);
-				break;
-			case 2:
-				position = top + ((bottom - top) * 2.0 / 3);
-				break;
-			case 3:
-				position = bottom;
-				break;
-			}
-			break;
-		}
-
-		position -= 24;
-	}
-	else {
-		position = GetActor().battle_y * SCREEN_TARGET_HEIGHT / 240;
-	}
-
-	return (int)position;
 }
 
 const std::string& Game_Actor::GetSkillName() const {

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -677,20 +677,6 @@ public:
 	bool GetAutoBattle() const;
 
 	/**
-	 * Gets X position on battlefield
-	 *
-	 * @return X position in battle scene
-	 */
-	int GetBattleX() const override;
-
-	/**
-	 * Gets Y position on battlefield
-	 *
-	 * @return Y position in battle scene
-	 */
-	int GetBattleY() const override;
-
-	/**
 	 * Gets name of skill menu item
 	 *
 	 * @return name of skill menu item

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -59,6 +59,8 @@ public:
 
 	virtual PermanentStates GetPermanentStates() const override;
 
+	Point GetOriginalPosition() const override;
+
 	/**
 	 * Sets up the game actor
 	 * This is automatically called in the constructor.

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -66,6 +66,7 @@ namespace {
 }
 
 void Game_Battle::Init(int troop_id) {
+	Main_Data::game_enemyparty->ResetBattle(troop_id);
 	interpreter.reset(new Game_Interpreter_Battle());
 	spriteset.reset(new Spriteset_Battle(background_name, terrain_id));
 	spriteset->Update();
@@ -120,6 +121,7 @@ void Game_Battle::Quit() {
 	page_can_run.clear();
 
 	Game_Actors::ResetBattle();
+	Main_Data::game_enemyparty->ResetBattle(0);
 	Main_Data::game_pictures->OnBattleEnd();
 }
 

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -615,9 +615,8 @@ Point Game_Battle::Calculate2k3BattlePosition(const Game_Enemy& enemy) {
 		}
 	}
 
-	// RPG_RT has a bug where the pincer table is only used for enemies on terrain battles but not on
-	// non terrain battles. We don't emulate this because it looks better when the surrounding party is lined up evenly.
-	const int table_y_idx = (cond == lcf::rpg::System::BattleCondition_pincers) ? 2 : 1;
+	// RPG_RT has a bug where the pincer table is only used for enemies on terrain battles but not on non terrain battles.
+	const int table_y_idx = (cond == lcf::rpg::System::BattleCondition_pincers && terrain_id >= 1) ? 2 : 1;
 	const auto grid = CalculateBaseGridPosition(idx, party_size, 0, table_y_idx, form, terrain_id);
 	const auto ti = grid_tables[3][party_size - 1][idx];
 

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -57,6 +57,7 @@ namespace {
 	std::vector<bool> page_executed;
 	int terrain_id;
 	lcf::rpg::System::BattleCondition battle_cond = lcf::rpg::System::BattleCondition_none;
+	lcf::rpg::System::BattleFormation battle_form = lcf::rpg::System::BattleFormation_terrain;
 	int target_enemy_index;
 	bool need_refresh;
 	std::vector<bool> page_can_run;
@@ -434,6 +435,14 @@ lcf::rpg::System::BattleCondition Game_Battle::GetBattleCondition() {
 	return battle_cond;
 }
 
+void Game_Battle::SetBattleFormation(lcf::rpg::System::BattleFormation form) {
+	battle_form = form;
+}
+
+lcf::rpg::System::BattleFormation Game_Battle::GetBattleFormation() {
+	return battle_form;
+}
+
 void Game_Battle::SetEnemyTargetIndex(int target_enemy) {
 	target_enemy_index = target_enemy;
 }
@@ -471,4 +480,244 @@ TeleportTarget Game_Battle::GetDeathHandlerTeleport() {
 
 const lcf::rpg::Troop* Game_Battle::GetActiveTroop() {
 	return IsBattleRunning() ? troop : nullptr;
+}
+
+static constexpr double grid_tables[4][8][8] = {
+{
+// In DynRPG 0x4CC16C
+	{ 0.5, },
+	{ 0.0, 1.0, },
+	{ 0.0, 0.5, 1.0, },
+	{ 0.0, 0.33, 0.66, 1.0, },
+	{ 0.0, 0.25, 0.5, 0.75, 1.0, },
+	{ 0.0, 0.0, 0.5, 0.5, 1.0, 1.0, },
+	{ 0.0, 0.25, 0.33, 0.5, 0.66, 0.75, 1.0, },
+	{ 0.0, 0.0, 0.33, 0.33, 0.66, 0.66, 1.0, 1.0, },
+}, {
+// In DynRPG 0x4CC36C
+	{ 0.5, },
+	{ 0.0, 1.0, },
+	{ 0.0, 1.0, 0.5, },
+	{ 0.0, 0.75, 0.25, 1.0, },
+	{ 0.0, 0.5, 1.0, 0.25, 0.75, },
+	{ 0.0, 0.4, 0.8, 0.2, 0.6, 1.0, },
+	{ 0.0, 0.33, 0.66, 1.0, 0.25, 0.5, 1.0, },
+	{ 0.0, 0.28, 0.56, 0.84, 0.14, 0.42, 0.7, 0.98, }
+}, {
+// In DynRPG 0x4CC35C
+	{ 0.5, },
+	{ 0.5, 0.5, },
+	{ 0.0, 0.5, 1.0, },
+	{ 0.0, 0.0, 1.0, 1.0, },
+	{ 0.0, 0.33, 0.5, 0.66, 1.0, },
+	{ 0.0, 0.0, 0.5, 0.5, 1.0, 1.0, },
+	{ 0.0, 0.25, 0.33, 0.5, 0.66, 0.75, 1.0,},
+	{ 0.0, 0.0, 0.33, 0.33, 0.66, 0.66, 1.0, 1.0, }
+}, {
+// In DynRPG 0x4CC76C
+	{ },
+	{ 24, },
+	{ 48, 48, },
+	{ 48, 48, },
+	{ 56, 56, 56, 8, 8, },
+	{ 56, 56, 56, 8, 8, },
+	{ 64, 64, 64, 64, 16, 16, 16, },
+	{ 64, 64, 64, 64, 16, 16, 16, 16 },
+}};
+
+
+Point Game_Battle::CalculateBaseGridPosition(
+		int party_idx,
+		int party_size,
+		int table_x,
+		int table_y,
+		lcf::rpg::System::BattleFormation form,
+		int terrain_id)
+{
+	Point pos;
+
+	assert(party_idx >= 0);
+	assert(party_idx < party_size);
+	assert(party_size <= 8);
+
+	int grid_top_y = 112;
+	double grid_elongation = 392;
+	double grid_inclination = 16000;
+	if (terrain_id > 0) {
+		const auto* terrain = lcf::ReaderUtil::GetElement(lcf::Data::terrains, Game_Battle::GetTerrainId());
+		if (terrain) {
+			grid_top_y = terrain->grid_top_y;
+			grid_elongation = static_cast<double>(terrain->grid_elongation);
+			grid_inclination = static_cast<double>(terrain->grid_inclination);
+		}
+	} else if (form == lcf::rpg::System::BattleFormation_tight) {
+		grid_top_y = 132;
+		grid_elongation = 196;
+		grid_inclination = 24000;
+	}
+
+	const auto tdx = grid_tables[table_x][party_size - 1][party_idx];
+	const auto tdy = grid_tables[table_y][party_size - 1][party_idx];
+
+	pos.x = static_cast<int>((1.0 - tdx) * (grid_inclination / 1000.0));
+	pos.y = grid_top_y + static_cast<int>(std::sin(grid_elongation / 1000.0) * 120.0 * tdy);
+
+	return pos;
+}
+
+
+Point Game_Battle::Calculate2k3BattlePosition(const Game_Enemy& enemy) {
+	assert(troop);
+
+	const auto terrain_id = Game_Battle::GetTerrainId();
+	const auto cond = Game_Battle::GetBattleCondition();
+	const auto form = Game_Battle::GetBattleFormation();
+	auto* sprite = Game_Battle::GetSpriteset().FindBattler(&enemy);
+
+	int half_height = 0;
+	int half_width = 0;
+	if (sprite) {
+		half_height = sprite->GetHeight() / 2;
+		half_width = sprite->GetWidth() / 2;
+	}
+
+	// Manual position case
+	if (!troop->auto_alignment
+			&& cond != lcf::rpg::System::BattleCondition_pincers
+			&& cond != lcf::rpg::System::BattleCondition_surround) {
+		auto position = enemy.GetOriginalPosition();
+		if (cond == lcf::rpg::System::BattleCondition_back) {
+			position.x = 320 - position.x;
+		}
+
+		// RPG_RT only clamps Y position for enemies
+		position.y = Utils::Clamp(position.y, half_height, 240 - half_height);
+		return position;
+	}
+
+	// Auto position case
+
+	int party_size = 0;
+	int idx = 0;
+	bool found_myself = false;
+	// Position is computed based on this monster's index relative to party size
+	// If monster is hidden -> use real party idx / real party size
+	// If monster is visible -> use visible party idx / visible party size
+	for (auto& e: Main_Data::game_enemyparty->GetEnemies()) {
+		if (e.get() == &enemy) {
+			found_myself = true;
+		}
+		if (enemy.IsHidden() || !e->IsHidden()) {
+			party_size += 1;
+			idx += !(found_myself);
+		}
+	}
+
+	// RPG_RT has a bug where the pincer table is only used for enemies on terrain battles but not on
+	// non terrain battles. We don't emulate this because it looks better when the surrounding party is lined up evenly.
+	const int table_y_idx = (cond == lcf::rpg::System::BattleCondition_pincers) ? 2 : 1;
+	const auto grid = CalculateBaseGridPosition(idx, party_size, 0, table_y_idx, form, terrain_id);
+	const auto ti = grid_tables[3][party_size - 1][idx];
+
+	Point position;
+
+	const bool is_odd = (idx & 1);
+
+	switch (cond) {
+		case lcf::rpg::System::BattleCondition_none:
+		case lcf::rpg::System::BattleCondition_initiative:
+			position.x = grid.x + ti + half_width;
+			break;
+		case lcf::rpg::System::BattleCondition_back:
+			position.x = 320 - (grid.x + ti + half_width);
+			break;
+		case lcf::rpg::System::BattleCondition_surround:
+			position.x = 160 + (is_odd ? 16 : -16);
+			break;
+		case lcf::rpg::System::BattleCondition_pincers:
+			position.x = grid.x + half_width + 16;
+			if (!is_odd) {
+				position.x = 320 - position.x;
+			}
+			break;
+	}
+
+	position.y = grid.y - half_height;
+
+	// RPG_RT only clamps Y position for enemies
+	position.y = Utils::Clamp(position.y, half_height, 240 - half_height);
+
+	return position;
+}
+
+Point Game_Battle::Calculate2k3BattlePosition(const Game_Actor& actor) {
+	assert(troop);
+
+	const auto terrain_id = Game_Battle::GetTerrainId();
+	const auto cond = Game_Battle::GetBattleCondition();
+	const auto form = Game_Battle::GetBattleFormation();
+	auto* sprite = Game_Battle::GetSpriteset().FindBattler(&actor);
+
+	int half_height = 0;
+	int half_width = 0;
+	if (sprite) {
+		half_height = sprite->GetHeight() / 2;
+		half_width = sprite->GetWidth() / 2;
+	}
+
+	int row_x_offset = 0;
+	if (actor.GetBattleRow() == Game_Actor::RowType::RowType_front) {
+		row_x_offset = half_width;
+	}
+
+	// Manual position case
+	if (lcf::Data::battlecommands.placement == lcf::rpg::BattleCommands::Placement_manual) {
+		auto position = actor.GetOriginalPosition();
+
+		if (cond == lcf::rpg::System::BattleCondition_back) {
+			position.x = 320 - (position.x + row_x_offset);
+		} else {
+			position.x = position.x - row_x_offset;
+		}
+
+		// RPG_RT doesn't clamp Y for actors
+		position.x = Utils::Clamp(position.x, half_width, 320 - half_width);
+		return position;
+	}
+
+	const auto idx = Main_Data::game_party->GetActorPositionInParty(actor.GetId());
+	const auto party_size = Main_Data::game_party->GetBattlerCount();
+
+	const int table_y_idx = (cond == lcf::rpg::System::BattleCondition_surround) ? 2 : 0;
+	const auto grid = CalculateBaseGridPosition(idx, party_size, 0, table_y_idx, form, terrain_id);
+
+	Point position;
+
+	const bool is_odd = (idx & 1);
+
+	switch (cond) {
+		case lcf::rpg::System::BattleCondition_none:
+		case lcf::rpg::System::BattleCondition_initiative:
+			position.x = 320 - (grid.x + half_width + row_x_offset);
+			break;
+		case lcf::rpg::System::BattleCondition_back:
+			position.x = grid.x + 2 * half_width - row_x_offset;
+			break;
+		case lcf::rpg::System::BattleCondition_surround:
+			position.x = grid.x + half_width + row_x_offset;
+			if (!is_odd) {
+				position.x = 320 - position.x;
+			}
+			break;
+		case lcf::rpg::System::BattleCondition_pincers:
+			position.x = 160 + (half_width / 2) - row_x_offset;
+			break;
+	}
+
+	position.y = grid.y - half_height;
+
+	// RPG_RT doesn't clamp Y for actors
+	position.x = Utils::Clamp(position.x, half_width, 320 - half_width);
+
+	return position;
 }

--- a/src/game_battle.h
+++ b/src/game_battle.h
@@ -23,8 +23,11 @@
 #include <lcf/rpg/troop.h>
 #include "teleport_target.h"
 #include "utils.h"
+#include "point.h"
 
 class Game_Battler;
+class Game_Enemy;
+class Game_Actor;
 class Game_Interpreter;
 class Spriteset_Battle;
 
@@ -154,6 +157,42 @@ namespace Game_Battle {
 
 	void SetBattleCondition(lcf::rpg::System::BattleCondition cond);
 	lcf::rpg::System::BattleCondition GetBattleCondition();
+
+	void SetBattleFormation(lcf::rpg::System::BattleFormation form);
+	lcf::rpg::System::BattleFormation GetBattleFormation();
+
+	/**
+	 * Calculates the base grid position from the parameters used for both actors and enemies.
+	 *
+	 * @param party_idx the index of the party member
+	 * @param party_size the size of the party
+	 * @param table_x Which grid table to use for X position
+	 * @param table_y which grid table to use for Y position
+	 * @param cond the battle condition
+	 * @param form the battle formation
+	 * @param terrain_id the battle terrain id
+	 */
+	Point CalculateBaseGridPosition(
+			int party_idx,
+			int party_size,
+			int x_table,
+			int y_table,
+			lcf::rpg::System::BattleFormation form,
+			int terrain_id);
+
+	/**
+	 * Calculate the battler position that would be used for the enemy
+	 *
+	 * @param enemy the enemy to calculate.
+	 */
+	Point Calculate2k3BattlePosition(const Game_Enemy& enemy);
+
+	/**
+	 * Calculate the battler position that would be used for the enemy
+	 *
+	 * @param enemy the enemy to calculate.
+	 */
+	Point Calculate2k3BattlePosition(const Game_Actor& actor);
 
 	/**
 	 * Sets the party index of the latest targeted enemy. Only used by battle branch "is target"

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -92,6 +92,9 @@ public:
 	 */
 	Game_Battler* GetTarget() const;
 
+	/** @return true if this algorithm targets a party */
+	bool IsTargetingParty() const;
+
 	/**
 	 * Allows changing of the target.
 	 * Purpose is to allow attacking someone else if the old target is
@@ -653,6 +656,10 @@ inline bool AlgorithmBase::HasStartMessage() const {
 
 inline const std::vector<StateEffect>& AlgorithmBase::GetStateEffects() const {
 	return states;
+}
+
+inline bool AlgorithmBase::IsTargetingParty() const {
+	return party_target != nullptr;
 }
 
 } //namespace Game_BattleAlgorithm

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -674,6 +674,7 @@ void Game_Battler::ResetBattle() {
 	SetCharged(false);
 	SetIsDefending(false);
 	SetHidden(false);
+	SetDirectionFlipped(false);
 	battle_turn = 0;
 	last_battle_action = -1;
 	atk_modifier = 0;

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -616,12 +616,12 @@ int Game_Battler::GetAgi() const {
 
 int Game_Battler::GetDisplayX() const {
 	int shake_pos = Main_Data::game_screen->GetShakeOffsetX() + shake.position;
-	return GetBattleX() + shake_pos;
+	return (GetBattlePosition().x + shake_pos) * SCREEN_TARGET_WIDTH / 320;
 }
 
 int Game_Battler::GetDisplayY() const {
 	int shake_pos = Main_Data::game_screen->GetShakeOffsetY();
-	return GetBattleY() + GetFlyingOffset() + shake_pos;
+	return (GetBattlePosition().y + GetFlyingOffset() + shake_pos) * SCREEN_TARGET_HEIGHT / 240;
 }
 
 Game_Party_Base& Game_Battler::GetParty() const {

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -27,6 +27,7 @@
 #include "color.h"
 #include "flash.h"
 #include "utils.h"
+#include "point.h"
 
 class Game_Actor;
 class Game_Party_Base;
@@ -493,6 +494,9 @@ public:
 	 * @return Y position in battle scene
 	 */
 	virtual int GetBattleY() const = 0;
+
+	/** @return original (x,y) position from the database */
+	virtual Point GetOriginalPosition() const  = 0;
 
 	/**
 	 * Gets X position on the screen.

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -355,6 +355,16 @@ public:
 	 */
 	virtual int GetBaseAgi() const = 0;
 
+	/** @return whether the battler is facing the opposite it's normal direction */
+	bool IsDirectionFlipped() const;
+
+	/**
+	 * Set whether the battler is facing the opposite it's normal direction
+	 *
+	 * @param flip to flip or not
+	 */
+	void SetDirectionFlipped(bool flip);
+
 	void SetHidden(bool hidden);
 	bool IsHidden() const;
 	virtual bool IsImmortal() const;
@@ -707,6 +717,7 @@ protected:
 	bool defending = false;
 	bool charged = false;
 	bool hidden = false;
+	bool direction_flipped = false;
 
 	std::vector<int> attribute_shift;
 
@@ -890,6 +901,14 @@ inline Point Game_Battler::GetBattlePosition() const {
 
 inline void Game_Battler::SetBattlePosition(Point pos) {
 	position = pos;
+}
+
+inline bool Game_Battler::IsDirectionFlipped() const {
+	return direction_flipped;
+}
+
+inline void Game_Battler::SetDirectionFlipped(bool flip) {
+	direction_flipped = flip;
 }
 
 #endif

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -21,6 +21,7 @@
 // Headers
 #include <string>
 #include <vector>
+#include <limits>
 #include <lcf/rpg/state.h>
 #include "system.h"
 #include "state.h"
@@ -481,34 +482,23 @@ public:
 	 */
 	bool HasReflectState() const;
 
-	/**
-	 * Gets X position against the battle background.
-	 *
-	 * @return X position in battle scene
-	 */
-	virtual int GetBattleX() const = 0;
+	/* @return current (x,y) position in the battle scene */
+	Point GetBattlePosition() const;
 
 	/**
-	 * Gets Y position against the battle background.
+	 *  Set (x,y) position in the battle scene.
 	 *
-	 * @return Y position in battle scene
+	 *  @param pos new position to set
 	 */
-	virtual int GetBattleY() const = 0;
+	void SetBattlePosition(Point pos);
 
 	/** @return original (x,y) position from the database */
 	virtual Point GetOriginalPosition() const  = 0;
 
-	/**
-	 * Gets X position on the screen.
-	 *
-	 * This is equal to GetBattleX, plus a displacement for
-	 * any screen shaking.
-	 */
+	/** @return Adjusted X position on the screen.  */
 	int GetDisplayX() const;
 
-	/**
-	 * Gets Y position on the screen.
-	 */
+	/** @return Adjusted Y position on the screen.  */
 	int GetDisplayY() const;
 
 	virtual int GetHue() const;
@@ -713,6 +703,7 @@ protected:
 	int last_battle_action;
 	int battle_combo_command_id;
 	int battle_combo_times;
+	Point position;
 	bool defending = false;
 	bool charged = false;
 	bool hidden = false;
@@ -891,6 +882,14 @@ inline void Game_Battler::SetBattleOrderAgi(int val) {
 
 inline int Game_Battler::GetBattleOrderAgi() {
 	return battle_order;
+}
+
+inline Point Game_Battler::GetBattlePosition() const {
+	return position;
+}
+
+inline void Game_Battler::SetBattlePosition(Point pos) {
+	position = pos;
 }
 
 #endif

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -33,19 +33,17 @@ namespace {
 	constexpr int levitation_frame_cycle = 20;
 }
 
-Game_Enemy::Game_Enemy(int enemy_id) : Game_Battler() {
-	Setup(enemy_id);
-}
+Game_Enemy::Game_Enemy(const lcf::rpg::TroopMember& member)
+	: troop_member(&member)
+{
+	Transform(troop_member->enemy_id);
 
-void Game_Enemy::Setup(int enemy_id) {
-	Transform(enemy_id);
 	hp = GetMaxHp();
 	sp = GetMaxSp();
-	x = 0;
-	y = 0;
-	SetHidden(false);
+	SetHidden(troop_member->invisible);
 	cycle = Utils::GetRandomNumber(0, levitation_frame_count - 1) * levitation_frame_cycle;
-	flying_offset = 0;
+	x = troop_member->x;
+	y = troop_member->y;
 }
 
 int Game_Enemy::MaxHpValue() const {
@@ -103,20 +101,23 @@ int Game_Enemy::GetBattleY() const {
 	return (y*SCREEN_TARGET_HEIGHT/240);
 }
 
-void Game_Enemy::Transform(int new_enemy_id) {
-	enemy_id = new_enemy_id;
+static lcf::rpg::Enemy makeDummyEnemy() {
+	lcf::rpg::Enemy enemy;
+	enemy.ID = 1;
+	return enemy;
+}
 
-	enemy = lcf::ReaderUtil::GetElement(lcf::Data::enemies, enemy_id);
+void Game_Enemy::Transform(int new_enemy_id) {
+	enemy = lcf::ReaderUtil::GetElement(lcf::Data::enemies, new_enemy_id);
 
 	if (!enemy) {
 		// Some games (e.g. Battle 5 in Embric) have invalid monsters in the battle.
 		// This case will fail in RPG Maker and the game will exit with an error message.
 		// Create a warning instead and continue the battle.
 		Output::Warning("Invalid enemy ID {}", new_enemy_id);
-		enemy_id = 1;
 		// This generates an invisible monster with 0 HP
-		static lcf::rpg::Enemy dummy_enemy;
-		enemy = &dummy_enemy;
+		static auto dummy = makeDummyEnemy();
+		enemy = &dummy;
 	}
 }
 
@@ -204,6 +205,7 @@ bool Game_Enemy::IsActionValid(const lcf::rpg::EnemyAction& action) {
 
 const lcf::rpg::EnemyAction* Game_Enemy::ChooseRandomAction() {
 	if (IsCharged()) {
+		static lcf::rpg::EnemyAction normal_atk;
 		return &normal_atk;
 	}
 

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -42,8 +42,8 @@ Game_Enemy::Game_Enemy(const lcf::rpg::TroopMember& member)
 	sp = GetMaxSp();
 	SetHidden(troop_member->invisible);
 	cycle = Utils::GetRandomNumber(0, levitation_frame_count - 1) * levitation_frame_cycle;
-	x = troop_member->x;
-	y = troop_member->y;
+
+	SetBattlePosition(GetOriginalPosition());
 }
 
 int Game_Enemy::MaxHpValue() const {
@@ -95,14 +95,6 @@ void Game_Enemy::SetSp(int _sp) {
 
 Point Game_Enemy::GetOriginalPosition() const {
 	return { troop_member->x, troop_member->y };
-}
-
-int Game_Enemy::GetBattleX() const {
-	return (x*SCREEN_TARGET_WIDTH/320);
-}
-
-int Game_Enemy::GetBattleY() const {
-	return (y*SCREEN_TARGET_HEIGHT/240);
 }
 
 static lcf::rpg::Enemy makeDummyEnemy() {

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -93,6 +93,10 @@ void Game_Enemy::SetSp(int _sp) {
 	sp = std::min(std::max(_sp, 0), GetMaxSp());
 }
 
+Point Game_Enemy::GetOriginalPosition() const {
+	return { troop_member->x, troop_member->y };
+}
+
 int Game_Enemy::GetBattleX() const {
 	return (x*SCREEN_TARGET_WIDTH/320);
 }

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -114,8 +114,9 @@ void Game_Enemy::Transform(int new_enemy_id) {
 		// Create a warning instead and continue the battle.
 		Output::Warning("Invalid enemy ID {}", new_enemy_id);
 		enemy_id = 1;
-		// This generates an invisible monster with 0 HP and a minor memory leak
-		enemy = new lcf::rpg::Enemy();
+		// This generates an invisible monster with 0 HP
+		static lcf::rpg::Enemy dummy_enemy;
+		enemy = &dummy_enemy;
 	}
 }
 

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -41,6 +41,8 @@ public:
 
 	int MaxStatBaseValue() const override;
 
+	Point GetOriginalPosition() const override;
+
 	/**
 	 * Gets probability that a state can be inflicted on this actor.
 	 *

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -21,6 +21,8 @@
 // Headers
 #include "game_battler.h"
 #include <lcf/rpg/enemy.h>
+#include <lcf/rpg/enemyaction.h>
+#include <lcf/rpg/troopmember.h>
 
 /**
  * Represents a single enemy in the battle scene
@@ -28,7 +30,7 @@
 class Game_Enemy final : public Game_Battler
 {
 public:
-	Game_Enemy(int enemy_id);
+	explicit Game_Enemy(const lcf::rpg::TroopMember& tm);
 
 	const std::vector<int16_t>& GetStates() const override;
 	std::vector<int16_t>& GetStates() override;
@@ -124,6 +126,7 @@ public:
 	 * @return enemy X position
 	 */
 	int GetBattleX() const override;
+
 	/**
 	 * Gets enemy Y position
 	 *
@@ -191,24 +194,15 @@ public:
 	bool IsInParty() const override;
 
 protected:
-	void Setup(int enemy_id);
-
-	int x;
-	int y;
-
-	int enemy_id;
-	// hidden at battle begin
-	bool hidden;
-	int hp;
-	int sp;
-	int cycle;
-	int flying_offset;
+	const lcf::rpg::Enemy* enemy = nullptr;
+	const lcf::rpg::TroopMember* troop_member = nullptr;
 	std::vector<int16_t> states;
-
-	lcf::rpg::Enemy* enemy;
-
-	// normal attack instance for use after charge
-	lcf::rpg::EnemyAction normal_atk;
+	int hp = 0;
+	int sp = 0;
+	int cycle = 0;
+	int flying_offset = 0;
+	int x = 0;
+	int y = 0;
 };
 
 inline Game_Battler::BattlerType Game_Enemy::GetType() const {
@@ -252,7 +246,7 @@ inline int Game_Enemy::GetHue() const {
 }
 
 inline int Game_Enemy::GetId() const {
-	return enemy_id;
+	return enemy->ID;
 }
 
 inline int Game_Enemy::GetBaseMaxHp() const {

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -122,34 +122,6 @@ public:
 	 */
 	int GetBaseAgi() const override;
 
-	/**
-	 * Gets enemy X position
-	 *
-	 * @return enemy X position
-	 */
-	int GetBattleX() const override;
-
-	/**
-	 * Gets enemy Y position
-	 *
-	 * @return enemy Y position
-	 */
-	int GetBattleY() const override;
-
-	/**
-	 * Sets enemy X position
-	 * 
-	 * @param new_x New X position
-	 */
-	void SetBattleX(int new_x);
-
-	/**
-	 * Sets enemy Y position
-	 * 
-	 * @param new_y New Y position
-	 */
-	void SetBattleY(int new_y);
-
 	int GetHue() const override;
 
 	int GetHp() const override;
@@ -203,8 +175,6 @@ protected:
 	int sp = 0;
 	int cycle = 0;
 	int flying_offset = 0;
-	int x = 0;
-	int y = 0;
 };
 
 inline Game_Battler::BattlerType Game_Enemy::GetType() const {
@@ -233,14 +203,6 @@ inline bool Game_Enemy::IsTransparent() const {
 
 inline int Game_Enemy::GetBattleAnimationId() const {
 	return 0;
-}
-
-inline void Game_Enemy::SetBattleX(int new_x) {
-	x = new_x;
-}
-
-inline void Game_Enemy::SetBattleY(int new_y) {
-	y = new_y;
 }
 
 inline int Game_Enemy::GetHue() const {

--- a/src/game_enemyparty.cpp
+++ b/src/game_enemyparty.cpp
@@ -40,6 +40,14 @@ int Game_EnemyParty::GetBattlerCount() const {
 	return (int)enemies.size();
 }
 
+int Game_EnemyParty::GetVisibleBattlerCount() const {
+	int visible = 0;
+	for (const auto& enemy: enemies) {
+		visible += !enemy->IsHidden();
+	}
+	return visible;
+}
+
 void Game_EnemyParty::Setup(int battle_troop_id) {
 	enemies.clear();
 	const lcf::rpg::Troop* troop = lcf::ReaderUtil::GetElement(lcf::Data::troops, battle_troop_id);

--- a/src/game_enemyparty.cpp
+++ b/src/game_enemyparty.cpp
@@ -49,32 +49,28 @@ void Game_EnemyParty::Setup(int battle_troop_id) {
 		return;
 	}
 
-	int non_hidden = 0;
-	for (const lcf::rpg::TroopMember& mem : troop->members) {
-		non_hidden += (!mem.invisible ? 1 : 0);
+	int non_hidden = static_cast<int>(troop->members.size());
+	for (const auto& mem : troop->members) {
+		enemies.push_back(std::make_shared<Game_Enemy>(mem));
+		non_hidden -= enemies.back()->IsHidden();
 	}
 
-	for (const lcf::rpg::TroopMember& mem : troop->members) {
-		std::shared_ptr<Game_Enemy> enemy = std::make_shared<Game_Enemy>(mem.enemy_id);
-		enemy->SetBattleX(mem.x);
-		enemy->SetBattleY(mem.y);
-
-		if (!mem.invisible) {
-			if (troop->appear_randomly) {
+	if (troop->appear_randomly) {
+		for (auto& enemy: enemies) {
+			if (non_hidden <= 1) {
 				// At least one party member must be visible
-				if (non_hidden > 1) {
-					bool hide = Utils::ChanceOf(1, 2);
-					enemy->SetHidden(hide);
-					non_hidden -= (hide ? 1 : 0);
-				}
-			} else {
-				enemy->SetHidden(false);
+				break;
 			}
-		} else {
-			enemy->SetHidden(true);
-		}
+			if (enemy->IsHidden()) {
+				continue;
+			}
 
-		enemies.push_back(enemy);
+			const bool hide = Utils::ChanceOf(1, 2);
+			if (hide) {
+				enemy->SetHidden(true);
+				--non_hidden;
+			}
+		}
 	}
 }
 

--- a/src/game_enemyparty.cpp
+++ b/src/game_enemyparty.cpp
@@ -65,8 +65,7 @@ void Game_EnemyParty::Setup(int battle_troop_id) {
 				continue;
 			}
 
-			const bool hide = Utils::ChanceOf(1, 2);
-			if (hide) {
+			if (Utils::PercentChance(40)) {
 				enemy->SetHidden(true);
 				--non_hidden;
 			}

--- a/src/game_enemyparty.cpp
+++ b/src/game_enemyparty.cpp
@@ -48,12 +48,11 @@ int Game_EnemyParty::GetVisibleBattlerCount() const {
 	return visible;
 }
 
-void Game_EnemyParty::Setup(int battle_troop_id) {
+void Game_EnemyParty::ResetBattle(int battle_troop_id) {
 	enemies.clear();
-	const lcf::rpg::Troop* troop = lcf::ReaderUtil::GetElement(lcf::Data::troops, battle_troop_id);
+	const auto* troop = lcf::ReaderUtil::GetElement(lcf::Data::troops, battle_troop_id);
 	if (!troop) {
-		// Shouldn't happen because Scene_Battle verifies this
-		Output::Warning("Invalid battle troop ID {}", battle_troop_id);
+		// Valid case when battle quits
 		return;
 	}
 

--- a/src/game_enemyparty.h
+++ b/src/game_enemyparty.h
@@ -39,11 +39,11 @@ public:
 	int GetVisibleBattlerCount() const override;
 
 	/**
-	 * Setups initial enemy party.
+	 * Reset the party for a new battle.
 	 * 
-	 * @param battle_troop_id ID of the enemy party
+	 * @param battle_troop_id ID of the enemy party, or 0 for empty.
 	 */
-	void Setup(int battle_troop_id);
+	void ResetBattle(int battle_troop_id);
 
 	/**
 	 * Gets a list with all party members

--- a/src/game_enemyparty.h
+++ b/src/game_enemyparty.h
@@ -36,6 +36,7 @@ public:
 	Game_Enemy& operator[] (const int index) override;
 
 	int GetBattlerCount() const override;
+	int GetVisibleBattlerCount() const override;
 
 	/**
 	 * Setups initial enemy party.

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -89,6 +89,14 @@ int Game_Party::GetBattlerCount() const {
 	return (int)GetActors().size();
 }
 
+int Game_Party::GetVisibleBattlerCount() const {
+	int visible = 0;
+	for (const auto& actor: GetActors()) {
+		visible += !actor->IsHidden();
+	}
+	return visible;
+}
+
 void Game_Party::SetupBattleTestMembers() {
 	Clear();
 

--- a/src/game_party.h
+++ b/src/game_party.h
@@ -45,6 +45,7 @@ public:
 	Game_Actor& operator[] (const int index) override;
 
 	int GetBattlerCount() const override;
+	int GetVisibleBattlerCount() const override;
 
 	/**
 	 * Setups battle test party.

--- a/src/game_party_base.h
+++ b/src/game_party_base.h
@@ -45,6 +45,13 @@ public:
 	virtual int GetBattlerCount() const = 0;
 
 	/**
+	 * Returns how many members are in the party and not hidden
+	 *
+	 * @return Number of members in the party who are not hidden
+	 */
+	virtual int GetVisibleBattlerCount() const = 0;
+
+	/**
 	 * Returns a list of all battlers in the party
 	 *
 	 * @param out List of all battlers

--- a/src/point.h
+++ b/src/point.h
@@ -1,0 +1,77 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_POINT_H
+#define EP_POINT_H
+
+#include <ostream>
+
+/**
+ * Point.
+ */
+class Point {
+public:
+	/**
+	 * Constructor. All values are set to 0.
+	 */
+	constexpr Point() = default;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param x initial x.
+	 * @param y initial y.
+	 */
+	constexpr Point(int x, int y) : x(x), y(y) {}
+
+	/** X coordinate. */
+	int x = 0;
+
+	/** Y coordinate. */
+	int y = 0;
+};
+
+inline bool operator==(const Point &l, const Point& r) {
+	return l.x == r.x && l.y == r.y;
+}
+
+inline bool operator!=(const Point &l, const Point& r) {
+	return !(l == r);
+}
+
+inline bool operator<(const Point &l, const Point& r) {
+	return l.x < r.x || (l.x == r.x && l.y < r.y);
+}
+
+inline bool operator>(const Point &l, const Point& r) {
+	return l.x > r.x || (l.x == r.x && l.y > r.y);
+}
+
+inline bool operator<=(const Point &l, const Point& r) {
+	return !(l > r);
+}
+
+inline bool operator>=(const Point &l, const Point& r) {
+	return !(l < r);
+}
+
+inline std::ostream& operator<<(std::ostream& os, Point r) {
+	os << "Point{" << r.x << "," << r.y << "}";
+	return os;
+}
+
+#endif

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -61,6 +61,7 @@ Scene_Battle::Scene_Battle(const BattleArgs& args)
 	Game_Battle::SetTerrainId(args.terrain_id);
 	Game_Battle::ChangeBackground(args.background);
 	Game_Battle::SetBattleCondition(args.condition);
+	Game_Battle::SetBattleFormation(args.formation);
 }
 
 Scene_Battle::~Scene_Battle() {

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -92,8 +92,6 @@ void Scene_Battle::Start() {
 	if (Game_Battle::battle_test.enabled) {
 		Main_Data::game_party->SetupBattleTestMembers();
 	}
-	Main_Data::game_enemyparty.reset(new Game_EnemyParty());
-	Main_Data::game_enemyparty->Setup(troop_id);
 
 	Game_Battle::Init(troop_id);
 

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -65,7 +65,8 @@ void Scene_Battle_Rpg2k3::InitBattleCondition(lcf::rpg::System::BattleCondition 
 
 void Scene_Battle_Rpg2k3::Start() {
 	Scene_Battle::Start();
-	InitBattlerPositions();
+	InitEnemies();
+	InitActors();
 	InitAtbGauges();
 }
 
@@ -170,18 +171,36 @@ void Scene_Battle_Rpg2k3::PlaceActor(Game_Actor& actor) {
 void Scene_Battle_Rpg2k3::PlaceEnemy(Game_Enemy& actor) {
 }
 
-void Scene_Battle_Rpg2k3::InitBattlerPositions() {
-	float position = 0.0;
-
-	for (auto& actor: Main_Data::game_party->GetActors()) {
-		PlaceActor(*actor);
-	}
-
+void Scene_Battle_Rpg2k3::InitEnemies() {
 	for (auto& enemy: Main_Data::game_enemyparty->GetEnemies()) {
 		PlaceEnemy(*enemy);
 	}
 }
 
+void Scene_Battle_Rpg2k3::InitActors() {
+	const auto& actors = Main_Data::game_party->GetActors();
+
+	// If all actors in the front row have battle loss conditions,
+	// all back row actors forced to the front row.
+	// FIXME: Does this happen mid battle too?
+	bool force_front_row = true;
+	for (auto& actor: actors) {
+		if (actor->GetBattleRow() == Game_Actor::RowType::RowType_front
+				&& !actor->IsHidden()
+				&& actor->CanActOrRecoverable()) {
+			force_front_row = false;
+		}
+	}
+	if (force_front_row) {
+		for (auto& actor: actors) {
+			actor->SetBattleRow(Game_Actor::RowType::RowType_front);
+		}
+	}
+
+	for (auto& actor: Main_Data::game_party->GetActors()) {
+		PlaceActor(*actor);
+	}
+}
 
 Scene_Battle_Rpg2k3::~Scene_Battle_Rpg2k3() {
 }

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -49,6 +49,9 @@ void Scene_Battle_Rpg2k3::Start() {
 	InitActors();
 	InitAtbGauges();
 
+	// Changed enemy place means we need to recompute Z order
+	Game_Battle::GetSpriteset().ResetAllBattlerZ();
+
 	// Needed so transition in reflects updated battler positions
 	Game_Battle::UpdateGraphics();
 }

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -40,35 +40,35 @@ Scene_Battle_Rpg2k3::Scene_Battle_Rpg2k3(const BattleArgs& args) :
 	Scene_Battle(args),
 	first_strike(args.first_strike)
 {
-	InitBattleCondition(args.condition);
-}
-
-void Scene_Battle_Rpg2k3::InitBattleCondition(lcf::rpg::System::BattleCondition condition) {
-	if (condition == lcf::rpg::System::BattleCondition_pincers
-			&& (lcf::Data::battlecommands.placement == lcf::rpg::BattleCommands::Placement_manual
-				|| Main_Data::game_enemyparty->GetBattlerCount() <= 1))
-	{
-		condition = lcf::rpg::System::BattleCondition_back;
-	}
-
-	if (condition == lcf::rpg::System::BattleCondition_surround
-			&& (lcf::Data::battlecommands.placement == lcf::rpg::BattleCommands::Placement_manual
-				|| Main_Data::game_party->GetBattlerCount() <= 1))
-	{
-		condition = lcf::rpg::System::BattleCondition_initiative;
-	}
-
-	Game_Battle::SetBattleCondition(condition);
 }
 
 void Scene_Battle_Rpg2k3::Start() {
 	Scene_Battle::Start();
+	InitBattleCondition(Game_Battle::GetBattleCondition());
 	InitEnemies();
 	InitActors();
 	InitAtbGauges();
 
 	// Needed so transition in reflects updated battler positions
 	Game_Battle::UpdateGraphics();
+}
+
+void Scene_Battle_Rpg2k3::InitBattleCondition(lcf::rpg::System::BattleCondition condition) {
+	if (condition == lcf::rpg::System::BattleCondition_pincers
+			&& (lcf::Data::battlecommands.placement == lcf::rpg::BattleCommands::Placement_manual
+				|| Main_Data::game_enemyparty->GetVisibleBattlerCount() <= 1))
+	{
+		condition = lcf::rpg::System::BattleCondition_back;
+	}
+
+	if (condition == lcf::rpg::System::BattleCondition_surround
+			&& (lcf::Data::battlecommands.placement == lcf::rpg::BattleCommands::Placement_manual
+				|| Main_Data::game_party->GetVisibleBattlerCount() <= 1))
+	{
+		condition = lcf::rpg::System::BattleCondition_initiative;
+	}
+
+	Game_Battle::SetBattleCondition(condition);
 }
 
 void Scene_Battle_Rpg2k3::InitEnemies() {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -172,11 +172,85 @@ void Scene_Battle_Rpg2k3::InitAtbGauges() {
 	}
 }
 
+template <typename O, typename M, typename C>
+static bool CheckFlip(const O& others, const M& me, bool prefer_flipped, C&& cmp) {
+	for (auto& other: others) {
+			if (!other->IsHidden() && cmp(other->GetBattlePosition().x, me.GetBattlePosition().x)) {
+				return prefer_flipped;
+			}
+		}
+		return !prefer_flipped;
+	}
+
+void Scene_Battle_Rpg2k3::UpdateEnemiesDirection() {
+	const auto& enemies = Main_Data::game_enemyparty->GetEnemies();
+	const auto& actors = Main_Data::game_party->GetActors();
+
+	for (int real_idx = 0, visible_idx = 0; real_idx < static_cast<int>(enemies.size()); ++real_idx) {
+		auto& enemy = *enemies[real_idx];
+		const auto idx = enemy.IsHidden() ? real_idx : visible_idx;
+
+		switch(Game_Battle::GetBattleCondition()) {
+			case RPG::System::BattleCondition_none:
+			case RPG::System::BattleCondition_initiative:
+				enemy.SetDirectionFlipped(CheckFlip(actors, enemy, false, std::greater_equal<>()));
+				break;
+			case RPG::System::BattleCondition_back:
+				enemy.SetDirectionFlipped(CheckFlip(actors, enemy, true, std::less_equal<>()));
+				break;
+			case RPG::System::BattleCondition_surround:
+			case RPG::System::BattleCondition_pincers:
+				enemy.SetDirectionFlipped(!(idx & 1));
+				break;
+		}
+
+		visible_idx += !enemy.IsHidden();
+	}
+}
+
+void Scene_Battle_Rpg2k3::UpdateActorsDirection() {
+	const auto& actors = Main_Data::game_party->GetActors();
+	const auto& enemies = Main_Data::game_enemyparty->GetEnemies();
+
+	for (int idx = 0; idx < static_cast<int>(actors.size()); ++idx) {
+		auto& actor = *actors[idx];
+
+		switch(Game_Battle::GetBattleCondition()) {
+			case RPG::System::BattleCondition_none:
+			case RPG::System::BattleCondition_initiative:
+				actor.SetDirectionFlipped(CheckFlip(enemies, actor, false, std::less_equal<>()));
+				break;
+			case RPG::System::BattleCondition_back:
+				actor.SetDirectionFlipped(CheckFlip(enemies, actor, true, std::greater_equal<>()));
+				break;
+			case RPG::System::BattleCondition_surround:
+			case RPG::System::BattleCondition_pincers:
+				actor.SetDirectionFlipped(idx & 1);
+				break;
+		}
+	}
+}
+
+
+
 void Scene_Battle_Rpg2k3::Update() {
+	// FIXME: RPG_RT sets initial directions on start, displays any
+	// battle start messages, and then monsters may turn to face the party
+	// and the party turns to face the monsters.
+	// This only happens once on battle start. Until we refactor 2k3 state machine,
+	// we emulate the behavior with this bool.
+	// Monster directions never change during battle, but actors can.
+	if (!initial_directions_updated) {
+		UpdateEnemiesDirection();
+		UpdateActorsDirection();
+		initial_directions_updated = true;
+	}
+
 	switch (state) {
 		case State_SelectActor:
 		case State_AutoBattle: {
 			if (!IsWindowMoving()) {
+
 				if (battle_actions.empty()) {
 					Game_Battle::UpdateAtbGauges();
 				}

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -45,15 +45,18 @@ Scene_Battle_Rpg2k3::Scene_Battle_Rpg2k3(const BattleArgs& args) :
 void Scene_Battle_Rpg2k3::Start() {
 	Scene_Battle::Start();
 	InitBattleCondition(Game_Battle::GetBattleCondition());
+
+	// We need to wait for actor and enemy graphics to load before we can finish initializing the battle.
+	AsyncNext([this]() { Start2(); });
+}
+
+void Scene_Battle_Rpg2k3::Start2() {
 	InitEnemies();
 	InitActors();
 	InitAtbGauges();
 
 	// Changed enemy place means we need to recompute Z order
 	Game_Battle::GetSpriteset().ResetAllBattlerZ();
-
-	// Needed so transition in reflects updated battler positions
-	Game_Battle::UpdateGraphics();
 }
 
 void Scene_Battle_Rpg2k3::InitBattleCondition(lcf::rpg::System::BattleCondition condition) {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -34,6 +34,7 @@
 #include "scene_gameover.h"
 #include "utils.h"
 #include "font.h"
+#include "output.h"
 
 Scene_Battle_Rpg2k3::Scene_Battle_Rpg2k3(const BattleArgs& args) :
 	Scene_Battle(args),
@@ -41,6 +42,25 @@ Scene_Battle_Rpg2k3::Scene_Battle_Rpg2k3(const BattleArgs& args) :
 	battle_action_state(BattleActionState_Execute),
 	first_strike(args.first_strike)
 {
+	InitBattleCondition(args.condition);
+}
+
+void Scene_Battle_Rpg2k3::InitBattleCondition(RPG::System::BattleCondition condition) {
+	if (condition == RPG::System::BattleCondition_pincers
+			&& (Data::battlecommands.placement == RPG::BattleCommands::Placement_manual
+				|| Main_Data::game_enemyparty->GetBattlerCount() <= 1))
+	{
+		condition = RPG::System::BattleCondition_back;
+	}
+
+	if (condition == RPG::System::BattleCondition_surround
+			&& (Data::battlecommands.placement == RPG::BattleCommands::Placement_manual
+				|| Main_Data::game_party->GetBattlerCount() <= 1))
+	{
+		condition = RPG::System::BattleCondition_initiative;
+	}
+
+	Game_Battle::SetBattleCondition(condition);
 }
 
 void Scene_Battle_Rpg2k3::Start() {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -45,19 +45,19 @@ Scene_Battle_Rpg2k3::Scene_Battle_Rpg2k3(const BattleArgs& args) :
 	InitBattleCondition(args.condition);
 }
 
-void Scene_Battle_Rpg2k3::InitBattleCondition(RPG::System::BattleCondition condition) {
-	if (condition == RPG::System::BattleCondition_pincers
-			&& (Data::battlecommands.placement == RPG::BattleCommands::Placement_manual
+void Scene_Battle_Rpg2k3::InitBattleCondition(lcf::rpg::System::BattleCondition condition) {
+	if (condition == lcf::rpg::System::BattleCondition_pincers
+			&& (lcf::Data::battlecommands.placement == lcf::rpg::BattleCommands::Placement_manual
 				|| Main_Data::game_enemyparty->GetBattlerCount() <= 1))
 	{
-		condition = RPG::System::BattleCondition_back;
+		condition = lcf::rpg::System::BattleCondition_back;
 	}
 
-	if (condition == RPG::System::BattleCondition_surround
-			&& (Data::battlecommands.placement == RPG::BattleCommands::Placement_manual
+	if (condition == lcf::rpg::System::BattleCondition_surround
+			&& (lcf::Data::battlecommands.placement == lcf::rpg::BattleCommands::Placement_manual
 				|| Main_Data::game_party->GetBattlerCount() <= 1))
 	{
-		condition = RPG::System::BattleCondition_initiative;
+		condition = lcf::rpg::System::BattleCondition_initiative;
 	}
 
 	Game_Battle::SetBattleCondition(condition);

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -89,15 +89,15 @@ void Scene_Battle_Rpg2k3::InitEnemies() {
 		enemy.SetBattlePosition(Game_Battle::Calculate2k3BattlePosition(enemy));
 
 		switch(cond) {
-			case RPG::System::BattleCondition_none:
+			case lcf::rpg::System::BattleCondition_none:
 				enemy.SetDirectionFlipped(false);
 				break;
-			case RPG::System::BattleCondition_initiative:
-			case RPG::System::BattleCondition_back:
-			case RPG::System::BattleCondition_surround:
+			case lcf::rpg::System::BattleCondition_initiative:
+			case lcf::rpg::System::BattleCondition_back:
+			case lcf::rpg::System::BattleCondition_surround:
 				enemy.SetDirectionFlipped(true);
 				break;
-			case RPG::System::BattleCondition_pincers:
+			case lcf::rpg::System::BattleCondition_pincers:
 				enemy.SetDirectionFlipped(!(idx & 1));
 				break;
 		}
@@ -134,7 +134,7 @@ void Scene_Battle_Rpg2k3::InitActors() {
 
 		actor.SetBattlePosition(Game_Battle::Calculate2k3BattlePosition(actor));
 
-		if (cond == RPG::System::BattleCondition_surround) {
+		if (cond == lcf::rpg::System::BattleCondition_surround) {
 			actor.SetDirectionFlipped(idx & 1);
 		} else {
 			actor.SetDirectionFlipped(false);
@@ -197,15 +197,15 @@ void Scene_Battle_Rpg2k3::UpdateEnemiesDirection() {
 		const auto idx = enemy.IsHidden() ? real_idx : visible_idx;
 
 		switch(Game_Battle::GetBattleCondition()) {
-			case RPG::System::BattleCondition_none:
-			case RPG::System::BattleCondition_initiative:
+			case lcf::rpg::System::BattleCondition_none:
+			case lcf::rpg::System::BattleCondition_initiative:
 				enemy.SetDirectionFlipped(CheckFlip(actors, enemy, false, std::greater_equal<>()));
 				break;
-			case RPG::System::BattleCondition_back:
+			case lcf::rpg::System::BattleCondition_back:
 				enemy.SetDirectionFlipped(CheckFlip(actors, enemy, true, std::less_equal<>()));
 				break;
-			case RPG::System::BattleCondition_surround:
-			case RPG::System::BattleCondition_pincers:
+			case lcf::rpg::System::BattleCondition_surround:
+			case lcf::rpg::System::BattleCondition_pincers:
 				enemy.SetDirectionFlipped(!(idx & 1));
 				break;
 		}
@@ -222,15 +222,15 @@ void Scene_Battle_Rpg2k3::UpdateActorsDirection() {
 		auto& actor = *actors[idx];
 
 		switch(Game_Battle::GetBattleCondition()) {
-			case RPG::System::BattleCondition_none:
-			case RPG::System::BattleCondition_initiative:
+			case lcf::rpg::System::BattleCondition_none:
+			case lcf::rpg::System::BattleCondition_initiative:
 				actor.SetDirectionFlipped(CheckFlip(enemies, actor, false, std::less_equal<>()));
 				break;
-			case RPG::System::BattleCondition_back:
+			case lcf::rpg::System::BattleCondition_back:
 				actor.SetDirectionFlipped(CheckFlip(enemies, actor, true, std::greater_equal<>()));
 				break;
-			case RPG::System::BattleCondition_surround:
-			case RPG::System::BattleCondition_pincers:
+			case lcf::rpg::System::BattleCondition_surround:
+			case lcf::rpg::System::BattleCondition_pincers:
 				actor.SetDirectionFlipped(idx & 1);
 				break;
 		}

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -76,7 +76,7 @@ public:
 
 protected:
 	void InitAtbGauge(Game_Battler& battler, int preempt_atb, int ambush_atb);
-	void InitBattleCondition(RPG::System::BattleCondition condition);
+	void InitBattleCondition(lcf::rpg::System::BattleCondition condition);
 	void InitAtbGauges();
 	void OnSystem2Ready(FileRequestResult* result);
 	void SetupSystem2Graphics();

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -76,6 +76,7 @@ public:
 
 protected:
 	void InitAtbGauge(Game_Battler& battler, int preempt_atb, int ambush_atb);
+	void InitBattleCondition(RPG::System::BattleCondition condition);
 	void InitAtbGauges();
 	void OnSystem2Ready(FileRequestResult* result);
 	void SetupSystem2Graphics();

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -81,6 +81,9 @@ protected:
 	void InitActors();
 	void InitAtbGauges();
 
+	void UpdateEnemiesDirection();
+	void UpdateActorsDirection();
+
 	void OnSystem2Ready(FileRequestResult* result);
 	void SetupSystem2Graphics();
 	void CreateUi() override;
@@ -141,6 +144,7 @@ protected:
 	FileRequestBinding request_id;
 	bool battle_action_pending = false;
 	bool first_strike = false;
+	bool initial_directions_updated = false;
 };
 
 #endif

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -77,7 +77,8 @@ public:
 protected:
 	void InitAtbGauge(Game_Battler& battler, int preempt_atb, int ambush_atb);
 	void InitBattleCondition(lcf::rpg::System::BattleCondition condition);
-	void InitBattlerPositions();
+	void InitEnemies();
+	void InitActors();
 	void InitAtbGauges();
 	void PlaceActor(Game_Actor& actor);
 	void PlaceEnemy(Game_Enemy& actor);

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -104,6 +104,7 @@ protected:
 
 	void ProcessActions() override;
 	bool ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase* action);
+	void FaceTarget(Game_Actor& source, const Game_Battler& target);
 	void ProcessInput() override;
 
 	void OptionSelected();

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -79,7 +79,6 @@ protected:
 	void InitBattleCondition(lcf::rpg::System::BattleCondition condition);
 	void InitEnemies();
 	void InitActors();
-	void InitActorsRow();
 	void InitAtbGauges();
 
 	void OnSystem2Ready(FileRequestResult* result);

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -75,6 +75,7 @@ public:
 	void Update() override;
 
 protected:
+	void Start2();
 	void InitAtbGauge(Game_Battler& battler, int preempt_atb, int ambush_atb);
 	void InitBattleCondition(lcf::rpg::System::BattleCondition condition);
 	void InitEnemies();

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -79,9 +79,8 @@ protected:
 	void InitBattleCondition(lcf::rpg::System::BattleCondition condition);
 	void InitEnemies();
 	void InitActors();
+	void InitActorsRow();
 	void InitAtbGauges();
-	void PlaceActor(Game_Actor& actor);
-	void PlaceEnemy(Game_Enemy& actor);
 
 	void OnSystem2Ready(FileRequestResult* result);
 	void SetupSystem2Graphics();
@@ -127,9 +126,8 @@ protected:
 	};
 
 	std::vector<FloatText> floating_texts;
-
-	int battle_action_wait;
-	int battle_action_state;
+	int battle_action_wait = 30;
+	int battle_action_state = BattleActionState_Execute;
 	bool battle_action_need_event_refresh = true;
 	int combo_repeat = 1;
 	bool play_reflected_anim = false;

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -77,7 +77,11 @@ public:
 protected:
 	void InitAtbGauge(Game_Battler& battler, int preempt_atb, int ambush_atb);
 	void InitBattleCondition(lcf::rpg::System::BattleCondition condition);
+	void InitBattlerPositions();
 	void InitAtbGauges();
+	void PlaceActor(Game_Actor& actor);
+	void PlaceEnemy(Game_Enemy& actor);
+
 	void OnSystem2Ready(FileRequestResult* result);
 	void SetupSystem2Graphics();
 	void CreateUi() override;

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -276,7 +276,7 @@ void Sprite_Battler::ResetZ() {
 
 	constexpr int id_limit = 128;
 
-	int y = battler->GetBattleY();
+	int y = battler->GetBattlePosition().y;
 	if (battler->GetType() == Game_Battler::Type_Enemy && graphic) {
 		y += graphic->GetHeight() / 2;
 	}

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -184,6 +184,12 @@ void Sprite_Battler::Update() {
 	if (animation) {
 		animation->SetVisible(IsVisible());
 	}
+
+	const bool flip = battler->IsDirectionFlipped();
+	SetFlipX(flip);
+	if (animation) {
+		SetFlipX(flip);
+	}
 }
 
 void Sprite_Battler::SetAnimationState(int state, LoopState loop) {

--- a/src/sprite_battler.h
+++ b/src/sprite_battler.h
@@ -100,13 +100,17 @@ public:
 	 */
 	void SetForcedAlive(bool value);
 
+	/**
+	 * Recompute the Z value for the sprite from it's Y coordinate.
+	 */
+	void ResetZ();
+
 protected:
 	void CreateSprite();
 	void DoIdleAnimation();
 	void OnMonsterSpriteReady(FileRequestResult* result);
 	void OnBattlercharsetReady(FileRequestResult* result, int32_t battler_index);
 	int GetMaxOpacity() const;
-	void ResetZ();
 
 	std::string sprite_name;
 	int hue = 0;

--- a/src/spriteset_battle.cpp
+++ b/src/spriteset_battle.cpp
@@ -108,3 +108,9 @@ Sprite_Battler* Spriteset_Battle::FindBattler(const Game_Battler* battler)
 	}
 	return NULL;
 }
+
+void Spriteset_Battle::ResetAllBattlerZ() {
+	for (auto& sprite: sprites) {
+		sprite->ResetZ();
+	}
+}

--- a/src/spriteset_battle.h
+++ b/src/spriteset_battle.h
@@ -36,6 +36,8 @@ public:
 	void Update();
 	Sprite_Battler* FindBattler(const Game_Battler* battler);
 
+	void ResetAllBattlerZ();
+
 protected:
 	std::unique_ptr<Background> background;
 	std::vector<std::shared_ptr<Sprite_Battler>> sprites;

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -310,7 +310,6 @@ void Window_Base::DrawGauge(const Game_Battler& actor, int cx, int cy) const {
 	}
 
 	bool full = actor.IsAtbGaugeFull();
-	int gauge_w = 25 * actor.GetAtbGauge() / actor.GetMaxAtbGauge();
 
 	// Which gauge (0 - 2)
 	int gauge_y = 32 + 2 * 16;
@@ -320,15 +319,18 @@ void Window_Base::DrawGauge(const Game_Battler& actor, int cx, int cy) const {
 	Rect gauge_center(16, gauge_y, 16, 16);
 	Rect gauge_right(32, gauge_y, 16, 16);
 
-	// Full or not full bar
-	Rect gauge_bar(full ? 64 : 48, gauge_y, 16, 16);
-
 	Rect dst_rect(cx + 16, cy, 25, 16);
-	Rect bar_rect(cx + 16, cy, gauge_w, 16);
 
 	contents->Blit(cx + 0, cy, *system2, gauge_left, 255);
 	contents->Blit(cx + 16 + 25, cy, *system2, gauge_right, 255);
-
 	contents->StretchBlit(dst_rect, *system2, gauge_center, 255);
-	contents->StretchBlit(bar_rect, *system2, gauge_bar, 255);
+
+	const auto atb = actor.GetAtbGauge();
+	if (atb > 0) {
+		// Full or not full bar
+		int gauge_w = 25 * atb / actor.GetMaxAtbGauge();
+		Rect gauge_bar(full ? 64 : 48, gauge_y, 16, 16);
+		Rect bar_rect(cx + 16, cy, gauge_w, 16);
+		contents->StretchBlit(bar_rect, *system2, gauge_bar, 255);
+	}
 }

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -326,9 +326,9 @@ void Window_Base::DrawGauge(const Game_Battler& actor, int cx, int cy) const {
 	contents->StretchBlit(dst_rect, *system2, gauge_center, 255);
 
 	const auto atb = actor.GetAtbGauge();
-	if (atb > 0) {
+	const auto gauge_w = 25 * atb / actor.GetMaxAtbGauge();
+	if (gauge_w > 0) {
 		// Full or not full bar
-		int gauge_w = 25 * atb / actor.GetMaxAtbGauge();
 		Rect gauge_bar(full ? 64 : 48, gauge_y, 16, 16);
 		Rect bar_rect(cx + 16, cy, gauge_w, 16);
 		contents->StretchBlit(bar_rect, *system2, gauge_bar, 255);


### PR DESCRIPTION
Depends on #2217 

Fix: #2141 
Fix: #278 

Battle Conditions
----------------
- [x] Convert surround to initiative when conditions not met
- [x] Convert pincer to back when conditions not met
    - [x] Handle hidden enemies
- [x] Use correct percentage for `Troop::appear_randomly`

Placement
----------
- [x] Manual enemy placement
- [x] Enemy placement for Normal / Initiative
- [x] Enemy placement for Back
- [x] Enemy placement for surround
- [x] Enemy placement for pincer
- [x] Double check edge cases for hidden enemies in pincer / surround
- [x] Verify clamping behavior on edges of screen for enemies - enemies clamp in Y only
- [x] Verify clamping behavior on edges of screen for enemies when they transform to different enemy - nothing happens
- [x] Manual actor placement
- [x] Actor placement for Normal / Initiative
- [x] Actor placement for Back
- [x] Actor placement for surround
- [x] Actor placement for pincer
- [x] Verify clamping behavior on edges of screen for actors
- [x] Verify clamping behavior on edges of screen for actors if placed on the edge and back row pushes them out of the screen

Facing Direction
------------------
- [x] Enemy initial facing direction on battle start
- [x] Actor initial facing direction on battle start
- [x] Enemies turn to face actors once when battle begins
    - [x] Test complex manual placement
- [x] Actors turn to face enemies once when battle begins
    - [x] Test complex manual placement
- [x] Actor changes direction to attack enemy
- [x] Actor changes direction to use skill on enemy
- [x] Actor does not change direction to use skill on ally
- [x] Action does not change direction on action which targets all enemies
- [x] Enemies never change direction after battle startup

Row
----
- [x] Logic which forces back actors to the front row if all front row actors incapacitated at start of battle.
- [x] Full row implementation TDB in later PR

Things to investigate
- [x] Placement depends on battle sprite sizes. Emscripten async issues?
- [ ] Check how animation battle sprites (i.e.) "large battlers" behave