### PR TITLE
Allow debug flag from gamebrowser

### DIFF
--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -39,6 +39,7 @@ Scene_GameBrowser::Scene_GameBrowser() {
 }
 
 void Scene_GameBrowser::Start() {
+	initial_debug_flag = Player::debug_flag;
 	Game_System::SetSystemGraphic(CACHE_DEFAULT_BITMAP, lcf::rpg::System::Stretch_stretch, lcf::rpg::System::Font_gothic);
 	CreateWindows();
 	Game_Clock::ResetFrame(Game_Clock::now());
@@ -62,6 +63,8 @@ void Scene_GameBrowser::Continue(SceneType /* prev_scene */) {
 
 	Game_System::SetSystemGraphic(CACHE_DEFAULT_BITMAP, lcf::rpg::System::Stretch_stretch, lcf::rpg::System::Font_gothic);
 	Game_System::BgmStop();
+
+	Player::debug_flag = initial_debug_flag;
 }
 
 void Scene_GameBrowser::Update() {
@@ -159,6 +162,10 @@ void Scene_GameBrowser::UpdateGameListSelection() {
 		old_gamelist_index = gamelist_window->GetIndex();
 		gamelist_window->SetIndex(-1);
 	} else if (Input::IsTriggered(Input::DECISION)) {
+		load_window->SetVisible(true);
+		game_loading = true;
+	} else if (Input::IsTriggered(Input::DEBUG_MENU) || Input::IsTriggered(Input::SHIFT)) {
+		Player::debug_flag = true;
 		load_window->SetVisible(true);
 		game_loading = true;
 	}

--- a/src/scene_gamebrowser.h
+++ b/src/scene_gamebrowser.h
@@ -85,6 +85,9 @@ private:
 	bool game_loading = false;
 
 	int old_gamelist_index = 0;
+
+	/** What the state of the Player::debug_flag was at launch time */
+	bool initial_debug_flag = false;
 };
 
 #endif


### PR DESCRIPTION
Adds ability to start a game with debug flag enabled by pressing SHIFT (or its mappings) to launch it instead of ENTER. Also maps the Vita START button to F9 if running with debug flag instead of ESCAPE, which should allow you to open the debug menu with the Vita's START button if running in this mode.

This is useful for playing certain RPGMaker games that are buggy or are otherwise incomplete, since tweaking variables and switches would otherwise be the only method to get past certain events.

This is my first PR so I'm very keen to hear any feedback, especially if I've broken any style guides or other rules. I'm really keen to help out more with this project!