### PR TITLE
Use fmtlib core.h instead of format.h in Output logging.

### DIFF
--- a/src/output.h
+++ b/src/output.h
@@ -21,8 +21,7 @@
 // Headers
 #include <string>
 #include <iosfwd>
-#include <fmt/format.h>
-#include <fmt/ostream.h>
+#include <fmt/core.h>
 
 /**
  * Output Namespace.


### PR DESCRIPTION
Reduces the compile times to there previous state.

Fix #2229