### PR TITLE
Message regression fixes

### DIFF
--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1691,7 +1691,7 @@ namespace {
  * Otherwise, the result is filled out from the default for the current map.
  */
 static Game_Map::Parallax::Params GetParallaxParams() {
-	Game_Map::Parallax::Params params;
+	Game_Map::Parallax::Params params = {};
 
 	if (!map_info.parallax_name.empty()) {
 		params.name = map_info.parallax_name;

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -17,6 +17,8 @@
 
 // Headers
 #include "game_message.h"
+#include "game_actor.h"
+#include "game_party.h"
 #include "game_player.h"
 #include "game_battle.h"
 #include "main_data.h"
@@ -324,10 +326,12 @@ static Game_Message::ParseParamResult ParseParamImpl(
 		++iter;
 	}
 
-	// RPG_RT will replace varible substitutions that result in 0
-	// with 1 to avoid invalid actor crash.
+	// Actor 0 references the first party member
 	if (upper == 'N' && value == 0 && got_valid_number) {
-		value = 1;
+		auto* party = Main_Data::game_party.get();
+		if (party->GetBattlerCount() > 0) {
+			value = (*party)[0].GetId();
+		}
 	}
 
 	return { iter, value };

--- a/src/scene_name.cpp
+++ b/src/scene_name.cpp
@@ -116,9 +116,9 @@ void Scene_Name::Update() {
 					name_window->Refresh();
 				} else {
 					actor->SetName(name_window->Get());
+					Scene::Pop();
 				}
 			}
-			Scene::Pop();
 		} else if (s == Window_Keyboard::NEXT_PAGE) {
 			++layout_index;
 			if (layout_index >= static_cast<int>(layouts.size())) {


### PR DESCRIPTION
1st commit is unrelated to messages, detected by UbSan

2nd fixes a regression introduced by moving the Scene::Pop to a new location while removing Game_Temp: https://github.com/EasyRPG/Player/commit/993ef100e106c8f3d9845b92f29e8c0d3df11a77#diff-ad788c966e27c5a83ba8ac104b2b3c73R117-R121 (no idea why it was moved though)

3rd fixes \n[0]. Was broken during refactoring.
https://github.com/EasyRPG/Player/blob/0.6.1/src/window_message.cpp#L589-L605