### PR TITLE
Refactor Battle Algorithm effect and hit rate calculations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(${PROJECT_NAME}
 	src/async_handler.cpp
 	src/async_handler.h
 	src/async_op.h
+	src/algo.h
+	src/algo.cpp
 	src/attribute.h
 	src/attribute.cpp
 	src/audio_al.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(${PROJECT_NAME}
 	src/async_handler.cpp
 	src/async_handler.h
 	src/async_op.h
+	src/attribute.h
+	src/attribute.cpp
 	src/audio_al.cpp
 	src/audio_al.h
 	src/audio.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,6 +10,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/async_handler.cpp \
 	src/async_handler.h \
 	src/async_op.h \
+	src/algo.h \
+	src/algo.cpp \
 	src/attribute.h \
 	src/attribute.cpp \
 	src/audio.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,6 +10,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/async_handler.cpp \
 	src/async_handler.h \
 	src/async_op.h \
+	src/attribute.h \
+	src/attribute.cpp \
 	src/audio.cpp \
 	src/audio.h \
 	src/audio_al.cpp \

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -28,7 +28,7 @@ namespace Algo {
 
 bool IsRowAdjusted(lcf::rpg::SaveActor::RowType row, lcf::rpg::System::BattleCondition cond, bool offense) {
 	return (cond == lcf::rpg::System::BattleCondition_surround
-			|| (row == (1 - offense)
+			|| (row != offense
 				&& (cond == lcf::rpg::System::BattleCondition_none || cond == lcf::rpg::System::BattleCondition_initiative))
 			|| (row == offense
 				&& (cond == lcf::rpg::System::BattleCondition_back))
@@ -103,15 +103,14 @@ int CalcNormalAttackToHit(const Game_Battler &source,
 int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const lcf::rpg::Skill& skill) {
 	auto to_hit = skill.hit;
 
+	// RPG_RT BUG: rm2k3 editor doesn't let you set the failure message for skills, and so you can't make them physical type anymore.
+	// Despite that, RPG_RT still checks the flag and run the below code?
 	if (skill.failure_message != 3
 		   || (skill.scope != lcf::rpg::Skill::Scope_enemy && skill.scope != lcf::rpg::Skill::Scope_enemies)) {
 		return to_hit;
 	}
 
-	// RPG_RT BUG: rm2k3 editor doesn't let you set the failure message for skills, and so you can't make them physical type anymore.
-	// Despite that, RPG_RT still checks the flag and run the below code?
-	// FIXME: Verify if skills ported from 2k retain this flag and exercise the evasion logic in 2k3?
-	// RPG_RT BUG: RPG_RT does not check for "EvadesAllPhysicaAttacks() states here
+	// RPG_RT BUG: RPG_RT 2k3 does not check for "EvadesAllPhysicaAttacks() states here
 
 	// If target has Restriction "do_nothing", the attack always hits
 	if (!target.CanAct()) {

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -1,3 +1,19 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "algo.h"
 #include "game_battler.h"
 #include "game_actor.h"

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -42,6 +42,8 @@ int CalcNormalAttackToHit(const Game_Battler &source, const Game_Battler &target
 	}
 
 	// AGI adjustment.
+	// NOTE: RPG_RT 2k3 has a bug where if the source is an actor with a selected weapon, the agi
+	// calculation calls a bespoke function which doesn't consider states which can cause half or double AGI.
 	to_hit = 100 - (100 - to_hit) * (1.0f + (float(target.GetAgi()) / float(source.GetAgi(weapon)) - 1.0f) / 2.0f) ;
 
 	// If target has physical dodge evasion:

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -19,7 +19,7 @@ bool IsRowAdjusted(const Game_Actor& actor, lcf::rpg::System::BattleCondition co
 		   );
 }
 
-static int CalcToHitAgiAdjustment(int to_hit, const Game_Battler& source, const Game_Battler& target, int weapon) {
+static int CalcToHitAgiAdjustment(int to_hit, const Game_Battler& source, const Game_Battler& target, Game_Battler::Weapon weapon) {
 	// NOTE: RPG_RT 2k3 has a bug where if the source is an actor with a selected weapon, the agi
 	// calculation calls a bespoke function which doesn't consider states which can cause half or double AGI.
 	const float src_agi = std::max(1, source.GetAgi(weapon));
@@ -28,7 +28,7 @@ static int CalcToHitAgiAdjustment(int to_hit, const Game_Battler& source, const 
 	return 100 - (100 - to_hit) * (1.0f + (tgt_agi / src_agi - 1.0f) / 2.0f);
 }
 
-int CalcNormalAttackToHit(const Game_Battler &source, const Game_Battler &target, int weapon, lcf::rpg::System::BattleCondition cond) {
+int CalcNormalAttackToHit(const Game_Battler &source, const Game_Battler &target, Game_Battler::Weapon weapon, lcf::rpg::System::BattleCondition cond) {
 	auto to_hit = source.GetHitChance(weapon);
 
 	// If target has rm2k3 state which grants 100% dodge.
@@ -94,12 +94,12 @@ int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const
 
 	// Stop here if attacker ignores evasion.
 	if (source.GetType() == Game_Battler::Type_Ally
-		&& static_cast<const Game_Actor&>(source).AttackIgnoresEvasion(Game_Battler::kWeaponAll)) {
+		&& static_cast<const Game_Actor&>(source).AttackIgnoresEvasion(Game_Battler::WeaponAll)) {
 		return to_hit;
 	}
 
 	// AGI adjustment.
-	to_hit = CalcToHitAgiAdjustment(to_hit, source, target, Game_Battler::kWeaponAll);
+	to_hit = CalcToHitAgiAdjustment(to_hit, source, target, Game_Battler::WeaponAll);
 
 	// If target has physical dodge evasion:
 	if (target.GetType() == Game_Battler::Type_Ally
@@ -110,7 +110,7 @@ int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const
 	return to_hit;
 }
 
-int CalcCriticalHitChance(const Game_Battler& source, const Game_Battler& target, int weapon) {
+int CalcCriticalHitChance(const Game_Battler& source, const Game_Battler& target, Game_Battler::Weapon weapon) {
 	// FIXME: Make this function return int 0 to 100.
 	auto crit_chance = static_cast<int>(source.GetCriticalHitChance(weapon) * 100.0);
 	if (target.GetType() == Game_Battler::Type_Ally && static_cast<const Game_Actor&>(target).PreventsCritical()) {
@@ -142,7 +142,7 @@ int AdjustDamageForDefend(int dmg, const Game_Battler& target) {
 
 int CalcNormalAttackEffect(const Game_Battler& source,
 		const Game_Battler& target,
-		int weapon,
+		Game_Battler::Weapon weapon,
 		bool is_critical_hit,
 		bool apply_variance,
 		lcf::rpg::System::BattleCondition cond) {

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -1,0 +1,230 @@
+#include "algo.h"
+#include "game_battler.h"
+#include "game_actor.h"
+#include "game_enemy.h"
+#include "attribute.h"
+#include "player.h"
+#include <lcf/rpg/skill.h>
+
+#include <algorithm>
+
+namespace Algo {
+
+bool IsRowAdjusted(const Game_Actor& actor, lcf::rpg::System::BattleCondition cond, bool offense) {
+	return (cond == lcf::rpg::System::BattleCondition_surround
+			|| (actor.GetBattleRow() == (1 - offense)
+				&& (cond == lcf::rpg::System::BattleCondition_none || cond == lcf::rpg::System::BattleCondition_initiative))
+			|| (actor.GetBattleRow() == offense
+				&& (cond == lcf::rpg::System::BattleCondition_back))
+		   );
+}
+
+int CalcNormalAttackToHit(const Game_Battler &source, const Game_Battler &target, lcf::rpg::System::BattleCondition cond) {
+	auto to_hit = source.GetHitChance();
+
+	// If target has rm2k3 state which grants 100% dodge.
+	if (target.EvadesAllPhysicalAttacks()) {
+		return 0;
+	}
+
+	// If target has Restriction "do_nothing", the attack always hits
+	if (!target.CanAct()) {
+		return 100;
+	}
+
+	// Modify hit chance for each state the source has
+	to_hit = (to_hit * source.GetHitChanceModifierFromStates()) / 100;
+
+	// Stop here if attacker ignores evasion.
+	if (source.GetType() == Game_Battler::Type_Ally
+		&& static_cast<const Game_Actor&>(source).AttackIgnoresEvasion()) {
+		return to_hit;
+	}
+
+	// AGI adjustment.
+	to_hit = 100 - (100 - to_hit) * (1.0f + (float(target.GetAgi()) / float(source.GetAgi()) - 1.0f) / 2.0f) ;
+
+	// If target has physical dodge evasion:
+	if (target.GetType() == Game_Battler::Type_Ally
+			&& static_cast<const Game_Actor&>(target).HasPhysicalEvasionUp()) {
+		to_hit -= 25;
+	}
+
+	// Defender row adjustment
+	if (Player::IsRPG2k3() && target.GetType() == Game_Battler::Type_Ally) {
+		if (IsRowAdjusted(static_cast<const Game_Actor&>(target), cond, false)) {
+			to_hit -= 25;
+		} else if(source.GetType() == Game_Battler::Type_Ally
+				&& target.GetType() == Game_Battler::Type_Enemy
+				&& cond == lcf::rpg::System::BattleCondition_back) {
+			// FIXME: RPG_RT always adjusts damage down for back attack, regardless of row - when to handle and not handle this?
+			to_hit -= 25;
+		}
+	}
+
+	return to_hit;
+}
+
+
+int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const lcf::rpg::Skill& skill) {
+	auto to_hit = skill.hit;
+
+	if (skill.failure_message != 3
+		   || (skill.scope != lcf::rpg::Skill::Scope_enemy && skill.scope != lcf::rpg::Skill::Scope_enemies)) {
+		return to_hit;
+	}
+
+	// If target has Restriction "do_nothing", the attack always hits
+	if (!target.CanAct()) {
+		return 100;
+	}
+
+	// Modify hit chance for each state the source has
+	to_hit = (to_hit * source.GetHitChanceModifierFromStates()) / 100;
+
+	// Stop here if attacker ignores evasion.
+	if (source.GetType() == Game_Battler::Type_Ally
+		&& static_cast<const Game_Actor&>(source).AttackIgnoresEvasion()) {
+		return to_hit;
+	}
+
+	// AGI adjustment.
+	to_hit = 100 - (100 - to_hit) * (1.0f + (float(target.GetAgi()) / float(source.GetAgi()) - 1.0f) / 2.0f) ;
+
+	// If target has physical dodge evasion:
+	if (target.GetType() == Game_Battler::Type_Ally
+			&& static_cast<const Game_Actor&>(target).HasPhysicalEvasionUp()) {
+		to_hit -= 25;
+	}
+
+	return to_hit;
+}
+
+int CalcCriticalHitChance(const Game_Battler& source, const Game_Battler& target) {
+	// FIXME: Make this function return int 0 to 100.
+	auto crit_chance = static_cast<int>(source.GetCriticalHitChance() * 100.0);
+	if (target.GetType() == Game_Battler::Type_Ally && static_cast<const Game_Actor&>(target).PreventsCritical()) {
+		crit_chance = 0;
+	}
+	if (source.GetType() == target.GetType()) {
+		crit_chance = 0;
+	}
+	return crit_chance;
+}
+
+int VarianceAdjustEffect(int base, int var) {
+	if (var > 0) {
+		int adj = std::max(1, var * base / 10);
+		return base + Utils::GetRandomNumber(0, adj) - adj / 2;
+	}
+	return base;
+}
+
+int AdjustDamageForDefend(int dmg, const Game_Battler& target) {
+	if (target.IsDefending()) {
+		dmg /= 2;
+		if (target.HasStrongDefense()) {
+			dmg /= 2;
+		}
+	}
+	return dmg;
+}
+
+int CalcNormalAttackEffect(const Game_Battler& source,
+		const Game_Battler& target,
+		bool is_critical_hit,
+		bool apply_variance,
+		lcf::rpg::System::BattleCondition cond) {
+	const auto atk = source.GetAtk();
+	const auto def = target.GetDef();
+
+	// Base damage
+	auto dmg = std::max(0, atk / 2 - def / 4);
+
+	// Attacker row adjustment
+	if (Player::IsRPG2k3() && source.GetType() == Game_Battler::Type_Ally) {
+		if (IsRowAdjusted(static_cast<const Game_Actor&>(source), cond, true)) {
+			dmg = 125 * dmg / 100;
+		}
+	}
+
+	// Attacker weapon attribute adjustment
+	const lcf::rpg::Item* weapons[2] = { nullptr, nullptr };
+	if (source.GetType() == Game_Battler::Type_Ally) {
+		weapons[0] = static_cast<const Game_Actor&>(source).GetWeapon();
+		weapons[1] = static_cast<const Game_Actor&>(source).Get2ndWeapon();
+	}
+	Attribute::ApplyAttributeMultiplier(dmg, weapons[0], weapons[1], target);
+
+	// Defender row adjustment
+	if (Player::IsRPG2k3()) {
+		if (target.GetType() == Game_Battler::Type_Ally && IsRowAdjusted(static_cast<const Game_Actor&>(target), cond, false)) {
+			dmg = 75 * dmg / 100;
+		} else if(source.GetType() == Game_Battler::Type_Ally
+				&& target.GetType() == Game_Battler::Type_Enemy
+				&& cond == lcf::rpg::System::BattleCondition_back) {
+			// FIXME: RPG_RT always adjusts damage down for back attack, regardless of row - when to handle and not handle this?
+			dmg = 75 * dmg / 100;
+		}
+	}
+
+	// Critical and charge adjustment
+	if (is_critical_hit) {
+		dmg *= 3;
+	} else if (source.IsCharged()) {
+		dmg *= 2;
+	}
+
+	// Variance Adjustment
+	// FIXME: RPG_RT 2k3 doesn't apply variance if negative attribute flips damage
+	if (apply_variance && (dmg > 0 || Player::IsLegacy())) {
+		dmg = VarianceAdjustEffect(dmg, 4);
+	}
+
+	return dmg;
+}
+
+int CalcSkillEffect(const Game_Battler& source,
+		const Game_Battler& target,
+		const lcf::rpg::Skill& skill,
+		bool apply_variance) {
+
+	auto effect = skill.power;
+	effect += skill.physical_rate * source.GetAtk() / 20;
+	effect += skill.magical_rate * source.GetSpi() / 40;
+
+	if ((skill.scope == lcf::rpg::Skill::Scope_enemy
+			|| skill.scope == lcf::rpg::Skill::Scope_enemies)
+			&& !skill.ignore_defense) {
+		effect -= skill.physical_rate * target.GetDef() / 40;
+		effect -= skill.magical_rate * target.GetSpi() / 40;
+	}
+
+	effect = std::max(0, effect);
+
+	effect = Attribute::ApplyAttributeMultiplier(effect, skill, target);
+
+	// FIXME: RPG_RT 2k3 doesn't apply variance if negative attribute flips damage
+	if (apply_variance && (effect > 0 || Player::IsLegacy())) {
+		effect = VarianceAdjustEffect(effect, skill.variance);
+	}
+
+	return effect;
+}
+
+int CalcSelfDestructEffect(const Game_Battler& source,
+		const Game_Battler& target,
+		bool apply_variance) {
+
+	auto effect = source.GetAtk() - target.GetDef() / 2;
+	effect = std::max(0, effect);
+
+	// FIXME: RPG_RT 2k3 doesn't apply variance if negative attribute flips damage
+	if (apply_variance && (effect > 0 || Player::IsLegacy())) {
+		effect = VarianceAdjustEffect(effect, 4);
+	}
+
+	return effect;
+}
+
+} // namespace Algo

--- a/src/algo.h
+++ b/src/algo.h
@@ -54,10 +54,11 @@ int VarianceAdjustEffect(int base, int var);
  * @param source The source of the action
  * @param target The target of the action
  * @param cond The current battle condition
+ * @param weapon Which weapon to use or kWeaponAll for combined
  *
  * @return Success hit rate
  */
-int CalcNormalAttackToHit(const Game_Battler& source, const Game_Battler& target, lcf::rpg::System::BattleCondition cond);
+int CalcNormalAttackToHit(const Game_Battler& source, const Game_Battler& target, int weapon, lcf::rpg::System::BattleCondition cond);
 
 /**
  * Compute the hit rate for a skill
@@ -74,10 +75,11 @@ int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const
  *
  * @param source The attacker
  * @param target The defender
+ * @param weapon Which weapon to use or kWeaponAll for combined
  *
  * @return Critical hit rate.
  */
-int CalcCriticalHitChance(const Game_Battler& source, const Game_Battler& target);
+int CalcCriticalHitChance(const Game_Battler& source, const Game_Battler& target, int weapon);
 
 /**
  * Check if target is defending and perform damage adjustment if so.
@@ -96,6 +98,7 @@ int AdjustDamageForDefend(int dmg, const Game_Battler& target);
  *
  * @param source The source of the action
  * @param target The target of the action
+ * @param weapon Which weapon to use or kWeaponAll for combined
  * @param is_critical_hit If true, apply critical hit bonus
  * @param apply_variance If true, apply variance to the damage
  * @param cond The current battle condition
@@ -104,6 +107,7 @@ int AdjustDamageForDefend(int dmg, const Game_Battler& target);
  */
 int CalcNormalAttackEffect(const Game_Battler& source,
 		const Game_Battler& target,
+		int weapon,
 		bool is_critical_hit,
 		bool apply_variance,
 		lcf::rpg::System::BattleCondition cond);

--- a/src/algo.h
+++ b/src/algo.h
@@ -1,0 +1,146 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_ALGO_H
+#define EP_ALGO_H
+
+#include <lcf/rpg/fwd.h>
+#include <lcf/rpg/system.h>
+
+class Game_Battler;
+class Game_Actor;
+class Game_Enemy;
+
+namespace Algo {
+
+/**
+ * Compute whether a row adjustment should occur.
+ * 
+ * @param actor The actor whose row to check
+ * @param cond The current battle condition
+ * @param offense Whether to adjust for an offensive action (true) or defensive action (false)
+ *
+ * @return Whether the row adjustment should apply or not.
+ */
+bool IsRowAdjusted(const Game_Actor& actor, lcf::rpg::System::BattleCondition cond, bool offense);
+
+/**
+ * Uses RPG_RT algorithm for performing a variance adjument to damage/healing effects and returns the result.
+ *
+ * @param base - the base amount of the effect
+ * @param var - the variance level from 0 to 10
+ *
+ * @return the adjusted damage amount
+ */
+int VarianceAdjustEffect(int base, int var);
+
+/**
+ * Compute the hit rate for a physical attack
+ *
+ * @param source The source of the action
+ * @param target The target of the action
+ * @param cond The current battle condition
+ *
+ * @return Success hit rate
+ */
+int CalcNormalAttackToHit(const Game_Battler& source, const Game_Battler& target, lcf::rpg::System::BattleCondition cond);
+
+/**
+ * Compute the hit rate for a skill
+ *
+ * @param source The source of the action
+ * @param target The target of the action
+ *
+ * @return Success hit rate
+ */
+int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const lcf::rpg::Skill& skill);
+
+/**
+ * Compute the critical hit rate if source attacks target.
+ *
+ * @param source The attacker
+ * @param target The defender
+ *
+ * @return Critical hit rate.
+ */
+int CalcCriticalHitChance(const Game_Battler& source, const Game_Battler& target);
+
+/**
+ * Check if target is defending and perform damage adjustment if so.
+ *
+ * @param dmg The base amount of damage.
+ * @param target who is to receive damage
+ *
+ * @return The adjusted damage.
+ */
+int AdjustDamageForDefend(int dmg, const Game_Battler& target);
+
+/**
+ * Compute the base damage for a normal attack
+ * This includes: source atk, target def, source row, attributes, target row, critical, source charged, and variance
+ * It does not include: hit rate, critical hit rate, target defend adjustment, value clamping
+ *
+ * @param source The source of the action
+ * @param target The target of the action
+ * @param is_critical_hit If true, apply critical hit bonus
+ * @param apply_variance If true, apply variance to the damage
+ * @param cond The current battle condition
+ *
+ * @return effect amount
+ */
+int CalcNormalAttackEffect(const Game_Battler& source,
+		const Game_Battler& target,
+		bool is_critical_hit,
+		bool apply_variance,
+		lcf::rpg::System::BattleCondition cond);
+
+/**
+ * Compute the base damage for a skill
+ * This includes: power, source atk/mag, target def/mag, attributes, variance
+ * It does not include: hit rate, target defend adjustment, value clamping
+ *
+ * @param source The source of the action
+ * @param target The target of the action
+ * @param skill The skill to use
+ * @param apply_variance If true, apply variance to the damage
+ *
+ * @return effect amount
+ */
+int CalcSkillEffect(const Game_Battler& source,
+		const Game_Battler& target,
+		const lcf::rpg::Skill& skill,
+		bool apply_variance);
+
+/**
+ * Compute the base damage for self-destruct
+ * This includes: power, source atk, target def, variance
+ * It does not include: hit rate, target defend adjustment, value clamping
+ *
+ * @param source The source of the action
+ * @param target The target of the action
+ * @param apply_variance If true, apply variance to the damage
+ *
+ * @return effect amount
+ */
+int CalcSelfDestructEffect(const Game_Battler& source,
+		const Game_Battler& target,
+		bool apply_variance);
+
+} // namespace Algo
+
+
+#endif

--- a/src/algo.h
+++ b/src/algo.h
@@ -20,8 +20,8 @@
 
 #include <lcf/rpg/fwd.h>
 #include <lcf/rpg/system.h>
+#include <game_battler.h>
 
-class Game_Battler;
 class Game_Actor;
 class Game_Enemy;
 
@@ -58,7 +58,7 @@ int VarianceAdjustEffect(int base, int var);
  *
  * @return Success hit rate
  */
-int CalcNormalAttackToHit(const Game_Battler& source, const Game_Battler& target, int weapon, lcf::rpg::System::BattleCondition cond);
+int CalcNormalAttackToHit(const Game_Battler& source, const Game_Battler& target, Game_Battler::Weapon weapon, lcf::rpg::System::BattleCondition cond);
 
 /**
  * Compute the hit rate for a skill
@@ -79,7 +79,7 @@ int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const
  *
  * @return Critical hit rate.
  */
-int CalcCriticalHitChance(const Game_Battler& source, const Game_Battler& target, int weapon);
+int CalcCriticalHitChance(const Game_Battler& source, const Game_Battler& target, Game_Battler::Weapon weapon);
 
 /**
  * Check if target is defending and perform damage adjustment if so.
@@ -107,7 +107,7 @@ int AdjustDamageForDefend(int dmg, const Game_Battler& target);
  */
 int CalcNormalAttackEffect(const Game_Battler& source,
 		const Game_Battler& target,
-		int weapon,
+		Game_Battler::Weapon weapon,
 		bool is_critical_hit,
 		bool apply_variance,
 		lcf::rpg::System::BattleCondition cond);

--- a/src/algo.h
+++ b/src/algo.h
@@ -20,6 +20,7 @@
 
 #include <lcf/rpg/fwd.h>
 #include <lcf/rpg/system.h>
+#include <lcf/rpg/saveactor.h>
 #include <game_battler.h>
 
 class Game_Actor;
@@ -30,13 +31,28 @@ namespace Algo {
 /**
  * Compute whether a row adjustment should occur.
  * 
- * @param actor The actor whose row to check
+ * @param row The row value to check
  * @param cond The current battle condition
  * @param offense Whether to adjust for an offensive action (true) or defensive action (false)
  *
  * @return Whether the row adjustment should apply or not.
  */
-bool IsRowAdjusted(const Game_Actor& actor, lcf::rpg::System::BattleCondition cond, bool offense);
+bool IsRowAdjusted(lcf::rpg::SaveActor::RowType row, lcf::rpg::System::BattleCondition cond, bool offense);
+
+/**
+ * Compute whether a row adjustment should occur.
+ * 
+ * @param actor The actor whose row to check
+ * @param cond The current battle condition
+ * @param offense Whether to adjust for an offensive action (true) or defensive action (false)
+ * @param allow_enemy Compute row adjustment for enemies also and treat them as always in front row.
+ *
+ * @return Whether the row adjustment should apply or not.
+ */
+bool IsRowAdjusted(const Game_Battler& battler,
+		lcf::rpg::System::BattleCondition cond,
+		bool offense,
+		bool allow_enemy);
 
 /**
  * Uses RPG_RT algorithm for performing a variance adjument to damage/healing effects and returns the result.
@@ -55,10 +71,15 @@ int VarianceAdjustEffect(int base, int var);
  * @param target The target of the action
  * @param cond The current battle condition
  * @param weapon Which weapon to use or kWeaponAll for combined
+ * @param emulate_2k3_enemy_row_bug Whether or not to emulate 2k3 bug where RPG_RT considers defending enemies in the front row
  *
  * @return Success hit rate
  */
-int CalcNormalAttackToHit(const Game_Battler& source, const Game_Battler& target, Game_Battler::Weapon weapon, lcf::rpg::System::BattleCondition cond);
+int CalcNormalAttackToHit(const Game_Battler& source,
+		const Game_Battler& target,
+		Game_Battler::Weapon weapon,
+		lcf::rpg::System::BattleCondition cond,
+		bool emulate_2k3_enemy_row_bug);
 
 /**
  * Compute the hit rate for a skill
@@ -102,6 +123,7 @@ int AdjustDamageForDefend(int dmg, const Game_Battler& target);
  * @param is_critical_hit If true, apply critical hit bonus
  * @param apply_variance If true, apply variance to the damage
  * @param cond The current battle condition
+ * @param emulate_2k3_enemy_row_bug Whether or not to emulate 2k3 bug where RPG_RT considers defending enemies in the front row
  *
  * @return effect amount
  */
@@ -110,7 +132,8 @@ int CalcNormalAttackEffect(const Game_Battler& source,
 		Game_Battler::Weapon weapon,
 		bool is_critical_hit,
 		bool apply_variance,
-		lcf::rpg::System::BattleCondition cond);
+		lcf::rpg::System::BattleCondition cond,
+		bool emulate_2k3_enemy_row_bug);
 
 /**
  * Compute the base damage for a skill

--- a/src/algo.h
+++ b/src/algo.h
@@ -21,7 +21,7 @@
 #include <lcf/rpg/fwd.h>
 #include <lcf/rpg/system.h>
 #include <lcf/rpg/saveactor.h>
-#include <game_battler.h>
+#include "game_battler.h"
 
 class Game_Actor;
 class Game_Enemy;
@@ -86,6 +86,7 @@ int CalcNormalAttackToHit(const Game_Battler& source,
  *
  * @param source The source of the action
  * @param target The target of the action
+ * @param skill Which skill to calculate hit rate for
  *
  * @return Success hit rate
  */

--- a/src/attribute.cpp
+++ b/src/attribute.cpp
@@ -12,7 +12,7 @@
 
 namespace Attribute {
 
-int GetAttributeRate(int attribute_id, int rate) {
+int GetAttributeRateModifier(int attribute_id, int rate) {
 	const auto* attribute = lcf::ReaderUtil::GetElement(lcf::Data::attributes, attribute_id);
 
 	if (!attribute) {
@@ -20,10 +20,10 @@ int GetAttributeRate(int attribute_id, int rate) {
 		return 0;
 	}
 
-	return GetAttributeRate(*attribute, rate);
+	return GetAttributeRateModifier(*attribute, rate);
 }
 
-int GetAttributeRate(const lcf::rpg::Attribute& attr, int rate) {
+int GetAttributeRateModifier(const lcf::rpg::Attribute& attr, int rate) {
 	switch (rate) {
 	case 0:
 		return attr.a_rate;
@@ -74,11 +74,12 @@ int ApplyAttributeMultiplier(int effect, const Game_Battler& target, Span<const 
 			break;
 		}
 
-		const auto m = target.GetAttributeModifier(id);
+		const auto rate = target.GetAttributeRate(id);
+		const auto mod = GetAttributeRateModifier(id, rate);
 		if (attr->type == lcf::rpg::Attribute::Type_physical) {
-			physical = std::max(physical, m);
+			physical = std::max(physical, mod);
 		} else {
-			magical = std::max(magical, m);
+			magical = std::max(magical, mod);
 		}
 	}
 

--- a/src/attribute.cpp
+++ b/src/attribute.cpp
@@ -43,7 +43,7 @@ int GetAttributeRate(const lcf::rpg::Attribute& attr, int rate) {
 
 static bool HasAttribute(Span<const lcf::DBBitArray*> attribute_sets, int id) {
 	for (auto* as: attribute_sets) {
-		if (as->size() < id && (*as)[id - 1]) {
+		if (static_cast<int>(as->size()) < id && (*as)[id - 1]) {
 			return true;
 		}
 	}

--- a/src/attribute.cpp
+++ b/src/attribute.cpp
@@ -1,3 +1,19 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "attribute.h"
 #include <lcf/rpg/item.h>
 #include <lcf/rpg/skill.h>

--- a/src/attribute.cpp
+++ b/src/attribute.cpp
@@ -122,7 +122,7 @@ int ApplyAttributeNormalAttackMultiplier(int effect, const Game_Battler& source_
 	}
 	auto& source = static_cast<const Game_Actor&>(source_battler);
 
-	std::array<const lcf::DBBitArray*, 2> attribute_sets;
+	std::array<const lcf::DBBitArray*, 2> attribute_sets = {{}};
 
 	size_t n = 0;
 	auto add = [&](int i) {

--- a/src/attribute.cpp
+++ b/src/attribute.cpp
@@ -1,0 +1,122 @@
+#include "attribute.h"
+#include <lcf/rpg/item.h>
+#include <lcf/rpg/skill.h>
+#include <lcf/rpg/attribute.h>
+#include <lcf/reader_util.h>
+#include <lcf/data.h>
+#include "game_battler.h"
+#include "output.h"
+#include "player.h"
+#include <climits>
+
+namespace Attribute {
+
+int GetAttributeRate(int attribute_id, int rate) {
+	const auto* attribute = lcf::ReaderUtil::GetElement(lcf::Data::attributes, attribute_id);
+
+	if (!attribute) {
+		Output::Warning("GetAttributeRate: Invalid attribute ID {}", attribute_id);
+		return 0;
+	}
+
+	return GetAttributeRate(*attribute, rate);
+}
+
+int GetAttributeRate(const lcf::rpg::Attribute& attr, int rate) {
+	switch (rate) {
+	case 0:
+		return attr.a_rate;
+	case 1:
+		return attr.b_rate;
+	case 2:
+		return attr.c_rate;
+	case 3:
+		return attr.d_rate;
+	case 4:
+		return attr.e_rate;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+static bool HasAttribute(Span<const lcf::DBBitArray*> attribute_sets, int id) {
+	for (auto* as: attribute_sets) {
+		if (as->size() < id && (*as)[id - 1]) {
+			return true;
+		}
+	}
+	return false;
+}
+
+int ApplyAttributeMultiplier(int effect, Span<const lcf::DBBitArray*> attribute_sets, const Game_Battler& target) {
+	int physical = INT_MIN;
+	int magical = INT_MIN;
+
+	int n = 0;
+	for (auto* as: attribute_sets) {
+		n = std::max(static_cast<int>(as->size()), n);
+	}
+
+	for (int i = 0; i < n; ++i) {
+		const auto id = i + 1;
+
+		if (!HasAttribute(attribute_sets, id)) {
+			continue;
+		}
+
+		const auto* attr = lcf::ReaderUtil::GetElement(lcf::Data::attributes, id);
+		if (!attr) {
+			Output::Warning("ApplyAttributeMultipler: Invalid attribute ID {}", id);
+			break;
+		}
+
+		const auto m = target.GetAttributeModifier(id);
+		if (attr->type == lcf::rpg::Attribute::Type_physical) {
+			physical = std::max(physical, m);
+		} else {
+			magical = std::max(magical, m);
+		}
+	}
+
+	// Negative attributes not supported in 2k.
+	auto limit = Player::IsRPG2k() ? -1 : INT_MIN;
+
+	if (physical > limit && magical > limit) {
+		if (physical >= 0 && magical >= 0) {
+			effect = magical * (physical * effect / 100) / 100;
+		} else {
+			effect = effect * std::max(physical, magical) / 100;
+		}
+	} else if (physical > limit) {
+		effect = physical * effect / 100;
+	} else if (magical > limit) {
+		effect = magical * effect / 100;
+	}
+	return effect;
+}
+
+int ApplyAttributeMultiplier(int effect, const lcf::rpg::Item* weapon1, const lcf::rpg::Item* weapon2, const Game_Battler& target) {
+	std::array<const lcf::DBBitArray*, 2> attribute_sets;
+
+	size_t n = 0;
+	if (weapon1 && weapon1->type == lcf::rpg::Item::Type_weapon) {
+		attribute_sets[n++] = &weapon1->attribute_set;
+	}
+	if (weapon2 && weapon2->type == lcf::rpg::Item::Type_weapon) {
+		attribute_sets[n++] = &weapon2->attribute_set;
+	}
+	if (n == 0) {
+		return effect;
+	}
+
+	return ApplyAttributeMultiplier(effect, Span<const lcf::DBBitArray*>(attribute_sets.data(), n), target);
+}
+
+int ApplyAttributeMultiplier(int effect, const lcf::rpg::Skill& skill, const Game_Battler& target) {
+	std::array<const lcf::DBBitArray*, 1> attribute_sets = { &skill.attribute_effects };
+	return ApplyAttributeMultiplier(effect, MakeSpan(attribute_sets), target);
+}
+
+} // namespace Attribute

--- a/src/attribute.cpp
+++ b/src/attribute.cpp
@@ -44,7 +44,8 @@ int GetAttributeRate(const lcf::rpg::Attribute& attr, int rate) {
 
 static bool HasAttribute(Span<const lcf::DBBitArray*> attribute_sets, int id) {
 	for (auto* as: attribute_sets) {
-		if (static_cast<int>(as->size()) < id && (*as)[id - 1]) {
+		const auto idx = id - 1;
+		if (idx < static_cast<int>(as->size()) && (*as)[idx]) {
 			return true;
 		}
 	}
@@ -104,7 +105,7 @@ int ApplyAttributeNormalAttackMultiplier(int effect, const Game_Actor& source, c
 	size_t n = 0;
 	auto add = [&](int i) {
 		if (weapon == i || weapon == Game_Battler::kWeaponAll) {
-			auto* item = source.GetEquipment(i);
+			auto* item = source.GetEquipment(i + 1);
 			if (item && item->type == lcf::rpg::Item::Type_weapon) {
 				attribute_sets[n++] = &item->attribute_set;
 			}
@@ -119,7 +120,7 @@ int ApplyAttributeNormalAttackMultiplier(int effect, const Game_Actor& source, c
 }
 
 int ApplyAttributeSkillMultiplier(int effect, const Game_Battler& target, const lcf::rpg::Skill& skill) {
-	std::array<const lcf::DBBitArray*, 1> attribute_sets = { &skill.attribute_effects };
+	auto attribute_sets = Utils::MakeArray(&skill.attribute_effects);
 	return ApplyAttributeMultiplier(effect, target, MakeSpan(attribute_sets));
 }
 

--- a/src/attribute.cpp
+++ b/src/attribute.cpp
@@ -100,12 +100,12 @@ int ApplyAttributeMultiplier(int effect, const Game_Battler& target, Span<const 
 	return effect;
 }
 
-int ApplyAttributeNormalAttackMultiplier(int effect, const Game_Actor& source, const Game_Battler& target, int weapon) {
+int ApplyAttributeNormalAttackMultiplier(int effect, const Game_Actor& source, const Game_Battler& target, Game_Battler::Weapon weapon) {
 	std::array<const lcf::DBBitArray*, 2> attribute_sets;
 
 	size_t n = 0;
 	auto add = [&](int i) {
-		if (weapon == i || weapon == Game_Battler::kWeaponAll) {
+		if (weapon == Game_Battler::Weapon(i + 1) || weapon == Game_Battler::WeaponAll) {
 			auto* item = source.GetEquipment(i + 1);
 			if (item && item->type == lcf::rpg::Item::Type_weapon) {
 				attribute_sets[n++] = &item->attribute_set;

--- a/src/attribute.cpp
+++ b/src/attribute.cpp
@@ -100,7 +100,12 @@ int ApplyAttributeMultiplier(int effect, const Game_Battler& target, Span<const 
 	return effect;
 }
 
-int ApplyAttributeNormalAttackMultiplier(int effect, const Game_Actor& source, const Game_Battler& target, Game_Battler::Weapon weapon) {
+int ApplyAttributeNormalAttackMultiplier(int effect, const Game_Battler& source_battler, const Game_Battler& target, Game_Battler::Weapon weapon) {
+	if (source_battler.GetType() != Game_Battler::Type_Ally) {
+		return effect;
+	}
+	auto& source = static_cast<const Game_Actor&>(source_battler);
+
 	std::array<const lcf::DBBitArray*, 2> attribute_sets;
 
 	size_t n = 0;

--- a/src/attribute.h
+++ b/src/attribute.h
@@ -35,7 +35,7 @@ namespace Attribute {
  * @param rate Attribute rate to get
  * @return Attribute rate
  */
-int GetAttributeRate(int attribute_id, int rate);
+int GetAttributeRateModifier(int attribute_id, int rate);
 
 /**
  * Gets the attribute damage multiplier/protection (A-E).
@@ -44,7 +44,7 @@ int GetAttributeRate(int attribute_id, int rate);
  * @param rate Attribute rate to get
  * @return Attribute rate
  */
-int GetAttributeRate(const lcf::rpg::Attribute& attr, int rate);
+int GetAttributeRateModifier(const lcf::rpg::Attribute& attr, int rate);
 
 /**
  * Modifies the effect by weapon attributes against the target.

--- a/src/attribute.h
+++ b/src/attribute.h
@@ -56,7 +56,7 @@ int GetAttributeRateModifier(const lcf::rpg::Attribute& attr, int rate);
  * @param weapon The weapon to use, or kWeaponAll
  * @return modified effect
  */
-int ApplyAttributeNormalAttackMultiplier(int effect, const Game_Actor& source, const Game_Battler& target, Game_Battler::Weapon weapon);
+int ApplyAttributeNormalAttackMultiplier(int effect, const Game_Battler& source, const Game_Battler& target, Game_Battler::Weapon weapon);
 
 /**
  * Modifies the effect by weapon attributes against the target.

--- a/src/attribute.h
+++ b/src/attribute.h
@@ -23,6 +23,7 @@
 #include <span.h>
 
 class Game_Battler;
+class Game_Actor;
 
 /** Namespace of functions dealing with attribute modifiers */
 namespace Attribute {
@@ -49,22 +50,22 @@ int GetAttributeRate(const lcf::rpg::Attribute& attr, int rate);
  * Modifies the effect by weapon attributes against the target.
  *
  * @param effect Base effect to adjust
- * @param weapon1 First weapon being used against target. If nullptr or type is not weapon type, is ignored.
- * @param weapon2 Second weapon being used against target. If nullptr or type is not weapon type, is ignored.
+ * @param source Source who is attacking target
  * @param target Target to apply attributes against
+ * @param weapon The weapon to use, or kWeaponAll
  * @return modified effect
  */
-int ApplyAttributeMultiplier(int effect, const lcf::rpg::Item* weapon1, const lcf::rpg::Item* weapon2, const Game_Battler& target);
+int ApplyAttributeNormalAttackMultiplier(int effect, const Game_Actor& source, const Game_Battler& target, int weapon);
 
 /**
  * Modifies the effect by weapon attributes against the target.
  *
  * @param effect Base effect to adjust
- * @param skill Skill being used against target
  * @param target Target to apply attributes against
+ * @param skill Skill being used against target
  * @return modified effect
  */
-int ApplyAttributeMultiplier(int effect, const lcf::rpg::Skill& skill, const Game_Battler& target);
+int ApplyAttributeSkillMultiplier(int effect, const Game_Battler& target, const lcf::rpg::Skill& skill);
 
 /**
  * Modifies the effect by weapon attributes against the target.
@@ -74,7 +75,7 @@ int ApplyAttributeMultiplier(int effect, const lcf::rpg::Skill& skill, const Gam
  * @param target Target to apply attributes against
  * @return modified effect
  */
-int ApplyAttributeMultiplier(int effect, Span<const lcf::DBBitArray*> attribute_sets, const Game_Battler& target);
+int ApplyAttributeMultiplier(int effect, const Game_Battler& target, Span<const lcf::DBBitArray*> attribute_sets);
 
 } // namespace Attribute
 

--- a/src/attribute.h
+++ b/src/attribute.h
@@ -1,0 +1,82 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_ATTRIBUTE_H
+#define EP_ATTRIBUTE_H
+
+#include <lcf/rpg/fwd.h>
+#include <lcf/dbbitarray.h>
+#include <span.h>
+
+class Game_Battler;
+
+/** Namespace of functions dealing with attribute modifiers */
+namespace Attribute {
+
+/**
+ * Gets the attribute damage multiplier/protection (A-E).
+ *
+ * @param attribute_id Attribute to test
+ * @param rate Attribute rate to get
+ * @return Attribute rate
+ */
+int GetAttributeRate(int attribute_id, int rate);
+
+/**
+ * Gets the attribute damage multiplier/protection (A-E).
+ *
+ * @param attr Attribute to test
+ * @param rate Attribute rate to get
+ * @return Attribute rate
+ */
+int GetAttributeRate(const lcf::rpg::Attribute& attr, int rate);
+
+/**
+ * Modifies the effect by weapon attributes against the target.
+ *
+ * @param effect Base effect to adjust
+ * @param weapon1 First weapon being used against target. If nullptr or type is not weapon type, is ignored.
+ * @param weapon2 Second weapon being used against target. If nullptr or type is not weapon type, is ignored.
+ * @param target Target to apply attributes against
+ * @return modified effect
+ */
+int ApplyAttributeMultiplier(int effect, const lcf::rpg::Item* weapon1, const lcf::rpg::Item* weapon2, const Game_Battler& target);
+
+/**
+ * Modifies the effect by weapon attributes against the target.
+ *
+ * @param effect Base effect to adjust
+ * @param skill Skill being used against target
+ * @param target Target to apply attributes against
+ * @return modified effect
+ */
+int ApplyAttributeMultiplier(int effect, const lcf::rpg::Skill& skill, const Game_Battler& target);
+
+/**
+ * Modifies the effect by weapon attributes against the target.
+ *
+ * @param effect Base effect to adjust
+ * @param attribute_sets A Span of attribute bitsets to check for attributes to apply against the target.
+ * @param target Target to apply attributes against
+ * @return modified effect
+ */
+int ApplyAttributeMultiplier(int effect, Span<const lcf::DBBitArray*> attribute_sets, const Game_Battler& target);
+
+} // namespace Attribute
+
+
+#endif

--- a/src/attribute.h
+++ b/src/attribute.h
@@ -20,7 +20,8 @@
 
 #include <lcf/rpg/fwd.h>
 #include <lcf/dbbitarray.h>
-#include <span.h>
+#include "span.h"
+#include "game_battler.h"
 
 class Game_Battler;
 class Game_Actor;
@@ -55,7 +56,7 @@ int GetAttributeRateModifier(const lcf::rpg::Attribute& attr, int rate);
  * @param weapon The weapon to use, or kWeaponAll
  * @return modified effect
  */
-int ApplyAttributeNormalAttackMultiplier(int effect, const Game_Actor& source, const Game_Battler& target, int weapon);
+int ApplyAttributeNormalAttackMultiplier(int effect, const Game_Actor& source, const Game_Battler& target, Game_Battler::Weapon weapon);
 
 /**
  * Modifies the effect by weapon attributes against the target.

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -207,24 +207,6 @@ int Game_Actor::CalculateSkillCost(int skill_id) const {
 	return cost;
 }
 
-int Game_Actor::CalculateWeaponSpCost() const {
-	int cost = 0;
-	auto* w1 = GetWeapon();
-	if (w1) {
-		cost += w1->sp_cost;
-	}
-	auto* w2 = Get2ndWeapon();
-	if (w2) {
-		cost += w2->sp_cost;
-	}
-
-	if (HasHalfSpCost()) {
-		cost = (cost + 1) / 2;
-	}
-
-	return cost;
-}
-
 bool Game_Actor::LearnSkill(int skill_id, PendingMessage* pm) {
 	if (skill_id > 0 && !IsSkillLearned(skill_id)) {
 		const lcf::rpg::Skill* skill = lcf::ReaderUtil::GetElement(lcf::Data::skills, skill_id);
@@ -1356,6 +1338,16 @@ bool Game_Actor::HasHalfSpCost() const {
 	bool rc = false;
 	ForEachEquipment<false, true>(GetWholeEquipment(), [&](auto& item) { rc |= item.half_sp_cost; });
 	return rc;
+}
+
+int Game_Actor::CalculateWeaponSpCost(Weapon weapon) const {
+	int cost = 0;
+	ForEachEquipment<true, false>(GetWholeEquipment(), [&](auto& item) { cost += item.sp_cost; }, weapon);
+	if (HasHalfSpCost()) {
+		cost = (cost + 1) / 2;
+	}
+
+	return cost;
 }
 
 void Game_Actor::AdjustEquipmentStates(const lcf::rpg::Item* item, bool add, bool allow_battle_states) {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -55,8 +55,29 @@ int Game_Actor::MaxStatBaseValue() const {
 
 Game_Actor::Game_Actor(int actor_id) {
 	data.ID = actor_id;
+	if (actor_id == 0) {
+		return;
+	}
+
 	data.Setup(actor_id);
 	Setup();
+
+	const auto& skills = GetActor().skills;
+	for (auto& skill: skills) {
+		if (skill.level <= GetLevel()) {
+			LearnSkill(skill.skill_id, nullptr);
+		}
+	}
+
+	RemoveInvalidData();
+
+	if (GetLevel() > 0) {
+		SetHp(GetMaxHp());
+		SetSp(GetMaxSp());
+		SetExp(exp_list[GetLevel() - 1]);
+	}
+
+	ResetEquipmentStates(false);
 }
 
 void Game_Actor::Setup() {
@@ -75,22 +96,7 @@ const lcf::rpg::SaveActor& Game_Actor::GetSaveData() const {
 }
 
 void Game_Actor::Init() {
-	const std::vector<lcf::rpg::Learning>& skills = GetActor().skills;
-	for (int i = 0; i < (int)skills.size(); i++) {
-		if (skills[i].level <= GetLevel()) {
-			LearnSkill(skills[i].skill_id, nullptr);
-		}
-	}
 
-	RemoveInvalidData();
-
-	if (GetLevel() > 0) {
-		SetHp(GetMaxHp());
-		SetSp(GetMaxSp());
-		SetExp(exp_list[GetLevel() - 1]);
-	}
-
-	ResetEquipmentStates(false);
 }
 
 void Game_Actor::Fixup() {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -46,7 +46,7 @@ int Game_Actor::MaxHpValue() const {
 }
 
 int Game_Actor::MaxStatBattleValue() const {
-	return Player::IsRPG2k() ? 999 : 9999;
+	return 9999;
 }
 
 int Game_Actor::MaxStatBaseValue() const {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -411,7 +411,7 @@ static bool IsArmorType(const lcf::rpg::Item* item) {
 }
 
 template <bool allow_weapon, bool allow_armor, typename F>
-void ForEachEquipment(Span<const short> equipped, F&& f, int weapon = Game_Battler::kWeaponAll) {
+void ForEachEquipment(Span<const short> equipped, F&& f, Game_Battler::Weapon weapon = Game_Battler::WeaponAll) {
 	for (int slot = 0; slot < static_cast<int>(equipped.size()); ++slot) {
 		const auto item_id = equipped[slot];
 		if (item_id <= 0) {
@@ -423,7 +423,7 @@ void ForEachEquipment(Span<const short> equipped, F&& f, int weapon = Game_Battl
 		assert(item != nullptr);
 
 		if (item->type == lcf::rpg::Item::Type_weapon) {
-			if (!allow_weapon || (weapon != Game_Battler::kWeaponAll && weapon != slot)) {
+			if (!allow_weapon || (weapon != Game_Battler::WeaponAll && weapon != slot + 1)) {
 				continue;
 			}
 		} else if (IsArmorType(item)) {
@@ -438,7 +438,7 @@ void ForEachEquipment(Span<const short> equipped, F&& f, int weapon = Game_Battl
 	}
 }
 
-int Game_Actor::GetBaseAtk(int weapon, bool mod, bool equip) const {
+int Game_Actor::GetBaseAtk(Weapon weapon, bool mod, bool equip) const {
 	int n = 0;
 	if (GetLevel() > 0) {
 		n = data.class_id > 0
@@ -457,11 +457,11 @@ int Game_Actor::GetBaseAtk(int weapon, bool mod, bool equip) const {
 	return Utils::Clamp(n, 1, MaxStatBaseValue());
 }
 
-int Game_Actor::GetBaseAtk(int weapon) const {
+int Game_Actor::GetBaseAtk(Weapon weapon) const {
 	return GetBaseAtk(weapon, true, true);
 }
 
-int Game_Actor::GetBaseDef(int weapon, bool mod, bool equip) const {
+int Game_Actor::GetBaseDef(Weapon weapon, bool mod, bool equip) const {
 	int n = 0;
 	if (GetLevel() > 0) {
 		n = data.class_id > 0
@@ -480,11 +480,11 @@ int Game_Actor::GetBaseDef(int weapon, bool mod, bool equip) const {
 	return Utils::Clamp(n, 1, MaxStatBaseValue());
 }
 
-int Game_Actor::GetBaseDef(int weapon) const {
+int Game_Actor::GetBaseDef(Weapon weapon) const {
 	return GetBaseDef(weapon, true, true);
 }
 
-int Game_Actor::GetBaseSpi(int weapon, bool mod, bool equip) const {
+int Game_Actor::GetBaseSpi(Weapon weapon, bool mod, bool equip) const {
 	int n = 0;
 	if (GetLevel() > 0) {
 		n = data.class_id > 0
@@ -503,11 +503,11 @@ int Game_Actor::GetBaseSpi(int weapon, bool mod, bool equip) const {
 	return Utils::Clamp(n, 1, MaxStatBaseValue());
 }
 
-int Game_Actor::GetBaseSpi(int weapon) const {
+int Game_Actor::GetBaseSpi(Weapon weapon) const {
 	return GetBaseSpi(weapon, true, true);
 }
 
-int Game_Actor::GetBaseAgi(int weapon, bool mod, bool equip) const {
+int Game_Actor::GetBaseAgi(Weapon weapon, bool mod, bool equip) const {
 	int n = 0;
 	if (GetLevel() > 0) {
 		n = data.class_id > 0
@@ -526,7 +526,7 @@ int Game_Actor::GetBaseAgi(int weapon, bool mod, bool equip) const {
 	return Utils::Clamp(n, 1, MaxStatBaseValue());
 }
 
-int Game_Actor::GetBaseAgi(int weapon) const {
+int Game_Actor::GetBaseAgi(Weapon weapon) const {
 	return GetBaseAgi(weapon, true, true);
 }
 
@@ -1154,14 +1154,14 @@ int Game_Actor::GetBattleAnimationId() const {
 	return anim;
 }
 
-int Game_Actor::GetHitChance(int weapon) const {
+int Game_Actor::GetHitChance(Weapon weapon) const {
 	int hit = INT_MIN;
 	ForEachEquipment<true, false>(GetWholeEquipment(), [&](auto& item) { hit = std::max(hit, static_cast<int>(item.hit)); }, weapon);
 
 	return hit != INT_MIN ? hit : 90;
 }
 
-float Game_Actor::GetCriticalHitChance(int weapon) const {
+float Game_Actor::GetCriticalHitChance(Weapon weapon) const {
 	auto& actor = GetActor();
 	float crit_chance = actor.critical_hit ? 1.0f / actor.critical_hit_chance : 0.0f;
 
@@ -1309,25 +1309,25 @@ const lcf::rpg::Item* Game_Actor::GetAccessory() const {
 	return nullptr;
 }
 
-bool Game_Actor::HasPreemptiveAttack(int weapon) const {
+bool Game_Actor::HasPreemptiveAttack(Weapon weapon) const {
 	bool rc = false;
 	ForEachEquipment<true, false>(GetWholeEquipment(), [&](auto& item) { rc |= item.preemptive; }, weapon);
 	return rc;
 }
 
-bool Game_Actor::HasDualAttack(int weapon) const {
+bool Game_Actor::HasDualAttack(Weapon weapon) const {
 	bool rc = false;
 	ForEachEquipment<true, false>(GetWholeEquipment(), [&](auto& item) { rc |= item.dual_attack; }, weapon);
 	return rc;
 }
 
-bool Game_Actor::HasAttackAll(int weapon) const {
+bool Game_Actor::HasAttackAll(Weapon weapon) const {
 	bool rc = false;
 	ForEachEquipment<true, false>(GetWholeEquipment(), [&](auto& item) { rc |= item.attack_all; }, weapon);
 	return rc;
 }
 
-bool Game_Actor::AttackIgnoresEvasion(int weapon) const {
+bool Game_Actor::AttackIgnoresEvasion(Weapon weapon) const {
 	bool rc = false;
 	ForEachEquipment<true, false>(GetWholeEquipment(), [&](auto& item) { rc |= item.ignore_evasion; }, weapon);
 	return rc;

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -32,6 +32,7 @@
 #include "utils.h"
 #include "pending_message.h"
 #include "compiler.h"
+#include "attribute.h"
 
 constexpr int max_level_2k = 50;
 constexpr int max_level_2k3 = 99;
@@ -637,7 +638,7 @@ int Game_Actor::GetAttributeModifier(int attribute_id) const {
 		rate = 4;
 	}
 
-	return GetAttributeRate(attribute_id, rate);
+	return Attribute::GetAttributeRate(attribute_id, rate);
 }
 
 int Game_Actor::GetWeaponId() const {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -431,6 +431,7 @@ void ForEachEquipment(Span<const short> equipped, F&& f, Game_Battler::Weapon we
 				continue;
 			}
 		} else {
+			assert(false && "Invalid item type equipped!");
 			continue;
 		}
 

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -662,6 +662,24 @@ public:
 	 */
 	void SetBaseAgi(int _agi);
 
+	/** @return Permanent max hp modifier */
+	int GetMaxHpMod() const;
+
+	/** @return Permanent max sp modifier */
+	int GetMaxSpMod() const;
+
+	/** @return Permanent atk modifier */
+	int GetAtkMod() const;
+
+	/** @return Permanent atk modifier */
+	int GetDefMod() const;
+
+	/** @return Permanent def modifier */
+	int GetSpiMod() const;
+
+	/** @return Permanent agi modifier */
+	int GetAgiMod() const;
+
 	/**
 	 * Gets if actor has two weapons.
 	 *
@@ -960,6 +978,30 @@ inline const std::vector<int16_t>& Game_Actor::GetWholeEquipment() const {
 
 inline int Game_Actor::GetId() const {
 	return data.ID;
+}
+
+inline int Game_Actor::GetMaxHpMod() const {
+	return data.hp_mod;
+}
+
+inline int Game_Actor::GetMaxSpMod() const {
+	return data.sp_mod;
+}
+
+inline int Game_Actor::GetAtkMod() const {
+	return data.attack_mod;
+}
+
+inline int Game_Actor::GetDefMod() const {
+	return data.defense_mod;
+}
+
+inline int Game_Actor::GetSpiMod() const {
+	return data.spirit_mod;
+}
+
+inline int Game_Actor::GetAgiMod() const {
+	return data.agility_mod;
 }
 
 #endif

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -151,9 +151,12 @@ public:
 	int CalculateSkillCost(int skill_id) const override;
 
 	/**
+	 * Calculates the Sp cost for attacking with a weapon.
+	 *
+	 * @param weapon which weapons to include in calculating result.
 	 * @return sp cost for attacking with weapon.
 	 */
-	int CalculateWeaponSpCost() const;
+	int CalculateWeaponSpCost(Weapon weapon = WeaponAll) const;
 
 	/**
 	 * Gets the actor ID.

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -229,12 +229,12 @@ public:
 	int GetStateProbability(int state_id) const override;
 
 	/**
-	 * Gets attribute protection when the actor is damaged.
-	 *
-	 * @param attribute_id Attribute to test
-	 * @return Attribute resistence
+	 * Gets the base attribute rate when actor is damaged.
+	 * 
+	 * @param attribute_id Attribute to query
+	 * @return Attribute rate
 	 */
-	int GetAttributeModifier(int attribute_id) const override;
+	int GetBaseAttributeRate(int attribute_id) const override;
 
 	/**
 	 * Gets actor name.

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -44,6 +44,9 @@ public:
 	 */
 	Game_Actor(int actor_id);
 
+	void SetSaveData(lcf::rpg::SaveActor save);
+	const lcf::rpg::SaveActor& GetSaveData() const;
+
 	int MaxHpValue() const override;
 
 	int MaxStatBattleValue() const override;
@@ -858,18 +861,12 @@ private:
 	 */
 	const lcf::rpg::Actor& GetActor() const;
 
-	// same reason as for Game_Picture, see comment
-	/**
-	 * @return Reference to the SaveActor data
-	 */
-	lcf::rpg::SaveActor& GetData() const;
-
 	/**
 	 * Removes invalid data from the actor.
 	 */
 	void RemoveInvalidData();
 
-	int actor_id;
+	lcf::rpg::SaveActor data;
 	std::vector<int> exp_list;
 };
 
@@ -878,90 +875,87 @@ inline Game_Battler::BattlerType Game_Actor::GetType() const {
 }
 
 inline void Game_Actor::SetName(const std::string &new_name) {
-	GetData().name = new_name;
+	data.name = new_name;
 }
 
-
 inline StringView Game_Actor::GetName() const {
-	return GetData().name;
+	return data.name;
 }
 
 inline void Game_Actor::SetTitle(const std::string &new_title) {
-	GetData().title = new_title;
+	data.title = new_title;
 }
 
 inline const std::string& Game_Actor::GetTitle() const {
-	return GetData().title;
+	return data.title;
 }
 
 inline StringView Game_Actor::GetSpriteName() const {
-	return GetData().sprite_name;
+	return data.sprite_name;
 }
 
 inline int Game_Actor::GetSpriteIndex() const {
-	return GetData().sprite_id;
+	return data.sprite_id;
 }
 
 inline int Game_Actor::GetSpriteTransparency() const {
-	return GetData().transparency;
+	return data.transparency;
 }
 
 inline StringView Game_Actor::GetFaceName() const {
-	return GetData().face_name;
+	return data.face_name;
 }
 
 inline int Game_Actor::GetFaceIndex() const {
-	return GetData().face_id;
+	return data.face_id;
 }
 
 inline int Game_Actor::GetLevel() const {
-	return GetData().level;
+	return data.level;
 }
 
 inline int Game_Actor::GetExp() const {
-	return GetData().exp;
+	return data.exp;
 }
 
 inline int Game_Actor::GetHp() const {
-	return GetData().current_hp;
+	return data.current_hp;
 }
 
 inline int Game_Actor::GetSp() const {
-	return GetData().current_sp;
+	return data.current_sp;
 }
 
 inline bool Game_Actor::HasTwoWeapons() const {
-	return GetData().two_weapon;
+	return data.two_weapon;
 }
 
 inline bool Game_Actor::GetAutoBattle() const {
-	return GetData().auto_battle;
+	return data.auto_battle;
 }
 
 inline bool Game_Actor::HasStrongDefense() const {
-	return GetData().super_guard;
+	return data.super_guard;
 }
 
 inline const std::vector<int16_t>& Game_Actor::GetSkills() const {
-	return GetData().skills;
+	return data.skills;
 }
 
 inline const std::vector<int16_t>& Game_Actor::GetStates() const {
-	return GetData().status;
+	return data.status;
 }
 
 inline std::vector<int16_t>& Game_Actor::GetStates() {
-	return GetData().status;
+	return data.status;
 }
 
 inline const std::vector<int16_t>& Game_Actor::GetWholeEquipment() const {
-	return GetData().equipped;
+	return data.equipped;
 }
 
 inline int Game_Actor::GetId() const {
-	return actor_id;
+	return data.ID;
 }
-
-
 
 #endif

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -587,24 +587,28 @@ public:
 	/**
 	 * Gets the attack for the current level.
 	 * Modifier and equipment bonuses are included.
+	 * @param weapon Which weapons to include in calculating result.
 	 */
 	int GetBaseAtk(Weapon weapon = WeaponAll) const override;
 
 	/**
 	 * Gets the defense for the current level.
 	 * Modifier and equipment bonuses are included.
+	 * @param weapon Which weapons to include in calculating result.
 	 */
 	int GetBaseDef(Weapon weapon = WeaponAll) const override;
 
 	/**
 	 * Gets the spirit for the current level.
 	 * Modifier and equipment bonuses are included.
+	 * @param weapon Which weapons to include in calculating result.
 	 */
 	int GetBaseSpi(Weapon weapon = WeaponAll) const override;
 
 	/**
 	 * Gets the agility for the current level.
 	 * Modifier and equipment bonuses are included.
+	 * @param weapon Which weapons to include in calculating result.
 	 */
 	int GetBaseAgi(Weapon weapon = WeaponAll) const override;
 
@@ -808,6 +812,7 @@ public:
 	/**
 	 * Tests if the battler has a weapon that grants preemption.
 	 *
+	 * @param weapon Which weapons to include in calculating result.
 	 * @return true if a weapon is having preempt attribute
 	 */
 	bool HasPreemptiveAttack(Weapon weapon = WeaponAll) const override;
@@ -815,6 +820,7 @@ public:
 	/**
 	 * Tests if the battler has a weapon that grants dual attack.
 	 *
+	 * @param weapon Which weapons to include in calculating result.
 	 * @return true if a weapon is having dual attack attribute
 	 */
 	bool HasDualAttack(Weapon weapon = WeaponAll) const;
@@ -822,11 +828,15 @@ public:
 	/**
 	 * Tests if the battler has a weapon that grants attack all
 	 *
+	 * @param weapon Which weapons to include in calculating result.
 	 * @return true if a weapon is having attack all attribute
 	 */
 	bool HasAttackAll(Weapon weapon = WeaponAll) const;
 
 	/**
+	 * Tests if the battler has a weapon which ignores evasion.
+	 *
+	 * @param weapon Which weapons to include in calculating result.
 	 * @return If the actor has weapon that ignores evasion
 	 */
 	bool AttackIgnoresEvasion(Weapon weapon = WeaponAll) const;
@@ -853,7 +863,20 @@ public:
 
 	int GetBattleAnimationId() const override;
 
+	/**
+	 * Gets the chance to hit for a normal attack.
+	 *
+	 * @param weapon Which weapons to include in calculating result.
+	 * @return hit rate. [0-100]
+	 */
 	int GetHitChance(Weapon weapon = WeaponAll) const override;
+
+	/**
+	 * Gets the chance to critical hit for a normal attack.
+	 *
+	 * @param weapon Which weapons to include in calculating result.
+	 * @return critical hit rate [0.0f-1.0f]
+	 */
 	float GetCriticalHitChance(Weapon weapon = WeaponAll) const override;
 
 	std::string GetLevelUpMessage(int new_level) const;

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -539,34 +539,38 @@ public:
 	/**
 	 * Gets the attack for the current level.
 	 *
+	 * @param weapon which weapons to include in calculating result.
 	 * @param mod include the modifier bonus.
 	 * @param equip include the equipment bonuses.
 	 */
-	int GetBaseAtk(int weapon, bool mod, bool equip) const;
+	int GetBaseAtk(Weapon weapon, bool mod, bool equip) const;
 
 	/**
 	 * Gets the defense for the current level.
 	 *
+	 * @param weapon which weapons to include in calculating result.
 	 * @param mod include the modifier bonus.
 	 * @param equip include the equipment bonuses.
 	 */
-	int GetBaseDef(int weapon, bool mod, bool equip) const;
+	int GetBaseDef(Weapon weapon, bool mod, bool equip) const;
 
 	/**
 	 * Gets the spirit for the current level.
 	 *
+	 * @param weapon which weapons to include in calculating result.
 	 * @param mod include the modifier bonus.
 	 * @param equip include the equipment bonuses.
 	 */
-	int GetBaseSpi(int weapon, bool mod, bool equip) const;
+	int GetBaseSpi(Weapon weapon, bool mod, bool equip) const;
 
 	/**
 	 * Gets the agility for the current level.
 	 *
+	 * @param weapon which weapons to include in calculating result.
 	 * @param mod include the modifier bonus.
 	 * @param equip include the equipment bonuses.
 	 */
-	int GetBaseAgi(int weapon, bool mod, bool equip) const;
+	int GetBaseAgi(Weapon weapon, bool mod, bool equip) const;
 
 	/**
 	 * Gets the max HP for the current level.
@@ -584,25 +588,25 @@ public:
 	 * Gets the attack for the current level.
 	 * Modifier and equipment bonuses are included.
 	 */
-	int GetBaseAtk(int weapon = kWeaponAll) const override;
+	int GetBaseAtk(Weapon weapon = WeaponAll) const override;
 
 	/**
 	 * Gets the defense for the current level.
 	 * Modifier and equipment bonuses are included.
 	 */
-	int GetBaseDef(int weapon = kWeaponAll) const override;
+	int GetBaseDef(Weapon weapon = WeaponAll) const override;
 
 	/**
 	 * Gets the spirit for the current level.
 	 * Modifier and equipment bonuses are included.
 	 */
-	int GetBaseSpi(int weapon = kWeaponAll) const override;
+	int GetBaseSpi(Weapon weapon = WeaponAll) const override;
 
 	/**
 	 * Gets the agility for the current level.
 	 * Modifier and equipment bonuses are included.
 	 */
-	int GetBaseAgi(int weapon = kWeaponAll) const override;
+	int GetBaseAgi(Weapon weapon = WeaponAll) const override;
 
 	/**
 	 * Sets the base max HP by adjusting the modifier bonus.
@@ -788,26 +792,26 @@ public:
 	 *
 	 * @return true if a weapon is having preempt attribute
 	 */
-	bool HasPreemptiveAttack(int weapon = kWeaponAll) const override;
+	bool HasPreemptiveAttack(Weapon weapon = WeaponAll) const override;
 
 	/**
 	 * Tests if the battler has a weapon that grants dual attack.
 	 *
 	 * @return true if a weapon is having dual attack attribute
 	 */
-	bool HasDualAttack(int weapon = kWeaponAll) const;
+	bool HasDualAttack(Weapon weapon = WeaponAll) const;
 
 	/**
 	 * Tests if the battler has a weapon that grants attack all
 	 *
 	 * @return true if a weapon is having attack all attribute
 	 */
-	bool HasAttackAll(int weapon = kWeaponAll) const;
+	bool HasAttackAll(Weapon weapon = WeaponAll) const;
 
 	/**
 	 * @return If the actor has weapon that ignores evasion
 	 */
-	bool AttackIgnoresEvasion(int weapon = kWeaponAll) const;
+	bool AttackIgnoresEvasion(Weapon weapon = WeaponAll) const;
 
 	/**
 	 * @return If the actor has equipment that protects against terrain damage.
@@ -831,8 +835,8 @@ public:
 
 	int GetBattleAnimationId() const override;
 
-	int GetHitChance(int weapon = kWeaponAll) const override;
-	float GetCriticalHitChance(int weapon = kWeaponAll) const override;
+	int GetHitChance(Weapon weapon = WeaponAll) const override;
+	float GetCriticalHitChance(Weapon weapon = WeaponAll) const override;
 
 	std::string GetLevelUpMessage(int new_level) const;
 	std::string GetLearningMessage(const lcf::rpg::Skill& skill) const;

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -36,6 +36,7 @@ class PendingMessage;
 class Game_Actor final : public Game_Battler {
 public:
 	using RowType = lcf::rpg::SaveActor::RowType;
+
 	/**
 	 * Constructor.
 	 *
@@ -538,7 +539,7 @@ public:
 	 * @param mod include the modifier bonus.
 	 * @param equip include the equipment bonuses.
 	 */
-	int GetBaseAtk(bool mod, bool equip) const;
+	int GetBaseAtk(int weapon, bool mod, bool equip) const;
 
 	/**
 	 * Gets the defense for the current level.
@@ -546,7 +547,7 @@ public:
 	 * @param mod include the modifier bonus.
 	 * @param equip include the equipment bonuses.
 	 */
-	int GetBaseDef(bool mod, bool equip) const;
+	int GetBaseDef(int weapon, bool mod, bool equip) const;
 
 	/**
 	 * Gets the spirit for the current level.
@@ -554,7 +555,7 @@ public:
 	 * @param mod include the modifier bonus.
 	 * @param equip include the equipment bonuses.
 	 */
-	int GetBaseSpi(bool mod, bool equip) const;
+	int GetBaseSpi(int weapon, bool mod, bool equip) const;
 
 	/**
 	 * Gets the agility for the current level.
@@ -562,7 +563,7 @@ public:
 	 * @param mod include the modifier bonus.
 	 * @param equip include the equipment bonuses.
 	 */
-	int GetBaseAgi(bool mod, bool equip) const;
+	int GetBaseAgi(int weapon, bool mod, bool equip) const;
 
 	/**
 	 * Gets the max HP for the current level.
@@ -580,25 +581,25 @@ public:
 	 * Gets the attack for the current level.
 	 * Modifier and equipment bonuses are included.
 	 */
-	int GetBaseAtk() const override;
+	int GetBaseAtk(int weapon = kWeaponAll) const override;
 
 	/**
 	 * Gets the defense for the current level.
 	 * Modifier and equipment bonuses are included.
 	 */
-	int GetBaseDef() const override;
+	int GetBaseDef(int weapon = kWeaponAll) const override;
 
 	/**
 	 * Gets the spirit for the current level.
 	 * Modifier and equipment bonuses are included.
 	 */
-	int GetBaseSpi() const override;
+	int GetBaseSpi(int weapon = kWeaponAll) const override;
 
 	/**
 	 * Gets the agility for the current level.
 	 * Modifier and equipment bonuses are included.
 	 */
-	int GetBaseAgi() const override;
+	int GetBaseAgi(int weapon = kWeaponAll) const override;
 
 	/**
 	 * Sets the base max HP by adjusting the modifier bonus.
@@ -784,26 +785,26 @@ public:
 	 *
 	 * @return true if a weapon is having preempt attribute
 	 */
-	bool HasPreemptiveAttack() const override;
+	bool HasPreemptiveAttack(int weapon = kWeaponAll) const override;
 
 	/**
 	 * Tests if the battler has a weapon that grants dual attack.
 	 *
 	 * @return true if a weapon is having dual attack attribute
 	 */
-	bool HasDualAttack() const;
+	bool HasDualAttack(int weapon = kWeaponAll) const;
 
 	/**
 	 * Tests if the battler has a weapon that grants attack all
 	 *
 	 * @return true if a weapon is having attack all attribute
 	 */
-	bool HasAttackAll() const;
+	bool HasAttackAll(int weapon = kWeaponAll) const;
 
 	/**
 	 * @return If the actor has weapon that ignores evasion
 	 */
-	bool AttackIgnoresEvasion() const;
+	bool AttackIgnoresEvasion(int weapon = kWeaponAll) const;
 
 	/**
 	 * @return If the actor has equipment that protects against terrain damage.
@@ -827,8 +828,8 @@ public:
 
 	int GetBattleAnimationId() const override;
 
-	int GetHitChance() const override;
-	float GetCriticalHitChance() const override;
+	int GetHitChance(int weapon = kWeaponAll) const override;
+	float GetCriticalHitChance(int weapon = kWeaponAll) const override;
 
 	std::string GetLevelUpMessage(int new_level) const;
 	std::string GetLearningMessage(const lcf::rpg::Skill& skill) const;

--- a/src/game_actors.cpp
+++ b/src/game_actors.cpp
@@ -29,9 +29,6 @@ Game_Actors::Game_Actors() {
 	}
 }
 
-Game_Actors::~Game_Actors() {
-}
-
 void Game_Actors::SetSaveData(std::vector<lcf::rpg::SaveActor> save) {
 	// Ensure actor save data and LDB actors has correct size
 	if (save.size() > data.size()) {

--- a/src/game_actors.cpp
+++ b/src/game_actors.cpp
@@ -32,26 +32,24 @@ Game_Actors::Game_Actors() {
 Game_Actors::~Game_Actors() {
 }
 
-void Game_Actors::Fixup() {
+void Game_Actors::SetSaveData(std::vector<lcf::rpg::SaveActor> save) {
 	// Ensure actor save data and LDB actors has correct size
-	if (Main_Data::game_data.actors.size() != data.size()) {
-		size_t save_actor_size = Main_Data::game_data.actors.size();
-
-		Output::Warning("Actor array size doesn't match Savegame actor array size ({} != {})",
-						data.size(), save_actor_size);
-
-		Main_Data::game_data.actors.resize(data.size());
-
-		// When the save data size is smaller than the LDB size set the additional actors to nullptr.
-		// GetActor will copy the actor data to the savegame data next time it is invoked.
-		if (save_actor_size < data.size()) {
-			std::fill(data.begin() + save_actor_size, data.end(), nullptr);
-		}
+	if (save.size() > data.size()) {
+		Output::Warning("Game_Actors: Save game array size {} is larger than number of LDB actors {} : Dropping extras ...", save.size(), data.size());
 	}
 
-	for (size_t i = 1; i <= data.size(); ++i) {
-		GetActor(i)->Fixup();
+	for (size_t i = 0; i < std::min(save.size(), data.size()); ++i) {
+		data[i]->SetSaveData(std::move(save[i]));
 	}
+}
+
+std::vector<lcf::rpg::SaveActor> Game_Actors::GetSaveData() const {
+	std::vector<lcf::rpg::SaveActor> save;
+	save.reserve(data.size());
+	for (auto& actor: data) {
+		save.push_back(actor->GetSaveData());
+	}
+	return save;
 }
 
 Game_Actor* Game_Actors::GetActor(int actor_id) {

--- a/src/game_actors.cpp
+++ b/src/game_actors.cpp
@@ -23,9 +23,9 @@
 #include "output.h"
 
 Game_Actors::Game_Actors() {
-	data.resize(lcf::Data::actors.size());
-	for (size_t i = 1; i <= data.size(); i++) {
-		GetActor(i)->Init();
+	data.resize(lcf::Data::actors.size(), Game_Actor(0));
+	for (size_t i = 0; i < data.size(); i++) {
+		data[i] = Game_Actor(i + 1);
 	}
 }
 
@@ -39,7 +39,7 @@ void Game_Actors::SetSaveData(std::vector<lcf::rpg::SaveActor> save) {
 	}
 
 	for (size_t i = 0; i < std::min(save.size(), data.size()); ++i) {
-		data[i]->SetSaveData(std::move(save[i]));
+		data[i].SetSaveData(std::move(save[i]));
 	}
 }
 
@@ -47,7 +47,7 @@ std::vector<lcf::rpg::SaveActor> Game_Actors::GetSaveData() const {
 	std::vector<lcf::rpg::SaveActor> save;
 	save.reserve(data.size());
 	for (auto& actor: data) {
-		save.push_back(actor->GetSaveData());
+		save.push_back(actor.GetSaveData());
 	}
 	return save;
 }
@@ -55,20 +55,17 @@ std::vector<lcf::rpg::SaveActor> Game_Actors::GetSaveData() const {
 Game_Actor* Game_Actors::GetActor(int actor_id) {
 	if (!ActorExists(actor_id)) {
 		return nullptr;
-	} else if (!data[actor_id - 1]) {
-		data[actor_id - 1].reset(new Game_Actor(actor_id));
 	}
 
-	return data[actor_id - 1].get();
+	return &data[actor_id - 1];
 }
 
 bool Game_Actors::ActorExists(int actor_id) {
-	return actor_id > 0 && (size_t)actor_id <= data.size();
+	return actor_id > 0 && actor_id <= static_cast<int>(data.size());
 }
 
 void Game_Actors::ResetBattle() {
-	for (size_t i = 1; i <= data.size(); ++i) {
-		GetActor(i)->ResetBattle();
+	for (auto& actor: data) {
+		actor.ResetBattle();
 	}
-
 }

--- a/src/game_actors.cpp
+++ b/src/game_actors.cpp
@@ -22,14 +22,14 @@
 #include "main_data.h"
 #include "output.h"
 
-namespace {
-	std::vector<std::shared_ptr<Game_Actor> > data;
+Game_Actors::Game_Actors() {
+	data.resize(lcf::Data::actors.size());
+	for (size_t i = 1; i <= data.size(); i++) {
+		GetActor(i)->Init();
+	}
 }
 
-void Game_Actors::Init() {
-	data.resize(lcf::Data::actors.size());
-	for (size_t i = 1; i <= data.size(); i++)
-		GetActor(i)->Init();
+Game_Actors::~Game_Actors() {
 }
 
 void Game_Actors::Fixup() {
@@ -52,10 +52,6 @@ void Game_Actors::Fixup() {
 	for (size_t i = 1; i <= data.size(); ++i) {
 		GetActor(i)->Fixup();
 	}
-}
-
-void Game_Actors::Dispose() {
-	data.clear();
 }
 
 Game_Actor* Game_Actors::GetActor(int actor_id) {

--- a/src/game_actors.h
+++ b/src/game_actors.h
@@ -36,11 +36,6 @@ public:
 	Game_Actors(const Game_Actors&) = delete;
 	Game_Actors& operator=(const Game_Actors&) = delete;
 
-	/**
-	 * Disposes Game Actors.
-	 */
-	~Game_Actors();
-
 	void SetSaveData(std::vector<lcf::rpg::SaveActor> save);
 	std::vector<lcf::rpg::SaveActor> GetSaveData() const;
 

--- a/src/game_actors.h
+++ b/src/game_actors.h
@@ -33,6 +33,9 @@ public:
 	 */
 	Game_Actors();
 
+	Game_Actors(const Game_Actors&) = delete;
+	Game_Actors& operator=(const Game_Actors&) = delete;
+
 	/**
 	 * Disposes Game Actors.
 	 */
@@ -63,7 +66,7 @@ public:
 	void ResetBattle();
 
 private:
-	std::vector<std::shared_ptr<Game_Actor> > data;
+	std::vector<Game_Actor> data;
 };
 
 #endif

--- a/src/game_actors.h
+++ b/src/game_actors.h
@@ -26,22 +26,23 @@
 /**
  * Game_Actors namespace.
  */
-namespace Game_Actors {
+class Game_Actors {
+public:
 	/**
 	 * Initializes Game Actors.
 	 */
-	void Init();
+	Game_Actors();
+
+	/**
+	 * Disposes Game Actors.
+	 */
+	~Game_Actors();
 
 	/**
 	 * Used after savegame loading to replace savegame default values with
 	 * database ones.
 	 */
 	void Fixup();
-
-	/**
-	 * Disposes Game Actors.
-	 */
-	void Dispose();
 
 	/**
 	 * Gets an actor by its ID.
@@ -63,6 +64,9 @@ namespace Game_Actors {
 	 * Resets battle modifiers of all actors.
 	 */
 	void ResetBattle();
-}
+
+private:
+	std::vector<std::shared_ptr<Game_Actor> > data;
+};
 
 #endif

--- a/src/game_actors.h
+++ b/src/game_actors.h
@@ -38,11 +38,8 @@ public:
 	 */
 	~Game_Actors();
 
-	/**
-	 * Used after savegame loading to replace savegame default values with
-	 * database ones.
-	 */
-	void Fixup();
+	void SetSaveData(std::vector<lcf::rpg::SaveActor> save);
+	std::vector<lcf::rpg::SaveActor> GetSaveData() const;
 
 	/**
 	 * Gets an actor by its ID.

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -593,7 +593,7 @@ Point Game_Battle::Calculate2k3BattlePosition(const Game_Enemy& enemy) {
 	// If monster is hidden -> use real party idx / real party size
 	// If monster is visible -> use visible party idx / visible party size
 	for (auto& e: Main_Data::game_enemyparty->GetEnemies()) {
-		if (e.get() == &enemy) {
+		if (e == &enemy) {
 			found_myself = true;
 		}
 		if (enemy.IsHidden() || !e->IsHidden()) {

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -87,7 +87,7 @@ void Game_Battle::Init(int troop_id) {
 		return false;
 	});
 
-	Game_Actors::ResetBattle();
+	Main_Data::game_actors->ResetBattle();
 
 	for (auto* actor: Main_Data::game_party->GetActors()) {
 		actor->ResetEquipmentStates(true);
@@ -118,7 +118,7 @@ void Game_Battle::Quit() {
 	page_executed.clear();
 	page_can_run.clear();
 
-	Game_Actors::ResetBattle();
+	Main_Data::game_actors->ResetBattle();
 	Main_Data::game_enemyparty->ResetBattle(0);
 	Main_Data::game_pictures->OnBattleEnd();
 }
@@ -203,8 +203,8 @@ void Game_Battle::NextTurn(Game_Battler* battler) {
 			// Reset pages of specific actor after that actors turn
 			if (page_executed[page.ID - 1]) {
 				if (battler->GetType() == Game_Battler::Type_Ally &&
-						((condition.flags.turn_actor && Game_Actors::GetActor(condition.turn_actor_id) == battler) ||
-						(condition.flags.command_actor && Game_Actors::GetActor(condition.command_actor_id) == battler))) {
+						((condition.flags.turn_actor && Main_Data::game_actors->GetActor(condition.turn_actor_id) == battler) ||
+						(condition.flags.command_actor && Main_Data::game_actors->GetActor(condition.command_actor_id) == battler))) {
 					page_executed[page.ID - 1] = false;
 				}
 			}
@@ -309,7 +309,7 @@ bool Game_Battle::AreConditionsMet(const lcf::rpg::TroopPageCondition& condition
 		return false;
 
 	if (condition.flags.turn_actor &&
-		!CheckTurns(Game_Actors::GetActor(condition.turn_actor_id)->GetBattleTurn(), condition.turn_actor_b, condition.turn_actor_a))
+		!CheckTurns(Main_Data::game_actors->GetActor(condition.turn_actor_id)->GetBattleTurn(), condition.turn_actor_b, condition.turn_actor_a))
 		return false;
 
 	if (condition.flags.fatigue) {
@@ -328,7 +328,7 @@ bool Game_Battle::AreConditionsMet(const lcf::rpg::TroopPageCondition& condition
 	}
 
 	if (condition.flags.actor_hp) {
-		Game_Actor* actor = Game_Actors::GetActor(condition.actor_id);
+		Game_Actor* actor = Main_Data::game_actors->GetActor(condition.actor_id);
 		int hp = actor->GetHp();
 		int hpmin = actor->GetMaxHp() * condition.actor_hp_min / 100;
 		int hpmax = actor->GetMaxHp() * condition.actor_hp_max / 100;
@@ -337,7 +337,7 @@ bool Game_Battle::AreConditionsMet(const lcf::rpg::TroopPageCondition& condition
 	}
 
 	if (condition.flags.command_actor &&
-		condition.command_id != Game_Actors::GetActor(condition.command_actor_id)->GetLastBattleAction())
+		condition.command_id != Main_Data::game_actors->GetActor(condition.command_actor_id)->GetLastBattleAction())
 		return false;
 
 	return true;

--- a/src/game_battle.h
+++ b/src/game_battle.h
@@ -207,16 +207,6 @@ namespace Game_Battle {
 	 */
 	void SetNeedRefresh(bool refresh);
 
-	/**
-	 * Uses RPG_RT algorithm for performing a variance adjument to damage/healing effects and returns the result.
-	 *
-	 * @param base - the base amount of the effect
-	 * @param var - the variance level from 0 to 10
-	 *
-	 * @return the adjusted damage amount
-	 */
-	int VarianceAdjustEffect(int base, int var);
-
 	struct BattleTest {
 		bool enabled = false;
 		int troop_id = 0;
@@ -246,14 +236,6 @@ namespace Game_Battle {
 
 inline bool Game_Battle::IsBattleRunning() {
 	return battle_running;
-}
-
-inline int Game_Battle::VarianceAdjustEffect(int base, int var) {
-	if (var > 0) {
-		int adj = std::max(1, var * base / 10);
-		return base + Utils::GetRandomNumber(0, adj) - adj / 2;
-	}
-	return base;
 }
 
 #endif

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -914,7 +914,7 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 	auto& source = *GetSource();
 	auto& target = *GetTarget();
 
-	auto to_hit = Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, Game_Battle::GetBattleCondition());
+	auto to_hit = Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, Game_Battle::GetBattleCondition(), true);
 	auto crit_chance = Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll);
 
 	// Damage calculation
@@ -923,7 +923,8 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 			critical_hit = true;
 		}
 
-		auto effect = Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, critical_hit, true, Game_Battle::GetBattleCondition());
+		// FIXME: Differentiate the cases where 2k3 back attack bug applies
+		auto effect = Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, critical_hit, true, Game_Battle::GetBattleCondition(), true);
 		effect = Algo::AdjustDamageForDefend(effect, target);
 		// FIXME: Handle negative effect from attributes
 		effect = Utils::Clamp(effect, 0, MaxDamageValue());

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -914,8 +914,8 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 	auto& source = *GetSource();
 	auto& target = *GetTarget();
 
-	auto to_hit = Algo::CalcNormalAttackToHit(source, target, Game_Battler::kWeaponAll, Game_Battle::GetBattleCondition());
-	auto crit_chance = Algo::CalcCriticalHitChance(source, target, Game_Battler::kWeaponAll);
+	auto to_hit = Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, Game_Battle::GetBattleCondition());
+	auto crit_chance = Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll);
 
 	// Damage calculation
 	if (Utils::PercentChance(to_hit)) {
@@ -923,7 +923,7 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 			critical_hit = true;
 		}
 
-		auto effect = Algo::CalcNormalAttackEffect(source, target, Game_Battler::kWeaponAll, critical_hit, true, Game_Battle::GetBattleCondition());
+		auto effect = Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, critical_hit, true, Game_Battle::GetBattleCondition());
 		effect = Algo::AdjustDamageForDefend(effect, target);
 		// FIXME: Handle negative effect from attributes
 		effect = Utils::Clamp(effect, 0, MaxDamageValue());

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -914,8 +914,8 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 	auto& source = *GetSource();
 	auto& target = *GetTarget();
 
-	auto to_hit = Algo::CalcNormalAttackToHit(source, target, Game_Battle::GetBattleCondition());
-	auto crit_chance = Algo::CalcCriticalHitChance(source, target);
+	auto to_hit = Algo::CalcNormalAttackToHit(source, target, Game_Battler::kWeaponAll, Game_Battle::GetBattleCondition());
+	auto crit_chance = Algo::CalcCriticalHitChance(source, target, Game_Battler::kWeaponAll);
 
 	// Damage calculation
 	if (Utils::PercentChance(to_hit)) {
@@ -923,7 +923,7 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 			critical_hit = true;
 		}
 
-		auto effect = Algo::CalcNormalAttackEffect(source, target, critical_hit, true, Game_Battle::GetBattleCondition());
+		auto effect = Algo::CalcNormalAttackEffect(source, target, Game_Battler::kWeaponAll, critical_hit, true, Game_Battle::GetBattleCondition());
 		effect = Algo::AdjustDamageForDefend(effect, target);
 		// FIXME: Handle negative effect from attributes
 		effect = Utils::Clamp(effect, 0, MaxDamageValue());

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -503,19 +503,19 @@ static int AdjustParam(int base, int mod, int maxval, Span<const int16_t> states
 }
 
 int Game_Battler::GetAtk(Weapon weapon) const {
-	return AdjustParam(GetBaseAtk(weapon), atk_modifier, MaxStatBaseValue(), GetInflictedStates(), &lcf::rpg::State::affect_attack);
+	return AdjustParam(GetBaseAtk(weapon), atk_modifier, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_attack);
 }
 
 int Game_Battler::GetDef(Weapon weapon) const {
-	return AdjustParam(GetBaseDef(weapon), def_modifier, MaxStatBaseValue(), GetInflictedStates(), &lcf::rpg::State::affect_defense);
+	return AdjustParam(GetBaseDef(weapon), def_modifier, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_defense);
 }
 
 int Game_Battler::GetSpi(Weapon weapon) const {
-	return AdjustParam(GetBaseSpi(weapon), spi_modifier, MaxStatBaseValue(), GetInflictedStates(), &lcf::rpg::State::affect_spirit);
+	return AdjustParam(GetBaseSpi(weapon), spi_modifier, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_spirit);
 }
 
 int Game_Battler::GetAgi(Weapon weapon) const {
-	return AdjustParam(GetBaseAgi(weapon), agi_modifier, MaxStatBaseValue(), GetInflictedStates(), &lcf::rpg::State::affect_agility);
+	return AdjustParam(GetBaseAgi(weapon), agi_modifier, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_agility);
 }
 
 int Game_Battler::GetDisplayX() const {

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -43,8 +43,6 @@
 #include "attribute.h"
 #include "algo.h"
 
-constexpr int Game_Battler::kWeaponAll;
-
 Game_Battler::Game_Battler() {
 	ResetBattle();
 }
@@ -504,19 +502,19 @@ static int AdjustParam(int base, int mod, int maxval, Span<const int16_t> states
 	return value;
 }
 
-int Game_Battler::GetAtk(int weapon) const {
+int Game_Battler::GetAtk(Weapon weapon) const {
 	return AdjustParam(GetBaseAtk(weapon), atk_modifier, MaxStatBaseValue(), GetInflictedStates(), &lcf::rpg::State::affect_attack);
 }
 
-int Game_Battler::GetDef(int weapon) const {
+int Game_Battler::GetDef(Weapon weapon) const {
 	return AdjustParam(GetBaseDef(weapon), def_modifier, MaxStatBaseValue(), GetInflictedStates(), &lcf::rpg::State::affect_defense);
 }
 
-int Game_Battler::GetSpi(int weapon) const {
+int Game_Battler::GetSpi(Weapon weapon) const {
 	return AdjustParam(GetBaseSpi(weapon), spi_modifier, MaxStatBaseValue(), GetInflictedStates(), &lcf::rpg::State::affect_spirit);
 }
 
-int Game_Battler::GetAgi(int weapon) const {
+int Game_Battler::GetAgi(Weapon weapon) const {
 	return AdjustParam(GetBaseAgi(weapon), agi_modifier, MaxStatBaseValue(), GetInflictedStates(), &lcf::rpg::State::affect_agility);
 }
 

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -43,6 +43,8 @@
 #include "attribute.h"
 #include "algo.h"
 
+constexpr int Game_Battler::kWeaponAll;
+
 Game_Battler::Game_Battler() {
 	ResetBattle();
 }
@@ -476,8 +478,8 @@ static int AffectParameter(const int type, const int val) {
 		val;
 }
 
-int Game_Battler::GetAtk() const {
-	int base_atk = GetBaseAtk();
+int Game_Battler::GetAtk(int weapon) const {
+	int base_atk = GetBaseAtk(weapon);
 	int n = Utils::Clamp(base_atk, 1, MaxStatBaseValue());
 
 	for (int16_t i : GetInflictedStates()) {
@@ -496,8 +498,8 @@ int Game_Battler::GetAtk() const {
 	return n;
 }
 
-int Game_Battler::GetDef() const {
-	int base_def = GetBaseDef();
+int Game_Battler::GetDef(int weapon) const {
+	int base_def = GetBaseDef(weapon);
 	int n = Utils::Clamp(base_def, 1, MaxStatBaseValue());
 
 	for (int16_t i : GetInflictedStates()) {
@@ -516,8 +518,8 @@ int Game_Battler::GetDef() const {
 	return n;
 }
 
-int Game_Battler::GetSpi() const {
-	int base_spi = GetBaseSpi();
+int Game_Battler::GetSpi(int weapon) const {
+	int base_spi = GetBaseSpi(weapon);
 	int n = Utils::Clamp(base_spi, 1, MaxStatBaseValue());
 
 	for (int16_t i : GetInflictedStates()) {
@@ -536,8 +538,8 @@ int Game_Battler::GetSpi() const {
 	return n;
 }
 
-int Game_Battler::GetAgi() const {
-	int base_agi = GetBaseAgi();
+int Game_Battler::GetAgi(int weapon) const {
+	int base_agi = GetBaseAgi(weapon);
 	int n = Utils::Clamp(base_agi, 1, MaxStatBaseValue());
 
 	for (int16_t i : GetInflictedStates()) {

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -595,12 +595,12 @@ void Game_Battler::ResetBattle() {
 }
 
 void Game_Battler::ShiftAttributeRate(int attribute_id, int shift) {
-	if (attribute_id < 1 || attribute_id > (int)lcf::Data::attributes.size()) {
-		assert(false && "invalid attribute_id");
+	if (attribute_id < 1 || attribute_id > static_cast<int>(lcf::Data::attributes.size())) {
+		return;
 	}
 
 	if (shift < -1 || shift > 1) {
-		assert(false && "Invalid shift");
+		return;
 	}
 
 	if (shift == 0) {
@@ -615,15 +615,15 @@ void Game_Battler::ShiftAttributeRate(int attribute_id, int shift) {
 	}
 }
 
-int Game_Battler::GetAttributeRateShift(int attribute_id) {
-	if (attribute_id < 1 || attribute_id >(int)lcf::Data::attributes.size()) {
-		assert(false && "invalid attribute_id");
+int Game_Battler::GetAttributeRateShift(int attribute_id) const {
+	if (attribute_id < 1 || attribute_id > static_cast<int>(lcf::Data::attributes.size())) {
+		return 0;
 	}
 	return attribute_shift[attribute_id - 1];
 }
 
 bool Game_Battler::CanShiftAttributeRate(int attribute_id, int shift) const {
-	if (attribute_id < 1 || attribute_id > (int)lcf::Data::attributes.size()) {
+	if (attribute_id < 1 || attribute_id > static_cast<int>(lcf::Data::attributes.size())) {
 		return false;
 	}
 	auto new_shift = attribute_shift[attribute_id - 1] + shift;

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -594,25 +594,19 @@ void Game_Battler::ResetBattle() {
 	SetBattleAlgorithm(nullptr);
 }
 
+int Game_Battler::GetAttributeRate(int attribute_id) const {
+	auto rate = GetBaseAttributeRate(attribute_id);
+	rate += GetAttributeRateShift(attribute_id);
+	return Utils::Clamp(rate, 0, 4);
+}
+
 void Game_Battler::ShiftAttributeRate(int attribute_id, int shift) {
 	if (attribute_id < 1 || attribute_id > static_cast<int>(lcf::Data::attributes.size())) {
 		return;
 	}
 
-	if (shift < -1 || shift > 1) {
-		return;
-	}
-
-	if (shift == 0) {
-		return;
-	}
-
-	int& old_shift = attribute_shift[attribute_id - 1];
-	if ((old_shift == -1 || old_shift == 0) && shift == 1) {
-		++old_shift;
-	} else if ((old_shift == 1 || old_shift == 0) && shift == -1) {
-		--old_shift;
-	}
+	auto& a = attribute_shift[attribute_id -1];
+	a = Utils::Clamp(a + shift, -1, 1);
 }
 
 int Game_Battler::GetAttributeRateShift(int attribute_id) const {

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -469,13 +469,6 @@ bool Game_Battler::HasFullSp() const {
 	return GetMaxSp() == GetSp();
 }
 
-static int AffectParameter(const int type, const int val) {
-	return
-		type == 0? val / 2 :
-		type == 1? val * 2 :
-		val;
-}
-
 static int AdjustParam(int base, int mod, int maxval, Span<const int16_t> states, bool lcf::rpg::State::*adj) {
 	auto value = Utils::Clamp(base + mod, 1, maxval);
 	bool half = false;
@@ -492,7 +485,7 @@ static int AdjustParam(int base, int mod, int maxval, Span<const int16_t> states
 		if (dbl) {
 			value *= 2;
 		} else {
-			value = std::max(1, value /= 2);
+			value = std::max(1, value / 2);
 		}
 	}
 	// NOTE: RPG_RT does not clamp these values to the upper range!

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -41,6 +41,7 @@
 #include "state.h"
 #include "shake.h"
 #include "attribute.h"
+#include "algo.h"
 
 Game_Battler::Game_Battler() {
 	ResetBattle();
@@ -265,17 +266,8 @@ bool Game_Battler::UseSkill(int skill_id, const Game_Battler* source) {
 		}
 
 		// Calculate effect:
-		int effect = skill->power;
-		if (source != nullptr) {
-			effect += source->GetAtk() * skill->physical_rate / 20 +
-				source->GetSpi() * skill->magical_rate / 40;
-		}
-		Attribute::ApplyAttributeMultiplier(effect, *skill, *source);
-
-		if (Player::IsLegacy() || effect > 0) effect = Game_Battle::VarianceAdjustEffect(effect, skill->variance);
-
-		if (effect < 0)
-			effect = 0;
+		// FIXME: What about negative attributes? Does it do damage here? Can it kill?
+		auto effect = Algo::CalcSkillEffect(*source, *this, *skill, true);
 
 		// Cure states
 		for (int i = 0; i < (int)skill->state_effects.size(); i++) {

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -173,7 +173,7 @@ public:
 	 * @param attribute_id Attribute modified
 	 * @return shift Shift applied.
 	 */
-	int GetAttributeRateShift(int attribute_id);
+	int GetAttributeRateShift(int attribute_id) const;
 
 	/**
 	 * Gets probability that a state can be inflicted on this actor.

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -694,7 +694,7 @@ public:
 	/**
 	 * Initializes battle related data to there default values.
 	 */
-	virtual void ResetBattle();
+	void ResetBattle();
 
 	/**
 	 * @return Effective physical hit rate modifier from inflicted states.

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -147,15 +147,6 @@ public:
 	int GetStateRate(int state_id, int rate) const;
 
 	/**
-	 * Gets the attribute damage multiplier/protection (A-E).
-	 *
-	 * @param attribute_id Attribute to test
-	 * @param rate Attribute rate to get
-	 * @return Attribute rate
-	 */
-	int GetAttributeRate(int attribute_id, int rate) const;
-
-	/**
 	 * Applies a modifier (buff/debuff) to an attribute rate.
 	 * GetAttributeModifier will use this shift in the rate lookup.
 	 * A shift of +1 changed a C to D and a -1 a C to B.
@@ -197,14 +188,6 @@ public:
 	 * @return Attribute resistence
 	 */
 	virtual int GetAttributeModifier(int attribute_id) const = 0;
-
-	/**
-	 * Gets the final effect multiplier when a skill/attack is targeting this battler.
-	 *
-	 * @param attributes set for the incoming action
-	 * @return effect multiplier
-	 */
-	float GetAttributeMultiplier(const lcf::DBBitArray& attributes_set) const;
 
 	/**
 	 * Gets the characters name

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -149,6 +149,22 @@ public:
 	int GetStateRate(int state_id, int rate) const;
 
 	/**
+	 * Gets the base attribute rate when actor is damaged, without battle attribute shifts.
+	 * 
+	 * @param attribute_id Attribute to query
+	 * @return Attribute rate
+	 */
+	virtual int GetBaseAttributeRate(int attribute_id) const;
+
+	/**
+	 * Gets the attribute rate when actor is damaged.
+	 * 
+	 * @param attribute_id Attribute to query
+	 * @return Attribute rate
+	 */
+	int GetAttributeRate(int attribute_id) const;
+
+	/**
 	 * Applies a modifier (buff/debuff) to an attribute rate.
 	 * GetAttributeModifier will use this shift in the rate lookup.
 	 * A shift of +1 changed a C to D and a -1 a C to B.
@@ -182,14 +198,6 @@ public:
 	 * @return Probability of state infliction
 	 */
 	virtual int GetStateProbability(int state_id) const = 0;
-
-	/**
-	 * Gets attribute protection when the actor is damaged.
-	 *
-	 * @param attribute_id Attribute to test
-	 * @return Attribute resistence
-	 */
-	virtual int GetAttributeModifier(int attribute_id) const = 0;
 
 	/**
 	 * Gets the characters name
@@ -896,6 +904,10 @@ inline bool Game_Battler::IsDirectionFlipped() const {
 
 inline void Game_Battler::SetDirectionFlipped(bool flip) {
 	direction_flipped = flip;
+}
+
+inline int Game_Battler::GetBaseAttributeRate(int attribute_id) const {
+	return 2;
 }
 
 #endif

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -937,7 +937,7 @@ inline void Game_Battler::SetDirectionFlipped(bool flip) {
 	direction_flipped = flip;
 }
 
-inline int Game_Battler::GetBaseAttributeRate(int attribute_id) const {
+inline int Game_Battler::GetBaseAttributeRate(int) const {
 	return 2;
 }
 

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -164,7 +164,7 @@ public:
 	 * @param attribute_id Attribute to query
 	 * @return Attribute rate
 	 */
-	virtual int GetBaseAttributeRate(int attribute_id) const;
+	virtual int GetBaseAttributeRate(int attribute_id) const = 0;
 
 	/**
 	 * Gets the attribute rate when actor is damaged.
@@ -935,10 +935,6 @@ inline bool Game_Battler::IsDirectionFlipped() const {
 
 inline void Game_Battler::SetDirectionFlipped(bool flip) {
 	direction_flipped = flip;
-}
-
-inline int Game_Battler::GetBaseAttributeRate(int) const {
-	return 2;
 }
 
 #endif

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -46,6 +46,8 @@ typedef std::shared_ptr<Game_BattleAlgorithm::AlgorithmBase> BattleAlgorithmRef;
  */
 class Game_Battler {
 public:
+	static constexpr int kWeaponAll = -1;
+
 	/**
 	 * Constructor.
 	 */
@@ -275,28 +277,28 @@ public:
 	 *
 	 * @return current attack.
 	 */
-	virtual int GetAtk() const;
+	int GetAtk(int weapon = Game_Battler::kWeaponAll) const;
 
 	/**
 	 * Gets the current battler defense.
 	 *
 	 * @return current defense.
 	 */
-	virtual int GetDef() const;
+	int GetDef(int weapon = Game_Battler::kWeaponAll) const;
 
 	/**
 	 * Gets the current battler spirit.
 	 *
 	 * @return current spirit.
 	 */
-	virtual int GetSpi() const;
+	int GetSpi(int weapon = Game_Battler::kWeaponAll) const;
 
 	/**
 	 * Gets the current battler agility.
 	 *
 	 * @return current agility.
 	 */
-	virtual int GetAgi() const;
+	int GetAgi(int weapon = Game_Battler::kWeaponAll) const;
 
 	/**
 	 * Gets the maximum HP for the current level.
@@ -317,28 +319,28 @@ public:
 	 *
 	 * @return attack.
 	 */
-	virtual int GetBaseAtk() const = 0;
+	virtual int GetBaseAtk(int weapon = kWeaponAll) const = 0;
 
 	/**
 	 * Gets the defense for the current level.
 	 *
 	 * @return defense.
 	 */
-	virtual int GetBaseDef() const = 0;
+	virtual int GetBaseDef(int weapon = kWeaponAll) const = 0;
 
 	/**
 	 * Gets the spirit for the current level.
 	 *
 	 * @return spirit.
 	 */
-	virtual int GetBaseSpi() const = 0;
+	virtual int GetBaseSpi(int weapon = kWeaponAll) const = 0;
 
 	/**
 	 * Gets the agility for the current level.
 	 *
 	 * @return agility.
 	 */
-	virtual int GetBaseAgi() const = 0;
+	virtual int GetBaseAgi(int weapon = kWeaponAll) const = 0;
 
 	/** @return whether the battler is facing the opposite it's normal direction */
 	bool IsDirectionFlipped() const;
@@ -500,9 +502,9 @@ public:
 
 	virtual int GetBattleAnimationId() const = 0;
 
-	virtual int GetHitChance() const = 0;
+	virtual int GetHitChance(int weapon = kWeaponAll) const = 0;
 
-	virtual float GetCriticalHitChance() const = 0;
+	virtual float GetCriticalHitChance(int weapon = kWeaponAll) const = 0;
 
 	/**
 	 * @return If battler is charged (next attack double damages)
@@ -538,7 +540,7 @@ public:
 	 *
 	 * @return true if a weapon is having preempt attribute
 	 */
-	virtual bool HasPreemptiveAttack() const;
+	virtual bool HasPreemptiveAttack(int weapon = kWeaponAll) const;
 
 	enum BattlerType {
 		Type_Ally,
@@ -794,7 +796,7 @@ inline bool Game_Battler::HasStrongDefense() const {
 	return false;
 }
 
-inline bool Game_Battler::HasPreemptiveAttack() const {
+inline bool Game_Battler::HasPreemptiveAttack(int) const {
 	return false;
 }
 

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -46,7 +46,17 @@ typedef std::shared_ptr<Game_BattleAlgorithm::AlgorithmBase> BattleAlgorithmRef;
  */
 class Game_Battler {
 public:
-	static constexpr int kWeaponAll = -1;
+	/** Weapon mode used for various accessors, used to specify which weapons to include in calculation */
+	enum Weapon {
+		/** Use all weapons combined */
+		WeaponAll = -1,
+		/** Use no weapons */
+		WeaponNone = 0,
+		/** Use only primary weapon */
+		WeaponPrimary = 1,
+		/** Use only secondary weapon */
+		WeaponSecondary = 2,
+	};
 
 	/**
 	 * Constructor.
@@ -283,30 +293,34 @@ public:
 	/**
 	 * Gets the current battler attack.
 	 *
+	 * @param weapon Which weapons to include in calculating result.
 	 * @return current attack.
 	 */
-	int GetAtk(int weapon = Game_Battler::kWeaponAll) const;
+	int GetAtk(Weapon weapon = Game_Battler::WeaponAll) const;
 
 	/**
 	 * Gets the current battler defense.
 	 *
+	 * @param weapon Which weapons to include in calculating result.
 	 * @return current defense.
 	 */
-	int GetDef(int weapon = Game_Battler::kWeaponAll) const;
+	int GetDef(Weapon weapon = Game_Battler::WeaponAll) const;
 
 	/**
 	 * Gets the current battler spirit.
 	 *
+	 * @param weapon Which weapons to include in calculating result.
 	 * @return current spirit.
 	 */
-	int GetSpi(int weapon = Game_Battler::kWeaponAll) const;
+	int GetSpi(Weapon weapon = Game_Battler::WeaponAll) const;
 
 	/**
 	 * Gets the current battler agility.
 	 *
+	 * @param weapon Which weapons to include in calculating result.
 	 * @return current agility.
 	 */
-	int GetAgi(int weapon = Game_Battler::kWeaponAll) const;
+	int GetAgi(Weapon weapon = Game_Battler::WeaponAll) const;
 
 	/**
 	 * Gets the maximum HP for the current level.
@@ -325,30 +339,34 @@ public:
 	/**
 	 * Gets the attack for the current level.
 	 *
+	 * @param weapon Which weapons to include in calculating result.
 	 * @return attack.
 	 */
-	virtual int GetBaseAtk(int weapon = kWeaponAll) const = 0;
+	virtual int GetBaseAtk(Weapon weapon = WeaponAll) const = 0;
 
 	/**
 	 * Gets the defense for the current level.
 	 *
+	 * @param weapon Which weapons to include in calculating result.
 	 * @return defense.
 	 */
-	virtual int GetBaseDef(int weapon = kWeaponAll) const = 0;
+	virtual int GetBaseDef(Weapon weapon = WeaponAll) const = 0;
 
 	/**
 	 * Gets the spirit for the current level.
 	 *
+	 * @param weapon Which weapons to include in calculating result.
 	 * @return spirit.
 	 */
-	virtual int GetBaseSpi(int weapon = kWeaponAll) const = 0;
+	virtual int GetBaseSpi(Weapon weapon = WeaponAll) const = 0;
 
 	/**
 	 * Gets the agility for the current level.
 	 *
+	 * @param weapon Which weapons to include in calculating result.
 	 * @return agility.
 	 */
-	virtual int GetBaseAgi(int weapon = kWeaponAll) const = 0;
+	virtual int GetBaseAgi(Weapon weapon = WeaponAll) const = 0;
 
 	/** @return whether the battler is facing the opposite it's normal direction */
 	bool IsDirectionFlipped() const;
@@ -510,9 +528,21 @@ public:
 
 	virtual int GetBattleAnimationId() const = 0;
 
-	virtual int GetHitChance(int weapon = kWeaponAll) const = 0;
+	/**
+	 * Gets the chance to hit for a normal attack.
+	 *
+	 * @param weapon Which weapons to include in calculating result.
+	 * @return hit rate. [0-100]
+	 */
+	virtual int GetHitChance(Weapon weapon = WeaponAll) const = 0;
 
-	virtual float GetCriticalHitChance(int weapon = kWeaponAll) const = 0;
+	/**
+	 * Gets the chance to critical hit for a normal attack.
+	 *
+	 * @param weapon Which weapons to include in calculating result.
+	 * @return critical hit rate [0.0f-1.0f]
+	 */
+	virtual float GetCriticalHitChance(Weapon weapon = WeaponAll) const = 0;
 
 	/**
 	 * @return If battler is charged (next attack double damages)
@@ -546,9 +576,10 @@ public:
 	/**
 	 * Tests if the battler has a weapon that grants preemption.
 	 *
+	 * @param weapon Which weapons to include in calculating result.
 	 * @return true if a weapon is having preempt attribute
 	 */
-	virtual bool HasPreemptiveAttack(int weapon = kWeaponAll) const;
+	virtual bool HasPreemptiveAttack(Weapon weapon = WeaponAll) const;
 
 	enum BattlerType {
 		Type_Ally,
@@ -804,7 +835,7 @@ inline bool Game_Battler::HasStrongDefense() const {
 	return false;
 }
 
-inline bool Game_Battler::HasPreemptiveAttack(int) const {
+inline bool Game_Battler::HasPreemptiveAttack(Weapon) const {
 	return false;
 }
 

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -77,13 +77,13 @@ int Game_Enemy::GetAttributeModifier(int attribute_id) const {
 
 	if (attribute_id >= 1 && attribute_id <= (int)enemy->attribute_ranks.size()) {
 		rate = enemy->attribute_ranks[attribute_id - 1];
-	}
 
-	rate += attribute_shift[attribute_id - 1];
-	if (rate < 0) {
-		rate = 0;
-	} else if (rate > 4) {
-		rate = 4;
+		rate += attribute_shift[attribute_id - 1];
+		if (rate < 0) {
+			rate = 0;
+		} else if (rate > 4) {
+			rate = 4;
+		}
 	}
 
 	return Attribute::GetAttributeRate(attribute_id, rate);

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -27,6 +27,7 @@
 #include "output.h"
 #include "utils.h"
 #include "player.h"
+#include "attribute.h"
 
 namespace {
 	constexpr int levitation_frame_count = 14;
@@ -82,7 +83,7 @@ int Game_Enemy::GetAttributeModifier(int attribute_id) const {
 		rate = 4;
 	}
 
-	return GetAttributeRate(attribute_id, rate);
+	return Attribute::GetAttributeRate(attribute_id, rate);
 }
 
 void Game_Enemy::SetHp(int _hp) {

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -118,11 +118,11 @@ void Game_Enemy::Transform(int new_enemy_id) {
 	}
 }
 
-int Game_Enemy::GetHitChance() const {
+int Game_Enemy::GetHitChance(int) const {
 	return enemy->miss ? 70 : 90;
 }
 
-float Game_Enemy::GetCriticalHitChance() const {
+float Game_Enemy::GetCriticalHitChance(int) const {
 	return enemy->critical_hit ? (1.0f / enemy->critical_hit_chance) : 0.0f;
 }
 

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -114,11 +114,11 @@ void Game_Enemy::Transform(int new_enemy_id) {
 	}
 }
 
-int Game_Enemy::GetHitChance(int) const {
+int Game_Enemy::GetHitChance(Weapon) const {
 	return enemy->miss ? 70 : 90;
 }
 
-float Game_Enemy::GetCriticalHitChance(int) const {
+float Game_Enemy::GetCriticalHitChance(Weapon) const {
 	return enemy->critical_hit ? (1.0f / enemy->critical_hit_chance) : 0.0f;
 }
 

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -65,7 +65,7 @@ int Game_Enemy::MaxStatBaseValue() const {
 int Game_Enemy::GetStateProbability(int state_id) const {
 	int rate = 2; // C - default
 
-	if (state_id <= (int)enemy->state_ranks.size()) {
+	if (state_id >= 1 && state_id <= (int)enemy->state_ranks.size()) {
 		rate = enemy->state_ranks[state_id - 1];
 	}
 
@@ -75,7 +75,7 @@ int Game_Enemy::GetStateProbability(int state_id) const {
 int Game_Enemy::GetAttributeModifier(int attribute_id) const {
 	int rate = 2; // C - default
 
-	if (attribute_id <= (int)enemy->attribute_ranks.size()) {
+	if (attribute_id >= 1 && attribute_id <= (int)enemy->attribute_ranks.size()) {
 		rate = enemy->attribute_ranks[attribute_id - 1];
 	}
 

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -34,9 +34,12 @@ namespace {
 	constexpr int levitation_frame_cycle = 20;
 }
 
-Game_Enemy::Game_Enemy(const lcf::rpg::TroopMember& member)
-	: troop_member(&member)
+Game_Enemy::Game_Enemy(const lcf::rpg::TroopMember* member)
+	: troop_member(member)
 {
+	if (troop_member == nullptr) {
+		return;
+	}
 	Transform(troop_member->enemy_id);
 
 	hp = GetMaxHp();

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -72,21 +72,14 @@ int Game_Enemy::GetStateProbability(int state_id) const {
 	return GetStateRate(state_id, rate);
 }
 
-int Game_Enemy::GetAttributeModifier(int attribute_id) const {
+int Game_Enemy::GetBaseAttributeRate(int attribute_id) const {
 	int rate = 2; // C - default
 
 	if (attribute_id >= 1 && attribute_id <= (int)enemy->attribute_ranks.size()) {
 		rate = enemy->attribute_ranks[attribute_id - 1];
-
-		rate += attribute_shift[attribute_id - 1];
-		if (rate < 0) {
-			rate = 0;
-		} else if (rate > 4) {
-			rate = 4;
-		}
 	}
 
-	return Attribute::GetAttributeRate(attribute_id, rate);
+	return rate;
 }
 
 void Game_Enemy::SetHp(int _hp) {

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -52,12 +52,12 @@ public:
 	int GetStateProbability(int state_id) const override;
 
 	/**
-	 * Gets attribute multiplier when the enemy is damaged.
-	 *
-	 * @param attribute_id Attribute to test
-	 * @return Attribute resistence
+	 * Gets the base attribute rate when actor is damaged.
+	 * 
+	 * @param attribute_id Attribute to query
+	 * @return Attribute rate
 	 */
-	int GetAttributeModifier(int attribute_id) const override;
+	int GetBaseAttributeRate(int attribute_id) const override;
 
 	/**
 	 * Gets the enemy ID.

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -97,6 +97,7 @@ public:
 	/**
 	 * Gets the attack for the current level.
 	 *
+	 * @param weapon which weapons to include in calculating result.
 	 * @return attack.
 	 */
 	int GetBaseAtk(Weapon = WeaponAll) const override;
@@ -104,6 +105,7 @@ public:
 	/**
 	 * Gets the defense for the current level.
 	 *
+	 * @param weapon which weapons to include in calculating result.
 	 * @return defense.
 	 */
 	int GetBaseDef(Weapon = WeaponAll) const override;
@@ -111,6 +113,7 @@ public:
 	/**
 	 * Gets the spirit for the current level.
 	 *
+	 * @param weapon which weapons to include in calculating result.
 	 * @return spirit.
 	 */
 	int GetBaseSpi(Weapon = WeaponAll) const override;
@@ -118,6 +121,7 @@ public:
 	/**
 	 * Gets the agility for the current level.
 	 *
+	 * @param weapon which weapons to include in calculating result.
 	 * @return agility.
 	 */
 	int GetBaseAgi(Weapon = WeaponAll) const override;
@@ -132,7 +136,20 @@ public:
 
 	void Transform(int new_enemy_id);
 
+	/**
+	 * Gets the chance to hit for a normal attack.
+	 *
+	 * @param weapon Which weapons to include in calculating result.
+	 * @return hit rate. [0-100]
+	 */
 	int GetHitChance(Weapon = WeaponAll) const override;
+
+	/**
+	 * Gets the chance to hit for a normal attack.
+	 *
+	 * @param weapon Which weapons to include in calculating result.
+	 * @return hit rate. [0-100]
+	 */
 	float GetCriticalHitChance(Weapon = WeaponAll) const override;
 	int GetBattleAnimationId() const override;
 

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -99,28 +99,28 @@ public:
 	 *
 	 * @return attack.
 	 */
-	int GetBaseAtk(int = kWeaponAll) const override;
+	int GetBaseAtk(Weapon = WeaponAll) const override;
 
 	/**
 	 * Gets the defense for the current level.
 	 *
 	 * @return defense.
 	 */
-	int GetBaseDef(int = kWeaponAll) const override;
+	int GetBaseDef(Weapon = WeaponAll) const override;
 
 	/**
 	 * Gets the spirit for the current level.
 	 *
 	 * @return spirit.
 	 */
-	int GetBaseSpi(int = kWeaponAll) const override;
+	int GetBaseSpi(Weapon = WeaponAll) const override;
 
 	/**
 	 * Gets the agility for the current level.
 	 *
 	 * @return agility.
 	 */
-	int GetBaseAgi(int = kWeaponAll) const override;
+	int GetBaseAgi(Weapon = WeaponAll) const override;
 
 	int GetHue() const override;
 
@@ -132,8 +132,8 @@ public:
 
 	void Transform(int new_enemy_id);
 
-	int GetHitChance(int = kWeaponAll) const override;
-	float GetCriticalHitChance(int = kWeaponAll) const override;
+	int GetHitChance(Weapon = WeaponAll) const override;
+	float GetCriticalHitChance(Weapon = WeaponAll) const override;
 	int GetBattleAnimationId() const override;
 
 	int GetExp() const;
@@ -221,19 +221,19 @@ inline int Game_Enemy::GetBaseMaxSp() const {
 	return enemy->max_sp;
 }
 
-inline int Game_Enemy::GetBaseAtk(int) const {
+inline int Game_Enemy::GetBaseAtk(Weapon) const {
 	return enemy->attack;
 }
 
-inline int Game_Enemy::GetBaseDef(int) const {
+inline int Game_Enemy::GetBaseDef(Weapon) const {
 	return enemy->defense;
 }
 
-inline int Game_Enemy::GetBaseSpi(int) const {
+inline int Game_Enemy::GetBaseSpi(Weapon) const {
 	return enemy->spirit;
 }
 
-inline int Game_Enemy::GetBaseAgi(int) const {
+inline int Game_Enemy::GetBaseAgi(Weapon) const {
 	return enemy->agility;
 }
 

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -132,8 +132,8 @@ public:
 
 	void Transform(int new_enemy_id);
 
-	int GetHitChance(int) const override;
-	float GetCriticalHitChance(int) const override;
+	int GetHitChance(int = kWeaponAll) const override;
+	float GetCriticalHitChance(int = kWeaponAll) const override;
 	int GetBattleAnimationId() const override;
 
 	int GetExp() const;

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -99,28 +99,28 @@ public:
 	 *
 	 * @return attack.
 	 */
-	int GetBaseAtk() const override;
+	int GetBaseAtk(int = kWeaponAll) const override;
 
 	/**
 	 * Gets the defense for the current level.
 	 *
 	 * @return defense.
 	 */
-	int GetBaseDef() const override;
+	int GetBaseDef(int = kWeaponAll) const override;
 
 	/**
 	 * Gets the spirit for the current level.
 	 *
 	 * @return spirit.
 	 */
-	int GetBaseSpi() const override;
+	int GetBaseSpi(int = kWeaponAll) const override;
 
 	/**
 	 * Gets the agility for the current level.
 	 *
 	 * @return agility.
 	 */
-	int GetBaseAgi() const override;
+	int GetBaseAgi(int = kWeaponAll) const override;
 
 	int GetHue() const override;
 
@@ -132,8 +132,8 @@ public:
 
 	void Transform(int new_enemy_id);
 
-	int GetHitChance() const override;
-	float GetCriticalHitChance() const override;
+	int GetHitChance(int) const override;
+	float GetCriticalHitChance(int) const override;
 	int GetBattleAnimationId() const override;
 
 	int GetExp() const;
@@ -221,19 +221,19 @@ inline int Game_Enemy::GetBaseMaxSp() const {
 	return enemy->max_sp;
 }
 
-inline int Game_Enemy::GetBaseAtk() const {
+inline int Game_Enemy::GetBaseAtk(int) const {
 	return enemy->attack;
 }
 
-inline int Game_Enemy::GetBaseDef() const {
+inline int Game_Enemy::GetBaseDef(int) const {
 	return enemy->defense;
 }
 
-inline int Game_Enemy::GetBaseSpi() const {
+inline int Game_Enemy::GetBaseSpi(int) const {
 	return enemy->spirit;
 }
 
-inline int Game_Enemy::GetBaseAgi() const {
+inline int Game_Enemy::GetBaseAgi(int) const {
 	return enemy->agility;
 }
 

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -30,7 +30,7 @@
 class Game_Enemy final : public Game_Battler
 {
 public:
-	explicit Game_Enemy(const lcf::rpg::TroopMember& tm);
+	explicit Game_Enemy(const lcf::rpg::TroopMember* tm);
 
 	const std::vector<int16_t>& GetStates() const override;
 	std::vector<int16_t>& GetStates() override;

--- a/src/game_enemyparty.h
+++ b/src/game_enemyparty.h
@@ -50,7 +50,7 @@ public:
 	 *
 	 * @return list of party members
 	 */
-	std::vector<std::shared_ptr<Game_Enemy> >& GetEnemies();
+	std::vector<Game_Enemy*> GetEnemies();
 
 	/**
 	 * Sums up the experience points of all enemy party members.
@@ -74,7 +74,7 @@ public:
 	void GenerateDrops(std::vector<int>& out) const;
 
 private:
-	std::vector<std::shared_ptr<Game_Enemy> > enemies;
+	std::vector<Game_Enemy> enemies;
 };
 
 #endif

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -995,7 +995,7 @@ bool Game_Interpreter::CommandControlVariables(lcf::rpg::EventCommand const& com
 			break;
 		case 5:
 			// Hero
-			actor = Game_Actors::GetActor(com.parameters[5]);
+			actor = Main_Data::game_actors->GetActor(com.parameters[5]);
 
 			if (!actor) {
 				Output::Warning("ControlVariables: Invalid actor ID {}", com.parameters[5]);
@@ -1354,7 +1354,7 @@ std::vector<Game_Actor*> Game_Interpreter::GetActors(int mode, int id) {
 		break;
 	case 1:
 		// Hero
-		actor = Game_Actors::GetActor(id);
+		actor = Main_Data::game_actors->GetActor(id);
 
 		if (!actor) {
 			Output::Warning("Invalid actor ID {}", id);
@@ -1365,7 +1365,7 @@ std::vector<Game_Actor*> Game_Interpreter::GetActors(int mode, int id) {
 		break;
 	case 2:
 		// Var hero
-		actor = Game_Actors::GetActor(Main_Data::game_variables->Get(id));
+		actor = Main_Data::game_actors->GetActor(Main_Data::game_variables->Get(id));
 		if (!actor) {
 			Output::Warning("Invalid actor ID {}", Main_Data::game_variables->Get(id));
 			return actors;
@@ -1482,7 +1482,7 @@ bool Game_Interpreter::CommandChangePartyMember(lcf::rpg::EventCommand const& co
 		id = Main_Data::game_variables->Get(com.parameters[2]);
 	}
 
-	actor = Game_Actors::GetActor(id);
+	actor = Main_Data::game_actors->GetActor(id);
 
 	if (!actor) {
 		Output::Warning("ChangePartyMember: Invalid actor ID {}", id);
@@ -1884,7 +1884,7 @@ bool Game_Interpreter::CommandGameOver(lcf::rpg::EventCommand const& /* com */) 
 }
 
 bool Game_Interpreter::CommandChangeHeroName(lcf::rpg::EventCommand const& com) { // code 10610
-	Game_Actor* actor = Game_Actors::GetActor(com.parameters[0]);
+	Game_Actor* actor = Main_Data::game_actors->GetActor(com.parameters[0]);
 
 	if (!actor) {
 		Output::Warning("ChangeHeroName: Invalid actor ID {}", com.parameters[0]);
@@ -1896,7 +1896,7 @@ bool Game_Interpreter::CommandChangeHeroName(lcf::rpg::EventCommand const& com) 
 }
 
 bool Game_Interpreter::CommandChangeHeroTitle(lcf::rpg::EventCommand const& com) { // code 10620
-	Game_Actor* actor = Game_Actors::GetActor(com.parameters[0]);
+	Game_Actor* actor = Main_Data::game_actors->GetActor(com.parameters[0]);
 
 	if (!actor) {
 		Output::Warning("ChangeHeroTitle: Invalid actor ID {}", com.parameters[0]);
@@ -1908,7 +1908,7 @@ bool Game_Interpreter::CommandChangeHeroTitle(lcf::rpg::EventCommand const& com)
 }
 
 bool Game_Interpreter::CommandChangeSpriteAssociation(lcf::rpg::EventCommand const& com) { // code 10630
-	Game_Actor* actor = Game_Actors::GetActor(com.parameters[0]);
+	Game_Actor* actor = Main_Data::game_actors->GetActor(com.parameters[0]);
 
 	if (!actor) {
 		Output::Warning("ChangeSpriteAssociation: Invalid actor ID {}", com.parameters[0]);
@@ -1924,7 +1924,7 @@ bool Game_Interpreter::CommandChangeSpriteAssociation(lcf::rpg::EventCommand con
 }
 
 bool Game_Interpreter::CommandChangeActorFace(lcf::rpg::EventCommand const& com) { // code 10640
-	Game_Actor* actor = Game_Actors::GetActor(com.parameters[0]);
+	Game_Actor* actor = Main_Data::game_actors->GetActor(com.parameters[0]);
 
 	if (!actor) {
 		Output::Warning("CommandChangeActorFace: Invalid actor ID {}", com.parameters[0]);
@@ -3039,7 +3039,7 @@ bool Game_Interpreter::CommandConditionalBranch(lcf::rpg::EventCommand const& co
 	case 5:
 		// Hero
 		actor_id = com.parameters[1];
-		actor = Game_Actors::GetActor(actor_id);
+		actor = Main_Data::game_actors->GetActor(actor_id);
 
 		if (!actor) {
 			Output::Warning("ConditionalBranch: Invalid actor ID {}", actor_id);

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -53,6 +53,7 @@
 #include "utils.h"
 #include "transition.h"
 #include "baseui.h"
+#include "algo.h"
 
 enum BranchSubcommand {
 	eOptionBranchElse = 1
@@ -1793,7 +1794,7 @@ bool Game_Interpreter::CommandSimulatedAttack(lcf::rpg::EventCommand const& com)
 		result -= (actor->GetDef() * def) / 400;
 		result -= (actor->GetSpi() * spi) / 800;
 		result = std::max(result, 0);
-		result = Game_Battle::VarianceAdjustEffect(result, var);
+		result = Algo::VarianceAdjustEffect(result, var);
 
 		result = std::max(0, result);
 		actor->ChangeHp(-result);

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -139,7 +139,7 @@ bool Game_Interpreter_Battle::CommandEnableCombo(lcf::rpg::EventCommand const& c
 	int command_id = com.parameters[1];
 	int multiple = com.parameters[2];
 
-	Game_Actor* actor = Game_Actors::GetActor(actor_id);
+	Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
 
 	if (!actor) {
 		Output::Warning("EnableCombo: Invalid actor ID {}", actor_id);
@@ -346,7 +346,7 @@ bool Game_Interpreter_Battle::CommandConditionalBranchBattle(lcf::rpg::EventComm
 			break;
 		case 2: {
 			// Hero can act
-			Game_Actor* actor = Game_Actors::GetActor(com.parameters[1]);
+			Game_Actor* actor = Main_Data::game_actors->GetActor(com.parameters[1]);
 
 			if (!actor) {
 				Output::Warning("ConditionalBranchBattle: Invalid actor ID {}", com.parameters[1]);
@@ -371,7 +371,7 @@ bool Game_Interpreter_Battle::CommandConditionalBranchBattle(lcf::rpg::EventComm
 			break;
 		case 5: {
 			// Hero uses the ... command
-			Game_Actor *actor = Game_Actors::GetActor(com.parameters[1]);
+			Game_Actor *actor = Main_Data::game_actors->GetActor(com.parameters[1]);
 
 			if (!actor) {
 				Output::Warning("ConditionalBranchBattle: Invalid actor ID {}", com.parameters[1]);

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -102,7 +102,7 @@ void Game_Party::SetupBattleTestMembers() {
 
 	for (auto& btdata : lcf::Data::system.battletest_data) {
 		AddActor(btdata.actor_id);
-		Game_Actor* actor = Game_Actors::GetActor(btdata.actor_id);
+		Game_Actor* actor = Main_Data::game_actors->GetActor(btdata.actor_id);
 
 		// Filter garbage btdata inserted by the editor
 		std::array<int, 5> ids = {{ btdata.weapon_id, btdata.shield_id, btdata.armor_id, btdata.helmet_id, btdata.accessory_id }};
@@ -140,7 +140,7 @@ int Game_Party::GetEquippedItemCount(int item_id) const {
 	int number = 0;
 	if (item_id > 0) {
 		for (int i = 0; i < (int) data.party.size(); i++) {
-			Game_Actor* actor = Game_Actors::GetActor(data.party[i]);
+			Game_Actor* actor = Main_Data::game_actors->GetActor(data.party[i]);
 			number += actor->GetItemCount(item_id);
 		}
 	}
@@ -474,13 +474,13 @@ std::vector<Game_Actor*> Game_Party::GetActors() const {
 	std::vector<Game_Actor*> actors;
 	std::vector<int16_t>::const_iterator it;
 	for (it = data.party.begin(); it != data.party.end(); ++it)
-		actors.push_back(Game_Actors::GetActor(*it));
+		actors.push_back(Main_Data::game_actors->GetActor(*it));
 	return actors;
 }
 
 Game_Actor* Game_Party::GetActor(int idx) const {
 	if (idx < static_cast<int>(data.party.size())) {
-		return Game_Actors::GetActor(data.party[idx]);
+		return Main_Data::game_actors->GetActor(data.party[idx]);
 	}
 	return nullptr;
 }
@@ -652,7 +652,7 @@ void Game_Party::RemoveInvalidData() {
 	std::swap(temp_party, data.party);
 	std::vector<int16_t>::iterator it;
 	for (it = temp_party.begin(); it != temp_party.end(); ++it) {
-		if (Game_Actors::ActorExists(*it)) {
+		if (Main_Data::game_actors->ActorExists(*it)) {
 			data.party.push_back(*it);
 		} else {
 			Output::Warning("Removing invalid party member {}", *it);

--- a/src/main_data.cpp
+++ b/src/main_data.cpp
@@ -61,6 +61,7 @@ namespace Main_Data {
 	std::unique_ptr<Game_Variables> game_variables;
 	std::unique_ptr<Game_Screen> game_screen;
 	std::unique_ptr<Game_Pictures> game_pictures;
+	std::unique_ptr<Game_Actors> game_actors;
 	std::unique_ptr<Game_Player> game_player;
 	std::unique_ptr<Game_Party> game_party;
 	std::unique_ptr<Game_EnemyParty> game_enemyparty;
@@ -157,7 +158,6 @@ void Main_Data::Init() {
 
 void Main_Data::Cleanup() {
 	Game_Map::Quit();
-	Game_Actors::Dispose();
 
 	game_switches.reset();
 	game_screen.reset();
@@ -165,6 +165,7 @@ void Main_Data::Cleanup() {
 	game_player.reset();
 	game_party.reset();
 	game_enemyparty.reset();
+	game_actors.reset();
 	game_targets.reset();
 	game_quit.reset();
 

--- a/src/main_data.h
+++ b/src/main_data.h
@@ -30,6 +30,7 @@
 class Game_Player;
 class Game_Screen;
 class Game_Pictures;
+class Game_Actors;
 class Game_Party;
 class Game_EnemyParty;
 class Game_Switches;
@@ -44,6 +45,7 @@ namespace Main_Data {
 	extern std::unique_ptr<Game_Screen> game_screen;
 	extern std::unique_ptr<Game_Pictures> game_pictures;
 	extern std::unique_ptr<Game_Player> game_player;
+	extern std::unique_ptr<Game_Actors> game_actors;
 	extern std::unique_ptr<Game_Party> game_party;
 	extern std::unique_ptr<Game_EnemyParty> game_enemyparty;
 	extern std::unique_ptr<Game_Targets> game_targets;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -55,18 +55,13 @@
 using namespace std::chrono_literals;
 
 namespace {
-	enum class LogLevel {
-		Error,
-		Warning,
-		Info,
-		Debug
-	};
 	constexpr const char* const log_prefix[4] = {
 		"Error: ",
 		"Warning: ",
 		"Info: ",
 		"Debug: "
 	};
+	LogLevel log_level = LogLevel::Debug;
 
 	static const char* GetLogPrefix(LogLevel lvl) {
 		return log_prefix[static_cast<int>(lvl)];
@@ -123,6 +118,14 @@ namespace {
 	};
 #endif
 
+}
+
+LogLevel Output::GetLogLevel() {
+	return log_level;
+}
+
+void Output::SetLogLevel(LogLevel ll) {
+	log_level = ll;
 }
 
 void Output::IgnorePause(bool const val) {
@@ -291,14 +294,23 @@ void Output::ErrorStr(std::string const& err) {
 }
 
 void Output::WarningStr(std::string const& warn) {
+	if (log_level < LogLevel::Warning) {
+		return;
+	}
 	WriteLog(LogLevel::Warning, warn, Color(255, 255, 0, 255));
 }
 
 void Output::InfoStr(std::string const& msg) {
+	if (log_level < LogLevel::Info) {
+		return;
+	}
 	WriteLog(LogLevel::Info, msg, Color(255, 255, 255, 255));
 }
 
 void Output::DebugStr(std::string const& msg) {
+	if (log_level < LogLevel::Debug) {
+		return;
+	}
 	WriteLog(LogLevel::Debug, msg, Color(128, 128, 128, 255));
 }
 

--- a/src/output.h
+++ b/src/output.h
@@ -33,10 +33,27 @@ inline fmt::basic_string_view<char> to_string_view(const lcf::DBString& s) {
 }
 }
 
+enum class LogLevel {
+	Error,
+	Warning,
+	Info,
+	Debug
+};
+
 /**
  * Output Namespace.
  */
 namespace Output {
+	/** @return the configurated log level */
+	LogLevel GetLogLevel();
+
+	/**
+	 * Sets the log level for filtering logs
+	 *
+	 * @param ll the new log level
+	 */
+	void SetLogLevel(LogLevel ll);
+
 	/**
 	 * Closes the log file handle and trims the file.
 	 */

--- a/src/pending_message.cpp
+++ b/src/pending_message.cpp
@@ -108,7 +108,7 @@ std::string PendingMessage::ApplyTextInsertingCommands(std::string input, uint32
 			iter = parse_ret.next;
 			int value = parse_ret.value;
 
-			const auto* actor = Game_Actors::GetActor(value);
+			const auto* actor = Main_Data::game_actors->GetActor(value);
 			if (!actor) {
 				Output::Warning("Invalid Actor Id {} in message text", value);
 			} else{

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -987,7 +987,7 @@ void Player::LoadSavegame(const std::string& save_name) {
 	Main_Data::game_data = *save.get();
 	Main_Data::game_data.system.Fixup();
 
-	Main_Data::game_actors->Fixup();
+	Main_Data::game_actors->SetSaveData(std::move(Main_Data::game_data.actors));
 	Main_Data::game_party->SetupFromSave(std::move(Main_Data::game_data.inventory));
 	Main_Data::game_switches->SetData(std::move(Main_Data::game_data.system.switches));
 	Main_Data::game_variables->SetData(std::move(Main_Data::game_data.system.variables));

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -815,7 +815,8 @@ void Player::ResetGameObjects() {
 	Main_Data::game_screen = std::make_unique<Game_Screen>();
 	Main_Data::game_pictures = std::make_unique<Game_Pictures>();
 
-	Game_Actors::Init();
+	Main_Data::game_actors = std::make_unique<Game_Actors>();
+
 	Game_Map::Init();
 	Game_Message::Init();
 	Game_System::Init();
@@ -986,7 +987,7 @@ void Player::LoadSavegame(const std::string& save_name) {
 	Main_Data::game_data = *save.get();
 	Main_Data::game_data.system.Fixup();
 
-	Game_Actors::Fixup();
+	Main_Data::game_actors->Fixup();
 	Main_Data::game_party->SetupFromSave(std::move(Main_Data::game_data.inventory));
 	Main_Data::game_switches->SetData(std::move(Main_Data::game_data.system.switches));
 	Main_Data::game_variables->SetData(std::move(Main_Data::game_data.system.variables));

--- a/src/scene_name.cpp
+++ b/src/scene_name.cpp
@@ -29,7 +29,7 @@ Scene_Name::Scene_Name(int actor_id, int charset, bool use_default_name)
 {
 	Scene::type = Scene::Name;
 
-	auto *actor = Game_Actors::GetActor(actor_id);
+	auto *actor = Main_Data::game_actors->GetActor(actor_id);
 	if (!actor) {
 		Output::Error("EnterHeroName: Invalid actor ID {}", actor_id);
 	}
@@ -38,7 +38,7 @@ Scene_Name::Scene_Name(int actor_id, int charset, bool use_default_name)
 void Scene_Name::Start() {
 	// Create the windows
 
-	auto *actor = Game_Actors::GetActor(actor_id);
+	auto *actor = Main_Data::game_actors->GetActor(actor_id);
 	assert(actor);
 
 	name_window.reset(new Window_Name(96, 40, 192, 32));
@@ -109,7 +109,7 @@ void Scene_Name::Update() {
 		assert(!s.empty());
 
 		if (s == Window_Keyboard::DONE) {
-			auto* actor = Game_Actors::GetActor(actor_id);
+			auto* actor = Main_Data::game_actors->GetActor(actor_id);
 			if (actor != nullptr) {
 				if (name_window->Get().empty()) {
 					name_window->Set(ToString(actor->GetName()));

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -30,6 +30,7 @@
 #include "game_switches.h"
 #include "game_variables.h"
 #include "game_party.h"
+#include "game_actors.h"
 #include "game_system.h"
 #include "game_targets.h"
 #include "game_screen.h"
@@ -138,6 +139,7 @@ void Scene_Save::Save(std::ostream& os, int slot_id, bool prepare_save) {
 	data_copy.system.switches = Main_Data::game_switches->GetData();
 	data_copy.system.variables = Main_Data::game_variables->GetData();
 	data_copy.inventory = Main_Data::game_party->GetSaveData();
+	data_copy.actors = Main_Data::game_actors->GetSaveData();
 
 	data_copy.screen = Main_Data::game_screen->GetSaveData();
 	data_copy.pictures = Main_Data::game_pictures->GetSaveData();

--- a/src/spriteset_battle.cpp
+++ b/src/spriteset_battle.cpp
@@ -47,7 +47,7 @@ Spriteset_Battle::Spriteset_Battle(const std::string bg_name, int terrain_id)
 	Main_Data::game_enemyparty->GetBattlers(battler);
 	if (Player::IsRPG2k3()) {
 		for (unsigned int i = 0; i < lcf::Data::actors.size(); ++i) {
-			battler.push_back(Game_Actors::GetActor(i + 1));
+			battler.push_back(Main_Data::game_actors->GetActor(i + 1));
 		}
 	}
 

--- a/src/window_actorinfo.cpp
+++ b/src/window_actorinfo.cpp
@@ -41,10 +41,10 @@ void Window_ActorInfo::Refresh() {
 
 void Window_ActorInfo::DrawInfo() {
 	// Draw Row formation.
-	std::string battle_row = Game_Actors::GetActor(actor_id)->GetBattleRow() == Game_Actor::RowType::RowType_back ? "Back" : "Front";
+	std::string battle_row = Main_Data::game_actors->GetActor(actor_id)->GetBattleRow() == Game_Actor::RowType::RowType_back ? "Back" : "Front";
 	contents->TextDraw(contents->GetWidth(), 2, Font::ColorDefault, battle_row, Text::AlignRight);
 
-	const Game_Actor& actor = *Game_Actors::GetActor(actor_id);
+	const Game_Actor& actor = *Main_Data::game_actors->GetActor(actor_id);
 
 	// Draw Face
 	DrawActorFace(actor, 0, 0);

--- a/src/window_actorstatus.cpp
+++ b/src/window_actorstatus.cpp
@@ -41,7 +41,7 @@ void Window_ActorStatus::Refresh() {
 
 void Window_ActorStatus::DrawStatus(){
 
-	Game_Actor* actor = Game_Actors::GetActor(actor_id);
+	Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
 
 	// Draw Hp
 	contents->TextDraw(1, 2, 1, lcf::Data::terms.health_points);
@@ -61,13 +61,13 @@ void Window_ActorStatus::DrawMinMax(int cx, int cy, int min, int max){
 	if (max >= 0)
 		ss << min;
 	else
-		ss << Game_Actors::GetActor(actor_id)->GetExpString();
+		ss << Main_Data::game_actors->GetActor(actor_id)->GetExpString();
 	contents->TextDraw(cx, cy, Font::ColorDefault, ss.str(), Text::AlignRight);
 	contents->TextDraw(cx, cy, Font::ColorDefault, "/");
 	ss.str("");
 	if (max >= 0)
 		ss << max;
 	else
-		ss << Game_Actors::GetActor(actor_id)->GetNextExpString();
+		ss << Main_Data::game_actors->GetActor(actor_id)->GetNextExpString();
 	contents->TextDraw(cx+48, cy, Font::ColorDefault, ss.str(), Text::AlignRight);
 }

--- a/src/window_battlecommand.cpp
+++ b/src/window_battlecommand.cpp
@@ -143,7 +143,7 @@ void Window_BattleCommand::SetActor(int _actor_id) {
 		commands.push_back(!lcf::Data::terms.command_skill.empty() ? ToString(lcf::Data::terms.command_skill) : "Skill");
 	}
 	else {
-		Game_Actor* actor = Game_Actors::GetActor(actor_id);
+		Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
 		const std::vector<const lcf::rpg::BattleCommand*> bcmds = actor->GetBattleCommands();
 		for (const lcf::rpg::BattleCommand* command : bcmds) {
 			commands.push_back(ToString(command->name));
@@ -158,7 +158,7 @@ int Window_BattleCommand::GetSkillSubset() {
 	if (actor_id == 0)
 		return lcf::rpg::Skill::Type_normal;
 
-	Game_Actor* actor = Game_Actors::GetActor(actor_id);
+	Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
 	const std::vector<const lcf::rpg::BattleCommand*> bcmds = actor->GetBattleCommands();
 	int bcmd = bcmds[index]->ID;
 

--- a/src/window_equip.cpp
+++ b/src/window_equip.cpp
@@ -42,7 +42,7 @@ void Window_Equip::Refresh() {
 
 	// Add the equipment of the actor to data
 	data.clear();
-	Game_Actor* actor = Game_Actors::GetActor(actor_id);
+	Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
 	for (int i = 1; i <= 5; ++i) {
 		const lcf::rpg::Item* item = actor->GetEquipment(i);
 		data.push_back(item ? item->ID : 0);

--- a/src/window_equipitem.cpp
+++ b/src/window_equipitem.cpp
@@ -31,7 +31,7 @@ Window_EquipItem::Window_EquipItem(int actor_id, int equip_type) :
 	}
 
 	if (this->equip_type == Window_EquipItem::shield &&
-		Game_Actors::GetActor(actor_id)->HasTwoWeapons()) {
+		Main_Data::game_actors->GetActor(actor_id)->HasTwoWeapons()) {
 
 		this->equip_type = Window_EquipItem::weapon;
 	}
@@ -73,7 +73,7 @@ bool Window_EquipItem::CheckInclude(int item_id) {
 		if (Main_Data::game_party->GetItemCount(item_id) == 0) {
 			return false;
 		} else {
-			return Game_Actors::GetActor(actor_id)->IsEquippable(item_id);
+			return Main_Data::game_actors->GetActor(actor_id)->IsEquippable(item_id);
 		}
 	} else {
 		return false;

--- a/src/window_equipstatus.cpp
+++ b/src/window_equipstatus.cpp
@@ -43,7 +43,7 @@ void Window_EquipStatus::Refresh() {
 
 		y_offset = 18;
 		// Actor data is guaranteed to be valid
-		DrawActorName(*Game_Actors::GetActor(actor_id), 0, 2);
+		DrawActorName(*Main_Data::game_actors->GetActor(actor_id), 0, 2);
 
 		for (int i = 0; i < 4; ++i) {
 			DrawParameter(0, y_offset + ((12 + 4) * i), i);
@@ -91,22 +91,22 @@ void Window_EquipStatus::DrawParameter(int cx, int cy, int type) {
 	switch (type) {
 	case 0:
 		name = lcf::Data::terms.attack;
-		value = Game_Actors::GetActor(actor_id)->GetAtk();
+		value = Main_Data::game_actors->GetActor(actor_id)->GetAtk();
 		new_value = atk;
 		break;
 	case 1:
 		name = lcf::Data::terms.defense;
-		value = Game_Actors::GetActor(actor_id)->GetDef();
+		value = Main_Data::game_actors->GetActor(actor_id)->GetDef();
 		new_value = def;
 		break;
 	case 2:
 		name = lcf::Data::terms.spirit;
-		value = Game_Actors::GetActor(actor_id)->GetSpi();
+		value = Main_Data::game_actors->GetActor(actor_id)->GetSpi();
 		new_value = spi;
 		break;
 	case 3:
 		name = lcf::Data::terms.agility;
-		value = Game_Actors::GetActor(actor_id)->GetAgi();
+		value = Main_Data::game_actors->GetActor(actor_id)->GetAgi();
 		new_value = agi;
 		break;
 	default:

--- a/src/window_face.cpp
+++ b/src/window_face.cpp
@@ -29,7 +29,7 @@ Window_Face::Window_Face(int ix, int iy, int iwidth, int iheight) :
 void Window_Face::Refresh() {
 	contents->Clear();
 	// Actor data is guaranteed to be valid
-	DrawActorFace(*Game_Actors::GetActor(actor_id), 0, 0);
+	DrawActorFace(*Main_Data::game_actors->GetActor(actor_id), 0, 0);
 }
 
 void Window_Face::Set(int id) {

--- a/src/window_paramstatus.cpp
+++ b/src/window_paramstatus.cpp
@@ -36,7 +36,7 @@ Window_ParamStatus::Window_ParamStatus(int ix, int iy, int iwidth, int iheight, 
 void Window_ParamStatus::Refresh() {
 	contents->Clear();
 
-	auto* actor = Game_Actors::GetActor(actor_id);
+	auto* actor = Main_Data::game_actors->GetActor(actor_id);
 
 	auto draw = [this](int y, StringView name, int value) {
 		// Draw Term

--- a/src/window_skill.cpp
+++ b/src/window_skill.cpp
@@ -50,7 +50,7 @@ const lcf::rpg::Skill* Window_Skill::GetSkill() const {
 void Window_Skill::Refresh() {
 	data.clear();
 
-	const std::vector<int16_t>& skills = Game_Actors::GetActor(actor_id)->GetSkills();
+	const std::vector<int16_t>& skills = Main_Data::game_actors->GetActor(actor_id)->GetSkills();
 	for (size_t i = 0; i < skills.size(); ++i) {
 		if (CheckInclude(skills[i]))
 			data.push_back(skills[i]);
@@ -78,7 +78,7 @@ void Window_Skill::DrawItem(int index) {
 	int skill_id = data[index];
 
 	if (skill_id > 0) {
-		const Game_Actor* actor = Game_Actors::GetActor(actor_id);
+		const Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
 		int costs = actor->CalculateSkillCost(skill_id);
 
 		bool enabled = CheckEnable(skill_id);
@@ -122,7 +122,7 @@ bool Window_Skill::CheckInclude(int skill_id) {
 }
 
 bool Window_Skill::CheckEnable(int skill_id) {
-	const Game_Actor* actor = Game_Actors::GetActor(actor_id);
+	const Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
 
 	return actor->IsSkillLearned(skill_id) && Main_Data::game_party->IsSkillUsable(skill_id, actor);
 }

--- a/src/window_skillstatus.cpp
+++ b/src/window_skillstatus.cpp
@@ -38,7 +38,7 @@ void Window_SkillStatus::Refresh() {
 	contents->ClearRect(Rect(0, 0, contents->GetWidth(), 16));
 
 	// Actors are guaranteed to be valid
-	const Game_Actor& actor = *Game_Actors::GetActor(actor_id);
+	const Game_Actor& actor = *Main_Data::game_actors->GetActor(actor_id);
 
 	int x = 0;
 	int y = 2;

--- a/tests/algo.cpp
+++ b/tests/algo.cpp
@@ -589,6 +589,33 @@ static void testSkillStats(int power, int phys, int mag, Game_Battler& source, G
 	MakeDBSkill(10, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_party;
 	SetDBSkillAttribute(10, 1, true);
 
+	MakeDBSkill(11, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_enemy;
+	lcf::Data::skills[10].ignore_defense = true;
+	MakeDBSkill(12, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_enemies;
+	lcf::Data::skills[11].ignore_defense = true;
+	MakeDBSkill(13, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_self;
+	lcf::Data::skills[12].ignore_defense = true;
+	MakeDBSkill(14, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_ally;
+	lcf::Data::skills[13].ignore_defense = true;
+	MakeDBSkill(15, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_party;
+	lcf::Data::skills[14].ignore_defense = true;
+
+	MakeDBSkill(16, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_enemy;
+	SetDBSkillAttribute(16, 1, true);
+	lcf::Data::skills[15].ignore_defense = true;
+	MakeDBSkill(17, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_enemies;
+	SetDBSkillAttribute(17, 1, true);
+	lcf::Data::skills[16].ignore_defense = true;
+	MakeDBSkill(18, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_self;
+	SetDBSkillAttribute(18, 1, true);
+	lcf::Data::skills[17].ignore_defense = true;
+	MakeDBSkill(19, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_ally;
+	SetDBSkillAttribute(19, 1, true);
+	lcf::Data::skills[18].ignore_defense = true;
+	MakeDBSkill(20, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_party;
+	SetDBSkillAttribute(20, 1, true);
+	lcf::Data::skills[19].ignore_defense = true;
+
 	SUBCASE("baseline") {
 		REQUIRE_EQ(dmg, Algo::CalcSkillEffect(source, target, lcf::Data::skills[0], false));
 		REQUIRE_EQ(dmg, Algo::CalcSkillEffect(source, target, lcf::Data::skills[1], false));
@@ -603,6 +630,22 @@ static void testSkillStats(int power, int phys, int mag, Game_Battler& source, G
 		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[7], false));
 		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[8], false));
 		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[9], false));
+	}
+
+	SUBCASE("ignore_defense") {
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[10], false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[11], false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[12], false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[13], false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[14], false));
+	}
+
+	SUBCASE("ignore_defense+attr2x") {
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[15], false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[16], false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[17], false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[18], false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[19], false));
 	}
 }
 

--- a/tests/algo.cpp
+++ b/tests/algo.cpp
@@ -17,48 +17,98 @@ static Game_Enemy& MakeEnemy(int id) {
 
 TEST_SUITE_BEGIN("Algo");
 
+static void testRowAdj(lcf::rpg::SaveActor::RowType row, bool offense, bool none, bool back, bool surround, bool pincers) {
+	REQUIRE_EQ(none, Algo::IsRowAdjusted(row, lcf::rpg::System::BattleCondition_none, offense));
+	REQUIRE_EQ(none, Algo::IsRowAdjusted(row, lcf::rpg::System::BattleCondition_initiative, offense));
+	REQUIRE_EQ(back, Algo::IsRowAdjusted(row, lcf::rpg::System::BattleCondition_back, offense));
+	REQUIRE_EQ(surround, Algo::IsRowAdjusted(row, lcf::rpg::System::BattleCondition_surround, offense));
+	REQUIRE_EQ(pincers, Algo::IsRowAdjusted(row, lcf::rpg::System::BattleCondition_pincers, offense));
+}
+
+
 TEST_CASE("RowAdj") {
 	const MockActor m;
 
-	auto actor = MakeActor(1);
-
 	SUBCASE("front") {
-		actor.SetBattleRow(lcf::rpg::SaveActor::RowType_front);
+		auto row = lcf::rpg::SaveActor::RowType_front;
 
 		SUBCASE("offsense") {
-			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_none, true));
-			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_initiative, true));
-			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_back, true));
-			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_surround, true));
-			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_pincers, true));
+			testRowAdj(row, true, true, false, true, false);
 		}
 
 		SUBCASE("defense") {
-			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_none, false));
-			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_initiative, false));
-			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_back, false));
-			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_surround, false));
-			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_pincers, false));
+			testRowAdj(row, false, false, true, true, false);
 		}
 	}
 
 	SUBCASE("back") {
-		actor.SetBattleRow(lcf::rpg::SaveActor::RowType_back);
+		auto row = lcf::rpg::SaveActor::RowType_back;
 
 		SUBCASE("offsense") {
-			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_none, true));
-			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_initiative, true));
-			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_back, true));
-			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_surround, true));
-			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_pincers, true));
+			testRowAdj(row, true, false, true, true, false);
 		}
 
 		SUBCASE("defense") {
-			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_none, false));
-			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_initiative, false));
-			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_back, false));
-			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_surround, false));
-			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_pincers, false));
+			testRowAdj(row, false, true, false, true, false);
+		}
+	}
+}
+
+static void testRowAdjBattler(const Game_Battler& battler, bool offense, bool bug,
+		bool none, bool back, bool surround, bool pincers) {
+	REQUIRE_EQ(none, Algo::IsRowAdjusted(battler, lcf::rpg::System::BattleCondition_none, offense, bug));
+	REQUIRE_EQ(none, Algo::IsRowAdjusted(battler, lcf::rpg::System::BattleCondition_initiative, offense, bug));
+	REQUIRE_EQ(back, Algo::IsRowAdjusted(battler, lcf::rpg::System::BattleCondition_back, offense, bug));
+	REQUIRE_EQ(surround, Algo::IsRowAdjusted(battler, lcf::rpg::System::BattleCondition_surround, offense, bug));
+	REQUIRE_EQ(pincers, Algo::IsRowAdjusted(battler, lcf::rpg::System::BattleCondition_pincers, offense, bug));
+}
+
+TEST_CASE("RowAdjBattler") {
+	const MockActor m;
+
+	SUBCASE("actor") {
+		auto actor = MakeActor(1);
+
+		SUBCASE("front") {
+			actor.SetBattleRow(lcf::rpg::SaveActor::RowType_front);
+
+			SUBCASE("offsense") {
+				testRowAdjBattler(actor, true, true, true, false, true, false);
+				testRowAdjBattler(actor, true, false, true, false, true, false);
+			}
+
+			SUBCASE("defense") {
+				testRowAdjBattler(actor, false, true, false, true, true, false);
+				testRowAdjBattler(actor, false, false, false, true, true, false);
+			}
+		}
+
+		SUBCASE("back") {
+			actor.SetBattleRow(lcf::rpg::SaveActor::RowType_back);
+
+			SUBCASE("offsense") {
+				testRowAdjBattler(actor, true, true, false, true, true, false);
+				testRowAdjBattler(actor, true, false, false, true, true, false);
+			}
+
+			SUBCASE("defense") {
+				testRowAdjBattler(actor, false, true, true, false, true, false);
+				testRowAdjBattler(actor, false, false, true, false, true, false);
+			}
+		}
+	}
+
+	SUBCASE("enemy") {
+		auto enemy = MakeEnemy(1);
+
+		SUBCASE("offsense") {
+			testRowAdjBattler(enemy, true, true, true, false, true, false);
+			testRowAdjBattler(enemy, true, false, false, false, false, false);
+		}
+
+		SUBCASE("defense") {
+			testRowAdjBattler(enemy, false, true, false, true, true, false);
+			testRowAdjBattler(enemy, false, false, false, false, false, false);
 		}
 	}
 }
@@ -159,7 +209,7 @@ static void testAgi(int src, int tgt, int res) {
 	auto source = MakeAgiActor(1, src);
 	auto target = MakeAgiEnemy(1, tgt);
 
-	REQUIRE_EQ(res, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+	REQUIRE_EQ(res, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, true));
 	REQUIRE_EQ(res, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
 	REQUIRE_EQ(res, Algo::CalcSkillToHit(source, target, lcf::Data::skills[1]));
 	for (int i = 2; i < 6; ++i) {
@@ -184,13 +234,13 @@ TEST_CASE("HitRateAgi") {
 static void testStates(Game_Battler& source, Game_Battler& target, int base) {
 	SUBCASE("Cannot act") {
 		target.AddState(2, true);
-		REQUIRE_EQ(100, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+		REQUIRE_EQ(100, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, true));
 		REQUIRE_EQ(100, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
 	}
 
 	SUBCASE("Avoid attacks") {
 		target.AddState(3, true);
-		REQUIRE_EQ(0, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+		REQUIRE_EQ(0, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, true));
 		// RPG_RT bug
 		REQUIRE_EQ(base, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
 	}
@@ -198,7 +248,7 @@ static void testStates(Game_Battler& source, Game_Battler& target, int base) {
 	SUBCASE("Avoid attacks and cannot act") {
 		target.AddState(2, true);
 		target.AddState(3, true);
-		REQUIRE_EQ(0, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+		REQUIRE_EQ(0, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, true));
 		// RPG_RT bug
 		REQUIRE_EQ(100, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
 	}
@@ -218,11 +268,25 @@ TEST_CASE("HitRateStates") {
 
 	SUBCASE("source blind50") {
 		source.AddState(4, true);
-		REQUIRE_EQ(45, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+		REQUIRE_EQ(45, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, true));
 		REQUIRE_EQ(45, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
 
 		testStates(source, target, 45);
 	}
+}
+
+static void testHitRateRow(Game_Battler& source, Game_Battler& target, int none, int back, int surround, int pincer, int back_no_bug, int surround_no_bug) {
+	REQUIRE_EQ(none, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, true));
+	REQUIRE_EQ(none, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative, true));
+	REQUIRE_EQ(back, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back, true));
+	REQUIRE_EQ(surround, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround, true));
+	REQUIRE_EQ(pincer, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers, true));
+
+	REQUIRE_EQ(none, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, false));
+	REQUIRE_EQ(none, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative, false));
+	REQUIRE_EQ(back_no_bug, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back, false));
+	REQUIRE_EQ(surround_no_bug, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround, false));
+	REQUIRE_EQ(pincer, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers, false));
 }
 
 TEST_CASE("HitRateArmorAndRow2k3") {
@@ -239,11 +303,7 @@ TEST_CASE("HitRateArmorAndRow2k3") {
 			target.SetBattleRow(lcf::rpg::SaveActor::RowType_front);
 
 			SUBCASE("no armor") {
-				REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
-				REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative));
-				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back));
-				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround));
-				REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers));
+				testHitRateRow(source, target, 90, 65, 65, 90, 65, 65);
 
 				REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
 			}
@@ -252,11 +312,7 @@ TEST_CASE("HitRateArmorAndRow2k3") {
 				target.SetEquipment(3, 1);
 				REQUIRE(target.HasPhysicalEvasionUp());
 
-				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
-				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative));
-				REQUIRE_EQ(40, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back));
-				REQUIRE_EQ(40, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround));
-				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers));
+				testHitRateRow(source, target, 65, 40, 40, 65, 40, 40);
 
 				REQUIRE_EQ(65, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
 			}
@@ -266,11 +322,7 @@ TEST_CASE("HitRateArmorAndRow2k3") {
 			target.SetBattleRow(lcf::rpg::SaveActor::RowType_back);
 
 			SUBCASE("no armor") {
-				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
-				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative));
-				REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back));
-				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround));
-				REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers));
+				testHitRateRow(source, target, 65, 90, 65, 90, 90, 65);
 
 				REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
 			}
@@ -278,11 +330,8 @@ TEST_CASE("HitRateArmorAndRow2k3") {
 			SUBCASE("phys eva up") {
 				target.SetEquipment(3, 1);
 				REQUIRE(target.HasPhysicalEvasionUp());
-				REQUIRE_EQ(40, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
-				REQUIRE_EQ(40, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative));
-				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back));
-				REQUIRE_EQ(40, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround));
-				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers));
+
+				testHitRateRow(source, target, 40, 65, 40, 65, 65, 40);
 
 				REQUIRE_EQ(65, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
 			}
@@ -292,15 +341,14 @@ TEST_CASE("HitRateArmorAndRow2k3") {
 	SUBCASE("enemy target") {
 		auto target = MakeAgiEnemy(2, 100);
 
-		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
-		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative));
-		// RPG_RT bug we implement
-		REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back));
-		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround));
-		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers));
+		testHitRateRow(source, target, 90, 65, 65, 90, 90, 90);
 
 		REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
 	}
+}
+
+static void testHitRateRow2k(Game_Battler& source, Game_Battler& target, int rate) {
+	testHitRateRow(source, target, rate, rate, rate, rate, rate, rate);
 }
 
 TEST_CASE("HitRateArmorAndRow2k") {
@@ -314,11 +362,7 @@ TEST_CASE("HitRateArmorAndRow2k") {
 		auto target = MakeAgiActor(2, 100);
 
 		SUBCASE("no armor") {
-			REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
-			REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative));
-			REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back));
-			REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround));
-			REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers));
+			testHitRateRow2k(source, target, 90);
 
 			REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
 		}
@@ -327,11 +371,7 @@ TEST_CASE("HitRateArmorAndRow2k") {
 			target.SetEquipment(3, 1);
 			REQUIRE(target.HasPhysicalEvasionUp());
 
-			REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
-			REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative));
-			REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back));
-			REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround));
-			REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers));
+			testHitRateRow2k(source, target, 65);
 
 			REQUIRE_EQ(65, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
 		}
@@ -340,11 +380,7 @@ TEST_CASE("HitRateArmorAndRow2k") {
 	SUBCASE("enemy target") {
 		auto target = MakeAgiEnemy(2, 100);
 
-		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
-		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative));
-		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back));
-		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround));
-		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers));
+		testHitRateRow2k(source, target, 90);
 
 		REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
 	}
@@ -363,19 +399,19 @@ TEST_CASE("HitRateWeapons") {
 
 	REQUIRE_EQ(source.GetAgi(Game_Battler::WeaponAll), 150);
 	REQUIRE(source.AttackIgnoresEvasion(Game_Battler::WeaponAll));
-	REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+	REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, true));
 
 	REQUIRE_EQ(source.GetAgi(Game_Battler::WeaponNone), 100);
 	REQUIRE_FALSE(source.AttackIgnoresEvasion(Game_Battler::WeaponNone));
-	REQUIRE_EQ(85, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponNone, lcf::rpg::System::BattleCondition_none));
+	REQUIRE_EQ(85, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponNone, lcf::rpg::System::BattleCondition_none, true));
 
 	REQUIRE_EQ(source.GetAgi(Game_Battler::WeaponPrimary), 100);
 	REQUIRE(source.AttackIgnoresEvasion(Game_Battler::WeaponPrimary));
-	REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponPrimary, lcf::rpg::System::BattleCondition_none));
+	REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponPrimary, lcf::rpg::System::BattleCondition_none, true));
 
 	REQUIRE_EQ(source.GetAgi(Game_Battler::WeaponSecondary), 150);
 	REQUIRE_FALSE(source.AttackIgnoresEvasion(Game_Battler::WeaponSecondary));
-	REQUIRE_EQ(88, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponSecondary, lcf::rpg::System::BattleCondition_none));
+	REQUIRE_EQ(88, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponSecondary, lcf::rpg::System::BattleCondition_none, true));
 
 	REQUIRE_EQ(100, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
 }
@@ -520,12 +556,12 @@ TEST_CASE("SelfDestructEffect") {
 		REQUIRE_EQ(0, Algo::CalcSelfDestructEffect(source, target, false));
 	}
 
-	SUBCASE("150_0") {
+	SUBCASE("150_100") {
 		auto source = MakeStatEnemy(1, 150, 0, 0);
 		REQUIRE_EQ(100, Algo::CalcSelfDestructEffect(source, target, false));
 	}
 
-	SUBCASE("150_0_var") {
+	SUBCASE("150_100_var") {
 		auto source = MakeStatEnemy(1, 150, 0, 0);
 		for (int i = 0; i < 200; ++i) {
 			auto effect = Algo::CalcSelfDestructEffect(source, target, true);
@@ -616,22 +652,30 @@ static void testEnemyAttackEnemy(Game_Battler& source, Game_Battler& target, int
 			CAPTURE(cid);
 
 			SUBCASE("no crit") {
-				REQUIRE_EQ(dmg, Algo::CalcNormalAttackEffect(source, target, Game_Battler::Weapon(wid), false, false, lcf::rpg::System::BattleCondition(cid)));
+				REQUIRE_EQ(dmg, Algo::CalcNormalAttackEffect(source, target, Game_Battler::Weapon(wid), false, false, lcf::rpg::System::BattleCondition(cid), true));
+				REQUIRE_EQ(dmg, Algo::CalcNormalAttackEffect(source, target, Game_Battler::Weapon(wid), false, false, lcf::rpg::System::BattleCondition(cid), false));
 			}
 
 			SUBCASE("crit") {
-				REQUIRE_EQ(crit, Algo::CalcNormalAttackEffect(source, target, Game_Battler::Weapon(wid), true, false, lcf::rpg::System::BattleCondition(cid)));
+				REQUIRE_EQ(crit, Algo::CalcNormalAttackEffect(source, target, Game_Battler::Weapon(wid), true, false, lcf::rpg::System::BattleCondition(cid), true));
+				REQUIRE_EQ(crit, Algo::CalcNormalAttackEffect(source, target, Game_Battler::Weapon(wid), true, false, lcf::rpg::System::BattleCondition(cid), false));
 			}
 		}
 	}
 }
 
-static void testActorAttackRow(Game_Battler& source, Game_Battler& target, int none, int init, int back, int surround, int pincers) {
-	REQUIRE_EQ(none, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_none));
-	REQUIRE_EQ(init, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_initiative));
-	REQUIRE_EQ(back, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_back));
-	REQUIRE_EQ(surround, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_surround));
-	REQUIRE_EQ(pincers, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_pincers));
+static void testActorAttackRow(Game_Battler& source, Game_Battler& target, int none, int back, int surround, int pincers, int back_no_bug, int surround_no_bug) {
+	REQUIRE_EQ(none, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_none, true));
+	REQUIRE_EQ(none, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_initiative, true));
+	REQUIRE_EQ(back, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_back, true));
+	REQUIRE_EQ(surround, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_surround, true));
+	REQUIRE_EQ(pincers, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_pincers, true));
+
+	REQUIRE_EQ(none, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_none, false));
+	REQUIRE_EQ(none, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_initiative, false));
+	REQUIRE_EQ(back_no_bug, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_back, false));
+	REQUIRE_EQ(surround_no_bug, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_surround, false));
+	REQUIRE_EQ(pincers, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_pincers, false));
 }
 
 static void TestNormalAttack(int engine) {
@@ -662,14 +706,14 @@ static void TestNormalAttack(int engine) {
 		auto source = MakeStatEnemy(1, 0, 0, 0);
 		auto target = MakeStatEnemy(2, 0, 100, 0);
 
-		REQUIRE_EQ(0, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_none));
+		REQUIRE_EQ(0, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_none, true));
 	}
 
 	SUBCASE("enemy 9999/0 -> enemy 0/0") {
 		auto source = MakeStatEnemy(1, 9999, 0, 0);
 		auto target = MakeStatEnemy(2, 0, 0, 0);
 
-		REQUIRE_EQ(4999, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_none));
+		REQUIRE_EQ(4999, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_none, true));
 	}
 
 	SUBCASE("actor 120/0 -> enemy 0/90") {
@@ -682,18 +726,18 @@ static void TestNormalAttack(int engine) {
 		SUBCASE("front row") {
 			source.SetBattleRow(lcf::rpg::SaveActor::RowType_front);
 			if (is2k3) {
-				testActorAttackRow(source, target, 47, 47, /* RPG_RT bug */ 28, 47, 38);
+				testActorAttackRow(source, target, 47, 28, 35, 38, 38, 47);
 			} else {
-				testActorAttackRow(source, target, 38, 38, 38, 38, 38);
+				testActorAttackRow(source, target, 38, 38, 38, 38, 38, 38);
 			}
 		}
 
 		SUBCASE("back row") {
 			source.SetBattleRow(lcf::rpg::SaveActor::RowType_back);
 			if (is2k3) {
-				testActorAttackRow(source, target, 38, 38, /* RPG_RT bug */ 35, 47, 38);
+				testActorAttackRow(source, target, 38, 35, 35, 38, 47, 47);
 			} else {
-				testActorAttackRow(source, target, 38, 38, 38, 38, 38);
+				testActorAttackRow(source, target, 38, 38, 38, 38, 38, 38);
 			}
 		}
 
@@ -712,16 +756,16 @@ static void TestNormalAttack(int engine) {
 
 			if (is2k3) {
 				REQUIRE_EQ(140, source.GetAtk(Game_Battler::WeaponAll));
-				REQUIRE_EQ(120, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_none));
-				REQUIRE_EQ(47, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponNone, false, false, lcf::rpg::System::BattleCondition_none));
-				REQUIRE_EQ(60, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponPrimary, false, false, lcf::rpg::System::BattleCondition_none));
-				REQUIRE_EQ(94, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponSecondary, false, false, lcf::rpg::System::BattleCondition_none));
+				REQUIRE_EQ(120, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_none, true));
+				REQUIRE_EQ(47, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponNone, false, false, lcf::rpg::System::BattleCondition_none, true));
+				REQUIRE_EQ(60, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponPrimary, false, false, lcf::rpg::System::BattleCondition_none, true));
+				REQUIRE_EQ(94, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponSecondary, false, false, lcf::rpg::System::BattleCondition_none, true));
 			} else {
 				REQUIRE_EQ(140, source.GetAtk(Game_Battler::WeaponAll));
-				REQUIRE_EQ(96, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_none));
-				REQUIRE_EQ(38, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponNone, false, false, lcf::rpg::System::BattleCondition_none));
-				REQUIRE_EQ(48, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponPrimary, false, false, lcf::rpg::System::BattleCondition_none));
-				REQUIRE_EQ(76, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponSecondary, false, false, lcf::rpg::System::BattleCondition_none));
+				REQUIRE_EQ(96, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_none, true));
+				REQUIRE_EQ(38, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponNone, false, false, lcf::rpg::System::BattleCondition_none, true));
+				REQUIRE_EQ(48, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponPrimary, false, false, lcf::rpg::System::BattleCondition_none, true));
+				REQUIRE_EQ(76, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponSecondary, false, false, lcf::rpg::System::BattleCondition_none, true));
 			}
 		}
 	}
@@ -738,17 +782,17 @@ static void TestNormalAttack(int engine) {
 			SUBCASE("target front") {
 				target.SetBattleRow(lcf::rpg::SaveActor::RowType_front);
 				if (is2k3) {
-					testActorAttackRow(source, target, 47, 47, 28, 35, 38);
+					testActorAttackRow(source, target, 47, 28, 35, 38, 28, 35);
 				} else {
-					testActorAttackRow(source, target, 38, 38, 38, 38, 38);
+					testActorAttackRow(source, target, 38, 38, 38, 38, 38, 38);
 				}
 			}
 			SUBCASE("target back") {
 				target.SetBattleRow(lcf::rpg::SaveActor::RowType_back);
 				if (is2k3) {
-					testActorAttackRow(source, target, 35, 35, 38, 35, 38);
+					testActorAttackRow(source, target, 35, 38, 35, 38, 38, 35);
 				} else {
-					testActorAttackRow(source, target, 38, 38, 38, 38, 38);
+					testActorAttackRow(source, target, 38, 38, 38, 38, 38, 38);
 				}
 			}
 		}
@@ -758,17 +802,17 @@ static void TestNormalAttack(int engine) {
 			SUBCASE("target front") {
 				target.SetBattleRow(lcf::rpg::SaveActor::RowType_front);
 				if (is2k3) {
-					testActorAttackRow(source, target, 38, 38, 35, 35, 38);
+					testActorAttackRow(source, target, 38, 35, 35, 38, 35, 35);
 				} else {
-					testActorAttackRow(source, target, 38, 38, 38, 38, 38);
+					testActorAttackRow(source, target, 38, 38, 38, 38, 38, 38);
 				}
 			}
 			SUBCASE("target back") {
 				target.SetBattleRow(lcf::rpg::SaveActor::RowType_back);
 				if (is2k3) {
-					testActorAttackRow(source, target, 28, 28, 47, 35, 38);
+					testActorAttackRow(source, target, 28, 47, 35, 38, 47, 35);
 				} else {
-					testActorAttackRow(source, target, 38, 38, 38, 38, 38);
+					testActorAttackRow(source, target, 38, 38, 38, 38, 38, 38);
 				}
 			}
 		}

--- a/tests/algo.cpp
+++ b/tests/algo.cpp
@@ -817,6 +817,31 @@ static void TestNormalAttack(int engine) {
 			}
 		}
 	}
+
+	SUBCASE("enemy 120/0 -> actor 0/90") {
+		auto source = MakeStatEnemy(1, 120, 0, 0);
+		auto target = MakeStatActor(1, 0, 90, 0);
+
+		REQUIRE_EQ(source.GetAtk(), 120);
+		REQUIRE_EQ(target.GetDef(), 90);
+
+		SUBCASE("target front") {
+			target.SetBattleRow(lcf::rpg::SaveActor::RowType_front);
+			if (is2k3) {
+				testActorAttackRow(source, target, 38, 28, 28, 38, 28, 28);
+			} else {
+				testActorAttackRow(source, target, 38, 38, 38, 38, 38, 38);
+			}
+		}
+		SUBCASE("target back") {
+			target.SetBattleRow(lcf::rpg::SaveActor::RowType_back);
+			if (is2k3) {
+				testActorAttackRow(source, target, 28, 38, 28, 38, 38, 28);
+			} else {
+				testActorAttackRow(source, target, 38, 38, 38, 38, 38, 38);
+			}
+		}
+	}
 }
 
 TEST_CASE("NormalAttackEffect") {

--- a/tests/algo.cpp
+++ b/tests/algo.cpp
@@ -1,0 +1,789 @@
+#include "test_mock_actor.h"
+#include "algo.h"
+#include "doctest.h"
+
+static Game_Actor MakeActor(int id) {
+	return Game_Actor(id);
+}
+
+static Game_Enemy& MakeEnemy(int id) {
+	auto& tp = lcf::Data::troops[0];
+	tp.members.resize(8);
+	tp.members[id - 1].enemy_id = id;
+	Main_Data::game_enemyparty->ResetBattle(1);
+	auto& enemy = (*Main_Data::game_enemyparty)[id - 1];
+	return enemy;
+}
+
+TEST_SUITE_BEGIN("Algo");
+
+TEST_CASE("RowAdj") {
+	const MockActor m;
+
+	auto actor = MakeActor(1);
+
+	SUBCASE("front") {
+		actor.SetBattleRow(lcf::rpg::SaveActor::RowType_front);
+
+		SUBCASE("offsense") {
+			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_none, true));
+			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_initiative, true));
+			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_back, true));
+			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_surround, true));
+			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_pincers, true));
+		}
+
+		SUBCASE("defense") {
+			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_none, false));
+			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_initiative, false));
+			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_back, false));
+			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_surround, false));
+			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_pincers, false));
+		}
+	}
+
+	SUBCASE("back") {
+		actor.SetBattleRow(lcf::rpg::SaveActor::RowType_back);
+
+		SUBCASE("offsense") {
+			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_none, true));
+			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_initiative, true));
+			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_back, true));
+			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_surround, true));
+			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_pincers, true));
+		}
+
+		SUBCASE("defense") {
+			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_none, false));
+			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_initiative, false));
+			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_back, false));
+			REQUIRE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_surround, false));
+			REQUIRE_FALSE(Algo::IsRowAdjusted(actor, lcf::rpg::System::BattleCondition_pincers, false));
+		}
+	}
+}
+
+TEST_CASE("Variance") {
+	SUBCASE("0 var disabled") {
+		REQUIRE_EQ(Algo::VarianceAdjustEffect(100, 0), 100);
+	}
+
+	const int num_iterations = 200;
+	SUBCASE(">0") {
+		for (int var = 1; var <= 10; ++var) {
+			for (int i = 0; i < num_iterations; ++i) {
+				auto adj = Algo::VarianceAdjustEffect(100, 1);
+				REQUIRE_GE(adj, 100 - 5 * var);
+				REQUIRE_LE(adj, 100 + 5 * var);
+			}
+		}
+	}
+
+	SUBCASE("one") {
+		for (int i = 0; i < num_iterations; ++i) {
+			auto adj = Algo::VarianceAdjustEffect(1, 10);
+			REQUIRE_GE(adj, 1);
+			REQUIRE_LE(adj, 2);
+		}
+	}
+
+	SUBCASE("zero") {
+
+		SUBCASE("modern") {
+			const MockActor m(Player::EngineEnglish);
+			REQUIRE_FALSE(Player::IsLegacy());
+
+			for (int i = 0; i < num_iterations; ++i) {
+				REQUIRE_EQ(Algo::VarianceAdjustEffect(0, 0), 0);
+				REQUIRE_EQ(Algo::VarianceAdjustEffect(0, 1), 0);
+			}
+		}
+		SUBCASE("legacy") {
+			const MockActor m(Player::EngineRpg2k);
+			REQUIRE(Player::IsLegacy());
+
+			for (int i = 0; i < num_iterations; ++i) {
+				REQUIRE_EQ(Algo::VarianceAdjustEffect(0, 0), 0);
+				auto adj = Algo::VarianceAdjustEffect(0, 1);
+				REQUIRE_GE(adj, 0);
+				REQUIRE_LE(adj, 1);
+			}
+		}
+	}
+
+	SUBCASE("neg never varies") {
+		REQUIRE_EQ(Algo::VarianceAdjustEffect(-100, 0), -100);
+	}
+}
+
+void makeAgiSkills() {
+	// Does physical evasion
+	auto* s = MakeDBSkill(1, 90, 0, 0, 0, 0);
+	s->scope = lcf::rpg::Skill::Scope_enemy;
+	s->failure_message = 3;
+
+	s = MakeDBSkill(2, 90, 0, 0, 0, 0);
+	s->scope = lcf::rpg::Skill::Scope_enemies;
+	s->failure_message = 3;
+
+	// All ignore physical evasion
+	s = MakeDBSkill(3, 90, 0, 0, 0, 0);
+	s->scope = lcf::rpg::Skill::Scope_self;
+	s->failure_message = 3;
+
+	s = MakeDBSkill(4, 90, 0, 0, 0, 0);
+	s->scope = lcf::rpg::Skill::Scope_ally;
+	s->failure_message = 3;
+
+	s = MakeDBSkill(5, 90, 0, 0, 0, 0);
+	s->scope = lcf::rpg::Skill::Scope_party;
+	s->failure_message = 3;
+
+	s = MakeDBSkill(6, 90, 0, 0, 0, 0);
+	s->scope = lcf::rpg::Skill::Scope_enemy;
+	s->failure_message = 0;
+}
+
+decltype(auto) MakeAgiEnemy(int id, int agi) {
+	MakeDBEnemy(id, 1, 1, 1, 1, 1, agi);
+	return MakeEnemy(id);
+}
+
+decltype(auto) MakeAgiActor(int id, int agi) {
+	auto actor = MakeActor(id);
+	actor.SetBaseAgi(agi);
+	return actor;
+}
+
+static void testAgi(int src, int tgt, int res) {
+	auto source = MakeAgiActor(1, src);
+	auto target = MakeAgiEnemy(1, tgt);
+
+	REQUIRE_EQ(res, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+	REQUIRE_EQ(res, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+	REQUIRE_EQ(res, Algo::CalcSkillToHit(source, target, lcf::Data::skills[1]));
+	for (int i = 2; i < 6; ++i) {
+		CAPTURE(i);
+		REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[i]));
+
+	}
+}
+
+TEST_CASE("HitRateAgi") {
+	const MockActor m;
+	makeAgiSkills();
+
+	SUBCASE("100_100") { testAgi(100, 100, 90); }
+	SUBCASE("100_50") { testAgi(100, 50, 92); }
+	SUBCASE("50_100") { testAgi(50, 100, 85); }
+	SUBCASE("10_1") { testAgi(10, 1, 94); }
+	SUBCASE("10_0") { testAgi(10, 0, 94); }
+	SUBCASE("0_1") { testAgi(0, 1, 90); }
+}
+
+static void testStates(Game_Battler& source, Game_Battler& target, int base) {
+	SUBCASE("Cannot act") {
+		target.AddState(2, true);
+		REQUIRE_EQ(100, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+		REQUIRE_EQ(100, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+	}
+
+	SUBCASE("Avoid attacks") {
+		target.AddState(3, true);
+		REQUIRE_EQ(0, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+		// RPG_RT bug
+		REQUIRE_EQ(base, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+	}
+
+	SUBCASE("Avoid attacks and cannot act") {
+		target.AddState(2, true);
+		target.AddState(3, true);
+		REQUIRE_EQ(0, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+		// RPG_RT bug
+		REQUIRE_EQ(100, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+	}
+}
+
+TEST_CASE("HitRateStates") {
+	const MockActor m;
+	makeAgiSkills();
+	lcf::Data::states[2 - 1].restriction = lcf::rpg::State::Restriction_do_nothing;
+	lcf::Data::states[3 - 1].avoid_attacks = true;
+	lcf::Data::states[4 - 1].reduce_hit_ratio = 50;
+
+	auto source = MakeAgiActor(1, 100);
+	auto target = MakeAgiEnemy(1, 100);
+
+	testStates(source, target, 90);
+
+	SUBCASE("source blind50") {
+		source.AddState(4, true);
+		REQUIRE_EQ(45, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+		REQUIRE_EQ(45, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+
+		testStates(source, target, 45);
+	}
+}
+
+TEST_CASE("HitRateArmorAndRow2k3") {
+	const MockActor m(Player::EngineRpg2k3);
+	makeAgiSkills();
+	MakeDBEquip(1, lcf::rpg::Item::Type_armor, 0, 0, 0, 0, 100, 0, false, false, false, false, false, true, false, false);
+
+	auto source = MakeAgiActor(1, 100);
+
+	SUBCASE("actor target") {
+		auto target = MakeAgiActor(2, 100);
+
+		SUBCASE("Front") {
+			target.SetBattleRow(lcf::rpg::SaveActor::RowType_front);
+
+			SUBCASE("no armor") {
+				REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+				REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative));
+				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back));
+				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround));
+				REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers));
+
+				REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+			}
+
+			SUBCASE("phys eva up") {
+				target.SetEquipment(3, 1);
+				REQUIRE(target.HasPhysicalEvasionUp());
+
+				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative));
+				REQUIRE_EQ(40, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back));
+				REQUIRE_EQ(40, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround));
+				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers));
+
+				REQUIRE_EQ(65, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+			}
+		}
+
+		SUBCASE("Back") {
+			target.SetBattleRow(lcf::rpg::SaveActor::RowType_back);
+
+			SUBCASE("no armor") {
+				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative));
+				REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back));
+				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround));
+				REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers));
+
+				REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+			}
+
+			SUBCASE("phys eva up") {
+				target.SetEquipment(3, 1);
+				REQUIRE(target.HasPhysicalEvasionUp());
+				REQUIRE_EQ(40, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+				REQUIRE_EQ(40, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative));
+				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back));
+				REQUIRE_EQ(40, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround));
+				REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers));
+
+				REQUIRE_EQ(65, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+			}
+		}
+	}
+
+	SUBCASE("enemy target") {
+		auto target = MakeAgiEnemy(2, 100);
+
+		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative));
+		// RPG_RT bug we implement
+		REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back));
+		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround));
+		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers));
+
+		REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+	}
+}
+
+TEST_CASE("HitRateArmorAndRow2k") {
+	const MockActor m(Player::EngineRpg2k);
+	makeAgiSkills();
+	MakeDBEquip(1, lcf::rpg::Item::Type_armor, 0, 0, 0, 0, 100, 0, false, false, false, false, false, true, false, false);
+
+	auto source = MakeAgiActor(1, 100);
+
+	SUBCASE("actor target") {
+		auto target = MakeAgiActor(2, 100);
+
+		SUBCASE("no armor") {
+			REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+			REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative));
+			REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back));
+			REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround));
+			REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers));
+
+			REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+		}
+
+		SUBCASE("phys eva up") {
+			target.SetEquipment(3, 1);
+			REQUIRE(target.HasPhysicalEvasionUp());
+
+			REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+			REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative));
+			REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back));
+			REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround));
+			REQUIRE_EQ(65, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers));
+
+			REQUIRE_EQ(65, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+		}
+	}
+
+	SUBCASE("enemy target") {
+		auto target = MakeAgiEnemy(2, 100);
+
+		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_initiative));
+		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_back));
+		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_surround));
+		REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_pincers));
+
+		REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+	}
+}
+
+TEST_CASE("HitRateWeapons") {
+	const MockActor m(Player::EngineRpg2k3);
+	MakeDBEquip(1, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 90, 0, false, false, false, true, false, false, false, false);
+	MakeDBEquip(2, lcf::rpg::Item::Type_weapon, 0, 0, 0, 50, 90, 0, false, false, false, false, false, false, false, false);
+
+	auto source = MakeAgiActor(1, 100);
+	auto target = MakeAgiEnemy(1, 200);
+
+	source.SetEquipment(1, 1);
+	source.SetEquipment(2, 2);
+
+	REQUIRE_EQ(source.GetAgi(Game_Battler::WeaponAll), 150);
+	REQUIRE(source.AttackIgnoresEvasion(Game_Battler::WeaponAll));
+	REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none));
+
+	REQUIRE_EQ(source.GetAgi(Game_Battler::WeaponNone), 100);
+	REQUIRE_FALSE(source.AttackIgnoresEvasion(Game_Battler::WeaponNone));
+	REQUIRE_EQ(85, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponNone, lcf::rpg::System::BattleCondition_none));
+
+	REQUIRE_EQ(source.GetAgi(Game_Battler::WeaponPrimary), 100);
+	REQUIRE(source.AttackIgnoresEvasion(Game_Battler::WeaponPrimary));
+	REQUIRE_EQ(90, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponPrimary, lcf::rpg::System::BattleCondition_none));
+
+	REQUIRE_EQ(source.GetAgi(Game_Battler::WeaponSecondary), 150);
+	REQUIRE_FALSE(source.AttackIgnoresEvasion(Game_Battler::WeaponSecondary));
+	REQUIRE_EQ(88, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponSecondary, lcf::rpg::System::BattleCondition_none));
+
+	REQUIRE_EQ(100, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+}
+
+TEST_CASE("CritRate") {
+	const MockActor m(Player::EngineRpg2k3);
+	lcf::Data::enemies[0].critical_hit = true;
+	lcf::Data::enemies[0].critical_hit_chance = 30;
+	lcf::Data::enemies[1].critical_hit = true;
+	lcf::Data::enemies[1].critical_hit_chance = 30;
+	MakeDBEquip(1, lcf::rpg::Item::Type_weapon)->critical_hit = 50;
+	MakeDBEquip(2, lcf::rpg::Item::Type_weapon)->critical_hit = 80;
+	MakeDBEquip(3, lcf::rpg::Item::Type_armor)->prevent_critical = true;
+
+	SUBCASE("actor -> actor - always fails") {
+		auto source = MakeActor(1);
+		auto target = MakeActor(2);
+
+		REQUIRE_GT(source.GetCriticalHitChance(), 0.0f);
+
+		REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll));
+	}
+
+	SUBCASE("enemy -> enemy - always fails") {
+		auto source = MakeEnemy(1);
+		auto target = MakeEnemy(2);
+
+		REQUIRE_GT(source.GetCriticalHitChance(), 0.0f);
+
+		REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll));
+	}
+
+	SUBCASE("actor -> enemy") {
+		auto source = MakeActor(1);
+		auto target = MakeEnemy(1);
+
+		REQUIRE_GT(source.GetCriticalHitChance(), 0.0f);
+
+		SUBCASE("baseline") {
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll));
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponNone));
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponPrimary));
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponSecondary));
+		}
+
+		SUBCASE("weapons") {
+			source.SetEquipment(1, 1);
+			source.SetEquipment(2, 2);
+
+			REQUIRE_EQ(83, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll));
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponNone));
+			REQUIRE_EQ(53, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponPrimary));
+			REQUIRE_EQ(83, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponSecondary));
+		}
+	}
+
+	SUBCASE("enemy -> actor") {
+		auto source = MakeEnemy(1);
+		auto target = MakeActor(1);
+
+		REQUIRE_GT(source.GetCriticalHitChance(), 0.0f);
+
+		SUBCASE("baseline") {
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll));
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponNone));
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponPrimary));
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponSecondary));
+		}
+
+		SUBCASE("armor prevents critical") {
+			target.SetEquipment(3, 3);
+
+			REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll));
+			REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponNone));
+			REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponPrimary));
+			REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponSecondary));
+		}
+	}
+}
+
+decltype(auto) MakeStatEnemy(int id, int atk, int def, int spi) {
+	MakeDBEnemy(id, 1, 1, atk, def, spi, 1);
+	return MakeEnemy(id);
+}
+
+decltype(auto) MakeStatActor(int id, int atk, int def, int spi) {
+	auto actor = MakeActor(id);
+	actor.SetBaseAtk(atk);
+	actor.SetBaseDef(def);
+	actor.SetBaseSpi(spi);
+	return actor;
+}
+
+TEST_CASE("DefendAdjustment") {
+	const MockActor m;
+
+	SUBCASE("no strong") {
+		auto target = MakeActor(1);
+
+		SUBCASE("baseline") {
+			REQUIRE_EQ(100, Algo::AdjustDamageForDefend(100, target));
+		}
+
+		SUBCASE("defend") {
+			target.SetIsDefending(true);
+			REQUIRE_EQ(50, Algo::AdjustDamageForDefend(100, target));
+		}
+	}
+
+	SUBCASE("strong") {
+		lcf::Data::actors[0].super_guard = true;
+		auto target = MakeActor(1);
+
+		SUBCASE("baseline") {
+			REQUIRE_EQ(100, Algo::AdjustDamageForDefend(100, target));
+		}
+
+		SUBCASE("defend") {
+			target.SetIsDefending(true);
+			REQUIRE_EQ(25, Algo::AdjustDamageForDefend(100, target));
+		}
+	}
+}
+
+TEST_CASE("SelfDestructEffect") {
+	const MockActor m;
+
+	auto target = MakeStatActor(1, 0, 100, 0);
+
+	SUBCASE("100_100") {
+		auto source = MakeStatEnemy(1, 100, 0, 0);
+		REQUIRE_EQ(50, Algo::CalcSelfDestructEffect(source, target, false));
+	}
+
+	SUBCASE("200_100") {
+		auto source = MakeStatEnemy(1, 200, 0, 0);
+		REQUIRE_EQ(150, Algo::CalcSelfDestructEffect(source, target, false));
+	}
+
+	SUBCASE("1_100") {
+		auto source = MakeStatEnemy(1, 1, 0, 0);
+		REQUIRE_EQ(0, Algo::CalcSelfDestructEffect(source, target, false));
+	}
+
+	SUBCASE("150_0") {
+		auto source = MakeStatEnemy(1, 150, 0, 0);
+		REQUIRE_EQ(100, Algo::CalcSelfDestructEffect(source, target, false));
+	}
+
+	SUBCASE("150_0_var") {
+		auto source = MakeStatEnemy(1, 150, 0, 0);
+		for (int i = 0; i < 200; ++i) {
+			auto effect = Algo::CalcSelfDestructEffect(source, target, true);
+			REQUIRE_GE(effect, 80);
+			REQUIRE_LE(effect, 120);
+		}
+	}
+}
+
+static void testSkillStats(int power, int phys, int mag, Game_Battler& source, Game_Battler& target, int dmg, int heal) {
+	MakeDBSkill(1, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_enemy;
+	MakeDBSkill(2, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_enemies;
+	MakeDBSkill(3, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_self;
+	MakeDBSkill(4, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_ally;
+	MakeDBSkill(5, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_party;
+
+	MakeDBSkill(6, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_enemy;
+	SetDBSkillAttribute(6, 1, true);
+	MakeDBSkill(7, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_enemies;
+	SetDBSkillAttribute(7, 1, true);
+	MakeDBSkill(8, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_self;
+	SetDBSkillAttribute(8, 1, true);
+	MakeDBSkill(9, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_ally;
+	SetDBSkillAttribute(9, 1, true);
+	MakeDBSkill(10, 100, power, phys, mag, 0)->scope = lcf::rpg::Skill::Scope_party;
+	SetDBSkillAttribute(10, 1, true);
+
+	SUBCASE("baseline") {
+		REQUIRE_EQ(dmg, Algo::CalcSkillEffect(source, target, lcf::Data::skills[0], false));
+		REQUIRE_EQ(dmg, Algo::CalcSkillEffect(source, target, lcf::Data::skills[1], false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[2], false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[3], false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[4], false));
+	}
+
+	SUBCASE("attr2x") {
+		REQUIRE_EQ(dmg * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[5], false));
+		REQUIRE_EQ(dmg * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[6], false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[7], false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[8], false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[9], false));
+	}
+}
+
+TEST_CASE("SkillEffect") {
+	const MockActor m;
+	MakeDBAttribute(1, lcf::rpg::Attribute::Type_magical, 200, 200, 200, 200, 200);
+
+	SUBCASE("100/0/120 -> 0/100/90") {
+		auto source = MakeStatActor(1, 100, 0, 120);
+		auto target = MakeStatActor(1, 0, 100, 90);
+
+		SUBCASE("10/10/10") {
+			testSkillStats(10, 10, 10, source, target, 54, 90);
+		}
+
+		SUBCASE("0/10/10") {
+			testSkillStats(0, 10, 10, source, target, 44, 80);
+		}
+
+		SUBCASE("10/0/10") {
+			testSkillStats(10, 0, 10, source, target, 29, 40);
+		}
+
+		SUBCASE("10/10/0") {
+			testSkillStats(10, 10, 0, source, target, 35, 60);
+		}
+
+		SUBCASE("0/0/0") {
+			testSkillStats(0, 0, 0, source, target, 0, 0);
+		}
+	}
+
+	SUBCASE("10/0/10 -> 0/100/100") {
+		auto source = MakeStatActor(1, 10, 0, 10);
+		auto target = MakeStatActor(1, 0, 100, 100);
+
+		SUBCASE("0/10/10") {
+			testSkillStats(0, 10, 10, source, target, 0, 7);
+		}
+	}
+}
+
+static void testEnemyAttackEnemy(Game_Battler& source, Game_Battler& target, int dmg, int crit) {
+	for (int wid = -1; wid <= 2; ++wid) {
+		for (int cid = 0; cid <= 4; ++cid) {
+			CAPTURE(wid);
+			CAPTURE(cid);
+
+			SUBCASE("no crit") {
+				REQUIRE_EQ(dmg, Algo::CalcNormalAttackEffect(source, target, Game_Battler::Weapon(wid), false, false, lcf::rpg::System::BattleCondition(cid)));
+			}
+
+			SUBCASE("crit") {
+				REQUIRE_EQ(crit, Algo::CalcNormalAttackEffect(source, target, Game_Battler::Weapon(wid), true, false, lcf::rpg::System::BattleCondition(cid)));
+			}
+		}
+	}
+}
+
+static void testActorAttackRow(Game_Battler& source, Game_Battler& target, int none, int init, int back, int surround, int pincers) {
+	REQUIRE_EQ(none, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_none));
+	REQUIRE_EQ(init, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_initiative));
+	REQUIRE_EQ(back, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_back));
+	REQUIRE_EQ(surround, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_surround));
+	REQUIRE_EQ(pincers, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_pincers));
+}
+
+static void TestNormalAttack(int engine) {
+	const MockActor m(engine);
+	lcf::Data::enemies[1].attribute_ranks[0] = 2;
+	MakeDBAttribute(1, lcf::rpg::Attribute::Type_physical, 200, 200, 200, 200, 200);
+
+	const bool is2k3 = Player::IsRPG2k3();
+
+	SUBCASE("enemy 120/0 -> enemy 0/90") {
+		auto source = MakeStatEnemy(1, 120, 0, 0);
+		auto target = MakeStatEnemy(2, 0, 90, 0);
+
+		REQUIRE_EQ(source.GetAtk(), 120);
+		REQUIRE_EQ(target.GetDef(), 90);
+
+		SUBCASE("baseline") {
+			testEnemyAttackEnemy(source, target, 38, 114);
+		}
+
+		SUBCASE("charged") {
+			source.SetCharged(true);
+			testEnemyAttackEnemy(source, target, 76, 114);
+		}
+	}
+
+	SUBCASE("enemy 0/0 -> enemy 0/100") {
+		auto source = MakeStatEnemy(1, 0, 0, 0);
+		auto target = MakeStatEnemy(2, 0, 100, 0);
+
+		REQUIRE_EQ(0, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_none));
+	}
+
+	SUBCASE("enemy 9999/0 -> enemy 0/0") {
+		auto source = MakeStatEnemy(1, 9999, 0, 0);
+		auto target = MakeStatEnemy(2, 0, 0, 0);
+
+		REQUIRE_EQ(4999, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_none));
+	}
+
+	SUBCASE("actor 120/0 -> enemy 0/90") {
+		auto source = MakeStatActor(1, 120, 0, 0);
+		auto target = MakeStatEnemy(1, 0, 90, 0);
+
+		REQUIRE_EQ(source.GetAtk(), 120);
+		REQUIRE_EQ(target.GetDef(), 90);
+
+		SUBCASE("front row") {
+			source.SetBattleRow(lcf::rpg::SaveActor::RowType_front);
+			if (is2k3) {
+				testActorAttackRow(source, target, 47, 47, /* RPG_RT bug */ 28, 47, 38);
+			} else {
+				testActorAttackRow(source, target, 38, 38, 38, 38, 38);
+			}
+		}
+
+		SUBCASE("back row") {
+			source.SetBattleRow(lcf::rpg::SaveActor::RowType_back);
+			if (is2k3) {
+				testActorAttackRow(source, target, 38, 38, /* RPG_RT bug */ 35, 47, 38);
+			} else {
+				testActorAttackRow(source, target, 38, 38, 38, 38, 38);
+			}
+		}
+
+		SUBCASE("weapons and attributes") {
+			MakeDBEquip(1, lcf::rpg::Item::Type_weapon, 20, 0, 0, 0, 0);
+			MakeDBEquip(2, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 0);
+			SetDBItemAttribute(2, 1, true);
+
+			REQUIRE(lcf::Data::items[1].attribute_set[0]);
+
+			source.SetEquipment(1, 1);
+			source.SetEquipment(2, 2);
+
+			REQUIRE_EQ(source.GetWeaponId(), 1);
+			REQUIRE_EQ(source.GetShieldId(), 2);
+
+			if (is2k3) {
+				REQUIRE_EQ(140, source.GetAtk(Game_Battler::WeaponAll));
+				REQUIRE_EQ(120, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_none));
+				REQUIRE_EQ(47, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponNone, false, false, lcf::rpg::System::BattleCondition_none));
+				REQUIRE_EQ(60, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponPrimary, false, false, lcf::rpg::System::BattleCondition_none));
+				REQUIRE_EQ(94, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponSecondary, false, false, lcf::rpg::System::BattleCondition_none));
+			} else {
+				REQUIRE_EQ(140, source.GetAtk(Game_Battler::WeaponAll));
+				REQUIRE_EQ(96, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponAll, false, false, lcf::rpg::System::BattleCondition_none));
+				REQUIRE_EQ(38, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponNone, false, false, lcf::rpg::System::BattleCondition_none));
+				REQUIRE_EQ(48, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponPrimary, false, false, lcf::rpg::System::BattleCondition_none));
+				REQUIRE_EQ(76, Algo::CalcNormalAttackEffect(source, target, Game_Battler::WeaponSecondary, false, false, lcf::rpg::System::BattleCondition_none));
+			}
+		}
+	}
+
+	SUBCASE("actor 120/0 -> actor 0/90") {
+		auto source = MakeStatActor(1, 120, 0, 0);
+		auto target = MakeStatActor(2, 0, 90, 0);
+
+		REQUIRE_EQ(source.GetAtk(), 120);
+		REQUIRE_EQ(target.GetDef(), 90);
+
+		SUBCASE("source front") {
+			source.SetBattleRow(lcf::rpg::SaveActor::RowType_front);
+			SUBCASE("target front") {
+				target.SetBattleRow(lcf::rpg::SaveActor::RowType_front);
+				if (is2k3) {
+					testActorAttackRow(source, target, 47, 47, 28, 35, 38);
+				} else {
+					testActorAttackRow(source, target, 38, 38, 38, 38, 38);
+				}
+			}
+			SUBCASE("target back") {
+				target.SetBattleRow(lcf::rpg::SaveActor::RowType_back);
+				if (is2k3) {
+					testActorAttackRow(source, target, 35, 35, 38, 35, 38);
+				} else {
+					testActorAttackRow(source, target, 38, 38, 38, 38, 38);
+				}
+			}
+		}
+
+		SUBCASE("source back") {
+			source.SetBattleRow(lcf::rpg::SaveActor::RowType_back);
+			SUBCASE("target front") {
+				target.SetBattleRow(lcf::rpg::SaveActor::RowType_front);
+				if (is2k3) {
+					testActorAttackRow(source, target, 38, 38, 35, 35, 38);
+				} else {
+					testActorAttackRow(source, target, 38, 38, 38, 38, 38);
+				}
+			}
+			SUBCASE("target back") {
+				target.SetBattleRow(lcf::rpg::SaveActor::RowType_back);
+				if (is2k3) {
+					testActorAttackRow(source, target, 28, 28, 47, 35, 38);
+				} else {
+					testActorAttackRow(source, target, 38, 38, 38, 38, 38);
+				}
+			}
+		}
+	}
+}
+
+TEST_CASE("NormalAttackEffect") {
+	SUBCASE("2k") {
+		TestNormalAttack(Player::EngineRpg2k | Player::EngineEnglish);
+	}
+
+	SUBCASE("2k3") {
+		TestNormalAttack(Player::EngineRpg2k3 | Player::EngineEnglish);
+	}
+}
+
+
+TEST_SUITE_END();

