### PR TITLE
Battle 2k3: Add support for flipped battle animations

### DIFF
--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -108,8 +108,10 @@ void BattleAnimation::DrawAt(Bitmap& dst, int x, int y) {
 		}
 
 		SetX(cell.x + x);
+		if (invert) SetX(x - cell.x);
 		SetY(cell.y + y);
 		int sx = cell.cell_id % 5;
+		if (invert) sx = 4 - sx;
 		int sy = cell.cell_id / 5;
 		int size = animation.large ? 128 : 96;
 		SetSrcRect(Rect(sx * size, sy * size, size, size));
@@ -122,6 +124,7 @@ void BattleAnimation::DrawAt(Bitmap& dst, int x, int y) {
 		SetOpacity(255 * (100 - cell.transparency) / 100);
 		SetZoomX(cell.zoom / 100.0);
 		SetZoomY(cell.zoom / 100.0);
+		SetFlipX(invert);
 		Sprite::Draw(dst);
 	}
 
@@ -274,9 +277,10 @@ void BattleAnimationMap::ShakeTargets(int /* str */, int /* spd */, int /* time 
 
 /////////
 
-BattleAnimationBattle::BattleAnimationBattle(const lcf::rpg::Animation& anim, std::vector<Game_Battler*> battlers, bool only_sound, int cutoff_frame) :
+BattleAnimationBattle::BattleAnimationBattle(const lcf::rpg::Animation& anim, std::vector<Game_Battler*> battlers, bool only_sound, int cutoff_frame, bool set_invert) :
 	BattleAnimation(anim, only_sound, cutoff_frame), battlers(std::move(battlers))
 {
+	invert = set_invert;
 }
 
 void BattleAnimationBattle::Draw(Bitmap& dst) {

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -107,8 +107,7 @@ void BattleAnimation::DrawAt(Bitmap& dst, int x, int y) {
 			continue;
 		}
 
-		SetX(cell.x + x);
-		if (invert) SetX(x - cell.x);
+		SetX(invert ? x - cell.x : cell.x + x);
 		SetY(cell.y + y);
 		int sx = cell.cell_id % 5;
 		if (invert) sx = 4 - sx;

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -84,6 +84,7 @@ protected:
 
 	FileRequestBinding request_id;
 	bool only_sound = false;
+	bool invert = false;
 };
 
 // For playing animations on the map.
@@ -104,7 +105,7 @@ protected:
 // For playing animations against a (group of) battlers in battle.
 class BattleAnimationBattle : public BattleAnimation {
 public:
-	BattleAnimationBattle(const lcf::rpg::Animation& anim, std::vector<Game_Battler*> battlers, bool only_sound = false, int cutoff_frame = -1);
+	BattleAnimationBattle(const lcf::rpg::Animation& anim, std::vector<Game_Battler*> battlers, bool only_sound = false, int cutoff_frame = -1, bool set_invert = false);
 	void Draw(Bitmap& dst) override;
 protected:
 	void FlashTargets(int r, int g, int b, int p) override;

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -170,14 +170,14 @@ Spriteset_Battle& Game_Battle::GetSpriteset() {
 	return *spriteset;
 }
 
-int Game_Battle::ShowBattleAnimation(int animation_id, std::vector<Game_Battler*> targets, bool only_sound, int cutoff) {
+int Game_Battle::ShowBattleAnimation(int animation_id, std::vector<Game_Battler*> targets, bool only_sound, int cutoff, bool invert) {
 	const lcf::rpg::Animation* anim = lcf::ReaderUtil::GetElement(lcf::Data::animations, animation_id);
 	if (!anim) {
 		Output::Warning("ShowBattleAnimation Many: Invalid animation ID {}", animation_id);
 		return 0;
 	}
 
-	animation.reset(new BattleAnimationBattle(*anim, std::move(targets), only_sound, cutoff));
+	animation.reset(new BattleAnimationBattle(*anim, std::move(targets), only_sound, cutoff, invert));
 	auto frames = animation->GetFrames();
 	return cutoff >= 0 ? std::min(frames, cutoff) : frames;
 }

--- a/src/game_battle.h
+++ b/src/game_battle.h
@@ -93,7 +93,7 @@ namespace Game_Battle {
 	 *
 	 * @return the number of frames of the animation.
 	 */
-	int ShowBattleAnimation(int animation_id, std::vector<Game_Battler*> targets, bool only_sound = false, int cutoff = -1);
+	int ShowBattleAnimation(int animation_id, std::vector<Game_Battler*> targets, bool only_sound = false, int cutoff = -1, bool invert = false);
 
 	/**
 	 * Whether or not a battle animation is currently playing.

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -250,12 +250,7 @@ void Game_BattleAlgorithm::AlgorithmBase::PlayAnimation(bool on_original_targets
 		anim_targets.push_back(*current_target);
 	} while (TargetNextInternal());
 
-	Game_Battle::ShowBattleAnimation(
-		GetAnimation()->ID,
-		anim_targets,
-		false,
-		-1,
-		invert);
+	Game_Battle::ShowBattleAnimation(GetAnimation()->ID, anim_targets, false, -1, invert);
 	has_animation_played = true;
 
 	current_target = old_current_target;
@@ -763,7 +758,6 @@ void Game_BattleAlgorithm::AlgorithmBase::TargetFirst() {
 	if (party_target) {
 		if (IsReflected()) {
 			party_target->GetBattlers(original_targets);
-			current_original_target = original_targets.begin();
 			targets.clear();
 			source->GetParty().GetActiveBattlers(targets);
 		} else {
@@ -773,7 +767,6 @@ void Game_BattleAlgorithm::AlgorithmBase::TargetFirst() {
 	} else {
 		if (IsReflected()) {
 			original_targets.push_back(GetTarget());
-			current_original_target = original_targets.begin();
 			targets.clear();
 			targets.push_back(source);
 		}
@@ -823,12 +816,8 @@ bool Game_BattleAlgorithm::AlgorithmBase::OriginalTargetsSet() const {
 	return (original_targets.size() > 0);
 }
 
-Game_Battler* Game_BattleAlgorithm::AlgorithmBase::GetOriginalTarget() const {
-	if (current_original_target == original_targets.end()) {
-		return NULL;
-	}
-
-	return *current_original_target;
+Game_Battler* Game_BattleAlgorithm::AlgorithmBase::GetFirstOriginalTarget() const {
+	return *original_targets.begin();
 }
 
 void Game_BattleAlgorithm::AlgorithmBase::SetSwitchEnable(int switch_id) {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -277,12 +277,7 @@ void Game_BattleAlgorithm::AlgorithmBase::PlaySecondAnimation(bool on_original_t
 		anim_targets.push_back(*current_target);
 	} while (TargetNextInternal());
 
-	Game_Battle::ShowBattleAnimation(
-		GetSecondAnimation()->ID,
-		anim_targets,
-		false,
-		-1,
-		invert);
+	Game_Battle::ShowBattleAnimation(GetSecondAnimation()->ID, anim_targets, false, -1, invert);
 	has_animation2_played = true;
 
 	current_target = old_current_target;
@@ -817,7 +812,11 @@ bool Game_BattleAlgorithm::AlgorithmBase::OriginalTargetsSet() const {
 }
 
 Game_Battler* Game_BattleAlgorithm::AlgorithmBase::GetFirstOriginalTarget() const {
-	return *original_targets.begin();
+	if (original_targets.empty()) {
+		return NULL;
+	} else {
+		return *original_targets.begin();
+	}
 }
 
 void Game_BattleAlgorithm::AlgorithmBase::SetSwitchEnable(int switch_id) {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -813,7 +813,7 @@ bool Game_BattleAlgorithm::AlgorithmBase::OriginalTargetsSet() const {
 
 Game_Battler* Game_BattleAlgorithm::AlgorithmBase::GetFirstOriginalTarget() const {
 	if (original_targets.empty()) {
-		return NULL;
+		return nullptr;
 	} else {
 		return *original_targets.begin();
 	}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -230,13 +230,13 @@ const lcf::rpg::Animation* Game_BattleAlgorithm::AlgorithmBase::GetSecondAnimati
 	return animation2;
 }
 
-void Game_BattleAlgorithm::AlgorithmBase::PlayAnimation(bool on_original_targets) {
+void Game_BattleAlgorithm::AlgorithmBase::PlayAnimation(bool on_original_targets, bool invert) {
 	if (current_target == targets.end() || !GetAnimation()) {
 		return;
 	}
 
 	if (on_original_targets) {
-		Game_Battle::ShowBattleAnimation(GetAnimation()->ID, original_targets);
+		Game_Battle::ShowBattleAnimation(GetAnimation()->ID, original_targets, false, -1, invert);
 		has_animation_played = true;
 		return;
 	}
@@ -252,20 +252,23 @@ void Game_BattleAlgorithm::AlgorithmBase::PlayAnimation(bool on_original_targets
 
 	Game_Battle::ShowBattleAnimation(
 		GetAnimation()->ID,
-		anim_targets);
+		anim_targets,
+		false,
+		-1,
+		invert);
 	has_animation_played = true;
 
 	current_target = old_current_target;
 	first_attack = old_first_attack;
 }
 
-void Game_BattleAlgorithm::AlgorithmBase::PlaySecondAnimation(bool on_original_targets) {
+void Game_BattleAlgorithm::AlgorithmBase::PlaySecondAnimation(bool on_original_targets, bool invert) {
 	if (current_target == targets.end() || !GetSecondAnimation()) {
 		return;
 	}
 
 	if (on_original_targets) {
-		Game_Battle::ShowBattleAnimation(GetSecondAnimation()->ID, original_targets);
+		Game_Battle::ShowBattleAnimation(GetSecondAnimation()->ID, original_targets, false, -1, invert);
 		has_animation2_played = true;
 		return;
 	}
@@ -281,7 +284,10 @@ void Game_BattleAlgorithm::AlgorithmBase::PlaySecondAnimation(bool on_original_t
 
 	Game_Battle::ShowBattleAnimation(
 		GetSecondAnimation()->ID,
-		anim_targets);
+		anim_targets,
+		false,
+		-1,
+		invert);
 	has_animation2_played = true;
 
 	current_target = old_current_target;
@@ -757,6 +763,7 @@ void Game_BattleAlgorithm::AlgorithmBase::TargetFirst() {
 	if (party_target) {
 		if (IsReflected()) {
 			party_target->GetBattlers(original_targets);
+			current_original_target = original_targets.begin();
 			targets.clear();
 			source->GetParty().GetActiveBattlers(targets);
 		} else {
@@ -766,6 +773,7 @@ void Game_BattleAlgorithm::AlgorithmBase::TargetFirst() {
 	} else {
 		if (IsReflected()) {
 			original_targets.push_back(GetTarget());
+			current_original_target = original_targets.begin();
 			targets.clear();
 			targets.push_back(source);
 		}
@@ -813,6 +821,14 @@ void Game_BattleAlgorithm::AlgorithmBase::SetRepeat(int repeat) {
 
 bool Game_BattleAlgorithm::AlgorithmBase::OriginalTargetsSet() const {
 	return (original_targets.size() > 0);
+}
+
+Game_Battler* Game_BattleAlgorithm::AlgorithmBase::GetOriginalTarget() const {
+	if (current_original_target == original_targets.end()) {
+		return NULL;
+	}
+
+	return *current_original_target;
 }
 
 void Game_BattleAlgorithm::AlgorithmBase::SetSwitchEnable(int switch_id) {

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -427,11 +427,11 @@ public:
 	bool OriginalTargetsSet() const;
 
 	/**
-	 * Returns the current original target.
+	 * Returns the first original target.
 	 *
-	 * @return current original target battler
+	 * @return current first original target battler
 	 */
-	Game_Battler* GetOriginalTarget() const;
+	Game_Battler* GetFirstOriginalTarget() const;
 
 	/**
 	 * @return the critical hit message
@@ -508,7 +508,6 @@ protected:
 	std::vector<int> switch_off;
 
 	std::vector<Game_Battler*> original_targets;
-	mutable std::vector<Game_Battler*>::iterator current_original_target;
 };
 
 // Special algorithm for battlers which have no action. 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -242,9 +242,10 @@ public:
 	 * @param on_original_targets Renders the animation on the original
 	 *                            targets instead of the current
 	 *                            targets (required for reflect)
+	 * @param invert Flips the animation
 	 */
-	void PlayAnimation(bool on_original_targets = false);
-	void PlaySecondAnimation(bool on_original_targets = false);
+	void PlayAnimation(bool on_original_targets = false, bool invert = false);
+	void PlaySecondAnimation(bool on_original_targets = false, bool invert = false);
 
 	void PlaySoundAnimation(bool on_original_targets = false, int cutoff = -1);
 
@@ -426,6 +427,13 @@ public:
 	bool OriginalTargetsSet() const;
 
 	/**
+	 * Returns the current original target.
+	 *
+	 * @return current original target battler
+	 */
+	Game_Battler* GetOriginalTarget() const;
+
+	/**
 	 * @return the critical hit message
 	 */
 	std::string GetCriticalHitMessage() const;
@@ -500,6 +508,7 @@ protected:
 	std::vector<int> switch_off;
 
 	std::vector<Game_Battler*> original_targets;
+	mutable std::vector<Game_Battler*>::iterator current_original_target;
 };
 
 // Special algorithm for battlers which have no action. 

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -575,6 +575,6 @@ Color Game_System::GetBackgroundColor() {
 	return bg_color;
 }
 
