### PR TITLE
SDL Audio: Fix Lock/UnlockMutex. 

### DIFF
--- a/src/audio_sdl.cpp
+++ b/src/audio_sdl.cpp
@@ -80,7 +80,7 @@ SdlAudio::SdlAudio() :
 	want.userdata = this;
 
 #if SDL_MAJOR_VERSION >= 2
-	audio_dev_id = SDL_OpenAudioDevice(NULL, 0, &want, &have, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
+	audio_dev_id = SDL_OpenAudioDevice(nullptr, 0, &want, &have, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
 	bool init_success = audio_dev_id > 0;
 #else
 	bool init_success = SDL_OpenAudio(&want, &have) >= 0;
@@ -110,11 +110,19 @@ SdlAudio::~SdlAudio() {
 }
 
 void SdlAudio::LockMutex() const {
+#if SDL_MAJOR_VERSION >= 2
+	SDL_LockAudioDevice(audio_dev_id);
+#else
 	SDL_LockAudio();
+#endif
 }
 
 void SdlAudio::UnlockMutex() const {
+#if SDL_MAJOR_VERSION >= 2
+	SDL_UnlockAudioDevice(audio_dev_id);
+#else
 	SDL_UnlockAudio();
+#endif
 }
 
 #endif


### PR DESCRIPTION
Our Mutex locking never worked :o

They always operated on the wrong audio device because SDL_LockAudio was used and not SDL_LockAudioDevice.

This was never noticed before because all the decoder destruction was in the Audio thread but now the BGM can be destroyed by the main thread.

But no idea how so many Android users encountered this, I had to add an artificial delay of 100ms and then it still didn't crash that often. But there are 20000 users and only 20 encountered it, so you have to be kinda unlucky :)

