### PR TITLE
Add if()s around circular find_package() calls

### DIFF
--- a/builds/cmake/Modules/FindFreetype.cmake
+++ b/builds/cmake/Modules/FindFreetype.cmake
@@ -174,10 +174,12 @@ if(Freetype_FOUND)
       INTERFACE_INCLUDE_DIRECTORIES "${FREETYPE_INCLUDE_DIRS}")
 
     # Handle circular dependency on harfbuzz
-    find_package(Harfbuzz QUIET)
-    if(HARFBUZZ_FOUND)
-      set_target_properties(Freetype::Freetype PROPERTIES
-        INTERFACE_LINK_LIBRARIES Harfbuzz::Harfbuzz)
+    if(NOT TARGET Harfbuzz::Harfbuzz)
+      find_package(Harfbuzz QUIET)
+      if(HARFBUZZ_FOUND)
+        set_target_properties(Freetype::Freetype PROPERTIES
+          INTERFACE_LINK_LIBRARIES Harfbuzz::Harfbuzz)
+      endif()
     endif()
 
     if(FREETYPE_LIBRARY_RELEASE)

--- a/builds/cmake/Modules/FindHarfbuzz.cmake
+++ b/builds/cmake/Modules/FindHarfbuzz.cmake
@@ -55,7 +55,11 @@ if(HARFBUZZ_FOUND)
 
 	if(NOT TARGET Harfbuzz::Harfbuzz)
 		add_library(Harfbuzz::Harfbuzz UNKNOWN IMPORTED)
-		find_library(Freetype REQUIRED)
+
+		if(NOT TARGET Freetype::Freetype)
+			find_library(Freetype REQUIRED)
+		endif()
+
 		set_target_properties(Harfbuzz::Harfbuzz PROPERTIES
 			INTERFACE_INCLUDE_DIRECTORIES "${HARFBUZZ_INCLUDE_DIRS}"
 			INTERFACE_LINK_LIBRARIES Freetype::Freetype

--- a/builds/cmake/Modules/FindHarfbuzz.cmake
+++ b/builds/cmake/Modules/FindHarfbuzz.cmake
@@ -57,7 +57,7 @@ if(HARFBUZZ_FOUND)
 		add_library(Harfbuzz::Harfbuzz UNKNOWN IMPORTED)
 
 		if(NOT TARGET Freetype::Freetype)
-			find_library(Freetype REQUIRED)
+			find_package(Freetype REQUIRED)
 		endif()
 
 		set_target_properties(Harfbuzz::Harfbuzz PROPERTIES


### PR DESCRIPTION
While packaging EasyRPG Player for the Fedora Linux distribution ([link](https://src.fedoraproject.org/rpms/easyrpg-player)), I stumbled across this problem with the circular dependency between Feeetype and Harfbuzz:
1) CMake would find Freetype
2) It would then try to find HarfBuzz, as wanted by FreeType
3) It would find HarfBuzz
4) It would then try to find FreeType, as wanted by HarfBuzz
5) This second search for FreeType would fail.

This patch adds some `if(NOT TARGET)` guards around the circular `find_package()` calls, solving the problem described above.