### PR TITLE
CommandControlVariables fixes

### DIFF
--- a/bench/variables.cpp
+++ b/bench/variables.cpp
@@ -6,7 +6,7 @@ constexpr int max_vars = 1024; // Keep this a power of 2 so no expensive modulus
 static Game_Variables make(int size = max_vars) {
 	Data::variables.resize(size);
 	Game_Variables variables(Game_Variables::min_2k3, Game_Variables::max_2k3);
-	variables.Set(size, 0);
+	variables.SetRange(1, size, 1);
 	return variables;
 }
 
@@ -15,7 +15,7 @@ static void BM_VariableOp(benchmark::State& state, F&& op) {
 	auto v = make();
 	int i = 0;
 	for (auto _: state) {
-		op(v, i + 1, i);
+		op(v, i + 1, i + 1);
 		i = (i + 1) % max_vars;
 	}
 }
@@ -104,5 +104,23 @@ static void BM_VariableModRange(benchmark::State& state) {
 }
 
 BENCHMARK(BM_VariableModRange);
+
+static void BM_VariableSetRangeVariable(benchmark::State& state) {
+	BM_VariableOp(state, [](auto& v, auto, auto val) { v.SetRangeVariable(1, max_vars, val); });
+}
+
+BENCHMARK(BM_VariableSetRangeVariable);
+
+static void BM_VariableSetRangeVariableIndirect(benchmark::State& state) {
+	BM_VariableOp(state, [](auto& v, auto, auto val) { v.SetRangeVariableIndirect(1, max_vars, val); });
+}
+
+BENCHMARK(BM_VariableSetRangeVariableIndirect);
+
+static void BM_VariableSetRangeRandom(benchmark::State& state) {
+	BM_VariableOp(state, [](auto& v, auto, auto val) { v.SetRangeRandom(1, max_vars, -100, 100); });
+}
+
+BENCHMARK(BM_VariableSetRangeRandom);
 
 BENCHMARK_MAIN();

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1066,10 +1066,20 @@ bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { /
 			// Characters
 			character = GetCharacter(com.parameters[5]);
 			if (character != NULL) {
+				int event_id = com.parameters[5];
 				switch (com.parameters[6]) {
 					case 0:
 						// Map ID
-						value = character->GetMapId();
+						if (!Player::IsRPG2k()
+								|| event_id == Game_Character::CharPlayer
+								|| event_id == Game_Character::CharBoat
+								|| event_id == Game_Character::CharShip
+								|| event_id == Game_Character::CharAirship) {
+							value = character->GetMapId();
+						} else {
+							// This is an RPG_RT bug for 2k only. Requesting the map id of an event always returns 0.
+							value = 0;
+						}
 						break;
 					case 1:
 						// X Coordinate

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -956,25 +956,22 @@ bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { /
 			break;
 		case 1:
 			// Var A ops B
-			value = Main_Data::game_variables->Get(com.parameters[5]);
+			if (com.parameters[0] != 1) {
+				value = Main_Data::game_variables->Get(com.parameters[5]);
+			}
 			break;
 		case 2:
 			// Number of var A ops B
-			value = Main_Data::game_variables->Get(Main_Data::game_variables->Get(com.parameters[5]));
+			if (com.parameters[0] != 1) {
+				value = Main_Data::game_variables->Get(Main_Data::game_variables->Get(com.parameters[5]));
+			}
 			break;
 		case 3:
 			// Random between range
-			int a, b;
-			a = max(com.parameters[5], com.parameters[6]);
-			b = min(com.parameters[5], com.parameters[6]);
 			if (com.parameters[0] != 1) {
-				// In the set single value case, we just set the value to a random number here.
-				// This avoids adding a branch check for random in the other more common code paths.
-				value = Utils::GetRandomNumber(b, a);
-			} else {
-				// In the set multiple values case, we need to call the SetRangeRandom() methods.
-				value = b;
-				max_random_value = a;
+				int rmax = max(com.parameters[5], com.parameters[6]);
+				int rmin = min(com.parameters[5], com.parameters[6]);
+				value = Utils::GetRandomNumber(rmin, rmax);
 			}
 			break;
 		case 4:
@@ -1223,8 +1220,78 @@ bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { /
 					Main_Data::game_variables->Mod(start, value);
 					break;
 			}
-		} else if (max_random_value <= value) {
-			// Multiple variables - not random
+		} else if (com.parameters[4] == 1) {
+			// Multiple variables - Direct variable lookup
+			int var_id = com.parameters[5];
+			switch (com.parameters[3]) {
+				case 0:
+					Main_Data::game_variables->SetRangeVariable(start, end, var_id);
+					break;
+				case 1:
+					Main_Data::game_variables->AddRangeVariable(start, end, var_id);
+					break;
+				case 2:
+					Main_Data::game_variables->SubRangeVariable(start, end, var_id);
+					break;
+				case 3:
+					Main_Data::game_variables->MultRangeVariable(start, end, var_id);
+					break;
+				case 4:
+					Main_Data::game_variables->DivRangeVariable(start, end, var_id);
+					break;
+				case 5:
+					Main_Data::game_variables->ModRangeVariable(start, end, var_id);
+					break;
+			}
+		} else if (com.parameters[4] == 2) {
+			// Multiple variables - Indirect variable lookup
+			int var_id = com.parameters[5];
+			switch (com.parameters[3]) {
+				case 0:
+					Main_Data::game_variables->SetRangeVariableIndirect(start, end, var_id);
+					break;
+				case 1:
+					Main_Data::game_variables->AddRangeVariableIndirect(start, end, var_id);
+					break;
+				case 2:
+					Main_Data::game_variables->SubRangeVariableIndirect(start, end, var_id);
+					break;
+				case 3:
+					Main_Data::game_variables->MultRangeVariableIndirect(start, end, var_id);
+					break;
+				case 4:
+					Main_Data::game_variables->DivRangeVariableIndirect(start, end, var_id);
+					break;
+				case 5:
+					Main_Data::game_variables->ModRangeVariableIndirect(start, end, var_id);
+					break;
+			}
+		} else if (com.parameters[4] == 3) {
+			// Multiple variables - random
+			int rmax = max(com.parameters[5], com.parameters[6]);
+			int rmin = min(com.parameters[5], com.parameters[6]);
+			switch (com.parameters[3]) {
+				case 0:
+					Main_Data::game_variables->SetRangeRandom(start, end, rmin, rmax);
+					break;
+				case 1:
+					Main_Data::game_variables->AddRangeRandom(start, end, rmin, rmax);
+					break;
+				case 2:
+					Main_Data::game_variables->SubRangeRandom(start, end, rmin, rmax);
+					break;
+				case 3:
+					Main_Data::game_variables->MultRangeRandom(start, end, rmin, rmax);
+					break;
+				case 4:
+					Main_Data::game_variables->DivRangeRandom(start, end, rmin, rmax);
+					break;
+				case 5:
+					Main_Data::game_variables->ModRangeRandom(start, end, rmin, rmax);
+					break;
+			}
+		} else {
+			// Multiple variables - constant
 			switch (com.parameters[3]) {
 				case 0:
 					Main_Data::game_variables->SetRange(start, end, value);
@@ -1243,28 +1310,6 @@ bool Game_Interpreter::CommandControlVariables(RPG::EventCommand const& com) { /
 					break;
 				case 5:
 					Main_Data::game_variables->ModRange(start, end, value);
-					break;
-			}
-		} else {
-			// Multiple variables - random
-			switch (com.parameters[3]) {
-				case 0:
-					Main_Data::game_variables->SetRangeRandom(start, end, value, max_random_value);
-					break;
-				case 1:
-					Main_Data::game_variables->AddRangeRandom(start, end, value, max_random_value);
-					break;
-				case 2:
-					Main_Data::game_variables->SubRangeRandom(start, end, value, max_random_value);
-					break;
-				case 3:
-					Main_Data::game_variables->MultRangeRandom(start, end, value, max_random_value);
-					break;
-				case 4:
-					Main_Data::game_variables->DivRangeRandom(start, end, value, max_random_value);
-					break;
-				case 5:
-					Main_Data::game_variables->ModRangeRandom(start, end, value, max_random_value);
 					break;
 			}
 		}

--- a/src/game_variables.cpp
+++ b/src/game_variables.cpp
@@ -95,6 +95,22 @@ void Game_Variables::SetOpRange(const int first_id, const int last_id, const Var
 	}
 }
 
+template <typename F>
+void Game_Variables::SetOpRangeRandom(const int first_id, const int last_id, const Var_t minval, const Var_t maxval, F&& op, const char* warn) {
+	if (EP_UNLIKELY(ShouldWarn(first_id, last_id))) {
+		Output::Debug(warn, first_id, last_id, minval, maxval);
+		--_warnings;
+	}
+	auto& vv = _variables;
+	if (EP_UNLIKELY(last_id > static_cast<int>(vv.size()))) {
+		vv.resize(last_id, 0);
+	}
+	for (int i = std::max(0, first_id - 1); i < last_id; ++i) {
+		auto& v = vv[i];
+		v = Utils::Clamp(op(v, Utils::GetRandomNumber(minval, maxval)), _min, _max);
+	}
+}
+
 Game_Variables::Var_t Game_Variables::Set(int variable_id, Var_t value) {
 	return SetOp(variable_id, value, VarSet, "Invalid write var[%d] = %d!");
 }
@@ -141,6 +157,30 @@ void Game_Variables::DivRange(int first_id, int last_id, Var_t value) {
 
 void Game_Variables::ModRange(int first_id, int last_id, Var_t value) {
 	SetOpRange(first_id, last_id, value, VarMod, "Invalid write var[%d,%d] %= %d!");
+}
+
+void Game_Variables::SetRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
+	SetOpRangeRandom(first_id, last_id, minval, maxval, VarSet, "Invalid write var[%d,%d] = rand(%d,%d)!");
+}
+
+void Game_Variables::AddRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
+	SetOpRangeRandom(first_id, last_id, minval, maxval, VarAdd, "Invalid write var[%d,%d] += rand(%d,%d)!");
+}
+
+void Game_Variables::SubRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
+	SetOpRangeRandom(first_id, last_id, minval, maxval, VarSub, "Invalid write var[%d,%d] -= rand(%d,%d)!");
+}
+
+void Game_Variables::MultRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
+	SetOpRangeRandom(first_id, last_id, minval, maxval, VarMult, "Invalid write var[%d,%d] *= rand(%d,%d)!");
+}
+
+void Game_Variables::DivRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
+	SetOpRangeRandom(first_id, last_id, minval, maxval, VarDiv, "Invalid write var[%d,%d] /= rand(%d,%d)!");
+}
+
+void Game_Variables::ModRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
+	SetOpRangeRandom(first_id, last_id, minval, maxval, VarMod, "Invalid write var[%d,%d] %= rand(%d,%d)!");
 }
 
 std::string Game_Variables::GetName(int _id) const {

--- a/src/game_variables.cpp
+++ b/src/game_variables.cpp
@@ -79,35 +79,24 @@ Game_Variables::Var_t Game_Variables::SetOp(int variable_id, Var_t value, F&& op
 	return v;
 }
 
-template <typename F>
-void Game_Variables::SetOpRange(const int first_id, const int last_id, const Var_t value, F&& op, const char* warn) {
+template <typename... Args>
+void Game_Variables::PrepareRange(const int first_id, const int last_id, const char* warn, Args... args) {
 	if (EP_UNLIKELY(ShouldWarn(first_id, last_id))) {
-		Output::Debug(warn, first_id, last_id, value);
+		Output::Debug(warn, first_id, last_id, args...);
 		--_warnings;
 	}
 	auto& vv = _variables;
 	if (EP_UNLIKELY(last_id > static_cast<int>(vv.size()))) {
 		vv.resize(last_id, 0);
-	}
-	for (int i = std::max(0, first_id - 1); i < last_id; ++i) {
-		auto& v = vv[i];
-		v = Utils::Clamp(op(v, value), _min, _max);
 	}
 }
 
-template <typename F>
-void Game_Variables::SetOpRangeRandom(const int first_id, const int last_id, const Var_t minval, const Var_t maxval, F&& op, const char* warn) {
-	if (EP_UNLIKELY(ShouldWarn(first_id, last_id))) {
-		Output::Debug(warn, first_id, last_id, minval, maxval);
-		--_warnings;
-	}
+template <typename V, typename F>
+void Game_Variables::WriteRange(const int first_id, const int last_id, V&& value, F&& op) {
 	auto& vv = _variables;
-	if (EP_UNLIKELY(last_id > static_cast<int>(vv.size()))) {
-		vv.resize(last_id, 0);
-	}
 	for (int i = std::max(0, first_id - 1); i < last_id; ++i) {
 		auto& v = vv[i];
-		v = Utils::Clamp(op(v, Utils::GetRandomNumber(minval, maxval)), _min, _max);
+		v = Utils::Clamp(op(v, value()), _min, _max);
 	}
 }
 
@@ -136,51 +125,135 @@ Game_Variables::Var_t Game_Variables::Mod(int variable_id, Var_t value) {
 }
 
 void Game_Variables::SetRange(int first_id, int last_id, Var_t value) {
-	SetOpRange(first_id, last_id, value, VarSet, "Invalid write var[%d,%d] = %d!");
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] = %d!", value);
+	WriteRange(first_id, last_id, [value](){ return value; }, VarSet);
 }
 
 void Game_Variables::AddRange(int first_id, int last_id, Var_t value) {
-	SetOpRange(first_id, last_id, value, VarAdd, "Invalid write var[%d,%d] += %d!");
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] += %d!", value);
+	WriteRange(first_id, last_id, [value](){ return value; }, VarAdd);
 }
 
 void Game_Variables::SubRange(int first_id, int last_id, Var_t value) {
-	SetOpRange(first_id, last_id, value, VarSub, "Invalid write var[%d,%d] -= %d!");
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] -= %d!", value);
+	WriteRange(first_id, last_id, [value](){ return value; }, VarSub);
 }
 
 void Game_Variables::MultRange(int first_id, int last_id, Var_t value) {
-	SetOpRange(first_id, last_id, value, VarMult, "Invalid write var[%d,%d] *= %d!");
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] *= %d!", value);
+	WriteRange(first_id, last_id, [value](){ return value; }, VarMult);
 }
 
 void Game_Variables::DivRange(int first_id, int last_id, Var_t value) {
-	SetOpRange(first_id, last_id, value, VarDiv, "Invalid write var[%d,%d] /= %d!");
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] /= %d!", value);
+	WriteRange(first_id, last_id, [value](){ return value; }, VarDiv);
 }
 
 void Game_Variables::ModRange(int first_id, int last_id, Var_t value) {
-	SetOpRange(first_id, last_id, value, VarMod, "Invalid write var[%d,%d] %= %d!");
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] %= %d!", value);
+	WriteRange(first_id, last_id, [value](){ return value; }, VarMod);
+}
+
+template <typename F>
+void Game_Variables::WriteRangeVariable(int first_id, const int last_id, const int var_id, F&& op) {
+	if (var_id >= first_id && var_id <= last_id) {
+		auto value = Get(var_id);
+		WriteRange(first_id, var_id, [value](){ return value; }, std::forward<F>(op));
+		first_id = var_id + 1;
+	}
+	auto value = Get(var_id);
+	WriteRange(first_id, last_id, [value](){ return value; }, std::forward<F>(op));
+}
+
+
+void Game_Variables::SetRangeVariable(int first_id, int last_id, int var_id) {
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] = Var(%d)!", var_id);
+	WriteRangeVariable(first_id, last_id, var_id, VarSet);
+}
+
+void Game_Variables::AddRangeVariable(int first_id, int last_id, int var_id) {
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] += var[%d]!", var_id);
+	WriteRangeVariable(first_id, last_id, var_id, VarAdd);
+}
+
+void Game_Variables::SubRangeVariable(int first_id, int last_id, int var_id) {
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] -= var[%d]!", var_id);
+	WriteRangeVariable(first_id, last_id, var_id, VarSub);
+}
+
+void Game_Variables::MultRangeVariable(int first_id, int last_id, int var_id) {
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] *= var[%d]!", var_id);
+	WriteRangeVariable(first_id, last_id, var_id, VarMult);
+}
+
+void Game_Variables::DivRangeVariable(int first_id, int last_id, int var_id) {
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] /= var[%d]!", var_id);
+	WriteRangeVariable(first_id, last_id, var_id, VarDiv);
+}
+
+void Game_Variables::ModRangeVariable(int first_id, int last_id, int var_id) {
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] /= var[%d]!", var_id);
+	WriteRangeVariable(first_id, last_id, var_id, VarMod);
+}
+
+void Game_Variables::SetRangeVariableIndirect(int first_id, int last_id, int var_id) {
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] = var[var[%d]]!", var_id);
+	WriteRange(first_id, last_id, [this,var_id](){ return Get(Get(var_id)); }, VarSet);
+}
+
+void Game_Variables::AddRangeVariableIndirect(int first_id, int last_id, int var_id) {
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] += var[var[%d]]!", var_id);
+	WriteRange(first_id, last_id, [this,var_id](){ return Get(Get(var_id)); }, VarAdd);
+}
+
+void Game_Variables::SubRangeVariableIndirect(int first_id, int last_id, int var_id) {
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] -= var[var[%d]]!", var_id);
+	WriteRange(first_id, last_id, [this,var_id](){ return Get(Get(var_id)); }, VarSub);
+}
+
+void Game_Variables::MultRangeVariableIndirect(int first_id, int last_id, int var_id) {
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] *= var[var[%d]]!", var_id);
+	WriteRange(first_id, last_id, [this,var_id](){ return Get(Get(var_id)); }, VarMult);
+}
+
+void Game_Variables::DivRangeVariableIndirect(int first_id, int last_id, int var_id) {
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] /= var[var[%d]]!", var_id);
+	WriteRange(first_id, last_id, [this,var_id](){ return Get(Get(var_id)); }, VarDiv);
+}
+
+void Game_Variables::ModRangeVariableIndirect(int first_id, int last_id, int var_id) {
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] %= var[var[%d]]!", var_id);
+	WriteRange(first_id, last_id, [this,var_id](){ return Get(Get(var_id)); }, VarMod);
 }
 
 void Game_Variables::SetRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
