### PR TITLE
Fix HSL to RGB overflow error

### DIFF
--- a/src/bitmap_hslrgb.h
+++ b/src/bitmap_hslrgb.h
@@ -56,7 +56,7 @@ static inline void HSL_to_RGB(const int& h, const int& s, const int& l,
 
 static inline void HSL_adjust(int& h, int& s, int& l, int hue) {
 	h += hue;
-	if (h > 0x600) h -= 0x600;
+	if (h >= 0x600) h -= 0x600;
 	if (s > 0xFF) s = 0xFF;
 	l = (l > 0xFF) ? 0xFF : (l < 0) ? 0 : l;
 }

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1486,7 +1486,7 @@ void Scene_Battle_Rpg2k3::ShowNotification(std::string text) {
 
 bool Scene_Battle_Rpg2k3::CheckAnimFlip(Game_Battler* battler) {
 	if (Game_System::GetInvertAnimations()) {
-		return battler->IsDirectionFlipped() ^ battler->GetType() == Game_Battler::Type_Enemy;
+		return battler->IsDirectionFlipped() ^ (battler->GetType() == Game_Battler::Type_Enemy);
 	}
 	return false;
 }


### PR DESCRIPTION
This PR fixes #2266. If the hue value in the HSL_to_RGB function was greater than or equal to 1536, the color was not converted. Using modulo 1536 on the hue value fixes this because the hue ranges between 0 and 1536 in this function.