### PR TITLE
Emscripten: Disable SDL2 async handling.

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -274,6 +274,11 @@ void Player::MainLoop() {
 	if (Game_Clock::now() < next) {
 		iframe.End();
 		Game_Clock::SleepFor(next - now);
+	} else {
+#ifdef EMSCRIPTEN
+		// Yield back to browser once per frame
+		emscripten_sleep(0);
+#endif
 	}
 }
 

--- a/src/sdl2_ui.cpp
+++ b/src/sdl2_ui.cpp
@@ -141,6 +141,9 @@ Sdl2Ui::Sdl2Ui(long width, long height, bool fullscreen, int zoom)
 	// Set the application class name
 	setenv("SDL_VIDEO_X11_WMCLASS", GAME_TITLE, 0);
 #endif
+#ifdef EMSCRIPTEN
+	SDL_SetHint(SDL_HINT_EMSCRIPTEN_ASYNCIFY, "0");
+#endif
 
 	if (SDL_Init(SDL_INIT_VIDEO) < 0) {
 		Output::Error("Couldn't initialize SDL.\n{}\n", SDL_GetError());


### PR DESCRIPTION
This allows the usage of ASYNCIFY_IGNORE_INDIRECT and is much faster.