### PR TITLE
FmMidi: naive harmony-like loop support

### DIFF
--- a/src/decoder_fmmidi.cpp
+++ b/src/decoder_fmmidi.cpp
@@ -20,11 +20,14 @@
 #ifdef WANT_FMMIDI
 
 // Headers
+#include <algorithm>
 #include <cstdio>
 #include <cassert>
 #include "audio_decoder.h"
 #include "output.h"
 #include "decoder_fmmidi.h"
+
+constexpr int FmMidiDecoder::midi_default_tempo;
 
 FmMidiDecoder::FmMidiDecoder() {
 	note_factory.reset(new midisynth::fm_note_factory());
@@ -66,22 +69,33 @@ bool FmMidiDecoder::Open(FILE* file) {
 	}
 	seq->rewind();
 
-	ticks_per_sec = (float)seq->get_division() / tempo * 1000000;
+	tempo.emplace_back(this, midi_default_tempo);
 
 	return true;
 }
 
 bool FmMidiDecoder::Seek(size_t offset, Origin origin) {
+	assert(!tempo.empty());
+
 	if (offset == 0 && origin == Origin::Begin) {
 		mtime = seq->rewind_to_loop();
-		mtime_last_tempo_change = mtime_ltc_loopstart;
-		ticks_last_tempo_change = ticks_ltc_loopstart;
+
 		if (mtime > 0.0f) {
+			// Throw away all tempo data after the loop point
+			auto rit = std::find_if(tempo.rbegin(), tempo.rend(), [&](auto& t) { return t.mtime <= mtime; });
+			auto it = rit.base();
+			if (it != tempo.end()) {
+				tempo.erase(it, tempo.end());
+			}
+
 			// Bit of a hack, prevent stuck notes
 			// TODO: verify with a MIDI event stream inspector whether RPG_RT does this?
 			synth->all_note_off();
-			tempo = tempo_loopstart;
+		} else {
+			tempo.clear();
+			tempo.emplace_back(this, midi_default_tempo);
 		}
+
 		begin = true;
 
 		return true;
@@ -117,8 +131,9 @@ bool FmMidiDecoder::SetPitch(int pitch) {
 }
 
 int FmMidiDecoder::GetTicks() const {
-	float delta = mtime - mtime_last_tempo_change;
-	return ticks_last_tempo_change + static_cast<int>(ticks_per_sec * delta);
+	assert(!tempo.empty());
+
+	return tempo.back().GetTicks(mtime);
 }
 
 int FmMidiDecoder::FillBuffer(uint8_t* buffer, int length) {
@@ -145,13 +160,6 @@ int FmMidiDecoder::synthesize(int_least16_t * output, std::size_t samples, float
 }
 
 void FmMidiDecoder::midi_message(int, uint_least32_t message) {
-	// If message is a B06F loopstart control change...
-	if ((message & 0xFFFF) == 0x6FB0) {
-		// Save the state of these fields to restore them when looping
-		tempo_loopstart = tempo;
-		mtime_ltc_loopstart = mtime_last_tempo_change;
-		ticks_ltc_loopstart = ticks_last_tempo_change;
-	}
 	synth->midi_event(message);
 }
 
@@ -160,15 +168,15 @@ void FmMidiDecoder::sysex_message(int, const void * data, std::size_t size) {
 }
 
 void FmMidiDecoder::meta_event(int event, const void * data, std::size_t size) {
+	assert(!tempo.empty());
+
 	const auto* d = reinterpret_cast<const uint8_t*>(data);
 
 	if (size == 3 && event == 0x51) {
-		tempo = (static_cast<uint_least32_t>(static_cast<unsigned char>(d[0])) << 16)
+		uint32_t new_tempo = (static_cast<uint32_t>(static_cast<unsigned char>(d[0])) << 16)
 				| (static_cast<unsigned char>(d[1]) << 8)
 				| static_cast<unsigned char>(d[2]);
-		ticks_per_sec = (float)seq->get_division() / tempo * 1000000;
-		ticks_last_tempo_change = GetTicks();
-		mtime_last_tempo_change = mtime;
+		tempo.emplace_back(this, new_tempo, &tempo.back());
 	}
 }
 
@@ -179,6 +187,21 @@ void FmMidiDecoder::reset() {
 void FmMidiDecoder::load_programs() {
 	// beautiful
 	#include "midiprogram.h"
+}
+
+FmMidiDecoder::MidiTempoData::MidiTempoData(const FmMidiDecoder* midi, uint32_t cur_tempo, const MidiTempoData* prev)
+	: tempo(cur_tempo) {
+	ticks_per_sec = (float)midi->seq->get_division() / tempo * 1000000;
+	mtime = midi->mtime;
+	if (prev) {
+		float delta = mtime - prev->mtime;
+		ticks = prev->ticks + static_cast<int>(ticks_per_sec * delta);
+	}
+}
+
+int FmMidiDecoder::MidiTempoData::GetTicks(float mtime_cur) const {
+	float delta = mtime_cur - mtime;
+	return ticks + static_cast<int>(ticks_per_sec * delta);
 }
 
 #endif

--- a/src/decoder_fmmidi.h
+++ b/src/decoder_fmmidi.h
@@ -65,6 +65,12 @@ private:
 	float mtime_last_tempo_change = 0.0f;
 	int ticks_last_tempo_change = 0;
 
+	// Save mtime_last_tempo_change, ticks_last_tempo_change, and tempo
+	// state at loopstart
+	int ticks_ltc_loopstart = 0;
+	float mtime_ltc_loopstart = 0.0f;
+	uint32_t tempo_loopstart = 500000;
+
 	// midisequencer::output interface
 	int synthesize(int_least16_t* output, std::size_t samples, float rate);
 	void midi_message(int, uint_least32_t message) override;

--- a/src/decoder_fmmidi.h
+++ b/src/decoder_fmmidi.h
@@ -52,6 +52,8 @@ public:
 	std::vector<uint8_t> file_buffer;
 	size_t file_buffer_pos = 0;
 private:
+	static constexpr int midi_default_tempo = 500000;
+
 	int FillBuffer(uint8_t* buffer, int length) override;
 
 	FILE* file;
@@ -59,17 +61,21 @@ private:
 	float pitch = 1.0f;
 	int frequency = 44100;
 	bool begin = true;
-	uint32_t tempo = 500000;
 
-	float ticks_per_sec = 0.0f;
-	float mtime_last_tempo_change = 0.0f;
-	int ticks_last_tempo_change = 0;
+	struct MidiTempoData {
+		MidiTempoData(const FmMidiDecoder* midi, uint32_t cur_tempo, const MidiTempoData* prev = nullptr);
 
-	// Save mtime_last_tempo_change, ticks_last_tempo_change, and tempo
-	// state at loopstart
-	int ticks_ltc_loopstart = 0;
-	float mtime_ltc_loopstart = 0.0f;
-	uint32_t tempo_loopstart = 500000;
+		uint32_t tempo = midi_default_tempo;
+		float ticks_per_sec = 0.0f;
+		float mtime = 0.0f;
+		int ticks = 0;
+
+		int GetTicks(float cur_mtime) const;
+	};
+
+	// Contains one entry per tempo change (latest on top)
+	// When looping all entries after the loop point are dropped
+	std::vector<MidiTempoData> tempo;
 
 	// midisequencer::output interface
 	int synthesize(int_least16_t* output, std::size_t samples, float rate);

--- a/src/midisequencer.h
+++ b/src/midisequencer.h
@@ -68,7 +68,8 @@ namespace midisequencer{
     public:
         sequencer();
         void clear();
-	void rewind();
+        void rewind();
+        float rewind_to_loop();
         bool load(void* fp, int(*fgetc)(void*));
         bool load(std::FILE* fp);
         int get_num_ports()const;
@@ -82,6 +83,7 @@ namespace midisequencer{
     private:
         std::vector<midi_message> messages;
         std::vector<midi_message>::iterator position;
+        std::vector<midi_message>::iterator loop_position;
         std::vector<std::string> long_messages;
         uint32_t division = 0;
         void load_smf(void* fp, int(*fgetc)(void*));


### PR DESCRIPTION
Pretty naive implementation but follows the same MIDI message that harmony/rm2k3 uses for looping, namely the `b06f` event, which is a Control Change event on channel 1 with value `111`. You can quickly look for that by seeing if the MIDI message is `0x6fb0`, which is what that magical number check is.

Unfortunately fmmidi looks like it's the only decoder that lets me inspect the MIDI messages as they're passing through like this, which is what made this such a simple patch.