### PR TITLE
Battle 2k: When selecting a previous actor remove "NoMove" actions of dead actors

### DIFF
--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -1288,11 +1288,6 @@ void Scene_Battle_Rpg2k::SelectPreviousActor() {
 	actor_index--;
 	active_actor = allies[actor_index];
 
-	if (active_actor->IsDead()) {
-		SelectPreviousActor();
-		return;
-	}
-
 	battle_actions.back()->SetBattleAlgorithm(std::shared_ptr<Game_BattleAlgorithm::AlgorithmBase>());
 	battle_actions.pop_back();
 


### PR DESCRIPTION
No idea how we could miss this during testing :thinking: 

To reproduce you need at least 2 in your party:
- 1st Death
- 2nd Normal

When the "Normal" is selected press ESC, then select the "Normal" again and start a fight. You will get a warning.
