### PR TITLE
UI changes (1/2)

### DIFF
--- a/src/window_item.cpp
+++ b/src/window_item.cpp
@@ -123,11 +123,8 @@ void Window_Item::DrawItem(int index) {
 		bool enabled = CheckEnable(item_id);
 		DrawItemName(*item, rect.x, rect.y, enabled);
 
-		std::stringstream ss;
-		ss << number;
 		Font::SystemColor color = enabled ? Font::ColorDefault : Font::ColorDisabled;
-		contents->TextDraw(rect.x + rect.width - 28, rect.y, color, "x");
-		contents->TextDraw(rect.x + rect.width - 6, rect.y, color, ss.str(), Text::AlignRight);
+		contents->TextDraw(rect.x + rect.width - 24, rect.y, color, fmt::format(":{:3d}", number));
 	}
 }
 

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -124,15 +124,13 @@ void Window_Selectable::Update() {
 	Window_Base::Update();
 	if (active && item_max > 0 && index >= 0) {
 		if (Input::IsRepeated(Input::DOWN) || Input::IsTriggered(Input::SCROLL_DOWN)) {
-			if (index < item_max - column_max || (column_max == 1 &&
-				(Input::IsTriggered(Input::DOWN) || Input::IsTriggered(Input::SCROLL_DOWN)))) {
+			if (index < item_max - column_max || column_max == 1) {
 				Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cursor));
 				index = (index + column_max) % item_max;
 			}
 		}
 		if (Input::IsRepeated(Input::UP) || Input::IsTriggered(Input::SCROLL_UP)) {
-			if (index >= column_max || (column_max == 1 &&
-				(Input::IsTriggered(Input::UP) || Input::IsTriggered(Input::SCROLL_UP)))) {
+			if (index >= column_max || column_max == 1) {
 				Game_System::SePlay(Game_System::GetSystemSE(Game_System::SFX_Cursor));
 				index = (index - column_max + item_max) % item_max;
 			}

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -64,12 +64,9 @@ int Window_Selectable::GetPageItemMax() {
 
 Rect Window_Selectable::GetItemRect(int index) {
 	Rect rect = Rect();
-	rect.width = (contents->GetWidth()) / column_max - 4;
+	rect.width = (width / column_max - 16);
+	rect.x = (index % column_max * (rect.width + 16));
 	rect.height = 12;
-	rect.x = index % column_max * rect.width;
-	if (rect.x > 0){
-		rect.x += 8;
-	}
 	rect.y = index / column_max * 16 + 2;
 	return rect;
 }
@@ -103,14 +100,8 @@ void Window_Selectable::UpdateCursorRect() {
 		SetTopRow(row - (GetPageRowMax() - 1));
 	}
 
-	if (column_max > 1){
-		cursor_width = (width / column_max - 16) + 12;
-		x = (index % column_max * cursor_width) - 4 ;
-	}
-	else{
-		cursor_width = (width / column_max - 16) + 8;
-		x = (index % column_max * (cursor_width + 16)) - 4;
-	}
+	cursor_width = (width / column_max - 16) + 8;
+	x = (index % column_max * (cursor_width + 8)) - 4;
 
 	int y = index / column_max * 16 - oy;
 	SetCursorRect(Rect(x, y, cursor_width, 16));

--- a/src/window_shopbuy.cpp
+++ b/src/window_shopbuy.cpp
@@ -77,7 +77,7 @@ void Window_ShopBuy::DrawItem(int index) {
 	DrawItemName(*item, rect.x, rect.y, enabled);
 
 	std::string str = std::to_string(price);
-	contents->TextDraw(rect.width + 4, rect.y, enabled ? Font::ColorDefault : Font::ColorDisabled, str, Text::AlignRight);
+	contents->TextDraw(rect.width + 8, rect.y, enabled ? Font::ColorDefault : Font::ColorDisabled, str, Text::AlignRight);
 }
 
 void Window_ShopBuy::UpdateHelp() {

--- a/src/window_shopparty.cpp
+++ b/src/window_shopparty.cpp
@@ -29,6 +29,7 @@ Window_ShopParty::Window_ShopParty(int ix, int iy, int iwidth, int iheight) :
 	Window_Base(ix, iy, iwidth, iheight) {
 
 	SetBorderX(4);
+	SetBorderY(4);
 	SetContents(Bitmap::Create(width - GetBorderX() * 2, height - 16));
 
 	cycle = 0;
@@ -99,6 +100,7 @@ void Window_ShopParty::Refresh() {
 	for (int i = 0; i < static_cast<int>(actors.size()) && i < 4; i++) {
 		Game_Actor *actor = actors[i];
 		int phase = (cycle / anim_rate) % 4;
+		int phasecmp = phase;
 		if (phase == 3) {
 			phase = 1;
 		}
@@ -132,13 +134,13 @@ void Window_ShopParty::Refresh() {
 			else {
 				int cmp = CmpEquip(actor, new_item);
 				if (cmp > 0) {
-					contents->Blit(i * 32 + 20, 24, *system, Rect(128 + 8 * phase, 0, 8, 8), 255);
+					contents->Blit(i * 32 + 20, 24, *system, Rect(128 + 8 * phasecmp, 0, 8, 8), 255);
 				}
 				else if (cmp < 0) {
-					contents->Blit(i * 32 + 20, 24, *system, Rect(128 + 8 * phase, 16, 8, 8), 255);
+					contents->Blit(i * 32 + 20, 24, *system, Rect(128 + 8 * phasecmp, 16, 8, 8), 255);
 				}
 				else {
-					contents->Blit(i * 32 + 20, 24, *system, Rect(128 + 8 * phase, 8, 8, 8), 255);
+					contents->Blit(i * 32 + 20, 24, *system, Rect(128 + 8 * phasecmp, 8, 8, 8), 255);
 				}
 			}
 		}

--- a/src/window_skill.cpp
+++ b/src/window_skill.cpp
@@ -84,10 +84,7 @@ void Window_Skill::DrawItem(int index) {
 		bool enabled = CheckEnable(skill_id);
 		int color = !enabled ? Font::ColorDisabled : Font::ColorDefault;
 
-		std::stringstream ss;
-		ss << costs;
-		contents->TextDraw(rect.x + rect.width - 28, rect.y, color, "-");
-		contents->TextDraw(rect.x + rect.width - 6, rect.y, color, ss.str(), Text::AlignRight);
+		contents->TextDraw(rect.x + rect.width - 24, rect.y, color, fmt::format("-{:3d}", costs));
 
 		// Skills are guaranteed to be valid
 		DrawSkillName(*lcf::ReaderUtil::GetElement(lcf::Data::skills, skill_id), rect.x, rect.y, enabled);


### PR DESCRIPTION
This PR and #2361 provides partial fixes for #2216 and #2264. In #2216 the things mentioned in the checkboxes 1, 3, 4 and 5 get fixed. One major change is the addition of an optional "halfwidthspace" parameter in the Window_Base which is set to true by default. Setting it to false makes the help window draw full width spaces which is required in the ActorTarget scene for the skill/item name and in the EndGame scene for the confirmation message (this is handled in part 2: #2361). The second major change is the addition of a gap between the menu items in multi-column selection windows (this is handled in this part).

More changes in this part:
- The item count/skill cost is now displayed on the right end of the selector in the Item and Skill windows.
- Endless scrolling has been implemented.
- Shops: Change animation behavior of the comparison indicators and move prices to the right end.

Things mentioned in #2264 not covered by both PRs:
- Equipment scene (for context see #1660, and I personally prefer it that way too)
- Arrows in the Savegame window (this is a special case because the arrows are currently only implemented in the window class and in RPG_RT the arrows are drawn outside of any window in the Savegame window).
- Scrolling speed
- Text shadows