### PR TITLE
Fix healing display in RPG Maker 2003 battles

### DIFF
--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1232,8 +1232,13 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 
 			effect = Utils::Clamp(effect, 0, MaxDamageValue());
 
-			if (skill.affect_hp)
-				this->hp = std::max<int>(0, std::min<int>(effect, GetTarget()->GetMaxHp() - GetTarget()->GetHp()));
+			if (skill.affect_hp) {
+				if (Player::IsRPG2k3()) {
+					this->hp = effect;
+				} else {
+					this->hp = std::max<int>(0, std::min<int>(effect, GetTarget()->GetMaxHp() - GetTarget()->GetHp()));
+				}
+			}
 			if (skill.affect_sp) {
 				int sp_cost = GetSource() == GetTarget() ? source->CalculateSkillCost(skill.ID) : 0;
 				this->sp = std::max<int>(0, std::min<int>(effect, GetTarget()->GetMaxSp() - GetTarget()->GetSp() + sp_cost));
@@ -1611,7 +1616,11 @@ bool Game_BattleAlgorithm::Item::Execute() {
 
 		// HP recovery
 		if (item.recover_hp != 0 || item.recover_hp_rate != 0) {
-			this->hp = std::max<int>(0, std::min<int>(item.recover_hp_rate * GetTarget()->GetMaxHp() / 100 + item.recover_hp, GetTarget()->GetMaxHp() - GetTarget()->GetHp()));
+			if (Player::IsRPG2k3()) {
+				this->hp = item.recover_hp_rate * GetTarget()->GetMaxHp() / 100 + item.recover_hp;
+			} else {
+				this->hp = std::max<int>(0, std::min<int>(item.recover_hp_rate * GetTarget()->GetMaxHp() / 100 + item.recover_hp, GetTarget()->GetMaxHp() - GetTarget()->GetHp()));
+			}
 		}
 
 		// SP recovery


### PR DESCRIPTION
This PR tries to fix #1680. It checks if RPG Maker 2003 is used and if it's true, then the clamping on this->hp in game_battlealgorithm.cpp gets disabled when a healing spell or healing item is used. This makes the jumping number always show the amount of HP healed. The function SetHp in game_actor.cpp makes sure that the maximum HP doesn't get exceeded despite the disabled clamping.