### PR TITLE
Battle algorithm changes

### DIFF
--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -667,7 +667,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedAttack() != -1) {
 		int atk = GetAffectedAttack();
 		target->ChangeAtkModifier(IsPositive() ? atk : -atk);
-		if (IsAbsorb() && Player::IsRPG2k3()) {
+		if (IsAbsorb() && Player::IsRPG2k3Updated()) {
 			atk = std::max<int>(0, std::min<int>(atk, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk()));
 			source->ChangeAtkModifier(atk);
 		}
@@ -676,7 +676,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedDefense() != -1) {
 		int def = GetAffectedDefense();
 		target->ChangeDefModifier(IsPositive() ? def : -def);
-		if (IsAbsorb() && Player::IsRPG2k3()) {
+		if (IsAbsorb() && Player::IsRPG2k3Updated()) {
 			def = std::max<int>(0, std::min<int>(def, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk()));
 			source->ChangeDefModifier(def);
 		}
@@ -685,7 +685,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedSpirit() != -1) {
 		int spi = GetAffectedSpirit();
 		target->ChangeSpiModifier(IsPositive() ? spi : -spi);
-		if (IsAbsorb() && Player::IsRPG2k3()) {
+		if (IsAbsorb() && Player::IsRPG2k3Updated()) {
 			spi = std::max<int>(0, std::min<int>(spi, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk()));
 			source->ChangeSpiModifier(spi);
 		}
@@ -694,7 +694,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedAgility() != -1) {
 		int agi = GetAffectedAgility();
 		target->ChangeAgiModifier(IsPositive() ? agi : -agi);
-		if (IsAbsorb() && Player::IsRPG2k3()) {
+		if (IsAbsorb() && Player::IsRPG2k3Updated()) {
 			agi = std::max<int>(0, std::min<int>(agi, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk()));
 			source->ChangeAgiModifier(agi);
 		}
@@ -1004,7 +1004,7 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 			}
 		}
 
-		if ((Player::IsRPG2k() && !Player::IsRPG2kUpdated()) || effect > 0) {
+		if (Player::IsLegacy() || effect > 0) {
 			effect = Game_Battle::VarianceAdjustEffect(effect, 4);
 		}
 
@@ -1228,7 +1228,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 
 			effect *= GetTarget()->GetAttributeMultiplier(skill.attribute_effects);
 
-			if ((Player::IsRPG2k() && !Player::IsRPG2kUpdated()) || effect > 0) effect = Game_Battle::VarianceAdjustEffect(effect, skill.variance);
+			if (Player::IsLegacy() || effect > 0) effect = Game_Battle::VarianceAdjustEffect(effect, skill.variance);
 
 			effect = Utils::Clamp(effect, 0, MaxDamageValue());
 
@@ -1274,7 +1274,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 			}
 			effect *= GetTarget()->GetAttributeMultiplier(skill.attribute_effects);
 
-			if ((Player::IsRPG2k() && !Player::IsRPG2kUpdated()) || effect > 0) effect = Game_Battle::VarianceAdjustEffect(effect, skill.variance);
+			if (Player::IsLegacy() || effect > 0) effect = Game_Battle::VarianceAdjustEffect(effect, skill.variance);
 
 			effect = Utils::Clamp(effect, 0, MaxDamageValue());
 
@@ -1856,7 +1856,7 @@ bool Game_BattleAlgorithm::SelfDestruct::Execute() {
 	// Like a normal attack, but with double damage and always hitting
 	// Never crits, ignores charge
 	int effect = source->GetAtk() - GetTarget()->GetDef() / 2;
-	if ((Player::IsRPG2k() && !Player::IsRPG2kUpdated()) || effect > 0) {
+	if (Player::IsLegacy() || effect > 0) {
 		effect = Game_Battle::VarianceAdjustEffect(effect, 4);
 	}
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1004,7 +1004,7 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 			}
 		}
 
-		if (effect > 0) {
+		if ((Player::IsRPG2k() && !Player::IsRPG2kUpdated()) || effect > 0) {
 			effect = Game_Battle::VarianceAdjustEffect(effect, 4);
 		}
 
@@ -1228,7 +1228,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 
 			effect *= GetTarget()->GetAttributeMultiplier(skill.attribute_effects);
 
-			effect = Game_Battle::VarianceAdjustEffect(effect, skill.variance);
+			if ((Player::IsRPG2k() && !Player::IsRPG2kUpdated()) || effect > 0) effect = Game_Battle::VarianceAdjustEffect(effect, skill.variance);
 
 			effect = Utils::Clamp(effect, 0, MaxDamageValue());
 
@@ -1274,7 +1274,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 			}
 			effect *= GetTarget()->GetAttributeMultiplier(skill.attribute_effects);
 
-			effect = Game_Battle::VarianceAdjustEffect(effect, skill.variance);
+			if ((Player::IsRPG2k() && !Player::IsRPG2kUpdated()) || effect > 0) effect = Game_Battle::VarianceAdjustEffect(effect, skill.variance);
 
 			effect = Utils::Clamp(effect, 0, MaxDamageValue());
 
@@ -1835,7 +1835,7 @@ bool Game_BattleAlgorithm::SelfDestruct::Execute() {
 	// Like a normal attack, but with double damage and always hitting
 	// Never crits, ignores charge
 	int effect = source->GetAtk() - GetTarget()->GetDef() / 2;
-	if (effect > 0) {
+	if ((Player::IsRPG2k() && !Player::IsRPG2kUpdated()) || effect > 0) {
 		effect = Game_Battle::VarianceAdjustEffect(effect, 4);
 	}
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -667,7 +667,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedAttack() != -1) {
 		int atk = GetAffectedAttack();
 		target->ChangeAtkModifier(IsPositive() ? atk : -atk);
-		if (IsAbsorb()) {
+		if (IsAbsorb() && Player::IsRPG2k3()) {
 			atk = std::max<int>(0, std::min<int>(atk, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk()));
 			source->ChangeAtkModifier(atk);
 		}
@@ -676,7 +676,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedDefense() != -1) {
 		int def = GetAffectedDefense();
 		target->ChangeDefModifier(IsPositive() ? def : -def);
-		if (IsAbsorb()) {
+		if (IsAbsorb() && Player::IsRPG2k3()) {
 			def = std::max<int>(0, std::min<int>(def, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk()));
 			source->ChangeDefModifier(def);
 		}
@@ -685,7 +685,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedSpirit() != -1) {
 		int spi = GetAffectedSpirit();
 		target->ChangeSpiModifier(IsPositive() ? spi : -spi);
-		if (IsAbsorb()) {
+		if (IsAbsorb() && Player::IsRPG2k3()) {
 			spi = std::max<int>(0, std::min<int>(spi, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk()));
 			source->ChangeSpiModifier(spi);
 		}
@@ -694,7 +694,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedAgility() != -1) {
 		int agi = GetAffectedAgility();
 		target->ChangeAgiModifier(IsPositive() ? agi : -agi);
-		if (IsAbsorb()) {
+		if (IsAbsorb() && Player::IsRPG2k3()) {
 			agi = std::max<int>(0, std::min<int>(agi, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk()));
 			source->ChangeAgiModifier(agi);
 		}

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -326,7 +326,7 @@ bool Game_Battler::UseSkill(int skill_id, const Game_Battler* source) {
 		}
 		effect *= mul;
 
-		effect += (effect * Utils::GetRandomNumber(-skill->variance * 10, skill->variance * 10) / 100);
+		if ((Player::IsRPG2k() && !Player::IsRPG2kUpdated()) || effect > 0) effect = Game_Battle::VarianceAdjustEffect(effect, skill->variance);
 
 		if (effect < 0)
 			effect = 0;

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -455,7 +455,7 @@ int Game_Battler::ApplyConditions() {
 			}
 		}
 		else if(state.hp_change_type == state.ChangeType_gain) {
-			src_hp = std::min(source_hp, hp);
+			src_hp = hp;
 			if(src_hp < 0) {
 				src_hp = 0;
 			}
@@ -471,8 +471,8 @@ int Game_Battler::ApplyConditions() {
 
 		}
 		else if (state.sp_change_type == state.ChangeType_gain) {
-			src_sp = std::min(source_sp, sp);
-			if(src_sp < 0 ) {
+			src_sp = sp;
+			if(src_sp < 0) {
 				src_sp = 0;
 			}
 		}

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -327,7 +327,7 @@ bool Game_Battler::UseSkill(int skill_id, const Game_Battler* source) {
 		}
 		effect *= mul;
 
-		if ((Player::IsRPG2k() && !Player::IsRPG2kUpdated()) || effect > 0) effect = Game_Battle::VarianceAdjustEffect(effect, skill->variance);
+		if (Player::IsLegacy() || effect > 0) effect = Game_Battle::VarianceAdjustEffect(effect, skill->variance);
 
 		if (effect < 0)
 			effect = 0;


### PR DESCRIPTION
This PR fixes some minor bugs I came across in battles:

- States which recover HP and SP: HP and SP recovery is not restricted by the current amount of the mentioned stats.
- Random variance: In RPG Maker 2000 the variance calculation is even performed on zero damage. I know from playing RPG Maker 2000 games before that attacks sometimes do 1 damage despite too high defense or full magic immunity.
- Random variance of healing skills outside of battles: The old variance formula was still applied so it got replaced by the VarianceAdjustEffect function.
- Skills which do absorbing: Absorbing attack, defense, spirit and agility is only supported in RPG Maker 2003. In RPG Maker 2000 the stats only get decreased.
- Skill accuracy: Accuracy checks are performed on every affected stat. These checks are performed on skills which affects allies too. And on skills which hit the enemy special checks are performed: If affect_hp is set and the check fails, the whole skill fails. With affect_sp it is the same. And if both affect_hp and affect_sp are set then the whole skill fails if both checks fail.
- Revival outside of battles: If a dead actor gets revived outside of battles, he gained 1 HP too much. Moreover skills which cure death only (with affect_hp unset) work only on dead actors even outside of battles.