### PR TITLE
Add Emscripten support to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.7)
 
-project(EasyRPG_Player VERSION 0.6.2 LANGUAGES C CXX)
+project(EasyRPG_Player VERSION 0.6.2 LANGUAGES CXX)
 
 # Extra CMake Module files
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/Modules")
@@ -778,18 +778,16 @@ if (${PLAYER_BUILD_EXECUTABLE})
 	target_link_libraries(${EXE_NAME} ${PROJECT_NAME})
 
 	if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-		# These must be set before calling em_link_*
-		# See emscripten repo: tests/cmake/target_js/CMakeLists.txt#L94
-		set_property(TARGET ${PROJECT_NAME}_exe PROPERTY LINK_FLAGS "-s ALLOW_MEMORY_GROWTH=1 -s ASYNCIFY=1")
+		set_property(TARGET ${PROJECT_NAME}_exe PROPERTY LINK_FLAGS "-s ALLOW_MEMORY_GROWTH=1 -s ASYNCIFY=1  --pre-js ${PLAYER_JS_PREJS} --post-js ${PLAYER_JS_POSTJS}")
+		set_source_files_properties("src/main.cpp" PROPERTIES OBJECT_DEPENDS "${PLAYER_JS_PREJS};${PLAYER_JS_POSTJS}")
 
 		if(PLAYER_JS_BUILD_SHELL)
 			set_target_properties(${PROJECT_NAME}_exe PROPERTIES SUFFIX ".html")
-			set_property(TARGET ${PROJECT_NAME}_exe PROPERTY LINK_FLAGS "--shell-file ${PLAYER_JS_SHELL}")
+			set_property(TARGET ${PROJECT_NAME}_exe APPEND_STRING PROPERTY LINK_FLAGS " --shell-file ${PLAYER_JS_SHELL}")
 		endif()
 
 		target_link_libraries(${PROJECT_NAME}_exe "idbfs.js")
-		em_link_pre_js(${PROJECT_NAME}_exe "${PLAYER_JS_PREJS}")
-		em_link_post_js(${PROJECT_NAME}_exe "${PLAYER_JS_POSTJS}")
+
 	endif()
 
 	# installation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.7)
 
-project(EasyRPG_Player VERSION 0.6.2 LANGUAGES CXX)
+project(EasyRPG_Player VERSION 0.6.2 LANGUAGES C CXX)
 
 # Extra CMake Module files
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/Modules")
@@ -474,6 +474,15 @@ if(APPLE)
 		src/platform/macos/utils.h)
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+	option(PLAYER_JS_BUILD_SHELL "Build the Player executable as a shell file (.html) instead of a standalone javascript file (.js)" OFF)
+	set(PLAYER_JS_PREJS "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-pre.js" CACHE STRING "File to use for --pre-js")
+	set(PLAYER_JS_POSTJS "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-post.js" CACHE STRING "File to use for --post-js")
+	set(PLAYER_JS_SHELL "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-shell.html" CACHE STRING "Shell file to use (--shell-file). Requires PLAYER_JS_BUILD_SHELL=ON")
+	set(PLAYER_JS_GAME_URL "games/" CACHE STRING "Game URL/directory where the web player searches for games")
+	set_property(SOURCE src/async_handler.cpp APPEND PROPERTY COMPILE_DEFINITIONS "EM_GAME_URL=\"${PLAYER_JS_GAME_URL}\"")
+endif()
+
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 	target_compile_definitions(${PROJECT_NAME} PUBLIC _DEBUG=1)
 endif()
@@ -752,7 +761,7 @@ if (${PLAYER_BUILD_EXECUTABLE})
 		add_executable(${EXE_NAME} WIN32 "src/main.cpp")
 		set_target_properties(${EXE_NAME} PROPERTIES OUTPUT_NAME "easyrpg-player")
 	endif()