--- a/tests/attribute.cpp
+++ b/tests/attribute.cpp
@@ -3,8 +3,6 @@
 #include "doctest.h"
 #include "utils.h"
 
-static void nullDBEnemy(lcf::rpg::Enemy& e) {}
-
 static Game_Actor MakeActor(int id) {
 	return Game_Actor(id);
 }
@@ -354,37 +352,51 @@ TEST_CASE("NormalAttack") {
 	MakeDBEquip(2, lcf::rpg::Item::Type_weapon);
 	SetDBItemAttribute(2, 2, true);
 	MakeDBEquip(3, lcf::rpg::Item::Type_weapon);
+	MakeDBEquip(4, lcf::rpg::Item::Type_shield);
+	SetDBItemAttribute(1, 4, true);
 
 	lcf::Data::actors[1].two_weapon = true;
 	auto source = MakeActor(2);
 	const auto& target = MakeActor(1);
 
 	SUBCASE("none") {
-		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::kWeaponAll), 100);
-		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, 0), 100);
-		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, 1), 100);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponAll), 100);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponNone), 100);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponPrimary), 100);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponSecondary), 100);
 	}
 
 	SUBCASE("primary") {
 		source.SetEquipment(1, 1);
-		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::kWeaponAll), 300);
-		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, 0), 300);
-		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, 1), 100);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponAll), 300);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponNone), 100);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponPrimary), 300);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponSecondary), 100);
 	}
 
 	SUBCASE("secondary") {
 		source.SetEquipment(2, 2);
-		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::kWeaponAll), 200);
-		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, 0), 100);
-		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, 1), 200);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponAll), 200);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponNone), 100);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponPrimary), 100);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponSecondary), 200);
 	}
 
 	SUBCASE("dual") {
 		source.SetEquipment(1, 1);
 		source.SetEquipment(2, 2);
-		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::kWeaponAll), 300);
-		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, 0), 300);
-		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, 1), 200);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponAll), 300);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponNone), 100);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponPrimary), 300);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponSecondary), 200);
+	}
+
+	SUBCASE("shield") {
+		source.SetEquipment(2, 4);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponAll), 100);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponNone), 100);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponPrimary), 100);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::WeaponSecondary), 100);
 	}
 }
 

