### PR TITLE
Remove the MorphOS macro undefs

### DIFF
--- a/builds/amiga/Makefile
+++ b/builds/amiga/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OSTYPE), MorphOS)
 PREFIX  = ppc-morphos
 CC      = $(PREFIX)-gcc -noixemul
 CXX     = $(PREFIX)-g++ -noixemul
-PLATFORM_CXXFLAGS = -D_GLIBCXX_USE_C99
+PLATFORM_CXXFLAGS = -D_GLIBCXX_USE_C99 -D_NO_PPCINLINE
 TOOLCHAIN_DIR := /gg/usr
 SDL_LIBS = -L$(TOOLCHAIN_DIR)/local/lib -lSDL_mixer -lSDL
 SDL_CFLAGS = -I$(TOOLCHAIN_DIR)/local/include/SDL -I$(TOOLCHAIN_DIR)/local/include

--- a/src/async_handler.h
+++ b/src/async_handler.h
@@ -23,10 +23,6 @@
 #include <string>
 #include <vector>
 
-#ifdef __MORPHOS__
-#undef bind
-#endif
-
 class FileRequestAsync;
 struct FileRequestResult;
 

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -37,10 +37,6 @@
 #   include <SDL_system.h>
 #endif
 
-#ifdef __MORPHOS__
-#undef bind
-#endif
-
 #include "system.h"
 #include "options.h"
 #include "utils.h"

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -27,10 +27,6 @@
 #include "rpg_savemapeventbase.h"
 #include "utils.h"
 
-#ifdef __MORPHOS__
-#undef Wait
-#endif
-
 /**
  * Game_Character class.
  */

--- a/src/output.h
+++ b/src/output.h
@@ -22,10 +22,6 @@
 #include <string>
 #include <iosfwd>
 
-#ifdef __MORPHOS__
-#undef Debug
-#endif
-
 /**
  * Output Namespace.
  */


### PR DESCRIPTION
I managed to get rid of the undefs I added to avoid namespace clashes on MorphOS. It turns out the inline macros can be safely replaced with linker stubs by defining _NO_PPCINLINE. This should take care of the Amiga part of #1428

---

Edit by carstene1ns: Fixes #1428