-	
+
 	if(WIN32)
 		# Open console for Debug builds
 		if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -768,6 +777,22 @@ if (${PLAYER_BUILD_EXECUTABLE})
 
 	target_link_libraries(${EXE_NAME} ${PROJECT_NAME})
 
+	if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+		# These must be set before calling em_link_*
+		# See emscripten repo: tests/cmake/target_js/CMakeLists.txt#L94
+		set_property(TARGET ${PROJECT_NAME}_exe PROPERTY LINK_FLAGS "-s ALLOW_MEMORY_GROWTH=1 -s ASYNCIFY=1")
+
+		if(PLAYER_JS_BUILD_SHELL)
+			set_target_properties(${PROJECT_NAME}_exe PROPERTIES SUFFIX ".html")
+			set_property(TARGET ${PROJECT_NAME}_exe PROPERTY LINK_FLAGS "--shell-file ${PLAYER_JS_SHELL}")
+		endif()
+
+		target_link_libraries(${PROJECT_NAME}_exe "idbfs.js")
+		em_link_pre_js(${PROJECT_NAME}_exe "${PLAYER_JS_PREJS}")
+		em_link_post_js(${PROJECT_NAME}_exe "${PLAYER_JS_POSTJS}")
+	endif()
+
+	# installation
 	include(GNUInstallDirs)
 	if(APPLE)
 		install(TARGETS ${EXE_NAME} RUNTIME DESTINATION BUNDLE DESTINATION "${CMAKE_BINARY_DIR}/Package")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,6 +477,7 @@ endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
 	option(PLAYER_JS_BUILD_SHELL "Build the Player executable as a shell file (.html) instead of a standalone javascript file (.js)" OFF)
 	set(PLAYER_JS_GAME_URL "games/" CACHE STRING "Game URL/directory where the web player searches for games")
+	set(PLAYER_JS_OUTPUT_NAME "easyrpg-player" CACHE STRING "Output name of the js, html and wasm files")
 	set_property(SOURCE src/async_handler.cpp APPEND PROPERTY COMPILE_DEFINITIONS "EM_GAME_URL=\"${PLAYER_JS_GAME_URL}\"")
 endif()
 
@@ -789,6 +790,7 @@ if (${PLAYER_BUILD_EXECUTABLE})
 
 		target_link_libraries(${PROJECT_NAME}_exe "idbfs.js")
 
+		set_target_properties(${EXE_NAME} PROPERTIES OUTPUT_NAME "${PLAYER_JS_OUTPUT_NAME}")
 	endif()
 
 	# installation
@@ -801,6 +803,14 @@ if (${PLAYER_BUILD_EXECUTABLE})
 
 	if(MSVC)
 		install(FILES $<TARGET_PDB_FILE:${EXE_NAME}> DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)
+	endif()
+
+	if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+		# Emscripten does not install the wasm file (or the js file when building a shell)
+		if(PLAYER_JS_BUILD_SHELL)
+			install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PLAYER_JS_OUTPUT_NAME}.js DESTINATION ${CMAKE_INSTALL_BINDIR})
+		endif()
+		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PLAYER_JS_OUTPUT_NAME}.wasm DESTINATION ${CMAKE_INSTALL_BINDIR})
 	endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -779,7 +779,7 @@ if (${PLAYER_BUILD_EXECUTABLE})
 		set(PLAYER_JS_POSTJS "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-post.js")
 		set(PLAYER_JS_SHELL "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-shell.html")
 
