### PR TITLE
Regression fixes

### DIFF
--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -110,8 +110,13 @@ namespace {
 			// Fix the path and continue searching.
 			size_t pos = canon.find_first_of("/");
 			if (pos == std::string::npos) {
-				corrected_dir = ".";
-				corrected_name = canon;
+				for (char const** c = exts; *c != NULL; ++c) {
+					std::string res = FindDefault(tree, canon + *c);
+					if (!res.empty()) {
+						return res;
+					}
+				}
+				return "";
 			} else {
 				corrected_dir = canon.substr(0, pos);
 				corrected_name = canon.substr(pos + 1);

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2504,6 +2504,9 @@ bool Game_Interpreter::CommandShowPicture(RPG::EventCommand const& com) { // cod
 		// transparency. >= 1.12 Editor only let you set one transparency field but it affects
 		// both chunks here.
 		params.bottom_trans = com.parameters[14];
+	} else if (Player::IsRPG2k3() && !Player::IsRPG2k3E()) {
+		// Corner case when 2k maps are used in 2k3 (pre-1.10) and don't contain this chunk
+		params.bottom_trans = params.top_trans;
 	}
 
 	if (param_size > 16) {


### PR DESCRIPTION
That's a flaw (well, the structure made sense because there is no way to read stuff from ./, but then "creative" games appeared...) with the FileFinder data structure: The root-directory files are stored in a different location than the submembers, so there must be extra handling for finding files in the root-dir.

Fix #2176

Regression caused by 7de54b62