### PR TITLE
Fix self-target skills outside of battles

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -16,6 +16,7 @@ EasyRPG Player authors
 * Matthew Fioravante (fmatthew5876)
 * Patrick Müssig (Tondorian)
 * Paulo "Zhek" Vizcaino (paulo_v)
+* rueter37
 * scurest
 * Shin-NiL
 * Takeshi Watanabe (takecheeze)

--- a/src/scene_actortarget.cpp
+++ b/src/scene_actortarget.cpp
@@ -82,7 +82,7 @@ void Scene_ActorTarget::Start() {
 		}
 
 		if (skill->scope == lcf::rpg::Skill::Scope_self) {
-			target_window->SetIndex(-actor_index);
+			target_window->SetIndex(-actor_index - 1);
 		} else if (skill->scope == lcf::rpg::Skill::Scope_party) {
 			target_window->SetIndex(-100);
 		}

--- a/src/window_actortarget.cpp
+++ b/src/window_actortarget.cpp
@@ -56,7 +56,7 @@ void Window_ActorTarget::UpdateCursorRect() {
 	if (index < -10) { // Entire Party
 		cursor_rect = { 48 + 4, 0, 120, item_max * (48 + 10) - 10 };
 	} else if (index < 0) { // Fixed to one
-		cursor_rect = { 48 + 4, -index * (48 + 10), 120, 48 };
+		cursor_rect = { 48 + 4, (-index - 1) * (48 + 10), 120, 48 };
 	} else {
 		cursor_rect = { 48 + 4, index * (48 + 10), 120, 48 };
 	}
@@ -65,7 +65,7 @@ void Window_ActorTarget::UpdateCursorRect() {
 Game_Actor* Window_ActorTarget::GetActor() {
 	int ind = GetIndex();
 	if (ind >= -10 && ind < 0) {
-		ind = -ind;
+		ind = -ind - 1;
 	}
 	else if (ind == -100) {
 		return NULL;


### PR DESCRIPTION
Outside of battles the first party member is able to use self-target skills on the other party members too. This is because the ActorTarget scene checks for a negative index to lock the selection. But the first party member has the index zero and things like "negative zero" doesn't exist. This PR aims to fix this by shifting the party member index.