### PR TITLE
RFC: Add db:: accessor for LDB and LMT data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,8 @@ add_library(${PROJECT_NAME}
 	src/hslrgb.cpp
 	src/hslrgb.h
 	src/icon.h
+	src/idutils.h
+	src/idutils.cpp
 	src/image_bmp.cpp
 	src/image_bmp.h
 	src/image_png.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ add_library(${PROJECT_NAME}
 	src/color.h
 	src/compiler.h
 	src/config_param.h
+	src/db.cpp
+	src/db.h
 	src/decoder_fluidsynth.cpp
 	src/decoder_fluidsynth.h
 	src/decoder_libsndfile.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -158,6 +158,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/hslrgb.cpp \
 	src/hslrgb.h \
 	src/icon.h \
+	src/idutils.h \
+	src/idutils.cpp \
 	src/image_bmp.cpp \
 	src/image_bmp.h \
 	src/image_png.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -52,6 +52,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/cmdline_parser.h \
 	src/color.h \
 	src/compiler.h \
+	src/db.cpp \
+	src/db.h \
 	src/decoder_fluidsynth.cpp \
 	src/decoder_fluidsynth.h \
 	src/decoder_fmmidi.cpp \

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -1,0 +1,44 @@
+#include "db.h"
+#include <lcf/rpg/database.h>
+#include <lcf/rpg/treemap.h>
+#include <lcf/rpg/map.h>
+
+namespace db {
+
+namespace _impl {
+Db db = {};
+} // _impl
+
+/** Load a new game */
+void LoadGame(const lcf::rpg::Database* database, const lcf::rpg::TreeMap* treemap) {
+	Clear();
+
+	_impl::db.database = database;
+	_impl::db.treemap = treemap;
+
+	_impl::db.actors = database->actors;
+	_impl::db.skills = database->skills;
+	_impl::db.items = database->items;
+	_impl::db.enemies = database->enemies;
+	_impl::db.troops = database->troops;
+	_impl::db.terrains = database->terrains;
+	_impl::db.attributes = database->attributes;
+	_impl::db.states = database->states;
+	_impl::db.animations = database->animations;
+	_impl::db.chipsets = database->chipsets;
+	_impl::db.commonevents = database->commonevents;
+	_impl::db.battlecommands = &database->battlecommands;
+	_impl::db.classes = database->classes;
+	_impl::db.battleranimations = database->battleranimations;
+	_impl::db.terms = &database->terms;
+	_impl::db.system = &database->system;
+	_impl::db.switches = database->switches;
+	_impl::db.variables = database->variables;
+}
+
+/** Clear all state */
+void Clear() {
+	_impl::db = {};
+}
+
+} // namespace db

--- a/src/db.h
+++ b/src/db.h
@@ -1,0 +1,147 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_DB_H
+#define EP_DB_H
+
+#include <lcf/rpg/fwd.h>
+#include "span.h"
+#include "idutils.h"
+
+#include <memory>
+#include <cassert>
+
+namespace db {
+
+/** @return database actors */
+Span<const lcf::rpg::Actor> Actors();
+
+/** @return database skills */
+Span<const lcf::rpg::Skill> Skills();
+
+/** @return database items */
+Span<const lcf::rpg::Item> Items();
+
+/** @return database enemies */
+Span<const lcf::rpg::Enemy> Enemies();
+
+/** @return database troops */
+Span<const lcf::rpg::Troop> Troops();
+
+/** @return database terrains */
+Span<const lcf::rpg::Terrain> Terrains();
+
+/** @return database attributes */
+Span<const lcf::rpg::Attribute> Attributes();
+
+/** @return database states */
+Span<const lcf::rpg::State> States();
+
+/** @return database animations */
+Span<const lcf::rpg::Animation> Animations();
+
+/** @return database chipsets */
+Span<const lcf::rpg::Chipset> Chipsets();
+
+/** @return database commonevents */
+Span<const lcf::rpg::CommonEvent> Commonevents();
+
+/** @return database battlecommands */
+const lcf::rpg::BattleCommands& Battlecommands();
+
+/** @return database classes */
+Span<const lcf::rpg::Class> Classes();
+
+/** @return database battleranimations */
+Span<const lcf::rpg::BattlerAnimation> Battleranimations();
+
+/** @return database terms */
+const lcf::rpg::Terms& Terms();
+
+/** @return database system */
+const lcf::rpg::System& System();
+
+/** @return database switches */
+Span<const lcf::rpg::Switch> Switches();
+
+/** @return database variables */
+Span<const lcf::rpg::Variable> Variables();
+
+/** @return LDB database */
+const lcf::rpg::Database& Database();
+
+/** @return LMT treemap */
+const lcf::rpg::TreeMap& Treemap();
+
+/** Load a new game */
+void LoadGame(const lcf::rpg::Database* db, const lcf::rpg::TreeMap* treemap);
+
+/** Clear all state */
+void Clear();
+
+namespace _impl {
+struct Db {
+	const lcf::rpg::Database* database = nullptr;
+	const lcf::rpg::TreeMap* treemap = nullptr;
+
+	Span<const lcf::rpg::Actor> actors;
+	Span<const lcf::rpg::Skill> skills;
+	Span<const lcf::rpg::Item> items;
+	Span<const lcf::rpg::Enemy> enemies;
+	Span<const lcf::rpg::Troop> troops;
+	Span<const lcf::rpg::Terrain> terrains;
+	Span<const lcf::rpg::Attribute> attributes;
+	Span<const lcf::rpg::State> states;
+	Span<const lcf::rpg::Animation> animations;
+	Span<const lcf::rpg::Chipset> chipsets;
+	Span<const lcf::rpg::CommonEvent> commonevents;
+	const lcf::rpg::BattleCommands* battlecommands = nullptr;
+	Span<const lcf::rpg::Class> classes;
+	Span<const lcf::rpg::BattlerAnimation> battleranimations;
+	const lcf::rpg::Terms* terms = nullptr;
+	const lcf::rpg::System* system = nullptr;
+	Span<const lcf::rpg::Switch> switches;
+	Span<const lcf::rpg::Variable> variables;
+};
+
+extern Db db;
+} // impl
+
+inline Span<const lcf::rpg::Actor> Actors() { return _impl::db.actors; }
+inline Span<const lcf::rpg::Skill> Skills() { return _impl::db.skills; }
+inline Span<const lcf::rpg::Item> Items() { return _impl::db.items; }
+inline Span<const lcf::rpg::Enemy> Enemies() { return _impl::db.enemies; }
+inline Span<const lcf::rpg::Troop> Troops() { return _impl::db.troops; }
+inline Span<const lcf::rpg::Terrain> Terrains() { return _impl::db.terrains; }
+inline Span<const lcf::rpg::Attribute> Attributes() { return _impl::db.attributes; }
+inline Span<const lcf::rpg::State> States() { return _impl::db.states; }
+inline Span<const lcf::rpg::Animation> Animations() { return _impl::db.animations; }
+inline Span<const lcf::rpg::Chipset> Chipsets() { return _impl::db.chipsets; }
+inline Span<const lcf::rpg::CommonEvent> Commonevents() { return _impl::db.commonevents; }
+inline const lcf::rpg::BattleCommands& Battlecommands() { return *_impl::db.battlecommands; }
+inline Span<const lcf::rpg::Class> Classes() { return _impl::db.classes; }
+inline Span<const lcf::rpg::BattlerAnimation> Battleranimations() { return _impl::db.battleranimations; }
+inline const lcf::rpg::Terms& Terms() { return *_impl::db.terms; }
+inline const lcf::rpg::System& System() { return *_impl::db.system; }
+inline Span<const lcf::rpg::Switch> Switches() { return _impl::db.switches; }
+inline Span<const lcf::rpg::Variable> Variables() { return _impl::db.variables; }
+
+inline const lcf::rpg::Database& Database() { return *_impl::db.database; }
+inline const lcf::rpg::TreeMap& Treemap() { return *_impl::db.treemap; }
+
+} // namespace db
+#endif

--- a/src/idutils.cpp
+++ b/src/idutils.cpp
@@ -1,0 +1,6 @@
+#include "idutils.h"
+#include "output.h"
+
+void IdUtils::Warning(int id, StringView objname, StringView log_context) {
+	Output::Warning("{}: Invalid DB {} ID {}!", log_context, objname, id);
+}

--- a/src/idutils.h
+++ b/src/idutils.h
@@ -1,0 +1,110 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_GET_H
+#define EP_GET_H
+
+#include "span.h"
+#include "string_view.h"
+
+#include <memory>
+#include <cassert>
+
+namespace IdUtils {
+
+/**
+ * Check with a 1 based id is valid.
+ *
+ * @param array the array to check
+ * @param the id to check against array
+ * @return true if the id valid
+ */
+template <typename T>
+bool IsValid(Span<T> array, int id);
+
+/**
+ * Retrieve an element from the array using it's 1 based index.
+ *
+ * @param array the array to look into.
+ * @param id the 1 based id.
+ * @return reference to the requested object
+ * @pre If id is not valid id into the dataset the result is undefined.
+ */
+template <typename T>
+T& Get(Span<T> array, int id);
+
+/**
+ * Retrieve an element from the array using it's 1 based index.
+ *
+ * @param array the array to look into.
+ * @param id the 1 based id.
+ * @return pointer to the requested object, or null if the id is invalid.
+ */
+template <typename T>
+T* GetPtr(Span<T> array, int id);
+
+/**
+ * Retrieve an element from the array using it's 1 based index and log a warning if the id is invalid.
+ *
+ * @param array the array to look into.
+ * @param id the 1 based id.
+ * @param objname The name of the object type
+ * @param log_context A string describing the content with which this was called.
+ * @return pointer to the requested object, or null if the id is invalid.
+ */
+template <typename T>
+T* GetPtr(Span<T> array, int id, StringView objname, StringView log_context);
+
+/**
+ * Log a warning about an invalid id.
+ *
+ * @param id the 1 based id.
+ * @param objname The name of the object type
+ * @param log_context A string describing the content with which this was called.
+ */
+void Warning(int id, StringView objname, StringView log_context);
+
+template <typename T>
+inline bool IsValid(Span<T> array, int id) {
+	return id >= 1 && id <= static_cast<int>(array.size());
+}
+
+template <typename T>
+inline T& Get(Span<T> array, int id) {
+	assert(IsValid(array, id));
+	return array[id - 1];
+}
+
+
+template <typename T>
+inline T* GetPtr(Span<T> array, int id) {
+	return IsValid(array, id)
+		? array.data() + id - 1
+		: nullptr;
+}
+
+template <typename T>
+inline T* GetPtr(Span<T> array, int id, StringView objname, StringView log_context) {
+	auto* p = GetPtr(array, id);
+	if (p == nullptr) {
+		Warning(id, objname, log_context);
+	}
+	return p;
+}
+
+} // namespace IdUtils
+#endif

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -84,6 +84,7 @@
 #include <lcf/scope_guard.h>
 #include "baseui.h"
 #include "game_clock.h"
+#include "db.h"
 
 #ifndef EMSCRIPTEN
 // This is not used on Emscripten.
@@ -874,6 +875,7 @@ void Player::GuessNonStandardExtensions() {
 void Player::LoadDatabase() {
 	// Load lcf::Database
 	lcf::Data::Clear();
+	db::Clear();
 
 	if (is_easyrpg_project) {
 		std::string edb = FileFinder::FindDefault(DATABASE_NAME_EASYRPG);
@@ -907,6 +909,7 @@ void Player::LoadDatabase() {
 			FileExtGuesser::GuessAndAddLmuExtension(*FileFinder::GetDirectoryTree(), *meta, fileext_map);
 		}
 	}
+	db::LoadGame(&lcf::Data::data, &lcf::Data::treemap);
 }
 
 static void FixSaveGames() {

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -25,6 +25,7 @@
 #include "scene_title.h"
 #include "bitmap.h"
 #include "audio.h"
+#include "db.h"
 
 #ifdef _WIN32
 	#include <Windows.h>
@@ -55,6 +56,7 @@ void Scene_GameBrowser::Continue(SceneType /* prev_scene */) {
 	Cache::Clear();
 	AudioSeCache::Clear();
 	lcf::Data::Clear();
+	db::Clear();
 	Main_Data::Cleanup();
 	FileFinder::Quit();
 


### PR DESCRIPTION
Depends on: https://github.com/EasyRPG/liblcf/pull/384

Fix: #2281 

This is a new interface to access the lcf database and treemap from all Player code.

Essentially we will change from this:
```
auto& actors = lcf::Data::actors;
auto* actor = lcf::ReaderUtil::GetElement(actors, 1);
```

To this
```
auto& actors = db::Actors();

// Assumed id is always valid, asserts in debug build
auto& actor = db::Get(actors, 1);

// Requires you to check the pointer for validity
auto* actor = db::GetPtr(actors, 1);

// Like before, but also logs a warning if id is invalid
auto* actor = db::GetPtr(actors, 1, "MyFunction");
```

The reasons for changing this interface are:
* The database singleton is now part of player code and not lcf
* Enables us refactor player *before* removing `lcf::Data` and all singletons from liblcf.
* More concise name `db::`
* Potentially faster compile speeds. Including `db.h` doesn't bring in any lcf/rpg headers, only forward declarations.

I'm posting this for review on the interface. Once everyone is on board with the design, I'll add commits to this porting Player code to use the new interface. Need to avoid rebase hell on this one.