### PR TITLE
Battle 2k: Prevent crash when battle action is NULL

### DIFF
--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -627,6 +627,13 @@ void Scene_Battle::CreateEnemyActionSkill(Game_Enemy* enemy, const RPG::EnemyAct
 
 void Scene_Battle::ActionSelectedCallback(Game_Battler* for_battler) {
 	assert(for_battler->GetBattleAlgorithm() != nullptr);
+
+	if (for_battler->GetBattleAlgorithm() == nullptr) {
+		Output::Warning("ActionSelectedCallback: Invalid action for battler %d (%s)",
+				for_battler->GetId(), for_battler->GetName().c_str());
+		Output::Warning("Please report a bug!");
+	}
+
 	battle_actions.push_back(for_battler);
 
 	if (for_battler->GetType() == Game_Battler::Type_Ally) {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -317,7 +317,12 @@ void Scene_Battle_Rpg2k::ProcessActions() {
 				// such as death, paralyze, confuse, etc..
 				PrepareBattleAction(battler);
 			}
+
 			auto* alg = battler->GetBattleAlgorithm().get();
+			if (alg == nullptr) {
+				Output::Warning("ProcessActions: Invalid action for battler %d (%s)", battler->GetId(), battler->GetName().c_str());
+				Output::Warning("Please report a bug!");
+			}
 
 			if (ProcessBattleAction(alg)) {
 				battle_action_pending = false;
@@ -395,6 +400,12 @@ bool Scene_Battle_Rpg2k::ProcessNextSubState(int substate, Game_BattleAlgorithm:
 }
 
 bool Scene_Battle_Rpg2k::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBase* action) {
+	if (action == nullptr) {
+		Output::Warning("ProcessBattleAction: Invalid battle action");
+		Output::Warning("Please report a bug!");
+		return true;
+	}
+
 	if (!battle_action_pending) {
 		// First time we are called, do initialization.
 		battle_action_wait = 0;
@@ -538,7 +549,8 @@ bool Scene_Battle_Rpg2k::ProcessActionUsage1(Game_BattleAlgorithm::AlgorithmBase
 		if (!action->GetTarget()) {
 			// No target but not a target-only action.
 			// Maybe a bug report will help later
-			Output::Warning("Battle: BattleAction without valid target.");
+			Output::Warning("ProcessActionUsage1: BattleAction without valid target.");
+			Output::Warning("Please report a bug!");
 			return true;
 		}
 
@@ -1313,6 +1325,14 @@ void Scene_Battle_Rpg2k::CreateExecutionOrder() {
 			[](Game_Battler* l, Game_Battler* r) {
 			return l->GetBattleOrderAgi() > r->GetBattleOrderAgi();
 			});
+
+	for (const auto& battler : battle_actions) {
+		if (std::count(battle_actions.begin(), battle_actions.end(), battler) > 1) {
+			Output::Warning("CreateExecutionOrder: Battler %d (%s) has multiple battle actions", battler->GetId(), battler->GetName().c_str());
+			Output::Warning("Please report a bug!");
+			break;
+		}
+	}
 }
 
 void Scene_Battle_Rpg2k::CreateEnemyActions() {


### PR DESCRIPTION
This adds warnings to the Battle2k code in an attempt to solve 2. in #2166 with the help of our users.

My guess is that the bug is caused by an actor/enemy with multiple battle actions but I can't find a way to generate such a situation.

This crash is very rare. It affected only two users but these users 10 times so it must be a very specific edge case that is not randomly hit. Therefore I think knowing game and monster party is enough to figure this out. By showing a visual warning and not crashing maybe we can motivate the users to send us a bug report with a logfile :).

This is for inclusion in 0.6.2, but the solution is obviously not.