### PR TITLE
Upstream DynRpg Parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,8 @@ add_library(${PROJECT_NAME} STATIC
 	src/drawable_list.h
 	src/drawable_mgr.cpp
 	src/drawable_mgr.h
+	src/dynrpg.cpp
+	src/dynrpg.h
 	src/exe_reader.cpp
 	src/exe_reader.h
 	src/exfont.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,8 @@ add_library(${PROJECT_NAME} STATIC
 	src/drawable_mgr.h
 	src/dynrpg.cpp
 	src/dynrpg.h
+	src/dynrpg_easyrpg.cpp
+	src/dynrpg_easyrpg.h
 	src/exe_reader.cpp
 	src/exe_reader.h
 	src/exfont.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -81,6 +81,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/drawable_list.h \
 	src/drawable_mgr.cpp \
 	src/drawable_mgr.h \
+	src/dynrpg.h \
+	src/dynrpg.cpp \
 	src/exe_reader.cpp \
 	src/exe_reader.h \
 	src/exfont.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -81,8 +81,10 @@ libeasyrpg_player_a_SOURCES = \
 	src/drawable_list.h \
 	src/drawable_mgr.cpp \
 	src/drawable_mgr.h \
-	src/dynrpg.h \
 	src/dynrpg.cpp \
+	src/dynrpg.h \
+	src/dynrpg_easyrpg.cpp \
+	src/dynrpg_easyrpg.h \
 	src/exe_reader.cpp \
 	src/exe_reader.h \
 	src/exfont.h \

--- a/src/dynrpg.cpp
+++ b/src/dynrpg.cpp
@@ -38,6 +38,9 @@ typedef std::map<std::string, dynfunc> dyn_rpg_func;
 namespace {
 	bool init = false;
 
+	// Registered DynRpg Plugins
+	std::vector<std::unique_ptr<DynRpgPlugin>> plugins;
+
 	// DynRpg Functions
 
 	bool Oput(const dyn_arg_list& args) {
@@ -259,6 +262,12 @@ static bool ValidFunction(const std::string& token) {
 	return true;
 }
 
+void create_all_plugins() {
+	for (auto& plugin : plugins) {
+		plugin->RegisterFunctions();
+	}
+}
+
 bool DynRpg::Invoke(const std::string& command) {
 	if (command.empty()) {
 		// Not a DynRPG function (empty comment)
@@ -279,7 +288,7 @@ bool DynRpg::Invoke(const std::string& command) {
 
 	if (!init) {
 		init = true;
-		// Register functions here
+		create_all_plugins();
 	}
 
 	DynRpg_ParseMode mode = ParseMode_Function;
@@ -442,10 +451,29 @@ bool DynRpg::Invoke(const std::string& command) {
 	return true;
 }
 
-void DynRpg::Update() {
+void DynRpg::Load(std::vector<uint8_t>& save_data) {
+	// ToDo: Processing
 
+	for (auto& plugin : plugins) {
+		plugin->Load(save_data);
+	}
+}
+
+std::vector<uint8_t> DynRpg::Save() {
+	// ToDo: Processing
+
+	for (auto &plugin : plugins) {
+		std::vector<uint8_t> save_data = plugin->Save();
+	}
+}
+
+void DynRpg::Update() {
+	for (auto& plugin : plugins) {
+		plugin->Update();
+	}
 }
 
 void DynRpg::Reset() {
-
+	dyn_rpg_functions.clear();
+	plugins.clear();
 }

--- a/src/dynrpg.cpp
+++ b/src/dynrpg.cpp
@@ -89,7 +89,9 @@ namespace {
 			return true;
 		}
 
-		return true;
+		dyn_arg_list new_args(args.begin() + 1, args.end());
+
+		return dyn_rpg_functions[token](new_args);
 	}
 }
 
@@ -131,12 +133,12 @@ std::string DynRpg::ParseVarArg(const dyn_arg_list& args, int index) {
 	std::stringstream msg;
 
 	for (; text_index != end; ++text_index) {
-		char32_t chr = *text_index;
+		char chr = *text_index;
 
 		// Test for "" -> append "
 		// otherwise end of string
 		if (chr == '$' && std::distance(text_index, end) > 1) {
-			char32_t n = *std::next(text_index, 1);
+			char n = *std::next(text_index, 1);
 
 			if (n == '$') {
 				// $$ = $
@@ -172,7 +174,7 @@ static std::string ParseToken(const std::string& token, const std::string& funct
 	text_index = text.begin();
 	end = text.end();
 
-	char32_t chr = *text_index;
+	char chr = *text_index;
 
 	bool first = true;
 
@@ -201,7 +203,7 @@ static std::string ParseToken(const std::string& token, const std::string& funct
 					}
 
 					// N is last
-					return Game_Actors::GetActor(number)->GetName();
+					return ToString(Game_Actors::GetActor(number)->GetName());
 				} else {
 					// Variable
 					if (!Main_Data::game_variables->IsValid(number)) {
@@ -257,18 +259,18 @@ static bool ValidFunction(const std::string& token) {
 	return true;
 }
 
-bool DynRpg::Invoke(const lcf::rpg::EventCommand& com) {
-	if (com.string.empty()) {
+bool DynRpg::Invoke(const std::string& command) {
+	if (command.empty()) {
 		// Not a DynRPG function (empty comment)
 		return true;
 	}
 
 	std::string::iterator text_index, end;
-	std::string text = com.string;
+	std::string text = command;
 	text_index = text.begin();
 	end = text.end();
 
-	char32_t chr = *text_index;
+	char chr = *text_index;
 
 	if (chr != '@') {
 		// Not a DynRPG function, normal comment
@@ -316,7 +318,7 @@ bool DynRpg::Invoke(const lcf::rpg::EventCommand& com) {
 				// no-op
 				break;
 			case ParseMode_WaitForArg:
-				if (args.size() > 0) {
+				if (!args.empty()) {
 					// Found , but no token -> empty arg
 					args.push_back("");
 				}
@@ -407,7 +409,7 @@ bool DynRpg::Invoke(const lcf::rpg::EventCommand& com) {
 				if (chr == '"') {
 					// Test for "" -> append "
 					// otherwise end of string
-					if (std::distance(text_index, end) > 1 && *std::next(text_index, 2) == '"') {
+					if (std::distance(text_index, end) > 1 && *std::next(text_index, 1) == '"') {
 						token << '"';
 						++text_index;
 					}

--- a/src/dynrpg.cpp
+++ b/src/dynrpg.cpp
@@ -40,7 +40,7 @@ namespace {
 
 	// DynRpg Functions
 
-	bool Oput(dyn_arg_list args) {
+	bool Oput(const dyn_arg_list& args) {
 		DYNRPG_FUNCTION("output")
 
 		DYNRPG_CHECK_ARG_LENGTH(2);
@@ -61,7 +61,7 @@ namespace {
 		return true;
 	}
 
-	bool Call(dyn_arg_list args);
+	bool Call(const dyn_arg_list& args);
 
 	// Function table
 	dyn_rpg_func dyn_rpg_functions = {
@@ -69,7 +69,7 @@ namespace {
 			{"call", Call}
 	};
 
-	bool Call(dyn_arg_list args) {
+	bool Call(const dyn_arg_list& args) {
 		DYNRPG_FUNCTION("call")
 
 		DYNRPG_CHECK_ARG_LENGTH(1)
@@ -118,7 +118,7 @@ float DynRpg::GetFloat(const std::string& str, bool* valid) {
 }
 
 // Var arg referenced by $n
-std::string DynRpg::ParseVarArg(const dyn_arg_list &args, int index) {
+std::string DynRpg::ParseVarArg(const dyn_arg_list& args, int index) {
 	if (index >= args.size()) {
 		return "";
 	}

--- a/src/dynrpg.cpp
+++ b/src/dynrpg.cpp
@@ -61,9 +61,36 @@ namespace {
 		return true;
 	}
 
+	bool Call(dyn_arg_list args);
+
 	// Function table
 	dyn_rpg_func dyn_rpg_functions = {
-			{"easyrpg_output", Oput}};
+			{"easyrpg_output", Oput},
+			{"call", Call}
+	};
+
+	bool Call(dyn_arg_list args) {
+		DYNRPG_FUNCTION("call")
+
+		DYNRPG_CHECK_ARG_LENGTH(1)
+
+		DYNRPG_GET_STR_ARG(0, token)
+
+		if (token.empty()) {
+			// empty function name
+			Output::Warning("call: Empty RPGSS function name");
+
+			return true;
+		}
+
+		if (dyn_rpg_functions.find(token) == dyn_rpg_functions.end()) {
+			// Not a supported function
+			Output::Warning("Unsupported RPGSS function: {}", token);
+			return true;
+		}
+
+		return true;
+	}
 }
 
 void DynRpg::RegisterFunction(const std::string& name, dynfunc func) {

--- a/src/dynrpg.cpp
+++ b/src/dynrpg.cpp
@@ -1,0 +1,432 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Headers
+#include "dynrpg.h"
+#include "game_actors.h"
+#include "game_variables.h"
+#include "main_data.h"
+#include "output.h"
+#include "player.h"
+#include "utils.h"
+
+#include <map>
+#include <sstream>
+#include <string>
+
+enum DynRpg_ParseMode {
+	ParseMode_Function,
+	ParseMode_WaitForComma,
+	ParseMode_WaitForArg,
+	ParseMode_String,
+	ParseMode_Token
+};
+
+typedef std::vector<std::string> dyn_arg_list;
+typedef bool(*dynfunc)(dyn_arg_list);
+typedef std::map<std::string, dynfunc> dyn_rpg_func;
+
+namespace {
+	float GetFloat(const std::string& str, bool* valid = nullptr) {
+		std::istringstream iss(str);
+		float f;
+		iss >> f;
+
+		if (valid) {
+			*valid = iss.eof() && !iss.fail();
+		}
+
+		return f;
+	}
+
+	// Var arg referenced by $n
+	std::string ParseVarArg(const dyn_arg_list &args, int index) {
+		if (index >= args.size()) {
+			return "";
+		}
+
+		std::string::iterator text_index, end;
+		std::string text = args[index];
+		text_index = text.begin();
+		end = text.end();
+
+		char32_t chr = *text_index;
+
+		std::stringstream msg;
+
+		for (; text_index != end; ++text_index) {
+			char32_t chr = *text_index;
+
+			// Test for "" -> append "
+			// otherwise end of string
+			if (chr == '$' && std::distance(text_index, end) > 1) {
+				char32_t n = *std::next(text_index, 1);
+
+				if (n == '$') {
+					// $$ = $
+					msg << n;
+					++text_index;
+				} else if (n >= '1' && n <= '9') {
+					int i = (int)(n - '0');
+
+					if (i + index < args.size()) {
+						msg << args[i + index];
+					}
+					else {
+						// $-ref out of range
+						return "";
+					}
+
+					++text_index;
+				} else {
+					msg << chr;
+				}
+			} else {
+				msg << chr;
+			}
+		}
+
+		return msg.str();
+	}
+
+	// Macros
+
+#define DYNRPG_FUNCTION(var) \
+	std::string func_name = var;
+
+#define DYNRPG_CHECK_ARG_LENGTH(len) \
+	if (args.size() != len) {\
+	Output::Warning("%s: Got %d args (needs %d)", func_name.c_str(), args.size(), len); \
+	return true; \
+	}
+
+#define DYNRPG_CHECK_ARG_MIN(len) \
+	if (args.size() < len) { \
+		Output::Warning("%s: Got %d args (needs %d or more)", func_name.c_str(), args.size(), len); \
+		return true; \
+	}
+
+#define DYNRPG_GET_FLOAT_ARG(i, var) \
+	float var; \
+	bool valid_float##var; \
+	var = GetFloat(args[i], &valid_float##var); \
+	if (!valid_float##var) { \
+	Output::Warning("%s: Arg %d (%s) is not numeric", func_name.c_str(), i, args[i].c_str()); \
+	return true; \
+	}
+
+#define DYNRPG_GET_INT_ARG(i, var) \
+	DYNRPG_GET_FLOAT_ARG(i, var##_float_arg) \
+	int var = (int)var##_float_arg;
+
+#define DYNRPG_GET_STR_ARG(i, var) \
+	std::string& var = args[i];
+
+#define DYNRPG_GET_VAR_ARG(i, var) \
+	std::string var = ParseVarArg(args, i); \
+	if (var.empty()) { \
+	Output::Warning("%s: Vararg %d out of range", func_name.c_str(), i); \
+	}
+
+	// DynRpg Functions
+
+	bool Oput(dyn_arg_list args) {
+		DYNRPG_FUNCTION("output")
+
+		DYNRPG_CHECK_ARG_MIN(2);
+
+		DYNRPG_GET_STR_ARG(0, mode);
+		DYNRPG_GET_VAR_ARG(1, msg);
+
+		if (mode == "Debug") {
+			Output::DebugStr(msg);
+		} else if (mode == "Info") {
+			Output::InfoStr(msg);
+		} else if (mode == "Warning") {
+			Output::WarningStr(msg);
+		} else if (mode == "Error") {
+			Output::ErrorStr(msg);
+		}
+
+		return true;
+	}
+
+	// Function table
+
+	dyn_rpg_func const dyn_rpg_functions = {
+			{"easyrpg_output", Oput}};
+}
+
+static std::string ParseToken(const std::string& token, const std::string& function_name) {
+	std::string::iterator text_index, end;
+	std::string text = token;
+	text_index = text.begin();
+	end = text.end();
+
+	char32_t chr = *text_index;
+
+	bool first = true;
+
+	bool number_encountered = false;
+
+	std::stringstream var_part;
+	std::stringstream number_part;
+
+	for (;;) {
+		if (text_index != end) {
+			chr = *std::next(text_index, 1);
+		}
+
+		if (text_index == end) {
+			// Convert backwards
+			std::string tmp = number_part.str();
+			int number = atoi(tmp.c_str());
+			tmp = var_part.str();
+
+			for (std::string::reverse_iterator it = tmp.rbegin(); it != tmp.rend(); ++it) {
+				if (*it == 'N') {
+					if (!Game_Actors::ActorExists(number)) {
+						Output::Warning("{}: Invalid actor id {} in {}", function_name, number, token);
+						return "";
+					}
+
+					// N is last
+					return Game_Actors::GetActor(number)->GetName();
+				} else {
+					// Variable
+					if (!Main_Data::game_variables->IsValid(number)) {
+						Output::Warning("{}: Invalid variable {} in {}", function_name, number, token);
+						return "";
+					}
+
+					number = Main_Data::game_variables->Get(number);
+				}
+			}
+
+			number_part.str("");
+			number_part << number;
+			return number_part.str();
+		} else if (chr == 'N') {
+			if (!first || number_encountered) {
+				break;
+			}
+			var_part << chr;
+		} else if (chr == 'V') {
+			if (number_encountered) {
+				break;
+			}
+			var_part << chr;
+		}
+		else if (chr >= '0' && chr <= '9') {
+			number_encountered = true;
+			number_part << chr;
+		} else {
+			break;
+		}
+
+		++text_index;
+		first = false;
+	}
+
+	// Normal token
+	return token;
+}
+
+static bool ValidFunction(const std::string& token) {
+	if (token.empty()) {
+		// empty function name
+		return false;
+	}
+
+	if (dyn_rpg_functions.find(token) == dyn_rpg_functions.end()) {
+		// Not a supported function
+		Output::Warning("Unsupported DynRPG function: {}", token);
+		return false;
+	}
+
+	return true;
+}
+
+bool DynRpg::Invoke(const lcf::rpg::EventCommand& com) {
+	if (com.string.empty()) {
+		// Not a DynRPG function (empty comment)
+		return true;
+	}
+
+	std::string::iterator text_index, end;
+	std::string text = com.string;
+	text_index = text.begin();
+	end = text.end();
+
+	char32_t chr = *text_index;
+
+	if (chr != '@') {
+		// Not a DynRPG function, normal comment
+		return true;
+	}
+
+	DynRpg_ParseMode mode = ParseMode_Function;
+	std::string function_name;
+	std::string tmp;
+	dyn_arg_list args;
+	std::stringstream token;
+
+	// Parameters can be of type Token, Number or String
+	// Strings are in "", a "-literal is represented by ""
+	// Number is a valid float number
+	// Tokens are Strings without "" and with Whitespace stripped o_O
+	// If a token is (regex) N?V+[0-9]+ it is resolved to a var or an actor
+
+	// All arguments are passed as string to the DynRpg functions and are
+	// converted to int or float on demand.
+
+	for (;;) {
+		if (text_index != end) {
+			chr = *std::next(text_index, 1);
+		}
+
+		if (text_index == end) {
+			switch (mode) {
+			case ParseMode_Function:
+				// End of function token
+				if (!ValidFunction(token.str())) {
+					return true;
+				}
+				function_name = token.str();
+				token.str("");
+
+				mode = ParseMode_WaitForArg;
+				break;
+			case ParseMode_WaitForComma:
+			case ParseMode_WaitForArg:
+				// no-op
+				break;
+			case ParseMode_String:
+				Output::Warning("%s: Unterminated literal", function_name.c_str());
+				return true;
+			case ParseMode_Token:
+				tmp = ParseToken(token.str(), function_name);
+				if (tmp.empty()) {
+					return true;
+				}
+				args.push_back(tmp);
+				mode = ParseMode_WaitForComma;
+				token.str("");
+				break;
+			}
+
+			break;
+		} else if (chr == ' ') {
+			switch (mode) {
+			case ParseMode_Function:
+				// End of function token
+				if (!ValidFunction(token.str())) {
+					return true;
+				}
+				function_name = token.str();
+				token.str("");
+
+				mode = ParseMode_WaitForArg;
+				break;
+			case ParseMode_WaitForComma:
+			case ParseMode_WaitForArg:
+				// no-op
+				break;
+			case ParseMode_String:
+				token << chr;
+				break;
+			case ParseMode_Token:
+				// Skip whitespace
+				break;
+			}
+		} else if (chr == ',') {
+			switch (mode) {
+			case ParseMode_Function:
+				// End of function token
+				Output::Warning("%s: Expected space or end, got \",\"", function_name.c_str());
+				return true;
+			case ParseMode_WaitForComma:
+				mode = ParseMode_WaitForArg;
+				break;
+			case ParseMode_WaitForArg:
+				Output::Warning("%s: Expected token, got \",\"", function_name.c_str());
+				return true;
+			case ParseMode_String:
+				token << chr;
+				break;
+			case ParseMode_Token:
+				tmp = ParseToken(token.str(), function_name);
+				if (tmp.empty()) {
+					return true;
+				}
+				args.push_back(tmp);
+				// already on a comma
+				mode = ParseMode_WaitForArg;
+				token.str("");
+				break;
+			}
+		} else {
+			// Anything else that isn't special purpose
+			switch (mode) {
+			case ParseMode_Function:
+				token << chr;
+				break;
+			case ParseMode_WaitForComma:
+				Output::Warning("%s: Expected \",\", got token", function_name.c_str());
+				return true;
+			case ParseMode_WaitForArg:
+				if (chr == '"') {
+					mode = ParseMode_String;
+					// begin of string
+				}
+				else {
+					mode = ParseMode_Token;
+					token << chr;
+				}
+				break;
+			case ParseMode_String:
+				if (chr == '"') {
+					// Test for "" -> append "
+					// otherwise end of string
+					if (std::distance(text_index, end) > 1 && *std::next(text_index, 2) == '"') {
+						token << '"';
+						++text_index;
+					}
+					else {
+						// End of string
+						args.push_back(token.str());
+
+						mode = ParseMode_WaitForComma;
+						token.str("");
+					}
+				}
+				else {
+					token << chr;
+				}
+				break;
+			case ParseMode_Token:
+				token << chr;
+				break;
+			}
+		}
+
+		++text_index;
+	}
+
+	dyn_rpg_func::const_iterator const name_it = dyn_rpg_functions.find(function_name);
+	return name_it->second(args);
+}

--- a/src/dynrpg.cpp
+++ b/src/dynrpg.cpp
@@ -439,3 +439,11 @@ bool DynRpg::Invoke(const lcf::rpg::EventCommand& com) {
 	}
 	return true;
 }
+
+void DynRpg::Update() {
+
+}
+
+void DynRpg::Reset() {
+
+}

--- a/src/dynrpg.cpp
+++ b/src/dynrpg.cpp
@@ -43,7 +43,7 @@ namespace {
 	bool Oput(dyn_arg_list args) {
 		DYNRPG_FUNCTION("output")
 
-		DYNRPG_CHECK_ARG_LENGTH_MIN(2);
+		DYNRPG_CHECK_ARG_LENGTH(2);
 
 		DYNRPG_GET_STR_ARG(0, mode);
 		DYNRPG_GET_VAR_ARG(1, msg);
@@ -71,12 +71,20 @@ void DynRpg::RegisterFunction(const std::string& name, dynfunc func) {
 }
 
 float DynRpg::GetFloat(const std::string& str, bool* valid) {
+	if (str.empty()) {
+		if (valid) {
+			*valid = true;
+		}
+
+		return 0.0f;
+	}
+
 	std::istringstream iss(str);
 	float f;
 	iss >> f;
 
 	if (valid) {
-		*valid = iss.eof() && !iss.fail();
+		*valid = !iss.fail();
 	}
 
 	return f;
@@ -148,7 +156,7 @@ static std::string ParseToken(const std::string& token, const std::string& funct
 
 	for (;;) {
 		if (text_index != end) {
-			chr = *std::next(text_index, 1);
+			chr = *text_index;
 		}
 
 		if (text_index == end) {
@@ -251,6 +259,8 @@ bool DynRpg::Invoke(const lcf::rpg::EventCommand& com) {
 	dyn_arg_list args;
 	std::stringstream token;
 
+	++text_index;
+
 	// Parameters can be of type Token, Number or String
 	// Strings are in "", a "-literal is represented by ""
 	// Number is a valid float number
@@ -262,7 +272,7 @@ bool DynRpg::Invoke(const lcf::rpg::EventCommand& com) {
 
 	for (;;) {
 		if (text_index != end) {
-			chr = *std::next(text_index, 1);
+			chr = *text_index;
 		}
 
 		if (text_index == end) {

--- a/src/dynrpg.h
+++ b/src/dynrpg.h
@@ -75,6 +75,8 @@ namespace DynRpg {
 	float GetFloat(const std::string& str, bool* valid = nullptr);
 	std::string ParseVarArg(const dyn_arg_list &args, int index);
 	bool Invoke(const lcf::rpg::EventCommand& com);
+	void Update();
+	void Reset();
 }
 
 #endif

--- a/src/dynrpg.h
+++ b/src/dynrpg.h
@@ -115,7 +115,7 @@ namespace DynRpg {
 			Output::Warning("{}: Got {} args (needs {} or more)", func_name, args.size(), sizeof...(Targs));
 			return t;
 		}
-		bool okay;
+		bool okay = true;
 		detail::parse_args(func_name, args, t, okay, std::make_index_sequence<sizeof...(Targs)>{});
 		if (parse_okay)
 			*parse_okay = okay;

--- a/src/dynrpg.h
+++ b/src/dynrpg.h
@@ -18,6 +18,12 @@
 #ifndef EP_DYNRPG_H
 #define EP_DYNRPG_H
 
+#include <vector>
+#include <sstream>
+#include <string>
+#include "output.h"
+#include "utils.h"
+
 // Headers
 namespace lcf {
 namespace rpg {
@@ -25,10 +31,55 @@ namespace rpg {
 }
 }
 
+typedef std::vector<std::string> dyn_arg_list;
+typedef bool(*dynfunc)(dyn_arg_list);
+
+// Macros
+
+#define DYNRPG_FUNCTION(var) \
+	std::string func_name = var;
+
+#define DYNRPG_CHECK_ARG_LENGTH(len) \
+	if (args.size() != len) {\
+	Output::Warning("{}: Got {} args (needs {})", func_name, args.size(), len); \
+	return true; \
+	}
+
+#define DYNRPG_CHECK_ARG_LENGTH_MIN(len) \
+	if (args.size() < len) { \
+		Output::Warning("{}: Got {} args (needs {} or more)", func_name, args.size(), len); \
+		return true; \
+	}
+
+#define DYNRPG_GET_FLOAT_ARG(i, var) \
+	float var; \
+	bool valid_float##var; \
+	var = DynRpg::GetFloat(args[i], &valid_float##var); \
+	if (!valid_float##var) { \
+	Output::Warning("{}: Arg {} ({}) is not numeric", func_name, i, args[i]); \
+	return true; \
+	}
+
+#define DYNRPG_GET_INT_ARG(i, var) \
+	DYNRPG_GET_FLOAT_ARG(i, var##_float_arg) \
+	int var = (int)var##_float_arg;
+
+#define DYNRPG_GET_STR_ARG(i, var) \
+	std::string& var = args[i];
+
+#define DYNRPG_GET_VAR_ARG(i, var) \
+	std::string var = DynRpg::ParseVarArg(args, i); \
+	if (var.empty()) { \
+	Output::Warning("{}: Vararg {} out of range", func_name, i); \
+	}
+
 /**
  * DynRPG namespace
  */
 namespace DynRpg {
+	void RegisterFunction(const std::string& name, dynfunc function);
+	float GetFloat(const std::string& str, bool* valid = nullptr);
+	std::string ParseVarArg(const dyn_arg_list &args, int index);
 	bool Invoke(const lcf::rpg::EventCommand& com);
 }
 

--- a/src/dynrpg.h
+++ b/src/dynrpg.h
@@ -32,7 +32,7 @@ namespace rpg {
 }
 
 typedef std::vector<std::string> dyn_arg_list;
-typedef bool(*dynfunc)(dyn_arg_list);
+typedef bool(*dynfunc)(const dyn_arg_list&);
 
 // Macros
 
@@ -59,7 +59,7 @@ typedef bool(*dynfunc)(dyn_arg_list);
 	int var = (int)var##_float_arg;
 
 #define DYNRPG_GET_STR_ARG(i, var) \
-	std::string& var = args[i];
+	const std::string& var = args[i];
 
 #define DYNRPG_GET_VAR_ARG(i, var) \
 	std::string var = DynRpg::ParseVarArg(args, i); \

--- a/src/dynrpg.h
+++ b/src/dynrpg.h
@@ -40,12 +40,6 @@ typedef bool(*dynfunc)(dyn_arg_list);
 	std::string func_name = var;
 
 #define DYNRPG_CHECK_ARG_LENGTH(len) \
-	if (args.size() != len) {\
-	Output::Warning("{}: Got {} args (needs {})", func_name, args.size(), len); \
-	return true; \
-	}
-
-#define DYNRPG_CHECK_ARG_LENGTH_MIN(len) \
 	if (args.size() < len) { \
 		Output::Warning("{}: Got {} args (needs {} or more)", func_name, args.size(), len); \
 		return true; \

--- a/src/dynrpg.h
+++ b/src/dynrpg.h
@@ -74,7 +74,7 @@ namespace DynRpg {
 	void RegisterFunction(const std::string& name, dynfunc function);
 	float GetFloat(const std::string& str, bool* valid = nullptr);
 	std::string ParseVarArg(const dyn_arg_list &args, int index);
-	bool Invoke(const lcf::rpg::EventCommand& com);
+	bool Invoke(const std::string& command);
 	void Update();
 	void Reset();
 }

--- a/src/dynrpg.h
+++ b/src/dynrpg.h
@@ -77,14 +77,15 @@ namespace DynRpg {
 	bool Invoke(const std::string& command);
 	void Update();
 	void Reset();
-	void Load(std::vector<uint8_t> &save_data);
-	std::vector<uint8_t> Save();
+	void Load(int slot);
+	void Save(int slot);
 }
 
 class DynRpgPlugin {
 public:
 	virtual ~DynRpgPlugin() {}
 
+	virtual std::string GetIdentifier() = 0;
 	virtual void RegisterFunctions() {}
 	virtual void Update() {}
 	virtual void Load(std::vector<uint8_t>&) {}

--- a/src/dynrpg.h
+++ b/src/dynrpg.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_DYNRPG_H
+#define EP_DYNRPG_H
+
+// Headers
+namespace lcf {
+namespace rpg {
+	class EventCommand;
+}
+}
+
+/**
+ * DynRPG namespace
+ */
+namespace DynRpg {
+	bool Invoke(const lcf::rpg::EventCommand& com);
+}
+
+#endif

--- a/src/dynrpg.h
+++ b/src/dynrpg.h
@@ -77,6 +77,21 @@ namespace DynRpg {
 	bool Invoke(const std::string& command);
 	void Update();
 	void Reset();
+	void Load(std::vector<uint8_t> &save_data);
+	std::vector<uint8_t> Save();
 }
+
+class DynRpgPlugin {
+public:
+	virtual ~DynRpgPlugin() {}
+
+	virtual void RegisterFunctions() {}
+	virtual void Update() {}
+	virtual void Load(std::vector<uint8_t>&) {}
+	virtual std::vector<uint8_t> Save() { return {}; }
+
+protected:
+	DynRpgPlugin() {}
+};
 
 #endif

--- a/src/dynrpg.h
+++ b/src/dynrpg.h
@@ -98,6 +98,7 @@ namespace DynRpg {
 	void RegisterFunction(const std::string& name, dynfunc function);
 	bool HasFunction(const std::string& name);
 	std::string ParseVarArg(StringView func_name, dyn_arg_list args, int index, bool& parse_okay);
+	std::string ParseCommand(const std::string& command, std::vector<std::string>& params);
 	bool Invoke(const std::string& command);
 	bool Invoke(const std::string& func, dyn_arg_list args);
 	void Update();
@@ -127,7 +128,7 @@ public:
 	explicit DynRpgPlugin(std::string identifier) : identifier(std::move(identifier)) {}
 	DynRpgPlugin() = delete;
 
-	std::string GetIdentifier() const { return identifier; }
+	const std::string& GetIdentifier() const { return identifier; }
 	virtual void RegisterFunctions() {}
 	virtual void Update() {}
 	virtual void Load(std::vector<uint8_t>&) {}

--- a/src/dynrpg.h
+++ b/src/dynrpg.h
@@ -72,9 +72,11 @@ typedef bool(*dynfunc)(const dyn_arg_list&);
  */
 namespace DynRpg {
 	void RegisterFunction(const std::string& name, dynfunc function);
+	bool HasFunction(const std::string& name);
 	float GetFloat(const std::string& str, bool* valid = nullptr);
 	std::string ParseVarArg(const dyn_arg_list &args, int index);
 	bool Invoke(const std::string& command);
+	bool Invoke(const std::string& func, const dyn_arg_list& args);
 	void Update();
 	void Reset();
 	void Load(int slot);
@@ -83,16 +85,17 @@ namespace DynRpg {
 
 class DynRpgPlugin {
 public:
-	virtual ~DynRpgPlugin() {}
+	explicit DynRpgPlugin(std::string identifier) : identifier(std::move(identifier)) {}
+	DynRpgPlugin() = delete;
 
-	virtual std::string GetIdentifier() = 0;
+	std::string GetIdentifier() const { return identifier; }
 	virtual void RegisterFunctions() {}
 	virtual void Update() {}
 	virtual void Load(std::vector<uint8_t>&) {}
 	virtual std::vector<uint8_t> Save() { return {}; }
 
-protected:
-	DynRpgPlugin() {}
+private:
+	std::string identifier;
 };
 
 #endif

--- a/src/dynrpg.h
+++ b/src/dynrpg.h
@@ -135,7 +135,7 @@ public:
 	const std::string& GetIdentifier() const { return identifier; }
 	virtual void RegisterFunctions() {}
 	virtual void Update() {}
-	virtual void Load(std::vector<uint8_t>&) {}
+	virtual void Load(const std::vector<uint8_t>&) {}
 	virtual std::vector<uint8_t> Save() { return {}; }
 
 private:

--- a/src/dynrpg_easyrpg.cpp
+++ b/src/dynrpg_easyrpg.cpp
@@ -1,0 +1,116 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Headers
+#include <map>
+
+#include "dynrpg_easyrpg.h"
+#include "main_data.h"
+#include "game_variables.h"
+#include "utils.h"
+#include "version.h"
+
+static bool EasyOput(const dyn_arg_list& args) {
+	DYNRPG_FUNCTION("output")
+
+	DYNRPG_CHECK_ARG_LENGTH(2);
+
+	DYNRPG_GET_STR_ARG(0, mode);
+	DYNRPG_GET_VAR_ARG(1, msg);
+
+	if (mode == "Debug") {
+		Output::DebugStr(msg);
+	} else if (mode == "Info") {
+		Output::InfoStr(msg);
+	} else if (mode == "Warning") {
+		Output::WarningStr(msg);
+	} else if (mode == "Error") {
+		Output::ErrorStr(msg);
+	}
+
+	return true;
+}
+
+static bool EasyCall(const dyn_arg_list& args) {
+	DYNRPG_FUNCTION("call")
+
+	DYNRPG_CHECK_ARG_LENGTH(1)
+
+	DYNRPG_GET_STR_ARG(0, token)
+
+	if (token.empty()) {
+		// empty function name
+		Output::Warning("call: Empty RPGSS function name");
+
+		return true;
+	}
+
+	if (!DynRpg::HasFunction(token)) {
+		// Not a supported function
+		Output::Warning("Unsupported RPGSS function: {}", token);
+		return true;
+	}
+
+	dyn_arg_list new_args(args.begin() + 1, args.end());
+
+	return DynRpg::Invoke(token, new_args);
+}
+
+static bool EasyAdd(const dyn_arg_list& args) {
+	DYNRPG_FUNCTION("easyrpg_add")
+
+	DYNRPG_CHECK_ARG_LENGTH(2);
+
+	DYNRPG_GET_INT_ARG(0, target_var);
+
+	int res = 0;
+	for (size_t i = 1; i < args.size(); ++i) {
+		DYNRPG_GET_INT_ARG(i, val);
+		res += val;
+	}
+
+	Main_Data::game_variables->Set(target_var, res);
+
+	return true;
+}
+
+void DynRpg::EasyRpgPlugin::RegisterFunctions() {
+	DynRpg::RegisterFunction("call", EasyCall);
+	DynRpg::RegisterFunction("easyrpg_output", EasyOput);
+	DynRpg::RegisterFunction("easyrpg_add", EasyAdd);
+}
+
+void DynRpg::EasyRpgPlugin::Load(std::vector<uint8_t>& buffer) {
+	if (buffer.size() < 4) {
+		Output::Warning("EasyRpgPlugin: Bad savegame data");
+	} else {
+		uint32_t ver = *reinterpret_cast<uint32_t*>(buffer.data());
+		Utils::SwapByteOrder(ver);
+		Output::Debug("DynRpg Savegame version {}", ver);
+	}
+}
+
+std::vector<uint8_t> DynRpg::EasyRpgPlugin::Save() {
+	std::vector<uint8_t> save_data;
+	save_data.resize(4);
+
+	uint32_t version = PLAYER_SAVEGAME_VERSION;
+	Utils::SwapByteOrder(version);
+	memcpy(&save_data[0], reinterpret_cast<char*>(&version), 4);
+
+	return save_data;
+}

--- a/src/dynrpg_easyrpg.cpp
+++ b/src/dynrpg_easyrpg.cpp
@@ -93,11 +93,12 @@ void DynRpg::EasyRpgPlugin::RegisterFunctions() {
 	DynRpg::RegisterFunction("easyrpg_add", EasyAdd);
 }
 
-void DynRpg::EasyRpgPlugin::Load(std::vector<uint8_t>& buffer) {
+void DynRpg::EasyRpgPlugin::Load(const std::vector<uint8_t>& buffer) {
 	if (buffer.size() < 4) {
 		Output::Warning("EasyRpgPlugin: Bad savegame data");
 	} else {
-		uint32_t ver = *reinterpret_cast<uint32_t*>(buffer.data());
+		uint32_t ver;
+		memcpy(&ver, buffer.data(), 4);
 		Utils::SwapByteOrder(ver);
 		Output::Debug("DynRpg Savegame version {}", ver);
 	}

--- a/src/dynrpg_easyrpg.h
+++ b/src/dynrpg_easyrpg.h
@@ -1,0 +1,38 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_DYNRPG_EASYRPG_H
+#define EP_DYNRPG_EASYRPG_H
+
+#include "dynrpg.h"
+
+namespace DynRpg {
+	/**
+	 * A DynRPG plugin that provides EasyRPG specific built-in functions.
+	 * Mostly for testing.
+	 */
+	class EasyRpgPlugin : public DynRpgPlugin {
+	public:
+		EasyRpgPlugin() : DynRpgPlugin("EasyRpgPlugin") {}
+
+		void RegisterFunctions() override;
+		void Load(std::vector<uint8_t>& buffer) override;
+		std::vector<uint8_t> Save() override;
+	};
+}
+
+#endif

--- a/src/dynrpg_easyrpg.h
+++ b/src/dynrpg_easyrpg.h
@@ -30,7 +30,7 @@ namespace DynRpg {
 		EasyRpgPlugin() : DynRpgPlugin("EasyRpgPlugin") {}
 
 		void RegisterFunctions() override;
-		void Load(std::vector<uint8_t>& buffer) override;
+		void Load(const std::vector<uint8_t>& buffer) override;
 		std::vector<uint8_t> Save() override;
 	};
 }

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -23,6 +23,7 @@
 #include <cassert>
 #include "game_interpreter.h"
 #include "audio.h"
+#include "dynrpg.h"
 #include "filefinder.h"
 #include "game_map.h"
 #include "game_event.h"
@@ -597,6 +598,9 @@ bool Game_Interpreter::ExecuteCommand() {
 			return CommandEndEventProcessing(com);
 		case Cmd::Comment:
 		case Cmd::Comment_2:
+			if (Player::IsPatchDynRpg()) {
+				return DynRpg::Invoke(com);
+			}
 			return true;
 		case Cmd::GameOver:
 			return CommandGameOver(com);

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -200,6 +200,7 @@ protected:
 	bool CommandFadeOutBGM(lcf::rpg::EventCommand const& com);
 	bool CommandPlaySound(lcf::rpg::EventCommand const& com);
 	bool CommandEndEventProcessing(lcf::rpg::EventCommand const& com);
+	bool CommandComment(lcf::rpg::EventCommand const& com);
 	bool CommandGameOver(lcf::rpg::EventCommand const& com);
 	bool CommandChangeHeroName(lcf::rpg::EventCommand const& com);
 	bool CommandChangeHeroTitle(lcf::rpg::EventCommand const& com);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1030,7 +1030,7 @@ void Player::SetupNewGame() {
 
 	Main_Data::game_party->SetupNewGame();
 	SetupPlayerSpawn();
-	Scene::Push(std::make_shared<Scene_Map>(false));
+	Scene::Push(std::make_shared<Scene_Map>(0));
 }
 
 void Player::SetupPlayerSpawn() {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -46,6 +46,7 @@
 #include "cache.h"
 #include "rand.h"
 #include "cmdline_parser.h"
+#include "dynrpg.h"
 #include "filefinder.h"
 #include "fileext_guesser.h"
 #include "game_actors.h"
@@ -821,6 +822,8 @@ void Player::ResetGameObjects() {
 	Main_Data::game_party = std::make_unique<Game_Party>();
 	Main_Data::game_player = std::make_unique<Game_Player>();
 	Main_Data::game_quit = std::make_unique<Game_Quit>();
+
+	DynRpg::Reset();
 
 	Game_Clock::ResetFrame(Game_Clock::now());
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -398,6 +398,7 @@ void Player::Exit() {
 
 	Player::ResetGameObjects();
 	Font::Dispose();
+	DynRpg::Reset();
 	Graphics::Quit();
 	FileFinder::Quit();
 	Output::Quit();
@@ -924,7 +925,7 @@ static void OnMapSaveFileReady(FileRequestResult*, lcf::rpg::Save save) {
 			std::move(save.common_events));
 }
 
-void Player::LoadSavegame(const std::string& save_name) {
+void Player::LoadSavegame(const std::string& save_name, int save_id) {
 	Output::Debug("Loading Save {}", FileFinder::GetPathInsidePath(Main_Data::GetSavePath(), save_name));
 	Main_Data::game_system->BgmFade(800);
 
@@ -999,7 +1000,7 @@ void Player::LoadSavegame(const std::string& save_name) {
 	Main_Data::game_system->ReloadSystemGraphic();
 
 	map->Start();
-	Scene::Push(std::make_shared<Scene_Map>(true));
+	Scene::Push(std::make_shared<Scene_Map>(save_id));
 }
 
 static void OnMapFileReady(FileRequestResult*) {

--- a/src/player.h
+++ b/src/player.h
@@ -144,8 +144,9 @@ namespace Player {
 	 * Loads savegame data.
 	 *
 	 * @param save_file Savegame file to load
+	 * @param save_id ID of the savegame to load
 	 */
-	void LoadSavegame(const std::string& save_file);
+	void LoadSavegame(const std::string& save_file, int save_id = 0);
 
 	/**
 	 * Starts a new game

--- a/src/scene_load.cpp
+++ b/src/scene_load.cpp
@@ -17,7 +17,6 @@
 
 // Headers
 #include <sstream>
-#include "dynrpg.h"
 #include "filefinder.h"
 #include "output.h"
 #include "player.h"

--- a/src/scene_load.cpp
+++ b/src/scene_load.cpp
@@ -17,11 +17,11 @@
 
 // Headers
 #include <sstream>
+#include "dynrpg.h"
 #include "filefinder.h"
 #include "output.h"
 #include "player.h"
 #include "scene_load.h"
-#include "scene_file.h"
 #include "scene_map.h"
 
 Scene_Load::Scene_Load() :
@@ -32,7 +32,7 @@ Scene_Load::Scene_Load() :
 void Scene_Load::Action(int index) {
 	std::string save_name = FileFinder::FindDefault(*tree, fmt::format("Save{:02d}.lsd", index + 1));
 
-	Player::LoadSavegame(save_name);
+	Player::LoadSavegame(save_name, index + 1);
 }
 
 bool Scene_Load::IsSlotValid(int index) {

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -93,7 +93,7 @@ void Scene_Logo::Update() {
 				Output::Debug("Loading Save {}", ss.str());
 
 				std::string save_name = FileFinder::FindDefault(*tree, ss.str());
-				Player::LoadSavegame(save_name);
+				Player::LoadSavegame(save_name, Player::load_game_id);
 			}
 		}
 		else {

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -37,6 +37,7 @@
 #include "screen.h"
 #include "scene_load.h"
 #include "output.h"
+#include "dynrpg.h"
 
 static bool GetRunForegroundEvents(TeleportTarget::Type tt) {
 	switch (tt) {
@@ -50,8 +51,8 @@ static bool GetRunForegroundEvents(TeleportTarget::Type tt) {
 	return false;
 }
 
-Scene_Map::Scene_Map(bool from_save)
-	: from_save(from_save)
+Scene_Map::Scene_Map(int from_save_id)
+	: from_save_id(from_save_id)
 {
 	type = Scene::Map;
 
@@ -73,10 +74,11 @@ void Scene_Map::Start() {
 
 	// Called here instead of Scene Load, otherwise wrong graphic stack
 	// is used.
-	if (from_save) {
+	if (from_save_id > 0) {
 		auto current_music = Main_Data::game_system->GetCurrentBGM();
 		Main_Data::game_system->BgmStop();
 		Main_Data::game_system->BgmPlay(current_music);
+		DynRpg::Load(from_save_id);
 	} else {
 		Game_Map::PlayBgm();
 	}

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -33,7 +33,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	explicit Scene_Map(int from_save_id = 0);
+	explicit Scene_Map(int from_save_id);
 
 	~Scene_Map();
 

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -33,7 +33,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	explicit Scene_Map(bool from_save);
+	explicit Scene_Map(int from_save_id = 0);
 
 	~Scene_Map();
 
@@ -91,7 +91,7 @@ private:
 	std::unique_ptr<Window_Message> message_window;
 
 	int debug_menuoverwrite_counter = 0;
-	bool from_save = false;
+	int from_save_id = 0;
 	bool screen_erased_by_event = false;
 
 	AsyncContinuation map_async_continuation = {};

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -23,6 +23,7 @@
 #endif
 
 #include <lcf/data.h>
+#include "dynrpg.h"
 #include "filefinder.h"
 #include "game_actor.h"
 #include "game_map.h"
@@ -39,8 +40,6 @@
 #include "output.h"
 #include "player.h"
 #include "scene_save.h"
-#include "scene_file.h"
-#include <lcf/reader_util.h>
 #include "version.h"
 
 Scene_Save::Scene_Save() :
@@ -143,6 +142,8 @@ void Scene_Save::Save(std::ostream& os, int slot_id, bool prepare_save) {
 	}
 	save = lcf::LSD_Reader::ClearDefaults(save, Game_Map::GetMapInfo(), Game_Map::GetMap());
 	lcf::LSD_Reader::Save(os, save, Player::encoding);
+
+	DynRpg::Save(slot_id);
 
 #ifdef EMSCRIPTEN
 	// Save changed file system

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -18,6 +18,7 @@
 // Headers
 #include "spriteset_map.h"
 #include "cache.h"
+#include "dynrpg.h"
 #include "game_map.h"
 #include "main_data.h"
 #include "sprite_airshipshadow.h"
@@ -109,6 +110,8 @@ void Spriteset_Map::Update() {
 
 	timer1->Update();
 	timer2->Update();
+
+	DynRpg::Update();
 }
 
 // Finds the sprite for a specific character

--- a/tests/dynrpg.cpp
+++ b/tests/dynrpg.cpp
@@ -114,8 +114,10 @@ TEST_CASE("Variable names with junk") {
 }
 
 TEST_CASE("Arg parse") {
+	// 2.5x not tested here because the result differs between different C++ libraries
+	// See: https://bugs.llvm.org/show_bug.cgi?id=17782
 	LogGuard lg;
-	std::vector<std::string> args = {"A", "1x", "2.5y"};
+	std::vector<std::string> args = {"A", "1y", "2.5 x"};
 	bool okay = false;
 
 	std::string s, s2;
@@ -134,15 +136,28 @@ TEST_CASE("Arg parse") {
 	CHECK(i2 == 0);
 	CHECK(f == 0.0);
 
+	std::tie(f, i,s) = DynRpg::ParseArgs<float, int, std::string>("func", args, &okay);
+	CHECK(!okay);
+	CHECK(f == 0.0f);
+	CHECK(i == 0);
+	CHECK(s == "");
+
 	std::tie(s, s2, i) = DynRpg::ParseArgs<std::string, std::string, int>("func", args, &okay);
 	CHECK(okay);
 	CHECK(s == "A");
-	CHECK(s2 == "1x");
+	CHECK(s2 == "1y");
 	CHECK(i == 2);
 
 	std::tie(std::ignore, std::ignore, s) = DynRpg::ParseArgs<std::string, std::string, std::string>("func", args, &okay);
 	CHECK(okay);
-	CHECK(s == "2.5y");
+	CHECK(s == "2.5 x");
+
+	// DynRPG reports string here but for convenience empty strings are 0
+	args = {"", ""};
+	std::tie(f, i) = DynRpg::ParseArgs<float, int>("func", args, &okay);
+	CHECK(okay);
+	CHECK(f == 0.0f);
+	CHECK(i == 0);
 }
 
 TEST_CASE("easyrpg dynrpg invoke") {

--- a/tests/dynrpg.cpp
+++ b/tests/dynrpg.cpp
@@ -6,20 +6,6 @@
 
 TEST_SUITE_BEGIN("DynRPG");
 
-class LogGuard {
-public:
-	LogGuard() {
-		lvl = Output::GetLogLevel();
-		Output::SetLogLevel(LogLevel::Error);
-	}
-
-	~LogGuard() {
-		Output::SetLogLevel(lvl);
-	}
-
-	LogLevel lvl;
-};
-
 TEST_CASE("Basic parsing") {
 	std::vector<std::string> args;
 	CHECK(DynRpg::ParseCommand(R"(@FunC abc , "Hello World", 42, 1.5, 1.5a, "Str"",ing")", args) == "func");
@@ -64,7 +50,8 @@ TEST_CASE("Tokens") {
 }
 
 TEST_CASE("Variable names") {
-	Main_Data::game_variables = std::make_unique<Game_Variables>(-99999, 99999);
+	const MockActor m;
+
 	std::vector<int32_t> vars = {100, 4, 2, 1};
 	Main_Data::game_variables->SetData(vars);
 	Main_Data::game_variables->SetWarning(0);
@@ -80,7 +67,8 @@ TEST_CASE("Variable names") {
 }
 
 TEST_CASE("Variable names with junk") {
-	Main_Data::game_variables = std::make_unique<Game_Variables>(-99999, 99999);
+	const MockActor m;
+
 	std::vector<int32_t> vars = {0, 4, 2, 1};
 	Main_Data::game_variables->SetData(vars);
 	Main_Data::game_variables->SetWarning(0);
@@ -94,12 +82,12 @@ TEST_CASE("Variable names with junk") {
 }
 
 TEST_CASE("Variable names with junk") {
-	Main_Data::game_variables = std::make_unique<Game_Variables>(-99999, 99999);
+	const MockActor m;
+
 	std::vector<int32_t> vars = {0, 4, 2};
 	Main_Data::game_variables->SetData(vars);
 	Main_Data::game_variables->SetWarning(0);
 
-	MockActor m;
 	MakeDBActor(2);
 	MakeDBActor(4);
 	Main_Data::game_actors->GetActor(2)->SetName("Actor 2");
@@ -114,9 +102,10 @@ TEST_CASE("Variable names with junk") {
 }
 
 TEST_CASE("Arg parse") {
+	const MockActor m; // disable log
+
 	// 2.5x not tested here because the result differs between different C++ libraries
 	// See: https://bugs.llvm.org/show_bug.cgi?id=17782
-	LogGuard lg;
 	std::vector<std::string> args = {"A", "1y", "2.5 x"};
 	bool okay = false;
 
@@ -161,11 +150,11 @@ TEST_CASE("Arg parse") {
 }
 
 TEST_CASE("easyrpg dynrpg invoke") {
-	Main_Data::game_variables = std::make_unique<Game_Variables>(-99999, 99999);
+	const MockActor m;
+
 	std::vector<int32_t> vars = {-1};
 	Main_Data::game_variables->SetData(vars);
 	Main_Data::game_variables->SetWarning(0);
-	LogGuard lg;
 
 	DynRpg::Invoke("@easyrpg_add 1, 2, 4");
 	CHECK(Main_Data::game_variables->Get(1) == 6);
@@ -197,7 +186,8 @@ TEST_CASE("easyrpg dynrpg invoke") {
 }
 
 TEST_CASE("Incompatible changes") {
-	LogGuard lg;
+	const MockActor m; // disable log
+
 	std::vector<std::string> args;
 
 	// Empty function name (DynRPG accepts this, but makes no sense)

--- a/tests/dynrpg.cpp
+++ b/tests/dynrpg.cpp
@@ -1,0 +1,204 @@
+#include <lcf/data.h>
+#include "doctest.h"
+#include "dynrpg.h"
+#include "game_variables.h"
+#include "test_mock_actor.h"
+
+TEST_SUITE_BEGIN("DynRPG");
+
+class LogGuard {
+public:
+	LogGuard() {
+		lvl = Output::GetLogLevel();
+		Output::SetLogLevel(LogLevel::Error);
+	}
+
+	~LogGuard() {
+		Output::SetLogLevel(lvl);
+	}
+
+	LogLevel lvl;
+};
+
+TEST_CASE("Basic parsing") {
+	std::vector<std::string> args;
+	CHECK(DynRpg::ParseCommand(R"(@FunC abc , "Hello World", 42, 1.5, 1.5a, "Str"",ing")", args) == "func");
+	CHECK(args.size() == 6);
+	CHECK(args[0] == "abc");
+	CHECK(args[1] == "Hello World");
+	CHECK(args[2] == "42");
+	CHECK(args[3] == "1.5");
+	CHECK(args[4] == "1.5a"); // DynRPG returns 1.5, not critical, we extract float later
+	CHECK(args[5] == "Str\",ing");
+}
+
+TEST_CASE("Unterminated literal") {
+	std::vector<std::string> args;
+	CHECK(DynRpg::ParseCommand("@FunC abc , \"Hello ", args) == "func");
+	CHECK(args.size() == 2);
+	CHECK(args[0] == "abc");
+	CHECK(args[1] == "Hello ");
+}
+
+TEST_CASE("Comma") {
+	std::vector<std::string> args;
+	CHECK(DynRpg::ParseCommand("@FunC , abc,,,xyz,,", args) == "func");
+	CHECK(args.size() == 7);
+	CHECK(args[0] == "");
+	CHECK(args[1] == "abc");
+	CHECK(args[2] == "");
+	CHECK(args[3] == "");
+	CHECK(args[4] == "xyz");
+	CHECK(args[5] == "");
+	CHECK(args[6] == "");
+}
+
+TEST_CASE("Tokens") {
+	std::vector<std::string> args;
+	CHECK(DynRpg::ParseCommand("@FunC ab cd,Bla  ,   Bla Blub, Ab\"C \"d e", args) == "func");
+	CHECK(args.size() == 4);
+	CHECK(args[0] == "abcd");
+	CHECK(args[1] == "bla");
+	CHECK(args[2] == "blablub");
+	CHECK(args[3] == "ab\"c\"de");
+}
+
+TEST_CASE("Variable names") {
+	Main_Data::game_variables = std::make_unique<Game_Variables>(-99999, 99999);
+	std::vector<int32_t> vars = {100, 4, 2, 1};
+	Main_Data::game_variables->SetData(vars);
+	Main_Data::game_variables->SetWarning(0);
+
+	std::vector<std::string> args;
+	CHECK(DynRpg::ParseCommand("@FunC V2,VV3,VVVV3", args) == "func");
+	CHECK(args.size() == 3);
+	CHECK(args[0] == "4");
+	CHECK(args[1] == "4");
+	CHECK(args[2] == "100");
+
+	Output::SetLogLevel(LogLevel::Error);
+}
+
+TEST_CASE("Variable names with junk") {
+	Main_Data::game_variables = std::make_unique<Game_Variables>(-99999, 99999);
+	std::vector<int32_t> vars = {0, 4, 2, 1};
+	Main_Data::game_variables->SetData(vars);
+	Main_Data::game_variables->SetWarning(0);
+
+	std::vector<std::string> args;
+	CHECK(DynRpg::ParseCommand("@FunC V2junk,VV3 junk,VVVjunk3", args) == "func");
+	CHECK(args.size() == 3);
+	CHECK(args[0] == "4");
+	CHECK(args[1] == "4");
+	CHECK(args[2] == "vvvjunk3");
+}
+
+TEST_CASE("Variable names with junk") {
+	Main_Data::game_variables = std::make_unique<Game_Variables>(-99999, 99999);
+	std::vector<int32_t> vars = {0, 4, 2};
+	Main_Data::game_variables->SetData(vars);
+	Main_Data::game_variables->SetWarning(0);
+
+	MockActor m;
+	MakeDBActor(2);
+	MakeDBActor(4);
+	Main_Data::game_actors->GetActor(2)->SetName("Actor 2");
+	Main_Data::game_actors->GetActor(4)->SetName("Actor 4");
+
+	std::vector<std::string> args;
+	CHECK(DynRpg::ParseCommand("@FunC N2junk,NV3 junk,NVV3", args) == "func");
+	CHECK(args.size() == 3);
+	CHECK(args[0] == "Actor 2");
+	CHECK(args[1] == "Actor 2");
+	CHECK(args[2] == "Actor 4");
+}
+
+TEST_CASE("Arg parse") {
+	LogGuard lg;
+	std::vector<std::string> args = {"A", "1x", "2.5y"};
+	bool okay = false;
+
+	std::string s, s2;
+	int i, i2;
+	float f;
+
+	std::tie(s, i, f) = DynRpg::ParseArgs<std::string, int, float>("func", args, &okay);
+	CHECK(okay);
+	CHECK(s == "A");
+	CHECK(i == 1);
+	CHECK(f == 2.5);
+
+	std::tie(i, i2, f) = DynRpg::ParseArgs<int, int, float>("func", args, &okay);
+	CHECK(!okay);
+	CHECK(i == 0);
+	CHECK(i2 == 0);
+	CHECK(f == 0.0);
+
+	std::tie(s, s2, i) = DynRpg::ParseArgs<std::string, std::string, int>("func", args, &okay);
+	CHECK(okay);
+	CHECK(s == "A");
+	CHECK(s2 == "1x");
+	CHECK(i == 2);
+
+	std::tie(std::ignore, std::ignore, s) = DynRpg::ParseArgs<std::string, std::string, std::string>("func", args, &okay);
+	CHECK(okay);
+	CHECK(s == "2.5y");
+}
+
+TEST_CASE("easyrpg dynrpg invoke") {
+	Main_Data::game_variables = std::make_unique<Game_Variables>(-99999, 99999);
+	std::vector<int32_t> vars = {-1};
+	Main_Data::game_variables->SetData(vars);
+	Main_Data::game_variables->SetWarning(0);
+	LogGuard lg;
+
+	DynRpg::Invoke("@easyrpg_add 1, 2, 4");
+	CHECK(Main_Data::game_variables->Get(1) == 6);
+
+	// Invalid, stays 6
+	DynRpg::Invoke("@easyrpg_add 1, 2, a");
+	CHECK(Main_Data::game_variables->Get(1) == 6);
+
+	// Not enough args, stays 6
+	DynRpg::Invoke("@easyrpg_add 1");
+	CHECK(Main_Data::game_variables->Get(1) == 6);
+
+	DynRpg::Invoke("@easyrpg_add 1, 2");
+	CHECK(Main_Data::game_variables->Get(1) == 2);
+
+	DynRpg::Invoke("@call easyrpg_add, 1, 4.3, 7.7");
+	CHECK(Main_Data::game_variables->Get(1) == 11);
+
+	// Extra args ignored
+	DynRpg::Invoke("@call easyrpg_add, 1, 4, 8, -14.0");
+	CHECK(Main_Data::game_variables->Get(1) == -2);
+
+	// Invalid func, stays -2
+	DynRpg::Invoke("@call easyrpg_xxx, 1, 4, 7");
+	CHECK(Main_Data::game_variables->Get(1) == -2);
+
+	// does not crash
+	DynRpg::Invoke("@unknownfunc 1, 2, 3");
+}
+
+TEST_CASE("Incompatible changes") {
+	LogGuard lg;
+	std::vector<std::string> args;
+
+	// Empty function name (DynRPG accepts this, but makes no sense)
+	CHECK(DynRpg::ParseCommand("@ aaa", args).empty());
+
+	// Text after literal (DynRPG accepts this, extra data is removed)
+	CHECK(DynRpg::ParseCommand(R"(@FunC "Arg"junk)", args).empty());
+
+	// DynRpg interprets as float and reads V3
+	Main_Data::game_variables = std::make_unique<Game_Variables>(-99999, 99999);
+	std::vector<int32_t> vars = {0, 4, 5};
+	Main_Data::game_variables->SetData(vars);
+	args.clear();
+	CHECK(DynRpg::ParseCommand("@FunC V2.5", args) == "func");
+	CHECK(args.size() == 1);
+	CHECK(args[0] == "4");
+}
+
+TEST_SUITE_END();

--- a/tests/test_mock_actor.h
+++ b/tests/test_mock_actor.h
@@ -103,8 +103,8 @@ private:
 	LogLevel _ll = {};
 };
 
-inline lcf::rpg::Actor* MakeDBActor(int id, int level, int final_level,
-		int hp, int sp, int atk, int def, int spi, int agi,
+inline lcf::rpg::Actor* MakeDBActor(int id, int level = 1, int final_level = 50,
+		int hp = 1, int sp = 0, int atk = 0, int def = 0, int spi = 0, int agi = 0,
 		bool two_weapon = false, bool lock_equip = false, bool autobattle = false, bool super_guard = false)
 {
 	auto& actor = lcf::Data::actors[id - 1];

--- a/tests/test_mock_actor.h
+++ b/tests/test_mock_actor.h
@@ -5,6 +5,7 @@
 #include "game_party.h"
 #include "game_enemyparty.h"
 #include "game_system.h"
+#include "game_variables.h"
 #include "main_data.h"
 #include "player.h"
 #include "output.h"
@@ -87,6 +88,7 @@ public:
 		Main_Data::game_actors = std::make_unique<Game_Actors>();
 		Main_Data::game_enemyparty = std::make_unique<Game_EnemyParty>();
 		Main_Data::game_party = std::make_unique<Game_Party>();
+		Main_Data::game_variables = std::make_unique<Game_Variables>(Game_Variables::min_2k, Game_Variables::max_2k);
 
 		Main_Data::game_party->SetupNewGame();
 	}


### PR DESCRIPTION
This PR has the goal to upstream the DynRPG Parser.
This one was written as part of commisioned work in 2017/18 for the Deep8 game.

The main motivation for the submission is that this code bitrots and always updating to latest Player code is a huge task and this is imo useful code.
Right now I won't submit any plugins.
The only plugin worth upstreaming right now is the DynTextPlugin, all others are of terrible code quality or custom modifications for Deep8.

Obviously there is no plugin system in the Player, a "plugin" is just a class inheriting from DynRpgPlugin and registred in ``create_all_plugins``.

The code is not very invasive, I only added the following "Hook points":
 - Comment Event (parses and executes DynRPG commands)
 - Load
 - Save
 - Update (Spriteset graphics update)
 - Reset

Most code in dynrpg.cpp is the parser, which works by parsing the line char-by-char and keeps track of the current state through an enum. Nothing special, typical way to implement a parser. The parser is tested as it is used in Deep8 since 2 years but this is code you better don't ever touch again :).

A sample plugin (dynrpg_easyrpg) is provided. When DynRPG is enabled (dynloader.dll present) it will export the following functions:

 - \@call: This is a forwarder for RPGSS to get better warning output. It just takes the first argument as a function name and forwards the other arguments to the function
- \@easyrpg_add: 1st argument is the output variable, further arguments are the values that are added, example: ``@easyrpg_add 5, 10, V2, 30 <- V[5] = 10 + V[2] + 30``.
- \@easyrpg_output: Outputs to the console. 1st arg: Debug, Info, Warning, Error, 2nd vararg string, 3+ varargs, example: ``@easyrpg_output Info, "Hello $1! Var5 is $2", World, V5`` (this is a unique feature, DynRpg itself has no vararg support)

Basic DynRpg function syntax:
- The function name is always prefixed with a \@
- An argument is either a Token (a string without ""), a string (in "") or a Variable (Token prefixed with V)

How the Parser in the Player interprets different things: When parsed for simplicity everything is stored as a string and converted to int on demand.
- Hello - This is a Token, stored as "Hello"
- Hello World - This is a Token, stored as "HelloWorld" (DynRpg compatible - Whitespace is removed)
- "Hello World" - stored as "Hello World"
- V1 - Substituted with the variable, then the result stored as string. Is a valid number.
- VV1 - Variable Indirection, as above. Is a valid number.
- 10 - This is a Token, stored as "Hello". Is a valid number.

The Sample Plugin writes savedata. The save format of DynRPG is very simple:
- Header: DYNSAVE1
- Size of the Plugin Identifier (4 byte)
- Plugin Identifier
- Size of the Plugin data
- Plugin data
- [Repeat until EOF]

The sample plugin writes "EasyRpgPlugin" as identifier and the Player version as 4 byte as an indicator that EasyRPG wrote this file and not the official DynRpg.

Loading works by looking for a plugin that has the same identifier as the one in the save file.