--- a/tests/attribute.cpp
+++ b/tests/attribute.cpp
@@ -7,15 +7,6 @@ static Game_Actor MakeActor(int id) {
 	return Game_Actor(id);
 }
 
-static Game_Enemy& MakeEnemy(int id) {
-	auto& tp = lcf::Data::troops[0];
-	tp.members.resize(1);
-	tp.members[0].enemy_id = id;
-	Main_Data::game_enemyparty->ResetBattle(1);
-	auto& enemy = (*Main_Data::game_enemyparty)[0];
-	return enemy;
-}
-
 static lcf::DBBitArray MakeAttributeSet(std::initializer_list<bool> v = {}) {
 	auto a = lcf::DBBitArray(lcf::Data::attributes.size());
 	int idx = 0;
@@ -195,13 +186,6 @@ TEST_CASE("ApplyMultiplerMaxMulti") {
 
 	SUBCASE("mag") {
 		testMaxMulti(lcf::rpg::Attribute::Type_magical);
-	}
-}
-
-static void makeTestAttributes() {
-	for (int i = 1; i <= 8; ++i) {
-		auto type = (i >= 5) ? lcf::rpg::Attribute::Type_physical : lcf::rpg::Attribute::Type_magical;
-		MakeDBAttribute(i, type, -100, 200, 100, 50, 0);
 	}
 }
 

--- a/tests/attribute.cpp
+++ b/tests/attribute.cpp
@@ -1,0 +1,392 @@
+#include "test_mock_actor.h"
+#include "attribute.h"
+#include "doctest.h"
+#include "utils.h"
+
+static void nullDBEnemy(lcf::rpg::Enemy& e) {}
+
+static Game_Actor MakeActor(int id) {
+	return Game_Actor(id);
+}
+
+static Game_Enemy& MakeEnemy(int id) {
+	auto& tp = lcf::Data::troops[0];
+	tp.members.resize(1);
+	tp.members[0].enemy_id = id;
+	Main_Data::game_enemyparty->ResetBattle(1);
+	auto& enemy = (*Main_Data::game_enemyparty)[0];
+	return enemy;
+}
+
+static lcf::DBBitArray MakeAttributeSet(std::initializer_list<bool> v = {}) {
+	auto a = lcf::DBBitArray(lcf::Data::attributes.size());
+	int idx = 0;
+	for (auto b: v) {
+		a[idx++] = b;
+	}
+	return a;
+}
+
+TEST_SUITE_BEGIN("Attribute");
+
+TEST_CASE("Rate") {
+	const MockActor m;
+
+	MakeDBAttribute(1, lcf::rpg::Attribute::Type_physical, 1, -2, 3, -4, 5);
+	MakeDBAttribute(2, lcf::rpg::Attribute::Type_magical, -6, 7, -8, 9, -10);
+
+	SUBCASE("phys") {
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(1, 0), 1);
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(1, 1), -2);
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(1, 2), 3);
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(1, 3), -4);
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(1, 4), 5);
+	}
+
+	SUBCASE("mag") {
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(2, 0), -6);
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(2, 1), 7);
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(2, 2), -8);
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(2, 3), 9);
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(2, 4), -10);
+	}
+
+	SUBCASE("badrate") {
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(1, -1), 0);
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(1, 5), 0);
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(2, -1), 0);
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(2, 5), 0);
+	}
+
+	SUBCASE("badid") {
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(-1, 0), 0);
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(0, 0), 0);
+		REQUIRE_EQ(Attribute::GetAttributeRateModifier(INT_MAX, 0), 0);
+	}
+}
+
+template <typename... Args>
+auto MakeAttributeSetArray(const Args*... args) {
+	return Utils::MakeArray<const lcf::DBBitArray*>(args...);
+}
+
+TEST_CASE("ApplyMultiplerDefault") {
+	const MockActor m;
+
+	const auto& target = MakeActor(1);
+
+	auto as0 = MakeAttributeSet();
+	auto as1 = MakeAttributeSet();
+
+	SUBCASE("0") {
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, {}), 100);
+	}
+
+	SUBCASE("1") {
+		auto sets = MakeAttributeSetArray(&as0);
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, MakeSpan(sets)), 100);
+	}
+
+	SUBCASE("2") {
+		auto sets = MakeAttributeSetArray(&as0, &as1);
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, MakeSpan(sets)), 100);
+	}
+}
+
+void testSingle(int type) {
+	MakeDBAttribute(1, type, -100, 200, 100, 50, 0);
+	auto as0 = MakeAttributeSet({ true });
+	auto sets = MakeAttributeSetArray(&as0);
+
+	SUBCASE("0") {
+		SetDBActorAttribute(1, 1, 0);
+		const auto& target = MakeActor(1);
+
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), -100);
+	}
+
+	SUBCASE("1") {
+		SetDBActorAttribute(1, 1, 1);
+		const auto& target = MakeActor(1);
+
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), 200);
+	}
+
+	SUBCASE("2") {
+		SetDBActorAttribute(1, 1, 2);
+		const auto& target = MakeActor(1);
+
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), 100);
+	}
+
+	SUBCASE("3") {
+		SetDBActorAttribute(1, 1, 3);
+		const auto& target = MakeActor(1);
+
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), 50);
+	}
+
+	SUBCASE("4") {
+		SetDBActorAttribute(1, 1, 4);
+		const auto& target = MakeActor(1);
+
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), 0);
+	}
+}
+
+TEST_CASE("ApplyMultiplerSingle") {
+	const MockActor m;
+
+	SUBCASE("phys") {
+		testSingle(lcf::rpg::Attribute::Type_physical);
+	}
+
+	SUBCASE("mag") {
+		testSingle(lcf::rpg::Attribute::Type_magical);
+	}
+}
+
+void testMaxMulti(int type) {
+	for (int i = 0; i < 5; ++i) {
+		MakeDBAttribute(i + 1, type, -100, 200, 100, 50, 0);
+	}
+
+
+	SUBCASE("all") {
+		SetDBActorAttribute(1, 1, 0);
+		SetDBActorAttribute(1, 2, 1);
+		SetDBActorAttribute(1, 3, 2);
+		SetDBActorAttribute(1, 4, 3);
+		SetDBActorAttribute(1, 5, 4);
+
+		auto as0 = MakeAttributeSet({ true, true, true, true, true });
+		auto sets = MakeAttributeSetArray(&as0);
+		const auto& target = MakeActor(1);
+
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), 200);
+	}
+
+	SUBCASE("0") {
+		SetDBActorAttribute(1, 1, 0);
+		SetDBActorAttribute(1, 2, 4);
+
+		auto as0 = MakeAttributeSet({ true, true });
+		auto sets = MakeAttributeSetArray(&as0);
+		const auto& target = MakeActor(1);
+
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), 0);
+	}
+
+	SUBCASE("neg") {
+		SetDBActorAttribute(1, 3, 0);
+
+		auto as0 = MakeAttributeSet({ false, false, true });
+		auto sets = MakeAttributeSetArray(&as0);
+		const auto& target = MakeActor(1);
+
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), -100);
+	}
+}
+
+TEST_CASE("ApplyMultiplerMaxMulti") {
+	const MockActor m;
+
+	SUBCASE("phys") {
+		testMaxMulti(lcf::rpg::Attribute::Type_physical);
+	}
+
+	SUBCASE("mag") {
+		testMaxMulti(lcf::rpg::Attribute::Type_magical);
+	}
+}
+
+static void makeTestAttributes() {
+	for (int i = 1; i <= 8; ++i) {
+		auto type = (i >= 5) ? lcf::rpg::Attribute::Type_physical : lcf::rpg::Attribute::Type_magical;
+		MakeDBAttribute(i, type, -100, 200, 100, 50, 0);
+	}
+}
+
+TEST_CASE("ApplyComboPos") {
+	const MockActor m;
+
+	MakeDBAttribute(1, lcf::rpg::Attribute::Type_physical, -100, 200, 100, 50, 0);
+	MakeDBAttribute(2, lcf::rpg::Attribute::Type_magical, -100, 200, 100, 50, 0);
+
+	auto as0 = MakeAttributeSet({ true, true });
+	auto sets = MakeAttributeSetArray(&as0);
+
+	SUBCASE("100_100") {
+		SetDBActorAttribute(1, 1, 2);
+		SetDBActorAttribute(1, 2, 2);
+
+		const auto& target = MakeActor(1);
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), 100);
+	}
+
+	SUBCASE("200_100") {
+		SetDBActorAttribute(1, 1, 1);
+		SetDBActorAttribute(1, 2, 2);
+
+		const auto& target = MakeActor(1);
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), 200);
+	}
+
+	SUBCASE("50_100") {
+		SetDBActorAttribute(1, 1, 3);
+		SetDBActorAttribute(1, 2, 2);
+
+		const auto& target = MakeActor(1);
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), 50);
+	}
+
+	SUBCASE("50_0") {
+		SetDBActorAttribute(1, 1, 3);
+		SetDBActorAttribute(1, 2, 4);
+
+		const auto& target = MakeActor(1);
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), 0);
+	}
+
+	SUBCASE("200_50") {
+		SetDBActorAttribute(1, 1, 1);
+		SetDBActorAttribute(1, 2, 3);
+
+		const auto& target = MakeActor(1);
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), 100);
+	}
+}
+
+TEST_CASE("ApplyComboNeg2k3") {
+	const MockActor m(Player::EngineRpg2k3);
+
+	MakeDBAttribute(1, lcf::rpg::Attribute::Type_physical, -100, -50, 100, 50, 0);
+	MakeDBAttribute(2, lcf::rpg::Attribute::Type_magical, -100, -50, 100, 50, 0);
+
+	auto as0 = MakeAttributeSet({ true, true });
+	auto sets = MakeAttributeSetArray(&as0);
+
+	SUBCASE("-100_-50") {
+		SetDBActorAttribute(1, 1, 0);
+		SetDBActorAttribute(1, 2, 1);
+
+		const auto& target = MakeActor(1);
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), -50);
+	}
+
+	SUBCASE("-100_50") {
+		SetDBActorAttribute(1, 1, 0);
+		SetDBActorAttribute(1, 2, 3);
+
+		const auto& target = MakeActor(1);
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), 50);
+	}
+
+	SUBCASE("-100_0") {
+		SetDBActorAttribute(1, 1, 0);
+		SetDBActorAttribute(1, 2, 4);
+
+		const auto& target = MakeActor(1);
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), 0);
+	}
+}
+
+TEST_CASE("ApplyComboNeg2k") {
+	const MockActor m(Player::EngineRpg2k);
+
+	MakeDBAttribute(1, lcf::rpg::Attribute::Type_physical, -100, -50, 100, 50, 0);
+	MakeDBAttribute(2, lcf::rpg::Attribute::Type_magical, -100, -50, 100, 50, 0);
+
+	auto as0 = MakeAttributeSet({ true, true });
+	auto sets = MakeAttributeSetArray(&as0);
+
+	SUBCASE("-100_-50") {
+		SetDBActorAttribute(1, 1, 0);
+		SetDBActorAttribute(1, 2, 1);
+
+		const auto& target = MakeActor(1);
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), 100);
+	}
+
+	SUBCASE("-100_50") {
+		SetDBActorAttribute(1, 1, 0);
+		SetDBActorAttribute(1, 2, 3);
+
+		const auto& target = MakeActor(1);
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), 50);
+	}
+
+	SUBCASE("-100_0") {
+		SetDBActorAttribute(1, 1, 0);
+		SetDBActorAttribute(1, 2, 4);
+
+		const auto& target = MakeActor(1);
+		REQUIRE_EQ(Attribute::ApplyAttributeMultiplier(100, target, sets), 0);
+	}
+}
+
+TEST_CASE("Skill") {
+	const MockActor m(Player::EngineRpg2k);
+	auto* s0 = MakeDBSkill(1, 100, 1, 0, 0, 0);
+	SetDBSkillAttribute(1, 1, true);
+	auto* s1 = MakeDBSkill(2, 100, 1, 0, 0, 0);
+
+	MakeDBAttribute(1, lcf::rpg::Attribute::Type_physical, 300, 300, 300, 300, 300);
+	const auto& target = MakeActor(1);
+
+	SUBCASE("affect") {
+		REQUIRE_EQ(Attribute::ApplyAttributeSkillMultiplier(100, target, *s0), 300);
+	}
+
+	SUBCASE("none") {
+		REQUIRE_EQ(Attribute::ApplyAttributeSkillMultiplier(100, target, *s1), 100);
+	}
+}
+
+TEST_CASE("NormalAttack") {
+	const MockActor m(Player::EngineRpg2k);
+
+	MakeDBAttribute(1, lcf::rpg::Attribute::Type_physical, 300, 300, 300, 300, 300);
+	MakeDBAttribute(2, lcf::rpg::Attribute::Type_physical, 200, 200, 200, 200, 200);
+
+	MakeDBEquip(1, lcf::rpg::Item::Type_weapon);
+	SetDBItemAttribute(1, 1, true);
+	MakeDBEquip(2, lcf::rpg::Item::Type_weapon);
+	SetDBItemAttribute(2, 2, true);
+	MakeDBEquip(3, lcf::rpg::Item::Type_weapon);
+
+	lcf::Data::actors[1].two_weapon = true;
+	auto source = MakeActor(2);
+	const auto& target = MakeActor(1);
+
+	SUBCASE("none") {
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::kWeaponAll), 100);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, 0), 100);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, 1), 100);
+	}
+
+	SUBCASE("primary") {
+		source.SetEquipment(1, 1);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::kWeaponAll), 300);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, 0), 300);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, 1), 100);
+	}
+
+	SUBCASE("secondary") {
+		source.SetEquipment(2, 2);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::kWeaponAll), 200);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, 0), 100);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, 1), 200);
+	}
+
+	SUBCASE("dual") {
+		source.SetEquipment(1, 1);
+		source.SetEquipment(2, 2);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, Game_Battler::kWeaponAll), 300);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, 0), 300);
+		REQUIRE_EQ(Attribute::ApplyAttributeNormalAttackMultiplier(100, source, target, 1), 200);
+	}
+}
+
+TEST_SUITE_END();
+

