### PR TITLE
Input Recording v2

### DIFF
--- a/src/dynrpg.h
+++ b/src/dynrpg.h
@@ -44,6 +44,7 @@ namespace DynRpg {
 		template <typename T>
 		inline bool parse_arg(StringView, dyn_arg_list, const int, T& value, bool& parse_okay) {
 			static_assert(sizeof(T) == -1, "Only parsing int, float and std::string supported");
+			return false;
 		}
 
 		// FIXME: Extracting floats that are followed by chars behaviour varies depending on the C++ library

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -277,6 +277,13 @@ std::unique_ptr<lcf::rpg::Map> Game_Map::loadMapFile(int map_id) {
 
 		auto map_stream = FileFinder::OpenInputStream(map_file);
 		map = lcf::LMU_Reader::Load(map_stream, Player::encoding);
+
+		if (Input::IsRecording()) {
+			map_stream.clear();
+			map_stream.seekg(0);
+			Input::AddRecordingData(Input::RecordingData::Hash,
+						   fmt::format("map{} {:#08x}", Utils::CRC32(map_stream)));
+		}
 	} else {
 		auto map_stream = FileFinder::OpenInputStream(map_file);
 		map = lcf::LMU_Reader::LoadXml(map_stream);

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -316,3 +316,13 @@ bool Input::IsRawKeyReleased(Input::Keys::InputKey key) {
 Point Input::GetMousePosition() {
 	return source->GetMousePosition();
 }
+
+void Input::AddRecordingData(Input::RecordingData type, StringView data) {
+	assert(source);
+	source->AddRecordingData(type, data);
+}
+
+bool Input::IsRecording() {
+	assert(source);
+	return source->IsRecording();
+}

--- a/src/input.h
+++ b/src/input.h
@@ -231,6 +231,16 @@ namespace Input {
 	 */
 	Point GetMousePosition();
 
+	/**
+	 * Used to submit additional metadata for input recording
+	 * @param type type of data sent
+	 * @param data Sent data
+	 */
+	void AddRecordingData(RecordingData type, StringView data);
+
+	/** @return If the input is recorded */
+	bool IsRecording();
+
 	/** Buttons press time (in frames). */
 	extern std::array<int, BUTTON_COUNT> press_time;
 

--- a/src/input_source.cpp
+++ b/src/input_source.cpp
@@ -187,6 +187,12 @@ void Input::Source::Record() {
 	}
 }
 
+void Input::Source::AddRecordingData(Input::RecordingData type, StringView data) {
+	if (record_log) {
+		*record_log << static_cast<char>(type) << " " << data << "\n";
+	}
+}
+
 void Input::LogSource::UpdateSystem() {
 	// input log does not record actions outside of logical frames.
 }

--- a/src/input_source.cpp
+++ b/src/input_source.cpp
@@ -18,11 +18,15 @@
 #include <algorithm>
 #include <cstring>
 #include <cerrno>
+#include <ctime>
 
 #include "baseui.h"
 #include "input_source.h"
 #include "player.h"
 #include "output.h"
+#include "game_system.h"
+#include "main_data.h"
+#include "version.h"
 
 std::unique_ptr<Input::Source> Input::Source::Create(
 		Input::ButtonMappingArray buttons,
@@ -73,10 +77,52 @@ void Input::UiSource::UpdateSystem() {
 Input::LogSource::LogSource(const char* log_path, ButtonMappingArray buttons, DirectionMappingArray directions)
 	: Source(std::move(buttons), std::move(directions)),
 	log_file(FileFinder::OpenInputStream(log_path, std::ios::in))
-{}
+{
+	std::string header = Utils::ReadLine(log_file);
+	if (StringView(header).starts_with("H EasyRPG")) {
+		std::string ver = Utils::ReadLine(log_file);
+		if (StringView(ver).starts_with("V 2")) {
+			version = 2;
+		} else {
+			Output::Error("Unsupported logfile version {}", ver);
+		}
+	} else {
+		Output::Debug("Using legacy inputlog format");
+	}
+}
 
 void Input::LogSource::Update() {
-	log_file >> pressed_buttons;
+	if (version == 2) {
+		if (!Main_Data::game_system) {
+			return;
+		}
+
+		if (last_read_frame == -1) {
+			pressed_buttons.reset();
+
+			std::string line = Utils::ReadLine(log_file);
+			while (!StringView(line).starts_with("F ") && log_file) {
+				line = Utils::ReadLine(log_file);
+			}
+			if (!line.empty()) {
+				keys = Utils::Tokenize(line.substr(2), [](char32_t c) { return c == ','; });
+				if (!keys.empty()) {
+					last_read_frame = atoi(keys[0].c_str());
+				}
+			}
+		}
+		if (Main_Data::game_system->GetFrameCounter() == last_read_frame) {
+			for (const auto& key : keys) {
+				auto it = std::find(Input::kButtonNames.begin(), Input::kButtonNames.end(), key);
+				if (it != Input::kButtonNames.end()) {
+					pressed_buttons[std::distance(Input::kButtonNames.begin(), it)] = true;
+				}
+			}
+			last_read_frame = -1;
+		}
+	} else {
+		log_file >> pressed_buttons;
+	}
 
 	if (!log_file) {
 		Player::exit_flag = true;
@@ -96,13 +142,48 @@ bool Input::Source::InitRecording(const std::string& record_to_path) {
 			Output::Warning("Failed to open file {} for input recording : {}", path, strerror(errno));
 			return false;
 		}
+
+		*record_log << "H EasyRPG Player Recording\n";
+		*record_log << "V 2 " PLAYER_VERSION "\n";
+
+		std::time_t t = std::time(nullptr);
+		// trigraph ?-escapes
+		std::string date = R"(????-??-?? ??:??:??)";
+		char timestr[100];
+		if (std::strftime(timestr, sizeof(timestr), "%Y-%m-%d %H:%M:%S", std::localtime(&t))) {
+			date = std::string(timestr);
+		}
+
+		*record_log << "D " << date << '\n';
 	}
 	return true;
 }
 
 void Input::Source::Record() {
 	if (record_log) {
-		*record_log << GetPressedNonSystemButtons() << '\n';
+		const auto& buttons = GetPressedNonSystemButtons();
+		if (buttons.any()) {
+			if (!Main_Data::game_system) {
+				return;
+			}
+			int cur_frame = Main_Data::game_system->GetFrameCounter();
+			if (cur_frame == last_written_frame) {
+				return;
+			}
+			last_written_frame = cur_frame;
+
+			*record_log << "F " << cur_frame;
+
+			for (size_t i = 0; i < buttons.size(); ++i) {
+				if (!buttons[i]) {
+					continue;
+				}
+
+				*record_log << ',' << Input::kButtonNames[i];
+			}
+
+			*record_log << '\n';
+		}
 	}
 }
 

--- a/src/input_source.h
+++ b/src/input_source.h
@@ -26,6 +26,14 @@
 #include "keys.h"
 
 namespace Input {
+	enum class RecordingData : char {
+		CommandLine = 'C',
+		EventCommand = 'E', // unused - reserved
+		Hash = 'L',
+		MoveRoute = 'M', // unused - reserved
+		GameTitle = 'N'
+	};
+
 	/**
 	 * A source for button presses.
 	 */
@@ -47,6 +55,18 @@ namespace Input {
 
 		/** Called once each physical frame when no logical frames occured to update pressed_buttons for system buttons. */
 		virtual void UpdateSystem() = 0;
+
+		/**
+		 * Used to submit additional metadata for input recording
+		 * @param type type of data sent
+		 * @param data Sent data
+		 */
+		void AddRecordingData(RecordingData type, StringView data);
+
+		/** @return If the input is recorded */
+		bool IsRecording() const {
+			return bool(record_log);
+		}
 
 		const std::bitset<BUTTON_COUNT>& GetPressedButtons() const {
 			return pressed_buttons;

--- a/src/input_source.h
+++ b/src/input_source.h
@@ -85,6 +85,8 @@ namespace Input {
 
 		std::bitset<Input::Keys::KEYS_COUNT> keystates;
 		Point mouse_pos;
+
+		int last_written_frame = -1;
 	};
 
 	/**
@@ -115,6 +117,10 @@ namespace Input {
 		operator bool() const { return bool(log_file); }
 	private:
 		Filesystem_Stream::InputStream log_file;
+		int version = 1;
+		int last_read_frame = -1;
+		// NOTE: First field is the frame number
+		std::vector<std::string> keys;
 	};
 
 	extern std::unique_ptr<Source> source;

--- a/src/meta.cpp
+++ b/src/meta.cpp
@@ -21,7 +21,6 @@
 #include <fstream>
 #include <iomanip>
 #include <sstream>
-#include <zlib.h>
 #include <lcf/data.h>
 #include "filefinder.h"
 #include <lcf/lmt/reader.h>
@@ -55,9 +54,7 @@ std::string crc32file(std::string file_name) {
 	if (!file_name.empty()) {
 		auto in = FileFinder::OpenInputStream(file_name, std::ios::binary);
 		if (in) {
-			std::string buffer((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-			unsigned long crc = ::crc32(0, reinterpret_cast<const unsigned char*>(buffer.c_str()), buffer.length());
-
+			auto crc = Utils::CRC32(in);
 			std::stringstream res;
 			res <<std::hex <<std::setfill('0') <<std::setw(8) <<crc;
 			return res.str();

--- a/src/player.h
+++ b/src/player.h
@@ -333,6 +333,9 @@ namespace Player {
 	/** Path to record input log to */
 	extern std::string record_input_path;
 
+	/** The concatenated command line */
+	extern std::string command_line;
+
 	/** Game title. */
 	extern std::string game_title;
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -22,10 +22,11 @@
 #include <cassert>
 #include <cstdint>
 #include <cinttypes>
-#include <stdio.h>
+#include <cstdio>
 #include <algorithm>
 #include <random>
 #include <cctype>
+#include <zlib.h>
 
 namespace {
 	char Lower(char c) {
@@ -560,6 +561,16 @@ std::vector<uint8_t> Utils::ReadStream(std::istream& stream) {
 	outbuf.resize(outbuf.size() - buffer_incr + stream.gcount());
 
 	return outbuf;
+}
+
+uint32_t Utils::CRC32(std::istream& stream) {
+	uLong crc = crc32(0L, Z_NULL, 0);
+	std::array<uint8_t, 8192> buffer = {};
+	do {
+		stream.read(reinterpret_cast<char*>(buffer.data()), buffer.size());
+		crc = crc32(crc, buffer.data(), stream.gcount());
+	} while (stream.gcount() == buffer.size());
+	return crc;
 }
 
 std::string Utils::ReplacePlaceholders(StringView text_template, Span<const char> types, Span<const StringView> values) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -266,6 +266,13 @@ namespace Utils {
 	std::vector<uint8_t> ReadStream(std::istream& stream);
 
 	/**
+	 * Calculates the CRC32 of the stream content
+	 * @param stream Stream to calculate crc32 from
+	 * @return crc32
+	 */
+	uint32_t CRC32(std::istream& stream);
+
+	/**
 	 * Replaces placeholders (like %S, %O, %V, %U) in strings.
 	 *
 	 * @param text_template String with placeholders to replace.


### PR DESCRIPTION
A new input recording format that suites the regression test requirements. (Dependency: #2288)

The current format is just a bitfield of the pressed buttons everytime Input::Update is called. This is bad. Is enough for playback in Player but not for anything else.

The code still needs some polish but the new format looks like this. I already used it to successfully playback inputs in RPG_RT.

Format:
- 1st line: Header
- 2nd line: Version
- ...nth line: Everything else

Structure: It is a simple flatfile with a linecode (1st char is the ID, 2nd char is whitespace).
The line must be empty or start with a known linecode.

- H Header identifier <- On line 1
- V Version identifier <- On line 2
- N Game name
- D Recording date
- L LDBHash LMTHash <- CRC32 of LDB and LMT
- C Command line
- F FrameNum,[Pressed Keys,...]
- \# Comment
- E RESERVED (Event execution trace)
- M RESERVED (Move command trace)

N, D, L and C are not validated but useful for reproducible recordings.

```
H EasyRPG Player Record <- H - Header. Must be this string
V 2 <- V - Version information <- V - Must be 2
D 2020-08-23-23-27-37 <- D - Recording date
F 45,DECISION <- F - Frame information: First the number (from Game_System->frame), then the keys
F 0,DECISION <- The frame counter can go back to 0 when a "New Game" starts.
F 5,RIGHT
F 6,RIGHT
F 7,RIGHT
# This is a comment
F 8,RIGHT
F 9,RIGHT
F 10,RIGHT
F 11,RIGHT
F 12,RIGHT
F 13,RIGHT
F 14,RIGHT
F 31,RIGHT,UP <- Frames without input are omitted
F 32,RIGHT,UP
F 33,RIGHT,UP
F 34,RIGHT,UP
F 35,RIGHT,UP
F 36,RIGHT,UP
F 37,RIGHT,UP
F 38,RIGHT,UP
F 39,RIGHT,UP
F 40,RIGHT,UP
F 44,DECISION
F 45,DECISION
F 46,DECISION
F 47,DECISION
F 48,DECISION
F 49,DECISION
F 50,DECISION
```