-	SetOpRangeRandom(first_id, last_id, minval, maxval, VarSet, "Invalid write var[%d,%d] = rand(%d,%d)!");
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] = rand(%d,%d)!", minval, maxval);
+	WriteRange(first_id, last_id, [this,minval,maxval](){ return Utils::GetRandomNumber(minval, maxval); }, VarSet);
 }
 
 void Game_Variables::AddRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
-	SetOpRangeRandom(first_id, last_id, minval, maxval, VarAdd, "Invalid write var[%d,%d] += rand(%d,%d)!");
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] += rand(%d,%d)!", minval, maxval);
+	WriteRange(first_id, last_id, [this,minval,maxval](){ return Utils::GetRandomNumber(minval, maxval); }, VarAdd);
 }
 
 void Game_Variables::SubRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
-	SetOpRangeRandom(first_id, last_id, minval, maxval, VarSub, "Invalid write var[%d,%d] -= rand(%d,%d)!");
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] -= rand(%d,%d)!", minval, maxval);
+	WriteRange(first_id, last_id, [this,minval,maxval](){ return Utils::GetRandomNumber(minval, maxval); }, VarSub);
 }
 
 void Game_Variables::MultRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
-	SetOpRangeRandom(first_id, last_id, minval, maxval, VarMult, "Invalid write var[%d,%d] *= rand(%d,%d)!");
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] *= rand(%d,%d)!", minval, maxval);
+	WriteRange(first_id, last_id, [this,minval,maxval](){ return Utils::GetRandomNumber(minval, maxval); }, VarMult);
 }
 
 void Game_Variables::DivRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