-		set_property(TARGET ${PROJECT_NAME}_exe PROPERTY LINK_FLAGS "-s ALLOW_MEMORY_GROWTH=1 -s ASYNCIFY=1  --pre-js ${PLAYER_JS_PREJS} --post-js ${PLAYER_JS_POSTJS}")
+		set_property(TARGET ${PROJECT_NAME}_exe PROPERTY LINK_FLAGS "-s ALLOW_MEMORY_GROWTH=1 -s ASYNCIFY --pre-js ${PLAYER_JS_PREJS} --post-js ${PLAYER_JS_POSTJS} -sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=['$autoResumeAudioContext']")
 		set_source_files_properties("src/main.cpp" PROPERTIES OBJECT_DEPENDS "${PLAYER_JS_PREJS};${PLAYER_JS_POSTJS}")
 
 		if(PLAYER_JS_BUILD_SHELL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -779,7 +779,7 @@ if (${PLAYER_BUILD_EXECUTABLE})
 		set(PLAYER_JS_POSTJS "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-post.js")
 		set(PLAYER_JS_SHELL "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-shell.html")
 
-		set_property(TARGET ${PROJECT_NAME}_exe PROPERTY LINK_FLAGS "-s ALLOW_MEMORY_GROWTH=1 -s ASYNCIFY --pre-js ${PLAYER_JS_PREJS} --post-js ${PLAYER_JS_POSTJS} -sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=['$autoResumeAudioContext']")
+		set_property(TARGET ${PROJECT_NAME}_exe PROPERTY LINK_FLAGS "-s ALLOW_MEMORY_GROWTH=1 -s ASYNCIFY -s ASYNCIFY_IGNORE_INDIRECT --pre-js ${PLAYER_JS_PREJS} --post-js ${PLAYER_JS_POSTJS} -sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=['$autoResumeAudioContext']")
 		set_source_files_properties("src/main.cpp" PROPERTIES OBJECT_DEPENDS "${PLAYER_JS_PREJS};${PLAYER_JS_POSTJS}")
 
 		if(PLAYER_JS_BUILD_SHELL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,9 +476,6 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
 	option(PLAYER_JS_BUILD_SHELL "Build the Player executable as a shell file (.html) instead of a standalone javascript file (.js)" OFF)
-	set(PLAYER_JS_PREJS "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-pre.js" CACHE STRING "File to use for --pre-js")
-	set(PLAYER_JS_POSTJS "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-post.js" CACHE STRING "File to use for --post-js")
-	set(PLAYER_JS_SHELL "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-shell.html" CACHE STRING "Shell file to use (--shell-file). Requires PLAYER_JS_BUILD_SHELL=ON")
 	set(PLAYER_JS_GAME_URL "games/" CACHE STRING "Game URL/directory where the web player searches for games")
 	set_property(SOURCE src/async_handler.cpp APPEND PROPERTY COMPILE_DEFINITIONS "EM_GAME_URL=\"${PLAYER_JS_GAME_URL}\"")
 endif()
@@ -778,6 +775,10 @@ if (${PLAYER_BUILD_EXECUTABLE})
 	target_link_libraries(${EXE_NAME} ${PROJECT_NAME})
 
 	if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+		set(PLAYER_JS_PREJS "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-pre.js")
+		set(PLAYER_JS_POSTJS "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-post.js")
+		set(PLAYER_JS_SHELL "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-shell.html")
+
 		set_property(TARGET ${PROJECT_NAME}_exe PROPERTY LINK_FLAGS "-s ALLOW_MEMORY_GROWTH=1 -s ASYNCIFY=1  --pre-js ${PLAYER_JS_PREJS} --post-js ${PLAYER_JS_POSTJS}")
 		set_source_files_properties("src/main.cpp" PROPERTIES OBJECT_DEPENDS "${PLAYER_JS_PREJS};${PLAYER_JS_POSTJS}")
 

--- a/configure.ac
+++ b/configure.ac
@@ -23,10 +23,6 @@ PKG_PROG_PKG_CONFIG
 AC_PROG_OBJCXX
 
 # Options
-AC_ARG_VAR([EM_GAME_URL], [Game URL/directory (only used for the Emscripten port)])
-AS_IF([test "x$EM_GAME_URL" != "x"],[
-	AC_DEFINE_UNQUOTED([EM_GAME_URL], ["$EM_GAME_URL"], [Game URL (Emscripten)])
-])
 AC_ARG_ENABLE([fmmidi],
 	AS_HELP_STRING([--enable-fmmidi@<:@=fallback@:>@],[use internal MIDI sequencer/as fallback @<:@default=no@:>@]))
 AS_IF([test "x$enable_fmmidi" = "xyes"],[want_fmmidi=1],[test "x$enable_fmmidi" = "xfallback"],[want_fmmidi=2])
@@ -175,7 +171,6 @@ if test "yes" != "$silent"; then
 	echo "Paths:"
 	echo "  prefix: $prefix"
 	echo "  bash completion: $BASHCOMPLETION_DIR"
-	test -n "$EM_GAME_URL" && echo "Emscripten Game URL: $EM_GAME_URL"
 
 	# FIXME SDL version
 	echo "Backend: SDL"

--- a/resources/emscripten/emscripten-post.js
+++ b/resources/emscripten/emscripten-post.js
@@ -11,23 +11,3 @@ if (Module.EASYRPG_GAME.length > 0) {
 if (typeof(Module.EASYRPG_FS) === "undefined") {
     Module.EASYRPG_FS = IDBFS;
 }
-
-// Try resuming the audio playback because Chrome automutes it when there was
-// no user interaction
-function enableAudio() {
-    var audio_start_timer = function() {
-        setTimeout(function() {
-            if (Module.SDL2 != undefined && Module.SDL2.audioContext != undefined) {
-                if (Module.SDL2.audioContext.state == 'suspended') {
-                    Module.SDL2.audioContext.resume();
-                    audio_start_timer();
-                }
-            } else {
-                audio_start_timer();
-            };
-        }, 3000);
-    };
-
-    audio_start_timer();
-}
-enableAudio();

--- a/resources/emscripten/emscripten-shell.html
+++ b/resources/emscripten/emscripten-shell.html
@@ -23,7 +23,7 @@
   </head>
   <body>
 
-    <div id="controls"><input type="button" value="Full screen" onclick="if (Module.requestFullScreen) Module.requestFullScreen()"></div>
+    <div id="controls"><input type="button" value="Fullscreen" onclick="Module['canvas'].requestFullscreen()"></div>
 
     <div id="status">Downloading...</div>
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -259,6 +259,9 @@ void Player::MainLoop() {
 
 	auto frame_limit = DisplayUi->GetFrameLimit();
 	if (frame_limit == Game_Clock::duration()) {
+#ifdef EMSCRIPTEN
+		emscripten_sleep(0);
+#endif
 		return;
 	}
 
@@ -268,6 +271,11 @@ void Player::MainLoop() {
 	if (Game_Clock::now() < next) {
 		iframe.End();
 		Game_Clock::SleepFor(next - now);
+	} else {
+#ifdef EMSCRIPTEN
+		// Yield back to browser once per frame
+		emscripten_sleep(0);
+#endif
 	}
 }
 

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -124,9 +124,12 @@ void Scene_Logo::OnIndexReady(FileRequestResult*) {
 	ini->SetImportantFile(true);
 	FileRequestAsync* exfont = AsyncHandler::RequestFile("ExFont");
 	exfont->SetImportantFile(true);
+	FileRequestAsync* soundfont = AsyncHandler::RequestFile("easyrpg.soundfont");
+	soundfont->SetImportantFile(true);
 
 	db->Start();
 	tree->Start();
 	ini->Start();
 	exfont->Start();
+	soundfont->Start();
 }

--- a/src/sdl2_ui.cpp
+++ b/src/sdl2_ui.cpp
@@ -146,6 +146,9 @@ Sdl2Ui::Sdl2Ui(long width, long height, const Game_ConfigVideo& cfg) : BaseUi(cf
 	// Set the application class name
 	setenv("SDL_VIDEO_X11_WMCLASS", GAME_TITLE, 0);
 #endif
+#ifdef EMSCRIPTEN
+	SDL_SetHint(SDL_HINT_EMSCRIPTEN_ASYNCIFY, "0");
+#endif
 
 	if (SDL_Init(SDL_INIT_VIDEO) < 0) {
 		Output::Error("Couldn't initialize SDL.\n{}\n", SDL_GetError());

--- a/tests/cmdline_parser.cpp
+++ b/tests/cmdline_parser.cpp
@@ -1,3 +1,4 @@
+#include <ostream>
 #include "cmdline_parser.h"
 #include "doctest.h"
 

--- a/tests/config_param.cpp
+++ b/tests/config_param.cpp
@@ -1,3 +1,4 @@
+#include <ostream>
 #include "config_param.h"
 #include "doctest.h"
 #include <climits>

--- a/tests/directorytree.cpp
+++ b/tests/directorytree.cpp
@@ -2,7 +2,15 @@
 #include "main_data.h"
 #include "doctest.h"
 
-TEST_SUITE_BEGIN("DirectoryTree");
+static bool skip_tests() {
+#ifdef EMSCRIPTEN
+	return true;
+#else
+	return false;
+#endif
+}
+
+TEST_SUITE_BEGIN("DirectoryTree" * doctest::skip(skip_tests()));
 
 TEST_CASE("CreateDirectoryTree") {
 	Main_Data::Init();

--- a/tests/filefinder.cpp
+++ b/tests/filefinder.cpp
@@ -5,7 +5,15 @@
 #include "main_data.h"
 #include "doctest.h"
 
-TEST_SUITE_BEGIN("FileFinder");
+static bool skip_tests() {
+#ifdef EMSCRIPTEN
+	return true;
+#else
+	return false;
+#endif
+}
+
+TEST_SUITE_BEGIN("FileFinder" * doctest::skip(skip_tests()));
 
 TEST_CASE("IsDirectory") {
 	Main_Data::Init();

--- a/tests/platform.cpp
+++ b/tests/platform.cpp
@@ -3,7 +3,15 @@
 #include "platform.h"
 #include "doctest.h"
 
-TEST_SUITE_BEGIN("Platform");
+static bool skip_tests() {
+#ifdef EMSCRIPTEN
+	return true;
+#else
+	return false;
+#endif
+}
+
+TEST_SUITE_BEGIN("Platform" * doctest::skip(skip_tests()));
 
 namespace {
 	const std::string onekb = EP_TEST_PATH "/platform/1kb";

--- a/tests/rtp.cpp
+++ b/tests/rtp.cpp
@@ -1,5 +1,4 @@
-#include <cstring>
-#include <iostream>
+#include <ostream>
 #include "filefinder.h"
 #include "player.h"
 #include "rtp.h"


### PR DESCRIPTION
Fix #2228

How to build:
```
source EMSCRIPTEN_PATH/emsdk_env.fish
emcmake cmake . -GNinja -DPLAYER_JS_BUILD_SHELL=ON|OFF
```

```
cmake --build . --target check
[2/2] /bin/node /home/gabriel/code/easyrpg/easyrpg-player/test_runner.js
[doctest] doctest version is "2.3.5"
[doctest] run with "--help" for options
============================================
[doctest] test cases:     98 |     98 passed |      0 failed |     10 skipped
[doctest] assertions:   3391 |   3391 passed |      0 failed |
[doctest] Status: SUCCESS!
```

The ``LANGUAGES C`` is required for the ".js" files and I can't figure out a different way to enable C.

This allows changing the path with ``-DPLAYER_JS_GAME_URL`` and it will only recompile this one file! (at least when Ninja is used, Makefiles do a full recompile)
```set_property(SOURCE src/async_handler.cpp APPEND PROPERTY COMPILE_DEFINITIONS "EM_GAME_URL=\"${PLAYER_JS_GAME_URL}\"")``

File system access for unit tests would be possible in a Node environment but this is a huge change I don't want to do.

The Toolchain file must be patched right now because there is still this open issue:
https://github.com/emscripten-core/emscripten/pull/10184
I explain there why ``-DCMAKE_FIND_ROOT_PATH`` can't be used :/

Any suggestion for ``README.md`` edits?