### PR TITLE
Fluidsynth: Fix low audio samplerate and buildfix for v1.1.11

### DIFF
--- a/src/audio_midi.cpp
+++ b/src/audio_midi.cpp
@@ -73,9 +73,11 @@ std::unique_ptr<AudioDecoder> MidiDecoder::Create(Filesystem_Stream::InputStream
 	}
 #endif
 
+#ifdef USE_AUDIO_RESAMPLER
 	if (mididec && resample) {
 		mididec = std::make_unique<AudioResampler>(std::move(mididec));
 	}
+#endif
 
 	return mididec;
 }

--- a/src/audio_resampler.cpp
+++ b/src/audio_resampler.cpp
@@ -17,7 +17,7 @@
 
 #include "system.h"
 
-#if defined(HAVE_LIBSPEEXDSP) || defined(HAVE_LIBSAMPLERATE) 
+#ifdef USE_AUDIO_RESAMPLER
 
 #include <cassert>
 #include <cstring>

--- a/src/audio_sdl_mixer.cpp
+++ b/src/audio_sdl_mixer.cpp
@@ -427,13 +427,7 @@ void SdlMixerAudio::SetupAudioDecoder(Filesystem_Stream::InputStream stream, con
 	}
 	AudioDecoder::Format audio_format = sdl_format_to_format(sdl_format);
 
-	int target_rate = audio_rate;
-	if (audio_decoder->GetType() == "midi") {
-		// FM Midi is very CPU heavy and the difference between 44100 and 22050
-		// is not hearable for MIDI
-		target_rate /= 2;
-	}
-	audio_decoder->SetFormat(target_rate, audio_format, audio_channels);
+	audio_decoder->SetFormat(audio_rate, audio_format, audio_channels);
 
 	int device_rate;
 	AudioDecoder::Format device_format;

--- a/src/audio_secache.cpp
+++ b/src/audio_secache.cpp
@@ -139,9 +139,9 @@ std::unique_ptr<AudioDecoder> AudioSeCache::CreateSeDecoder() {
 		se = cache.find(filename)->second;
 		se->last_access = Game_Clock::GetFrameTime();
 
-		std::unique_ptr<AudioDecoder> dec = std::unique_ptr<AudioDecoder>(new AudioSeDecoder(se));
+		std::unique_ptr<AudioDecoder> dec = std::make_unique<AudioSeDecoder>(se);
 #ifdef USE_AUDIO_RESAMPLER
-		dec = std::unique_ptr<AudioDecoder>(new AudioResampler(std::move(dec)));
+		dec = std::make_unique<AudioResampler>(std::move(dec));
 #endif
 		Filesystem_Stream::InputStream is;
 		dec->Open(std::move(is));


### PR DESCRIPTION
This fixes the worst problem encountered after merging the FluidSynth branch:

- Bad audio quality ("vinyl") because I missed legacy code
- Buildfix for Fluidsynth v1.1.11 (Fedora seems to use this). There were already two reports about this so suppoting this is worth.

v1.1.11 has no VIO support for soundfonts this means that the nice-to-have feature "Load Soundfont from a ZIP/bundled in a APK/etc" will not work.