-	SetOpRangeRandom(first_id, last_id, minval, maxval, VarDiv, "Invalid write var[%d,%d] /= rand(%d,%d)!");
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] /= rand(%d,%d)!", minval, maxval);
+	WriteRange(first_id, last_id, [this,minval,maxval](){ return Utils::GetRandomNumber(minval, maxval); }, VarDiv);
 }
 
 void Game_Variables::ModRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
-	SetOpRangeRandom(first_id, last_id, minval, maxval, VarMod, "Invalid write var[%d,%d] %= rand(%d,%d)!");
+	PrepareRange(first_id, last_id, "Invalid write var[%d,%d] %= rand(%d,%d)!", minval, maxval);
+	WriteRange(first_id, last_id, [this,minval,maxval](){ return Utils::GetRandomNumber(minval, maxval); }, VarMod);
 }
 
 std::string Game_Variables::GetName(int _id) const {

--- a/src/game_variables.h
+++ b/src/game_variables.h
@@ -58,6 +58,13 @@ public:
 	void DivRange(int first_id, int last_id, Var_t value);
 	void ModRange(int first_id, int last_id, Var_t value);
 
+	void SetRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval);
+	void AddRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval);
+	void SubRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval);
+	void MultRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval);
+	void DivRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval);
+	void ModRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval);
+
 	std::string GetName(int _id) const;
 
 	int GetSize() const;
