### PR TITLE
Filesystem [1/N]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ add_library(${PROJECT_NAME}
 	src/filefinder.h
 	src/filesystem.cpp
 	src/filesystem.h
+	src/filesystem_stream.h
 	src/flash.h
 	src/flat_map.h
 	src/font.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ add_library(${PROJECT_NAME}
 	src/exfont.h
 	src/filefinder.cpp
 	src/filefinder.h
+	src/filesystem.cpp
+	src/filesystem.h
 	src/flash.h
 	src/flat_map.h
 	src/font.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -76,6 +76,7 @@ libeasyrpg_player_a_SOURCES = \
 	src/filefinder.h \
 	src/filesystem.cpp \
 	src/filesystem.h \
+	src/filesystem_stream.h \
 	src/flash.h \
 	src/flat_map.h \
 	src/font.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -74,6 +74,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/exfont.h \
 	src/filefinder.cpp \
 	src/filefinder.h \
+	src/filesystem.cpp \
+	src/filesystem.h \
 	src/flash.h \
 	src/flat_map.h \
 	src/font.cpp \

--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -81,7 +81,7 @@ namespace {
 
 void AsyncHandler::CreateRequestMapping(const std::string& file) {
 #ifdef EMSCRIPTEN
-	std::shared_ptr<std::iostream> f = FileFinder::openUTF8(file, std::ios_base::in | std::ios_base::binary);
+	std::shared_ptr<FileFinder::istream> f = FileFinder::openUTF8Input(file, std::ios_base::in | std::ios_base::binary);
 	picojson::value v;
 	picojson::parse(v, *f);
 

--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -81,7 +81,7 @@ namespace {
 
 void AsyncHandler::CreateRequestMapping(const std::string& file) {
 #ifdef EMSCRIPTEN
-	std::shared_ptr<FileFinder::istream> f = FileFinder::OpenInputStream(file, std::ios_base::in | std::ios_base::binary);
+	Filesystem::InputStream f = FileFinder::OpenInputStream(file, std::ios_base::in | std::ios_base::binary);
 	picojson::value v;
 	picojson::parse(v, *f);
 

--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -81,7 +81,7 @@ namespace {
 
 void AsyncHandler::CreateRequestMapping(const std::string& file) {
 #ifdef EMSCRIPTEN
-	std::shared_ptr<FileFinder::istream> f = FileFinder::openUTF8Input(file, std::ios_base::in | std::ios_base::binary);
+	std::shared_ptr<FileFinder::istream> f = FileFinder::OpenInputStream(file, std::ios_base::in | std::ios_base::binary);
 	picojson::value v;
 	picojson::parse(v, *f);
 

--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -81,7 +81,7 @@ namespace {
 
 void AsyncHandler::CreateRequestMapping(const std::string& file) {
 #ifdef EMSCRIPTEN
-	std::shared_ptr<std::fstream> f = FileFinder::openUTF8(file, std::ios_base::in | std::ios_base::binary);
+	std::shared_ptr<std::iostream> f = FileFinder::openUTF8(file, std::ios_base::in | std::ios_base::binary);
 	picojson::value v;
 	picojson::parse(v, *f);
 

--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -81,7 +81,7 @@ namespace {
 
 void AsyncHandler::CreateRequestMapping(const std::string& file) {
 #ifdef EMSCRIPTEN
-	Filesystem::InputStream f = FileFinder::OpenInputStream(file, std::ios_base::in | std::ios_base::binary);
+	Filesystem::InputStream f = FileFinder::OpenInputStream(file);
 	picojson::value v;
 	picojson::parse(v, *f);
 

--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -81,9 +81,9 @@ namespace {
 
 void AsyncHandler::CreateRequestMapping(const std::string& file) {
 #ifdef EMSCRIPTEN
-	Filesystem::InputStream f = FileFinder::OpenInputStream(file);
+	auto f = FileFinder::OpenInputStream(file);
 	picojson::value v;
-	picojson::parse(v, *f);
+	picojson::parse(v, f);
 
 	for (const auto& value : v.get<picojson::object>()) {
 		file_mapping[value.first] = value.second.to_str();

--- a/src/audio_decoder.cpp
+++ b/src/audio_decoder.cpp
@@ -104,7 +104,7 @@ public:
 		error_message = std::string("WMA audio files are not supported. Reinstall the\n") +
 			"game and don't convert them when asked by Windows!\n";
 	}
-	bool Open(Filesystem::InputStream stream) override { return false; }
+	bool Open(Filesystem::InputStream) override { return false; }
 	bool IsFinished() const override { return true; }
 	void GetFormat(int&, Format&, int&) const override {}
 	bool Seek(std::streamoff, std::ios_base::seekdir) override { return false; }

--- a/src/audio_decoder.cpp
+++ b/src/audio_decoder.cpp
@@ -107,6 +107,7 @@ public:
 	bool Open(Filesystem::InputStream stream) override { return false; }
 	bool IsFinished() const override { return true; }
 	void GetFormat(int&, Format&, int&) const override {}
+	bool Seek(std::streamoff, std::ios_base::seekdir) override { return false; }
 private:
 	int FillBuffer(uint8_t*, int) override { return -1; };
 };
@@ -337,7 +338,7 @@ int AudioDecoder::GetVolume() const {
 }
 
 void AudioDecoder::Rewind() {
-	if (!Seek(0, Origin::Begin)) {
+	if (!Seek(0, std::ios_base::beg)) {
 		// The libs guarantee that Rewind works
 		assert(false && "Rewind");
 	}
@@ -379,11 +380,7 @@ bool AudioDecoder::SetPitch(int) {
 	return false;
 }
 
-bool AudioDecoder::Seek(size_t, Origin) {
-	return false;
-}
-
-size_t AudioDecoder::Tell() const {
+std::streampos AudioDecoder::Tell() const {
 	return -1;
 }
 

--- a/src/audio_decoder.cpp
+++ b/src/audio_decoder.cpp
@@ -115,11 +115,10 @@ const char wma_magic[] = { (char)0x30, (char)0x26, (char)0xB2, (char)0x75 };
 
 std::unique_ptr<AudioDecoder> AudioDecoder::Create(Filesystem_Stream::InputStream& stream, const std::string& filename, bool resample) {
 	char magic[4] = { 0 };
-	stream.ReadIntoObj(magic);
 	if (!stream.ReadIntoObj(magic)) {
 		return nullptr;
 	}
-	stream.seekg(0, std::ios::ios_base::beg);
+	stream.seekg(0, std::ios::beg);
 
 #if !(defined(HAVE_WILDMIDI) || defined(HAVE_XMP))
 	/* WildMidi and XMP are the only audio decoders that need the filename passed
@@ -275,7 +274,7 @@ std::unique_ptr<AudioDecoder> AudioDecoder::Create(Filesystem_Stream::InputStrea
 		// Parsing MP3s seems to be the only reliable way to detect them
 		if (Mpg123Decoder::IsMp3(stream)) {
 			stream.clear();
-			stream.seekg(0, std::ios::ios_base::beg);
+			stream.seekg(0, std::ios_base::beg);
 			if (resample) {
 				mp3dec = new AudioResampler(std::unique_ptr<AudioDecoder>(new Mpg123Decoder()));
 			} else {

--- a/src/audio_decoder.cpp
+++ b/src/audio_decoder.cpp
@@ -178,10 +178,9 @@ std::unique_ptr<AudioDecoder> AudioDecoder::Create(std::shared_ptr<FileFinder::i
 #endif
 
 #if defined(HAVE_TREMOR) || defined(HAVE_OGGVORBIS)
-		fseek(file, 29, SEEK_SET);
-		if (fread(magic, 4, 1, file) != 1)
-			return nullptr;
-		fseek(file, 0, SEEK_SET);
+		stream->seekg(29, std::ios::ios_base::beg);
+		stream->read(magic, sizeof(magic));
+		stream->seekg(0, std::ios::ios_base::beg);
 
 		if (!strncmp(magic, "vorb", 4)) {
 			if (resample) {

--- a/src/audio_decoder.cpp
+++ b/src/audio_decoder.cpp
@@ -136,7 +136,7 @@ std::unique_ptr<AudioDecoder> AudioDecoder::Create(Filesystem::InputStream strea
 #ifdef HAVE_WILDMIDI
 		static bool wildmidi_works = true;
 		if (wildmidi_works) {
-			auto mididec = std::unique_ptr<AudioDecoder>(new WildMidiDecoder(filename));
+			auto mididec = std::unique_ptr<AudioDecoder>(new WildMidiDecoder());
 			if (mididec->WasInited()) {
 				if (resample) {
 					mididec = std::unique_ptr<AudioResampler>(new AudioResampler(std::move(mididec)));

--- a/src/audio_decoder.cpp
+++ b/src/audio_decoder.cpp
@@ -104,7 +104,7 @@ public:
 		error_message = std::string("WMA audio files are not supported. Reinstall the\n") +
 			"game and don't convert them when asked by Windows!\n";
 	}
-	bool Open(std::shared_ptr<FileFinder::istream> stream) override { return false; }
+	bool Open(Filesystem::InputStream stream) override { return false; }
 	bool IsFinished() const override { return true; }
 	void GetFormat(int&, Format&, int&) const override {}
 private:
@@ -112,7 +112,7 @@ private:
 };
 const char wma_magic[] = { (char)0x30, (char)0x26, (char)0xB2, (char)0x75 };
 
-std::unique_ptr<AudioDecoder> AudioDecoder::Create(std::shared_ptr<FileFinder::istream> stream, const std::string& filename, bool resample) {
+std::unique_ptr<AudioDecoder> AudioDecoder::Create(Filesystem::InputStream stream, const std::string& filename, bool resample) {
 	char magic[4] = { 0 };
 	if (stream->read(magic, sizeof(magic)).gcount() == 0) {
 		return nullptr;

--- a/src/audio_decoder.cpp
+++ b/src/audio_decoder.cpp
@@ -196,12 +196,12 @@ std::unique_ptr<AudioDecoder> AudioDecoder::Create(std::shared_ptr<FileFinder::i
 #ifdef WANT_FASTWAV
 	// Try to use a basic decoder for faster wav decoding if not ADPCM
 	if (!strncmp(magic, "RIFF", 4)) {
-		fseek(file, 20, SEEK_SET);
+		stream->seekg(20, std::ios::ios_base::beg);
 		uint16_t raw_enc;
-		if (fread(&raw_enc, 2, 1, file) != 1)
-			return nullptr;
+		stream->read(reinterpret_cast<char*>(&raw_enc), 2);
+
 		Utils::SwapByteOrder(raw_enc);
-		fseek(file, 0, SEEK_SET);
+		stream->seekg(0, std::ios::ios_base::beg);
 		if (raw_enc == 0x01) { // Codec is normal PCM
 			if (resample) {
 				return std::unique_ptr<AudioDecoder>(new AudioResampler(std::unique_ptr<AudioDecoder>(new WavDecoder())));

--- a/src/audio_decoder.h
+++ b/src/audio_decoder.h
@@ -46,13 +46,6 @@ public:
 		F32
 	};
 
-	/** Seek origin for Seek command */
-	enum class Origin {
-		Begin = 0,
-		Current = 1,
-		End = 2
-	};
-
 	/**
 	 * Writes 'size' bytes in the specified buffer. The data matches the format
 	 * reported by GetFormat.
@@ -253,13 +246,13 @@ public:
 	/**
 	 * Seeks in the audio stream. The value of offset is implementation
 	 * defined but is guaranteed to match the result of Tell.
-	 * Only Rewinding is guaranteed to work.
+	 * Libraries must support at least seek from the start for Rewind().
 	 *
 	 * @param offset Offset to seek to
 	 * @param origin Position to seek from
 	 * @return Whether seek was successful
 	 */
-	virtual bool Seek(size_t offset, Origin origin);
+	virtual bool Seek(std::streamoff offset, std::ios_base::seekdir origin) = 0;
 
 	/**
 	 * Tells the current stream position. The value is implementation
@@ -267,7 +260,7 @@ public:
 	 *
 	 * @return Position in the stream
 	 */
-	virtual size_t Tell() const;
+	virtual std::streampos Tell() const;
 
 	/**
 	 * Returns a value suitable for the GetMidiTicks command.

--- a/src/audio_decoder.h
+++ b/src/audio_decoder.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include "filefinder.h"
 
 /**
  * The AudioDecoder class provides an abstraction over the decoding of
@@ -73,20 +74,20 @@ public:
 	std::vector<uint8_t> DecodeAll();
 
 	/**
-	 * Parses the specified file handle and open a proper audio decoder to handle
+	 * Parses the specified stream and open a proper audio decoder to handle
 	 * the audio file.
-	 * Upon success the file handle is owned by the audio decoder and further
-	 * operations on it will be undefined! Upon failure the file handle points at
+	 * Upon success the stream is owned by the audio decoder and further
+	 * operations on it will be undefined! Upon failure the stream points at
 	 * the beginning.
 	 * The filename is used for debug purposes but should match the FILE handle.
 	 * Upon failure the FILE handle is valid and points at the beginning.
 	 *
-	 * @param file File handle to parse
+	 * @param stream File handle to parse
 	 * @param filename Path to the file handle
 	 * @param resample Whether the decoder shall be wrapped into a resampler (if supported)
 	 * @return An audio decoder instance when the format was detected, otherwise null
 	 */
-	static std::unique_ptr<AudioDecoder> Create(FILE* file, const std::string& filename, bool resample = true);
+	static std::unique_ptr<AudioDecoder> Create(std::shared_ptr<FileFinder::istream> stream, const std::string& filename, bool resample = true);
 
 	/**
 	 * Updates the volume for the fade in/out effect.
@@ -191,13 +192,13 @@ public:
 
 	// Functions to be implemented by the audio decoder
 	/**
-	 * Assigns a file handle to the audio decoder.
+	 * Assigns a stream to the audio decoder.
 	 * Open should be only called once per audio decoder instance.
 	 * Use GetError to get the error reason on failure.
 	 *
 	 * @return true if inititalizing was succesful, false otherwise
 	 */
-	virtual bool Open(FILE* file) = 0;
+	virtual bool Open(std::shared_ptr<FileFinder::istream> stream) = 0;
 
 	/**
 	 * Determines whether the stream is finished.

--- a/src/audio_decoder.h
+++ b/src/audio_decoder.h
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 #include <memory>
-#include "filesystem.h"
+#include "filesystem_stream.h"
 
 /**
  * The AudioDecoder class provides an abstraction over the decoding of
@@ -80,7 +80,7 @@ public:
 	 * @param resample Whether the decoder shall be wrapped into a resampler (if supported)
 	 * @return An audio decoder instance when the format was detected, otherwise null
 	 */
-	static std::unique_ptr<AudioDecoder> Create(Filesystem::InputStream stream, const std::string& filename, bool resample = true);
+	static std::unique_ptr<AudioDecoder> Create(Filesystem_Stream::InputStream& stream, const std::string& filename, bool resample = true);
 
 	/**
 	 * Updates the volume for the fade in/out effect.
@@ -191,7 +191,7 @@ public:
 	 *
 	 * @return true if inititalizing was succesful, false otherwise
 	 */
-	virtual bool Open(Filesystem::InputStream stream) = 0;
+	virtual bool Open(Filesystem_Stream::InputStream stream) = 0;
 
 	/**
 	 * Determines whether the stream is finished.

--- a/src/audio_decoder.h
+++ b/src/audio_decoder.h
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 #include <memory>
-#include "filefinder.h"
+#include "filesystem.h"
 
 /**
  * The AudioDecoder class provides an abstraction over the decoding of
@@ -87,7 +87,7 @@ public:
 	 * @param resample Whether the decoder shall be wrapped into a resampler (if supported)
 	 * @return An audio decoder instance when the format was detected, otherwise null
 	 */
-	static std::unique_ptr<AudioDecoder> Create(std::shared_ptr<FileFinder::istream> stream, const std::string& filename, bool resample = true);
+	static std::unique_ptr<AudioDecoder> Create(Filesystem::InputStream stream, const std::string& filename, bool resample = true);
 
 	/**
 	 * Updates the volume for the fade in/out effect.
@@ -198,7 +198,7 @@ public:
 	 *
 	 * @return true if inititalizing was succesful, false otherwise
 	 */
-	virtual bool Open(std::shared_ptr<FileFinder::istream> stream) = 0;
+	virtual bool Open(Filesystem::InputStream stream) = 0;
 
 	/**
 	 * Determines whether the stream is finished.

--- a/src/audio_generic.cpp
+++ b/src/audio_generic.cpp
@@ -177,14 +177,14 @@ bool GenericAudio::PlayOnChannel(BgmChannel& chan, const std::string& file, int 
 	chan.paused = true; // Pause channel so the audio thread doesn't work on it
 	chan.stopped = false; // Unstop channel so the audio thread doesn't delete it
 
-	FILE* filehandle = FileFinder::fopenUTF8(file, "rb");
-	if (!filehandle) {
+	auto filestream = FileFinder::openUTF8Input(file, std::ios::ios_base::in | std::ios::ios_base::binary);
+	if (!filestream) {
 		Output::Warning("BGM file not readable: {}", FileFinder::GetPathInsideGamePath(file));
 		return false;
 	}
 
-	chan.decoder = AudioDecoder::Create(filehandle, file);
-	if (chan.decoder && chan.decoder->Open(filehandle)) {
+	chan.decoder = AudioDecoder::Create(filestream, file);
+	if (chan.decoder && chan.decoder->Open(filestream)) {
 		chan.decoder->SetPitch(pitch);
 		chan.decoder->SetFormat(output_format.frequency, output_format.format, output_format.channels);
 		chan.decoder->SetFade(0, volume, fadein);
@@ -194,8 +194,6 @@ bool GenericAudio::PlayOnChannel(BgmChannel& chan, const std::string& file, int 
 		return true;
 	} else {
 		Output::Warning("Couldn't play BGM {}. Format not supported", FileFinder::GetPathInsideGamePath(file));
-		chan.decoder.reset();
-		fclose(filehandle);
 	}
 
 	return false;

--- a/src/audio_generic.cpp
+++ b/src/audio_generic.cpp
@@ -177,7 +177,7 @@ bool GenericAudio::PlayOnChannel(BgmChannel& chan, const std::string& file, int 
 	chan.paused = true; // Pause channel so the audio thread doesn't work on it
 	chan.stopped = false; // Unstop channel so the audio thread doesn't delete it
 
-	auto filestream = FileFinder::OpenInputStream(file, std::ios::ios_base::in | std::ios::ios_base::binary);
+	auto filestream = FileFinder::OpenInputStream(file);
 	if (!filestream) {
 		Output::Warning("BGM file not readable: {}", FileFinder::GetPathInsideGamePath(file));
 		return false;

--- a/src/audio_generic.cpp
+++ b/src/audio_generic.cpp
@@ -177,7 +177,7 @@ bool GenericAudio::PlayOnChannel(BgmChannel& chan, const std::string& file, int 
 	chan.paused = true; // Pause channel so the audio thread doesn't work on it
 	chan.stopped = false; // Unstop channel so the audio thread doesn't delete it
 
-	auto filestream = FileFinder::openUTF8Input(file, std::ios::ios_base::in | std::ios::ios_base::binary);
+	auto filestream = FileFinder::OpenInputStream(file, std::ios::ios_base::in | std::ios::ios_base::binary);
 	if (!filestream) {
 		Output::Warning("BGM file not readable: {}", FileFinder::GetPathInsideGamePath(file));
 		return false;

--- a/src/audio_generic.cpp
+++ b/src/audio_generic.cpp
@@ -184,7 +184,7 @@ bool GenericAudio::PlayOnChannel(BgmChannel& chan, const std::string& file, int 
 	}
 
 	chan.decoder = AudioDecoder::Create(filestream, file);
-	if (chan.decoder && chan.decoder->Open(filestream)) {
+	if (chan.decoder && chan.decoder->Open(std::move(filestream))) {
 		chan.decoder->SetPitch(pitch);
 		chan.decoder->SetFormat(output_format.frequency, output_format.format, output_format.channels);
 		chan.decoder->SetFade(0, volume, fadein);

--- a/src/audio_resampler.cpp
+++ b/src/audio_resampler.cpp
@@ -237,7 +237,7 @@ bool AudioResampler::WasInited() const {
 	return wrapped_decoder->WasInited();
 }
 
-bool AudioResampler::Open(std::shared_ptr<FileFinder::istream> stream) {
+bool AudioResampler::Open(Filesystem::InputStream stream) {
 	if (wrapped_decoder->Open(stream)) {
 		wrapped_decoder->GetFormat(input_rate, input_format, nr_of_channels);
 

--- a/src/audio_resampler.cpp
+++ b/src/audio_resampler.cpp
@@ -237,8 +237,8 @@ bool AudioResampler::WasInited() const {
 	return wrapped_decoder->WasInited();
 }
 
-bool AudioResampler::Open(Filesystem::InputStream stream) {
-	if (wrapped_decoder->Open(stream)) {
+bool AudioResampler::Open(Filesystem_Stream::InputStream stream) {
+	if (wrapped_decoder->Open(std::move(stream))) {
 		wrapped_decoder->GetFormat(input_rate, input_format, nr_of_channels);
 
 		//determine if the input format is supported by the resampler

--- a/src/audio_resampler.cpp
+++ b/src/audio_resampler.cpp
@@ -237,8 +237,8 @@ bool AudioResampler::WasInited() const {
 	return wrapped_decoder->WasInited();
 }
 
-bool AudioResampler::Open(FILE* file) {
-	if (wrapped_decoder->Open(file)) {
+bool AudioResampler::Open(std::shared_ptr<FileFinder::istream> stream) {
+	if (wrapped_decoder->Open(stream)) {
 		wrapped_decoder->GetFormat(input_rate, input_format, nr_of_channels);
 
 		//determine if the input format is supported by the resampler

--- a/src/audio_resampler.cpp
+++ b/src/audio_resampler.cpp
@@ -278,7 +278,7 @@ bool AudioResampler::Open(Filesystem::InputStream stream) {
 	return false;
 }
 
-bool AudioResampler::Seek(size_t offset, Origin origin) {
+bool AudioResampler::Seek(std::streamoff offset, std::ios_base::seekdir origin) {
 	if (wrapped_decoder->Seek(offset, origin)) {
 		//reset conversion data
 		conversion_data.input_frames = 0;
@@ -295,7 +295,7 @@ bool AudioResampler::Seek(size_t offset, Origin origin) {
 
 }
 
-size_t AudioResampler::Tell() const {
+std::streampos AudioResampler::Tell() const {
 	return wrapped_decoder->Tell();
 }
 

--- a/src/audio_resampler.h
+++ b/src/audio_resampler.h
@@ -73,7 +73,7 @@ public:
 	 * 
 	 * @return Whether the operation was successful or not
 	 */
-	bool Open(FILE* file) override;
+	bool Open(std::shared_ptr<FileFinder::istream> file) override;
 
 	/**
 	 * Wraps the seek function of the contained decoder

--- a/src/audio_resampler.h
+++ b/src/audio_resampler.h
@@ -85,14 +85,14 @@ public:
 	 *
 	 * @return Whether seek was successful
 	 */
-	bool Seek(size_t offset, Origin origin) override;
+	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 
 	/**
 	 * Wraps the tell function of the contained decoder
 	 *
 	 * @return Position in the stream
 	 */
-	size_t Tell() const override;
+	std::streampos Tell() const override;
 
 	/**
 	 * Wraps the GetTicks Function of the contained decoder

--- a/src/audio_resampler.h
+++ b/src/audio_resampler.h
@@ -73,7 +73,7 @@ public:
 	 * 
 	 * @return Whether the operation was successful or not
 	 */
-	bool Open(Filesystem::InputStream file) override;
+	bool Open(Filesystem_Stream::InputStream stream) override;
 
 	/**
 	 * Wraps the seek function of the contained decoder

--- a/src/audio_resampler.h
+++ b/src/audio_resampler.h
@@ -73,7 +73,7 @@ public:
 	 * 
 	 * @return Whether the operation was successful or not
 	 */
-	bool Open(std::shared_ptr<FileFinder::istream> file) override;
+	bool Open(Filesystem::InputStream file) override;
 
 	/**
 	 * Wraps the seek function of the contained decoder

--- a/src/audio_sdl_mixer.cpp
+++ b/src/audio_sdl_mixer.cpp
@@ -44,9 +44,9 @@
 using namespace std::chrono_literals;
 
 namespace {
-	Sint64 SDLCALL vio_size(struct SDL_RWops * context) {
-		auto stream = reinterpret_cast<Filesystem_Stream::InputStream*>(context->hidden.unknown.data1);
-		return stream->GetSize();
+	Sint64 SDLCALL vio_size(struct SDL_RWops *) {
+		// Unknown. SDL accepts -1 for "unknown size"
+		return -1;
 	}
 
 	Sint64 SDLCALL vio_seek(struct SDL_RWops * context, Sint64 offset, int whence) {

--- a/src/audio_sdl_mixer.cpp
+++ b/src/audio_sdl_mixer.cpp
@@ -44,6 +44,61 @@
 using namespace std::chrono_literals;
 
 namespace {
+
+	static Sint64 SDLCALL vio_size(struct SDL_RWops * context) {
+		FileFinder::istream* stream = (*reinterpret_cast<std::shared_ptr<FileFinder::istream>*>(context->hidden.unknown.data1)).get();
+		return stream->get_size();
+	}
+
+	static Sint64 SDLCALL vio_seek(struct SDL_RWops * context, Sint64 offset, int whence) {
+		FileFinder::istream* stream = (*reinterpret_cast<std::shared_ptr<FileFinder::istream>*>(context->hidden.unknown.data1)).get();
+		switch (whence) {
+		case RW_SEEK_CUR:
+			stream->seekg(offset, std::ios::ios_base::cur);
+			break;
+		case RW_SEEK_SET:
+			stream->seekg(offset, std::ios::ios_base::beg);
+			break;
+		case RW_SEEK_END:
+			stream->seekg(offset, std::ios::ios_base::end);
+			break;
+		default:
+			return -1;
+		}
+
+		return stream->tellg();
+	}
+
+	static size_t SDLCALL vio_read(struct SDL_RWops * context, void *ptr, size_t size, size_t maxnum) {
+		FileFinder::istream* stream = (*reinterpret_cast<std::shared_ptr<FileFinder::istream>*>(context->hidden.unknown.data1)).get();
+		if (size == 0) return 0;
+		return stream->read(reinterpret_cast<char*>(ptr), size*maxnum).gcount() / size;
+	}
+
+	static size_t SDLCALL vio_write(struct SDL_RWops * context, const void *ptr, size_t size, size_t num) {
+		//Not supported
+		return 0;
+	}
+
+	static int SDLCALL vio_close(struct SDL_RWops * context) {
+		//If this is the last shared pointer, the stream get's closed now
+		delete reinterpret_cast<std::shared_ptr<FileFinder::istream>*>(context->hidden.unknown.data1);
+		context->hidden.unknown.data1 = NULL;
+		return 0;
+	}
+
+	SDL_RWops * create_StreamRWOps(std::shared_ptr<FileFinder::istream> stream){
+		SDL_RWops * ret = SDL_AllocRW();
+		//create a new shared pointer to avoid deletion of the content when the scope of this function ends
+		ret->hidden.unknown.data1 = new std::shared_ptr<FileFinder::istream>(stream);
+		ret->close = vio_close;
+		ret->read = vio_read;
+		ret->write = vio_write;
+		ret->seek = vio_seek;
+
+		return ret;
+	}
+
 	void bgm_played_once() {
 		// FIXME: Can we break this reference to DisplayUi?
 		if (DisplayUi)
@@ -259,27 +314,27 @@ void SdlMixerAudio::BGM_OnPlayedOnce() {
 }
 
 void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int fadein) {
-	FILE* filehandle = FileFinder::fopenUTF8(file, "rb");
-	if (!filehandle) {
+	auto filestream = FileFinder::openUTF8Input(file, std::ios::ios_base::in| std::ios::ios_base::binary);
+	if (!filestream) {
 		Output::Warning("Music not readable: {}", FileFinder::GetPathInsideGamePath(file));
 		return;
 	}
-	audio_decoder = AudioDecoder::Create(filehandle, file);
+	audio_decoder = AudioDecoder::Create(filestream, file);
 	if (audio_decoder) {
-		SetupAudioDecoder(filehandle, file, volume, pitch, fadein);
+		SetupAudioDecoder(filestream, file, volume, pitch, fadein);
 		return;
 	}
-	fclose(filehandle);
 
-	SDL_RWops *rw = SDL_RWFromFile(file.c_str(), "rb");
+	filestream = FileFinder::openUTF8Input(file, std::ios::ios_base::in | std::ios::ios_base::binary);
+	SDL_RWops *rw = create_StreamRWOps(filestream); //SDL_RWFromFile(file.c_str(), "rb");
 
 	bgm_stop = false;
 	played_once = false;
 
 #if SDL_MIXER_MAJOR_VERSION>1
-	bgm.reset(Mix_LoadMUS_RW(rw, 0), &Mix_FreeMusic);
+	bgm.reset(Mix_LoadMUS_RW(rw, 0), &Mix_FreeMusic); //rw will be freed on MIX_FreeMusic
 #else
-	bgm.reset(Mix_LoadMUS_RW(rw), &Mix_FreeMusic);
+	bgm.reset(Mix_LoadMUS_RW(rw), &Mix_FreeMusic); //rw will be freed on MIX_FreeMusic
 #endif
 
 #if SDL_MIXER_MAJOR_VERSION>1
@@ -293,18 +348,17 @@ void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int
 #if WANT_FMMIDI == 2
 		// Fallback to FMMIDI when SDL Midi failed
 		char magic[4] = { 0 };
-		filehandle = FileFinder::fopenUTF8(file, "rb");
-		if (!filehandle) {
+		auto filestream = FileFinder::openUTF8Input(file, std::ios::ios_base::in | std::ios::ios_base::binary);
+		if (!filestream) {
 			Output::Warning("Music not readable: {}", FileFinder::GetPathInsideGamePath(file));
 			return;
 		}
-		if (fread(magic, 4, 1, filehandle) != 1)
-			return;
-		fseek(filehandle, 0, SEEK_SET);
+		filestream->read(magic, sizeof(magic));
+		filestream->seekg(0, std::ios::ios_base::beg);
 		if (!strncmp(magic, "MThd", 4)) {
 			Output::Debug("FmMidi fallback: {}", file);
 			audio_decoder.reset(new FmMidiDecoder());
-			SetupAudioDecoder(filehandle, file, volume, pitch, fadein);
+			SetupAudioDecoder(filestream, file, volume, pitch, fadein);
 			return;
 		}
 #endif
@@ -348,8 +402,8 @@ void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int
 	Mix_HookMusicFinished(&bgm_played_once);
 }
 
-void SdlMixerAudio::SetupAudioDecoder(FILE* handle, const std::string& file, int volume, int pitch, int fadein) {
-	if (!audio_decoder->Open(handle)) {
+void SdlMixerAudio::SetupAudioDecoder(std::shared_ptr<FileFinder::istream> stream, const std::string& file, int volume, int pitch, int fadein) {
+	if (!audio_decoder->Open(stream)) {
 		Output::Warning("Couldn't play {} BGM. {}", FileFinder::GetPathInsideGamePath(file), audio_decoder->GetError());
 		audio_decoder.reset();
 		return;

--- a/src/audio_sdl_mixer.cpp
+++ b/src/audio_sdl_mixer.cpp
@@ -326,7 +326,7 @@ void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int
 		return;
 	}
 
-	filestream = FileFinder::OpenInputStream(file, std::ios::ios_base::in | std::ios::ios_base::binary);
+	filestream = FileFinder::OpenInputStream(file);
 	SDL_RWops *rw = create_StreamRWOps(filestream); //SDL_RWFromFile(file.c_str(), "rb");
 
 	bgm_stop = false;
@@ -349,7 +349,7 @@ void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int
 #if WANT_FMMIDI == 2
 		// Fallback to FMMIDI when SDL Midi failed
 		char magic[4] = { 0 };
-		auto filestream = FileFinder::OpenInputStream(file, std::ios::ios_base::in | std::ios::ios_base::binary);
+		auto filestream = FileFinder::OpenInputStream(file);
 		if (!filestream) {
 			Output::Warning("Music not readable: {}", FileFinder::GetPathInsideGamePath(file));
 			return;

--- a/src/audio_sdl_mixer.cpp
+++ b/src/audio_sdl_mixer.cpp
@@ -314,7 +314,7 @@ void SdlMixerAudio::BGM_OnPlayedOnce() {
 }
 
 void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int fadein) {
-	auto filestream = FileFinder::openUTF8Input(file, std::ios::ios_base::in| std::ios::ios_base::binary);
+	auto filestream = FileFinder::OpenInputStream(file, std::ios::ios_base::in| std::ios::ios_base::binary);
 	if (!filestream) {
 		Output::Warning("Music not readable: {}", FileFinder::GetPathInsideGamePath(file));
 		return;
@@ -325,7 +325,7 @@ void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int
 		return;
 	}
 
-	filestream = FileFinder::openUTF8Input(file, std::ios::ios_base::in | std::ios::ios_base::binary);
+	filestream = FileFinder::OpenInputStream(file, std::ios::ios_base::in | std::ios::ios_base::binary);
 	SDL_RWops *rw = create_StreamRWOps(filestream); //SDL_RWFromFile(file.c_str(), "rb");
 
 	bgm_stop = false;
@@ -348,7 +348,7 @@ void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int
 #if WANT_FMMIDI == 2
 		// Fallback to FMMIDI when SDL Midi failed
 		char magic[4] = { 0 };
-		auto filestream = FileFinder::openUTF8Input(file, std::ios::ios_base::in | std::ios::ios_base::binary);
+		auto filestream = FileFinder::OpenInputStream(file, std::ios::ios_base::in | std::ios::ios_base::binary);
 		if (!filestream) {
 			Output::Warning("Music not readable: {}", FileFinder::GetPathInsideGamePath(file));
 			return;

--- a/src/audio_sdl_mixer.h
+++ b/src/audio_sdl_mixer.h
@@ -61,7 +61,7 @@ public:
 	AudioDecoder* GetDecoder();
 	SDL_AudioCVT& GetAudioCVT();
 private:
-	void SetupAudioDecoder(Filesystem::InputStream stream, const std::string& filename, int volume, int pitch, int fadein);
+	void SetupAudioDecoder(Filesystem_Stream::InputStream stream, const std::string& filename, int volume, int pitch, int fadein);
 
 	std::shared_ptr<Mix_Music> bgm;
 	int bgm_volume;

--- a/src/audio_sdl_mixer.h
+++ b/src/audio_sdl_mixer.h
@@ -61,7 +61,7 @@ public:
 	AudioDecoder* GetDecoder();
 	SDL_AudioCVT& GetAudioCVT();
 private:
-	void SetupAudioDecoder(FILE* handle, const std::string& filename, int volume, int pitch, int fadein);
+	void SetupAudioDecoder(std::shared_ptr<FileFinder::istream> stream, const std::string& filename, int volume, int pitch, int fadein);
 
 	std::shared_ptr<Mix_Music> bgm;
 	int bgm_volume;

--- a/src/audio_sdl_mixer.h
+++ b/src/audio_sdl_mixer.h
@@ -61,7 +61,7 @@ public:
 	AudioDecoder* GetDecoder();
 	SDL_AudioCVT& GetAudioCVT();
 private:
-	void SetupAudioDecoder(std::shared_ptr<FileFinder::istream> stream, const std::string& filename, int volume, int pitch, int fadein);
+	void SetupAudioDecoder(Filesystem::InputStream stream, const std::string& filename, int volume, int pitch, int fadein);
 
 	std::shared_ptr<Mix_Music> bgm;
 	int bgm_volume;

--- a/src/audio_secache.cpp
+++ b/src/audio_secache.cpp
@@ -78,7 +78,7 @@ std::unique_ptr<AudioSeCache> AudioSeCache::Create(const std::string& filename) 
 	if (it == cache.end()) {
 		// Not in cache
 
-		FILE *f = FileFinder::fopenUTF8(filename, "rb");
+		auto f = FileFinder::openUTF8Input(filename, std::ios::ios_base::in | std::ios::ios_base::binary);
 
 		if (!f) {
 			se.reset();

--- a/src/audio_secache.cpp
+++ b/src/audio_secache.cpp
@@ -78,7 +78,7 @@ std::unique_ptr<AudioSeCache> AudioSeCache::Create(const std::string& filename) 
 	if (it == cache.end()) {
 		// Not in cache
 
-		auto f = FileFinder::openUTF8Input(filename, std::ios::ios_base::in | std::ios::ios_base::binary);
+		auto f = FileFinder::OpenInputStream(filename, std::ios::ios_base::in | std::ios::ios_base::binary);
 
 		if (!f) {
 			se.reset();

--- a/src/audio_secache.cpp
+++ b/src/audio_secache.cpp
@@ -88,7 +88,7 @@ std::unique_ptr<AudioSeCache> AudioSeCache::Create(const std::string& filename) 
 		se->audio_decoder = AudioDecoder::Create(f, filename, false);
 
 		if (se->audio_decoder) {
-			if (!se->audio_decoder->Open(f)) {
+			if (!se->audio_decoder->Open(std::move(f))) {
 				se->audio_decoder.reset();
 			}
 		}
@@ -143,7 +143,8 @@ std::unique_ptr<AudioDecoder> AudioSeCache::CreateSeDecoder() {
 #ifdef USE_AUDIO_RESAMPLER
 		dec = std::unique_ptr<AudioDecoder>(new AudioResampler(std::move(dec)));
 #endif
-		dec->Open(nullptr);
+		Filesystem_Stream::InputStream is;
+		dec->Open(std::move(is));
 		return dec;
 	}
 
@@ -172,7 +173,8 @@ std::unique_ptr<AudioDecoder> AudioSeCache::CreateSeDecoder() {
 #ifdef USE_AUDIO_RESAMPLER
 	dec = std::unique_ptr<AudioDecoder>(new AudioResampler(std::move(dec)));
 #endif
-	dec->Open(nullptr);
+	Filesystem_Stream::InputStream is;
+	dec->Open(std::move(is));
 	return dec;
 }
 

--- a/src/audio_secache.cpp
+++ b/src/audio_secache.cpp
@@ -78,7 +78,7 @@ std::unique_ptr<AudioSeCache> AudioSeCache::Create(const std::string& filename) 
 	if (it == cache.end()) {
 		// Not in cache
 
-		auto f = FileFinder::OpenInputStream(filename, std::ios::ios_base::in | std::ios::ios_base::binary);
+		auto f = FileFinder::OpenInputStream(filename);
 
 		if (!f) {
 			se.reset();

--- a/src/audio_secache.h
+++ b/src/audio_secache.h
@@ -52,7 +52,7 @@ class AudioSeDecoder : public AudioDecoder {
 public:
 	AudioSeDecoder(AudioSeRef se);
 
-	bool Open(std::shared_ptr<FileFinder::istream> stream) override { return true; };
+	bool Open(Filesystem::InputStream stream) override { return true; };
 	bool IsFinished() const override;
 	void GetFormat(int& frequency, Format& format, int& channels) const override;
 	int GetPitch() const override;

--- a/src/audio_secache.h
+++ b/src/audio_secache.h
@@ -52,7 +52,7 @@ class AudioSeDecoder : public AudioDecoder {
 public:
 	AudioSeDecoder(AudioSeRef se);
 
-	bool Open(Filesystem::InputStream stream) override { return true; };
+	bool Open(Filesystem::InputStream) override { return true; };
 	bool IsFinished() const override;
 	void GetFormat(int& frequency, Format& format, int& channels) const override;
 	int GetPitch() const override;

--- a/src/audio_secache.h
+++ b/src/audio_secache.h
@@ -56,6 +56,7 @@ public:
 	bool IsFinished() const override;
 	void GetFormat(int& frequency, Format& format, int& channels) const override;
 	int GetPitch() const override;
+	bool Seek(std::streamoff, std::ios_base::seekdir) override { return false; }
 
 private:
 	int FillBuffer(uint8_t* buffer, int size) override;

--- a/src/audio_secache.h
+++ b/src/audio_secache.h
@@ -52,7 +52,7 @@ class AudioSeDecoder : public AudioDecoder {
 public:
 	AudioSeDecoder(AudioSeRef se);
 
-	bool Open(Filesystem::InputStream) override { return true; };
+	bool Open(Filesystem_Stream::InputStream) override { return true; };
 	bool IsFinished() const override;
 	void GetFormat(int& frequency, Format& format, int& channels) const override;
 	int GetPitch() const override;

--- a/src/audio_secache.h
+++ b/src/audio_secache.h
@@ -52,7 +52,7 @@ class AudioSeDecoder : public AudioDecoder {
 public:
 	AudioSeDecoder(AudioSeRef se);
 
-	bool Open(FILE*) override { return true; };
+	bool Open(std::shared_ptr<FileFinder::istream> stream) override { return true; };
 	bool IsFinished() const override;
 	void GetFormat(int& frequency, Format& format, int& channels) const override;
 	int GetPitch() const override;

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -95,7 +95,7 @@ Bitmap::Bitmap(const std::string& filename, bool transparent, uint32_t flags) {
 	format = (transparent ? pixel_format : opaque_pixel_format);
 	pixman_format = find_format(format);
 
-	std::shared_ptr<std::istream> stream = FileFinder::openUTF8Input(filename, std::ios::ios_base::binary | std::ios::ios_base::in);
+	auto stream = FileFinder::openUTF8Input(filename, std::ios::ios_base::binary | std::ios::ios_base::in);
 	if (!stream) {
 		Output::Error("Couldn't open image file {}", filename);
 		return;

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -106,8 +106,8 @@ Bitmap::Bitmap(const std::string& filename, bool transparent, uint32_t flags) {
 	void* pixels = nullptr;
 
 	uint8_t data[4] = {};
-	size_t bytes = stream->read(reinterpret_cast<char*>(data),  4).gcount();
-	stream->seekg(0, std::ios::ios_base::beg);
+	size_t bytes = stream.read(reinterpret_cast<char*>(data),  4).gcount();
+	stream.seekg(0, std::ios::ios_base::beg);
 
 	bool img_okay = false;
 
@@ -119,8 +119,6 @@ Bitmap::Bitmap(const std::string& filename, bool transparent, uint32_t flags) {
 		img_okay = ImagePNG::ReadPNG(stream, transparent, w, h, pixels);
 	else
 		Output::Warning("Unsupported image file {} (Magic: {:02X})", filename, *reinterpret_cast<uint32_t*>(data));
-
-	stream.reset();
 
 	if (!img_okay) {
 		free(pixels);
@@ -175,7 +173,7 @@ Bitmap::Bitmap(Bitmap const& source, Rect const& src_rect, bool transparent) {
 	Blit(0, 0, source, src_rect, Opacity::Opaque());
 }
 
-bool Bitmap::WritePNG(Filesystem::OutputStream& os) const {
+bool Bitmap::WritePNG(Filesystem_Stream::OutputStream& os) const {
 	size_t const width = GetWidth(), height = GetHeight();
 	size_t const stride = width * 4;
 

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -112,11 +112,11 @@ Bitmap::Bitmap(const std::string& filename, bool transparent, uint32_t flags) {
 	bool img_okay = false;
 
 	if (bytes >= 4 && strncmp((char*)data, "XYZ1", 4) == 0)
-		img_okay = ImageXYZ::ReadXYZ(*stream, transparent, w, h, pixels);
+		img_okay = ImageXYZ::ReadXYZ(stream, transparent, w, h, pixels);
 	else if (bytes > 2 && strncmp((char*)data, "BM", 2) == 0)
-		img_okay = ImageBMP::ReadBMP(*stream, transparent, w, h, pixels);
+		img_okay = ImageBMP::ReadBMP(stream, transparent, w, h, pixels);
 	else if (bytes >= 4 && strncmp((char*)(data + 1), "PNG", 3) == 0)
-		img_okay = ImagePNG::ReadPNG(*stream, transparent, w, h, pixels);
+		img_okay = ImagePNG::ReadPNG(stream, transparent, w, h, pixels);
 	else
 		Output::Warning("Unsupported image file {} (Magic: {:02X})", filename, *reinterpret_cast<uint32_t*>(data));
 
@@ -175,7 +175,7 @@ Bitmap::Bitmap(Bitmap const& source, Rect const& src_rect, bool transparent) {
 	Blit(0, 0, source, src_rect, Opacity::Opaque());
 }
 
-bool Bitmap::WritePNG(std::ostream& os) const {
+bool Bitmap::WritePNG(Filesystem::OutputStream& os) const {
 	size_t const width = GetWidth(), height = GetHeight();
 	size_t const stride = width * 4;
 

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -120,7 +120,7 @@ Bitmap::Bitmap(const std::string& filename, bool transparent, uint32_t flags) {
 	else
 		Output::Warning("Unsupported image file {} (Magic: {:02X})", filename, *reinterpret_cast<uint32_t*>(data));
 
-	stream.reset(); //Deletes the stream and closes the file
+	stream.reset();
 
 	if (!img_okay) {
 		free(pixels);

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -95,7 +95,7 @@ Bitmap::Bitmap(const std::string& filename, bool transparent, uint32_t flags) {
 	format = (transparent ? pixel_format : opaque_pixel_format);
 	pixman_format = find_format(format);
 
-	FILE* stream = FileFinder::fopenUTF8(filename, "rb");
+	std::shared_ptr<std::istream> stream = FileFinder::openUTF8Input(filename, std::ios::ios_base::binary | std::ios::ios_base::in);
 	if (!stream) {
 		Output::Error("Couldn't open image file {}", filename);
 		return;
@@ -106,21 +106,21 @@ Bitmap::Bitmap(const std::string& filename, bool transparent, uint32_t flags) {
 	void* pixels = nullptr;
 
 	uint8_t data[4] = {};
-	size_t bytes = fread(&data, 1, 4, stream);
-	fseek(stream, 0, SEEK_SET);
+	size_t bytes = stream->read(reinterpret_cast<char*>(data),  4).gcount();
+	stream->seekg(0, std::ios::ios_base::beg);
 
 	bool img_okay = false;
 
 	if (bytes >= 4 && strncmp((char*)data, "XYZ1", 4) == 0)
-		img_okay = ImageXYZ::ReadXYZ(stream, transparent, w, h, pixels);
+		img_okay = ImageXYZ::ReadXYZ(*stream, transparent, w, h, pixels);
 	else if (bytes > 2 && strncmp((char*)data, "BM", 2) == 0)
-		img_okay = ImageBMP::ReadBMP(stream, transparent, w, h, pixels);
+		img_okay = ImageBMP::ReadBMP(*stream, transparent, w, h, pixels);
 	else if (bytes >= 4 && strncmp((char*)(data + 1), "PNG", 3) == 0)
-		img_okay = ImagePNG::ReadPNG(stream, (void*)nullptr, transparent, w, h, pixels);
+		img_okay = ImagePNG::ReadPNG(*stream, transparent, w, h, pixels);
 	else
 		Output::Warning("Unsupported image file {} (Magic: {:02X})", filename, *reinterpret_cast<uint32_t*>(data));
 
-	fclose(stream);
+	stream.reset(); //Deletes the stream and closes the file
 
 	if (!img_okay) {
 		free(pixels);
@@ -149,7 +149,7 @@ Bitmap::Bitmap(const uint8_t* data, unsigned bytes, bool transparent, uint32_t f
 	else if (bytes > 2 && strncmp((char*) data, "BM", 2) == 0)
 		img_okay = ImageBMP::ReadBMP(data, bytes, transparent, w, h, pixels);
 	else if (bytes > 4 && strncmp((char*)(data + 1), "PNG", 3) == 0)
-		img_okay = ImagePNG::ReadPNG((FILE*)nullptr, (const void*) data, transparent, w, h, pixels);
+		img_okay = ImagePNG::ReadPNG((const void*) data, transparent, w, h, pixels);
 	else
 		Output::Warning("Unsupported image (Magic: {:02X})", bytes >= 4 ? *reinterpret_cast<const uint32_t*>(data) : 0);
 

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -95,7 +95,7 @@ Bitmap::Bitmap(const std::string& filename, bool transparent, uint32_t flags) {
 	format = (transparent ? pixel_format : opaque_pixel_format);
 	pixman_format = find_format(format);
 
-	auto stream = FileFinder::openUTF8Input(filename, std::ios::ios_base::binary | std::ios::ios_base::in);
+	auto stream = FileFinder::OpenInputStream(filename, std::ios::ios_base::binary | std::ios::ios_base::in);
 	if (!stream) {
 		Output::Error("Couldn't open image file {}", filename);
 		return;

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -33,6 +33,7 @@
 #include "text.h"
 #include "pixman_image_ptr.h"
 #include "opacity.h"
+#include "filesystem.h"
 
 struct Transform;
 
@@ -177,7 +178,7 @@ public:
 	 * @param os output stream that PNG will be output.
 	 * @return true if success, otherwise false.
 	 */
-	bool WritePNG(std::ostream& os) const;
+	bool WritePNG(Filesystem::OutputStream&) const;
 
 	/**
 	 * Gets the background color

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -33,7 +33,7 @@
 #include "text.h"
 #include "pixman_image_ptr.h"
 #include "opacity.h"
-#include "filesystem.h"
+#include "filesystem_stream.h"
 
 struct Transform;
 
@@ -178,7 +178,7 @@ public:
 	 * @param os output stream that PNG will be output.
 	 * @return true if success, otherwise false.
 	 */
-	bool WritePNG(Filesystem::OutputStream&) const;
+	bool WritePNG(Filesystem_Stream::OutputStream&) const;
 
 	/**
 	 * Gets the background color

--- a/src/decoder_fmmidi.cpp
+++ b/src/decoder_fmmidi.cpp
@@ -55,7 +55,7 @@ int read_func(void* instance) {
 bool FmMidiDecoder::Open(std::shared_ptr<FileFinder::istream> stream) {
 
 	seq->clear();
-	Output::Error("MIDI Size: %d\n", stream->get_size());
+	Output::Debug("MIDI Size: %d\n", stream->get_size());
 	file_buffer.resize(stream->get_size());
 	stream->read(reinterpret_cast<char*>(file_buffer.data()), stream->get_size());
 

--- a/src/decoder_fmmidi.cpp
+++ b/src/decoder_fmmidi.cpp
@@ -53,11 +53,11 @@ int read_func(void* instance) {
 }
 
 bool FmMidiDecoder::Open(std::shared_ptr<FileFinder::istream> stream) {
-
 	seq->clear();
 	Output::Debug("MIDI Size: %d\n", stream->get_size());
 	file_buffer.resize(stream->get_size());
 	stream->read(reinterpret_cast<char*>(file_buffer.data()), stream->get_size());
+	size_t bytes_read = stream->gcount();
 
 	if ((bytes_read != file_buffer.size()) || (!seq->load(this, read_func))) {
 		error_message = "FM Midi: Error reading file";

--- a/src/decoder_fmmidi.cpp
+++ b/src/decoder_fmmidi.cpp
@@ -40,7 +40,6 @@ FmMidiDecoder::FmMidiDecoder() {
 }
 
 FmMidiDecoder::~FmMidiDecoder() {
-	fclose(file);
 }
 
 int read_func(void* instance) {
@@ -53,15 +52,12 @@ int read_func(void* instance) {
 	return fmmidi->file_buffer[fmmidi->file_buffer_pos++];
 }
 
-bool FmMidiDecoder::Open(FILE* file) {
-	this->file = file;
+bool FmMidiDecoder::Open(std::shared_ptr<FileFinder::istream> stream) {
 
 	seq->clear();
-	off_t old_pos = ftell(file);
-	fseek(file, 0, SEEK_END);
-	file_buffer.resize(ftell(file) - old_pos);
-	fseek(file, old_pos, SEEK_SET);
-	size_t bytes_read = fread(file_buffer.data(), 1, file_buffer.size(), file);
+	Output::Error("MIDI Size: %d\n", stream->get_size());
+	file_buffer.resize(stream->get_size());
+	stream->read(reinterpret_cast<char*>(file_buffer.data()), stream->get_size());
 
 	if ((bytes_read != file_buffer.size()) || (!seq->load(this, read_func))) {
 		error_message = "FM Midi: Error reading file";

--- a/src/decoder_fmmidi.cpp
+++ b/src/decoder_fmmidi.cpp
@@ -54,7 +54,6 @@ int read_func(void* instance) {
 
 bool FmMidiDecoder::Open(Filesystem::InputStream stream) {
 	seq->clear();
-	Output::Debug("MIDI Size: %d\n", stream->get_size());
 	file_buffer.resize(stream->get_size());
 	stream->read(reinterpret_cast<char*>(file_buffer.data()), stream->get_size());
 	size_t bytes_read = stream->gcount();

--- a/src/decoder_fmmidi.cpp
+++ b/src/decoder_fmmidi.cpp
@@ -54,11 +54,9 @@ int read_func(void* instance) {
 
 bool FmMidiDecoder::Open(Filesystem_Stream::InputStream stream) {
 	seq->clear();
-	file_buffer.resize(stream.GetSize());
-	stream.read(reinterpret_cast<char*>(file_buffer.data()), stream.GetSize());
-	size_t bytes_read = stream.gcount();
+	file_buffer = Utils::ReadStream(stream);
 
-	if ((bytes_read != file_buffer.size()) || (!seq->load(this, read_func))) {
+	if (!seq->load(this, read_func)) {
 		error_message = "FM Midi: Error reading file";
 		return false;
 	}
@@ -69,10 +67,10 @@ bool FmMidiDecoder::Open(Filesystem_Stream::InputStream stream) {
 	return true;
 }
 
-bool FmMidiDecoder::Seek(size_t offset, Origin origin) {
+bool FmMidiDecoder::Seek(std::streamoff offset, std::ios_base::seekdir origin) {
 	assert(!tempo.empty());
 
-	if (offset == 0 && origin == Origin::Begin) {
+	if (offset == 0 && origin == std::ios_base::beg) {
 		mtime = seq->rewind_to_loop();
 
 		if (mtime > 0.0f) {

--- a/src/decoder_fmmidi.cpp
+++ b/src/decoder_fmmidi.cpp
@@ -52,7 +52,7 @@ int read_func(void* instance) {
 	return fmmidi->file_buffer[fmmidi->file_buffer_pos++];
 }
 
-bool FmMidiDecoder::Open(std::shared_ptr<FileFinder::istream> stream) {
+bool FmMidiDecoder::Open(Filesystem::InputStream stream) {
 	seq->clear();
 	Output::Debug("MIDI Size: %d\n", stream->get_size());
 	file_buffer.resize(stream->get_size());

--- a/src/decoder_fmmidi.cpp
+++ b/src/decoder_fmmidi.cpp
@@ -52,11 +52,11 @@ int read_func(void* instance) {
 	return fmmidi->file_buffer[fmmidi->file_buffer_pos++];
 }
 
-bool FmMidiDecoder::Open(Filesystem::InputStream stream) {
+bool FmMidiDecoder::Open(Filesystem_Stream::InputStream stream) {
 	seq->clear();
-	file_buffer.resize(stream->get_size());
-	stream->read(reinterpret_cast<char*>(file_buffer.data()), stream->get_size());
-	size_t bytes_read = stream->gcount();
+	file_buffer.resize(stream.GetSize());
+	stream.read(reinterpret_cast<char*>(file_buffer.data()), stream.GetSize());
+	size_t bytes_read = stream.gcount();
 
 	if ((bytes_read != file_buffer.size()) || (!seq->load(this, read_func))) {
 		error_message = "FM Midi: Error reading file";

--- a/src/decoder_fmmidi.h
+++ b/src/decoder_fmmidi.h
@@ -35,7 +35,7 @@ public:
 	~FmMidiDecoder();
 
 	// Audio Decoder interface
-	bool Open(std::shared_ptr<FileFinder::istream> stream) override;
+	bool Open(Filesystem::InputStream stream) override;
 
 	bool Seek(size_t offset, Origin origin) override;
 

--- a/src/decoder_fmmidi.h
+++ b/src/decoder_fmmidi.h
@@ -35,7 +35,7 @@ public:
 	~FmMidiDecoder();
 
 	// Audio Decoder interface
-	bool Open(FILE* file) override;
+	bool Open(std::shared_ptr<FileFinder::istream> stream) override;
 
 	bool Seek(size_t offset, Origin origin) override;
 
@@ -56,7 +56,6 @@ private:
 
 	int FillBuffer(uint8_t* buffer, int length) override;
 
-	FILE* file;
 	float mtime = 0.0f;
 	float pitch = 1.0f;
 	int frequency = 44100;

--- a/src/decoder_fmmidi.h
+++ b/src/decoder_fmmidi.h
@@ -35,7 +35,7 @@ public:
 	~FmMidiDecoder();
 
 	// Audio Decoder interface
-	bool Open(Filesystem::InputStream stream) override;
+	bool Open(Filesystem_Stream::InputStream stream) override;
 
 	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 

--- a/src/decoder_fmmidi.h
+++ b/src/decoder_fmmidi.h
@@ -37,7 +37,7 @@ public:
 	// Audio Decoder interface
 	bool Open(Filesystem::InputStream stream) override;
 
-	bool Seek(size_t offset, Origin origin) override;
+	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 
 	bool IsFinished() const override;
 

--- a/src/decoder_libsndfile.cpp
+++ b/src/decoder_libsndfile.cpp
@@ -26,12 +26,12 @@
 #include "output.h"
 
 static sf_count_t sf_vio_get_filelen_impl(void* userdata) {
-	FileFinder::istream* f = reinterpret_cast<FileFinder::istream*>(userdata);
+	auto* f = reinterpret_cast<Filesystem::InputStreamRaw*>(userdata);
 	return f->get_size();
 }
 
 static sf_count_t sf_vio_read_impl(void *ptr, sf_count_t count, void* userdata){
-	FileFinder::istream* f = reinterpret_cast<FileFinder::istream*>(userdata);
+	auto* f = reinterpret_cast<Filesystem::InputStreamRaw*>(userdata);
 	return f->read(reinterpret_cast<char*>(ptr), count).gcount();
 }
 
@@ -41,7 +41,7 @@ static sf_count_t sf_vio_write_impl(const void* /* ptr */, sf_count_t count, voi
 }
 
 static sf_count_t sf_vio_seek_impl(sf_count_t offset, int seek_type, void *userdata) {
-	FileFinder::istream* f = reinterpret_cast<FileFinder::istream*>(userdata);
+	auto* f = reinterpret_cast<Filesystem::InputStreamRaw*>(userdata);
 	if (f->eof()) f->clear(); //emulate behaviour of fseek
 	switch (seek_type) {
 	case SEEK_CUR:
@@ -58,7 +58,7 @@ static sf_count_t sf_vio_seek_impl(sf_count_t offset, int seek_type, void *userd
 }
 
 static sf_count_t sf_vio_tell_impl(void* userdata){
-	FileFinder::istream* f = reinterpret_cast<FileFinder::istream*>(userdata);
+	auto* f = reinterpret_cast<Filesystem::InputStreamRaw*>(userdata);
 	return f->tellg();
 }
 
@@ -82,7 +82,7 @@ LibsndfileDecoder::~LibsndfileDecoder() {
 	}
 }
 
-bool LibsndfileDecoder::Open(std::shared_ptr<FileFinder::istream> stream) {
+bool LibsndfileDecoder::Open(Filesystem::InputStream stream) {
 	this->stream=stream;
 	soundfile=sf_open_virtual(&vio,SFM_READ,&soundinfo,stream.get());
 	sf_command(soundfile, SFC_SET_SCALE_FLOAT_INT_READ, NULL, SF_TRUE);

--- a/src/decoder_libsndfile.cpp
+++ b/src/decoder_libsndfile.cpp
@@ -25,9 +25,9 @@
 #include "decoder_libsndfile.h"
 #include "output.h"
 
-static sf_count_t sf_vio_get_filelen_impl(void* userdata) {
-	auto* f = reinterpret_cast<Filesystem_Stream::InputStream*>(userdata);
-	return f->GetSize();
+static sf_count_t sf_vio_get_filelen_impl(void*) {
+	// Unknown. SF_COUNT_MAX is the size used by libsndfile for pipes.
+	return SF_COUNT_MAX;
 }
 
 static sf_count_t sf_vio_read_impl(void *ptr, sf_count_t count, void* userdata){
@@ -89,8 +89,9 @@ bool LibsndfileDecoder::Seek(std::streamoff offset, std::ios_base::seekdir origi
 	if(soundfile == 0)
 		return false;
 
-// FIXME: Proper sample count for seek
-	decoded_samples = 0;	return sf_seek(soundfile, offset, Filesystem_Stream::CppSeekdirToCSeekdir(origin))!=-1;
+	// FIXME: Proper sample count for seek
+	decoded_samples = 0;
+	return sf_seek(soundfile, offset, Filesystem_Stream::CppSeekdirToCSeekdir(origin))!=-1;
 }
 
 bool LibsndfileDecoder::IsFinished() const {

--- a/src/decoder_libsndfile.h
+++ b/src/decoder_libsndfile.h
@@ -35,7 +35,7 @@ public:
 
 	~LibsndfileDecoder();
 
-	bool Open(std::shared_ptr<FileFinder::istream> stream) override;
+	bool Open(Filesystem::InputStream stream) override;
 
 	bool Seek(size_t offset, Origin origin) override;
 
@@ -50,7 +50,7 @@ public:
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 	Format output_format;
-	std::shared_ptr<FileFinder::istream> stream;
+	Filesystem::InputStream stream;
 	bool finished;
 	int decoded_samples = 0;
 #ifdef HAVE_LIBSNDFILE

--- a/src/decoder_libsndfile.h
+++ b/src/decoder_libsndfile.h
@@ -35,7 +35,7 @@ public:
 
 	~LibsndfileDecoder();
 
-	bool Open(FILE* file) override;
+	bool Open(std::shared_ptr<FileFinder::istream> stream) override;
 
 	bool Seek(size_t offset, Origin origin) override;
 
@@ -50,7 +50,7 @@ public:
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 	Format output_format;
-	FILE * file_;
+	std::shared_ptr<FileFinder::istream> stream;
 	bool finished;
 	int decoded_samples = 0;
 #ifdef HAVE_LIBSNDFILE

--- a/src/decoder_libsndfile.h
+++ b/src/decoder_libsndfile.h
@@ -35,7 +35,7 @@ public:
 
 	~LibsndfileDecoder();
 
-	bool Open(Filesystem::InputStream stream) override;
+	bool Open(Filesystem_Stream::InputStream stream) override;
 
 	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 
@@ -50,7 +50,7 @@ public:
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 	Format output_format;
-	Filesystem::InputStream stream;
+	Filesystem_Stream::InputStream stream;
 	bool finished;
 	int decoded_samples = 0;
 #ifdef HAVE_LIBSNDFILE

--- a/src/decoder_libsndfile.h
+++ b/src/decoder_libsndfile.h
@@ -37,7 +37,7 @@ public:
 
 	bool Open(Filesystem::InputStream stream) override;
 
-	bool Seek(size_t offset, Origin origin) override;
+	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 
 	bool IsFinished() const override;
 

--- a/src/decoder_mpg123.cpp
+++ b/src/decoder_mpg123.cpp
@@ -30,12 +30,12 @@ static void Mpg123Decoder_deinit(void) {
 }
 
 static ssize_t custom_read(void* io, void* buffer, size_t nbyte) {
-	FileFinder::istream* f = reinterpret_cast<FileFinder::istream*>(io);
+	auto* f = reinterpret_cast<Filesystem::InputStreamRaw*>(io);
 	return f->read(reinterpret_cast<char*>(buffer), nbyte).gcount();
 }
 
 static off_t custom_seek(void* io, off_t offset, int seek_type) {
-	FileFinder::istream* f = reinterpret_cast<FileFinder::istream*>(io);
+	auto* f = reinterpret_cast<Filesystem::InputStreamRaw*>(io);
 	if (f->eof()) f->clear(); //emulate behaviour of fseek
 	switch (seek_type) {
 	case SEEK_CUR:
@@ -92,7 +92,7 @@ bool Mpg123Decoder::WasInited() const {
 	return init;
 }
 
-bool Mpg123Decoder::Open(std::shared_ptr<FileFinder::istream> stream) {
+bool Mpg123Decoder::Open(Filesystem::InputStream stream) {
 	if (!init) {
 		return false;
 	}
@@ -211,7 +211,7 @@ int Mpg123Decoder::GetTicks() const {
 }
 
 
-bool Mpg123Decoder::IsMp3(std::shared_ptr<FileFinder::istream> stream) {
+bool Mpg123Decoder::IsMp3(Filesystem::InputStream stream) {
 	Mpg123Decoder decoder;
 	// Prevent stream handle destruction
 	mpg123_replace_reader_handle(decoder.handle.get(), custom_read, custom_seek, noop_close);

--- a/src/decoder_mpg123.cpp
+++ b/src/decoder_mpg123.cpp
@@ -37,17 +37,8 @@ static ssize_t custom_read(void* io, void* buffer, size_t nbyte) {
 static off_t custom_seek(void* io, off_t offset, int seek_type) {
 	auto* f = reinterpret_cast<Filesystem::InputStreamRaw*>(io);
 	if (f->eof()) f->clear(); //emulate behaviour of fseek
-	switch (seek_type) {
-	case SEEK_CUR:
-		f->seekg(offset, std::ios::ios_base::cur);
-		break;
-	case SEEK_SET:
-		f->seekg(offset, std::ios::ios_base::beg);
-		break;
-	case SEEK_END:
-		f->seekg(offset, std::ios::ios_base::end);
-		break;
-	}
+
+	f->seekg(offset, Filesystem::CSeekdirToCppSeekdir(seek_type));
 
 	return f->tellg();
 }
@@ -113,9 +104,9 @@ bool Mpg123Decoder::Open(Filesystem::InputStream stream) {
 	return true;
 }
 
-bool Mpg123Decoder::Seek(size_t offset, Origin origin) {
+bool Mpg123Decoder::Seek(std::streamoff offset, std::ios_base::seekdir origin) {
 	finished = false;
-	mpg123_seek_frame(handle.get(), offset, (int)origin);
+	mpg123_seek_frame(handle.get(), offset, Filesystem::CppSeekdirToCSeekdir(origin));
 
 	return true;
 }

--- a/src/decoder_mpg123.cpp
+++ b/src/decoder_mpg123.cpp
@@ -43,8 +43,8 @@ static off_t custom_seek(void* io, off_t offset, int seek_type) {
 	return f->tellg();
 }
 
-static void custom_close(void* io) {
-	//do nothing
+static void custom_close(void*) {
+	// do nothing
 }
 
 static void noop_close(void*) {}
@@ -200,7 +200,6 @@ int Mpg123Decoder::GetTicks() const {
 	off_t pos = mpg123_tell(handle.get());
 	return pos / samplerate;
 }
-
 
 bool Mpg123Decoder::IsMp3(Filesystem::InputStream stream) {
 	Mpg123Decoder decoder;

--- a/src/decoder_mpg123.h
+++ b/src/decoder_mpg123.h
@@ -37,7 +37,7 @@ public:
 
 	bool WasInited() const override;
 
-	bool Open(Filesystem::InputStream stream) override;
+	bool Open(Filesystem_Stream::InputStream stream) override;
 
 	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 
@@ -49,14 +49,14 @@ public:
 
 	int GetTicks() const override;
 
-	static bool IsMp3(Filesystem::InputStream stream);
+	static bool IsMp3(Filesystem_Stream::InputStream& stream);
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 
 #ifdef HAVE_MPG123
 	std::unique_ptr<mpg123_handle, decltype(&mpg123_delete)> handle;
 #endif
-	Filesystem::InputStream stream;
+	Filesystem_Stream::InputStream stream;
 	int err = 0;
 	bool finished = false;
 

--- a/src/decoder_mpg123.h
+++ b/src/decoder_mpg123.h
@@ -37,7 +37,7 @@ public:
 
 	bool WasInited() const override;
 
-	bool Open(FILE* file) override;
+	bool Open(std::shared_ptr<FileFinder::istream> stream) override;
 
 	bool Seek(size_t offset, Origin origin) override;
 
@@ -49,13 +49,15 @@ public:
 
 	int GetTicks() const override;
 
-	static bool IsMp3(FILE* stream);
+
+	static bool IsMp3(std::shared_ptr<FileFinder::istream> stream);
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 
 #ifdef HAVE_MPG123
 	std::unique_ptr<mpg123_handle, decltype(&mpg123_delete)> handle;
 #endif
+	std::shared_ptr<FileFinder::istream> stream;
 	int err = 0;
 	bool finished = false;
 

--- a/src/decoder_mpg123.h
+++ b/src/decoder_mpg123.h
@@ -39,7 +39,7 @@ public:
 
 	bool Open(Filesystem::InputStream stream) override;
 
-	bool Seek(size_t offset, Origin origin) override;
+	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 
 	bool IsFinished() const override;
 
@@ -48,7 +48,6 @@ public:
 	bool SetFormat(int frequency, AudioDecoder::Format format, int channels) override;
 
 	int GetTicks() const override;
-
 
 	static bool IsMp3(Filesystem::InputStream stream);
 private:

--- a/src/decoder_mpg123.h
+++ b/src/decoder_mpg123.h
@@ -37,7 +37,7 @@ public:
 
 	bool WasInited() const override;
 
-	bool Open(std::shared_ptr<FileFinder::istream> stream) override;
+	bool Open(Filesystem::InputStream stream) override;
 
 	bool Seek(size_t offset, Origin origin) override;
 
@@ -50,14 +50,14 @@ public:
 	int GetTicks() const override;
 
 
-	static bool IsMp3(std::shared_ptr<FileFinder::istream> stream);
+	static bool IsMp3(Filesystem::InputStream stream);
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 
 #ifdef HAVE_MPG123
 	std::unique_ptr<mpg123_handle, decltype(&mpg123_delete)> handle;
 #endif
-	std::shared_ptr<FileFinder::istream> stream;
+	Filesystem::InputStream stream;
 	int err = 0;
 	bool finished = false;
 

--- a/src/decoder_oggvorbis.cpp
+++ b/src/decoder_oggvorbis.cpp
@@ -25,7 +25,6 @@
 #include "output.h"
 #include "decoder_oggvorbis.h"
 
-
 static size_t vio_read_func(void *ptr, size_t size,size_t nmemb,void* userdata) {
 	FileFinder::istream* f = reinterpret_cast<FileFinder::istream*>(userdata);
 	if (size == 0) return 0;
@@ -48,7 +47,7 @@ static int vio_seek_func(void* userdata, ogg_int64_t offset, int seek_type) {
 	default:
 		return -1;
 	}
-	
+
 	return f->tellg();
 }
 
@@ -59,9 +58,9 @@ static long vio_tell_func(void* userdata) {
 
 static ov_callbacks vio = {
 	vio_read_func,
-	vio_seek_func, /* Set to null to disable seeking*/
-	NULL,
-	vio_tell_func /* Set to null to disable seeking*/
+	vio_seek_func,
+	nullptr, // close not supported by istream interface
+	vio_tell_func
 };
 
 OggVorbisDecoder::OggVorbisDecoder() {

--- a/src/decoder_oggvorbis.cpp
+++ b/src/decoder_oggvorbis.cpp
@@ -24,15 +24,17 @@
 #include "audio_decoder.h"
 #include "output.h"
 #include "decoder_oggvorbis.h"
+#include "filesystem.h"
+
 
 static size_t vio_read_func(void *ptr, size_t size,size_t nmemb,void* userdata) {
-	FileFinder::istream* f = reinterpret_cast<FileFinder::istream*>(userdata);
+	auto* f = reinterpret_cast<Filesystem::InputStreamRaw*>(userdata);
 	if (size == 0) return 0;
 	return f->read(reinterpret_cast<char*>(ptr), size*nmemb).gcount()/size;
 }
 
 static int vio_seek_func(void* userdata, ogg_int64_t offset, int seek_type) {
-	FileFinder::istream* f = reinterpret_cast<FileFinder::istream*>(userdata);
+	auto* f = reinterpret_cast<Filesystem::InputStreamRaw*>(userdata);
 	if (f->eof()) f->clear(); //emulate behaviour of fseek
 	switch (seek_type) {
 	case SEEK_CUR:
@@ -52,7 +54,7 @@ static int vio_seek_func(void* userdata, ogg_int64_t offset, int seek_type) {
 }
 
 static long vio_tell_func(void* userdata) {
-	FileFinder::istream* f = reinterpret_cast<FileFinder::istream*>(userdata);
+	auto* f = reinterpret_cast<Filesystem::InputStreamRaw*>(userdata);
 	return f->tellg();
 }
 
@@ -74,7 +76,7 @@ OggVorbisDecoder::~OggVorbisDecoder() {
 	}
 }
 
-bool OggVorbisDecoder::Open(std::shared_ptr<FileFinder::istream> stream) {
+bool OggVorbisDecoder::Open(Filesystem::InputStream stream) {
 	finished = false;
 	this->stream = stream;
 	if (ovf) {

--- a/src/decoder_oggvorbis.cpp
+++ b/src/decoder_oggvorbis.cpp
@@ -26,7 +26,6 @@
 #include "decoder_oggvorbis.h"
 #include "filesystem.h"
 
-
 static size_t vio_read_func(void *ptr, size_t size,size_t nmemb,void* userdata) {
 	auto* f = reinterpret_cast<Filesystem::InputStreamRaw*>(userdata);
 	if (size == 0) return 0;

--- a/src/decoder_oggvorbis.cpp
+++ b/src/decoder_oggvorbis.cpp
@@ -36,19 +36,8 @@ static size_t vio_read_func(void *ptr, size_t size,size_t nmemb,void* userdata) 
 static int vio_seek_func(void* userdata, ogg_int64_t offset, int seek_type) {
 	auto* f = reinterpret_cast<Filesystem::InputStreamRaw*>(userdata);
 	if (f->eof()) f->clear(); //emulate behaviour of fseek
-	switch (seek_type) {
-	case SEEK_CUR:
-		f->seekg(offset, std::ios::ios_base::cur);
-		break;
-	case SEEK_SET:
-		f->seekg(offset, std::ios::ios_base::beg);
-		break;
-	case SEEK_END:
-		f->seekg(offset, std::ios::ios_base::end);
-		break;
-	default:
-		return -1;
-	}
+
+	f->seekg(offset, Filesystem::CSeekdirToCppSeekdir(seek_type));
 
 	return f->tellg();
 }
@@ -107,8 +96,8 @@ bool OggVorbisDecoder::Open(Filesystem::InputStream stream) {
 	return true;
 }
 
-bool OggVorbisDecoder::Seek(size_t offset, Origin origin) {
-	if (offset == 0 && origin == Origin::Begin) {
+bool OggVorbisDecoder::Seek(std::streamoff offset, std::ios_base::seekdir origin) {
+	if (offset == 0 && origin == std::ios_base::beg) {
 		if (ovf) {
 			ov_raw_seek(ovf, 0);
 		}

--- a/src/decoder_oggvorbis.h
+++ b/src/decoder_oggvorbis.h
@@ -41,7 +41,7 @@ public:
 	~OggVorbisDecoder();
 
 	// Audio Decoder interface
-	bool Open(FILE* file) override;
+	bool Open(std::shared_ptr<FileFinder::istream> stream) override;
 
 	bool Seek(size_t offset, Origin origin) override;
 
@@ -58,6 +58,8 @@ private:
 #if defined(HAVE_TREMOR) || defined(HAVE_OGGVORBIS)
 	OggVorbis_File *ovf = NULL;
 #endif
+
+	std::shared_ptr<FileFinder::istream> stream;
 	bool finished = false;
 	int frequency = 44100;
 	int channels = 2;

--- a/src/decoder_oggvorbis.h
+++ b/src/decoder_oggvorbis.h
@@ -41,7 +41,7 @@ public:
 	~OggVorbisDecoder();
 
 	// Audio Decoder interface
-	bool Open(std::shared_ptr<FileFinder::istream> stream) override;
+	bool Open(Filesystem::InputStream stream) override;
 
 	bool Seek(size_t offset, Origin origin) override;
 
@@ -59,7 +59,7 @@ private:
 	OggVorbis_File *ovf = NULL;
 #endif
 
-	std::shared_ptr<FileFinder::istream> stream;
+	Filesystem::InputStream stream;
 	bool finished = false;
 	int frequency = 44100;
 	int channels = 2;

--- a/src/decoder_oggvorbis.h
+++ b/src/decoder_oggvorbis.h
@@ -41,7 +41,7 @@ public:
 	~OggVorbisDecoder();
 
 	// Audio Decoder interface
-	bool Open(Filesystem::InputStream stream) override;
+	bool Open(Filesystem_Stream::InputStream stream) override;
 
 	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 
@@ -59,7 +59,7 @@ private:
 	OggVorbis_File *ovf = NULL;
 #endif
 
-	Filesystem::InputStream stream;
+	Filesystem_Stream::InputStream stream;
 	bool finished = false;
 	int frequency = 44100;
 	int channels = 2;

--- a/src/decoder_oggvorbis.h
+++ b/src/decoder_oggvorbis.h
@@ -43,7 +43,7 @@ public:
 	// Audio Decoder interface
 	bool Open(Filesystem::InputStream stream) override;
 
-	bool Seek(size_t offset, Origin origin) override;
+	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 
 	bool IsFinished() const override;
 

--- a/src/decoder_opus.cpp
+++ b/src/decoder_opus.cpp
@@ -25,13 +25,13 @@
 #include "decoder_opus.h"
 
 static int vio_read_func(void* stream, unsigned char* ptr, int nbytes) {
-	FileFinder::istream* f = reinterpret_cast<FileFinder::istream*>(stream);
+	auto* f = reinterpret_cast<Filesystem::InputStreamRaw*>(stream);
 	if (nbytes == 0) return 0;
 	return (int)(f->read(reinterpret_cast<char*>(ptr), nbytes).gcount());
 }
 
 static int vio_seek_func(void* stream, opus_int64 offset, int whence) {
-	FileFinder::istream* f = reinterpret_cast<FileFinder::istream*>(stream);
+	auto* f = reinterpret_cast<Filesystem::InputStreamRaw*>(stream);
 	if (f->eof()) f->clear(); //emulate behaviour of fseek
 	switch (whence) {
 		case SEEK_CUR:
@@ -51,7 +51,7 @@ static int vio_seek_func(void* stream, opus_int64 offset, int whence) {
 }
 
 static opus_int64 vio_tell_func(void* stream) {
-	FileFinder::istream* f = reinterpret_cast<FileFinder::istream*>(stream);
+	auto* f = reinterpret_cast<Filesystem::InputStreamRaw*>(stream);
 	return f->tellg();
 }
 
@@ -72,7 +72,7 @@ OpusDecoder::~OpusDecoder() {
 	}
 }
 
-bool OpusDecoder::Open(std::shared_ptr<FileFinder::istream> stream) {
+bool OpusDecoder::Open(Filesystem::InputStream stream) {
 	this->stream = stream;
 	finished = false;
 

--- a/src/decoder_opus.cpp
+++ b/src/decoder_opus.cpp
@@ -33,19 +33,8 @@ static int vio_read_func(void* stream, unsigned char* ptr, int nbytes) {
 static int vio_seek_func(void* stream, opus_int64 offset, int whence) {
 	auto* f = reinterpret_cast<Filesystem::InputStreamRaw*>(stream);
 	if (f->eof()) f->clear(); //emulate behaviour of fseek
-	switch (whence) {
-		case SEEK_CUR:
-			f->seekg(offset, std::ios::ios_base::cur);
-			break;
-		case SEEK_SET:
-			f->seekg(offset, std::ios::ios_base::beg);
-			break;
-		case SEEK_END:
-			f->seekg(offset, std::ios::ios_base::end);
-			break;
-		default:
-			return -1;
-	}
+
+	f->seekg(offset, Filesystem::CSeekdirToCppSeekdir(whence));
 
 	return 0;
 }
@@ -89,8 +78,8 @@ bool OpusDecoder::Open(Filesystem::InputStream stream) {
 	return true;
 }
 
-bool OpusDecoder::Seek(size_t offset, Origin origin) {
-	if (offset == 0 && origin == Origin::Begin) {
+bool OpusDecoder::Seek(std::streamoff offset, std::ios_base::seekdir origin) {
+	if (offset == 0 && origin == std::ios::beg) {
 		if (oof) {
 			op_raw_seek(oof, 0);
 		}

--- a/src/decoder_opus.cpp
+++ b/src/decoder_opus.cpp
@@ -32,7 +32,7 @@ static int vio_read_func(void* stream, unsigned char* ptr, int nbytes) {
 
 static int vio_seek_func(void* stream, opus_int64 offset, int whence) {
 	auto* f = reinterpret_cast<Filesystem_Stream::InputStream*>(stream);
-	if (f->eof()) f->clear(); //emulate behaviour of fseek
+	if (f->eof()) f->clear(); // emulate behaviour of fseek
 
 	f->seekg(offset, Filesystem_Stream::CSeekdirToCppSeekdir(whence));
 
@@ -41,7 +41,7 @@ static int vio_seek_func(void* stream, opus_int64 offset, int whence) {
 
 static opus_int64 vio_tell_func(void* stream) {
 	auto* f = reinterpret_cast<Filesystem_Stream::InputStream*>(stream);
-	return f->tellg();
+	return static_cast<opus_int64>(f->tellg());
 }
 
 static OpusFileCallbacks vio = {

--- a/src/decoder_opus.h
+++ b/src/decoder_opus.h
@@ -33,7 +33,7 @@ public:
 	~OpusDecoder();
 
 	// Audio Decoder interface
-	bool Open(std::shared_ptr<FileFinder::istream> stream) override;
+	bool Open(Filesystem::InputStream stream) override;
 
 	bool Seek(size_t offset, Origin origin) override;
 
@@ -50,7 +50,7 @@ private:
 #ifdef HAVE_OPUS
 	OggOpusFile* oof;
 #endif
-	std::shared_ptr<FileFinder::istream> stream;
+	Filesystem::InputStream stream;
 	bool finished = false;
 	int frequency = 48000;
 	int channels = 2;

--- a/src/decoder_opus.h
+++ b/src/decoder_opus.h
@@ -48,7 +48,7 @@ private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 
 #ifdef HAVE_OPUS
-	OggOpusFile* oof;
+	OggOpusFile* oof = nullptr;
 #endif
 	Filesystem_Stream::InputStream stream;
 	bool finished = false;

--- a/src/decoder_opus.h
+++ b/src/decoder_opus.h
@@ -33,7 +33,7 @@ public:
 	~OpusDecoder();
 
 	// Audio Decoder interface
-	bool Open(FILE* file) override;
+	bool Open(std::shared_ptr<FileFinder::istream> stream) override;
 
 	bool Seek(size_t offset, Origin origin) override;
 

--- a/src/decoder_opus.h
+++ b/src/decoder_opus.h
@@ -50,6 +50,7 @@ private:
 #ifdef HAVE_OPUS
 	OggOpusFile* oof;
 #endif
+	std::shared_ptr<FileFinder::istream> stream;
 	bool finished = false;
 	int frequency = 48000;
 	int channels = 2;

--- a/src/decoder_opus.h
+++ b/src/decoder_opus.h
@@ -33,7 +33,7 @@ public:
 	~OpusDecoder();
 
 	// Audio Decoder interface
-	bool Open(Filesystem::InputStream stream) override;
+	bool Open(Filesystem_Stream::InputStream stream) override;
 
 	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 
@@ -50,7 +50,7 @@ private:
 #ifdef HAVE_OPUS
 	OggOpusFile* oof;
 #endif
-	Filesystem::InputStream stream;
+	Filesystem_Stream::InputStream stream;
 	bool finished = false;
 	int frequency = 48000;
 	int channels = 2;

--- a/src/decoder_opus.h
+++ b/src/decoder_opus.h
@@ -35,7 +35,7 @@ public:
 	// Audio Decoder interface
 	bool Open(Filesystem::InputStream stream) override;
 
-	bool Seek(size_t offset, Origin origin) override;
+	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 
 	bool IsFinished() const override;
 

--- a/src/decoder_wav.cpp
+++ b/src/decoder_wav.cpp
@@ -35,7 +35,7 @@ WavDecoder::~WavDecoder() {
 	}
 }
 
-bool WavDecoder::Open(FILE* file) {
+bool WavDecoder::Open(std::shared_ptr<FileFinder::istream> stream) {
 	decoded_samples = 0;
 	file_=file;
 	fseek(file_, 16, SEEK_SET);

--- a/src/decoder_wav.cpp
+++ b/src/decoder_wav.cpp
@@ -94,7 +94,7 @@ bool WavDecoder::Open(Filesystem::InputStream stream) {
 	return stream->good();
 }
 
-bool WavDecoder::Seek(size_t offset, Origin origin) {
+bool WavDecoder::Seek(std::streamoff offset, std::ios_base::seekdir origin) {
 	finished = false;
 	if (!stream)
 		return false;
@@ -104,18 +104,8 @@ bool WavDecoder::Seek(size_t offset, Origin origin) {
 	// FIXME: Proper sample count for seek
 	decoded_samples = 0;
 
-	bool success = false;
-	switch (origin) {
-	case Origin::Begin:
-		success = stream->seekg(offset, std::ios::ios_base::beg).good();
-		break;
-	case Origin::Current:
-		success = stream->seekg(offset, std::ios::ios_base::cur).good();
-		break;
-	case Origin::End:
-		success = stream->seekg(offset, std::ios::ios_base::end).good();
-		break;
-	}
+	bool success = stream->seekg(offset, origin).good();
+
 	if (!success) { stream->clear(); }
 	cur_pos = stream->tellg();
 	return success;

--- a/src/decoder_wav.cpp
+++ b/src/decoder_wav.cpp
@@ -98,7 +98,7 @@ bool WavDecoder::Seek(std::streamoff offset, std::ios_base::seekdir origin) {
 	finished = false;
 	if (!stream)
 		return false;
-	if (origin == Origin::Begin) {
+	if (origin == std::ios_base::beg) {
 		offset += audiobuf_offset;
 	}
 	// FIXME: Proper sample count for seek

--- a/src/decoder_wav.cpp
+++ b/src/decoder_wav.cpp
@@ -32,7 +32,7 @@ WavDecoder::WavDecoder()
 WavDecoder::~WavDecoder() {
 }
 
-bool WavDecoder::Open(std::shared_ptr<FileFinder::istream> stream) {
+bool WavDecoder::Open(Filesystem::InputStream stream) {
 	decoded_samples = 0;
 	this->stream = stream;
 	stream->seekg(16, std::ios::ios_base::beg);

--- a/src/decoder_wav.cpp
+++ b/src/decoder_wav.cpp
@@ -71,7 +71,7 @@ bool WavDecoder::Open(std::shared_ptr<FileFinder::istream> stream) {
 	while (strncmp(chunk_name, "data", 4)) {
 		stream->read(reinterpret_cast<char*>(&chunk_size), sizeof(chunk_size));
 		Utils::SwapByteOrder(chunk_size);
-		stream->seekg(chunk_size, std::ios::ios_base::beg);
+		stream->seekg(chunk_size, std::ios::ios_base::cur);
 		stream->read(reinterpret_cast<char*>(chunk_name), sizeof(chunk_name));
 
 		if (!stream->good()) {

--- a/src/decoder_wav.h
+++ b/src/decoder_wav.h
@@ -34,7 +34,7 @@ public:
 
 	bool Open(Filesystem::InputStream stream) override;
 
-	bool Seek(size_t offset, Origin origin) override;
+	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 
 	bool IsFinished() const override;
 

--- a/src/decoder_wav.h
+++ b/src/decoder_wav.h
@@ -32,7 +32,7 @@ public:
 
 	~WavDecoder();
 
-	bool Open(std::shared_ptr<FileFinder::istream> stream) override;
+	bool Open(Filesystem::InputStream stream) override;
 
 	bool Seek(size_t offset, Origin origin) override;
 
@@ -47,7 +47,7 @@ public:
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 	Format output_format;
-	std::shared_ptr<FileFinder::istream> stream;
+	Filesystem::InputStream stream;
 	bool finished;
 	uint32_t samplerate;
 	uint16_t nchannels;

--- a/src/decoder_wav.h
+++ b/src/decoder_wav.h
@@ -32,7 +32,7 @@ public:
 
 	~WavDecoder();
 
-	bool Open(FILE* file) override;
+	bool Open(std::shared_ptr<FileFinder::istream> stream) override;
 
 	bool Seek(size_t offset, Origin origin) override;
 
@@ -47,7 +47,7 @@ public:
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 	Format output_format;
-	FILE * file_;
+	std::shared_ptr<FileFinder::istream> stream;
 	bool finished;
 	uint32_t samplerate;
 	uint16_t nchannels;

--- a/src/decoder_wav.h
+++ b/src/decoder_wav.h
@@ -32,7 +32,7 @@ public:
 
 	~WavDecoder();
 
-	bool Open(Filesystem::InputStream stream) override;
+	bool Open(Filesystem_Stream::InputStream stream) override;
 
 	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 
@@ -47,7 +47,7 @@ public:
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 	Format output_format;
-	Filesystem::InputStream stream;
+	Filesystem_Stream::InputStream stream;
 	bool finished;
 	uint32_t samplerate;
 	uint16_t nchannels;

--- a/src/decoder_wildmidi.cpp
+++ b/src/decoder_wildmidi.cpp
@@ -296,7 +296,7 @@ bool WildMidiDecoder::WasInited() const {
 	return init;
 }
 
-bool WildMidiDecoder::Open(std::shared_ptr<FileFinder::istream> stream) {
+bool WildMidiDecoder::Open(Filesystem::InputStream stream) {
 	if (!init)
 		return false;
 

--- a/src/decoder_wildmidi.cpp
+++ b/src/decoder_wildmidi.cpp
@@ -296,7 +296,7 @@ bool WildMidiDecoder::WasInited() const {
 	return init;
 }
 
-bool WildMidiDecoder::Open(FILE* file) {
+bool WildMidiDecoder::Open(std::shared_ptr<FileFinder::istream> stream) {
 	if (!init)
 		return false;
 
@@ -328,7 +328,6 @@ bool WildMidiDecoder::Open(FILE* file) {
 		division = 96;
 	}
 
-	fclose(file);
 	return true;
 }
 

--- a/src/decoder_wildmidi.cpp
+++ b/src/decoder_wildmidi.cpp
@@ -77,16 +77,17 @@ static void WildMidiDecoder_deinit() {
 
 #if LIBWILDMIDI_VERSION >= 1027 // at least 0.4.3
 static void* vio_allocate_file_func(const char* filename, uint32_t* size) {
-	auto&& stream = FileFinder::OpenInputStream(filename);
+	auto stream = FileFinder::OpenInputStream(filename);
 	if (!stream) {
 		return nullptr;
 	}
 
-	auto s = stream.GetSize();
-	*size = s;
+	auto buf = Utils::ReadStream(stream);
 
-	char* buffer = reinterpret_cast<char*>(malloc(s));
-	stream.read(buffer, s);
+	*size = static_cast<uint32_t>(buf.size());
+
+	char* buffer = reinterpret_cast<char*>(malloc(*size));
+	memcpy(buffer, buf.data(), buf.size());
 
 	return buffer;
 }

--- a/src/decoder_wildmidi.cpp
+++ b/src/decoder_wildmidi.cpp
@@ -77,16 +77,16 @@ static void WildMidiDecoder_deinit() {
 
 #if LIBWILDMIDI_VERSION >= 1027 // at least 0.4.3
 static void* vio_allocate_file_func(const char* filename, uint32_t* size) {
-	auto stream = FileFinder::OpenInputStream(filename);
+	auto&& stream = FileFinder::OpenInputStream(filename);
 	if (!stream) {
 		return nullptr;
 	}
 
-	auto s = stream->get_size();
+	auto s = stream.GetSize();
 	*size = s;
 
 	char* buffer = reinterpret_cast<char*>(malloc(s));
-	stream->read(buffer, s);
+	stream.read(buffer, s);
 
 	return buffer;
 }
@@ -326,7 +326,7 @@ bool WildMidiDecoder::WasInited() const {
 	return init;
 }
 
-bool WildMidiDecoder::Open(Filesystem::InputStream stream) {
+bool WildMidiDecoder::Open(Filesystem_Stream::InputStream stream) {
 	if (!init)
 		return false;
 
@@ -336,7 +336,7 @@ bool WildMidiDecoder::Open(Filesystem::InputStream stream) {
 		Output::Debug("WildMidi: Previous handle was not closed.");
 	}
 
-	file_buffer = Utils::ReadStream(*stream);
+	file_buffer = Utils::ReadStream(stream);
 
 	handle = WildMidi_OpenBuffer(file_buffer.data(), file_buffer.size());
 	if (!handle) {

--- a/src/decoder_wildmidi.cpp
+++ b/src/decoder_wildmidi.cpp
@@ -331,8 +331,8 @@ bool WildMidiDecoder::Open(Filesystem::InputStream stream) {
 	return true;
 }
 
-bool WildMidiDecoder::Seek(size_t offset, Origin origin) {
-	if (offset == 0 && origin == Origin::Begin) {
+bool WildMidiDecoder::Seek(std::streamoff offset, std::ios_base::seekdir origin) {
+	if (offset == 0 && origin == std::ios_base::beg) {
 		if (handle) {
 			unsigned long int pos = 0;
 			WildMidi_FastSeek(handle, &pos);

--- a/src/decoder_wildmidi.h
+++ b/src/decoder_wildmidi.h
@@ -38,7 +38,7 @@ public:
 	bool WasInited() const override;
 
 	// Audio Decoder interface
-	bool Open(FILE* file) override;
+	bool Open(std::shared_ptr<FileFinder::istream> stream) override;
 
 	bool Seek(size_t offset, Origin origin) override;
 

--- a/src/decoder_wildmidi.h
+++ b/src/decoder_wildmidi.h
@@ -40,7 +40,7 @@ public:
 	// Audio Decoder interface
 	bool Open(Filesystem::InputStream stream) override;
 
-	bool Seek(size_t offset, Origin origin) override;
+	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 
 	int GetTicks() const override;
 

--- a/src/decoder_wildmidi.h
+++ b/src/decoder_wildmidi.h
@@ -31,7 +31,7 @@
  */
 class WildMidiDecoder : public AudioDecoder {
 public:
-	WildMidiDecoder(const std::string file_name);
+	WildMidiDecoder();
 
 	~WildMidiDecoder();
 
@@ -52,11 +52,12 @@ public:
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
 
-	std::string filename;
 	uint32_t division = 96;
 #ifdef HAVE_WILDMIDI
-	midi* handle = NULL;
+	midi* handle = nullptr;
 #endif
+
+	std::vector<uint8_t> file_buffer;
 };
 
 #endif

--- a/src/decoder_wildmidi.h
+++ b/src/decoder_wildmidi.h
@@ -38,7 +38,7 @@ public:
 	bool WasInited() const override;
 
 	// Audio Decoder interface
-	bool Open(Filesystem::InputStream stream) override;
+	bool Open(Filesystem_Stream::InputStream stream) override;
 
 	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 

--- a/src/decoder_wildmidi.h
+++ b/src/decoder_wildmidi.h
@@ -38,7 +38,7 @@ public:
 	bool WasInited() const override;
 
 	// Audio Decoder interface
-	bool Open(std::shared_ptr<FileFinder::istream> stream) override;
+	bool Open(Filesystem::InputStream stream) override;
 
 	bool Seek(size_t offset, Origin origin) override;
 

--- a/src/decoder_xmp.cpp
+++ b/src/decoder_xmp.cpp
@@ -40,16 +40,19 @@ XMPDecoder::~XMPDecoder() {
 	}
 }
 
-bool XMPDecoder::Open(FILE* file) {
+bool XMPDecoder::Open(std::shared_ptr<FileFinder::istream> stream) {
 	finished = false;
 
 	if (!ctx)
 		return false;
 
-	int res =  xmp_load_module_from_file(ctx, file, 0);
+	Output::Debug("MOD Size: %d\n", stream->get_size());
+	file_buffer.resize(stream->get_size());
+	stream->read(reinterpret_cast<char*>(file_buffer.data()), stream->get_size());
+		
+	int res =  xmp_load_module_from_memory(ctx, file_buffer.data(), stream->get_size());
 	if (res != 0) {
 		error_message = "XMP: Error loading file";
-		fclose(file);
 		return false;
 	}
 

--- a/src/decoder_xmp.cpp
+++ b/src/decoder_xmp.cpp
@@ -40,16 +40,16 @@ XMPDecoder::~XMPDecoder() {
 	}
 }
 
-bool XMPDecoder::Open(Filesystem::InputStream stream) {
+bool XMPDecoder::Open(Filesystem_Stream::InputStream stream) {
 	finished = false;
 
 	if (!ctx)
 		return false;
 
-	file_buffer.resize(stream->get_size());
-	stream->read(reinterpret_cast<char*>(file_buffer.data()), stream->get_size());
+	file_buffer.resize(stream.GetSize());
+	stream.read(reinterpret_cast<char*>(file_buffer.data()), stream.GetSize());
 		
-	int res =  xmp_load_module_from_memory(ctx, file_buffer.data(), stream->get_size());
+	int res = xmp_load_module_from_memory(ctx, file_buffer.data(), stream.GetSize());
 	if (res != 0) {
 		error_message = "XMP: Error loading file";
 		return false;

--- a/src/decoder_xmp.cpp
+++ b/src/decoder_xmp.cpp
@@ -46,7 +46,6 @@ bool XMPDecoder::Open(Filesystem::InputStream stream) {
 	if (!ctx)
 		return false;
 
-	Output::Debug("MOD Size: %d\n", stream->get_size());
 	file_buffer.resize(stream->get_size());
 	stream->read(reinterpret_cast<char*>(file_buffer.data()), stream->get_size());
 		
@@ -73,11 +72,11 @@ bool XMPDecoder::Open(Filesystem::InputStream stream) {
 	return true;
 }
 
-bool XMPDecoder::Seek(size_t offset, Origin origin) {
+bool XMPDecoder::Seek(std::streamoff offset, std::ios_base::seekdir origin) {
 	if (!ctx)
 		return false;
 
-	if (offset == 0 && origin == Origin::Begin) {
+	if (offset == 0 && origin == std::ios_base::beg) {
 		xmp_restart_module(ctx);
 		finished = false;
 		return true;

--- a/src/decoder_xmp.cpp
+++ b/src/decoder_xmp.cpp
@@ -40,7 +40,7 @@ XMPDecoder::~XMPDecoder() {
 	}
 }
 
-bool XMPDecoder::Open(std::shared_ptr<FileFinder::istream> stream) {
+bool XMPDecoder::Open(Filesystem::InputStream stream) {
 	finished = false;
 
 	if (!ctx)

--- a/src/decoder_xmp.cpp
+++ b/src/decoder_xmp.cpp
@@ -46,10 +46,9 @@ bool XMPDecoder::Open(Filesystem_Stream::InputStream stream) {
 	if (!ctx)
 		return false;
 
-	file_buffer.resize(stream.GetSize());
-	stream.read(reinterpret_cast<char*>(file_buffer.data()), stream.GetSize());
-		
-	int res = xmp_load_module_from_memory(ctx, file_buffer.data(), stream.GetSize());
+	file_buffer = Utils::ReadStream(stream);
+
+	int res = xmp_load_module_from_memory(ctx, file_buffer.data(), file_buffer.size());
 	if (res != 0) {
 		error_message = "XMP: Error loading file";
 		return false;

--- a/src/decoder_xmp.h
+++ b/src/decoder_xmp.h
@@ -49,7 +49,8 @@ public:
 	static bool IsModule(std::string filename);
 private:
 	int FillBuffer(uint8_t* buffer, int length) override;
-
+	
+	std::vector<uint8_t> file_buffer;
 #ifdef HAVE_XMP
 	xmp_context ctx = nullptr;
 #endif

--- a/src/decoder_xmp.h
+++ b/src/decoder_xmp.h
@@ -36,7 +36,7 @@ public:
 	~XMPDecoder();
 
 	// Audio Decoder interface
-	bool Open(FILE* file) override;
+	bool Open(std::shared_ptr<FileFinder::istream> stream) override;
 
 	bool Seek(size_t offset, Origin origin) override;
 

--- a/src/decoder_xmp.h
+++ b/src/decoder_xmp.h
@@ -38,7 +38,7 @@ public:
 	// Audio Decoder interface
 	bool Open(Filesystem::InputStream stream) override;
 
-	bool Seek(size_t offset, Origin origin) override;
+	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 
 	bool IsFinished() const override;
 

--- a/src/decoder_xmp.h
+++ b/src/decoder_xmp.h
@@ -36,7 +36,7 @@ public:
 	~XMPDecoder();
 
 	// Audio Decoder interface
-	bool Open(Filesystem::InputStream stream) override;
+	bool Open(Filesystem_Stream::InputStream stream) override;
 
 	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 

--- a/src/decoder_xmp.h
+++ b/src/decoder_xmp.h
@@ -36,7 +36,7 @@ public:
 	~XMPDecoder();
 
 	// Audio Decoder interface
-	bool Open(std::shared_ptr<FileFinder::istream> stream) override;
+	bool Open(Filesystem::InputStream stream) override;
 
 	bool Seek(size_t offset, Origin origin) override;
 

--- a/src/exe_reader.cpp
+++ b/src/exe_reader.cpp
@@ -25,7 +25,7 @@
 #include <iostream>
 #include <fstream>
 
-EXEReader::EXEReader(Filesystem::InputStream& core) : corefile(core) {
+EXEReader::EXEReader(Filesystem_Stream::InputStream& core) : corefile(core) {
 	// The Incredibly Dumb Resource Grabber (tm)
 	// The idea is that this code will eventually be moved to happen earlier or broken down as-needed.
 	// Since EXFONT is the only thing that matters right now, it's the only thing handled.
@@ -71,18 +71,18 @@ static uint32_t djb2_hash(char* str, size_t length) {
 	return hash;
 }
 
-static std::vector<uint8_t> exe_reader_perform_exfont_save(Filesystem::InputStream& corefile, uint32_t position, uint32_t len) {
+static std::vector<uint8_t> exe_reader_perform_exfont_save(Filesystem_Stream::InputStream& corefile, uint32_t position, uint32_t len) {
 	std::vector<uint8_t> exfont;
 	constexpr int header_size = 14;
 	exfont.resize(len + header_size);
 
-	corefile->seekg(position, std::ios_base::beg);
+	corefile.seekg(position, std::ios_base::beg);
 
 	// Solely for calculating position of actual data
-	uint32_t hdrL = corefile->get();
-	hdrL |= ((uint32_t) corefile->get()) << 8;
-	hdrL |= ((uint32_t) corefile->get()) << 16;
-	hdrL |= ((uint32_t) corefile->get()) << 24;
+	uint32_t hdrL = corefile.get();
+	hdrL |= ((uint32_t) corefile.get()) << 8;
+	hdrL |= ((uint32_t) corefile.get()) << 16;
+	hdrL |= ((uint32_t) corefile.get()) << 24;
 	// As it turns out, EXFONTs appear to operate on all the same restrictions as an ordinary BMP.
 	// Given this particular resource is loaded by the RPG Maker half of the engine, this makes the usual amount of sense.
 	// This means 256 palette entries. Without fail. Even though only two are used, the first and last.
@@ -112,9 +112,9 @@ static std::vector<uint8_t> exe_reader_perform_exfont_save(Filesystem::InputStre
 	exfont[pos++] = (hdrL >> 16) & 0xFF;
 	exfont[pos++] = (hdrL >> 24) & 0xFF;
 
-	corefile->seekg(position, std::ios_base::beg);
+	corefile.seekg(position, std::ios_base::beg);
 	while (len > 0) {
-		int v = corefile->get();
+		int v = corefile.get();
 		if (v == -1)
 			break;
 		exfont[pos++] = v;
@@ -181,8 +181,8 @@ std::vector<uint8_t> EXEReader::GetExFont() {
 }
 
 uint8_t EXEReader::GetU8(uint32_t i) {
-	corefile->seekg(i, std::ios_base::beg);
-	int ch = corefile->get();
+	corefile.seekg(i, std::ios_base::beg);
+	int ch = corefile.get();
 	if (ch == -1)
 		ch = 0;
 	return (uint8_t) ch;

--- a/src/exe_reader.cpp
+++ b/src/exe_reader.cpp
@@ -25,7 +25,7 @@
 #include <iostream>
 #include <fstream>
 
-EXEReader::EXEReader(std::istream& core) : corefile(core) {
+EXEReader::EXEReader(Filesystem::InputStream& core) : corefile(core) {
 	// The Incredibly Dumb Resource Grabber (tm)
 	// The idea is that this code will eventually be moved to happen earlier or broken down as-needed.
 	// Since EXFONT is the only thing that matters right now, it's the only thing handled.
@@ -71,18 +71,18 @@ static uint32_t djb2_hash(char* str, size_t length) {
 	return hash;
 }
 
-static std::vector<uint8_t> exe_reader_perform_exfont_save(std::istream& corefile, uint32_t position, uint32_t len) {
+static std::vector<uint8_t> exe_reader_perform_exfont_save(Filesystem::InputStream& corefile, uint32_t position, uint32_t len) {
 	std::vector<uint8_t> exfont;
 	constexpr int header_size = 14;
 	exfont.resize(len + header_size);
 
-	corefile.seekg(position, std::ios_base::beg);
+	corefile->seekg(position, std::ios_base::beg);
 
 	// Solely for calculating position of actual data
-	uint32_t hdrL = corefile.get();
-	hdrL |= ((uint32_t) corefile.get()) << 8;
-	hdrL |= ((uint32_t) corefile.get()) << 16;
-	hdrL |= ((uint32_t) corefile.get()) << 24;
+	uint32_t hdrL = corefile->get();
+	hdrL |= ((uint32_t) corefile->get()) << 8;
+	hdrL |= ((uint32_t) corefile->get()) << 16;
+	hdrL |= ((uint32_t) corefile->get()) << 24;
 	// As it turns out, EXFONTs appear to operate on all the same restrictions as an ordinary BMP.
 	// Given this particular resource is loaded by the RPG Maker half of the engine, this makes the usual amount of sense.
 	// This means 256 palette entries. Without fail. Even though only two are used, the first and last.
@@ -112,9 +112,9 @@ static std::vector<uint8_t> exe_reader_perform_exfont_save(std::istream& corefil
 	exfont[pos++] = (hdrL >> 16) & 0xFF;
 	exfont[pos++] = (hdrL >> 24) & 0xFF;
 
-	corefile.seekg(position, std::ios_base::beg);
+	corefile->seekg(position, std::ios_base::beg);
 	while (len > 0) {
-		int v = corefile.get();
+		int v = corefile->get();
 		if (v == -1)
 			break;
 		exfont[pos++] = v;
@@ -181,8 +181,8 @@ std::vector<uint8_t> EXEReader::GetExFont() {
 }
 
 uint8_t EXEReader::GetU8(uint32_t i) {
-	corefile.seekg(i, std::ios_base::beg);
-	int ch = corefile.get();
+	corefile->seekg(i, std::ios_base::beg);
+	int ch = corefile->get();
 	if (ch == -1)
 		ch = 0;
 	return (uint8_t) ch;

--- a/src/exe_reader.h
+++ b/src/exe_reader.h
@@ -35,7 +35,7 @@ public:
 	// 1. everywhere else uses "unsigned", which is equally as odd...
 	// 2. max offset value is this size
 
-	EXEReader(Filesystem::InputStream& core);
+	EXEReader(Filesystem_Stream::InputStream& core);
 	~EXEReader();
 
 	// Extracts an EXFONT resource with BMP header if present
@@ -55,7 +55,7 @@ private:
 	uint32_t resource_ofs;
 	uint32_t resource_rva;
 
-	Filesystem::InputStream& corefile;
+	Filesystem_Stream::InputStream& corefile;
 };
 
 #endif

--- a/src/exe_reader.h
+++ b/src/exe_reader.h
@@ -35,7 +35,7 @@ public:
 	// 1. everywhere else uses "unsigned", which is equally as odd...
 	// 2. max offset value is this size
 
-	EXEReader(std::istream& core);
+	EXEReader(Filesystem::InputStream& core);
 	~EXEReader();
 
 	// Extracts an EXFONT resource with BMP header if present
@@ -55,7 +55,7 @@ private:
 	uint32_t resource_ofs;
 	uint32_t resource_rva;
 
-	std::istream& corefile;
+	Filesystem::InputStream& corefile;
 };
 
 #endif

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -655,7 +655,7 @@ FILE* FileFinder::fopenUTF8(const std::string& name_utf8, char const* mode) {
 #endif
 }
 
-std::shared_ptr<std::fstream> FileFinder::openUTF8(const std::string& name,
+std::shared_ptr<std::iostream> FileFinder::openUTF8(const std::string& name,
 													  std::ios_base::openmode m)
 {
 	std::shared_ptr<std::fstream> ret(new std::fstream(
@@ -666,6 +666,32 @@ std::shared_ptr<std::fstream> FileFinder::openUTF8(const std::string& name,
 #endif
 		m));
 	return (*ret)? ret : std::shared_ptr<std::fstream>();
+}
+
+std::shared_ptr<std::istream> FileFinder::openUTF8Input(const std::string& name,
+	std::ios_base::openmode m)
+{
+	std::shared_ptr<std::ifstream> ret(new std::ifstream(
+#ifdef _MSC_VER
+		Utils::ToWideString(name).c_str(),
+#else
+		name.c_str(),
+#endif
+		m));
+	return (*ret) ? ret : std::shared_ptr<std::ifstream>();
+}
+
+std::shared_ptr<std::ostream> FileFinder::openUTF8Output(const std::string& name,
+	std::ios_base::openmode m)
+{
+	std::shared_ptr<std::ofstream> ret(new std::ofstream(
+#ifdef _MSC_VER
+		Utils::ToWideString(name).c_str(),
+#else
+		name.c_str(),
+#endif
+		m));
+	return (*ret) ? ret : std::shared_ptr<std::ofstream>();
 }
 
 std::string FileFinder::FindImage(const std::string& dir, const std::string& name) {

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -646,14 +646,14 @@ void FileFinder::Quit() {
 	game_directory_tree.reset();
 }
 
-FILE* FileFinder::fopenUTF8(const std::string& name_utf8, char const* mode) {
+/*FILE* FileFinder::fopenUTF8(const std::string& name_utf8, char const* mode) {
 #ifdef _WIN32
 	return _wfopen(Utils::ToWideString(name_utf8).c_str(),
 				   Utils::ToWideString(mode).c_str());
 #else
 	return fopen(name_utf8.c_str(), mode);
 #endif
-}
+}*/
 
 std::shared_ptr<std::iostream> FileFinder::openUTF8(const std::string& name,
 													  std::ios_base::openmode m)
@@ -668,17 +668,21 @@ std::shared_ptr<std::iostream> FileFinder::openUTF8(const std::string& name,
 	return (*ret)? ret : std::shared_ptr<std::fstream>();
 }
 
-std::shared_ptr<std::istream> FileFinder::openUTF8Input(const std::string& name,
+std::shared_ptr<FileFinder::istream> FileFinder::openUTF8Input(const std::string& name,
 	std::ios_base::openmode m)
 {
-	std::shared_ptr<std::ifstream> ret(new std::ifstream(
+	std::streamsize size = FileFinder::GetFileSize(name);
+	std::filebuf *buf = new std::filebuf();
+
+	std::shared_ptr<FileFinder::istream> ret(new FileFinder::istream(buf->open(
 #ifdef _MSC_VER
 		Utils::ToWideString(name).c_str(),
 #else
 		name.c_str(),
 #endif
-		m));
-	return (*ret) ? ret : std::shared_ptr<std::ifstream>();
+		m), size));
+
+	return (*ret) ? ret : std::shared_ptr<FileFinder::istream>();
 }
 
 std::shared_ptr<std::ostream> FileFinder::openUTF8Output(const std::string& name,

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -646,29 +646,7 @@ void FileFinder::Quit() {
 	game_directory_tree.reset();
 }
 
-/*FILE* FileFinder::fopenUTF8(const std::string& name_utf8, char const* mode) {
-#ifdef _WIN32
-	return _wfopen(Utils::ToWideString(name_utf8).c_str(),
-				   Utils::ToWideString(mode).c_str());
-#else
-	return fopen(name_utf8.c_str(), mode);
-#endif
-}*/
-
-std::shared_ptr<std::iostream> FileFinder::openUTF8(const std::string& name,
-													  std::ios_base::openmode m)
-{
-	std::shared_ptr<std::fstream> ret(new std::fstream(
-#ifdef _MSC_VER
-		Utils::ToWideString(name).c_str(),
-#else
-		name.c_str(),
-#endif
-		m));
-	return (*ret)? ret : std::shared_ptr<std::fstream>();
-}
-
-std::shared_ptr<FileFinder::istream> FileFinder::openUTF8Input(const std::string& name,
+std::shared_ptr<FileFinder::istream> FileFinder::OpenInputStream(const std::string& name,
 	std::ios_base::openmode m)
 {
 	std::streamsize size = FileFinder::GetFileSize(name);
@@ -685,7 +663,7 @@ std::shared_ptr<FileFinder::istream> FileFinder::openUTF8Input(const std::string
 	return (*ret) ? ret : std::shared_ptr<FileFinder::istream>();
 }
 
-std::shared_ptr<std::ostream> FileFinder::openUTF8Output(const std::string& name,
+std::shared_ptr<std::ostream> FileFinder::OpenOutputStream(const std::string& name,
 	std::ios_base::openmode m)
 {
 	std::shared_ptr<std::ofstream> ret(new std::ofstream(

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -646,13 +646,13 @@ void FileFinder::Quit() {
 	game_directory_tree.reset();
 }
 
-std::shared_ptr<FileFinder::istream> FileFinder::OpenInputStream(const std::string& name,
+Filesystem::InputStream FileFinder::OpenInputStream(const std::string& name,
 	std::ios_base::openmode m)
 {
 	std::streamsize size = FileFinder::GetFileSize(name);
-	std::filebuf *buf = new std::filebuf();
+	auto *buf = new std::filebuf();
 
-	std::shared_ptr<FileFinder::istream> ret(new FileFinder::istream(buf->open(
+	Filesystem::InputStream ret(new Filesystem::InputStreamRaw(buf->open(
 #ifdef _MSC_VER
 		Utils::ToWideString(name).c_str(),
 #else
@@ -660,20 +660,23 @@ std::shared_ptr<FileFinder::istream> FileFinder::OpenInputStream(const std::stri
 #endif
 		m), size));
 
-	return (*ret) ? ret : std::shared_ptr<FileFinder::istream>();
+	return (*ret) ? ret : Filesystem::InputStream();
 }
 
-std::shared_ptr<std::ostream> FileFinder::OpenOutputStream(const std::string& name,
+Filesystem::OutputStream FileFinder::OpenOutputStream(const std::string& name,
 	std::ios_base::openmode m)
 {
-	std::shared_ptr<std::ofstream> ret(new std::ofstream(
+	auto *buf = new std::filebuf();
+
+	Filesystem::OutputStream ret(new Filesystem::OutputStreamRaw(buf->open(
 #ifdef _MSC_VER
-		Utils::ToWideString(name).c_str(),
+			Utils::ToWideString(name).c_str(),
 #else
-		name.c_str(),
+			name.c_str(),
 #endif
-		m));
-	return (*ret) ? ret : std::shared_ptr<std::ofstream>();
+		m)));
+
+	return (*ret) ? ret : Filesystem::OutputStream();
 }
 
 std::string FileFinder::FindImage(const std::string& dir, const std::string& name) {

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -646,37 +646,37 @@ void FileFinder::Quit() {
 	game_directory_tree.reset();
 }
 
-Filesystem::InputStream FileFinder::OpenInputStream(const std::string& name,
+Filesystem_Stream::InputStream FileFinder::OpenInputStream(const std::string& name,
 	std::ios_base::openmode m)
 {
 	std::streamsize size = FileFinder::GetFileSize(name);
 	auto *buf = new std::filebuf();
 
-	Filesystem::InputStream ret(new Filesystem::InputStreamRaw(buf->open(
+	Filesystem_Stream::InputStream is(buf->open(
 #ifdef _MSC_VER
 		Utils::ToWideString(name).c_str(),
 #else
 		name.c_str(),
 #endif
-		m), size));
+		m), size);
 
-	return (*ret) ? ret : Filesystem::InputStream();
+	return std::move(is);
 }
 
-Filesystem::OutputStream FileFinder::OpenOutputStream(const std::string& name,
+Filesystem_Stream::OutputStream FileFinder::OpenOutputStream(const std::string& name,
 	std::ios_base::openmode m)
 {
 	auto *buf = new std::filebuf();
 
-	Filesystem::OutputStream ret(new Filesystem::OutputStreamRaw(buf->open(
+	Filesystem_Stream::OutputStream os(buf->open(
 #ifdef _MSC_VER
 			Utils::ToWideString(name).c_str(),
 #else
 			name.c_str(),
 #endif
-		m)));
+		m));
 
-	return (*ret) ? ret : Filesystem::OutputStream();
+	return std::move(os);
 }
 
 std::string FileFinder::FindImage(const std::string& dir, const std::string& name) {

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -649,7 +649,6 @@ void FileFinder::Quit() {
 Filesystem_Stream::InputStream FileFinder::OpenInputStream(const std::string& name,
 	std::ios_base::openmode m)
 {
-	std::streamsize size = FileFinder::GetFileSize(name);
 	auto *buf = new std::filebuf();
 
 	Filesystem_Stream::InputStream is(buf->open(
@@ -658,7 +657,7 @@ Filesystem_Stream::InputStream FileFinder::OpenInputStream(const std::string& na
 #else
 		name.c_str(),
 #endif
-		m), size);
+		m));
 
 	return std::move(is);
 }

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -165,7 +165,25 @@ namespace FileFinder {
 	 * @param m stream mode.
 	 * @return NULL if open failed.
 	 */
-	std::shared_ptr<std::fstream> openUTF8(const std::string& name, std::ios_base::openmode m);
+	std::shared_ptr<std::iostream> openUTF8(const std::string& name, std::ios_base::openmode m);
+
+	/**
+	* Creates stream from UTF-8 file name.
+	*
+	* @param name UTF-8 string file name.
+	* @param m stream mode.
+	* @return NULL if open failed.
+	*/
+	std::shared_ptr<std::istream> openUTF8Input(const std::string& name, std::ios_base::openmode m);
+
+	/**
+	* Creates stream from UTF-8 file name.
+	*
+	* @param name UTF-8 string file name.
+	* @param m stream mode.
+	* @return NULL if open failed.
+	*/
+	std::shared_ptr<std::ostream> openUTF8Output(const std::string& name, std::ios_base::openmode m);
 
 	struct Directory {
 		std::string base;

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -158,7 +158,8 @@ namespace FileFinder {
 	* @param m stream mode.
 	* @return NULL if open failed.
 	*/
-	Filesystem::InputStream OpenInputStream(const std::string& name, std::ios_base::openmode m);
+	Filesystem::InputStream OpenInputStream(const std::string& name,
+			std::ios_base::openmode m = std::ios_base::in | std::ios_base::binary);
 
 	/**
 	* Creates stream from UTF-8 file name.
@@ -167,7 +168,8 @@ namespace FileFinder {
 	* @param m stream mode.
 	* @return NULL if open failed.
 	*/
-	Filesystem::OutputStream OpenOutputStream(const std::string& name, std::ios_base::openmode m);
+	Filesystem::OutputStream OpenOutputStream(const std::string& name,
+			std::ios_base::openmode m = std::ios_base::out | std::ios_base::binary);
 
 	struct Directory {
 		std::string base;

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -152,24 +152,6 @@ namespace FileFinder {
 	std::string FindFont(const std::string& name);
 
 	/**
-	 * Opens a file specified by a UTF-8 string.
-	 *
-	 * @param name_utf8 filename in UTF-8.
-	 * @param mode ("r", "w", etc).
-	 * @return FILE*.
-	 */
-	/*FILE* fopenUTF8(const std::string& name_utf8, char const* mode);*/
-
-	/**
-	 * Creates stream from UTF-8 file name.
-	 *
-	 * @param name UTF-8 string file name.
-	 * @param m stream mode.
-	 * @return NULL if open failed.
-	 */
-	std::shared_ptr<std::iostream> openUTF8(const std::string& name, std::ios_base::openmode m);
-
-	/**
 	 * A input stream anotated with the size of the connected file
 	 */
 	class istream : public std::istream {
@@ -190,7 +172,7 @@ namespace FileFinder {
 	* @param m stream mode.
 	* @return NULL if open failed.
 	*/
-	std::shared_ptr<istream> openUTF8Input(const std::string& name, std::ios_base::openmode m);
+	std::shared_ptr<istream> OpenInputStream(const std::string& name, std::ios_base::openmode m);
 
 	/**
 	* Creates stream from UTF-8 file name.
@@ -199,7 +181,7 @@ namespace FileFinder {
 	* @param m stream mode.
 	* @return NULL if open failed.
 	*/
-	std::shared_ptr<std::ostream> openUTF8Output(const std::string& name, std::ios_base::openmode m);
+	std::shared_ptr<std::ostream> OpenOutputStream(const std::string& name, std::ios_base::openmode m);
 
 	struct Directory {
 		std::string base;

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -20,7 +20,7 @@
 
 // Headers
 #include "system.h"
-#include "filesystem.h"
+#include "filesystem_stream.h"
 
 #include <string>
 #include <cstdio>
@@ -158,7 +158,7 @@ namespace FileFinder {
 	* @param m stream mode.
 	* @return NULL if open failed.
 	*/
-	Filesystem::InputStream OpenInputStream(const std::string& name,
+	Filesystem_Stream::InputStream OpenInputStream(const std::string& name,
 			std::ios_base::openmode m = std::ios_base::in | std::ios_base::binary);
 
 	/**
@@ -168,7 +168,7 @@ namespace FileFinder {
 	* @param m stream mode.
 	* @return NULL if open failed.
 	*/
-	Filesystem::OutputStream OpenOutputStream(const std::string& name,
+	Filesystem_Stream::OutputStream OpenOutputStream(const std::string& name,
 			std::ios_base::openmode m = std::ios_base::out | std::ios_base::binary);
 
 	struct Directory {

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <cstdio>
 #include <ios>
+#include <istream>
 #include <unordered_map>
 #include <vector>
 #include <istream>

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -26,6 +26,7 @@
 #include <ios>
 #include <unordered_map>
 #include <vector>
+#include <istream>
 
 /**
  * FileFinder contains helper methods for finding case
@@ -156,7 +157,7 @@ namespace FileFinder {
 	 * @param mode ("r", "w", etc).
 	 * @return FILE*.
 	 */
-	FILE* fopenUTF8(const std::string& name_utf8, char const* mode);
+	/*FILE* fopenUTF8(const std::string& name_utf8, char const* mode);*/
 
 	/**
 	 * Creates stream from UTF-8 file name.
@@ -168,13 +169,27 @@ namespace FileFinder {
 	std::shared_ptr<std::iostream> openUTF8(const std::string& name, std::ios_base::openmode m);
 
 	/**
+	 * A input stream anotated with the size of the connected file
+	 */
+	class istream : public std::istream {
+	public:
+		inline istream(std::streambuf * buf, std::streamsize size):
+			std::istream(buf),size(size),buffer(buf){}
+		~istream() { delete buffer; }
+		inline std::streamsize get_size() { return size; }
+	private:
+		std::streamsize size;
+		std::streambuf* buffer;
+	};
+
+	/**
 	* Creates stream from UTF-8 file name.
 	*
 	* @param name UTF-8 string file name.
 	* @param m stream mode.
 	* @return NULL if open failed.
 	*/
-	std::shared_ptr<std::istream> openUTF8Input(const std::string& name, std::ios_base::openmode m);
+	std::shared_ptr<istream> openUTF8Input(const std::string& name, std::ios_base::openmode m);
 
 	/**
 	* Creates stream from UTF-8 file name.

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -20,6 +20,7 @@
 
 // Headers
 #include "system.h"
+#include "filesystem.h"
 
 #include <string>
 #include <cstdio>
@@ -27,7 +28,6 @@
 #include <istream>
 #include <unordered_map>
 #include <vector>
-#include <istream>
 
 /**
  * FileFinder contains helper methods for finding case
@@ -152,18 +152,13 @@ namespace FileFinder {
 	std::string FindFont(const std::string& name);
 
 	/**
-	 * A input stream anotated with the size of the connected file
-	 */
-	class istream : public std::istream {
-	public:
-		inline istream(std::streambuf * buf, std::streamsize size):
-			std::istream(buf),size(size),buffer(buf){}
-		~istream() { delete buffer; }
-		inline std::streamsize get_size() { return size; }
-	private:
-		std::streamsize size;
-		std::streambuf* buffer;
-	};
+	* Creates stream from UTF-8 file name.
+	*
+	* @param name UTF-8 string file name.
+	* @param m stream mode.
+	* @return NULL if open failed.
+	*/
+	Filesystem::InputStream OpenInputStream(const std::string& name, std::ios_base::openmode m);
 
 	/**
 	* Creates stream from UTF-8 file name.
@@ -172,16 +167,7 @@ namespace FileFinder {
 	* @param m stream mode.
 	* @return NULL if open failed.
 	*/
-	std::shared_ptr<istream> OpenInputStream(const std::string& name, std::ios_base::openmode m);
-
-	/**
-	* Creates stream from UTF-8 file name.
-	*
-	* @param name UTF-8 string file name.
-	* @param m stream mode.
-	* @return NULL if open failed.
-	*/
-	std::shared_ptr<std::ostream> OpenOutputStream(const std::string& name, std::ios_base::openmode m);
+	Filesystem::OutputStream OpenOutputStream(const std::string& name, std::ios_base::openmode m);
 
 	struct Directory {
 		std::string base;

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -15,25 +15,7 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "filesystem.h"
+#include "filesystem_stream.h"
 
-Filesystem::vfs_istream::vfs_istream(std::streambuf *sb, std::streamsize size) :
-	size(size), std::istream(sb) {
-	// no-op
-}
-
-Filesystem::vfs_istream::~vfs_istream() {
-	delete rdbuf();
-}
-
-std::streamsize Filesystem::vfs_istream::get_size() const {
-	return size;
-}
-
-Filesystem::vfs_ostream::vfs_ostream(std::streambuf *sb) :
-	std::ostream(sb) {
-}
-
-Filesystem::vfs_ostream::~vfs_ostream() {
-	delete rdbuf();
-}
+// empty for now
+// impl in further PR

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -15,19 +15,25 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef EP_IMAGE_PNG_H
-#define EP_IMAGE_PNG_H
-
-#include "system.h"
 #include "filesystem.h"
 
-#include <istream>
-#include <ostream>
-
-namespace ImagePNG {
-	bool ReadPNG(const void* buffer, bool transparent, int& width, int& height, void*& pixels);
-	bool ReadPNG(Filesystem::InputStream& is, bool transparent, int& width, int& height, void*& pixels);
-	bool WritePNG(Filesystem::OutputStream& os, uint32_t width, uint32_t height, uint32_t* data);
+Filesystem::vfs_istream::vfs_istream(std::streambuf *sb, std::streamsize size) :
+	size(size), std::istream(sb) {
+	// no-op
 }
 
-#endif
+Filesystem::vfs_istream::~vfs_istream() {
+	delete rdbuf();
+}
+
+std::streamsize Filesystem::vfs_istream::get_size() const {
+	return size;
+}
+
+Filesystem::vfs_ostream::vfs_ostream(std::streambuf *sb) :
+	std::ostream(sb) {
+}
+
+Filesystem::vfs_ostream::~vfs_ostream() {
+	delete rdbuf();
+}

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -15,19 +15,41 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef EP_IMAGE_PNG_H
-#define EP_IMAGE_PNG_H
+#ifndef EP_FILESYSTEM_H
+#define EP_FILESYSTEM_H
 
-#include "system.h"
-#include "filesystem.h"
-
+// Headers
 #include <istream>
 #include <ostream>
+#include "system.h"
 
-namespace ImagePNG {
-	bool ReadPNG(const void* buffer, bool transparent, int& width, int& height, void*& pixels);
-	bool ReadPNG(Filesystem::InputStream& is, bool transparent, int& width, int& height, void*& pixels);
-	bool WritePNG(Filesystem::OutputStream& os, uint32_t width, uint32_t height, uint32_t* data);
-}
+class Filesystem {
+public:
+	class vfs_istream;
+	class vfs_ostream;
+
+	using InputStreamRaw = vfs_istream;
+	using OutputStreamRaw = vfs_ostream;
+
+	using InputStream = std::shared_ptr<InputStreamRaw>;
+	using OutputStream = std::shared_ptr<OutputStreamRaw>;
+
+	class vfs_istream : public std::istream {
+	public:
+		explicit vfs_istream(std::streambuf* sb, std::streamsize size);
+		~vfs_istream() override;
+
+		std::streamsize get_size() const;
+
+	private:
+		std::streamsize size;
+	};
+
+	class vfs_ostream : public std::ostream {
+	public:
+		explicit vfs_ostream(std::streambuf *sb);
+		~vfs_ostream() override;
+	};
+};
 
 #endif

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -19,6 +19,7 @@
 #define EP_FILESYSTEM_H
 
 // Headers
+#include <cassert>
 #include <istream>
 #include <ostream>
 #include "system.h"
@@ -50,6 +51,38 @@ public:
 		explicit vfs_ostream(std::streambuf *sb);
 		~vfs_ostream() override;
 	};
+
+	static constexpr std::ios_base::seekdir CSeekdirToCppSeekdir(int origin);
+
+	static constexpr int CppSeekdirToCSeekdir(std::ios_base::seekdir origin);
 };
+
+constexpr std::ios_base::seekdir Filesystem::CSeekdirToCppSeekdir(int origin) {
+	switch (origin) {
+		case SEEK_SET:
+			return std::ios_base::beg;
+		case SEEK_CUR:
+			return std::ios_base::cur;
+		case SEEK_END:
+			return std::ios_base::end;
+		default:
+			assert(false);
+			return std::ios_base::beg;
+	}
+}
+
+constexpr int Filesystem::CppSeekdirToCSeekdir(std::ios_base::seekdir origin) {
+	switch (origin) {
+		case std::ios_base::beg:
+			return SEEK_SET;
+		case std::ios_base::cur:
+			return SEEK_CUR;
+		case std::ios_base::end:
+			return SEEK_END;
+		default:
+			assert(false);
+			return SEEK_SET;
+	}
+}
 
 #endif

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -18,71 +18,12 @@
 #ifndef EP_FILESYSTEM_H
 #define EP_FILESYSTEM_H
 
-// Headers
-#include <cassert>
-#include <istream>
-#include <ostream>
-#include "system.h"
+#include "filesystem_stream.h"
 
 class Filesystem {
 public:
-	class vfs_istream;
-	class vfs_ostream;
-
-	using InputStreamRaw = vfs_istream;
-	using OutputStreamRaw = vfs_ostream;
-
-	using InputStream = std::shared_ptr<InputStreamRaw>;
-	using OutputStream = std::shared_ptr<OutputStreamRaw>;
-
-	class vfs_istream : public std::istream {
-	public:
-		explicit vfs_istream(std::streambuf* sb, std::streamsize size);
-		~vfs_istream() override;
-
-		std::streamsize get_size() const;
-
-	private:
-		std::streamsize size;
-	};
-
-	class vfs_ostream : public std::ostream {
-	public:
-		explicit vfs_ostream(std::streambuf *sb);
-		~vfs_ostream() override;
-	};
-
-	static constexpr std::ios_base::seekdir CSeekdirToCppSeekdir(int origin);
-
-	static constexpr int CppSeekdirToCSeekdir(std::ios_base::seekdir origin);
+	// empty for now
+	// impl in further PR
 };
-
-constexpr std::ios_base::seekdir Filesystem::CSeekdirToCppSeekdir(int origin) {
-	switch (origin) {
-		case SEEK_SET:
-			return std::ios_base::beg;
-		case SEEK_CUR:
-			return std::ios_base::cur;
-		case SEEK_END:
-			return std::ios_base::end;
-		default:
-			assert(false);
-			return std::ios_base::beg;
-	}
-}
-
-constexpr int Filesystem::CppSeekdirToCSeekdir(std::ios_base::seekdir origin) {
-	switch (origin) {
-		case std::ios_base::beg:
-			return SEEK_SET;
-		case std::ios_base::cur:
-			return SEEK_CUR;
-		case std::ios_base::end:
-			return SEEK_END;
-		default:
-			assert(false);
-			return SEEK_SET;
-	}
-}
 
 #endif

--- a/src/filesystem_stream.h
+++ b/src/filesystem_stream.h
@@ -28,7 +28,7 @@ namespace Filesystem_Stream {
 	class InputStream final : public std::istream {
 	public:
 		explicit InputStream(): std::istream(nullptr) {}
-		explicit InputStream(std::streambuf* sb, std::streamsize size) : std::istream(sb), size(size) {}
+		explicit InputStream(std::streambuf* sb) : std::istream(sb) {}
 		~InputStream() override {
 			delete rdbuf();
 		}
@@ -37,20 +37,14 @@ namespace Filesystem_Stream {
 		InputStream(InputStream&& is) : std::istream(std::move(is)) {
 			set_rdbuf(is.rdbuf());
 			is.set_rdbuf(nullptr);
-			size = is.size;
-			is.size = 0;
 		}
 		InputStream& operator=(InputStream&& is) {
 			if (this == &is) return is;
 			std::istream::operator=(std::move(is));
 			set_rdbuf(is.rdbuf());
 			is.set_rdbuf(nullptr);
-			size = is.size;
-			is.size = 0;
 			return is;
 		}
-
-		std::streamsize GetSize() const;
 
 		template <typename T>
 		bool ReadIntoObj(T& obj);
@@ -58,8 +52,6 @@ namespace Filesystem_Stream {
 	private:
 		template <typename T>
 		bool Read0(T& obj);
-
-		std::streamsize size = 0;
 	};
 
 	class OutputStream final : public std::ostream {
@@ -88,10 +80,6 @@ namespace Filesystem_Stream {
 
 	static constexpr int CppSeekdirToCSeekdir(std::ios_base::seekdir origin);
 };
-
-inline std::streamsize Filesystem_Stream::InputStream::GetSize() const {
-	return size;
-}
 
 template<typename T>
 inline bool Filesystem_Stream::InputStream::Read0(T& obj) {

--- a/src/filesystem_stream.h
+++ b/src/filesystem_stream.h
@@ -1,0 +1,166 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_FILESYSTEM_STREAM_H
+#define EP_FILESYSTEM_STREAM_H
+
+// Headers
+#include <cassert>
+#include <istream>
+#include <ostream>
+#include "utils.h"
+
+namespace Filesystem_Stream {
+	class InputStream final : public std::istream {
+	public:
+		explicit InputStream(): std::istream(nullptr) {}
+		explicit InputStream(std::streambuf* sb, std::streamsize size) : std::istream(sb), size(size) {}
+		~InputStream() override {
+			delete rdbuf();
+		}
+		InputStream(const InputStream&) = delete;
+		InputStream& operator=(const InputStream&) = delete;
+		InputStream(InputStream&& is) : std::istream(std::move(is)) {
+			set_rdbuf(is.rdbuf());
+			is.set_rdbuf(nullptr);
+			size = is.size;
+			is.size = 0;
+		}
+		InputStream& operator=(InputStream&& is) {
+			if (this == &is) return is;
+			std::istream::operator=(std::move(is));
+			set_rdbuf(is.rdbuf());
+			is.set_rdbuf(nullptr);
+			size = is.size;
+			is.size = 0;
+			return is;
+		}
+
+		std::streamsize GetSize() const;
+
+		template <typename T>
+		bool ReadIntoObj(T& obj);
+
+	private:
+		template <typename T>
+		bool Read0(T& obj);
+
+		std::streamsize size = 0;
+	};
+
+	class OutputStream final : public std::ostream {
+	public:
+		explicit OutputStream(): std::ostream(nullptr) {}
+		explicit OutputStream(std::streambuf* sb) : std::ostream(sb) {};
+		~OutputStream() override {
+			delete rdbuf();
+		}
+		OutputStream(const OutputStream&) = delete;
+		OutputStream& operator=(const OutputStream&) = delete;
+		OutputStream(OutputStream&& os) noexcept : std::ostream(std::move(os)) {
+			set_rdbuf(os.rdbuf());
+			os.set_rdbuf(nullptr);
+		}
+		OutputStream& operator=(OutputStream&& os) noexcept {
+			if (this == &os) return os;
+			std::ostream::operator=(std::move(os));
+			set_rdbuf(os.rdbuf());
+			os.set_rdbuf(nullptr);
+			return os;
+		}
+	};
+
+	static constexpr std::ios_base::seekdir CSeekdirToCppSeekdir(int origin);
+
+	static constexpr int CppSeekdirToCSeekdir(std::ios_base::seekdir origin);
+};
+
+inline std::streamsize Filesystem_Stream::InputStream::GetSize() const {
+	return size;
+}
+
+template<typename T>
+inline bool Filesystem_Stream::InputStream::Read0(T& obj) {
+	return read(reinterpret_cast<char*>(&obj), sizeof(obj)).gcount() == sizeof(obj);
+}
+
+template<typename T>
+inline bool Filesystem_Stream::InputStream::ReadIntoObj(T& obj) {
+	return Read0(obj);
+}
+
+template <>
+inline bool Filesystem_Stream::InputStream::ReadIntoObj(int16_t& obj) {
+	bool success = Read0(obj);
+	uint16_t uobj = obj;
+	Utils::SwapByteOrder(uobj);
+	obj = uobj;
+	return success;
+}
+
+template <>
+inline bool Filesystem_Stream::InputStream::ReadIntoObj(uint16_t& obj) {
+	bool success = Read0(obj);
+	Utils::SwapByteOrder(obj);
+	return success;
+}
+
+template <>
+inline bool Filesystem_Stream::InputStream::ReadIntoObj(int32_t& obj) {
+	bool success = Read0(obj);
+	uint32_t uobj = obj;
+	Utils::SwapByteOrder(uobj);
+	obj = uobj;
+	return success;
+}
+
+template <>
+inline bool Filesystem_Stream::InputStream::ReadIntoObj(uint32_t& obj) {
+	bool success = Read0(obj);
+	Utils::SwapByteOrder(obj);
+	return success;
+}
+
+constexpr std::ios_base::seekdir Filesystem_Stream::CSeekdirToCppSeekdir(int origin) {
+	switch (origin) {
+		case SEEK_SET:
+			return std::ios_base::beg;
+		case SEEK_CUR:
+			return std::ios_base::cur;
+		case SEEK_END:
+			return std::ios_base::end;
+		default:
+			assert(false);
+			return std::ios_base::beg;
+	}
+}
+
+constexpr int Filesystem_Stream::CppSeekdirToCSeekdir(std::ios_base::seekdir origin) {
+	switch (origin) {
+		case std::ios_base::beg:
+			return SEEK_SET;
+		case std::ios_base::cur:
+			return SEEK_CUR;
+		case std::ios_base::end:
+			return SEEK_END;
+		default:
+			assert(false);
+			return SEEK_SET;
+	}
+}
+
+#endif

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -285,10 +285,10 @@ void Game_Map::SetupCommon(int _id, bool is_load_savegame) {
 		}
 
 		auto map_stream = FileFinder::OpenInputStream(map_file);
-		map = lcf::LMU_Reader::Load(*map_stream, Player::encoding);
+		map = lcf::LMU_Reader::Load(map_stream, Player::encoding);
 	} else {
 		auto map_stream = FileFinder::OpenInputStream(map_file);
-		map = lcf::LMU_Reader::LoadXml(*map_stream);
+		map = lcf::LMU_Reader::LoadXml(map_stream);
 	}
 	Output::Debug("Loading Map {}", ss.str());
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -275,6 +275,7 @@ void Game_Map::SetupCommon(int _id, bool is_load_savegame) {
 	ss << "Map" << std::setfill('0') << std::setw(4) << location.map_id << ".emu";
 
 	std::string map_file = FileFinder::FindDefault(ss.str());
+	Output::Debug("Loading Map %s", ss.str().c_str());
 	if (map_file.empty()) {
 		ss.str("");
 		ss << "Map" << std::setfill('0') << std::setw(4) << location.map_id << ".lmu";
@@ -284,11 +285,12 @@ void Game_Map::SetupCommon(int _id, bool is_load_savegame) {
 			Output::Error("Loading of Map {} failed.\nThe map was not found.", ss.str());
 		}
 
-		map = lcf::LMU_Reader::Load(map_file, Player::encoding);
+		auto map_stream = FileFinder::openUTF8Input(map_file, std::ios::ios_base::in| std::ios::ios_base::binary);
+		map = lcf::LMU_Reader::Load(*map_stream, Player::encoding);
 	} else {
-		map = lcf::LMU_Reader::LoadXml(map_file);
+		auto map_stream = FileFinder::openUTF8Input(map_file, std::ios::ios_base::in);
+		map = lcf::LMU_Reader::LoadXml(*map_stream);
 	}
-
 	Output::Debug("Loading Map {}", ss.str());
 
 	if (map.get() == NULL) {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -285,10 +285,10 @@ void Game_Map::SetupCommon(int _id, bool is_load_savegame) {
 			Output::Error("Loading of Map {} failed.\nThe map was not found.", ss.str());
 		}
 
-		auto map_stream = FileFinder::openUTF8Input(map_file, std::ios::ios_base::in| std::ios::ios_base::binary);
+		auto map_stream = FileFinder::OpenInputStream(map_file, std::ios::ios_base::in| std::ios::ios_base::binary);
 		map = lcf::LMU_Reader::Load(*map_stream, Player::encoding);
 	} else {
-		auto map_stream = FileFinder::openUTF8Input(map_file, std::ios::ios_base::in);
+		auto map_stream = FileFinder::OpenInputStream(map_file, std::ios::ios_base::in);
 		map = lcf::LMU_Reader::LoadXml(*map_stream);
 	}
 	Output::Debug("Loading Map {}", ss.str());

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -275,7 +275,6 @@ void Game_Map::SetupCommon(int _id, bool is_load_savegame) {
 	ss << "Map" << std::setfill('0') << std::setw(4) << location.map_id << ".emu";
 
 	std::string map_file = FileFinder::FindDefault(ss.str());
-	Output::Debug("Loading Map %s", ss.str().c_str());
 	if (map_file.empty()) {
 		ss.str("");
 		ss << "Map" << std::setfill('0') << std::setw(4) << location.map_id << ".lmu";
@@ -285,10 +284,10 @@ void Game_Map::SetupCommon(int _id, bool is_load_savegame) {
 			Output::Error("Loading of Map {} failed.\nThe map was not found.", ss.str());
 		}
 
-		auto map_stream = FileFinder::OpenInputStream(map_file, std::ios::ios_base::in| std::ios::ios_base::binary);
+		auto map_stream = FileFinder::OpenInputStream(map_file);
 		map = lcf::LMU_Reader::Load(*map_stream, Player::encoding);
 	} else {
-		auto map_stream = FileFinder::OpenInputStream(map_file, std::ios::ios_base::in);
+		auto map_stream = FileFinder::OpenInputStream(map_file);
 		map = lcf::LMU_Reader::LoadXml(*map_stream);
 	}
 	Output::Debug("Loading Map {}", ss.str());

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -470,7 +470,7 @@ void Game_System::OnBgmReady(FileRequestResult* result) {
 
 	if (Utils::EndsWith(result->file, ".link")) {
 		// Handle Ineluki's MP3 patch
-		std::shared_ptr<std::istream> stream = FileFinder::openUTF8Input(path, std::ios_base::in);
+		auto stream = FileFinder::OpenInputStream(path, std::ios_base::in);
 		if (!stream) {
 			Output::Warning("Ineluki link read error: {}", path);
 			return;

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -477,7 +477,7 @@ void Game_System::OnBgmReady(FileRequestResult* result) {
 		}
 
 		// The first line contains the path to the actual audio file to play
-		std::string line = Utils::ReadLine(*stream.get());
+		std::string line = Utils::ReadLine(stream);
 		line = lcf::ReaderUtil::Recode(line, Player::encoding);
 
 		Output::Debug("Ineluki link file: {} -> {}", path, line);

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -470,7 +470,7 @@ void Game_System::OnBgmReady(FileRequestResult* result) {
 
 	if (Utils::EndsWith(result->file, ".link")) {
 		// Handle Ineluki's MP3 patch
-		std::shared_ptr<std::fstream> stream = FileFinder::openUTF8(path, std::ios_base::in);
+		std::shared_ptr<std::istream> stream = FileFinder::openUTF8Input(path, std::ios_base::in);
 		if (!stream) {
 			Output::Warning("Ineluki link read error: {}", path);
 			return;

--- a/src/image_bmp.cpp
+++ b/src/image_bmp.cpp
@@ -190,13 +190,13 @@ bool ImageBMP::ReadBMP(const uint8_t* data, unsigned len, bool transparent,
 	return true;
 }
 
-bool ImageBMP::ReadBMP(FILE* stream, bool transparent,
+bool ImageBMP::ReadBMP(std::istream& stream, bool transparent,
 					int& width, int& height, void*& pixels) {
-	fseek(stream, 0, SEEK_END);
-	long size = ftell(stream);
-	fseek(stream, 0, SEEK_SET);
+	stream.seekg(0, std::ios::ios_base::end);
+	long size = stream.tellg();
+	stream.seekg(0, std::ios::ios_base::beg);
 	std::vector<uint8_t> buffer(size);
-	long size_read = fread((void*) &buffer.front(), 1, size, stream);
+	long size_read = stream.read(reinterpret_cast<char*>(&buffer.front()), size).gcount();
 	if (size_read != size) {
 		Output::Warning("Error reading BMP file.");
 		return false;

--- a/src/image_bmp.cpp
+++ b/src/image_bmp.cpp
@@ -190,11 +190,11 @@ bool ImageBMP::ReadBMP(const uint8_t* data, unsigned len, bool transparent,
 	return true;
 }
 
-bool ImageBMP::ReadBMP(FileFinder::istream & stream, bool transparent,
+bool ImageBMP::ReadBMP(Filesystem::InputStream& stream, bool transparent,
 					int& width, int& height, void*& pixels) {
-	long size =stream.get_size();
+	long size = stream->get_size();
 	std::vector<uint8_t> buffer(size);
-	long size_read = stream.read(reinterpret_cast<char*>(&buffer.front()), size).gcount();
+	long size_read = stream->read(reinterpret_cast<char*>(&buffer.front()), size).gcount();
 	if (size_read != size) {
 		Output::Warning("Error reading BMP file.");
 		return false;

--- a/src/image_bmp.cpp
+++ b/src/image_bmp.cpp
@@ -192,12 +192,6 @@ bool ImageBMP::ReadBMP(const uint8_t* data, unsigned len, bool transparent,
 
 bool ImageBMP::ReadBMP(Filesystem_Stream::InputStream& stream, bool transparent,
 					int& width, int& height, void*& pixels) {
-	long size = stream.GetSize();
-	std::vector<uint8_t> buffer(size);
-	long size_read = stream.read(reinterpret_cast<char*>(&buffer.front()), size).gcount();
-	if (size_read != size) {
-		Output::Warning("Error reading BMP file.");
-		return false;
-	}
-	return ReadBMP(&buffer.front(), (unsigned) size, transparent, width, height, pixels);
+	std::vector<uint8_t> buffer = Utils::ReadStream(stream);
+	return ReadBMP(&buffer.front(), (unsigned) buffer.size(), transparent, width, height, pixels);
 }

--- a/src/image_bmp.cpp
+++ b/src/image_bmp.cpp
@@ -190,11 +190,9 @@ bool ImageBMP::ReadBMP(const uint8_t* data, unsigned len, bool transparent,
 	return true;
 }
 
-bool ImageBMP::ReadBMP(std::istream& stream, bool transparent,
+bool ImageBMP::ReadBMP(FileFinder::istream & stream, bool transparent,
 					int& width, int& height, void*& pixels) {
-	stream.seekg(0, std::ios::ios_base::end);
-	long size = stream.tellg();
-	stream.seekg(0, std::ios::ios_base::beg);
+	long size =stream.get_size();
 	std::vector<uint8_t> buffer(size);
 	long size_read = stream.read(reinterpret_cast<char*>(&buffer.front()), size).gcount();
 	if (size_read != size) {

--- a/src/image_bmp.cpp
+++ b/src/image_bmp.cpp
@@ -190,11 +190,11 @@ bool ImageBMP::ReadBMP(const uint8_t* data, unsigned len, bool transparent,
 	return true;
 }
 
-bool ImageBMP::ReadBMP(Filesystem::InputStream& stream, bool transparent,
+bool ImageBMP::ReadBMP(Filesystem_Stream::InputStream& stream, bool transparent,
 					int& width, int& height, void*& pixels) {
-	long size = stream->get_size();
+	long size = stream.GetSize();
 	std::vector<uint8_t> buffer(size);
-	long size_read = stream->read(reinterpret_cast<char*>(&buffer.front()), size).gcount();
+	long size_read = stream.read(reinterpret_cast<char*>(&buffer.front()), size).gcount();
 	if (size_read != size) {
 		Output::Warning("Error reading BMP file.");
 		return false;

--- a/src/image_bmp.h
+++ b/src/image_bmp.h
@@ -18,11 +18,14 @@
 #ifndef EP_IMAGE_BMP_H
 #define EP_IMAGE_BMP_H
 
+#include "system.h"
+#include "filefinder.h"
+
 #include <istream>
 
 namespace ImageBMP {
 	bool ReadBMP(const uint8_t* data, unsigned len, bool transparent, int& width, int& height, void*& pixels);
-	bool ReadBMP(std::istream& stream, bool transparent, int& width, int& height, void*& pixels);
+	bool ReadBMP(FileFinder::istream & stream, bool transparent, int& width, int& height, void*& pixels);
 }
 
 #endif

--- a/src/image_bmp.h
+++ b/src/image_bmp.h
@@ -18,10 +18,7 @@
 #ifndef EP_IMAGE_BMP_H
 #define EP_IMAGE_BMP_H
 
-#include "system.h"
 #include "filesystem.h"
-
-#include <istream>
 
 namespace ImageBMP {
 	bool ReadBMP(const uint8_t* data, unsigned len, bool transparent, int& width, int& height, void*& pixels);

--- a/src/image_bmp.h
+++ b/src/image_bmp.h
@@ -18,11 +18,11 @@
 #ifndef EP_IMAGE_BMP_H
 #define EP_IMAGE_BMP_H
 
-#include "filesystem.h"
+#include "filesystem_stream.h"
 
 namespace ImageBMP {
 	bool ReadBMP(const uint8_t* data, unsigned len, bool transparent, int& width, int& height, void*& pixels);
-	bool ReadBMP(Filesystem::InputStream& stream, bool transparent, int& width, int& height, void*& pixels);
+	bool ReadBMP(Filesystem_Stream::InputStream& stream, bool transparent, int& width, int& height, void*& pixels);
 }
 
 #endif

--- a/src/image_bmp.h
+++ b/src/image_bmp.h
@@ -19,13 +19,13 @@
 #define EP_IMAGE_BMP_H
 
 #include "system.h"
-#include "filefinder.h"
+#include "filesystem.h"
 
 #include <istream>
 
 namespace ImageBMP {
 	bool ReadBMP(const uint8_t* data, unsigned len, bool transparent, int& width, int& height, void*& pixels);
-	bool ReadBMP(FileFinder::istream & stream, bool transparent, int& width, int& height, void*& pixels);
+	bool ReadBMP(Filesystem::InputStream& stream, bool transparent, int& width, int& height, void*& pixels);
 }
 
 #endif

--- a/src/image_bmp.h
+++ b/src/image_bmp.h
@@ -18,11 +18,11 @@
 #ifndef EP_IMAGE_BMP_H
 #define EP_IMAGE_BMP_H
 
-#include <cstdio>
+#include <istream>
 
 namespace ImageBMP {
 	bool ReadBMP(const uint8_t* data, unsigned len, bool transparent, int& width, int& height, void*& pixels);
-	bool ReadBMP(FILE* stream, bool transparent, int& width, int& height, void*& pixels);
+	bool ReadBMP(std::istream& stream, bool transparent, int& width, int& height, void*& pixels);
 }
 
 #endif

--- a/src/image_png.cpp
+++ b/src/image_png.cpp
@@ -58,7 +58,7 @@ bool ImagePNG::ReadPNG(const void* buffer, bool transparent,
 	return ReadPNGWithReadFunction((png_voidp)&buffer, read_data, transparent, width, height, pixels);
 }
 
-bool ImagePNG::ReadPNG(std::istream& stream, bool transparent,
+bool ImagePNG::ReadPNG(FileFinder::istream & stream, bool transparent,
 	int& width, int& height, void*& pixels) {
 	return ReadPNGWithReadFunction(&stream, read_data_istream, transparent, width, height, pixels);
 }

--- a/src/image_png.cpp
+++ b/src/image_png.cpp
@@ -33,7 +33,7 @@ static void read_data(png_structp png_ptr, png_bytep data, png_size_t length) {
 
 static void read_data_istream(png_structp png_ptr, png_bytep data, png_size_t length) {
 	auto* bufp = reinterpret_cast<Filesystem_Stream::InputStream*>(png_get_io_ptr(png_ptr));
-	if (bufp != NULL&&*bufp) {
+	if (bufp != nullptr && *bufp) {
 		bufp->read(reinterpret_cast<char*>(data), length);
 	}
 }

--- a/src/image_png.cpp
+++ b/src/image_png.cpp
@@ -32,7 +32,7 @@ static void read_data(png_structp png_ptr, png_bytep data, png_size_t length) {
 }
 
 static void read_data_istream(png_structp png_ptr, png_bytep data, png_size_t length) {
-	auto* bufp = reinterpret_cast<Filesystem::InputStreamRaw*>(png_get_io_ptr(png_ptr));
+	auto* bufp = reinterpret_cast<Filesystem_Stream::InputStream*>(png_get_io_ptr(png_ptr));
 	if (bufp != NULL&&*bufp) {
 		bufp->read(reinterpret_cast<char*>(data), length);
 	}
@@ -58,9 +58,9 @@ bool ImagePNG::ReadPNG(const void* buffer, bool transparent,
 	return ReadPNGWithReadFunction((png_voidp)&buffer, read_data, transparent, width, height, pixels);
 }
 
-bool ImagePNG::ReadPNG(Filesystem::InputStream& stream, bool transparent,
+bool ImagePNG::ReadPNG(Filesystem_Stream::InputStream& stream, bool transparent,
 	int& width, int& height, void*& pixels) {
-	return ReadPNGWithReadFunction(stream.get(), read_data_istream, transparent, width, height, pixels);
+	return ReadPNGWithReadFunction(&stream, read_data_istream, transparent, width, height, pixels);
 }
 
 static bool ReadPNGWithReadFunction(png_voidp user_data, png_rw_ptr fn, bool transparent,
@@ -244,13 +244,13 @@ static void ReadRGBAData(
 }
 
 static void write_data(png_structp out_ptr, png_bytep data, png_size_t len) {
-	reinterpret_cast<Filesystem::OutputStreamRaw*>(png_get_io_ptr(out_ptr))->write(reinterpret_cast<char const*>(data), len);
+	reinterpret_cast<Filesystem_Stream::OutputStream*>(png_get_io_ptr(out_ptr))->write(reinterpret_cast<char const*>(data), len);
 }
 static void flush_stream(png_structp out_ptr) {
-	reinterpret_cast<Filesystem::OutputStreamRaw*>(png_get_io_ptr(out_ptr))->flush();
+	reinterpret_cast<Filesystem_Stream::OutputStream*>(png_get_io_ptr(out_ptr))->flush();
 }
 
-bool ImagePNG::WritePNG(Filesystem::OutputStream& os, uint32_t width, uint32_t height, uint32_t* data) {
+bool ImagePNG::WritePNG(Filesystem_Stream::OutputStream& os, uint32_t width, uint32_t height, uint32_t* data) {
 	png_structp write = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
 	if (!write) {
 		Output::Warning("Bitmap::WritePNG: error in png_create_write");
@@ -276,7 +276,7 @@ bool ImagePNG::WritePNG(Filesystem::OutputStream& os, uint32_t width, uint32_t h
 		return false;
 	}
 
-	png_set_write_fn(write, os.get(), &write_data, &flush_stream);
+	png_set_write_fn(write, &os, &write_data, &flush_stream);
 
 	png_set_IHDR(write, info, width, height, 8,
 				 PNG_COLOR_TYPE_RGB, PNG_INTERLACE_NONE,

--- a/src/image_png.h
+++ b/src/image_png.h
@@ -18,11 +18,7 @@
 #ifndef EP_IMAGE_PNG_H
 #define EP_IMAGE_PNG_H
 
-#include "system.h"
 #include "filesystem.h"
-
-#include <istream>
-#include <ostream>
 
 namespace ImagePNG {
 	bool ReadPNG(const void* buffer, bool transparent, int& width, int& height, void*& pixels);

--- a/src/image_png.h
+++ b/src/image_png.h
@@ -18,11 +18,12 @@
 #ifndef EP_IMAGE_PNG_H
 #define EP_IMAGE_PNG_H
 
-#include <cstdio>
+#include <istream>
 #include <ostream>
 
 namespace ImagePNG {
-	bool ReadPNG(FILE* stream, const void* buffer, bool transparent, int& width, int& height, void*& pixels);
+	bool ReadPNG(const void* buffer, bool transparent, int& width, int& height, void*& pixels);
+	bool ReadPNG(std::istream& is, bool transparent, int& width, int& height, void*& pixels);
 	bool WritePNG(std::ostream& os, uint32_t width, uint32_t height, uint32_t* data);
 }
 

--- a/src/image_png.h
+++ b/src/image_png.h
@@ -18,12 +18,15 @@
 #ifndef EP_IMAGE_PNG_H
 #define EP_IMAGE_PNG_H
 
+#include "system.h"
+#include "filefinder.h"
+
 #include <istream>
 #include <ostream>
 
 namespace ImagePNG {
 	bool ReadPNG(const void* buffer, bool transparent, int& width, int& height, void*& pixels);
-	bool ReadPNG(std::istream& is, bool transparent, int& width, int& height, void*& pixels);
+	bool ReadPNG(FileFinder::istream & is, bool transparent, int& width, int& height, void*& pixels);
 	bool WritePNG(std::ostream& os, uint32_t width, uint32_t height, uint32_t* data);
 }
 

--- a/src/image_png.h
+++ b/src/image_png.h
@@ -18,12 +18,12 @@
 #ifndef EP_IMAGE_PNG_H
 #define EP_IMAGE_PNG_H
 
-#include "filesystem.h"
+#include "filesystem_stream.h"
 
 namespace ImagePNG {
 	bool ReadPNG(const void* buffer, bool transparent, int& width, int& height, void*& pixels);
-	bool ReadPNG(Filesystem::InputStream& is, bool transparent, int& width, int& height, void*& pixels);
-	bool WritePNG(Filesystem::OutputStream& os, uint32_t width, uint32_t height, uint32_t* data);
+	bool ReadPNG(Filesystem_Stream::InputStream& is, bool transparent, int& width, int& height, void*& pixels);
+	bool WritePNG(Filesystem_Stream::OutputStream& os, uint32_t width, uint32_t height, uint32_t* data);
 }
 
 #endif

--- a/src/image_xyz.cpp
+++ b/src/image_xyz.cpp
@@ -71,11 +71,9 @@ bool ImageXYZ::ReadXYZ(const uint8_t* data, unsigned len, bool transparent,
 	return true;
 }
 
-bool ImageXYZ::ReadXYZ(std::istream& stream, bool transparent,
+bool ImageXYZ::ReadXYZ(FileFinder::istream& stream, bool transparent,
 					   int& width, int& height, void*& pixels) {
-	stream.seekg(0, std::ios::ios_base::end);
-	long size = stream.tellg();
-	stream.seekg(0, std::ios::ios_base::beg);
+	long size = stream.get_size();
 	std::vector<uint8_t> buffer(size);
 	long size_read = stream.read(reinterpret_cast<char*>(&buffer.front()), size).gcount();
 	if (size_read != size) {

--- a/src/image_xyz.cpp
+++ b/src/image_xyz.cpp
@@ -71,11 +71,11 @@ bool ImageXYZ::ReadXYZ(const uint8_t* data, unsigned len, bool transparent,
 	return true;
 }
 
-bool ImageXYZ::ReadXYZ(Filesystem::InputStream& stream, bool transparent,
+bool ImageXYZ::ReadXYZ(Filesystem_Stream::InputStream& stream, bool transparent,
 					   int& width, int& height, void*& pixels) {
-	long size = stream->get_size();
+	long size = stream.GetSize();
 	std::vector<uint8_t> buffer(size);
-	long size_read = stream->read(reinterpret_cast<char*>(&buffer.front()), size).gcount();
+	long size_read = stream.read(reinterpret_cast<char*>(&buffer.front()), size).gcount();
 	if (size_read != size) {
 		Output::Warning("Error reading XYZ file.");
 		return false;

--- a/src/image_xyz.cpp
+++ b/src/image_xyz.cpp
@@ -73,12 +73,6 @@ bool ImageXYZ::ReadXYZ(const uint8_t* data, unsigned len, bool transparent,
 
 bool ImageXYZ::ReadXYZ(Filesystem_Stream::InputStream& stream, bool transparent,
 					   int& width, int& height, void*& pixels) {
-	long size = stream.GetSize();
-	std::vector<uint8_t> buffer(size);
-	long size_read = stream.read(reinterpret_cast<char*>(buffer.data()), size).gcount();
-	if (size_read != size) {
-		Output::Warning("Error reading XYZ file.");
-		return false;
-	}
-	return ReadXYZ(&buffer.front(), (unsigned) size, transparent, width, height, pixels);
+	std::vector<uint8_t> buffer = Utils::ReadStream(stream);
+	return ReadXYZ(&buffer.front(), (unsigned) buffer.size(), transparent, width, height, pixels);
 }

--- a/src/image_xyz.cpp
+++ b/src/image_xyz.cpp
@@ -75,7 +75,7 @@ bool ImageXYZ::ReadXYZ(Filesystem_Stream::InputStream& stream, bool transparent,
 					   int& width, int& height, void*& pixels) {
 	long size = stream.GetSize();
 	std::vector<uint8_t> buffer(size);
-	long size_read = stream.read(reinterpret_cast<char*>(&buffer.front()), size).gcount();
+	long size_read = stream.read(reinterpret_cast<char*>(buffer.data()), size).gcount();
 	if (size_read != size) {
 		Output::Warning("Error reading XYZ file.");
 		return false;

--- a/src/image_xyz.cpp
+++ b/src/image_xyz.cpp
@@ -71,11 +71,11 @@ bool ImageXYZ::ReadXYZ(const uint8_t* data, unsigned len, bool transparent,
 	return true;
 }
 
-bool ImageXYZ::ReadXYZ(FileFinder::istream& stream, bool transparent,
+bool ImageXYZ::ReadXYZ(Filesystem::InputStream& stream, bool transparent,
 					   int& width, int& height, void*& pixels) {
-	long size = stream.get_size();
+	long size = stream->get_size();
 	std::vector<uint8_t> buffer(size);
-	long size_read = stream.read(reinterpret_cast<char*>(&buffer.front()), size).gcount();
+	long size_read = stream->read(reinterpret_cast<char*>(&buffer.front()), size).gcount();
 	if (size_read != size) {
 		Output::Warning("Error reading XYZ file.");
 		return false;

--- a/src/image_xyz.cpp
+++ b/src/image_xyz.cpp
@@ -18,6 +18,7 @@
 // Headers
 #include <cstdlib>
 #include <cstring>
+#include <istream>
 #include <zlib.h>
 #include <vector>
 #include "output.h"
@@ -70,13 +71,13 @@ bool ImageXYZ::ReadXYZ(const uint8_t* data, unsigned len, bool transparent,
 	return true;
 }
 
-bool ImageXYZ::ReadXYZ(FILE* stream, bool transparent,
+bool ImageXYZ::ReadXYZ(std::istream& stream, bool transparent,
 					   int& width, int& height, void*& pixels) {
-	fseek(stream, 0, SEEK_END);
-	long size = ftell(stream);
-	fseek(stream, 0, SEEK_SET);
+	stream.seekg(0, std::ios::ios_base::end);
+	long size = stream.tellg();
+	stream.seekg(0, std::ios::ios_base::beg);
 	std::vector<uint8_t> buffer(size);
-	long size_read = fread((void*) &buffer.front(), 1, size, stream);
+	long size_read = stream.read(reinterpret_cast<char*>(&buffer.front()), size).gcount();
 	if (size_read != size) {
 		Output::Warning("Error reading XYZ file.");
 		return false;

--- a/src/image_xyz.h
+++ b/src/image_xyz.h
@@ -19,10 +19,12 @@
 #define EP_IMAGE_XYZ_H
 
 #include <cstdio>
+#include "filefinder.h"
+#include "system.h"
 
 namespace ImageXYZ {
 	bool ReadXYZ(const uint8_t* data, unsigned len, bool transparent, int& width, int& height, void*& pixels);
-	bool ReadXYZ(std::istream & stream, bool transparent, int& width, int& height, void*& pixels);
+	bool ReadXYZ(FileFinder::istream & stream, bool transparent, int& width, int& height, void*& pixels);
 }
 
 #endif

--- a/src/image_xyz.h
+++ b/src/image_xyz.h
@@ -19,11 +19,11 @@
 #define EP_IMAGE_XYZ_H
 
 #include <cstdio>
-#include "filesystem.h"
+#include "filesystem_stream.h"
 
 namespace ImageXYZ {
 	bool ReadXYZ(const uint8_t* data, unsigned len, bool transparent, int& width, int& height, void*& pixels);
-	bool ReadXYZ(Filesystem::InputStream& stream, bool transparent, int& width, int& height, void*& pixels);
+	bool ReadXYZ(Filesystem_Stream::InputStream& stream, bool transparent, int& width, int& height, void*& pixels);
 }
 
 #endif

--- a/src/image_xyz.h
+++ b/src/image_xyz.h
@@ -22,7 +22,7 @@
 
 namespace ImageXYZ {
 	bool ReadXYZ(const uint8_t* data, unsigned len, bool transparent, int& width, int& height, void*& pixels);
-	bool ReadXYZ(FILE* stream, bool transparent, int& width, int& height, void*& pixels);
+	bool ReadXYZ(std::istream & stream, bool transparent, int& width, int& height, void*& pixels);
 }
 
 #endif

--- a/src/image_xyz.h
+++ b/src/image_xyz.h
@@ -20,7 +20,6 @@
 
 #include <cstdio>
 #include "filesystem.h"
-#include "system.h"
 
 namespace ImageXYZ {
 	bool ReadXYZ(const uint8_t* data, unsigned len, bool transparent, int& width, int& height, void*& pixels);

--- a/src/image_xyz.h
+++ b/src/image_xyz.h
@@ -19,12 +19,12 @@
 #define EP_IMAGE_XYZ_H
 
 #include <cstdio>
-#include "filefinder.h"
+#include "filesystem.h"
 #include "system.h"
 
 namespace ImageXYZ {
 	bool ReadXYZ(const uint8_t* data, unsigned len, bool transparent, int& width, int& height, void*& pixels);
-	bool ReadXYZ(FileFinder::istream & stream, bool transparent, int& width, int& height, void*& pixels);
+	bool ReadXYZ(Filesystem::InputStream& stream, bool transparent, int& width, int& height, void*& pixels);
 }
 
 #endif

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -57,10 +57,10 @@ bool Input::IsWaitingInput() { return wait_input; }
 void Input::WaitInput(bool v) { wait_input = v; }
 
 void Input::Init(
-	ButtonMappingArray buttons,
-	DirectionMappingArray directions,
-	const std::string& replay_from_path,
-	const std::string& record_to_path
+		ButtonMappingArray buttons,
+		DirectionMappingArray directions,
+		const std::string& replay_from_path,
+		const std::string& record_to_path
 ) {
 	std::fill(press_time.begin(), press_time.end(), 0);
 	triggered.reset();

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -57,10 +57,10 @@ bool Input::IsWaitingInput() { return wait_input; }
 void Input::WaitInput(bool v) { wait_input = v; }
 
 void Input::Init(
-		ButtonMappingArray buttons,
-		DirectionMappingArray directions,
-		const std::string& replay_from_path,
-		const std::string& record_to_path
+	ButtonMappingArray buttons,
+	DirectionMappingArray directions,
+	const std::string& replay_from_path,
+	const std::string& record_to_path
 ) {
 	std::fill(press_time.begin(), press_time.end(), 0);
 	triggered.reset();

--- a/src/input_source.cpp
+++ b/src/input_source.cpp
@@ -74,7 +74,7 @@ Input::LogSource::LogSource(const char* log_path, ButtonMappingArray buttons, Di
 {}
 
 void Input::LogSource::Update() {
-	*log_file >> pressed_buttons;
+	log_file >> pressed_buttons;
 
 	if (!log_file) {
 		Player::exit_flag = true;
@@ -88,7 +88,7 @@ bool Input::Source::InitRecording(const std::string& record_to_path) {
 	if (!record_to_path.empty()) {
 		auto path = record_to_path.c_str();
 
-		record_log = FileFinder::OpenOutputStream(path, std::ios::out | std::ios::trunc);
+		record_log = std::make_unique<Filesystem_Stream::OutputStream>(FileFinder::OpenOutputStream(path, std::ios::out | std::ios::trunc));
 
 		if (!record_log) {
 			Output::Warning("Failed to open file {} for input recording : {}", path, strerror(errno));

--- a/src/input_source.cpp
+++ b/src/input_source.cpp
@@ -70,11 +70,11 @@ void Input::UiSource::UpdateSystem() {
 
 Input::LogSource::LogSource(const char* log_path, ButtonMappingArray buttons, DirectionMappingArray directions)
 	: Source(std::move(buttons), std::move(directions)),
-	log_file(log_path, std::ios::in)
+	log_file(FileFinder::OpenInputStream(log_path, std::ios::in))
 {}
 
 void Input::LogSource::Update() {
-	log_file >> pressed_buttons;
+	*log_file >> pressed_buttons;
 
 	if (!log_file) {
 		Player::exit_flag = true;
@@ -88,7 +88,7 @@ bool Input::Source::InitRecording(const std::string& record_to_path) {
 	if (!record_to_path.empty()) {
 		auto path = record_to_path.c_str();
 
-		record_log.open(path, std::ios::out|std::ios::trunc);
+		record_log = FileFinder::OpenOutputStream(path, std::ios::out | std::ios::trunc);
 
 		if (!record_log) {
 			Output::Warning("Failed to open file {} for input recording : {}", path, strerror(errno));
@@ -99,8 +99,8 @@ bool Input::Source::InitRecording(const std::string& record_to_path) {
 }
 
 void Input::Source::Record() {
-	if (record_log.is_open()) {
-		record_log << GetPressedNonSystemButtons() << '\n';
+	if (record_log) {
+		*record_log << GetPressedNonSystemButtons() << '\n';
 	}
 }
 

--- a/src/input_source.h
+++ b/src/input_source.h
@@ -21,7 +21,7 @@
 #include <bitset>
 #include <fstream>
 #include <memory>
-#include <fstream>
+#include "filesystem.h"
 #include "input_buttons.h"
 
 namespace Input {
@@ -74,7 +74,7 @@ namespace Input {
 		std::bitset<BUTTON_COUNT> pressed_buttons;
 		ButtonMappingArray button_mappings;
 		DirectionMappingArray direction_mappings;
-		std::ofstream record_log;
+		Filesystem::OutputStream record_log;
 	};
 
 	/**
@@ -104,7 +104,7 @@ namespace Input {
 
 		operator bool() const { return bool(log_file); }
 	private:
-		std::ifstream log_file;
+		Filesystem::InputStream log_file;
 	};
 
 	extern std::unique_ptr<Source> source;

--- a/src/input_source.h
+++ b/src/input_source.h
@@ -21,7 +21,7 @@
 #include <bitset>
 #include <fstream>
 #include <memory>
-#include "filesystem.h"
+#include "filesystem_stream.h"
 #include "input_buttons.h"
 
 namespace Input {
@@ -74,7 +74,7 @@ namespace Input {
 		std::bitset<BUTTON_COUNT> pressed_buttons;
 		ButtonMappingArray button_mappings;
 		DirectionMappingArray direction_mappings;
-		Filesystem::OutputStream record_log;
+		std::unique_ptr<Filesystem_Stream::OutputStream> record_log;
 	};
 
 	/**
@@ -104,7 +104,7 @@ namespace Input {
 
 		operator bool() const { return bool(log_file); }
 	private:
-		Filesystem::InputStream log_file;
+		Filesystem_Stream::InputStream log_file;
 	};
 
 	extern std::unique_ptr<Source> source;

--- a/src/meta.cpp
+++ b/src/meta.cpp
@@ -52,7 +52,7 @@ std::string crc32file(std::string file_name) {
 	if (!file_name.empty()) {
 		auto in = FileFinder::OpenInputStream(file_name, std::ios::binary);
 		if (in) {
-			std::string buffer((std::istreambuf_iterator<char>(*in)), std::istreambuf_iterator<char>());
+			std::string buffer((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
 			unsigned long crc = ::crc32(0, reinterpret_cast<const unsigned char*>(buffer.c_str()), buffer.length());
 
 			std::stringstream res;

--- a/src/meta.cpp
+++ b/src/meta.cpp
@@ -50,9 +50,9 @@
 // Helper: Get the CRC32 of a given file as a hex string
 std::string crc32file(std::string file_name) {
 	if (!file_name.empty()) {
-		std::ifstream in(file_name.c_str(), std::ios::binary);
-		if (in.is_open()) {
-			std::string buffer((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+		auto in = FileFinder::OpenInputStream(file_name, std::ios::binary);
+		if (in) {
+			std::string buffer((std::istreambuf_iterator<char>(*in)), std::istreambuf_iterator<char>());
 			unsigned long crc = ::crc32(0, reinterpret_cast<const unsigned char*>(buffer.c_str()), buffer.length());
 
 			std::stringstream res;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -72,7 +72,7 @@ namespace {
 		return log_prefix[static_cast<int>(lvl)];
 	}
 
-	std::shared_ptr<std::ostream> LOG_FILE;
+	Filesystem::OutputStream LOG_FILE;
 	bool init = false;
 
 	std::ostream& output_time() {
@@ -83,7 +83,7 @@ namespace {
 		std::time_t t = std::time(NULL);
 		char timestr[100];
 		strftime(timestr, 100, "[%Y-%m-%d %H:%M:%S] ", std::localtime(&t));
-		return LOG_FILE << timestr;
+		return *LOG_FILE << timestr;
 	}
 
 	bool ignore_pause = false;
@@ -246,12 +246,11 @@ bool Output::TakeScreenshot() {
 }
 
 bool Output::TakeScreenshot(std::string const& file) {
-	std::shared_ptr<std::ostream> ret =
-		FileFinder::OpenOutputStream(file, std::ios_base::binary | std::ios_base::out | std::ios_base::trunc);
+	auto ret = FileFinder::OpenOutputStream(file, std::ios_base::binary | std::ios_base::out | std::ios_base::trunc);
 
 	if (ret) {
 		Output::Debug("Saving Screenshot {}", file);
-		return Output::TakeScreenshot(*ret);
+		return Output::TakeScreenshot(ret);
 	}
 	return false;
 }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -72,12 +72,12 @@ namespace {
 		return log_prefix[static_cast<int>(lvl)];
 	}
 
-	std::ofstream LOG_FILE;
+	std::shared_ptr<std::ostream> LOG_FILE;
 	bool init = false;
 
 	std::ostream& output_time() {
 		if (!init) {
-			LOG_FILE.open(FileFinder::MakePath(Main_Data::GetSavePath(), OUTPUT_FILENAME).c_str(), std::ios_base::out | std::ios_base::app);
+			LOG_FILE=FileFinder::openUTF8Output(FileFinder::MakePath(Main_Data::GetSavePath(), OUTPUT_FILENAME).c_str(), std::ios_base::out | std::ios_base::app);
 			init = true;
 		}
 		std::time_t t = std::time(NULL);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -213,8 +213,8 @@ void Output::Quit() {
 
 	char* buf = new char[log_size];
 
-	auto in = FileFinder::OpenInputStream(FileFinder::MakePath(Main_Data::GetSavePath(), OUTPUT_FILENAME).c_str(),std::ios::ios_base::in);
-	if (in&&!in.bad()) {
+	auto in = FileFinder::OpenInputStream(FileFinder::MakePath(Main_Data::GetSavePath(), OUTPUT_FILENAME), std::ios::ios_base::in);
+	if (in) {
 		in.seekg(0, std::ios_base::end);
 		if (in.tellg() > log_size) {
 			in.seekg(-log_size, std::ios_base::end);
@@ -223,7 +223,7 @@ void Output::Quit() {
 			in.read(buf, 1024 * 100);
 			size_t read = in.gcount();
 
-			auto out = FileFinder::OpenOutputStream(FileFinder::MakePath(Main_Data::GetSavePath(), OUTPUT_FILENAME).c_str(), std::ios::ios_base::out);
+			auto out = FileFinder::OpenOutputStream(FileFinder::MakePath(Main_Data::GetSavePath(), OUTPUT_FILENAME), std::ios::ios_base::out);
 			out.write(buf, read);
 		}
 	}

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -248,8 +248,8 @@ bool Output::TakeScreenshot() {
 }
 
 bool Output::TakeScreenshot(std::string const& file) {
-	std::shared_ptr<std::fstream> ret =
-		FileFinder::openUTF8(file, std::ios_base::binary | std::ios_base::out | std::ios_base::trunc);
+	std::shared_ptr<std::ostream> ret =
+		FileFinder::openUTF8Output(file, std::ios_base::binary | std::ios_base::out | std::ios_base::trunc);
 
 	if (ret) {
 		Output::Debug("Saving Screenshot {}", file);

--- a/src/output.h
+++ b/src/output.h
@@ -23,7 +23,7 @@
 #include <iosfwd>
 #include <fmt/core.h>
 
-#include "filesystem.h"
+#include "filesystem_stream.h"
 
 /**
  * Output Namespace.
@@ -55,7 +55,7 @@ namespace Output {
 	 * @param os output stream that PNG will be stored.
 	 * @return true if success, otherwise false.
 	 */
-	bool TakeScreenshot(Filesystem::OutputStream& os);
+	bool TakeScreenshot(Filesystem_Stream::OutputStream& os);
 
 	/**
 	 * Shows/Hides the output log overlay.

--- a/src/output.h
+++ b/src/output.h
@@ -23,6 +23,8 @@
 #include <iosfwd>
 #include <fmt/core.h>
 
+#include "filesystem.h"
+
 /**
  * Output Namespace.
  */
@@ -53,7 +55,7 @@ namespace Output {
 	 * @param os output stream that PNG will be stored.
 	 * @return true if success, otherwise false.
 	 */
-	bool TakeScreenshot(std::ostream& os);
+	bool TakeScreenshot(Filesystem::OutputStream& os);
 
 	/**
 	 * Shows/Hides the output log overlay.

--- a/src/platform/3ds/3ds_audio.cpp
+++ b/src/platform/3ds/3ds_audio.cpp
@@ -67,7 +67,7 @@ void CtrAudio::BGM_Play(std::string const& file, int volume, int pitch, int fade
 	if (!dsp_inited)
 		return;
 
-	auto filestream = FileFinder::openUTF8Input(file, std::ios::ios_base::in | std::ios::ios_base::binary);
+	auto filestream = FileFinder::OpenInputStream(file, std::ios::ios_base::in | std::ios::ios_base::binary);
 	if (!filestream) {
 		Output::Warning("Couldn't play BGM {}: File not readable", file);
 		return;

--- a/src/platform/3ds/3ds_audio.cpp
+++ b/src/platform/3ds/3ds_audio.cpp
@@ -67,15 +67,15 @@ void CtrAudio::BGM_Play(std::string const& file, int volume, int pitch, int fade
 	if (!dsp_inited)
 		return;
 
-	FILE* filehandle = FileFinder::fopenUTF8(file, "rb");
-	if (!filehandle) {
+	auto filestream = FileFinder::openUTF8Input(file, std::ios::ios_base::in | std::ios::ios_base::binary);
+	if (!filestream) {
 		Output::Warning("Couldn't play BGM {}: File not readable", file);
 		return;
 	}
 
 	LockMutex();
-	bgm_decoder = AudioDecoder::Create(filehandle, file);
-	if (bgm_decoder && bgm_decoder->Open(filehandle)) {
+	bgm_decoder = AudioDecoder::Create(filestream, file);
+	if (bgm_decoder && bgm_decoder->Open(filestream)) {
 		int frequency;
 		AudioDecoder::Format format, out_format;
 		int channels;
@@ -96,7 +96,6 @@ void CtrAudio::BGM_Play(std::string const& file, int volume, int pitch, int fade
 		bgm_buf[1].nsamples = nsamples;
 	} else {
 		Output::Warning("Couldn't play BGM {}: Format not supported", file);
-		fclose(filehandle);
 	}
 
 	UnlockMutex();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -715,7 +715,7 @@ void Player::CreateGameObjects() {
 	{ // Scope lifetime of variables for ini parsing
 		std::string ini_file = FileFinder::FindDefault(INI_NAME);
 		auto ini_stream = FileFinder::OpenInputStream(ini_file, std::ios::ios_base::in);
-		lcf::INIReader ini(*ini_stream);
+		lcf::INIReader ini(ini_stream);
 		if (ini.ParseError() != -1) {
 			std::string title = ini.Get("RPG_RT", "GameTitle", GAME_TITLE);
 			game_title = lcf::ReaderUtil::Recode(title, encoding);
@@ -807,7 +807,7 @@ void Player::CreateGameObjects() {
 		auto exfont_stream = FileFinder::OpenInputStream(exfont_file);
 		if (exfont_stream) {
 			Output::Debug("Using custom ExFont: {}", exfont_file);
-			Cache::exfont_custom = Utils::ReadStream(*exfont_stream);
+			Cache::exfont_custom = Utils::ReadStream(exfont_stream);
 		} else {
 			Output::Debug("Reading custom ExFont {} failed", exfont_file);
 		}
@@ -873,12 +873,12 @@ void Player::LoadDatabase() {
 
 	if (easyrpg_project) {
 		auto edb_stream = FileFinder::OpenInputStream(edb, std::ios::ios_base::in );
-		if (!lcf::LDB_Reader::LoadXml(*edb_stream)) {
+		if (!lcf::LDB_Reader::LoadXml(edb_stream)) {
 			Output::ErrorStr(lcf::LcfReader::GetError());
 		}
 
 		auto emt_stream = FileFinder::OpenInputStream(emt, std::ios::ios_base::in);
-		if (!lcf::LMT_Reader::LoadXml(*emt_stream)) {
+		if (!lcf::LMT_Reader::LoadXml(emt_stream)) {
 			Output::ErrorStr(lcf::LcfReader::GetError());
 		}
 	}
@@ -887,12 +887,12 @@ void Player::LoadDatabase() {
 		std::string lmt = FileFinder::FindDefault(TREEMAP_NAME);
 
 		auto ldb_stream = FileFinder::OpenInputStream(ldb);
-		if (!lcf::LDB_Reader::Load(*ldb_stream, encoding)) {
+		if (!lcf::LDB_Reader::Load(ldb_stream, encoding)) {
 			Output::ErrorStr(lcf::LcfReader::GetError());
 		}
 
 		auto lmt_stream = FileFinder::OpenInputStream(lmt);
-		if (!lcf::LMT_Reader::Load(*lmt_stream, encoding)) {
+		if (!lcf::LMT_Reader::Load(lmt_stream, encoding)) {
 			Output::ErrorStr(lcf::LcfReader::GetError());
 		}
 	}
@@ -939,7 +939,7 @@ void Player::LoadSavegame(const std::string& save_name) {
 	}
 
 	auto save_stream = FileFinder::OpenInputStream(save_name);
-	std::unique_ptr<lcf::rpg::Save> save = lcf::LSD_Reader::Load(*save_stream, encoding);
+	std::unique_ptr<lcf::rpg::Save> save = lcf::LSD_Reader::Load(save_stream, encoding);
 
 	if (!save.get()) {
 		Output::Error("{}", lcf::LcfReader::GetError());
@@ -1043,8 +1043,8 @@ std::string Player::GetEncoding() {
 	// command line > ini > detection > current locale
 	if (encoding.empty()) {
 		std::string ini = FileFinder::FindDefault(INI_NAME);
-		auto ini_stream = FileFinder::OpenInputStream(ini, std::ios::ios_base::in );
-		encoding = lcf::ReaderUtil::GetEncoding(*ini_stream);
+		auto ini_stream = FileFinder::OpenInputStream(ini);
+		encoding = lcf::ReaderUtil::GetEncoding(ini_stream);
 	}
 
 	if (encoding.empty() || encoding == "auto") {
@@ -1052,7 +1052,7 @@ std::string Player::GetEncoding() {
 
 		std::string ldb = FileFinder::FindDefault(DATABASE_NAME);
 		auto ldb_stream = FileFinder::OpenInputStream(ldb);
-		std::vector<std::string> encodings = lcf::ReaderUtil::DetectEncodings(*ldb_stream);
+		std::vector<std::string> encodings = lcf::ReaderUtil::DetectEncodings(ldb_stream);
 
 #ifndef EMSCRIPTEN
 		for (std::string& enc : encodings) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -714,7 +714,7 @@ void Player::CreateGameObjects() {
 	bool no_rtp_warning_flag = false;
 	{ // Scope lifetime of variables for ini parsing
 		std::string ini_file = FileFinder::FindDefault(INI_NAME);
-		auto ini_stream = FileFinder::openUTF8Input(ini_file, std::ios::ios_base::in);
+		auto ini_stream = FileFinder::OpenInputStream(ini_file, std::ios::ios_base::in);
 		lcf::INIReader ini(*ini_stream);
 		if (ini.ParseError() != -1) {
 			std::string title = ini.Get("RPG_RT", "GameTitle", GAME_TITLE);
@@ -790,7 +790,7 @@ void Player::CreateGameObjects() {
 		// a ExFont can be manually bundled there)
 		std::string exep = FileFinder::FindDefault(EXE_NAME);
 		if (!exep.empty()) {
-			auto exesp = FileFinder::openUTF8(exep, std::ios::binary | std::ios::in);
+			auto exesp = FileFinder::OpenInputStream(exep, std::ios::binary | std::ios::in);
 			if (exesp) {
 				Output::Debug("Loading ExFont from {}", exep);
 				EXEReader exe_reader = EXEReader(*exesp);
@@ -804,7 +804,7 @@ void Player::CreateGameObjects() {
 	}
 #endif
 	if (!exfont_file.empty()) {
-		auto exfont_stream = FileFinder::openUTF8(exfont_file, std::ios::binary | std::ios::in);
+		auto exfont_stream = FileFinder::OpenInputStream(exfont_file, std::ios::binary | std::ios::in);
 		if (exfont_stream) {
 			Output::Debug("Using custom ExFont: {}", exfont_file);
 			Cache::exfont_custom = Utils::ReadStream(*exfont_stream);
@@ -872,12 +872,12 @@ void Player::LoadDatabase() {
 	bool easyrpg_project = !edb.empty() && !emt.empty();
 
 	if (easyrpg_project) {
-		auto edb_stream = FileFinder::openUTF8Input(edb, std::ios::ios_base::in );
+		auto edb_stream = FileFinder::OpenInputStream(edb, std::ios::ios_base::in );
 		if (!lcf::LDB_Reader::LoadXml(*edb_stream)) {
 			Output::ErrorStr(lcf::LcfReader::GetError());
 		}
 
-		auto emt_stream = FileFinder::openUTF8Input(emt, std::ios::ios_base::in);
+		auto emt_stream = FileFinder::OpenInputStream(emt, std::ios::ios_base::in);
 		if (!lcf::LMT_Reader::LoadXml(*emt_stream)) {
 			Output::ErrorStr(lcf::LcfReader::GetError());
 		}
@@ -886,12 +886,12 @@ void Player::LoadDatabase() {
 		std::string ldb = FileFinder::FindDefault(DATABASE_NAME);
 		std::string lmt = FileFinder::FindDefault(TREEMAP_NAME);
 
-		auto ldb_stream = FileFinder::openUTF8Input(ldb, std::ios::ios_base::in| std::ios::ios_base::binary);
+		auto ldb_stream = FileFinder::OpenInputStream(ldb, std::ios::ios_base::in| std::ios::ios_base::binary);
 		if (!lcf::LDB_Reader::Load(*ldb_stream, encoding)) {
 			Output::ErrorStr(lcf::LcfReader::GetError());
 		}
 
-		auto lmt_stream = FileFinder::openUTF8Input(lmt, std::ios::ios_base::in | std::ios::ios_base::binary);
+		auto lmt_stream = FileFinder::OpenInputStream(lmt, std::ios::ios_base::in | std::ios::ios_base::binary);
 		if (!lcf::LMT_Reader::Load(*lmt_stream, encoding)) {
 			Output::ErrorStr(lcf::LcfReader::GetError());
 		}
@@ -938,7 +938,7 @@ void Player::LoadSavegame(const std::string& save_name) {
 		static_cast<Scene_Title*>(title_scene.get())->OnGameStart();
 	}
 
-	auto save_stream = FileFinder::openUTF8Input(save_name, std::ios::ios_base::in | std::ios::ios_base::binary);
+	auto save_stream = FileFinder::OpenInputStream(save_name, std::ios::ios_base::in | std::ios::ios_base::binary);
 	std::unique_ptr<lcf::rpg::Save> save = lcf::LSD_Reader::Load(*save_stream, encoding);
 
 	if (!save.get()) {
@@ -1043,7 +1043,7 @@ std::string Player::GetEncoding() {
 	// command line > ini > detection > current locale
 	if (encoding.empty()) {
 		std::string ini = FileFinder::FindDefault(INI_NAME);
-		auto ini_stream = FileFinder::openUTF8Input(ini, std::ios::ios_base::in );
+		auto ini_stream = FileFinder::OpenInputStream(ini, std::ios::ios_base::in );
 		encoding = lcf::ReaderUtil::GetEncoding(*ini_stream);
 	}
 
@@ -1051,7 +1051,7 @@ std::string Player::GetEncoding() {
 		encoding = "";
 
 		std::string ldb = FileFinder::FindDefault(DATABASE_NAME);
-		auto ldb_stream = FileFinder::openUTF8Input(ldb, std::ios::ios_base::in | std::ios::ios_base::binary);
+		auto ldb_stream = FileFinder::OpenInputStream(ldb, std::ios::ios_base::in | std::ios::ios_base::binary);
 		std::vector<std::string> encodings = lcf::ReaderUtil::DetectEncodings(*ldb_stream);
 
 #ifndef EMSCRIPTEN

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -790,7 +790,7 @@ void Player::CreateGameObjects() {
 		// a ExFont can be manually bundled there)
 		std::string exep = FileFinder::FindDefault(EXE_NAME);
 		if (!exep.empty()) {
-			auto exesp = FileFinder::OpenInputStream(exep, std::ios::binary | std::ios::in);
+			auto exesp = FileFinder::OpenInputStream(exep);
 			if (exesp) {
 				Output::Debug("Loading ExFont from {}", exep);
 				EXEReader exe_reader = EXEReader(exesp);
@@ -804,7 +804,7 @@ void Player::CreateGameObjects() {
 	}
 #endif
 	if (!exfont_file.empty()) {
-		auto exfont_stream = FileFinder::OpenInputStream(exfont_file, std::ios::binary | std::ios::in);
+		auto exfont_stream = FileFinder::OpenInputStream(exfont_file);
 		if (exfont_stream) {
 			Output::Debug("Using custom ExFont: {}", exfont_file);
 			Cache::exfont_custom = Utils::ReadStream(*exfont_stream);
@@ -886,7 +886,7 @@ void Player::LoadDatabase() {
 		std::string ldb = FileFinder::FindDefault(DATABASE_NAME);
 		std::string lmt = FileFinder::FindDefault(TREEMAP_NAME);
 
-		auto ldb_stream = FileFinder::OpenInputStream(ldb, std::ios::ios_base::in| std::ios::ios_base::binary);
+		auto ldb_stream = FileFinder::OpenInputStream(ldb);
 		if (!lcf::LDB_Reader::Load(*ldb_stream, encoding)) {
 			Output::ErrorStr(lcf::LcfReader::GetError());
 		}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -891,7 +891,7 @@ void Player::LoadDatabase() {
 			Output::ErrorStr(lcf::LcfReader::GetError());
 		}
 
-		auto lmt_stream = FileFinder::OpenInputStream(lmt, std::ios::ios_base::in | std::ios::ios_base::binary);
+		auto lmt_stream = FileFinder::OpenInputStream(lmt);
 		if (!lcf::LMT_Reader::Load(*lmt_stream, encoding)) {
 			Output::ErrorStr(lcf::LcfReader::GetError());
 		}
@@ -938,7 +938,7 @@ void Player::LoadSavegame(const std::string& save_name) {
 		static_cast<Scene_Title*>(title_scene.get())->OnGameStart();
 	}
 
-	auto save_stream = FileFinder::OpenInputStream(save_name, std::ios::ios_base::in | std::ios::ios_base::binary);
+	auto save_stream = FileFinder::OpenInputStream(save_name);
 	std::unique_ptr<lcf::rpg::Save> save = lcf::LSD_Reader::Load(*save_stream, encoding);
 
 	if (!save.get()) {
@@ -1051,7 +1051,7 @@ std::string Player::GetEncoding() {
 		encoding = "";
 
 		std::string ldb = FileFinder::FindDefault(DATABASE_NAME);
-		auto ldb_stream = FileFinder::OpenInputStream(ldb, std::ios::ios_base::in | std::ios::ios_base::binary);
+		auto ldb_stream = FileFinder::OpenInputStream(ldb);
 		std::vector<std::string> encodings = lcf::ReaderUtil::DetectEncodings(*ldb_stream);
 
 #ifndef EMSCRIPTEN

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -793,7 +793,7 @@ void Player::CreateGameObjects() {
 			auto exesp = FileFinder::OpenInputStream(exep, std::ios::binary | std::ios::in);
 			if (exesp) {
 				Output::Debug("Loading ExFont from {}", exep);
-				EXEReader exe_reader = EXEReader(*exesp);
+				EXEReader exe_reader = EXEReader(exesp);
 				Cache::exfont_custom = exe_reader.GetExFont();
 			} else {
 				Output::Debug("ExFont loading failed: {} not readable", exep);

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -73,7 +73,7 @@ void Scene_File::PopulateSaveWindow(Window_SaveFile& win, int id) {
 
 	if (!file.empty()) {
 		// File found
-		auto save_stream = FileFinder::openUTF8Input(file, std::ios::ios_base::in | std::ios::ios_base::binary);std::unique_ptr<lcf::rpg::Save> savegame =
+		auto save_stream = FileFinder::OpenInputStream(file, std::ios::ios_base::in | std::ios::ios_base::binary);std::unique_ptr<lcf::rpg::Save> savegame =
 			lcf::LSD_Reader::Load(*save_stream, Player::encoding);
 
 		if (savegame.get()) {

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -74,7 +74,7 @@ void Scene_File::PopulateSaveWindow(Window_SaveFile& win, int id) {
 	if (!file.empty()) {
 		// File found
 		auto save_stream = FileFinder::OpenInputStream(file);
-		std::unique_ptr<lcf::rpg::Save> savegame = lcf::LSD_Reader::Load(*save_stream, Player::encoding);
+		std::unique_ptr<lcf::rpg::Save> savegame = lcf::LSD_Reader::Load(save_stream, Player::encoding);
 
 		if (savegame) {
 			PopulatePartyFaces(win, id, *savegame);

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -73,8 +73,8 @@ void Scene_File::PopulateSaveWindow(Window_SaveFile& win, int id) {
 
 	if (!file.empty()) {
 		// File found
-		std::unique_ptr<lcf::rpg::Save> savegame =
-			lcf::LSD_Reader::Load(file, Player::encoding);
+		auto save_stream = FileFinder::openUTF8Input(file, std::ios::ios_base::in | std::ios::ios_base::binary);std::unique_ptr<lcf::rpg::Save> savegame =
+			lcf::LSD_Reader::Load(*save_stream, Player::encoding);
 
 		if (savegame.get()) {
 			PopulatePartyFaces(win, id, *savegame);

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -73,7 +73,7 @@ void Scene_File::PopulateSaveWindow(Window_SaveFile& win, int id) {
 
 	if (!file.empty()) {
 		// File found
-		auto save_stream = FileFinder::OpenInputStream(file, std::ios::ios_base::in | std::ios::ios_base::binary);std::unique_ptr<lcf::rpg::Save> savegame =
+		auto save_stream = FileFinder::OpenInputStream(file);std::unique_ptr<lcf::rpg::Save> savegame =
 			lcf::LSD_Reader::Load(*save_stream, Player::encoding);
 
 		if (savegame.get()) {

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -73,10 +73,10 @@ void Scene_File::PopulateSaveWindow(Window_SaveFile& win, int id) {
 
 	if (!file.empty()) {
 		// File found
-		auto save_stream = FileFinder::OpenInputStream(file);std::unique_ptr<lcf::rpg::Save> savegame =
-			lcf::LSD_Reader::Load(*save_stream, Player::encoding);
+		auto save_stream = FileFinder::OpenInputStream(file);
+		std::unique_ptr<lcf::rpg::Save> savegame = lcf::LSD_Reader::Load(*save_stream, Player::encoding);
 
-		if (savegame.get()) {
+		if (savegame) {
 			PopulatePartyFaces(win, id, *savegame);
 			UpdateLatestTimestamp(id, *savegame);
 		} else {

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -133,7 +133,8 @@ void Scene_Save::Action(int index) {
 			sme.map_id = 0;
 		}
 	}
-	lcf::LSD_Reader::Save(filename, data_copy, Player::encoding);
+	auto save_stream = FileFinder::openUTF8Output(filename, std::ios::ios_base::out | std::ios::ios_base::binary);
+	lcf::LSD_Reader::Save(*save_stream, data_copy, Player::encoding);
 
 #ifdef EMSCRIPTEN
 	// Save changed file system

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -134,7 +134,7 @@ void Scene_Save::Action(int index) {
 		}
 	}
 	auto save_stream = FileFinder::OpenOutputStream(filename);
-	lcf::LSD_Reader::Save(*save_stream, data_copy, Player::encoding);
+	lcf::LSD_Reader::Save(save_stream, data_copy, Player::encoding);
 
 #ifdef EMSCRIPTEN
 	// Save changed file system

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -133,7 +133,7 @@ void Scene_Save::Action(int index) {
 			sme.map_id = 0;
 		}
 	}
-	auto save_stream = FileFinder::openUTF8Output(filename, std::ios::ios_base::out | std::ios::ios_base::binary);
+	auto save_stream = FileFinder::OpenOutputStream(filename, std::ios::ios_base::out | std::ios::ios_base::binary);
 	lcf::LSD_Reader::Save(*save_stream, data_copy, Player::encoding);
 
 #ifdef EMSCRIPTEN

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -133,7 +133,7 @@ void Scene_Save::Action(int index) {
 			sme.map_id = 0;
 		}
 	}
-	auto save_stream = FileFinder::OpenOutputStream(filename, std::ios::ios_base::out | std::ios::ios_base::binary);
+	auto save_stream = FileFinder::OpenOutputStream(filename);
 	lcf::LSD_Reader::Save(*save_stream, data_copy, Player::encoding);
 
 #ifdef EMSCRIPTEN


### PR DESCRIPTION
This is a partial patchset from the VFS changes rebased to upstream.
It only changes how File input/output works across Player in a consistent way by now. You don't get any new features by this but it makes future VFS work muuuuuch easier when these stream changes are kept being updated upstream.

For reviewing I recommend to look at the change as a whole. The changes by ChrisBreiti are a bit old :)

- All uses of ``FILE*`` replaced with C++ streams
- All C++ streams use now ``Filesystem::InputStream/Filesystem::OutputStream`` which is by now a shallow wrapper around ``std::filebuf``. 

Basicly the VFS code will do the following later:

1. You open a file like ``/home/user/game.zip/RPG_RT.ldb``
2. This returns a ``Filesystem::InputStream`` that inherits from ``istream``. So most of C++ fstream API will work as expected.
3. Use normal istream read funcs on it.

Is a draft. Need to test if I broke any Read/Write code. All these raw buffer APIs are hard to get right when a shared pointer is mixed in ^^'. Type confusion.

