### PR TITLE
Reset facing lock flag on event page change

### DIFF
--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -95,6 +95,7 @@ void Game_Event::Setup(const RPG::EventPage* new_page) {
 
 	SetMoveSpeed(page->move_speed);
 	SetMoveFrequency(page->move_frequency);
+	SetFacingLocked(false);
 	if (page->move_type == RPG::EventPage::MoveType_custom) {
 		SetMaxStopCountForTurn();
 	} else {


### PR DESCRIPTION
This fixes the direction issue reported by the user in #2183 It does not fix the other timing issues I found with movement in that issue.