@@ -72,6 +79,8 @@ private:
 		Var_t SetOp(int variable_id, Var_t value, F&& op, const char* warn);
 	template <typename F>
 		void SetOpRange(int first_id, int last_id, Var_t value, F&& op, const char* warn);
+	template <typename F>
+		void SetOpRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval, F&& op, const char* warn);
 private:
 	Variables_t _variables;
 	Var_t _min = 0;

--- a/src/game_variables.h
+++ b/src/game_variables.h
@@ -58,6 +58,20 @@ public:
 	void DivRange(int first_id, int last_id, Var_t value);
 	void ModRange(int first_id, int last_id, Var_t value);
 
+	void SetRangeVariable(int first_id, int last_id, int var_id);
+	void AddRangeVariable(int first_id, int last_id, int var_id);
+	void SubRangeVariable(int first_id, int last_id, int var_id);
+	void MultRangeVariable(int first_id, int last_id, int var_id);
+	void DivRangeVariable(int first_id, int last_id, int var_id);
+	void ModRangeVariable(int first_id, int last_id, int var_id);
+
+	void SetRangeVariableIndirect(int first_id, int last_id, int var_id);
+	void AddRangeVariableIndirect(int first_id, int last_id, int var_id);
+	void SubRangeVariableIndirect(int first_id, int last_id, int var_id);
+	void MultRangeVariableIndirect(int first_id, int last_id, int var_id);
+	void DivRangeVariableIndirect(int first_id, int last_id, int var_id);
+	void ModRangeVariableIndirect(int first_id, int last_id, int var_id);
+
 	void SetRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval);
 	void AddRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval);
 	void SubRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval);