--- a/tests/game_actor.cpp
+++ b/tests/game_actor.cpp
@@ -539,6 +539,24 @@ TEST_CASE("ArmorWithWeaponFlags") {
 	}
 }
 
+TEST_CASE("WeaponSpCost") {
+	const MockActor m;
+	auto actor = MakeActor(1, 1, 99, 100, 10, 11, 12, 13, 14, true);
+
+	MakeDBEquip(1, lcf::rpg::Item::Type_weapon)->sp_cost = 0;
+	MakeDBEquip(2, lcf::rpg::Item::Type_weapon)->sp_cost = 5;
+
+	REQUIRE(actor.HasTwoWeapons());
+
+	actor.SetEquipment(1, 1);
+	actor.SetEquipment(2, 2);
+
+	REQUIRE_EQ(actor.CalculateWeaponSpCost(Game_Battler::WeaponAll), 5);
+	REQUIRE_EQ(actor.CalculateWeaponSpCost(Game_Battler::WeaponNone), 0);
+	REQUIRE_EQ(actor.CalculateWeaponSpCost(Game_Battler::WeaponPrimary), 0);
+	REQUIRE_EQ(actor.CalculateWeaponSpCost(Game_Battler::WeaponSecondary), 5);
+}
+
 static Game_Actor MakeActorAttribute(int id, int attr_id, int rank) {
 	SetDBActorAttribute(id, attr_id, rank);
 	return MakeActor(id, 1, 99, 1, 1, 1, 1, 1, 1);

--- a/tests/game_actor.cpp
+++ b/tests/game_actor.cpp
@@ -1,279 +1,202 @@
-#include "game_actors.h"
-#include "game_party.h"
-#include "game_enemyparty.h"
-#include "main_data.h"
-#include "player.h"
-#include <lcf/data.h>
-
+#include "test_mock_actor.h"
 #include "doctest.h"
 
-
-lcf::rpg::Item* MakeEquip(int id, int type,
-		int atk = 1, int def = 1, int spi = 1, int agi = 1,
-		int hit=100, int crt=0,
-		bool w1 = false, bool w2 = false, bool w3 = false, bool w4 = false,
-		bool a1 = false, bool a2 = false, bool a3 = false, bool a4 = false)
-{
-	auto& item = lcf::Data::items[id - 1];
-	item.type = type;
-	item.atk_points1 = atk;
-	item.def_points1 = def;
-	item.spi_points1 = spi;
-	item.agi_points1 = agi;
-	item.hit = hit;
-	item.critical_hit = 0;
-	item.preemptive = w1;
-	item.dual_attack = w2;
-	item.attack_all = w3;
-	item.ignore_evasion = w4;
-	item.prevent_critical = a1;
-	item.raise_evasion = a2;
-	item.half_sp_cost = a3;
-	item.no_terrain_damage = a4;
-	return &item;
+template <typename... Args>
+static Game_Actor MakeActor(int id, Args... args) {
+	MakeDBActor(id, args...);
+	return Game_Actor(id);
 }
-
-class MockActor {
-public:
-	MockActor(int eng = Player::EngineRpg2k3 | Player::EngineEnglish)
-	{
-		_engine = Player::engine;
-		Player::engine = eng;
-
-		lcf::Data::actors.resize(20);
-		for (size_t i = 0; i < lcf::Data::actors.size(); ++i) {
-			auto& actor = lcf::Data::actors[i];
-			actor.ID = i + 1;
-			actor.parameters.Setup(99);
-			for (int i = 0; i < 99; ++i) {
-				const auto lvl = i + 1;
-				actor.parameters.maxhp[i] = lvl * 100;
-				actor.parameters.maxsp[i]= lvl * 10;
-				actor.parameters.attack[i] = lvl * 10 + 1;
-				actor.parameters.defense[i] = lvl * 10 + 2;
-				actor.parameters.spirit[i] = lvl * 10 + 3;
-				actor.parameters.agility[i] = lvl * 10 + 4;
-			}
-			actor.initial_level = 1;
-			actor.final_level = 99;
-			actor.class_id = 0;
-			actor.exp_base = 1;
-			actor.exp_inflation = 677;
-			actor.exp_correction = 40;
-
-			actor.two_weapon = (i % 5) == 1;
-			actor.lock_equipment = (i % 5) == 2;
-			actor.auto_battle = (i % 5) == 3;
-			actor.super_guard = (i % 5) == 4;
-		}
-
-		lcf::Data::items.resize(200);
-		for (size_t i = 0; i < lcf::Data::items.size(); ++i) {
-			lcf::Data::items[i].ID = i + 1;
-		}
-
-		Main_Data::Cleanup();
-		Main_Data::game_data.Setup();
-
-		Main_Data::game_actors = std::make_unique<Game_Actors>();
-		Main_Data::game_enemyparty = std::make_unique<Game_EnemyParty>();
-		Main_Data::game_party = std::make_unique<Game_Party>();
-
-		Main_Data::game_party->SetupNewGame();
-	}
-
-	~MockActor() {
-		Main_Data::Cleanup();
-
-		lcf::Data::actors = {};
-		lcf::Data::items = {};
-		Player::engine = _engine;
-	}
-private:
-	int _engine = {};
-};
 
 TEST_SUITE_BEGIN("Game_Actor");
 
 TEST_CASE("Limits2k") {
 	const MockActor m(Player::EngineRpg2k);
+	auto actor = MakeActor(1, 1, 99, 100, 10, 11, 12, 13, 14);
 
-	auto* actor = Main_Data::game_actors->GetActor(1);
-
-	REQUIRE(actor != nullptr);
-	REQUIRE_EQ(actor->MaxHpValue(), 999);
-	REQUIRE_EQ(actor->MaxStatBaseValue(), 999);
+	REQUIRE_EQ(actor.MaxHpValue(), 999);
+	REQUIRE_EQ(actor.MaxStatBaseValue(), 999);
 	// FIXME: Verify Clamps
-	REQUIRE_EQ(actor->MaxStatBattleValue(), 999);
+	REQUIRE_EQ(actor.MaxStatBattleValue(), 999);
 }
 
 TEST_CASE("Limits2k3") {
 	const MockActor m(Player::EngineRpg2k3);
 
-	auto* actor = Main_Data::game_actors->GetActor(1);
+	auto actor = MakeActor(1, 1, 99, 100, 10, 11, 12, 13, 14);
 
-	REQUIRE(actor != nullptr);
-	REQUIRE_EQ(actor->MaxHpValue(), 9999);
-	REQUIRE_EQ(actor->MaxStatBaseValue(), 999);
+	REQUIRE_EQ(actor.MaxHpValue(), 9999);
+	REQUIRE_EQ(actor.MaxStatBaseValue(), 999);
 	// FIXME: Verify Clamps
-	REQUIRE_EQ(actor->MaxStatBattleValue(), 9999);
+	REQUIRE_EQ(actor.MaxStatBattleValue(), 9999);
 }
 
 
-TEST_CASE("Base") {
+TEST_CASE("Default") {
 	const MockActor m;
+	auto actor = MakeActor(1, 1, 99, 100, 10, 11, 12, 13, 14);
 
-	auto* actor = Main_Data::game_actors->GetActor(1);
+	REQUIRE_EQ(actor.GetType(), Game_Battler::Type_Ally);
+	REQUIRE_EQ(actor.GetId(), 1);
 
-	REQUIRE(actor != nullptr);
-	REQUIRE_EQ(actor->GetType(), Game_Battler::Type_Ally);
-	REQUIRE_EQ(actor->GetId(), 1);
+	REQUIRE_EQ(actor.GetLevel(), 1);
+	REQUIRE_EQ(actor.GetMaxLevel(), 99);
 
-	REQUIRE_EQ(actor->GetLevel(), 1);
-	REQUIRE_EQ(actor->GetMaxLevel(), 99);
+	REQUIRE_EQ(actor.GetExp(), 0);
+	REQUIRE_EQ(actor.GetBaseExp(), 0);
+	REQUIRE_EQ(actor.GetNextExp(), 718);
 
-	REQUIRE_EQ(actor->GetExp(), 0);
-	REQUIRE_EQ(actor->GetBaseExp(), 0);
-	REQUIRE_EQ(actor->GetNextExp(), 718);
+	REQUIRE_EQ(actor.GetClass(), nullptr);
 
-	REQUIRE_EQ(actor->GetClass(), nullptr);
+	REQUIRE_EQ(actor.GetBaseMaxHp(), 100);
+	REQUIRE_EQ(actor.GetBaseMaxSp(), 10);
+	REQUIRE_EQ(actor.GetMaxHp(), 100);
+	REQUIRE_EQ(actor.GetMaxSp(), 10);
 
-	REQUIRE_EQ(actor->GetBaseMaxHp(), 100);
-	REQUIRE_EQ(actor->GetBaseMaxSp(), 10);
-	REQUIRE_EQ(actor->GetMaxHp(), 100);
-	REQUIRE_EQ(actor->GetMaxSp(), 10);
-
-	REQUIRE_EQ(actor->GetHp(), 100);
-	REQUIRE_EQ(actor->GetSp(), 10);
+	REQUIRE_EQ(actor.GetHp(), 100);
+	REQUIRE_EQ(actor.GetSp(), 10);
 
 	for (int w = -1; w < 2; ++w) {
-		REQUIRE_EQ(actor->GetBaseAtk(w), 11);
-		REQUIRE_EQ(actor->GetBaseDef(w), 12);
-		REQUIRE_EQ(actor->GetBaseSpi(w), 13);
-		REQUIRE_EQ(actor->GetBaseAgi(w), 14);
+		REQUIRE_EQ(actor.GetBaseAtk(w), 11);
+		REQUIRE_EQ(actor.GetBaseDef(w), 12);
+		REQUIRE_EQ(actor.GetBaseSpi(w), 13);
+		REQUIRE_EQ(actor.GetBaseAgi(w), 14);
 
-		REQUIRE_EQ(actor->GetAtk(w), 11);
-		REQUIRE_EQ(actor->GetDef(w), 12);
-		REQUIRE_EQ(actor->GetSpi(w), 13);
-		REQUIRE_EQ(actor->GetAgi(w), 14);
+		REQUIRE_EQ(actor.GetAtk(w), 11);
+		REQUIRE_EQ(actor.GetDef(w), 12);
+		REQUIRE_EQ(actor.GetSpi(w), 13);
+		REQUIRE_EQ(actor.GetAgi(w), 14);
 
-		REQUIRE_FALSE(actor->HasPreemptiveAttack(w));
-		REQUIRE_FALSE(actor->HasDualAttack(w));
-		REQUIRE_FALSE(actor->HasAttackAll(w));
-		REQUIRE_FALSE(actor->AttackIgnoresEvasion(w));
+		REQUIRE_FALSE(actor.HasPreemptiveAttack(w));
+		REQUIRE_FALSE(actor.HasDualAttack(w));
+		REQUIRE_FALSE(actor.HasAttackAll(w));
+		REQUIRE_FALSE(actor.AttackIgnoresEvasion(w));
 
-		REQUIRE_EQ(actor->GetHitChance(w), 90);
-		REQUIRE(actor->GetCriticalHitChance(w) == doctest::Approx(0.03333f));
+		REQUIRE_EQ(actor.GetHitChance(w), 90);
+		REQUIRE(actor.GetCriticalHitChance(w) == doctest::Approx(0.03333f));
 	}
 
-	REQUIRE_FALSE(actor->PreventsTerrainDamage());
-	REQUIRE_FALSE(actor->PreventsCritical());
-	REQUIRE_FALSE(actor->HasPhysicalEvasionUp());
-	REQUIRE_FALSE(actor->HasHalfSpCost());
+	REQUIRE_FALSE(actor.PreventsTerrainDamage());
+	REQUIRE_FALSE(actor.PreventsCritical());
+	REQUIRE_FALSE(actor.HasPhysicalEvasionUp());
+	REQUIRE_FALSE(actor.HasHalfSpCost());
 
-	REQUIRE_EQ(actor->GetWeaponId(), 0);
-	REQUIRE_EQ(actor->GetShieldId(), 0);
-	REQUIRE_EQ(actor->GetArmorId(), 0);
-	REQUIRE_EQ(actor->GetHelmetId(), 0);
-	REQUIRE_EQ(actor->GetAccessoryId(), 0);
+	REQUIRE_EQ(actor.GetWeaponId(), 0);
+	REQUIRE_EQ(actor.GetShieldId(), 0);
+	REQUIRE_EQ(actor.GetArmorId(), 0);
+	REQUIRE_EQ(actor.GetHelmetId(), 0);
+	REQUIRE_EQ(actor.GetAccessoryId(), 0);
 
-	REQUIRE_EQ(actor->GetWeapon(), nullptr);
-	REQUIRE_EQ(actor->Get2ndWeapon(), nullptr);
-	REQUIRE_EQ(actor->GetShield(), nullptr);
-	REQUIRE_EQ(actor->GetArmor(), nullptr);
-	REQUIRE_EQ(actor->GetHelmet(), nullptr);
-	REQUIRE_EQ(actor->GetAccessory(), nullptr);
+	REQUIRE_EQ(actor.GetWeapon(), nullptr);
+	REQUIRE_EQ(actor.Get2ndWeapon(), nullptr);
+	REQUIRE_EQ(actor.GetShield(), nullptr);
+	REQUIRE_EQ(actor.GetArmor(), nullptr);
+	REQUIRE_EQ(actor.GetHelmet(), nullptr);
+	REQUIRE_EQ(actor.GetAccessory(), nullptr);
 
-	REQUIRE_FALSE(actor->IsEquipmentFixed());
-	REQUIRE_FALSE(actor->HasStrongDefense());
-	REQUIRE_FALSE(actor->HasTwoWeapons());
-	REQUIRE_FALSE(actor->GetAutoBattle());
+	REQUIRE_FALSE(actor.IsEquipmentFixed());
+	REQUIRE_FALSE(actor.HasStrongDefense());
+	REQUIRE_FALSE(actor.HasTwoWeapons());
+	REQUIRE_FALSE(actor.GetAutoBattle());
 
-	REQUIRE_EQ(actor->GetBattleRow(), Game_Actor::RowType::RowType_front);
+	REQUIRE_EQ(actor.GetBattleRow(), Game_Actor::RowType::RowType_front);
+}
+
+TEST_CASE("ActorFlags") {
+	const MockActor m;
+
+	for (auto two_weapon: { true, false }) {
+		for (auto lock_equip: { true, false }) {
+			for (auto auto_battle: { true, false }) {
+				for (auto super_guard: { true, false }) {
+					auto actor = MakeActor(1, 1, 99, 1, 1, 1, 1, 1, 1, two_weapon, lock_equip, auto_battle, super_guard);
+
+					REQUIRE_EQ(actor.HasTwoWeapons(), two_weapon);
+					REQUIRE_EQ(actor.IsEquipmentFixed(), lock_equip);
+					REQUIRE_EQ(actor.GetAutoBattle(), auto_battle);
+					REQUIRE_EQ(actor.HasStrongDefense(), super_guard);
+				}
+			}
+		}
+	}
 }
 
 TEST_CASE("AdjParams") {
 	const MockActor m;
+	auto actor = MakeActor(1, 1, 99, 100, 10, 11, 12, 13, 14);
 
-	auto* actor = Main_Data::game_actors->GetActor(1);
 
-	REQUIRE(actor != nullptr);
+	actor.SetBaseMaxHp(501);
+	actor.SetBaseMaxSp(502);
+	actor.SetBaseAtk(503);
+	actor.SetBaseDef(504);
+	actor.SetBaseSpi(505);
+	actor.SetBaseAgi(506);
 
-	actor->SetBaseMaxHp(501);
-	actor->SetBaseMaxSp(502);
-	actor->SetBaseAtk(503);
-	actor->SetBaseDef(504);
-	actor->SetBaseSpi(505);
-	actor->SetBaseAgi(506);
+	REQUIRE_EQ(actor.GetBaseMaxHp(), 501);
+	REQUIRE_EQ(actor.GetBaseMaxSp(), 502);
+	REQUIRE_EQ(actor.GetMaxHp(), 501);
+	REQUIRE_EQ(actor.GetMaxSp(), 502);
 
-	REQUIRE_EQ(actor->GetBaseMaxHp(), 501);
-	REQUIRE_EQ(actor->GetBaseMaxSp(), 502);
-	REQUIRE_EQ(actor->GetMaxHp(), 501);
-	REQUIRE_EQ(actor->GetMaxSp(), 502);
-
-	REQUIRE_EQ(actor->GetHp(), 100);
-	REQUIRE_EQ(actor->GetSp(), 10);
+	REQUIRE_EQ(actor.GetHp(), 100);
+	REQUIRE_EQ(actor.GetSp(), 10);
 
 	for (int w = -1; w < 2; ++w) {
-		REQUIRE_EQ(actor->GetBaseAtk(w), 503);
-		REQUIRE_EQ(actor->GetBaseDef(w), 504);
-		REQUIRE_EQ(actor->GetBaseSpi(w), 505);
-		REQUIRE_EQ(actor->GetBaseAgi(w), 506);
+		REQUIRE_EQ(actor.GetBaseAtk(w), 503);
+		REQUIRE_EQ(actor.GetBaseDef(w), 504);
+		REQUIRE_EQ(actor.GetBaseSpi(w), 505);
+		REQUIRE_EQ(actor.GetBaseAgi(w), 506);
 
-		REQUIRE_EQ(actor->GetAtk(w), 503);
-		REQUIRE_EQ(actor->GetDef(w), 504);
-		REQUIRE_EQ(actor->GetSpi(w), 505);
-		REQUIRE_EQ(actor->GetAgi(w), 506);
+		REQUIRE_EQ(actor.GetAtk(w), 503);
+		REQUIRE_EQ(actor.GetDef(w), 504);
+		REQUIRE_EQ(actor.GetSpi(w), 505);
+		REQUIRE_EQ(actor.GetAgi(w), 506);
 	}
 
-	actor->SetAtkModifier(10);
-	actor->SetDefModifier(20);
-	actor->SetSpiModifier(30);
-	actor->SetAgiModifier(40);
+	actor.SetAtkModifier(10);
+	actor.SetDefModifier(20);
+	actor.SetSpiModifier(30);
+	actor.SetAgiModifier(40);
 
 	for (int w = -1; w < 2; ++w) {
-		REQUIRE_EQ(actor->GetBaseAtk(w), 503);
-		REQUIRE_EQ(actor->GetBaseDef(w), 504);
-		REQUIRE_EQ(actor->GetBaseSpi(w), 505);
-		REQUIRE_EQ(actor->GetBaseAgi(w), 506);
+		REQUIRE_EQ(actor.GetBaseAtk(w), 503);
+		REQUIRE_EQ(actor.GetBaseDef(w), 504);
+		REQUIRE_EQ(actor.GetBaseSpi(w), 505);
+		REQUIRE_EQ(actor.GetBaseAgi(w), 506);
 
-		REQUIRE_EQ(actor->GetAtk(w), 513);
-		REQUIRE_EQ(actor->GetDef(w), 524);
-		REQUIRE_EQ(actor->GetSpi(w), 535);
-		REQUIRE_EQ(actor->GetAgi(w), 546);
+		REQUIRE_EQ(actor.GetAtk(w), 513);
+		REQUIRE_EQ(actor.GetDef(w), 524);
+		REQUIRE_EQ(actor.GetSpi(w), 535);
+		REQUIRE_EQ(actor.GetAgi(w), 546);
 	}
 }
 
 TEST_CASE("TryEquip") {
 	const MockActor m;
+	auto actor = MakeActor(1, 1, 99, 100, 10, 11, 12, 13, 14);
 
-	auto* actor = Main_Data::game_actors->GetActor(1);
-
-	REQUIRE(actor != nullptr);
-
-	MakeEquip(1, lcf::rpg::Item::Type_weapon, 1, 11, 21, 31);
-	MakeEquip(2, lcf::rpg::Item::Type_shield, 1, 11, 21, 31);
-	MakeEquip(3, lcf::rpg::Item::Type_armor, 1, 11, 21, 31);
-	MakeEquip(4, lcf::rpg::Item::Type_helmet, 1, 11, 21, 31);
-	MakeEquip(5, lcf::rpg::Item::Type_accessory, 1, 11, 21, 31);
+	MakeDBEquip(1, lcf::rpg::Item::Type_weapon, 1, 11, 21, 31);
+	MakeDBEquip(2, lcf::rpg::Item::Type_shield, 1, 11, 21, 31);
+	MakeDBEquip(3, lcf::rpg::Item::Type_armor, 1, 11, 21, 31);
+	MakeDBEquip(4, lcf::rpg::Item::Type_helmet, 1, 11, 21, 31);
+	MakeDBEquip(5, lcf::rpg::Item::Type_accessory, 1, 11, 21, 31);
 
 	for (int i = 1; i <= 5; ++i) {
-		actor->SetEquipment(i, i);
-		REQUIRE_EQ(actor->GetWeaponId(), 1);
-		if (i >= 2) REQUIRE_EQ(actor->GetShieldId(), 2);
-		if (i >= 3) REQUIRE_EQ(actor->GetArmorId(), 3);
-		if (i >= 4) REQUIRE_EQ(actor->GetHelmetId(), 4);
-		if (i >= 5) REQUIRE_EQ(actor->GetAccessoryId(), 5);
+		actor.SetEquipment(i, i);
+		REQUIRE_EQ(actor.GetWeaponId(), 1);
+		if (i >= 2) REQUIRE_EQ(actor.GetShieldId(), 2);
+		if (i >= 3) REQUIRE_EQ(actor.GetArmorId(), 3);
+		if (i >= 4) REQUIRE_EQ(actor.GetHelmetId(), 4);
+		if (i >= 5) REQUIRE_EQ(actor.GetAccessoryId(), 5);
 
-		REQUIRE_EQ(actor->GetBaseAtk(), 11 + i * 1);
-		REQUIRE_EQ(actor->GetBaseDef(), 12 + i * 11);
-		REQUIRE_EQ(actor->GetBaseSpi(), 13 + i * 21);
-		REQUIRE_EQ(actor->GetBaseAgi(), 14 + i * 31);
+		REQUIRE_EQ(actor.GetBaseAtk(), 11 + i * 1);
+		REQUIRE_EQ(actor.GetBaseDef(), 12 + i * 11);
+		REQUIRE_EQ(actor.GetBaseSpi(), 13 + i * 21);
+		REQUIRE_EQ(actor.GetBaseAgi(), 14 + i * 31);
 
-		REQUIRE_EQ(actor->GetAtk(), actor->GetBaseAtk());
-		REQUIRE_EQ(actor->GetDef(), actor->GetBaseDef());
-		REQUIRE_EQ(actor->GetSpi(), actor->GetBaseSpi());
-		REQUIRE_EQ(actor->GetAgi(), actor->GetBaseAgi());
+		REQUIRE_EQ(actor.GetAtk(), actor.GetBaseAtk());
+		REQUIRE_EQ(actor.GetDef(), actor.GetBaseDef());
+		REQUIRE_EQ(actor.GetSpi(), actor.GetBaseSpi());
+		REQUIRE_EQ(actor.GetAgi(), actor.GetBaseAgi());
 	}
 }
 
@@ -400,118 +323,108 @@ static void testWeapon(Game_Actor* a, int id1, int id2, int armor = 0, int helme
 
 TEST_CASE("SingleWeapon") {
 	const MockActor m;
+	auto actor = MakeActor(1, 1, 99, 100, 10, 11, 12, 13, 14, false);
 
-	MakeEquip(1, lcf::rpg::Item::Type_weapon, 1, 2, 3, 4);
-	MakeEquip(2, lcf::rpg::Item::Type_shield, 11, 12, 13, 14);
+	MakeDBEquip(1, lcf::rpg::Item::Type_weapon, 1, 2, 3, 4);
+	MakeDBEquip(2, lcf::rpg::Item::Type_shield, 11, 12, 13, 14);
 
-	auto* a = Main_Data::game_actors->GetActor(1);
-	REQUIRE(a != nullptr);
-	REQUIRE_FALSE(a->HasTwoWeapons());
+	REQUIRE_FALSE(actor.HasTwoWeapons());
 
-	testWeapon(a, 1, 2);
+	testWeapon(&actor, 1, 2);
 }
-
-
 
 TEST_CASE("DualWeaponParams") {
 	const MockActor m;
+	auto actor = MakeActor(1, 1, 99, 100, 10, 11, 12, 13, 14, true);
 
-	MakeEquip(1, lcf::rpg::Item::Type_weapon, 1, 2, 3, 4);
-	MakeEquip(2, lcf::rpg::Item::Type_weapon, 5, 6, 7, 8);
+	MakeDBEquip(1, lcf::rpg::Item::Type_weapon, 1, 2, 3, 4);
+	MakeDBEquip(2, lcf::rpg::Item::Type_weapon, 5, 6, 7, 8);
 
-	auto* a = Main_Data::game_actors->GetActor(2);
-	REQUIRE(a != nullptr);
-	REQUIRE(a->HasTwoWeapons());
+	REQUIRE(actor.HasTwoWeapons());
 
-	testWeapon(a, 1, 2);
+	testWeapon(&actor, 1, 2);
 }
 
 TEST_CASE("DualWeaponHit") {
 	const MockActor m;
+	auto actor = MakeActor(1, 1, 99, 100, 10, 11, 12, 13, 14, true);
 
-	MakeEquip(1, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 20, 40);
-	MakeEquip(2, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 75, 20);
+	MakeDBEquip(1, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 20, 40);
+	MakeDBEquip(2, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 75, 20);
 
-	auto* a = Main_Data::game_actors->GetActor(2);
-	REQUIRE(a != nullptr);
-	REQUIRE(a->HasTwoWeapons());
+	REQUIRE(actor.HasTwoWeapons());
 
-	testWeapon(a, 1, 2);
+	testWeapon(&actor, 1, 2);
 }
 
 TEST_CASE("DualWeaponFlags") {
 	const MockActor m;
+	auto actor = MakeActor(1, 1, 99, 100, 10, 11, 12, 13, 14, true);
 
-	MakeEquip(1, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 0, true, false, false, false);
-	MakeEquip(2, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 0, false, true, false, false);
-	MakeEquip(3, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 0, false, false, true, false);
-	MakeEquip(4, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 0, false, false, false, true);
+	MakeDBEquip(1, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 0, true, false, false, false);
+	MakeDBEquip(2, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 0, false, true, false, false);
+	MakeDBEquip(3, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 0, false, false, true, false);
+	MakeDBEquip(4, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 0, false, false, false, true);
 
-	auto* a = Main_Data::game_actors->GetActor(2);
-	REQUIRE(a != nullptr);
-	REQUIRE(a->HasTwoWeapons());
+	REQUIRE(actor.HasTwoWeapons());
 
 	for (int i = 1; i <= 4; ++i) {
 		for (int j = 1; j <= 4; ++j) {
-			testWeapon(a, i, j);
+			testWeapon(&actor, i, j);
 		}
 	}
 }
 
 TEST_CASE("ArmorFlags") {
 	const MockActor m;
+	auto actor = MakeActor(1, 1, 99, 100, 10, 11, 12, 13, 14);
 
-	MakeEquip(1, lcf::rpg::Item::Type_shield, 0, 0, 0, 0, 0, 0, false, false, false, false, true, false, false, false);
-	MakeEquip(2, lcf::rpg::Item::Type_armor, 0, 0, 0, 0, 0, 0, false, false, false, false, false, true, false, false);
-	MakeEquip(3, lcf::rpg::Item::Type_helmet, 0, 0, 0, 0, 0, 0, false, false, false, false, false, false, true, false);
-	MakeEquip(4, lcf::rpg::Item::Type_accessory, 0, 0, 0, 0, 0, 0, false, false, false, false, false, false, false, true);
+	MakeDBEquip(1, lcf::rpg::Item::Type_shield, 0, 0, 0, 0, 0, 0, false, false, false, false, true, false, false, false);
+	MakeDBEquip(2, lcf::rpg::Item::Type_armor, 0, 0, 0, 0, 0, 0, false, false, false, false, false, true, false, false);
+	MakeDBEquip(3, lcf::rpg::Item::Type_helmet, 0, 0, 0, 0, 0, 0, false, false, false, false, false, false, true, false);
+	MakeDBEquip(4, lcf::rpg::Item::Type_accessory, 0, 0, 0, 0, 0, 0, false, false, false, false, false, false, false, true);
 
-	auto* a = Main_Data::game_actors->GetActor(1);
-	REQUIRE(a != nullptr);
 
-	testWeapon(a, 0, 1, 0, 0, 0);
-	testWeapon(a, 0, 1, 2, 0, 0);
-	testWeapon(a, 0, 1, 2, 3, 0);
-	testWeapon(a, 0, 1, 2, 3, 4);
+	testWeapon(&actor, 0, 1, 0, 0, 0);
+	testWeapon(&actor, 0, 1, 2, 0, 0);
+	testWeapon(&actor, 0, 1, 2, 3, 0);
+	testWeapon(&actor, 0, 1, 2, 3, 4);
 }
 
 TEST_CASE("WeaponWithArmorFlags") {
 	const MockActor m;
+	auto actor = MakeActor(1, 1, 99, 100, 10, 11, 12, 13, 14);
 
-	MakeEquip(1, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 100, true, true, true, true, true, true, true, true);
+	MakeDBEquip(1, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 100, true, true, true, true, true, true, true, true);
 
-	auto* a = Main_Data::game_actors->GetActor(1);
-	REQUIRE(a != nullptr);
 
-	a->SetEquipment(1, 1);
-	REQUIRE_EQ(a->GetWeaponId(), 1);
+	actor.SetEquipment(1, 1);
+	REQUIRE_EQ(actor.GetWeaponId(), 1);
 
-	REQUIRE_FALSE(a->PreventsCritical());
-	REQUIRE_FALSE(a->HasPhysicalEvasionUp());
-	REQUIRE_FALSE(a->HasHalfSpCost());
-	REQUIRE_FALSE(a->PreventsTerrainDamage());
+	REQUIRE_FALSE(actor.PreventsCritical());
+	REQUIRE_FALSE(actor.HasPhysicalEvasionUp());
+	REQUIRE_FALSE(actor.HasHalfSpCost());
+	REQUIRE_FALSE(actor.PreventsTerrainDamage());
 }
 
 TEST_CASE("ArmorWithWeaponFlags") {
 	const MockActor m;
+	auto actor = MakeActor(1, 1, 99, 100, 10, 11, 12, 13, 14);
 
-	MakeEquip(1, lcf::rpg::Item::Type_armor, 0, 0, 0, 0, 100, 100, true, true, true, true, true, true, true, true);
+	MakeDBEquip(1, lcf::rpg::Item::Type_armor, 0, 0, 0, 0, 100, 100, true, true, true, true, true, true, true, true);
 
-	auto* a = Main_Data::game_actors->GetActor(1);
-	REQUIRE(a != nullptr);
-
-	a->SetEquipment(3, 1);
-	REQUIRE_EQ(a->GetArmorId(), 1);
+	actor.SetEquipment(3, 1);
+	REQUIRE_EQ(actor.GetArmorId(), 1);
 
 	for (int wid = -1; wid <= 5; ++wid ) {
 		CAPTURE(wid);
 
-		REQUIRE_EQ(a->GetHitChance(wid), 90);
-		REQUIRE_EQ(a->GetCriticalHitChance(wid), doctest::Approx(0.03333f));
-		REQUIRE_FALSE(a->HasPreemptiveAttack(wid));
-		REQUIRE_FALSE(a->HasDualAttack(wid));
-		REQUIRE_FALSE(a->HasAttackAll(wid));
-		REQUIRE_FALSE(a->AttackIgnoresEvasion(wid));
+		REQUIRE_EQ(actor.GetHitChance(wid), 90);
+		REQUIRE_EQ(actor.GetCriticalHitChance(wid), doctest::Approx(0.03333f));
+		REQUIRE_FALSE(actor.HasPreemptiveAttack(wid));
+		REQUIRE_FALSE(actor.HasDualAttack(wid));
+		REQUIRE_FALSE(actor.HasAttackAll(wid));
+		REQUIRE_FALSE(actor.AttackIgnoresEvasion(wid));
 	}
 }
 

--- a/tests/game_actor.cpp
+++ b/tests/game_actor.cpp
@@ -75,7 +75,7 @@ public:
 		Main_Data::Cleanup();
 		Main_Data::game_data.Setup();
 
-		Game_Actors::Init();
+		Main_Data::game_actors = std::make_unique<Game_Actors>();
 		Main_Data::game_enemyparty = std::make_unique<Game_EnemyParty>();
 		Main_Data::game_party = std::make_unique<Game_Party>();
 
@@ -83,10 +83,6 @@ public:
 	}
 
 	~MockActor() {
-		Main_Data::game_party = {};
-		Main_Data::game_enemyparty = {};
-		Game_Actors::Dispose();
-
 		Main_Data::Cleanup();
 
 		lcf::Data::actors = {};
@@ -102,7 +98,7 @@ TEST_SUITE_BEGIN("Game_Actor");
 TEST_CASE("Limits2k") {
 	const MockActor m(Player::EngineRpg2k);
 
-	auto* actor = Game_Actors::GetActor(1);
+	auto* actor = Main_Data::game_actors->GetActor(1);
 
 	REQUIRE(actor != nullptr);
 	REQUIRE_EQ(actor->MaxHpValue(), 999);
@@ -114,7 +110,7 @@ TEST_CASE("Limits2k") {
 TEST_CASE("Limits2k3") {
 	const MockActor m(Player::EngineRpg2k3);
 
-	auto* actor = Game_Actors::GetActor(1);
+	auto* actor = Main_Data::game_actors->GetActor(1);
 
 	REQUIRE(actor != nullptr);
 	REQUIRE_EQ(actor->MaxHpValue(), 9999);
@@ -127,7 +123,7 @@ TEST_CASE("Limits2k3") {
 TEST_CASE("Base") {
 	const MockActor m;
 
-	auto* actor = Game_Actors::GetActor(1);
+	auto* actor = Main_Data::game_actors->GetActor(1);
 
 	REQUIRE(actor != nullptr);
 	REQUIRE_EQ(actor->GetType(), Game_Battler::Type_Ally);
@@ -199,7 +195,7 @@ TEST_CASE("Base") {
 TEST_CASE("AdjParams") {
 	const MockActor m;
 
-	auto* actor = Game_Actors::GetActor(1);
+	auto* actor = Main_Data::game_actors->GetActor(1);
 
 	REQUIRE(actor != nullptr);
 
@@ -251,7 +247,7 @@ TEST_CASE("AdjParams") {
 TEST_CASE("TryEquip") {
 	const MockActor m;
 
-	auto* actor = Game_Actors::GetActor(1);
+	auto* actor = Main_Data::game_actors->GetActor(1);
 
 	REQUIRE(actor != nullptr);
 
@@ -408,7 +404,7 @@ TEST_CASE("SingleWeapon") {
 	MakeEquip(1, lcf::rpg::Item::Type_weapon, 1, 2, 3, 4);
 	MakeEquip(2, lcf::rpg::Item::Type_shield, 11, 12, 13, 14);
 
-	auto* a = Game_Actors::GetActor(1);
+	auto* a = Main_Data::game_actors->GetActor(1);
 	REQUIRE(a != nullptr);
 	REQUIRE_FALSE(a->HasTwoWeapons());
 
@@ -423,7 +419,7 @@ TEST_CASE("DualWeaponParams") {
 	MakeEquip(1, lcf::rpg::Item::Type_weapon, 1, 2, 3, 4);
 	MakeEquip(2, lcf::rpg::Item::Type_weapon, 5, 6, 7, 8);
 
-	auto* a = Game_Actors::GetActor(2);
+	auto* a = Main_Data::game_actors->GetActor(2);
 	REQUIRE(a != nullptr);
 	REQUIRE(a->HasTwoWeapons());
 
@@ -436,7 +432,7 @@ TEST_CASE("DualWeaponHit") {
 	MakeEquip(1, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 20, 40);
 	MakeEquip(2, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 75, 20);
 
-	auto* a = Game_Actors::GetActor(2);
+	auto* a = Main_Data::game_actors->GetActor(2);
 	REQUIRE(a != nullptr);
 	REQUIRE(a->HasTwoWeapons());
 
@@ -451,7 +447,7 @@ TEST_CASE("DualWeaponFlags") {
 	MakeEquip(3, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 0, false, false, true, false);
 	MakeEquip(4, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 0, false, false, false, true);
 
-	auto* a = Game_Actors::GetActor(2);
+	auto* a = Main_Data::game_actors->GetActor(2);
 	REQUIRE(a != nullptr);
 	REQUIRE(a->HasTwoWeapons());
 
@@ -470,7 +466,7 @@ TEST_CASE("ArmorFlags") {
 	MakeEquip(3, lcf::rpg::Item::Type_helmet, 0, 0, 0, 0, 0, 0, false, false, false, false, false, false, true, false);
 	MakeEquip(4, lcf::rpg::Item::Type_accessory, 0, 0, 0, 0, 0, 0, false, false, false, false, false, false, false, true);
 
-	auto* a = Game_Actors::GetActor(1);
+	auto* a = Main_Data::game_actors->GetActor(1);
 	REQUIRE(a != nullptr);
 
 	testWeapon(a, 0, 1, 0, 0, 0);
@@ -484,7 +480,7 @@ TEST_CASE("WeaponWithArmorFlags") {
 
 	MakeEquip(1, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 100, true, true, true, true, true, true, true, true);
 
-	auto* a = Game_Actors::GetActor(1);
+	auto* a = Main_Data::game_actors->GetActor(1);
 	REQUIRE(a != nullptr);
 
 	a->SetEquipment(1, 1);
@@ -501,7 +497,7 @@ TEST_CASE("ArmorWithWeaponFlags") {
 
 	MakeEquip(1, lcf::rpg::Item::Type_armor, 0, 0, 0, 0, 100, 100, true, true, true, true, true, true, true, true);
 
-	auto* a = Game_Actors::GetActor(1);
+	auto* a = Main_Data::game_actors->GetActor(1);
 	REQUIRE(a != nullptr);
 
 	a->SetEquipment(3, 1);

--- a/tests/game_actor.cpp
+++ b/tests/game_actor.cpp
@@ -195,7 +195,7 @@ TEST_CASE("Limits") {
 	SUBCASE("2k") {
 		const MockActor m(Player::EngineRpg2k);
 
-		testLimits(999, 999, 999);
+		testLimits(999, 999, 9999);
 	}
 	SUBCASE("2k3") {
 		const MockActor m(Player::EngineRpg2k3);

--- a/tests/game_actor.cpp
+++ b/tests/game_actor.cpp
@@ -1,0 +1,522 @@
+#include "game_actors.h"
+#include "game_party.h"
+#include "game_enemyparty.h"
+#include "main_data.h"
+#include "player.h"
+#include <lcf/data.h>
+
+#include "doctest.h"
+
+
+lcf::rpg::Item* MakeEquip(int id, int type,
+		int atk = 1, int def = 1, int spi = 1, int agi = 1,
+		int hit=100, int crt=0,
+		bool w1 = false, bool w2 = false, bool w3 = false, bool w4 = false,
+		bool a1 = false, bool a2 = false, bool a3 = false, bool a4 = false)
+{
+	auto& item = lcf::Data::items[id - 1];
+	item.type = type;
+	item.atk_points1 = atk;
+	item.def_points1 = def;
+	item.spi_points1 = spi;
+	item.agi_points1 = agi;
+	item.hit = hit;
+	item.critical_hit = 0;
+	item.preemptive = w1;
+	item.dual_attack = w2;
+	item.attack_all = w3;
+	item.ignore_evasion = w4;
+	item.prevent_critical = a1;
+	item.raise_evasion = a2;
+	item.half_sp_cost = a3;
+	item.no_terrain_damage = a4;
+	return &item;
+}
+
+class MockActor {
+public:
+	MockActor(int eng = Player::EngineRpg2k3 | Player::EngineEnglish)
+	{
+		_engine = Player::engine;
+		Player::engine = eng;
+
+		lcf::Data::actors.resize(20);
+		for (size_t i = 0; i < lcf::Data::actors.size(); ++i) {
+			auto& actor = lcf::Data::actors[i];
+			actor.ID = i + 1;
+			actor.parameters.Setup(99);
+			for (int i = 0; i < 99; ++i) {
+				const auto lvl = i + 1;
+				actor.parameters.maxhp[i] = lvl * 100;
+				actor.parameters.maxsp[i]= lvl * 10;
+				actor.parameters.attack[i] = lvl * 10 + 1;
+				actor.parameters.defense[i] = lvl * 10 + 2;
+				actor.parameters.spirit[i] = lvl * 10 + 3;
+				actor.parameters.agility[i] = lvl * 10 + 4;
+			}
+			actor.initial_level = 1;
+			actor.final_level = 99;
+			actor.class_id = 0;
+			actor.exp_base = 1;
+			actor.exp_inflation = 677;
+			actor.exp_correction = 40;
+
+			actor.two_weapon = (i % 5) == 1;
+			actor.lock_equipment = (i % 5) == 2;
+			actor.auto_battle = (i % 5) == 3;
+			actor.super_guard = (i % 5) == 4;
+		}
+
+		lcf::Data::items.resize(200);
+		for (size_t i = 0; i < lcf::Data::items.size(); ++i) {
+			lcf::Data::items[i].ID = i + 1;
+		}
+
+		Main_Data::Cleanup();
+		Main_Data::game_data.Setup();
+
+		Game_Actors::Init();
+		Main_Data::game_enemyparty = std::make_unique<Game_EnemyParty>();
+		Main_Data::game_party = std::make_unique<Game_Party>();
+
+		Main_Data::game_party->SetupNewGame();
+	}
+
+	~MockActor() {
+		Main_Data::game_party = {};
+		Main_Data::game_enemyparty = {};
+		Game_Actors::Dispose();
+
+		Main_Data::Cleanup();
+
+		lcf::Data::actors = {};
+		lcf::Data::items = {};
+		Player::engine = _engine;
+	}
+private:
+	int _engine = {};
+};
+
+TEST_SUITE_BEGIN("Game_Actor");
+
+TEST_CASE("Limits2k") {
+	const MockActor m(Player::EngineRpg2k);
+
+	auto* actor = Game_Actors::GetActor(1);
+
+	REQUIRE(actor != nullptr);
+	REQUIRE_EQ(actor->MaxHpValue(), 999);
+	REQUIRE_EQ(actor->MaxStatBaseValue(), 999);
+	// FIXME: Verify Clamps
+	REQUIRE_EQ(actor->MaxStatBattleValue(), 999);
+}
+
+TEST_CASE("Limits2k3") {
+	const MockActor m(Player::EngineRpg2k3);
+
+	auto* actor = Game_Actors::GetActor(1);
+
+	REQUIRE(actor != nullptr);
+	REQUIRE_EQ(actor->MaxHpValue(), 9999);
+	REQUIRE_EQ(actor->MaxStatBaseValue(), 999);
+	// FIXME: Verify Clamps
+	REQUIRE_EQ(actor->MaxStatBattleValue(), 9999);
+}
+
+
+TEST_CASE("Base") {
+	const MockActor m;
+
+	auto* actor = Game_Actors::GetActor(1);
+
+	REQUIRE(actor != nullptr);
+	REQUIRE_EQ(actor->GetType(), Game_Battler::Type_Ally);
+	REQUIRE_EQ(actor->GetId(), 1);
+
+	REQUIRE_EQ(actor->GetLevel(), 1);
+	REQUIRE_EQ(actor->GetMaxLevel(), 99);
+
+	REQUIRE_EQ(actor->GetExp(), 0);
+	REQUIRE_EQ(actor->GetBaseExp(), 0);
+	REQUIRE_EQ(actor->GetNextExp(), 718);
+
+	REQUIRE_EQ(actor->GetClass(), nullptr);
+
+	REQUIRE_EQ(actor->GetBaseMaxHp(), 100);
+	REQUIRE_EQ(actor->GetBaseMaxSp(), 10);
+	REQUIRE_EQ(actor->GetMaxHp(), 100);
+	REQUIRE_EQ(actor->GetMaxSp(), 10);
+
+	REQUIRE_EQ(actor->GetHp(), 100);
+	REQUIRE_EQ(actor->GetSp(), 10);
+
+	for (int w = -1; w < 2; ++w) {
+		REQUIRE_EQ(actor->GetBaseAtk(w), 11);
+		REQUIRE_EQ(actor->GetBaseDef(w), 12);
+		REQUIRE_EQ(actor->GetBaseSpi(w), 13);
+		REQUIRE_EQ(actor->GetBaseAgi(w), 14);
+
+		REQUIRE_EQ(actor->GetAtk(w), 11);
+		REQUIRE_EQ(actor->GetDef(w), 12);
+		REQUIRE_EQ(actor->GetSpi(w), 13);
+		REQUIRE_EQ(actor->GetAgi(w), 14);
+
+		REQUIRE_FALSE(actor->HasPreemptiveAttack(w));
+		REQUIRE_FALSE(actor->HasDualAttack(w));
+		REQUIRE_FALSE(actor->HasAttackAll(w));
+		REQUIRE_FALSE(actor->AttackIgnoresEvasion(w));
+
+		REQUIRE_EQ(actor->GetHitChance(w), 90);
+		REQUIRE(actor->GetCriticalHitChance(w) == doctest::Approx(0.03333f));
+	}
+
+	REQUIRE_FALSE(actor->PreventsTerrainDamage());
+	REQUIRE_FALSE(actor->PreventsCritical());
+	REQUIRE_FALSE(actor->HasPhysicalEvasionUp());
+	REQUIRE_FALSE(actor->HasHalfSpCost());
+
+	REQUIRE_EQ(actor->GetWeaponId(), 0);
+	REQUIRE_EQ(actor->GetShieldId(), 0);
+	REQUIRE_EQ(actor->GetArmorId(), 0);
+	REQUIRE_EQ(actor->GetHelmetId(), 0);
+	REQUIRE_EQ(actor->GetAccessoryId(), 0);
+
+	REQUIRE_EQ(actor->GetWeapon(), nullptr);
+	REQUIRE_EQ(actor->Get2ndWeapon(), nullptr);
+	REQUIRE_EQ(actor->GetShield(), nullptr);
+	REQUIRE_EQ(actor->GetArmor(), nullptr);
+	REQUIRE_EQ(actor->GetHelmet(), nullptr);
+	REQUIRE_EQ(actor->GetAccessory(), nullptr);
+
+	REQUIRE_FALSE(actor->IsEquipmentFixed());
+	REQUIRE_FALSE(actor->HasStrongDefense());
+	REQUIRE_FALSE(actor->HasTwoWeapons());
+	REQUIRE_FALSE(actor->GetAutoBattle());
+
+	REQUIRE_EQ(actor->GetBattleRow(), Game_Actor::RowType::RowType_front);
+}
+
+TEST_CASE("AdjParams") {
+	const MockActor m;
+
+	auto* actor = Game_Actors::GetActor(1);
+
+	REQUIRE(actor != nullptr);
+
+	actor->SetBaseMaxHp(501);
+	actor->SetBaseMaxSp(502);
+	actor->SetBaseAtk(503);
+	actor->SetBaseDef(504);
+	actor->SetBaseSpi(505);
+	actor->SetBaseAgi(506);
+
+	REQUIRE_EQ(actor->GetBaseMaxHp(), 501);
+	REQUIRE_EQ(actor->GetBaseMaxSp(), 502);
+	REQUIRE_EQ(actor->GetMaxHp(), 501);
+	REQUIRE_EQ(actor->GetMaxSp(), 502);
+
+	REQUIRE_EQ(actor->GetHp(), 100);
+	REQUIRE_EQ(actor->GetSp(), 10);
+
+	for (int w = -1; w < 2; ++w) {
+		REQUIRE_EQ(actor->GetBaseAtk(w), 503);
+		REQUIRE_EQ(actor->GetBaseDef(w), 504);
+		REQUIRE_EQ(actor->GetBaseSpi(w), 505);
+		REQUIRE_EQ(actor->GetBaseAgi(w), 506);
+
+		REQUIRE_EQ(actor->GetAtk(w), 503);
+		REQUIRE_EQ(actor->GetDef(w), 504);
+		REQUIRE_EQ(actor->GetSpi(w), 505);
+		REQUIRE_EQ(actor->GetAgi(w), 506);
+	}
+
+	actor->SetAtkModifier(10);
+	actor->SetDefModifier(20);
+	actor->SetSpiModifier(30);
+	actor->SetAgiModifier(40);
+
+	for (int w = -1; w < 2; ++w) {
+		REQUIRE_EQ(actor->GetBaseAtk(w), 503);
+		REQUIRE_EQ(actor->GetBaseDef(w), 504);
+		REQUIRE_EQ(actor->GetBaseSpi(w), 505);
+		REQUIRE_EQ(actor->GetBaseAgi(w), 506);
+
+		REQUIRE_EQ(actor->GetAtk(w), 513);
+		REQUIRE_EQ(actor->GetDef(w), 524);
+		REQUIRE_EQ(actor->GetSpi(w), 535);
+		REQUIRE_EQ(actor->GetAgi(w), 546);
+	}
+}
+
+TEST_CASE("TryEquip") {
+	const MockActor m;
+
+	auto* actor = Game_Actors::GetActor(1);
+
+	REQUIRE(actor != nullptr);
+
+	MakeEquip(1, lcf::rpg::Item::Type_weapon, 1, 11, 21, 31);
+	MakeEquip(2, lcf::rpg::Item::Type_shield, 1, 11, 21, 31);
+	MakeEquip(3, lcf::rpg::Item::Type_armor, 1, 11, 21, 31);
+	MakeEquip(4, lcf::rpg::Item::Type_helmet, 1, 11, 21, 31);
+	MakeEquip(5, lcf::rpg::Item::Type_accessory, 1, 11, 21, 31);
+
+	for (int i = 1; i <= 5; ++i) {
+		actor->SetEquipment(i, i);
+		REQUIRE_EQ(actor->GetWeaponId(), 1);
+		if (i >= 2) REQUIRE_EQ(actor->GetShieldId(), 2);
+		if (i >= 3) REQUIRE_EQ(actor->GetArmorId(), 3);
+		if (i >= 4) REQUIRE_EQ(actor->GetHelmetId(), 4);
+		if (i >= 5) REQUIRE_EQ(actor->GetAccessoryId(), 5);
+
+		REQUIRE_EQ(actor->GetBaseAtk(), 11 + i * 1);
+		REQUIRE_EQ(actor->GetBaseDef(), 12 + i * 11);
+		REQUIRE_EQ(actor->GetBaseSpi(), 13 + i * 21);
+		REQUIRE_EQ(actor->GetBaseAgi(), 14 + i * 31);
+
+		REQUIRE_EQ(actor->GetAtk(), actor->GetBaseAtk());
+		REQUIRE_EQ(actor->GetDef(), actor->GetBaseDef());
+		REQUIRE_EQ(actor->GetSpi(), actor->GetBaseSpi());
+		REQUIRE_EQ(actor->GetAgi(), actor->GetBaseAgi());
+	}
+}
+
+static void testWeapon3(const Game_Actor* a,
+		const lcf::rpg::Item* i1,
+		lcf::rpg::Item* i2,
+		lcf::rpg::Item* i3,
+		lcf::rpg::Item* i4,
+		lcf::rpg::Item* i5,
+		int wid)
+{
+	const auto isw1 = i1 && i1->type == lcf::rpg::Item::Type_weapon;
+	const auto atk1 = i1 ? i1->atk_points1 : 0;
+	const auto def1 = i1 ? i1->def_points1 : 0;
+	const auto spi1 = i1 ? i1->spi_points1 : 0;
+	const auto agi1 = i1 ? i1->agi_points1 : 0;
+
+	const auto pre1 = i1 && isw1 ? i1->preemptive : false;
+	const auto dul1 = i1 && isw1 ? i1->dual_attack : false;
+	const auto all1 = i1 && isw1 ? i1->attack_all : false;
+	const auto eva1 = i1 && isw1 ? i1->ignore_evasion : false;
+
+	const auto hit1 = i1 && isw1 ? i1->hit : 0;
+	const auto crt1 = i1 && isw1 ? i1->critical_hit : 0;
+
+	const auto isw2 = i2 && i2->type == lcf::rpg::Item::Type_weapon;
+	const auto atk2 = i2 ? i2->atk_points1 : 0;
+	const auto def2 = i2 ? i2->def_points1 : 0;
+	const auto spi2 = i2 ? i2->spi_points1 : 0;
+	const auto agi2 = i2 ? i2->agi_points1 : 0;
+
+	const auto pre2 = i2 && isw2 ? i2->preemptive : false;
+	const auto dul2 = i2 && isw2 ? i2->dual_attack : false;
+	const auto all2 = i2 && isw2 ? i2->attack_all : false;
+	const auto eva2 = i2 && isw2 ? i2->ignore_evasion : false;
+
+	const auto hit2 = i2 && isw2 && i2->type == lcf::rpg::Item::Type_weapon ? i2->hit : 0;
+	const auto crt2 = i2 && isw2 && i2->type == lcf::rpg::Item::Type_weapon ? i2->critical_hit : 0;
+
+	const auto atkA = (i3 ? i3->atk_points1 : 0) + (i4 ? i4->atk_points1 : 0) + (i5 ? i5->atk_points1 : 0);
+	const auto defA = (i3 ? i3->def_points1 : 0) + (i4 ? i4->def_points1 : 0) + (i5 ? i5->def_points1 : 0);
+	const auto spiA = (i3 ? i3->spi_points1 : 0) + (i4 ? i4->spi_points1 : 0) + (i5 ? i5->spi_points1 : 0);
+	const auto agiA = (i3 ? i3->agi_points1 : 0) + (i4 ? i4->agi_points1 : 0) + (i5 ? i5->agi_points1 : 0);
+
+	const auto pctA = (i2 && !isw2 && i2->prevent_critical) || (i3 && i3->prevent_critical) || (i4 && i4->prevent_critical) || (i5 && i5->prevent_critical);
+	const auto revA = (i2 && !isw2 && i2->raise_evasion) || (i3 && i3->raise_evasion) || (i4 && i4->raise_evasion) || (i5 && i5->raise_evasion);
+	const auto hspA = (i2 && !isw2 && i2->half_sp_cost) || (i3 && i3->half_sp_cost) || (i4 && i4->half_sp_cost) || (i5 && i5->half_sp_cost);
+	const auto notA = (i2 && !isw2 && i2->no_terrain_damage) || (i3 && i3->no_terrain_damage) || (i4 && i4->no_terrain_damage) || (i5 && i5->no_terrain_damage);
+
+	CAPTURE(wid);
+	CAPTURE(i1);
+	CAPTURE(i2);
+	CAPTURE(isw1);
+	CAPTURE(isw2);
+	CAPTURE(atk1);
+	CAPTURE(atk2);
+	CAPTURE(hit1);
+	CAPTURE(hit2);
+
+	REQUIRE_EQ(a->GetBaseAtk(wid), 11 + atk1 + atk2 + atkA);
+	REQUIRE_EQ(a->GetBaseDef(wid), 12 + def1 + def2 + defA);
+	REQUIRE_EQ(a->GetBaseSpi(wid), 13 + spi1 + spi2 + spiA);
+	REQUIRE_EQ(a->GetBaseAgi(wid), 14 + agi1 + agi2 + agiA);
+
+	REQUIRE_EQ(a->HasPreemptiveAttack(wid), pre1 | pre2);
+	REQUIRE_EQ(a->HasDualAttack(wid), dul1 | dul2);
+	REQUIRE_EQ(a->HasAttackAll(wid), all1 | all2);
+	REQUIRE_EQ(a->AttackIgnoresEvasion(wid), eva1 | eva2);
+
+	const auto mhit = (isw1 || isw2) ? std::max(hit1, hit2) : 90;
+	REQUIRE_EQ(a->GetHitChance(wid), mhit);
+	const auto mcrt = 0.03333f + static_cast<float>(std::max(crt1, crt2)) / 100.0f;
+	REQUIRE_EQ(a->GetCriticalHitChance(wid), doctest::Approx(mcrt));
+
+	REQUIRE_EQ(a->PreventsCritical(), pctA);
+	REQUIRE_EQ(a->HasPhysicalEvasionUp(), revA);
+	REQUIRE_EQ(a->HasHalfSpCost(), hspA);
+	REQUIRE_EQ(a->PreventsTerrainDamage(), notA);
+
+	REQUIRE_EQ(a->GetBaseAtk(wid), a->GetAtk(wid));
+	REQUIRE_EQ(a->GetBaseDef(wid), a->GetDef(wid));
+	REQUIRE_EQ(a->GetBaseSpi(wid), a->GetSpi(wid));
+	REQUIRE_EQ(a->GetBaseAgi(wid), a->GetAgi(wid));
+}
+
+static void testWeapon2(Game_Actor* a, int id1, int id2, int id3, int id4, int id5) {
+	CAPTURE(a->GetId());
+	CAPTURE(a->HasTwoWeapons());
+	CAPTURE(id1);
+	CAPTURE(id2);
+	CAPTURE(id3);
+	CAPTURE(id4);
+	CAPTURE(id5);
+
+	auto* i1 = id1 ? &lcf::Data::items[id1 - 1] : nullptr;
+	auto* i2 = id2 ? &lcf::Data::items[id2 - 1] : nullptr;
+	auto* i3 = id3 ? &lcf::Data::items[id3 - 1] : nullptr;
+	auto* i4 = id4 ? &lcf::Data::items[id4 - 1] : nullptr;
+	auto* i5 = id5 ? &lcf::Data::items[id5 - 1] : nullptr;
+
+	a->SetEquipment(1, id1);
+	a->SetEquipment(2, id2);
+	a->SetEquipment(3, id3);
+	a->SetEquipment(4, id4);
+	a->SetEquipment(5, id5);
+
+	REQUIRE_EQ(a->GetWeaponId(), id1);
+	REQUIRE_EQ(a->GetShieldId(), id2);
+	REQUIRE_EQ(a->GetArmorId(), id3);
+	REQUIRE_EQ(a->GetHelmetId(), id4);
+	REQUIRE_EQ(a->GetAccessoryId(), id5);
+
+	testWeapon3(a, i1, i2, i3, i4, i5, Game_Battler::kWeaponAll);
+	testWeapon3(a, i1, ((i2 && i2->type == lcf::rpg::Item::Type_weapon) ? nullptr : i2), i3, i4, i5, 0);
+	testWeapon3(a, ((i1 && i1->type == lcf::rpg::Item::Type_weapon) ? nullptr : i1), i2, i3, i4, i5, 1);
+}
+
+static void testWeapon(Game_Actor* a, int id1, int id2, int armor = 0, int helmet = 0, int acc = 0) {
+	testWeapon2(a, id1, id2, armor, helmet, acc);
+	testWeapon2(a, 0, id2, armor, helmet, acc);
+	testWeapon2(a, id1, 0, armor, helmet, acc);
+	testWeapon2(a, 0, 0, armor, helmet, acc);
+}
+
+TEST_CASE("SingleWeapon") {
+	const MockActor m;
+
+	MakeEquip(1, lcf::rpg::Item::Type_weapon, 1, 2, 3, 4);
+	MakeEquip(2, lcf::rpg::Item::Type_shield, 11, 12, 13, 14);
+
+	auto* a = Game_Actors::GetActor(1);
+	REQUIRE(a != nullptr);
+	REQUIRE_FALSE(a->HasTwoWeapons());
+
+	testWeapon(a, 1, 2);
+}
+
+
+
+TEST_CASE("DualWeaponParams") {
+	const MockActor m;
+
+	MakeEquip(1, lcf::rpg::Item::Type_weapon, 1, 2, 3, 4);
+	MakeEquip(2, lcf::rpg::Item::Type_weapon, 5, 6, 7, 8);
+
+	auto* a = Game_Actors::GetActor(2);
+	REQUIRE(a != nullptr);
+	REQUIRE(a->HasTwoWeapons());
+
+	testWeapon(a, 1, 2);
+}
+
+TEST_CASE("DualWeaponHit") {
+	const MockActor m;
+
+	MakeEquip(1, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 20, 40);
+	MakeEquip(2, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 75, 20);
+
+	auto* a = Game_Actors::GetActor(2);
+	REQUIRE(a != nullptr);
+	REQUIRE(a->HasTwoWeapons());
+
+	testWeapon(a, 1, 2);
+}
+
+TEST_CASE("DualWeaponFlags") {
+	const MockActor m;
+
+	MakeEquip(1, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 0, true, false, false, false);
+	MakeEquip(2, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 0, false, true, false, false);
+	MakeEquip(3, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 0, false, false, true, false);
+	MakeEquip(4, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 0, false, false, false, true);
+
+	auto* a = Game_Actors::GetActor(2);
+	REQUIRE(a != nullptr);
+	REQUIRE(a->HasTwoWeapons());
+
+	for (int i = 1; i <= 4; ++i) {
+		for (int j = 1; j <= 4; ++j) {
+			testWeapon(a, i, j);
+		}
+	}
+}
+
+TEST_CASE("ArmorFlags") {
+	const MockActor m;
+
+	MakeEquip(1, lcf::rpg::Item::Type_shield, 0, 0, 0, 0, 0, 0, false, false, false, false, true, false, false, false);
+	MakeEquip(2, lcf::rpg::Item::Type_armor, 0, 0, 0, 0, 0, 0, false, false, false, false, false, true, false, false);
+	MakeEquip(3, lcf::rpg::Item::Type_helmet, 0, 0, 0, 0, 0, 0, false, false, false, false, false, false, true, false);
+	MakeEquip(4, lcf::rpg::Item::Type_accessory, 0, 0, 0, 0, 0, 0, false, false, false, false, false, false, false, true);
+
+	auto* a = Game_Actors::GetActor(1);
+	REQUIRE(a != nullptr);
+
+	testWeapon(a, 0, 1, 0, 0, 0);
+	testWeapon(a, 0, 1, 2, 0, 0);
+	testWeapon(a, 0, 1, 2, 3, 0);
+	testWeapon(a, 0, 1, 2, 3, 4);
+}
+
+TEST_CASE("WeaponWithArmorFlags") {
+	const MockActor m;
+
+	MakeEquip(1, lcf::rpg::Item::Type_weapon, 0, 0, 0, 0, 100, 100, true, true, true, true, true, true, true, true);
+
+	auto* a = Game_Actors::GetActor(1);
+	REQUIRE(a != nullptr);
+
+	a->SetEquipment(1, 1);
+	REQUIRE_EQ(a->GetWeaponId(), 1);
+
+	REQUIRE_FALSE(a->PreventsCritical());
+	REQUIRE_FALSE(a->HasPhysicalEvasionUp());
+	REQUIRE_FALSE(a->HasHalfSpCost());
+	REQUIRE_FALSE(a->PreventsTerrainDamage());
+}
+
+TEST_CASE("ArmorWithWeaponFlags") {
+	const MockActor m;
+
+	MakeEquip(1, lcf::rpg::Item::Type_armor, 0, 0, 0, 0, 100, 100, true, true, true, true, true, true, true, true);
+
+	auto* a = Game_Actors::GetActor(1);
+	REQUIRE(a != nullptr);
+
+	a->SetEquipment(3, 1);
+	REQUIRE_EQ(a->GetArmorId(), 1);
+
+	for (int wid = -1; wid <= 5; ++wid ) {
+		CAPTURE(wid);
+
+		REQUIRE_EQ(a->GetHitChance(wid), 90);
+		REQUIRE_EQ(a->GetCriticalHitChance(wid), doctest::Approx(0.03333f));
+		REQUIRE_FALSE(a->HasPreemptiveAttack(wid));
+		REQUIRE_FALSE(a->HasDualAttack(wid));
+		REQUIRE_FALSE(a->HasAttackAll(wid));
+		REQUIRE_FALSE(a->AttackIgnoresEvasion(wid));
+	}
+}
+
+TEST_SUITE_END();

--- a/tests/game_actor.cpp
+++ b/tests/game_actor.cpp
@@ -419,8 +419,6 @@ static void testWeapon2(Game_Actor* a, int id1, int id2, int id3, int id4, int i
 	REQUIRE_EQ(a->GetHelmetId(), id4);
 	REQUIRE_EQ(a->GetAccessoryId(), id5);
 
-	const auto* w1 = ((i1 && i1->type == lcf::rpg::Item::Type_weapon) ? i1 : nullptr);
-
 	testWeapon3(a, i1, i2, i3, i4, i5, Game_Battler::WeaponAll);
 	testWeapon3(a, i1, i2, i3, i4, i5, Game_Battler::WeaponNone);
 	testWeapon3(a, i1, i2, i3, i4, i5, Game_Battler::WeaponPrimary);

--- a/tests/game_enemy.cpp
+++ b/tests/game_enemy.cpp
@@ -1,7 +1,7 @@
 #include "test_mock_actor.h"
 #include "doctest.h"
 
-static void nullDBEnemy(lcf::rpg::Enemy& e) {}
+static void nullDBEnemy(lcf::rpg::Enemy&) {}
 
 template <typename F = decltype(&nullDBEnemy)>
 static Game_Enemy& MakeEnemy(int id, int hp, int sp, int atk, int def, int spi, int agi, const F& f = &nullDBEnemy) {

--- a/tests/game_enemy.cpp
+++ b/tests/game_enemy.cpp
@@ -1,10 +1,18 @@
 #include "test_mock_actor.h"
 #include "doctest.h"
 
-template <typename... Args>
-static Game_Actor MakeEnemy(int id, Args... args) {
-	MakeDBActor(id, args...);
-	return Game_Actor(id);
+static void nullDBEnemy(lcf::rpg::Enemy& e) {}
+
+template <typename F = decltype(&nullDBEnemy)>
+static Game_Enemy& MakeEnemy(int id, int hp, int sp, int atk, int def, int spi, int agi, const F& f = &nullDBEnemy) {
+	auto& tp = lcf::Data::troops[0];
+	tp.members.resize(1);
+	tp.members[0].enemy_id = id;
+	auto* dbe = MakeDBEnemy(id, hp, sp, atk, def, spi, agi);
+	f(*dbe);
+	Main_Data::game_enemyparty->ResetBattle(1);
+	auto& enemy = (*Main_Data::game_enemyparty)[0];
+	return enemy;
 }
 
 TEST_SUITE_BEGIN("Game_Enemy");
@@ -12,7 +20,7 @@ TEST_SUITE_BEGIN("Game_Enemy");
 TEST_CASE("Limits2k") {
 	const MockActor m(Player::EngineRpg2k);
 
-	auto enemy = Game_Enemy(nullptr);
+	const auto& enemy = MakeEnemy(1, 100, 10, 11, 12, 13, 14);
 
 	REQUIRE_EQ(enemy.MaxHpValue(), 9999);
 	REQUIRE_EQ(enemy.MaxStatBaseValue(), 999);
@@ -22,11 +30,167 @@ TEST_CASE("Limits2k") {
 TEST_CASE("Limits2k3") {
 	const MockActor m(Player::EngineRpg2k3);
 
-	auto enemy = Game_Enemy(nullptr);
+	const auto& enemy = MakeEnemy(1, 100, 10, 11, 12, 13, 14);
 
 	REQUIRE_EQ(enemy.MaxHpValue(), 99999);
 	REQUIRE_EQ(enemy.MaxStatBaseValue(), 999);
 	REQUIRE_EQ(enemy.MaxStatBattleValue(), 9999);
+}
+
+TEST_CASE("Default") {
+	const MockActor m;
+
+	auto& e = MakeEnemy(1, 100, 10, 11, 12, 13, 14);
+	const auto& ce = e;
+
+	REQUIRE_EQ(e.GetId(), 1);
+	REQUIRE_EQ(e.GetType(), Game_Battler::Type_Enemy);
+
+	REQUIRE(e.GetStates().empty());
+	REQUIRE(ce.GetStates().empty());
+
+	REQUIRE_EQ(e.GetOriginalPosition(), Point{});
+
+	REQUIRE(e.GetName().empty());
+	REQUIRE(e.GetSpriteName().empty());
+
+	REQUIRE_EQ(e.GetBaseMaxHp(), 100);
+	REQUIRE_EQ(e.GetBaseMaxSp(), 10);
+	REQUIRE_EQ(e.GetHp(), 100);
+	REQUIRE_EQ(e.GetSp(), 10);
+	REQUIRE_EQ(e.GetBaseAtk(), 11);
+	REQUIRE_EQ(e.GetBaseDef(), 12);
+	REQUIRE_EQ(e.GetBaseSpi(), 13);
+	REQUIRE_EQ(e.GetBaseAgi(), 14);
+
+	REQUIRE_EQ(e.GetHue(), 0);
+
+
+	REQUIRE_EQ(e.GetBattleAnimationId(), 0);
+	REQUIRE_EQ(e.GetFlyingOffset(), 0);
+	REQUIRE_EQ(e.IsTransparent(), 0);
+	REQUIRE(e.IsInParty());
+}
+
+static decltype(auto) MakeEnemyHit(bool miss) {
+	return MakeEnemy(1, 1, 1, 1, 1, 1, 1, [&](auto& e) { e.miss = miss; });
+}
+
+TEST_CASE("HitRate") {
+	const MockActor m;
+
+	SUBCASE("default") {
+		auto& e = MakeEnemyHit(false);
+		REQUIRE_EQ(e.GetHitChance(), 90);
+	}
+
+	SUBCASE("miss") {
+		auto& e = MakeEnemyHit(true);
+		REQUIRE_EQ(e.GetHitChance(), 70);
+	}
+}
+
+static decltype(auto) MakeEnemyCrit(bool crit, int rate) {
+	return MakeEnemy(1, 1, 1, 1, 1, 1, 1, [&](auto& e) { e.critical_hit = crit; e.critical_hit_chance = rate; });
+}
+
+TEST_CASE("CritRate") {
+	const MockActor m;
+
+	SUBCASE("disable_0") {
+		auto& e = MakeEnemyCrit(false, 0);
+		REQUIRE_EQ(e.GetCriticalHitChance(), 0.0f);
+	}
+
+	SUBCASE("disable_1") {
+		auto& e = MakeEnemyCrit(false, 1);
+		REQUIRE_EQ(e.GetCriticalHitChance(), 0.0f);
+	}
+
+	SUBCASE("disable_30") {
+		auto& e = MakeEnemyCrit(false, 30);
+		REQUIRE_EQ(e.GetCriticalHitChance(), 0.0f);
+	}
+
+	SUBCASE("enable_0") {
+		auto& e = MakeEnemyCrit(true, 0);
+		REQUIRE_EQ(e.GetCriticalHitChance(), std::numeric_limits<float>::infinity());
+	}
+
+	SUBCASE("enable_1") {
+		auto& e = MakeEnemyCrit(true, 1);
+		REQUIRE_EQ(e.GetCriticalHitChance(), 1.0f);
+	}
+
+	SUBCASE("enable_30") {
+		auto& e = MakeEnemyCrit(true, 30);
+		REQUIRE_EQ(e.GetCriticalHitChance(), doctest::Approx(0.03333f));
+	}
+}
+
+static decltype(auto) MakeEnemyReward(int exp, int gold, int drop_id, int drop_prob) {
+	return MakeEnemy(1, 1, 1, 1, 1, 1, 1, [&](auto& e) {
+			e.exp = exp;
+			e.gold = gold;
+			e.drop_id = drop_id;
+			e.drop_prob = drop_prob;
+			});
+}
+
+TEST_CASE("RewardExp") {
+	const MockActor m;
+
+	SUBCASE("0") {
+		auto& e = MakeEnemyReward(0, 0, 0, 0);
+		REQUIRE_EQ(e.GetExp(), 0);
+	}
+
+	SUBCASE("55") {
+		auto& e = MakeEnemyReward(55, 0, 0, 0);
+		REQUIRE_EQ(e.GetExp(), 55);
+	}
+}
+
+TEST_CASE("RewardGold") {
+	const MockActor m;
+
+	SUBCASE("0") {
+		auto& e = MakeEnemyReward(0, 0, 0, 0);
+		REQUIRE_EQ(e.GetMoney(), 0);
+	}
+
+	SUBCASE("55") {
+		auto& e = MakeEnemyReward(0, 55, 0, 0);
+		REQUIRE_EQ(e.GetMoney(), 55);
+	}
+}
+
+TEST_CASE("RewardItem") {
+	const MockActor m;
+
+	SUBCASE("0_0") {
+		auto& e = MakeEnemyReward(0, 0, 0, 0);
+		REQUIRE_EQ(e.GetDropId(), 0);
+		REQUIRE_EQ(e.GetDropProbability(), 0);
+	}
+
+	SUBCASE("0_55") {
+		auto& e = MakeEnemyReward(0, 0, 0, 55);
+		REQUIRE_EQ(e.GetDropId(), 0);
+		REQUIRE_EQ(e.GetDropProbability(), 55);
+	}
+
+	SUBCASE("1_0") {
+		auto& e = MakeEnemyReward(0, 0, 1, 0);
+		REQUIRE_EQ(e.GetDropId(), 1);
+		REQUIRE_EQ(e.GetDropProbability(), 0);
+	}
+
+	SUBCASE("1_55") {
+		auto& e = MakeEnemyReward(0, 0, 1, 55);
+		REQUIRE_EQ(e.GetDropId(), 1);
+		REQUIRE_EQ(e.GetDropProbability(), 55);
+	}
 }
 
 TEST_SUITE_END();

--- a/tests/game_enemy.cpp
+++ b/tests/game_enemy.cpp
@@ -17,26 +17,6 @@ static Game_Enemy& MakeEnemy(int id, int hp, int sp, int atk, int def, int spi, 
 
 TEST_SUITE_BEGIN("Game_Enemy");
 
-TEST_CASE("Limits2k") {
-	const MockActor m(Player::EngineRpg2k);
-
-	const auto& enemy = MakeEnemy(1, 100, 10, 11, 12, 13, 14);
-
-	REQUIRE_EQ(enemy.MaxHpValue(), 9999);
-	REQUIRE_EQ(enemy.MaxStatBaseValue(), 999);
-	REQUIRE_EQ(enemy.MaxStatBattleValue(), 9999);
-}
-
-TEST_CASE("Limits2k3") {
-	const MockActor m(Player::EngineRpg2k3);
-
-	const auto& enemy = MakeEnemy(1, 100, 10, 11, 12, 13, 14);
-
-	REQUIRE_EQ(enemy.MaxHpValue(), 99999);
-	REQUIRE_EQ(enemy.MaxStatBaseValue(), 999);
-	REQUIRE_EQ(enemy.MaxStatBattleValue(), 9999);
-}
-
 TEST_CASE("Default") {
 	const MockActor m;
 
@@ -70,6 +50,49 @@ TEST_CASE("Default") {
 	REQUIRE_EQ(e.GetFlyingOffset(), 0);
 	REQUIRE_EQ(e.IsTransparent(), 0);
 	REQUIRE(e.IsInParty());
+}
+
+static void testLimits(int hp, int base, int battle) {
+	auto& enemy = MakeEnemy(1, 100, 10, 11, 12, 13, 14);
+
+	REQUIRE_EQ(enemy.MaxHpValue(), hp);
+	REQUIRE_EQ(enemy.MaxStatBaseValue(), base);
+	REQUIRE_EQ(enemy.MaxStatBattleValue(), battle);
+
+	SUBCASE("up") {
+		enemy.SetAtkModifier(999999);
+		enemy.SetDefModifier(999999);
+		enemy.SetSpiModifier(999999);
+		enemy.SetAgiModifier(999999);
+		REQUIRE_EQ(enemy.GetAtk(), battle);
+		REQUIRE_EQ(enemy.GetDef(), battle);
+		REQUIRE_EQ(enemy.GetSpi(), battle);
+		REQUIRE_EQ(enemy.GetAgi(), battle);
+	}
+
+	SUBCASE("down") {
+		enemy.SetAtkModifier(-999999);
+		enemy.SetDefModifier(-999999);
+		enemy.SetSpiModifier(-999999);
+		enemy.SetAgiModifier(-999999);
+		REQUIRE_EQ(enemy.GetAtk(), 1);
+		REQUIRE_EQ(enemy.GetDef(), 1);
+		REQUIRE_EQ(enemy.GetSpi(), 1);
+		REQUIRE_EQ(enemy.GetAgi(), 1);
+	}
+}
+
+TEST_CASE("Limits") {
+	SUBCASE("2k") {
+		const MockActor m(Player::EngineRpg2k);
+
+		testLimits(9999, 999, 9999);
+	}
+	SUBCASE("2k3") {
+		const MockActor m(Player::EngineRpg2k3);
+
+		testLimits(99999, 999, 9999);
+	}
 }
 
 static decltype(auto) MakeEnemyHit(bool miss) {

--- a/tests/game_enemy.cpp
+++ b/tests/game_enemy.cpp
@@ -1,0 +1,32 @@
+#include "test_mock_actor.h"
+#include "doctest.h"
+
+template <typename... Args>
+static Game_Actor MakeEnemy(int id, Args... args) {
+	MakeDBActor(id, args...);
+	return Game_Actor(id);
+}
+
+TEST_SUITE_BEGIN("Game_Enemy");
+
+TEST_CASE("Limits2k") {
+	const MockActor m(Player::EngineRpg2k);
+
+	auto enemy = Game_Enemy(nullptr);
+
+	REQUIRE_EQ(enemy.MaxHpValue(), 9999);
+	REQUIRE_EQ(enemy.MaxStatBaseValue(), 999);
+	REQUIRE_EQ(enemy.MaxStatBattleValue(), 9999);
+}
+
+TEST_CASE("Limits2k3") {
+	const MockActor m(Player::EngineRpg2k3);
+
+	auto enemy = Game_Enemy(nullptr);
+
+	REQUIRE_EQ(enemy.MaxHpValue(), 99999);
+	REQUIRE_EQ(enemy.MaxStatBaseValue(), 999);
+	REQUIRE_EQ(enemy.MaxStatBattleValue(), 9999);
+}
+
+TEST_SUITE_END();

--- a/tests/parse.cpp
+++ b/tests/parse.cpp
@@ -29,7 +29,7 @@ struct DataInit {
 		}
 		Main_Data::game_data.inventory.party.push_back(3);
 
-		Game_Actors::Init();
+		Main_Data::game_actors = std::make_unique<Game_Actors>();
 		Main_Data::game_party = std::make_unique<Game_Party>();
 		Main_Data::game_party->SetupFromSave(Main_Data::game_data.inventory);
 		Main_Data::game_variables = std::make_unique<Game_Variables>(Game_Variables::min_2k3, Game_Variables::max_2k3);

--- a/tests/test_mock_actor.h
+++ b/tests/test_mock_actor.h
@@ -1,0 +1,131 @@
+#ifndef EP_TEST_MOCK_ACTOR
+#define EP_TEST_MOCK_ACTOR
+
+#include "game_actors.h"
+#include "game_party.h"
+#include "game_enemyparty.h"
+#include "main_data.h"
+#include "player.h"
+#include <lcf/data.h>
+
+static void InitEmptyDB() {
+	auto initVec = [](auto& v, int size) {
+		v.resize(size);
+		for (int i = 0; i < size; ++i) {
+			v[i].ID = i + 1;
+		}
+	};
+	lcf::Data::data = {};
+
+	initVec(lcf::Data::actors, 20);
+	initVec(lcf::Data::skills, 200);
+	initVec(lcf::Data::items, 200);
+	initVec(lcf::Data::enemies, 20);
+	initVec(lcf::Data::troops, 20);
+	initVec(lcf::Data::terrains, 20);
+	initVec(lcf::Data::attributes, 20);
+	initVec(lcf::Data::chipsets, 20);
+	initVec(lcf::Data::commonevents, 20);
+	initVec(lcf::Data::battlecommands.commands, 20);
+	initVec(lcf::Data::classes, 100);
+	initVec(lcf::Data::battleranimations, 200);
+	initVec(lcf::Data::switches, 200);
+	initVec(lcf::Data::variables, 200);
+
+	for (auto& actor: lcf::Data::actors) {
+		actor.initial_level = 1;
+		actor.final_level = 99;
+		actor.parameters.Setup(actor.final_level);
+	}
+
+	for (auto& tp: lcf::Data::troops) {
+		initVec(tp.members, 8);
+	}
+
+}
+
+class MockActor {
+public:
+	MockActor(int eng = Player::EngineRpg2k3 | Player::EngineEnglish)
+	{
+		_engine = Player::engine;
+		Player::engine = eng;
+
+		InitEmptyDB();
+
+		Main_Data::Cleanup();
+		Main_Data::game_data.Setup();
+
+		Main_Data::game_actors = std::make_unique<Game_Actors>();
+		Main_Data::game_enemyparty = std::make_unique<Game_EnemyParty>();
+		Main_Data::game_party = std::make_unique<Game_Party>();
+
+		Main_Data::game_party->SetupNewGame();
+	}
+
+	~MockActor() {
+		Main_Data::Cleanup();
+
+		lcf::Data::data = {};
+		Player::engine = _engine;
+	}
+private:
+	int _engine = {};
+};
+
+static lcf::rpg::Actor* MakeDBActor(int id, int level, int final_level,
+		int hp, int sp, int atk, int def, int spi, int agi,
+		bool two_weapon = false, bool lock_equip = false, bool autobattle = false, bool super_guard = false)
+{
+	if (lcf::Data::actors.size() <= id) {
+		lcf::Data::actors.resize(id + 1);
+	}
+
+	auto& actor = lcf::Data::actors[id - 1];
+	actor.initial_level = 1;
+	actor.final_level = final_level;
+	actor.parameters.Setup(actor.final_level);
+	actor.parameters.maxhp[level - 1] = hp;
+	actor.parameters.maxsp[level - 1] = sp;
+	actor.parameters.attack[level - 1] = atk;
+	actor.parameters.defense[level - 1] = def;
+	actor.parameters.spirit[level - 1] = spi;
+	actor.parameters.agility[level - 1] = agi;
+	actor.two_weapon = two_weapon;
+	actor.lock_equipment = lock_equip;
+	actor.auto_battle = autobattle;
+	actor.super_guard = super_guard;
+
+	actor.class_id = 0;
+	actor.exp_base = 1;
+	actor.exp_inflation = 677;
+	actor.exp_correction = 40;
+	return &actor;
+}
+
+static lcf::rpg::Item* MakeDBEquip(int id, int type,
+		int atk = 1, int def = 1, int spi = 1, int agi = 1,
+		int hit=100, int crt=0,
+		bool w1 = false, bool w2 = false, bool w3 = false, bool w4 = false,
+		bool a1 = false, bool a2 = false, bool a3 = false, bool a4 = false)
+{
+	auto& item = lcf::Data::items[id - 1];
+	item.type = type;
+	item.atk_points1 = atk;
+	item.def_points1 = def;
+	item.spi_points1 = spi;
+	item.agi_points1 = agi;
+	item.hit = hit;
+	item.critical_hit = 0;
+	item.preemptive = w1;
+	item.dual_attack = w2;
+	item.attack_all = w3;
+	item.ignore_evasion = w4;
+	item.prevent_critical = a1;
+	item.raise_evasion = a2;
+	item.half_sp_cost = a3;
+	item.no_terrain_damage = a4;
+	return &item;
+}
+
+#endif

--- a/tests/test_mock_actor.h
+++ b/tests/test_mock_actor.h
@@ -104,8 +104,7 @@ static lcf::rpg::Actor* MakeDBActor(int id, int level, int final_level,
 }
 
 static lcf::rpg::Enemy* MakeDBEnemy(int id,
-		int hp, int sp, int atk, int def, int spi, int agi,
-		bool crit = false, int crit_chance = 30, bool miss = false)
+		int hp, int sp, int atk, int def, int spi, int agi)
 {
 	if (lcf::Data::enemies.size() <= id) {
 		lcf::Data::enemies.resize(id + 1);
@@ -118,9 +117,6 @@ static lcf::rpg::Enemy* MakeDBEnemy(int id,
 	enemy.defense = def;
 	enemy.spirit = spi;
 	enemy.agility = agi;
-	enemy.critical_hit = crit;
-	enemy.critical_hit_chance = crit_chance;
-	enemy.miss = miss;
 	return &enemy;
 }
 

--- a/tests/test_mock_actor.h
+++ b/tests/test_mock_actor.h
@@ -25,6 +25,7 @@ static void InitEmptyDB() {
 	initVec(lcf::Data::troops, 20);
 	initVec(lcf::Data::terrains, 20);
 	initVec(lcf::Data::attributes, 20);
+	initVec(lcf::Data::states, 20);
 	initVec(lcf::Data::chipsets, 20);
 	initVec(lcf::Data::commonevents, 20);
 	initVec(lcf::Data::battlecommands.commands, 20);
@@ -60,6 +61,10 @@ static void InitEmptyDB() {
 	for (auto& tp: lcf::Data::troops) {
 		initVec(tp.members, 8);
 	}
+
+	auto& death = lcf::Data::states[0];
+	death.priority = 100;
+	death.restriction = lcf::rpg::State::Restriction_do_nothing;
 
 }
 
@@ -153,7 +158,7 @@ static lcf::rpg::Item* MakeDBEquip(int id, int type,
 	item.spi_points1 = spi;
 	item.agi_points1 = agi;
 	item.hit = hit;
-	item.critical_hit = 0;
+	item.critical_hit = crt;
 	item.preemptive = w1;
 	item.dual_attack = w2;
 	item.attack_all = w3;

--- a/tests/test_mock_actor.h
+++ b/tests/test_mock_actor.h
@@ -102,14 +102,10 @@ private:
 	LogLevel _ll = {};
 };
 
-static lcf::rpg::Actor* MakeDBActor(int id, int level, int final_level,
+inline lcf::rpg::Actor* MakeDBActor(int id, int level, int final_level,
 		int hp, int sp, int atk, int def, int spi, int agi,
 		bool two_weapon = false, bool lock_equip = false, bool autobattle = false, bool super_guard = false)
 {
-	if (lcf::Data::actors.size() <= id) {
-		lcf::Data::actors.resize(id + 1);
-	}
-
 	auto& actor = lcf::Data::actors[id - 1];
 	actor.initial_level = 1;
 	actor.final_level = final_level;
@@ -132,7 +128,7 @@ static lcf::rpg::Actor* MakeDBActor(int id, int level, int final_level,
 	return &actor;
 }
 
-static lcf::rpg::Enemy* MakeDBEnemy(int id,
+inline lcf::rpg::Enemy* MakeDBEnemy(int id,
 		int hp, int sp, int atk, int def, int spi, int agi)
 {
 	auto& enemy = lcf::Data::enemies[id - 1];
@@ -145,7 +141,7 @@ static lcf::rpg::Enemy* MakeDBEnemy(int id,
 	return &enemy;
 }
 
-static lcf::rpg::Item* MakeDBEquip(int id, int type,
+inline lcf::rpg::Item* MakeDBEquip(int id, int type,
 		int atk = 1, int def = 1, int spi = 1, int agi = 1,
 		int hit=100, int crt=0,
 		bool w1 = false, bool w2 = false, bool w3 = false, bool w4 = false,
@@ -170,7 +166,7 @@ static lcf::rpg::Item* MakeDBEquip(int id, int type,
 	return &item;
 }
 
-static lcf::rpg::Skill* MakeDBSkill(int id, int hit, int power, int phys, int mag, int var)
+inline lcf::rpg::Skill* MakeDBSkill(int id, int hit, int power, int phys, int mag, int var)
 {
 	auto& skill = lcf::Data::skills[id - 1];
 	skill.type = lcf::rpg::Skill::Type_normal;
@@ -182,7 +178,7 @@ static lcf::rpg::Skill* MakeDBSkill(int id, int hit, int power, int phys, int ma
 	return &skill;
 }
 
-static lcf::rpg::Attribute* MakeDBAttribute(int id, int type, int a, int b, int c, int d, int e)
+inline lcf::rpg::Attribute* MakeDBAttribute(int id, int type, int a, int b, int c, int d, int e)
 {
 	auto& attr = lcf::Data::attributes[id - 1];
 	attr.type = type;
@@ -194,22 +190,22 @@ static lcf::rpg::Attribute* MakeDBAttribute(int id, int type, int a, int b, int 
 	return &attr;
 }
 
-static void SetDBActorAttribute(int id, int attr_id, int rank) {
+inline void SetDBActorAttribute(int id, int attr_id, int rank) {
 	auto& actor = lcf::Data::actors[id - 1];
 	actor.attribute_ranks[attr_id - 1] = rank;
 }
 
-static void SetDBEnemyAttribute(int id, int attr_id, int rank) {
+inline void SetDBEnemyAttribute(int id, int attr_id, int rank) {
 	auto& enemy = lcf::Data::enemies[id - 1];
 	enemy.attribute_ranks[attr_id - 1] = rank;
 }
 
-static void SetDBItemAttribute(int id, int attr_id, bool value) {
+inline void SetDBItemAttribute(int id, int attr_id, bool value) {
 	auto& item = lcf::Data::items[id - 1];
 	item.attribute_set[attr_id - 1] = value;
 }
 
-static void SetDBSkillAttribute(int id, int attr_id, bool value) {
+inline void SetDBSkillAttribute(int id, int attr_id, bool value) {
 	auto& skill = lcf::Data::skills[id - 1];
 	skill.attribute_effects[attr_id - 1] = value;
 }

--- a/tests/test_mock_actor.h
+++ b/tests/test_mock_actor.h
@@ -103,6 +103,27 @@ static lcf::rpg::Actor* MakeDBActor(int id, int level, int final_level,
 	return &actor;
 }
 
+static lcf::rpg::Enemy* MakeDBEnemy(int id,
+		int hp, int sp, int atk, int def, int spi, int agi,
+		bool crit = false, int crit_chance = 30, bool miss = false)
+{
+	if (lcf::Data::enemies.size() <= id) {
+		lcf::Data::enemies.resize(id + 1);
+	}
+
+	auto& enemy = lcf::Data::enemies[id - 1];
+	enemy.max_hp = hp;
+	enemy.max_sp = sp;
+	enemy.attack = atk;
+	enemy.defense = def;
+	enemy.spirit = spi;
+	enemy.agility = agi;
+	enemy.critical_hit = crit;
+	enemy.critical_hit_chance = crit_chance;
+	enemy.miss = miss;
+	return &enemy;
+}
+
 static lcf::rpg::Item* MakeDBEquip(int id, int type,
 		int atk = 1, int def = 1, int spi = 1, int agi = 1,
 		int hit=100, int crt=0,


### PR DESCRIPTION
This PR moves battle algo calculation logic into it's own namespace as a set of standalone free functions with minimal dependencies.

Goals:
- [x] Migrate battle algorithm logic into separate free functions that can be called from multiple contexts such as: battle, menu, events, auto battle, and unit tests
- [x] Unit tests around all edge cases in battle algos
- [x] Allow implementation of auto battle in a follow up PR
- [x] Restructure the code to be able to have confidence and converge on algo correctness
- [x] Support weapon modes, so we can implement correct dual wield in 2k3
- [x] Eliminate `Main_Data::game_data.actors` #1954

This also implements 2k3 negative attributes using logic taken from RE. It implements calculating a negative effect, but does not yet pass it through the battle system.

TODO:
- [x] Write unit tests for all edge cases
- [x] Verify each unit test by testing in RPG_RT
- [x] Implement weapon modes for 2k3 dual wield
- [x] Verify differences between actor / monster normal attack in RPG_RT including row
- [x] Recheck for differences in menu vs battle skills
- [x] Verify behavior in 2k3 dynrpg
- [x] Verify behavior in 2ke
- [x] Verify behavior in 2k legacy
- [x] Verify behavior in 2k3 legacy

DynRPG Addresses:
------------------

| address | class | function | Comments |
| -- | -- | -- | -- |
| 004B71AC | Actor | GetBaseAtk | level + mod + all equipment |
| 004B7408 | Actor | GetBaseDef | level + mod + all equipment |
| 004B74B8 | Actor | GetBaseInt | level + mod + all equipment |
| 004B7568 | Actor | GetBaseAgi | level + mod + all equipment |
| 004BFB28 | Battler | GetAtk | base + battle_mod + states |
| 004BFBF4 | Battler | GetDef | base + battle_mod + states |
| 004BFCC0 | Battler | GetInt | base + battle_mod + states |
| 004BFD5C | Battler | GetAgi | base + battle_mod + states |
| 004B760C | Actor | GetBaseAgiForUsedWeapon | level + mod + used weapon + all armor + battle mod (not states ❗ ) |
| 004B7250 | Actor | GetBaseAtkForUsedWeapon | level + mod + used weapon + all armor + battle mode + additional clamp(1, 9999) ❗ |
| 004B9834 | SceneBattle | ApplyNormalAttack | Always used by monster, sometimes used by actor - has states inflict bug for actor attacks |
| 0049B048 | SceneBattle | ApplyNormalWeaponAttack | Used only for actors attack |
| 004C0B2C | Battler | CalcNormalAttackDamage | Always used by monster attack, sometimes used by actor attack. For actors, always uses combined atk and agi from both weapons. Used for actor auto battle ranking. |
| 004B9834 | Actor | CalcNormalWeaponAttackDamage | Used only for actors attack - has back attack row bug not present in other version |
| 0049C644 | SceneBattle | ApplySkillEffect | 
| 004A20D8 | SceneMenu | ApplySkillEffect |
| 004C0DBC | Battler | ComputeSkillPower | Used for actor auto battle ranking |
| 0049B7E4 | SceneBattle | ProcessActionSelfDestruct |

List of RPG_RT bugs discovered ❗ 
---------------------------------

* When the battle condition is "back" all actor attacks against enemies are treated as if they were in the back row.
* When actor attack uses `ApplyNormalAttack` path, state infliction percentages are taken as the max rate of both weapons, instead of the just the weapon which is performing the attack.
* When actor uses a normal attack with a weapon, the actor's AGI used to calculate the hit probability ignores states which can double or half AGI.
* In 2k3, RPG_RT will still check if `failure_message = 3` and run physical evasion checks. There is no way to set this flags anymore in 2k3 editor. What about skills ported from 2k?
* In physical skill evasion checks, 2k3 will not check for states with `avoid_attacks` or `row`.
* When calculating the rank for skill use in auto battle, RPG_RT highly values skills which can revive dead allies. However RPG_RT does not check `invert_state` flag, and so it would prefer to use a skill which inflicts death on the party.
* 2k3 protects against divide by zero in the normal attack hit rate agi calculation. 2k does not. However in both cases, the agi value used is already clamped to >= 1..