### PR TITLE
Fix for games with altered file extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,8 @@ add_library(${PROJECT_NAME}
 	src/exfont.h
 	src/filefinder.cpp
 	src/filefinder.h
+	src/fileext_guesser.cpp
+	src/fileext_guesser.h
 	src/filesystem.cpp
 	src/filesystem.h
 	src/filesystem_stream.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -82,6 +82,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/exfont.h \
 	src/filefinder.cpp \
 	src/filefinder.h \
+	src/fileext_guesser.cpp \
+	src/fileext_guesser.h \
 	src/filesystem.cpp \
 	src/filesystem.h \
 	src/filesystem_stream.h \

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserHelper.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserHelper.java
@@ -30,7 +30,7 @@ import java.util.LinkedList;
 
 public class GameBrowserHelper {
     //Files' names
-    private final static String DATABASE_NAME = "RPG_RT.ldb", TREEMAP_NAME = "RPG_RT.lmt", INI_FILE = "RPG_RT.ini";
+    private final static String DATABASE_NAME = "RPG_RT.ldb", TREEMAP_NAME = "RPG_RT.lmt", INI_FILE = "RPG_RT.ini", EXE_FILE = "RPG_RT.exe";
 
     private final static String TAG_FIRST_LAUNCH = "FIRST_LAUNCH";
     private static int GRANTED_PERMISSION = 0;
@@ -50,6 +50,9 @@ public class GameBrowserHelper {
         boolean databaseFound = false;
         boolean treemapFound = false;
 
+        // Create a lookup by extension as we go, in case we are dealing with non-standard extensions.
+        int rpgrtCount = 0;
+
         for (File entry : dir.listFiles()) {
             if (entry.isFile() && entry.canRead()) {
                 if (!databaseFound && entry.getName().equalsIgnoreCase(DATABASE_NAME)) {
@@ -58,10 +61,24 @@ public class GameBrowserHelper {
                     treemapFound = true;
                 }
 
+                // Count non-standard files.
+                // NOTE: Do not put this in the 'else' statement, since only 1 extension may be non-standard and we want to count both.
+                if (entry.getName().toLowerCase().startsWith("rpg_rt.")) {
+                    if (!(entry.getName().equalsIgnoreCase(INI_FILE) || entry.getName().equalsIgnoreCase(EXE_FILE))) {
+                        rpgrtCount += 1;
+                    }
+                }
+
                 if (databaseFound && treemapFound) {
                     return true;
                 }
             }
+        }
+
+        // We might be dealing with a non-standard extension.
+        // Show it, and let the C++ code sort out which file is which.
+        if (rpgrtCount == 2) {
+            return true;
         }
 
         return false;

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameScanner.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameScanner.java
@@ -19,11 +19,6 @@ public class GameScanner {
     // (Such as caching games' thumbnail, avoiding some syscall ...)
     private static volatile GameScanner instance = null;
 
-    //Files' names
-    private final static String DATABASE_NAME = "RPG_RT.ldb",
-            TREEMAP_NAME = "RPG_RT.lmt",
-            INI_FILE = "RPG_RT.ini";
-
     private List<GameInformation> gameList;
     private List<String> errorList;
     private Activity context;
@@ -106,42 +101,11 @@ public class GameScanner {
         Log.i("Browser", gameList.size() + " games found : " + gameList);
     }
 
-    /**
-     * Tests if a folder is a RPG2k Game.
-     * (contains DATABASE_NAME and TREEMAP_NAME)
-     * @param dir Directory to test
-     * @return true if RPG2k game
-     */
-    private static boolean isRpg2kGame(File dir) {
-        if (!dir.isDirectory() || !dir.canRead()) {
-            return false;
-        }
-
-        boolean databaseFound = false;
-        boolean treemapFound = false;
-
-        for (File entry : dir.listFiles()) {
-            if (entry.isFile() && entry.canRead()) {
-                if (!databaseFound && entry.getName().equalsIgnoreCase(DATABASE_NAME)) {
-                    databaseFound = true;
-                } else if (!treemapFound && entry.getName().equalsIgnoreCase(TREEMAP_NAME)) {
-                    treemapFound = true;
-                }
-
-                if (databaseFound && treemapFound) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
     private void scanFolder(File[] list, int depth) {
         if (list != null) {
             for (File file : list) {
                 if (!file.getName().startsWith(".")) {
-                    if (isRpg2kGame(file)) {
+                    if (GameBrowserHelper.isRpg2kGame(file)) {
                         gameList.add(new GameInformation(file.getName(), file.getAbsolutePath()));
                     } else if (file.isDirectory() && file.canRead() && depth > 0) {
                         // Not a RPG2k Game but a directory -> recurse

--- a/resources/shared/easyrpg.ini
+++ b/resources/shared/easyrpg.ini
@@ -53,4 +53,8 @@ ImportSavePivotMap=133
 Name=Legion Saga III
 Crc32LDB=28ea6edc
 
+[44ca0b67/8a9a7f29]
+Name=Laxius Power ~ Random Story
+LmtFileAlias=lxb
+LdbFileAlias=set
 

--- a/src/fileext_guesser.cpp
+++ b/src/fileext_guesser.cpp
@@ -1,0 +1,147 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Headers
+
+#include "filefinder.h"
+#include "fileext_guesser.h"
+#include "meta.h"
+#include "output.h"
+#include "string_view.h"
+
+
+namespace {
+	const std::string RtPrefix = "rpg_rt.";
+	const std::string MapPrefix = "map";
+	const size_t MapPrefixLength = 8; // mapXXXX.
+}
+
+
+FileExtGuesser::RPG2KNonStandardFilenameGuesser FileExtGuesser::GetRPG2kProjectWithRenames(FileFinder::DirectoryTree const& dir) {
+	// Try to rescue and determine file extensions.
+	// We need to figure out the names of the map tree and the DB (maps come later).
+	std::vector<RPG2KNonStandardFilenameGuesser::ExtAndSize> candidates;
+	for (const std::pair<std::string, std::string>& item : dir.files) {
+		if (item.first.length()==RtPrefix.length()+3 && lcf::ToStringView(item.first).starts_with(RtPrefix)) {
+			std::string ext = item.first.substr(RtPrefix.length());
+			if (ext != "exe" && ext != "ini") {
+				candidates.push_back({item.second, ext, FileFinder::GetFileSize(FileFinder::FindDefault(dir, item.second))});
+			}
+		}
+
+		// Avoid needless scanning if we can't figure it out
+		if (candidates.size()>2) {
+			break;
+		}
+	}
+
+	// Return only if we matched exactly two files. 
+	if (candidates.size() == 2) {
+		RPG2KNonStandardFilenameGuesser res;
+		res.rpgRTs.first = candidates[0];
+		res.rpgRTs.second = candidates[1];
+		return res;
+	}
+
+	return RPG2KNonStandardFilenameGuesser();
+}
+
+void FileExtGuesser::GuessAndAddLmuExtension(FileFinder::DirectoryTree const& dir, Meta const& meta, RPG2KFileExtRemap& mapping)
+{
+	// If metadata is provided, rely on that.
+	std::string metaLmu = meta.GetLmuAlias();
+	if (!metaLmu.empty()) {
+		mapping.extMap[SUFFIX_LMU] = metaLmu;
+		Output::Debug("Metadata-provided non-standard extension for LMU({})", metaLmu);
+	} else {
+		// Try to rescue and determine file extensions.
+		// Without metadata, scan for matching files. Stop after you find a few;
+		//   we can't just pick the first since there may be some backup files on disk.
+		std::unordered_map<std::string, int> extCounts; // ext => count
+		for (const std::pair<std::string, std::string>& item : dir.files) {
+			if (item.first.length()==MapPrefixLength+3 &&  lcf::ToStringView(item.first).starts_with(MapPrefix)) {
+				std::string ext = item.first.substr(MapPrefixLength);
+				extCounts[ext] += 1;
+				if (extCounts[ext] >= 5) {
+					mapping.extMap[SUFFIX_LMU] = ext;
+					Output::Debug("Guessing non-standard extension for LMU({})", ext);
+					break;
+				}
+			}
+		}
+	}
+}
+
+FileExtGuesser::RPG2KFileExtRemap FileExtGuesser::RPG2KNonStandardFilenameGuesser::guessExtensions(Meta& meta)
+{
+	RPG2KFileExtRemap res;
+	
+	// Since the file extensions are non-standard, we 
+	// won't have CRCs for them, so we need to guess more
+	if (!this->Empty()) {
+		meta.ReInitForNonStandardExtensions(rpgRTs.first.fname, rpgRTs.second.fname);
+	}
+
+	// If metadata exists, we don't need to guess
+	std::string metaLdb = meta.GetLdbAlias();
+	std::string metaLmt = meta.GetLmtAlias();
+	if (!metaLdb.empty()) {
+		res.extMap[SUFFIX_LDB] = metaLdb;
+	}
+	if (!metaLmt.empty()) {
+		res.extMap[SUFFIX_LMT] = metaLmt;
+	}
+
+	// If neither exists, we have to fall back to guessing.
+	if (!(metaLdb.empty() && metaLmt.empty())) {
+		Output::Debug("Metadata-provided non-standard extension for LDB({}) and LMT({})", metaLdb, metaLmt);
+	} else {
+		// With no metadata, just assume the largest file is the database
+		// It's usually bigger by a factor of 10.
+		auto first = rpgRTs.first;
+		auto second = rpgRTs.second;
+		if (first.sz > second.sz) {
+			res.extMap[SUFFIX_LDB] = first.ext;
+			res.extMap[SUFFIX_LMT] = second.ext;
+		} else {
+			res.extMap[SUFFIX_LDB] = second.ext;
+			res.extMap[SUFFIX_LMT] = first.ext;
+		}
+
+		Output::Debug("Guessing non-standard extensions for LDB({}) and LMT({})", res.extMap[SUFFIX_LDB], res.extMap[SUFFIX_LMT]);
+	}
+
+	return res;
+}
+
+bool FileExtGuesser::RPG2KNonStandardFilenameGuesser::Empty() const {
+	return rpgRTs.first.ext.empty() || rpgRTs.second.ext.empty();
+}
+
+std::string FileExtGuesser::RPG2KFileExtRemap::MakeFilename(std::string const& prefix, std::string const& suffix)
+{
+	std::stringstream res;
+	res <<prefix <<".";
+
+	auto it = extMap.find(suffix);
+	if (it != extMap.end()) {
+		res << it->second;
+	} else {
+		res << suffix;
+	}
+	return res.str();
+}

--- a/src/fileext_guesser.h
+++ b/src/fileext_guesser.h
@@ -1,0 +1,98 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_FILEEXTGUESSER_H
+#define EP_FILEEXTGUESSER_H
+
+#include <string>
+#include <unordered_map>
+
+class Meta;
+namespace FileFinder {
+	class DirectoryTree;
+}
+
+/**
+ * FileExtGuesser contains helper methods for guessing the extensions used on non-standard RPG Projects.
+ */
+namespace FileExtGuesser {
+
+	// Bookkeeping structures for use with GuessAndAddLmuExtension()
+	struct RPG2KFileExtRemap {
+		/**
+		 * Construct a filename from a given prefix and suffix. 
+		 * Performs extension substitution based on the values stored in extMap
+		 *
+		 * @param prefix The prefix (e.g., 'Map0001')
+		 * @param suffix The suffix (e.g., 'lmu')
+		 * @return The joined filename (e.g., 'Map0001.lmu', OR 'Map0001.xyz')
+		 */
+		std::string MakeFilename(std::string const& prefix, std::string const& suffix);
+
+		std::unordered_map<std::string, std::string> extMap;
+	};
+
+	/**
+	 * Attempts to determine the LMU extension for non-standard projects. 
+	 * 
+	 * @param dir The directory tree of the project in question
+	 * @param meta The meta object, which can be used to directly specify the extension
+	 * @param mapping The resultant mapping, if any, is stored in this lookup.
+	 */
+	void GuessAndAddLmuExtension(FileFinder::DirectoryTree const& dir, Meta const& meta, RPG2KFileExtRemap& mapping);
+
+
+	// Bookkeeping structure for use with GetRPG2kProjectWithRenames()
+	struct RPG2KNonStandardFilenameGuesser {
+		struct ExtAndSize {
+			ExtAndSize(const std::string& fname="", const std::string& ext="", int64_t sz=0) : fname(fname), ext(ext), sz(sz) {}
+			std::string fname;
+			std::string ext;
+			int64_t sz;
+		};
+
+		// This contains the LMT and LDB files, in no particular order.
+		std::pair<ExtAndSize,ExtAndSize> rpgRTs;
+
+		/**
+		 * Is this struct 'empty' --i.e., does it contain no useful information?
+		 *
+		 * @return true if both rpgTRs's 'ext' properties are empty; false otherwise
+		 */
+		bool Empty() const;
+
+		/**
+		 * Perform a series of heuristical guesses to determine what the LDB/LMT extensions are.
+		 *
+		 * @param meta A Meta object loaded from the INI file
+		 * @return A mapping for the LDB and LMT extensions (may be empty if no guess could be made).
+		 */
+		RPG2KFileExtRemap guessExtensions(Meta& meta);
+	};
+
+	/**
+	 * Scans a directory tree and tries to identify the LMT/LDB files, but with non-standard extensions.
+	 *
+	 * @param dir The directory tree of the project in question
+	 * @return An object that contains the candidates (check with .Empty())
+	 */
+	RPG2KNonStandardFilenameGuesser GetRPG2kProjectWithRenames(FileFinder::DirectoryTree const& dir);
+
+}
+
+#endif
+

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -41,6 +41,7 @@
 #include "options.h"
 #include "utils.h"
 #include "filefinder.h"
+#include "fileext_guesser.h"
 #include "output.h"
 #include "player.h"
 #include "registry.h"
@@ -726,7 +727,7 @@ std::string FileFinder::FindDefault(const DirectoryTree& tree, const std::string
 }
 
 bool FileFinder::IsValidProject(DirectoryTree const & dir) {
-	return IsRPG2kProject(dir) || IsEasyRpgProject(dir);
+	return IsRPG2kProject(dir) || IsEasyRpgProject(dir) || IsRPG2kProjectWithRenames(dir);
 }
 
 std::string FileFinder::FindDefault(FileFinder::DirectoryTree const &tree, const std::string &dir, const std::string &name,	const char **exts) {
@@ -747,6 +748,10 @@ bool FileFinder::IsEasyRpgProject(DirectoryTree const& dir){
 		lmt_it = dir.files.find(Utils::LowerCase(TREEMAP_NAME_EASYRPG));
 
 	return(ldb_it != dir.files.end() && lmt_it != dir.files.end());
+}
+
+bool FileFinder::IsRPG2kProjectWithRenames(DirectoryTree const& dir) {
+	return !FileExtGuesser::GetRPG2kProjectWithRenames(dir).Empty();
 }
 
 bool FileFinder::HasSavegame() {

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -286,6 +286,15 @@ namespace FileFinder {
 	bool IsEasyRpgProject(DirectoryTree const& dir);
 
 	/**
+	 * Determines if the directory in question represents an RPG2k project with non-standard 
+	 *   database, map tree, or map file names.
+	 *
+	 * @param dir The directory tree in question
+	 * @return true if this is likely an RPG2k project; false otherwise
+	 */
+	bool IsRPG2kProjectWithRenames(DirectoryTree const& dir);
+
+	/**
 	 * Checks whether the save directory contains any savegame with name
 	 * SaveXX.lsd (XX from 00 to 15).
 	 *

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -649,6 +649,15 @@ namespace Game_Map {
 	bool UpdateMessage(MapUpdateAsyncContext& actx);
 	bool UpdateForegroundEvents(MapUpdateAsyncContext& actx);
 
+	/**
+	 * Construct a map name, either for EasyRPG or RPG Maker projects
+	 *
+	 * @param map_id The ID of the map to construct
+	 * @param isEasyRpg Is the an easyrpg (emu) project, or an RPG Maker (lmu) one?
+	 * @return The map name, as Map<map_id>.<map_extension>
+	 */
+	std::string ConstructMapName(int map_id, bool isEasyRpg);
+
 	FileRequestAsync* RequestMap(int map_id);
 
 	namespace Parallax {

--- a/src/meta.h
+++ b/src/meta.h
@@ -43,6 +43,16 @@ public:
 	Meta(const std::string& meta_file);
 
 	/**
+	 * When dealing with non-standard extensions, Meta will need
+	 * to be re-initialized with the two files that *might* be
+	 * database files, so that it can determine the CRC32 of them.
+	 *
+	 * @file1 The first of two identical files (either LMT/LDB, but with no way of knowing at the time)
+	 * @file2 The second of two identical files (either LMT/LDB, but with no way of knowing at the time)
+	 */
+	void ReInitForNonStandardExtensions(const std::string& file1, const std::string& file2);
+
+	/**
 	 * Retrieves the map used for pivoting between multi-game save files
 	 * All save files listed will match the given pivot map ID (i.e., "last saved here")
 	 * @return the pivot map ID, or 0 (on error) for "no map restriction"
@@ -79,6 +89,24 @@ public:
 	std::vector<FileItem> SearchImportPaths(const FileFinder::DirectoryTree& parent_tree, const std::string& child_path) const;
 
 	/**
+	 * Retrieve the LDB extension's replacement in non-standard projects.
+	 * @return The extension's alias, or the empty string if none could be found.
+	 */
+	std::string GetLdbAlias() const;
+
+	/**
+	 * Retrieve the LMT extension's replacement in non-standard projects.
+         * @return The extension's alias, or the empty string if none could be found.
+         */
+	std::string GetLmtAlias() const;
+
+	/**
+	 * Retrieve the LMU extension's replacement in non-standard projects.
+         * @return The extension's alias, or the empty string if none could be found.
+         */
+	std::string GetLmuAlias() const;
+
+	/**
 	 * Is multi-game save importing enabled? If so, the title screen should show an Import option.
 	 * @return true if the meta INI file contains a parentGame for this game
 	 */
@@ -110,8 +138,11 @@ private:
 	/**
 	 * Heuristically tries to guess the canonical name of this game,
 	 *  and stores it locally in this Meta object.
+	 *
+	 * @param lmtFile The path to the file we expect to be RPG_RT.lmt
+	 * @param ldbFile The path to the file we expect to be RPG_RT.ldb
 	 */
-	void IdentifyCanonName();
+	void IdentifyCanonName(const std::string& lmtFile, const std::string& ldbFile);
 
 	/**
 	 * Internal function called by SearchImportPaths

--- a/src/options.h
+++ b/src/options.h
@@ -48,13 +48,27 @@
 /** INI configuration filename. */
 #define INI_NAME "RPG_RT.ini"
 
+/** Prefix for .ldb and .lmt files; used when guessing non-standard extensions. */
+#define RPG_RT_PREFIX "RPG_RT"
+#define EASY_RT_PREFIX "EASY_RT"
+
+/** Suffixes for LDB/LMT/LMU files */
+#define SUFFIX_LDB "ldb"
+#define SUFFIX_LMT "lmt"
+#define SUFFIX_LMU "lmu"
+
+/** Suffixes for their EasyRPG equivalents */
+#define SUFFIX_EDB "edb"
+#define SUFFIX_EMT "emt"
+#define SUFFIX_EMU "emu"
+
 /** lcf::Database filename. */
-#define DATABASE_NAME "RPG_RT.ldb"
-#define DATABASE_NAME_EASYRPG "EASY_RT.edb"
+#define DATABASE_NAME RPG_RT_PREFIX "." SUFFIX_LDB
+#define DATABASE_NAME_EASYRPG EASY_RT_PREFIX "." SUFFIX_EDB
 
 /** Map tree filename. */
-#define TREEMAP_NAME "RPG_RT.lmt"
-#define TREEMAP_NAME_EASYRPG "EASY_RT.emt"
+#define TREEMAP_NAME RPG_RT_PREFIX "." SUFFIX_LMT
+#define TREEMAP_NAME_EASYRPG EASY_RT_PREFIX "." SUFFIX_EMT
 
 /** File name for additional metadata, such as multi-game save imports. */
 #define META_NAME "easyrpg.ini"

--- a/src/platform/libretro/libretro_ui.cpp
+++ b/src/platform/libretro/libretro_ui.cpp
@@ -556,7 +556,7 @@ RETRO_API void retro_get_system_info(struct retro_system_info* info) {
 	#endif
 	info->library_version = PLAYER_VERSION GIT_VERSION;
 	info->need_fullpath = true;
-	info->valid_extensions = "ldb";
+	info->valid_extensions = SUFFIX_LDB;
 }
 
 /* Gets information about system audio/video timings and geometry.

--- a/src/player.h
+++ b/src/player.h
@@ -130,6 +130,12 @@ namespace Player {
 	void ResetGameObjects();
 
 	/**
+	 * Determine if the LDB and LMT files are not present, and if so, guess 
+	 * if they may have been renamed. Populates fileext_map.
+	 */
+	void GuessNonStandardExtensions();
+
+	/**
 	 * Loads all databases.
 	 */
 	void LoadDatabase();
@@ -299,6 +305,9 @@ namespace Player {
 
 	/** Mutes audio playback */
 	extern bool no_audio_flag;
+
+	/** Is this project using EasyRPG files, or the RPG_RT format? */
+	extern bool is_easyrpg_project;
 
 	/** Encoding used */
 	extern std::string encoding;

--- a/src/player.h
+++ b/src/player.h
@@ -19,6 +19,7 @@
 #define EP_PLAYER_H
 
 // Headers
+#include "fileext_guesser.h"
 #include "meta.h"
 #include "game_clock.h"
 #include "game_config.h"
@@ -325,6 +326,9 @@ namespace Player {
 
 	/** Meta class containing additional external data for this game. */
 	extern std::shared_ptr<Meta> meta;
+
+	/** File extension rewriter, for non-standard extensions. */
+	extern FileExtGuesser::RPG2KFileExtRemap fileext_map;
 
 	/**
 	 * The default speed modifier applied when the speed up button is pressed


### PR DESCRIPTION
Ready to merge (from my point of view). 

This is my implementation for Issue #1920; please see the initial discussion there.

Regarding @Ghabry's comments:
1) Check only 2 files: Done, but see note
2) Assume larger==LDB: Done
3) LcfXXX checks: Done, but see note

Some notes on this fix:
1) What's the easiest way to cheaply check if a directory *might* be a game project? Right now I check for RPG_RT.ini, but as you said that's not always present. I expect RPG_RT.exe might also be stripped. Is there any good file to check, or should I just disable this minor performance hack?  ---Side note: it might be worth keeping if *all games with hacked extensions* have .ini files.
2) The Meta file now has "LmtHeaderString=XXX", which allows us to pass the "XXX" string in to liblcf (i.e., to tell it what string to expect within the file header). As you said, errors are disabled if this string doesn't match  --but it still shows a warning. Do we want to allow passing in the expected header string to liblcf when parsing to silence the warning, or is this not worth the trouble?
3) We cannot apply the Meta file until *after* scanning the directory. Main reason: the Meta instance is stored in player.cpp. Sub reason: we don't know which file to calculate the CRC32 of until we scan (since they were renamed). This is not a huge problem, since the scanning is pretty fast.
4) I scan the names of all mapXXXX.ext files to ensure the extension is consistent across files. This might be overkill; we could (a) just stop on the first file or (b) check for the starting map filename (pulled from LMT), assuming we've parsed LMT at this point (which I think we have).
5) This fix assumes all "rpg_rt.XXX" files are renamed by extension ONLY --i.e., if you rename it to "abc.lmt" then this fix won't find it. Do any hacks do this, and do we care?
6) Just reiterating that the meta file can be used to overcome most limitations as discussed (e.g., slow lmu scanning and small LDB files).