@@ -77,10 +91,12 @@ private:
 	void WarnGet(int variable_id) const;
 	template <typename F>
 		Var_t SetOp(int variable_id, Var_t value, F&& op, const char* warn);
+	template <typename... Args>
+		void PrepareRange(const int first_id, const int last_id, const char* warn, Args... args);
+	template <typename V, typename F>
+		void WriteRange(const int first_id, const int last_id, V&& value, F&& op);
 	template <typename F>
-		void SetOpRange(int first_id, int last_id, Var_t value, F&& op, const char* warn);
-	template <typename F>
-		void SetOpRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval, F&& op, const char* warn);
+		void WriteRangeVariable(const int first_id, const int last_id, int var_id, F&& op);
 private:
 	Variables_t _variables;
 	Var_t _min = 0;

--- a/tests/parse.cpp
+++ b/tests/parse.cpp
@@ -23,6 +23,7 @@ struct DataInit {
 		Data::actors.push_back({});
 
 		Main_Data::game_variables = std::make_unique<Game_Variables>(Game_Variables::min_2k3, Game_Variables::max_2k3);
+		Main_Data::game_variables->SetWarning(0);
 	}
 	~DataInit() {
 		Data::actors.clear();

--- a/tests/variables.cpp
+++ b/tests/variables.cpp
@@ -176,4 +176,109 @@ TEST_CASE("Mod") {
 	REQUIRE_EQ(s.Get(2), 0);
 }
 
+TEST_CASE("RangeVariable") {
+	constexpr int n = max_vars * 2;
+	auto s = make();
+	for (int i = 0; i < n; ++i) {
+		REQUIRE_EQ(s.Get(i), 0);
+	}
+
+	s.SetRange(2, 5, 0);
+	s.Set(2, 1);
+
+	REQUIRE_EQ(s.Get(1), 0);
+	REQUIRE_EQ(s.Get(2), 1);
+	REQUIRE_EQ(s.Get(3), 0);
+	REQUIRE_EQ(s.Get(4), 0);
+	REQUIRE_EQ(s.Get(5), 0);
+	REQUIRE_EQ(s.Get(6), 0);
+
+	s.AddRangeVariable(3, 5, 2);
+
+	REQUIRE_EQ(s.Get(1), 0);
+	REQUIRE_EQ(s.Get(2), 1);
+	REQUIRE_EQ(s.Get(3), 1);
+	REQUIRE_EQ(s.Get(4), 1);
+	REQUIRE_EQ(s.Get(5), 1);
+	REQUIRE_EQ(s.Get(6), 0);
+
+	s.AddRangeVariable(2, 4, 2);
+
+	REQUIRE_EQ(s.Get(1), 0);
+	REQUIRE_EQ(s.Get(2), 2);
+	REQUIRE_EQ(s.Get(3), 3);
+	REQUIRE_EQ(s.Get(4), 3);
+	REQUIRE_EQ(s.Get(5), 1);
+	REQUIRE_EQ(s.Get(6), 0);
+
+	s.SetRange(2, 5, 0);
+	s.Set(3, 1);
+	s.AddRangeVariable(2, 5, 3);
+
+	REQUIRE_EQ(s.Get(1), 0);
+	REQUIRE_EQ(s.Get(2), 1);
+	REQUIRE_EQ(s.Get(3), 2);
+	REQUIRE_EQ(s.Get(4), 2);
+	REQUIRE_EQ(s.Get(5), 2);
+	REQUIRE_EQ(s.Get(6), 0);
+
+	s.SetRange(2, 5, 0);
+	s.Set(5, 1);
+	s.AddRangeVariable(2, 5, 5);
+
+	REQUIRE_EQ(s.Get(1), 0);
+	REQUIRE_EQ(s.Get(2), 1);
+	REQUIRE_EQ(s.Get(3), 1);
+	REQUIRE_EQ(s.Get(4), 1);
+	REQUIRE_EQ(s.Get(5), 2);
+	REQUIRE_EQ(s.Get(6), 0);
+}
+
+
+TEST_CASE("RangeVariableIndirect") {
+	constexpr int n = max_vars * 2;
+	auto s = make();
+	for (int i = 0; i < n; ++i) {
+		REQUIRE_EQ(s.Get(i), 0);
+	}
+
+	s.Set(4, 10);
+	s.Set(2, 4);
+	s.Set(10, 42);
+
+	s.SetRangeVariableIndirect(1, 5, 2);
+
+	REQUIRE_EQ(s.Get(1), 10);
+	REQUIRE_EQ(s.Get(2), 10);
+	REQUIRE_EQ(s.Get(3), 42);
+	REQUIRE_EQ(s.Get(4), 42);
+	REQUIRE_EQ(s.Get(5), 42);
+	REQUIRE_EQ(s.Get(6), 0);
+}
+
+TEST_CASE("RangeRandom") {
+	constexpr int n = max_vars * 2;
+	auto s = make();
+	for (int i = 0; i < n; ++i) {
+		REQUIRE_EQ(s.Get(i), 0);
+	}
+
+	s.SetRangeRandom(1,100,-999,999);
+
+	int first_val = s.Get(1);
+	int first_diff = 0;
+	for (int i = 1; i <= 100; ++i) {
+		if (s.Get(i) != first_val && !first_diff) {
+			first_diff = i;
+		}
+		REQUIRE_GE(s.Get(i), -999);
+		REQUIRE_LE(s.Get(i), 999);
+	}
+
+	// Verifies the RNG was called for each value.
+	REQUIRE_NE(first_diff, 0);
+}
+
+
+
 TEST_SUITE_END();


### PR DESCRIPTION
When RPG_RT processes a command to set a range of variables to a
random value, it calls the RNG for each variable separately.

Fix: #2155 
Fix: #2156

@Ghabry can you please confirm it fixes the games in these issues? I don't have these japanese games working on my windows pc.

Confirmed this behavior in 2ke and 2k3e. Tested this with some example games.