### PR TITLE
Move __MORPHOS_SHAREDLIBS into the Makefile for MorphOS

### DIFF
--- a/builds/amiga/Makefile
+++ b/builds/amiga/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OSTYPE), MorphOS)
 PREFIX  = ppc-morphos
 CC      = $(PREFIX)-gcc -noixemul
 CXX     = $(PREFIX)-g++ -noixemul
-PLATFORM_CXXFLAGS = -D_GLIBCXX_USE_C99 -D_NO_PPCINLINE
+PLATFORM_CXXFLAGS = -D_GLIBCXX_USE_C99 -D_NO_PPCINLINE -D__MORPHOS_SHAREDLIBS
 TOOLCHAIN_DIR := /gg/usr
 SDL_LIBS = -L$(TOOLCHAIN_DIR)/local/lib -lSDL_mixer -lSDL
 SDL_CFLAGS = -I$(TOOLCHAIN_DIR)/local/include/SDL -I$(TOOLCHAIN_DIR)/local/include

--- a/src/image_png.cpp
+++ b/src/image_png.cpp
@@ -16,9 +16,6 @@
  */
 
 // Headers
-#ifdef __MORPHOS__
-#define __MORPHOS_SHAREDLIBS
-#endif
 #include <png.h>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
I missed this one in my previous PR, this should reduce the Amiga specific clutter in the source files to the minimum. 