### PR TITLE
Block key input processing while message is active

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -335,6 +335,10 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 		}
 
 		if (_state.wait_key_enter) {
+			if (Game_Message::IsMessageActive()) {
+				break;
+			}
+
 			if (!Input::IsTriggered(Input::DECISION)) {
 				break;
 			}
@@ -349,6 +353,10 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 		}
 
 		if (_keyinput.wait) {
+			if (Game_Message::IsMessageActive()) {
+				break;
+			}
+
 			const int key = _keyinput.CheckInput();
 			Main_Data::game_variables->Set(_keyinput.variable, key);
 			Game_Map::SetNeedRefresh(true);


### PR DESCRIPTION
Fix: #2284

Confirmed behavior in RE tools.

I would consider this for backporting to stable.