### PR TITLE
Transitions - wait for graphics loading if screen erased - dependency for battle2k3 PRs

### DIFF
--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -151,7 +151,7 @@ void FileRequestAsync::SetGraphicFile(bool graphic) {
 	// We need this flag in order to prevent show screen transitions
 	// from starting util all graphical assets are loaded.
 	// Also, the screen is erased, so you can't see any delays :)
-	if (Transition::instance().IsErased()) {
+	if (Transition::instance().IsErasedNotActive()) {
 		SetImportantFile(true);
 	}
 }

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -106,14 +106,11 @@ void Graphics::Draw(Bitmap& dst) {
 
 	int min_z = std::numeric_limits<int>::min();
 	int max_z = std::numeric_limits<int>::max();
-	if (transition.IsActive() || transition.IsErased()) {
+	if (transition.IsActive()) {
 		min_z = transition.GetZ();
-	}
-
-	if (transition.IsErased()) {
+	} else if (transition.IsErased()) {
+		min_z = transition.GetZ() + 1;
 		dst.Clear();
-		LocalDraw(dst, min_z, max_z);
-		return;
 	}
 	LocalDraw(dst, min_z, max_z);
 }

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -108,7 +108,7 @@ void Graphics::Draw(Bitmap& dst) {
 	int max_z = std::numeric_limits<int>::max();
 	if (transition.IsActive()) {
 		min_z = transition.GetZ();
-	} else if (transition.IsErased()) {
+	} else if (transition.IsErasedNotActive()) {
 		min_z = transition.GetZ() + 1;
 		dst.Clear();
 	}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -345,14 +345,14 @@ void Player::Update(bool update_scene) {
 	}
 
 	auto& transition = Transition::instance();
-	auto was_transition_pending = transition.IsActive();
 
-	transition.Update();
-
-	// If we aren't waiting on a transition, but we are waiting for scene delay.
-	if (!was_transition_pending) {
+	if (transition.IsActive()) {
+		transition.Update();
+	} else {
+		// If we aren't waiting on a transition, but we are waiting for scene delay.
 		Scene::instance->UpdateDelayFrames();
 	}
+
 	if (update_scene) {
 		Scene::instance->Update();
 		// Async file loading or transition. Don't increment the frame

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -88,9 +88,7 @@ void Scene::ScheduleTransitionIn(Scene::SceneType prev_scene_type) {
 	if (async_continuation) {
 		AsyncNext([this,fn=std::move(async_continuation),prev_scene_type]() {
 					fn();
-					if (Transition::instance().IsErasedNotActive()) {
-						TransitionIn(prev_scene_type);
-					}
+					ScheduleTransitionIn(prev_scene_type);
 				});
 	} else {
 		AsyncNext([this,prev_scene_type]() { TransitionIn(prev_scene_type); });

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -123,8 +123,6 @@ void Scene::MainFunction() {
 			if (!Transition::instance().IsActive()) {
 				TransitionIn(prev_scene_type);
 			}
-			Resume(prev_scene_type);
-
 
 			init = true;
 			return;
@@ -155,9 +153,6 @@ void Scene::Start() {
 }
 
 void Scene::Continue(SceneType /* prev_scene */) {
-}
-
-void Scene::Resume(SceneType /* prev_scene */) {
 }
 
 void Scene::Suspend(SceneType /* next_scene */) {

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -78,7 +78,7 @@ Scene::Scene() {
 }
 
 void Scene::ScheduleTransitionIn(Scene::SceneType prev_scene_type) {
-	if (!Transition::instance().IsErased()) {
+	if (!Transition::instance().IsErasedNotActive()) {
 		// Scene could have manually triggered transition earlier
 		return;
 	}
@@ -88,7 +88,7 @@ void Scene::ScheduleTransitionIn(Scene::SceneType prev_scene_type) {
 	if (async_continuation) {
 		AsyncNext([this,fn=std::move(async_continuation),prev_scene_type]() {
 					fn();
-					if (Transition::instance().IsErased()) {
+					if (Transition::instance().IsErasedNotActive()) {
 						TransitionIn(prev_scene_type);
 					}
 				});

--- a/src/scene.h
+++ b/src/scene.h
@@ -153,6 +153,11 @@ public:
 	virtual void Update();
 
 	/**
+	 * Update graphics in scene stack
+	 */
+	virtual void UpdateGraphics() {}
+
+	/**
 	 * Pushes a new scene on the scene execution stack.
 	 *
 	 * @param new_scene new scene.

--- a/src/scene.h
+++ b/src/scene.h
@@ -271,6 +271,12 @@ protected:
 	 */
 	void SetUseSharedDrawables(bool value);
 
+	/**
+	 * If no async operation is pending, call f() now. Otherwise
+	 * defer f until async operations are done.
+	 */
+	template <typename F> void AsyncNext(F&& f);
+
 private:
 	/** Scene stack. */
 	static std::vector<std::shared_ptr<Scene> > instances;
@@ -335,6 +341,15 @@ inline DrawableList& Scene::GetDrawableList() {
 
 inline void Scene::SetUseSharedDrawables(bool value) {
 	uses_shared_drawables = value;
+}
+
+template <typename F>
+inline void Scene::AsyncNext(F&& f) {
+	if (IsAsyncPending()) {
+		async_continuation = std::forward<F>(f);
+	} else {
+		f();
+	}
 }
 
 #endif

--- a/src/scene.h
+++ b/src/scene.h
@@ -278,6 +278,8 @@ protected:
 	template <typename F> void AsyncNext(F&& f);
 
 private:
+	void ScheduleTransitionIn(Scene::SceneType prev_scene_type);
+
 	/** Scene stack. */
 	static std::vector<std::shared_ptr<Scene> > instances;
 

--- a/src/scene.h
+++ b/src/scene.h
@@ -96,16 +96,6 @@ public:
 	virtual void Continue(SceneType prev_scene);
 
 	/**
-	 * Resume processing.
-	 * This function is executed after the fade in,
-	 * either when starting the scene or when returning
-	 * from a nested scene
-	 *
-	 * @param prev_scene The previous scene
-	 */
-	virtual void Resume(SceneType prev_scene);
-
-	/**
 	 * Suspend processing.
 	 * This function is executed before the fade out for
 	 * the scene change, either when terminating the scene

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -222,7 +222,7 @@ void Scene_Battle::Update() {
 	bool events_running = interp.IsRunning();
 	interp.Update();
 
-	Game_Battle::UpdateGraphics();
+	UpdateGraphics();
 	if (events_running && !interp.IsRunning()) {
 		// If an event that changed status finishes without displaying a message window,
 		// we need this so it can update automatically the status_window
@@ -240,6 +240,10 @@ void Scene_Battle::Update() {
 			return;
 		}
 	}
+}
+
+void Scene_Battle::UpdateGraphics() {
+	Game_Battle::UpdateGraphics();
 }
 
 bool Scene_Battle::IsWindowMoving() {

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -75,6 +75,7 @@ public:
 
 	void Start() override;
 	void Update() override;
+	void UpdateGraphics() override;
 
 	void Continue(SceneType prev_scene) override;
 	void TransitionIn(SceneType prev_scene) override;

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -386,15 +386,6 @@ void Scene_Map::PerformAsyncTeleport(TeleportTarget original_tt) {
 }
 
 template <typename F>
-void Scene_Map::AsyncNext(F&& f) {
-	if (IsAsyncPending()) {
-		async_continuation = std::forward<F>(f);
-	} else {
-		f();
-	}
-}
-
-template <typename F>
 void Scene_Map::OnAsyncSuspend(F&& f, AsyncOp aop, bool is_preupdate) {
 	if (CheckSceneExit(aop)) {
 		return;

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -110,7 +110,7 @@ void Scene_Map::Start2(MapUpdateAsyncContext actx) {
 	// We do the start game fade in transition here instead of TransitionIn callback,
 	// in order to make async logic work properly.
 	auto& transition = Transition::instance();
-	if (transition.IsErased()) {
+	if (transition.IsErasedNotActive()) {
 		transition.InitShow(Transition::TransitionFadeIn, this);
 	}
 
@@ -187,7 +187,7 @@ void Scene_Map::TransitionOut(SceneType next_scene) {
 	}
 
 	if (next_scene == Scene::Battle) {
-		if (!transition.IsErased()) {
+		if (!transition.IsErasedNotActive()) {
 			auto tt = Game_System::GetTransition(Game_System::Transition_BeginBattleErase);
 			if (tt == Transition::TransitionNone) {
 				// If transition type is none, RPG_RT flashes and then waits 40 frames before starting the battle.
@@ -303,7 +303,7 @@ void Scene_Map::UpdateSceneCalling() {
 void Scene_Map::StartPendingTeleport(TeleportParams tp) {
 	auto& transition = Transition::instance();
 
-	if (!transition.IsErased() && tp.erase_screen) {
+	if (!transition.IsErasedNotActive() && tp.erase_screen) {
 		transition.InitErase(Game_System::GetTransition(Game_System::Transition_TeleportErase), this);
 	}
 
@@ -341,7 +341,7 @@ void Scene_Map::FinishPendingTeleport2(MapUpdateAsyncContext actx, TeleportParam
 	auto& transition = Transition::instance();
 
 	// This logic was tested against RPG_RT and works this way ...
-	if (tp.use_default_transition_in && transition.IsErased()) {
+	if (tp.use_default_transition_in && transition.IsErasedNotActive()) {
 		transition.InitShow(Transition::TransitionFadeIn, this);
 	} else if (!tp.use_default_transition_in && !screen_erased_by_event) {
 		transition.InitShow(Game_System::GetTransition(Game_System::Transition_TeleportShow), this);

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -87,7 +87,7 @@ private:
 	template <typename F> void AsyncNext(F&& f);
 	template <typename F> void OnAsyncSuspend(F&& f, AsyncOp aop, bool is_preupdate);
 
-	void UpdateGraphics();
+	void UpdateGraphics() override;
 
 	std::unique_ptr<Window_Message> message_window;
 

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -84,7 +84,6 @@ private:
 	void UpdateInn();
 	void FinishInn();
 
-	template <typename F> void AsyncNext(F&& f);
 	template <typename F> void OnAsyncSuspend(F&& f, AsyncOp aop, bool is_preupdate);
 
 	void UpdateGraphics() override;

--- a/src/transition.cpp
+++ b/src/transition.cpp
@@ -389,12 +389,15 @@ void Transition::Update() {
 		return;
 	}
 
-
 	// FIXME: Break this dependency on DisplayUI
 	if (transition_type != TransitionNone && !screen2) {
 		// Wait for all graphics to load before drawing screens.
 		if (FromErase() && AsyncHandler::IsGraphicFilePending()) {
 			return;
+		}
+
+		if (scene) {
+			scene->UpdateGraphics();
 		}
 
 		if (!screen1) {

--- a/src/transition.cpp
+++ b/src/transition.cpp
@@ -102,7 +102,7 @@ void Transition::Init(Type type, Scene *linked_scene, int duration, bool next_er
 	}
 
 	// Total frames and erased have to be set *after* the above drawing code.
-	// Otherwise IsActive() / IsErased() will mess up drawing.
+	// Otherwise IsActive() / IsErasedNotActive() will mess up drawing.
 	total_frames = duration;
 
 	// TransitionNone is neither a Show or Erase, it just waits and does nothing.

--- a/src/transition.h
+++ b/src/transition.h
@@ -110,7 +110,7 @@ public:
 	void Update();
 
 	bool IsActive() const;
-	bool IsErased() const;
+	bool IsErasedNotActive() const;
 
 	bool FromErase() const;
 	bool ToErase() const;
@@ -169,7 +169,7 @@ inline bool Transition::IsActive() const {
 	return current_frame < total_frames || flash_iterations != 0;
 }
 
-inline bool Transition::IsErased() const {
+inline bool Transition::IsErasedNotActive() const {
 	return ToErase() && !IsActive();
 }
 

--- a/src/transition.h
+++ b/src/transition.h
@@ -109,8 +109,11 @@ public:
 	void Draw(Bitmap& dst) override;
 	void Update();
 
-	bool IsActive();
-	bool IsErased();
+	bool IsActive() const;
+	bool IsErased() const;
+
+	bool FromErase() const;
+	bool ToErase() const;
 
 private:
 	Transition();
@@ -126,7 +129,8 @@ private:
 	Scene *scene = nullptr;
 	int current_frame = 0;
 	int total_frames = 0;
-	bool screen_erased = false;
+	bool from_erase = false;
+	bool to_erase = false;
 
 	struct FlashData {
 		int32_t red = 0;
@@ -161,12 +165,20 @@ inline void Transition::InitErase(Type type, Scene *linked_scene, int duration) 
 	Init(type, linked_scene, duration, true);
 }
 
-inline bool Transition::IsActive() {
+inline bool Transition::IsActive() const {
 	return current_frame < total_frames || flash_iterations != 0;
 }
 
-inline bool Transition::IsErased() {
-	return screen_erased && !IsActive();
+inline bool Transition::IsErased() const {
+	return ToErase() && !IsActive();
+}
+
+inline bool Transition::FromErase() const {
+	return from_erase;
+}
+
+inline bool Transition::ToErase() const {
+	return to_erase;
 }
 
 #endif


### PR DESCRIPTION
This PR improves support for asynchronous functions during scene initialization. It's required for 2k3 battle and also fixes some issues with maps.

