### PR TITLE
Resampler: Fix buffer overflow in mono_to_stereo_resample

### DIFF
--- a/src/audio_resampler.cpp
+++ b/src/audio_resampler.cpp
@@ -385,7 +385,7 @@ int AudioResampler::FillBuffer(uint8_t* buffer, int length) {
 		int sample_size = AudioDecoder::GetSamplesizeForFormat(output_format);
 
 		// Duplicate data from the back, allows writing to the buffer directly
-		for (size_t i = amount_filled - sample_size; i > 0; i -= sample_size) {
+		for (int i = amount_filled - sample_size; i > 0; i -= sample_size) {
 			// left channel
 			memcpy(&buffer[i * 2], &buffer[i], sample_size);
 			// right channel
@@ -410,7 +410,7 @@ int AudioResampler::FillBufferSameRate(uint8_t* buffer, int length) {
 	int total_output_frames = length / (output_samplesize*nr_of_channels);
 	int amount_of_data_to_read = 0;
 	int amount_of_data_read = total_output_frames*nr_of_channels;
-	
+
 	int decoded = 0;
 
 	if (input_samplesize > output_samplesize) {

--- a/src/audio_resampler.cpp
+++ b/src/audio_resampler.cpp
@@ -377,28 +377,22 @@ int AudioResampler::FillBuffer(uint8_t* buffer, int length) {
 		}
 	}
 
-	if (amount_filled < 0) {
+	if (!mono_to_stereo_resample || amount_filled <= 0) {
 		return amount_filled;
 	}
 
-	if (mono_to_stereo_resample) {
-		int sample_size = AudioDecoder::GetSamplesizeForFormat(output_format);
+	// Resample mono to stereo
+	int sample_size = AudioDecoder::GetSamplesizeForFormat(output_format);
 
-		// Duplicate data from the back, allows writing to the buffer directly
-		for (int i = amount_filled - sample_size; i > 0; i -= sample_size) {
-			// left channel
-			memcpy(&buffer[i * 2], &buffer[i], sample_size);
-			// right channel
-			memcpy(&buffer[i * 2 + sample_size], &buffer[i], sample_size);
-		}
-
-		amount_filled *= 2;
+	// Duplicate data from the back, allows writing to the buffer directly
+	for (int i = amount_filled - sample_size; i > 0; i -= sample_size) {
+		// left channel
+		memcpy(&buffer[i * 2], &buffer[i], sample_size);
+		// right channel
+		memcpy(&buffer[i * 2 + sample_size], &buffer[i], sample_size);
 	}
 
-	// Clear the remaining buffer as specified in audio_decoder.h
-	memset(buffer + amount_filled, '\0', length - amount_filled);
-
-	return amount_filled;
+	return amount_filled * 2;
 }
 
 int AudioResampler::FillBufferSameRate(uint8_t* buffer, int length) {


### PR DESCRIPTION
...  when the amount of samples read was exactly 0.

This should be last problem with the audio code...

The check didn't work because of size_t instead of int.

This is also a year old bug btw. In the old code the mono-to-stereo code was in SeCache where always the entire SE was decoded -> Buffer was never empty. :/