### PR TITLE
Fix crash in ShowBattleAnimation() when target is invalid

### DIFF
--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -359,17 +359,20 @@ int Game_Screen::ShowBattleAnimation(int animation_id, int target_id, bool globa
 		return 0;
 	}
 
+	auto* chara = Game_Character::GetCharacter(target_id, target_id);
+	if (!chara) {
+		Output::Warning("ShowBattleAnimation: Invalid target event ID %d", target_id);
+		CancelBattleAnimation();
+		return 0;
+	}
+
 	data.battleanim_id = animation_id;
 	data.battleanim_target = target_id;
 	data.battleanim_global = global;
 	data.battleanim_active = true;
 	data.battleanim_frame = start_frame;
 
-	Game_Character* chara = Game_Character::GetCharacter(target_id, target_id);
-
-	if (chara) {
-		animation.reset(new BattleAnimationMap(*anim, *chara, global));
-	}
+	animation.reset(new BattleAnimationMap(*anim, *chara, global));
 
 	if (start_frame) {
 		animation->SetFrame(start_frame);


### PR DESCRIPTION
This crash can occur when loading a save game with an
invalid animation target.

Fixes crash #1 in #2166 

To test:

1. Make Ev01 show battle anim on EV02, no wait
2. Make Ev02
3. Start a new game
4. Trigger battle animation
5. save before animation completes
6. in editor, delete Ev02
7. Load your save

RPG_RT will  throw an invalid event exception. Player will crash.

This PR changes it so player will just show a warning and skip the animation