-const bool& Game_System::GetInvertAnimations() {
+bool Game_System::GetInvertAnimations() {
 	return lcf::Data::system.invert_animations;
 }

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -574,3 +574,7 @@ void Game_System::IncFrameCounter() {
 Color Game_System::GetBackgroundColor() {
 	return bg_color;
 }
+
+const bool& Game_System::GetInvertAnimations() {
+	return lcf::Data::system.invert_animations;
+}

--- a/src/game_system.h
+++ b/src/game_system.h
@@ -347,6 +347,9 @@ namespace Game_System {
 
 	/** Get the system background color */
 	Color GetBackgroundColor();
+
+	/** @return true if battle animations are flipped if attacked from behind */
+	const bool& GetInvertAnimations();
 }
 
 inline bool Game_System::HasSystemGraphic() {

--- a/src/game_system.h
+++ b/src/game_system.h
@@ -349,7 +349,7 @@ namespace Game_System {
 	Color GetBackgroundColor();
 
 	/** @return true if battle animations are flipped if attacked from behind */
-	const bool& GetInvertAnimations();
+	bool GetInvertAnimations();
 }
 
 inline bool Game_System::HasSystemGraphic() {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -837,7 +837,15 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 
 	if (play_reflect_anim) {
 		play_reflect_anim = false;
-		action->PlayAnimation();
+		if (Game_System::GetInvertAnimations()) {
+			invert_animation = false;
+			if (action->OriginalTargetsSet()) {
+				invert_animation = (action->GetOriginalTarget()->IsDirectionFlipped() ^ (action->GetOriginalTarget()->GetType() == Game_Battler::Type_Enemy));
+			}
+			action->PlayAnimation(false, invert_animation);
+		} else {
+			action->PlayAnimation(false, invert_animation);
+		}
 		return false;
 	}
 
@@ -924,11 +932,17 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 				Sprite_Battler::LoopState_WaitAfterFinish);
 		}
 
+		if (Game_System::GetInvertAnimations()) {
+			invert_animation = (action->GetSource()->IsDirectionFlipped() ^ (action->GetSource()->GetType() == Game_Battler::Type_Enemy));
+		} else {
+			invert_animation = false;
+		}
+
 		if (action->OriginalTargetsSet()) {
 			play_reflect_anim = true;
-			action->PlayAnimation(true);
+			action->PlayAnimation(true, invert_animation);
 		} else {
-			action->PlayAnimation();
+			action->PlayAnimation(false, invert_animation);
 		}
 
 		{

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -837,15 +837,7 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 
 	if (play_reflect_anim) {
 		play_reflect_anim = false;
-		if (Game_System::GetInvertAnimations()) {
-			invert_animation = false;
-			if (action->OriginalTargetsSet()) {
-				invert_animation = (action->GetOriginalTarget()->IsDirectionFlipped() ^ (action->GetOriginalTarget()->GetType() == Game_Battler::Type_Enemy));
-			}
-			action->PlayAnimation(false, invert_animation);
-		} else {
-			action->PlayAnimation(false, invert_animation);
-		}
+		action->PlayAnimation(false, CheckAnimFlip(action->GetFirstOriginalTarget()));
 		return false;
 	}
 
@@ -932,17 +924,11 @@ bool Scene_Battle_Rpg2k3::ProcessBattleAction(Game_BattleAlgorithm::AlgorithmBas
 				Sprite_Battler::LoopState_WaitAfterFinish);
 		}
 
-		if (Game_System::GetInvertAnimations()) {
-			invert_animation = (action->GetSource()->IsDirectionFlipped() ^ (action->GetSource()->GetType() == Game_Battler::Type_Enemy));
-		} else {
-			invert_animation = false;
-		}
-
 		if (action->OriginalTargetsSet()) {
 			play_reflect_anim = true;
-			action->PlayAnimation(true, invert_animation);
+			action->PlayAnimation(true, CheckAnimFlip(action->GetSource()));
 		} else {
-			action->PlayAnimation(false, invert_animation);
+			action->PlayAnimation(false, CheckAnimFlip(action->GetSource()));
 		}
 
 		{
@@ -1502,3 +1488,9 @@ void Scene_Battle_Rpg2k3::ShowNotification(const std::string& text) {
 	help_window->SetText(text);
 }
 
+bool Scene_Battle_Rpg2k3::CheckAnimFlip(Game_Battler* battler) {
+	if (Game_System::GetInvertAnimations()) {
+		return battler->IsDirectionFlipped() ^ battler->GetType() == Game_Battler::Type_Enemy;
+	}
+	return false;
+}

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -126,6 +126,8 @@ protected:
 	bool IsEscapeAllowedFromOptionWindow() const;
 	bool IsEscapeAllowedFromActorCommand() const;
 
+	bool CheckAnimFlip(Game_Battler* battler);
+
 	std::unique_ptr<Sprite> ally_cursor, enemy_cursor;
 
 	struct FloatText {
@@ -151,8 +153,6 @@ protected:
 	bool battle_action_pending = false;
 	bool first_strike = false;
 	bool initial_directions_updated = false;
-
-	bool invert_animation = false;
 };
 
 #endif

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -151,6 +151,8 @@ protected:
 	bool battle_action_pending = false;
 	bool first_strike = false;
 	bool initial_directions_updated = false;
+
+	bool invert_animation = false;
 };
 
 #endif


### PR DESCRIPTION
This PR takes on a more difficult task and fixes #1564. The changes look more intrusive so it is possible that changes are required on this PR. Anyway, this basically adds a optional invert parameter on the BattleAnimationBattle constructor, the ShowBattleAnimation method and the PlayAnimation methods which makes the animations display mirrored if the parameter is set to true. The new parameter gets used in Scene_Battle_Rpg2k3 only because this feature is used in RPG Maker 2003 only. Some particularities about the flipped animations: Animations get flipped only if the "Flip assets if facing the other direction" flag is set. If this condition is met then the animations will be flipped if either the battler sprite of the source is flipped or the source is belonging to the enemy party (XOR-Operation). On reflected spells the second animation will be flipped if either the battler sprite of the original target is flipped or the original target is belonging to the enemy party (XOR-Operation).