### PR TITLE
Yume2kki: Fix tilemap assert on Map 196

### DIFF
--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -573,7 +573,7 @@ inline ImageOpacity Bitmap::GetImageOpacity() const {
 }
 
 inline ImageOpacity Bitmap::GetTileOpacity(int x, int y) const {
-	return !tile_opacity.Empty() ? tile_opacity.Get(x, y) : ImageOpacity::Partial;
+	return tile_opacity.Get(x, y);
 }
 
 inline Color Bitmap::GetBackgroundColor() const {

--- a/src/opacity.h
+++ b/src/opacity.h
@@ -101,13 +101,17 @@ class TileOpacity {
 inline TileOpacity::TileOpacity(int w, int h)
 	: _p(new uint8_t[w * h]), _w(w), _h(h)
 {
-	assert(_w > 0);
-	assert(_h > 0);
+	assert(_w >= 0);
+	assert(_h >= 0);
 }
 
 inline ImageOpacity TileOpacity::Get(int x, int y) const {
-	assert(x >= 0 && x < _w);
-	assert(y >= 0 && y < _h);
+	assert(x >= 0);
+	assert(y >= 0);
+
+	if (x >= _w || y >= _h) {
+		return ImageOpacity::Partial;
+	}
 
 	return static_cast<ImageOpacity>(_p[x + y * _w]);
 }

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -383,6 +383,7 @@ void Scene_Debug::Update() {
 				} else {
 					PushUiRangeList();
 				}
+				break;
 			case eFullHeal:
 				if (sz > 1) {
 					DoFullHeal();
@@ -424,6 +425,7 @@ void Scene_Debug::Update() {
 						PushUiNumberInput(0, num_digits, false);
 					}
 				}
+				break;
 		}
 		Game_Map::SetNeedRefresh(true);
 	} else if (range_window->GetActive() && Input::IsRepeated(Input::RIGHT)) {


### PR DESCRIPTION
The map uses a 1x1 tilemap. I also fixed the case for tilemaps that fit at least one tile (triggered a different assert)

Caused by too strict assert checks in 61f859ec4f935da9c13e85f58251e0291d42faa8
