### PR TITLE
Spell reflect fix

### DIFF
--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -757,7 +757,6 @@ int Game_BattleAlgorithm::AlgorithmBase::GetSourceAnimationState() const {
 void Game_BattleAlgorithm::AlgorithmBase::TargetFirst() {
 	if (party_target) {
 		if (reflect_set) {
-			PlayAnimation();
 			targets.clear();
 			source->GetParty().GetActiveBattlers(targets);
 		} else {
@@ -766,7 +765,6 @@ void Game_BattleAlgorithm::AlgorithmBase::TargetFirst() {
 		party_target = nullptr;
 	} else {
 		if (reflect_set) {
-			PlayAnimation();
 			targets.clear();
 			targets.push_back(source);
 		}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1534,6 +1534,12 @@ bool Game_BattleAlgorithm::Skill::IsReflected() const {
 		return false;
 	}
 
+	// Items ignore reflect
+	if (item) {
+		reflect = 0;
+		return false;
+	}
+
 	std::vector<Game_Battler*> anim_targets;
 
 	bool has_reflect = false;

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -147,7 +147,6 @@ Game_BattleAlgorithm::AlgorithmBase::AlgorithmBase(Type ty, Game_Battler* source
 
 	current_target = targets.end();
 	party_target = target;
-	party_target_set = true;
 }
 
 void Game_BattleAlgorithm::AlgorithmBase::Reset() {
@@ -237,13 +236,7 @@ void Game_BattleAlgorithm::AlgorithmBase::PlayAnimation(bool on_source) {
 	}
 
 	if (on_source) {
-		if (!party_target_set) {
-			Game_Battle::ShowBattleAnimation(GetAnimation()->ID, { GetSource() });
-		} else {
-			std::vector<Game_Battler*> anim_targets;
-			source->GetParty().GetActiveBattlers(anim_targets);
-			Game_Battle::ShowBattleAnimation(GetAnimation()->ID, anim_targets);
-		}
+		Game_Battle::ShowBattleAnimation(GetAnimation()->ID, { GetSource() });
 		has_animation_played = true;
 		return;
 	}
@@ -613,16 +606,6 @@ Game_Battler* Game_BattleAlgorithm::AlgorithmBase::GetSource() const {
 }
 
 Game_Battler* Game_BattleAlgorithm::AlgorithmBase::GetTarget() const {
-	if (IsReflected()) {
-		if (!party_target_set) {
-			return source;
-		} else {
-			std::vector<Game_Battler*> newtargets;
-			source->GetParty().GetActiveBattlers(newtargets);
-			return *(newtargets.begin());
-		}
-	}
-
 	if (current_target == targets.end()) {
 		return NULL;
 	}
@@ -773,8 +756,20 @@ int Game_BattleAlgorithm::AlgorithmBase::GetSourceAnimationState() const {
 
 void Game_BattleAlgorithm::AlgorithmBase::TargetFirst() {
 	if (party_target) {
-		party_target->GetBattlers(targets);
+		if (reflect_set) {
+			PlayAnimation();
+			targets.clear();
+			source->GetParty().GetActiveBattlers(targets);
+		} else {
+			party_target->GetBattlers(targets);
+		}
 		party_target = nullptr;
+	} else {
+		if (reflect_set) {
+			PlayAnimation();
+			targets.clear();
+			targets.push_back(source);
+		}
 	}
 
 	current_target = targets.begin();
@@ -788,17 +783,6 @@ void Game_BattleAlgorithm::AlgorithmBase::TargetFirst() {
 }
 
 bool Game_BattleAlgorithm::AlgorithmBase::TargetNext() {
-	if (IsReflected()) {
-		if (!party_target_set) {
-			// Only source available, can't target again
-			return false;
-		} else {
-			targets.clear();
-			source->GetParty().GetActiveBattlers(targets);
-			current_target = targets.begin();
-			return TargetNextInternal();
-		}
-	}
 	++cur_repeat;
 	if (IsTargetValid() && cur_repeat < repeat) {
 		first_attack = false;
@@ -869,10 +853,6 @@ const lcf::rpg::Sound* Game_BattleAlgorithm::AlgorithmBase::GetDeathSe() const {
 
 int Game_BattleAlgorithm::AlgorithmBase::GetPhysicalDamageRate() const {
 	return 0;
-}
-
-bool Game_BattleAlgorithm::AlgorithmBase::IsReflected() const {
-	return false;
 }
 
 Game_BattleAlgorithm::Null::Null(Game_Battler* source) :
@@ -1174,6 +1154,32 @@ void Game_BattleAlgorithm::Skill::Init() {
 		animation = lcf::ReaderUtil::GetElement(lcf::Data::animations, skill.animation_id);
 		if (!animation) {
 			Output::Warning("Algorithm Skill: Invalid skill animation ID {}", skill.animation_id);
+		}
+	}
+
+	// Skill reflect checks
+	// Skills invoked by items ignore reflect
+	if (!item) {
+		// One or more targets?
+		if (party_target) {
+			std::vector<Game_Battler*> targetlist;
+			party_target->GetActiveBattlers(targetlist);
+			for (Game_Battler* t : targetlist) {
+				// Targets on enemy side?
+				if (GetSource()->GetType() != t->GetType()) {
+					// If at least one enemy has the reflect state, set reflect_set to true
+					if (t->HasReflectState()) {
+						reflect_set = true;
+						break;
+					}
+				}
+			}
+		} else {
+			// Target on enemy side?
+			if (GetSource()->GetType() != GetTarget()->GetType()) {
+				// If the target has the reflect state, set reflect_set to true
+				if (GetTarget()->HasReflectState()) reflect_set = true;
+			}
 		}
 	}
 }
@@ -1511,48 +1517,6 @@ std::string Game_BattleAlgorithm::Skill::GetFailureMessage() const {
 
 int Game_BattleAlgorithm::Skill::GetPhysicalDamageRate() const {
 	return skill.physical_rate * 10;
-}
-
-bool Game_BattleAlgorithm::Skill::IsReflected() const {
-	// Reflect must be stored because after "Apply" the return value for
-	// reflect can be incorrect when states are added.
-	if (reflect != -1) {
-		return !!reflect;
-	}
-
-	if (current_target == targets.end()) {
-		reflect = 0;
-		return false;
-	}
-
-	auto old_current_target = current_target;
-	bool old_first_attack = first_attack;
-
-	// Only negative skills are reflected
-	if (GetSource()->GetType() == (*current_target)->GetType()) {
-		reflect = 0;
-		return false;
-	}
-
-	// Items ignore reflect
-	if (item) {
-		reflect = 0;
-		return false;
-	}
-
-	std::vector<Game_Battler*> anim_targets;
-
-	bool has_reflect = false;
-
-	do {
-		has_reflect |= (*current_target)->HasReflectState();
-	} while (TargetNextInternal());
-
-	current_target = old_current_target;
-	first_attack = old_first_attack;
-
-	reflect = has_reflect ? 1 : 0;
-	return has_reflect;
 }
 
 bool Game_BattleAlgorithm::Skill::ActionIsPossible() const {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -756,7 +756,7 @@ int Game_BattleAlgorithm::AlgorithmBase::GetSourceAnimationState() const {
 
 void Game_BattleAlgorithm::AlgorithmBase::TargetFirst() {
 	if (party_target) {
-		if (reflect_set) {
+		if (IsReflected()) {
 			targets.clear();
 			source->GetParty().GetActiveBattlers(targets);
 		} else {
@@ -764,7 +764,7 @@ void Game_BattleAlgorithm::AlgorithmBase::TargetFirst() {
 		}
 		party_target = nullptr;
 	} else {
-		if (reflect_set) {
+		if (IsReflected()) {
 			targets.clear();
 			targets.push_back(source);
 		}
@@ -851,6 +851,10 @@ const lcf::rpg::Sound* Game_BattleAlgorithm::AlgorithmBase::GetDeathSe() const {
 
 int Game_BattleAlgorithm::AlgorithmBase::GetPhysicalDamageRate() const {
 	return 0;
+}
+
+bool Game_BattleAlgorithm::AlgorithmBase::IsReflected() const {
+	return false;
 }
 
 Game_BattleAlgorithm::Null::Null(Game_Battler* source) :
@@ -1152,32 +1156,6 @@ void Game_BattleAlgorithm::Skill::Init() {
 		animation = lcf::ReaderUtil::GetElement(lcf::Data::animations, skill.animation_id);
 		if (!animation) {
 			Output::Warning("Algorithm Skill: Invalid skill animation ID {}", skill.animation_id);
-		}
-	}
-
-	// Skill reflect checks
-	// Skills invoked by items ignore reflect
-	if (!item) {
-		// One or more targets?
-		if (party_target) {
-			std::vector<Game_Battler*> targetlist;
-			party_target->GetActiveBattlers(targetlist);
-			for (Game_Battler* t : targetlist) {
-				// Targets on enemy side?
-				if (GetSource()->GetType() != t->GetType()) {
-					// If at least one enemy has the reflect state, set reflect_set to true
-					if (t->HasReflectState()) {
-						reflect_set = true;
-						break;
-					}
-				}
-			}
-		} else {
-			// Target on enemy side?
-			if (GetSource()->GetType() != GetTarget()->GetType()) {
-				// If the target has the reflect state, set reflect_set to true
-				if (GetTarget()->HasReflectState()) reflect_set = true;
-			}
 		}
 	}
 }
@@ -1515,6 +1493,41 @@ std::string Game_BattleAlgorithm::Skill::GetFailureMessage() const {
 
 int Game_BattleAlgorithm::Skill::GetPhysicalDamageRate() const {
 	return skill.physical_rate * 10;
+}
+
+bool Game_BattleAlgorithm::Skill::IsReflected() const {
+	// Reflect already checked?
+	if (reflect == -1) {
+		reflect = 0;
+		// Skills invoked by items ignore reflect
+		if (!item) {
+			// One or more targets?
+			if (party_target) {
+				std::vector<Game_Battler*> targetlist;
+				party_target->GetActiveBattlers(targetlist);
+				for (Game_Battler* t : targetlist) {
+					// Targets on enemy side?
+					if (GetSource()->GetType() != t->GetType()) {
+						// If at least one enemy has the reflect state, return true
+						if (t->HasReflectState()) {
+							reflect = 1;
+							return true;
+						}
+					}
+				}
+			} else {
+				// Target on enemy side?
+				if (GetSource()->GetType() != GetTarget()->GetType()) {
+					// If the target has the reflect state, return true
+					if (GetTarget()->HasReflectState()) {
+						reflect = 1;
+						return true;
+					}
+				}
+			}
+		}
+	}
+	return !!reflect;
 }
 
 bool Game_BattleAlgorithm::Skill::ActionIsPossible() const {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -230,13 +230,13 @@ const lcf::rpg::Animation* Game_BattleAlgorithm::AlgorithmBase::GetSecondAnimati
 	return animation2;
 }
 
-void Game_BattleAlgorithm::AlgorithmBase::PlayAnimation(bool on_source) {
+void Game_BattleAlgorithm::AlgorithmBase::PlayAnimation(bool on_original_targets) {
 	if (current_target == targets.end() || !GetAnimation()) {
 		return;
 	}
 
-	if (on_source) {
-		Game_Battle::ShowBattleAnimation(GetAnimation()->ID, { GetSource() });
+	if (on_original_targets) {
+		Game_Battle::ShowBattleAnimation(GetAnimation()->ID, original_targets);
 		has_animation_played = true;
 		return;
 	}
@@ -259,13 +259,13 @@ void Game_BattleAlgorithm::AlgorithmBase::PlayAnimation(bool on_source) {
 	first_attack = old_first_attack;
 }
 
-void Game_BattleAlgorithm::AlgorithmBase::PlaySecondAnimation(bool on_source) {
+void Game_BattleAlgorithm::AlgorithmBase::PlaySecondAnimation(bool on_original_targets) {
 	if (current_target == targets.end() || !GetSecondAnimation()) {
 		return;
 	}
 
-	if (on_source) {
-		Game_Battle::ShowBattleAnimation(GetSecondAnimation()->ID, { GetSource() });
+	if (on_original_targets) {
+		Game_Battle::ShowBattleAnimation(GetSecondAnimation()->ID, original_targets);
 		has_animation2_played = true;
 		return;
 	}
@@ -288,13 +288,13 @@ void Game_BattleAlgorithm::AlgorithmBase::PlaySecondAnimation(bool on_source) {
 	first_attack = old_first_attack;
 }
 
-void Game_BattleAlgorithm::AlgorithmBase::PlaySoundAnimation(bool on_source, int cutoff) {
+void Game_BattleAlgorithm::AlgorithmBase::PlaySoundAnimation(bool on_original_targets, int cutoff) {
 	if (current_target == targets.end() || !GetAnimation()) {
 		return;
 	}
 
-	if (on_source) {
-		Game_Battle::ShowBattleAnimation(GetAnimation()->ID, { GetSource() }, true, cutoff);
+	if (on_original_targets) {
+		Game_Battle::ShowBattleAnimation(GetAnimation()->ID, original_targets, true, cutoff);
 		return;
 	}
 
@@ -757,6 +757,7 @@ int Game_BattleAlgorithm::AlgorithmBase::GetSourceAnimationState() const {
 void Game_BattleAlgorithm::AlgorithmBase::TargetFirst() {
 	if (party_target) {
 		if (IsReflected()) {
+			party_target->GetBattlers(original_targets);
 			targets.clear();
 			source->GetParty().GetActiveBattlers(targets);
 		} else {
@@ -765,6 +766,7 @@ void Game_BattleAlgorithm::AlgorithmBase::TargetFirst() {
 		party_target = nullptr;
 	} else {
 		if (IsReflected()) {
+			original_targets.push_back(GetTarget());
 			targets.clear();
 			targets.push_back(source);
 		}
@@ -808,6 +810,10 @@ bool Game_BattleAlgorithm::AlgorithmBase::TargetNextInternal() const {
 
 void Game_BattleAlgorithm::AlgorithmBase::SetRepeat(int repeat) {
 	this->repeat = repeat;
+}
+
+bool Game_BattleAlgorithm::AlgorithmBase::OriginalTargetsSet() const {
+	return (original_targets.size() > 0);
 }
 
 void Game_BattleAlgorithm::AlgorithmBase::SetSwitchEnable(int switch_id) {

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -492,6 +492,8 @@ protected:
 	std::vector<int16_t> shift_attributes;
 	std::vector<int> switch_on;
 	std::vector<int> switch_off;
+
+	bool party_target_set = false;
 };
 
 // Special algorithm for battlers which have no action. 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -392,6 +392,18 @@ public:
 	virtual int GetPhysicalDamageRate() const;
 
 	/**
+	 * Returns whether the attack is reflected to the source.
+	 * This is automatically handled by the battle algorithm class and
+	 * GetTarget will return the source instead.
+	 * The only exception is PlayAnimation which must be controlled through
+	 * an extra argument because a reflected skill renders both animations:
+	 * First time on target, then second time on source.
+	 *
+	 * @return true when reflected
+	 */
+	virtual bool IsReflected() const;
+
+	/**
 	 * Returns the algorithm type of this object.
 	 */
 	Type GetType() const;
@@ -480,8 +492,6 @@ protected:
 	std::vector<int16_t> shift_attributes;
 	std::vector<int> switch_on;
 	std::vector<int> switch_off;
-
-	bool reflect_set = false;
 };
 
 // Special algorithm for battlers which have no action. 
@@ -532,6 +542,7 @@ public:
 	const lcf::rpg::Sound* GetResultSe() const override;
 	std::string GetFailureMessage() const override;
 	int GetPhysicalDamageRate() const override;
+	bool IsReflected() const override;
 	bool ActionIsPossible() const override;
 
 private:

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -239,13 +239,14 @@ public:
 	 * Must be called before calling TargetNext, otherwise the result will
 	 * be incorrect.
 	 *
-	 * @param on_source Renders the animation on the source instead of the
-	 *                  targets (required for reflect)
+	 * @param on_original_targets Renders the animation on the original
+	 *                            targets instead of the current
+	 *                            targets (required for reflect)
 	 */
-	void PlayAnimation(bool on_source = false);
-	void PlaySecondAnimation(bool on_source = false);
+	void PlayAnimation(bool on_original_targets = false);
+	void PlaySecondAnimation(bool on_original_targets = false);
 
-	void PlaySoundAnimation(bool on_source = false, int cutoff = -1);
+	void PlaySoundAnimation(bool on_original_targets = false, int cutoff = -1);
 
 	/**
 	 * Returns whether the action hit the target.
@@ -420,6 +421,11 @@ public:
 	void SetRepeat(int repeat);
 
 	/**
+	 * @return true if the size of original_targets is greater than zero.
+	 */
+	bool OriginalTargetsSet() const;
+
+	/**
 	 * @return the critical hit message
 	 */
 	std::string GetCriticalHitMessage() const;
@@ -492,6 +498,8 @@ protected:
 	std::vector<int16_t> shift_attributes;
 	std::vector<int> switch_on;
 	std::vector<int> switch_off;
+
+	std::vector<Game_Battler*> original_targets;
 };
 
 // Special algorithm for battlers which have no action. 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -392,18 +392,6 @@ public:
 	virtual int GetPhysicalDamageRate() const;
 
 	/**
-	 * Returns whether the attack is reflected to the source.
-	 * This is automatically handled by the battle algorithm class and
-	 * GetTarget will return the source instead.
-	 * The only exception is PlayAnimation which must be controlled through
-	 * an extra argument because a reflected skill renders both animations:
-	 * First time on target, then second time on source.
-	 *
-	 * @return true when reflected
-	 */
-	virtual bool IsReflected() const;
-
-	/**
 	 * Returns the algorithm type of this object.
 	 */
 	Type GetType() const;
@@ -493,7 +481,7 @@ protected:
 	std::vector<int> switch_on;
 	std::vector<int> switch_off;
 
-	bool party_target_set = false;
+	bool reflect_set = false;
 };
 
 // Special algorithm for battlers which have no action. 
@@ -544,7 +532,6 @@ public:
 	const lcf::rpg::Sound* GetResultSe() const override;
 	std::string GetFailureMessage() const override;
 	int GetPhysicalDamageRate() const override;
-	bool IsReflected() const override;
 	bool ActionIsPossible() const override;
 
 private:

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -832,12 +832,6 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 		return false;
 	}
 
-	if (play_reflected_anim) {
-		action->PlayAnimation(true);
-		play_reflected_anim = false;
-		return false;
-	}
-
 	Sprite_Battler* source_sprite;
 	source_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetSource());
 
@@ -922,7 +916,6 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 		}
 
 		action->PlayAnimation();
-		play_reflected_anim = action->IsReflected();
 
 		{
 			std::vector<Game_Battler*> battlers;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -832,6 +832,12 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 		return false;
 	}
 
+	if (play_reflect_anim) {
+		play_reflect_anim = false;
+		action->PlayAnimation();
+		return false;
+	}
+
 	Sprite_Battler* source_sprite;
 	source_sprite = Game_Battle::GetSpriteset().FindBattler(action->GetSource());
 
@@ -915,7 +921,12 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 				Sprite_Battler::LoopState_WaitAfterFinish);
 		}
 
-		action->PlayAnimation();
+		if (action->OriginalTargetsSet()) {
+			play_reflect_anim = true;
+			action->PlayAnimation(true);
+		} else {
+			action->PlayAnimation();
+		}
 
 		{
 			std::vector<Game_Battler*> battlers;

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -134,7 +134,6 @@ protected:
 	int battle_action_state = BattleActionState_Execute;
 	bool battle_action_need_event_refresh = true;
 	int combo_repeat = 1;
-	bool play_reflected_anim = false;
 
 	std::unique_ptr<Window_BattleStatus> enemy_status_window;
 	std::unique_ptr<Window_ActorSp> sp_window;

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -134,6 +134,7 @@ protected:
 	int battle_action_state = BattleActionState_Execute;
 	bool battle_action_need_event_refresh = true;
 	int combo_repeat = 1;
+	bool play_reflect_anim = false;
 
 	std::unique_ptr<Window_BattleStatus> enemy_status_window;
 	std::unique_ptr<Window_ActorSp> sp_window;


### PR DESCRIPTION
This PR fixes #2251. Moreover a second commit has been added to check if an item has been used because skills invoked by items bypass spell reflection (compare with the Item "Heiliger Sand" in "Vampires Dawn II". Using that item removes all positive states on the enemies (including "Spiegel") and it doesn't get reflected in RPG_RT).