### PR TITLE
Add Rand::API + allow locking the RNG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,8 @@ add_library(${PROJECT_NAME}
 	src/player.cpp
 	src/player.h
 	src/point.h
+	src/rand.cpp
+	src/rand.h
 	src/rect.cpp
 	src/rect.h
 	src/registry.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -203,6 +203,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/point.h \
 	src/game_quit.cpp \
 	src/game_quit.h \
+	src/rand.cpp \
+	src/rand.h \
 	src/rect.cpp \
 	src/rect.h \
 	src/registry.cpp \

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -20,6 +20,7 @@
 #include "game_enemy.h"
 #include "attribute.h"
 #include "player.h"
+#include "rand.h"
 #include <lcf/rpg/skill.h>
 
 #include <algorithm>
@@ -153,7 +154,7 @@ int VarianceAdjustEffect(int base, int var) {
 	// FIXME: RPG_RT 2k3 doesn't apply variance if negative attribute flips damage
 	if (var > 0 && (base > 0 || Player::IsLegacy())) {
 		int adj = std::max(1, var * base / 10);
-		return base + Utils::GetRandomNumber(0, adj) - adj / 2;
+		return base + Rand::GetRandomNumber(0, adj) - adj / 2;
 	}
 	return base;
 }

--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -34,6 +34,7 @@
 #include <fstream>
 #include "utils.h"
 #include "transition.h"
+#include "rand.h"
 
 // When this option is enabled async requests are randomly delayed.
 // This allows testing some aspects of async file fetching locally.
@@ -231,7 +232,7 @@ void FileRequestAsync::UpdateProgress() {
 #ifndef EMSCRIPTEN
 	// Fake download for testing event handlers
 
-	if (!IsReady() && Utils::ChanceOf(1, 100)) {
+	if (!IsReady() && Rand::ChanceOf(1, 100)) {
 		DownloadDone(true);
 	}
 #endif

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -33,6 +33,7 @@
 #include "pending_message.h"
 #include "compiler.h"
 #include "attribute.h"
+#include "rand.h"
 
 constexpr int max_level_2k = 50;
 constexpr int max_level_2k3 = 99;
@@ -809,7 +810,7 @@ const lcf::rpg::Skill* Game_Actor::GetRandomSkill() const {
 	}
 
 	// Skills are guaranteed to be valid
-	return lcf::ReaderUtil::GetElement(lcf::Data::skills, skills[Utils::GetRandomNumber(0, skills.size() - 1)]);
+	return lcf::ReaderUtil::GetElement(lcf::Data::skills, skills[Rand::GetRandomNumber(0, skills.size() - 1)]);
 }
 
 Point Game_Actor::GetOriginalPosition() const {

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -35,6 +35,7 @@
 #include "spriteset_battle.h"
 #include "output.h"
 #include "utils.h"
+#include "rand.h"
 
 namespace Game_Battle {
 	const lcf::rpg::Troop* troop = nullptr;
@@ -709,3 +710,4 @@ Point Game_Battle::Calculate2k3BattlePosition(const Game_Actor& actor) {
 
 	return position;
 }
+

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -40,6 +40,7 @@
 #include <lcf/rpg/item.h>
 #include "sprite_battler.h"
 #include "utils.h"
+#include "rand.h"
 #include "state.h"
 #include "algo.h"
 #include "attribute.h"
@@ -66,7 +67,7 @@ static void BattlePhysicalStateHeal(int physical_rate, std::vector<int16_t>& tar
 		if (state->release_by_damage > 0) {
 			int release_chance = state->release_by_damage * physical_rate / 100;
 
-			if (!Utils::ChanceOf(release_chance, 100)) {
+			if (!Rand::ChanceOf(release_chance, 100)) {
 				continue;
 			}
 
@@ -932,8 +933,8 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 	auto crit_chance = Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll);
 
 	// Damage calculation
-	if (Utils::PercentChance(to_hit)) {
-		if (Utils::PercentChance(crit_chance)) {
+	if (Rand::PercentChance(to_hit)) {
+		if (Rand::PercentChance(crit_chance)) {
 			critical_hit = true;
 		}
 
@@ -985,7 +986,7 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 					if (!weapon_heals_states) {
 						pct = pct * GetTarget()->GetStateProbability(state_id) / 100;
 					}
-					if (!Utils::PercentChance(pct)) {
+					if (!Rand::PercentChance(pct)) {
 						return false;
 					}
 					if (weapon_heals_states) {
@@ -1161,17 +1162,17 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 					this->hp = std::max<int>(0, std::min<int>(effect, GetTarget()->GetMaxHp() - GetTarget()->GetHp()));
 				}
 			}
-			if (skill.affect_sp && Utils::PercentChance(to_hit)) {
+			if (skill.affect_sp && Rand::PercentChance(to_hit)) {
 				int sp_cost = GetSource() == GetTarget() ? source->CalculateSkillCost(skill.ID) : 0;
 				this->sp = std::max<int>(0, std::min<int>(effect, GetTarget()->GetMaxSp() - GetTarget()->GetSp() + sp_cost));
 			}
-			if (skill.affect_attack && Utils::PercentChance(to_hit))
+			if (skill.affect_attack && Rand::PercentChance(to_hit))
 				this->attack = std::max<int>(0, std::min<int>(effect, std::min<int>(GetTarget()->MaxStatBattleValue(), GetTarget()->GetBaseAtk() * 2) - GetTarget()->GetAtk()));
-			if (skill.affect_defense && Utils::PercentChance(to_hit))
+			if (skill.affect_defense && Rand::PercentChance(to_hit))
 				this->defense = std::max<int>(0, std::min<int>(effect, std::min<int>(GetTarget()->MaxStatBattleValue(), GetTarget()->GetBaseDef() * 2) - GetTarget()->GetDef()));
-			if (skill.affect_spirit && Utils::PercentChance(to_hit))
+			if (skill.affect_spirit && Rand::PercentChance(to_hit))
 				this->spirit = std::max<int>(0, std::min<int>(effect, std::min<int>(GetTarget()->MaxStatBattleValue(), GetTarget()->GetBaseSpi() * 2) - GetTarget()->GetSpi()));
-			if (skill.affect_agility && Utils::PercentChance(to_hit))
+			if (skill.affect_agility && Rand::PercentChance(to_hit))
 				this->agility = std::max<int>(0, std::min<int>(effect, std::min<int>(GetTarget()->MaxStatBattleValue(), GetTarget()->GetBaseAgi() * 2) - GetTarget()->GetAgi()));
 
 			this->success = GetAffectedHp() != -1 || GetAffectedSp() != -1 || GetAffectedAttack() > 0
@@ -1199,17 +1200,17 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				}
 			}
 
-			if (skill.affect_sp && Utils::PercentChance(to_hit)) {
+			if (skill.affect_sp && Rand::PercentChance(to_hit)) {
 				this->sp = std::min<int>(effect, GetTarget()->GetSp());
 			}
 
-			if (skill.affect_attack && Utils::PercentChance(to_hit))
+			if (skill.affect_attack && Rand::PercentChance(to_hit))
 				this->attack = std::max<int>(0, std::min<int>(effect, GetTarget()->GetAtk() - (GetTarget()->GetBaseAtk() + 1) / 2));
-			if (skill.affect_defense && Utils::PercentChance(to_hit))
+			if (skill.affect_defense && Rand::PercentChance(to_hit))
 				this->defense = std::max<int>(0, std::min<int>(effect, GetTarget()->GetDef() - (GetTarget()->GetBaseDef() + 1) / 2));
-			if (skill.affect_spirit && Utils::PercentChance(to_hit))
+			if (skill.affect_spirit && Rand::PercentChance(to_hit))
 				this->spirit = std::max<int>(0, std::min<int>(effect, GetTarget()->GetSpi() - (GetTarget()->GetBaseSpi() + 1) / 2));
-			if (skill.affect_agility && Utils::PercentChance(to_hit))
+			if (skill.affect_agility && Rand::PercentChance(to_hit))
 				this->agility = std::max<int>(0, std::min<int>(effect, GetTarget()->GetAgi() - (GetTarget()->GetBaseAgi() + 1) / 2));
 
 			if (skill.affect_hp) {
@@ -1268,7 +1269,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 			if (heals_states && !target_has_state) {
 				continue;
 			}
-			if (!Utils::PercentChance(to_hit)) {
+			if (!Rand::PercentChance(to_hit)) {
 				continue;
 			}
 
@@ -1278,7 +1279,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				if (State::Remove(state_id, target_states, target_perm_states)) {
 					states.push_back({state_id, StateEffect::Healed});
 				}
-			} else if (Utils::PercentChance(GetTarget()->GetStateProbability(state_id))) {
+			} else if (Rand::PercentChance(GetTarget()->GetStateProbability(state_id))) {
 				if (State::Add(state_id, target_states, target_perm_states, true)) {
 					this->success = true;
 					states.push_back({state_id, StateEffect::Inflicted});
@@ -1294,7 +1295,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 		if (skill.affect_attr_defence) {
 			for (int i = 0; i < static_cast<int>(skill.attribute_effects.size()); i++) {
 				if (skill.attribute_effects[i] && GetTarget()->CanShiftAttributeRate(i + 1, IsPositive() ? 1 : -1)) {
-					if (!Utils::PercentChance(to_hit))
+					if (!Rand::PercentChance(to_hit))
 						continue;
 					shift_attributes.push_back(i + 1);
 					this->success = true;

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -42,6 +42,7 @@
 #include "shake.h"
 #include "attribute.h"
 #include "algo.h"
+#include "rand.h"
 
 Game_Battler::Game_Battler() {
 	ResetBattle();
@@ -541,7 +542,7 @@ std::vector<int16_t> Game_Battler::BattleStateHeal() {
 	for (size_t i = 0; i < states.size(); ++i) {
 		if (HasState(i + 1)) {
 			if (states[i] > lcf::Data::states[i].hold_turn
-					&& Utils::ChanceOf(lcf::Data::states[i].auto_release_prob, 100)
+					&& Rand::ChanceOf(lcf::Data::states[i].auto_release_prob, 100)
 					&& RemoveState(i + 1, false)
 					) {
 				healed_states.push_back(i + 1);

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -30,6 +30,7 @@
 #include "utils.h"
 #include "util_macro.h"
 #include "output.h"
+#include "rand.h"
 #include <cmath>
 #include <cassert>
 
@@ -508,7 +509,7 @@ void Game_Character::Turn180Degree() {
 }
 
 void Game_Character::Turn90DegreeLeftOrRight() {
-	if (Utils::ChanceOf(1,2)) {
+	if (Rand::ChanceOf(1,2)) {
 		Turn90DegreeLeft();
 	} else {
 		Turn90DegreeRight();
@@ -546,7 +547,7 @@ void Game_Character::TurnAwayFromHero() {
 }
 
 void Game_Character::TurnRandom() {
-	SetDirection(Utils::GetRandomNumber(0, 3));
+	SetDirection(Rand::GetRandomNumber(0, 3));
 }
 
 void Game_Character::Wait() {

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -28,6 +28,7 @@
 #include "utils.h"
 #include "player.h"
 #include "attribute.h"
+#include "rand.h"
 
 namespace {
 	constexpr int levitation_frame_count = 14;
@@ -45,7 +46,7 @@ Game_Enemy::Game_Enemy(const lcf::rpg::TroopMember* member)
 	hp = GetMaxHp();
 	sp = GetMaxSp();
 	SetHidden(troop_member->invisible);
-	cycle = Utils::GetRandomNumber(0, levitation_frame_count - 1) * levitation_frame_cycle;
+	cycle = Rand::GetRandomNumber(0, levitation_frame_count - 1) * levitation_frame_cycle;
 
 	SetBattlePosition(GetOriginalPosition());
 }
@@ -227,7 +228,7 @@ const lcf::rpg::EnemyAction* Game_Enemy::ChooseRandomAction() {
 		return nullptr;
 	}
 
-	int which = Utils::GetRandomNumber(0, total - 1);
+	int which = Rand::GetRandomNumber(0, total - 1);
 	for (std::vector<int>::const_iterator it = valid.begin(); it != valid.end(); ++it) {
 		const lcf::rpg::EnemyAction& action = actions[*it];
 		if (which >= action.rating) {

--- a/src/game_enemyparty.cpp
+++ b/src/game_enemyparty.cpp
@@ -24,6 +24,7 @@
 #include <lcf/reader_util.h>
 #include "utils.h"
 #include "output.h"
+#include "rand.h"
 
 Game_EnemyParty::Game_EnemyParty() {
 }
@@ -72,7 +73,7 @@ void Game_EnemyParty::ResetBattle(int battle_troop_id) {
 				continue;
 			}
 
-			if (Utils::PercentChance(40)) {
+			if (Rand::PercentChance(40)) {
 				enemy.SetHidden(true);
 				--non_hidden;
 			}
@@ -115,7 +116,7 @@ void Game_EnemyParty::GenerateDrops(std::vector<int>& out) const {
 		if (enemy.IsDead()) {
 			// Only roll if the enemy has something to drop
 			if (enemy.GetDropId() != 0) {
-				if (Utils::ChanceOf(enemy.GetDropProbability(), 100)) {
+				if (Rand::ChanceOf(enemy.GetDropProbability(), 100)) {
 					out.push_back(enemy.GetDropId());
 				}
 			}

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -30,6 +30,7 @@
 #include "main_data.h"
 #include "player.h"
 #include "utils.h"
+#include "rand.h"
 #include "output.h"
 #include <cmath>
 #include <cassert>
@@ -464,12 +465,12 @@ void Game_Event::UpdateNextMovementAction() {
 
 void Game_Event::SetMaxStopCountForRandom() {
 	auto st = GetMaxStopCountForStep(GetMoveFrequency());
-	st *= (Utils::GetRandomNumber(0, 3) + 3) / 5;
+	st *= (Rand::GetRandomNumber(0, 3) + 3) / 5;
 	SetMaxStopCount(st);
 }
 
 void Game_Event::MoveTypeRandom() {
-	int draw = Utils::GetRandomNumber(0, 9);
+	int draw = Rand::GetRandomNumber(0, 9);
 
 	const auto prev_dir = GetDirection();
 
@@ -481,7 +482,7 @@ void Game_Event::MoveTypeRandom() {
 	} else if (draw < 8) {
 		Turn180Degree();
 	} else {
-		SetStopCount(Utils::GetRandomNumber(0, GetMaxStopCount()));
+		SetStopCount(Rand::GetRandomNumber(0, GetMaxStopCount()));
 		return;
 	}
 
@@ -553,13 +554,13 @@ void Game_Event::MoveTypeTowardsOrAwayPlayer(bool towards) {
 
 	int dir = 0;
 	if (!in_sight) {
-		dir = Utils::GetRandomNumber(0, 3);
+		dir = Rand::GetRandomNumber(0, 3);
 	} else {
-		int draw = Utils::GetRandomNumber(0, 9);
+		int draw = Rand::GetRandomNumber(0, 9);
 		if (draw == 0) {
 			dir = GetDirection();
 		} else if(draw == 1) {
-			dir = Utils::GetRandomNumber(0, 3);
+			dir = Rand::GetRandomNumber(0, 3);
 		} else {
 			dir = towards
 				? GetDirectionToHero()

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -54,6 +54,7 @@
 #include "transition.h"
 #include "baseui.h"
 #include "algo.h"
+#include "rand.h"
 
 enum BranchSubcommand {
 	eOptionBranchElse = 1
@@ -980,7 +981,7 @@ bool Game_Interpreter::CommandControlVariables(lcf::rpg::EventCommand const& com
 			// Random between range
 			int rmax = max(com.parameters[5], com.parameters[6]);
 			int rmin = min(com.parameters[5], com.parameters[6]);
-			value = Utils::GetRandomNumber(rmin, rmax);
+			value = Rand::GetRandomNumber(rmin, rmax);
 			break;
 		}
 		case 4:

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -46,6 +46,7 @@
 #include "player.h"
 #include "input.h"
 #include "utils.h"
+#include "rand.h"
 #include <lcf/scope_guard.h>
 #include "scene_gameover.h"
 
@@ -1219,9 +1220,9 @@ bool Game_Map::PrepareEncounter(BattleArgs& args) {
 		return false;
 	}
 
-	args.troop_id = encounters[Utils::GetRandomNumber(0, encounters.size() - 1)];
+	args.troop_id = encounters[Rand::GetRandomNumber(0, encounters.size() - 1)];
 
-	if (Utils::GetRandomNumber(1, 32) == 1) {
+	if (Rand::GetRandomNumber(1, 32) == 1) {
 		args.first_strike = true;
 	}
 

--- a/src/game_party_base.cpp
+++ b/src/game_party_base.cpp
@@ -19,6 +19,7 @@
 #include <list>
 #include "game_party_base.h"
 #include "utils.h"
+#include "rand.h"
 
 Game_Party_Base::~Game_Party_Base() {
 }
@@ -86,7 +87,7 @@ Game_Battler* Game_Party_Base::GetRandomActiveBattler() {
 	if (battlers.empty()) {
 		return NULL;
 	}
-	return battlers[Utils::GetRandomNumber(0, battlers.size() - 1)];
+	return battlers[Rand::GetRandomNumber(0, battlers.size() - 1)];
 }
 
 Game_Battler* Game_Party_Base::GetRandomDeadBattler() {
@@ -96,7 +97,7 @@ Game_Battler* Game_Party_Base::GetRandomDeadBattler() {
 		return NULL;
 	}
 
-	return battlers[Utils::GetRandomNumber(0, battlers.size() - 1)];
+	return battlers[Rand::GetRandomNumber(0, battlers.size() - 1)];
 }
 
 bool Game_Party_Base::IsAnyActive() {

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -31,6 +31,7 @@
 #include "util_macro.h"
 #include "game_switches.h"
 #include "output.h"
+#include "rand.h"
 #include "utils.h"
 #include <lcf/reader_util.h>
 #include <lcf/scope_guard.h>
@@ -705,7 +706,7 @@ void Game_Player::UpdateEncounterSteps() {
 	const auto pmod = row.pmod;
 	const auto p = (1.0f / float(encounter_rate)) * pmod * (float(terrain->encounter_rate) / 100.0f);
 
-	if (!Utils::PercentChance(p)) {
+	if (!Rand::PercentChance(p)) {
 		return;
 	}
 

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -35,6 +35,7 @@
 #include "weather.h"
 #include "flash.h"
 #include "shake.h"
+#include "rand.h"
 
 Game_Screen::Game_Screen()
 {
@@ -214,9 +215,9 @@ void Game_Screen::InitParticles(int num_particles) {
 		// RPG_RT always initializes all particles to these values on startup.
 		// This can cause minor visual glitches for the first few frames the
 		// first time you start the sandstorm effect. We're bug compatible with RPG_RT.
-		p.t = Utils::GetRandomNumber(0, 39);
-		p.x = Utils::GetRandomNumber(0, GetPanLimitX() / 16 - 1);
-		p.y = Utils::GetRandomNumber(0, GetPanLimitY() / 16 - 1);
+		p.t = Rand::GetRandomNumber(0, 39);
+		p.x = Rand::GetRandomNumber(0, GetPanLimitX() / 16 - 1);
+		p.y = Rand::GetRandomNumber(0, GetPanLimitY() / 16 - 1);
 	}
 }
 
@@ -226,10 +227,10 @@ void Game_Screen::UpdateRain() {
 			--p.t;
 			p.y += 4;
 			p.x -= 1;
-		} else if (Utils::PercentChance(10)) {
+		} else if (Rand::PercentChance(10)) {
 			p.t = 12;
-			p.x = Utils::GetRandomNumber(0, GetPanLimitX() / 16 - 1);
-			p.y = Utils::GetRandomNumber(0, GetPanLimitY() / 16 - 1);
+			p.x = Rand::GetRandomNumber(0, GetPanLimitX() / 16 - 1);
+			p.y = Rand::GetRandomNumber(0, GetPanLimitY() / 16 - 1);
 		}
 	}
 }
@@ -238,12 +239,12 @@ void Game_Screen::UpdateSnow() {
 	for (auto& p: particles) {
 		if (p.t > 0) {
 			--p.t;
-			p.x -= Utils::GetRandomNumber(0, 1);
-			p.y += Utils::GetRandomNumber(2, 3);
-		} else if (Utils::PercentChance(5)) {
+			p.x -= Rand::GetRandomNumber(0, 1);
+			p.y += Rand::GetRandomNumber(2, 3);
+		} else if (Rand::PercentChance(5)) {
 			p.t = 30;
-			p.x = Utils::GetRandomNumber(0, GetPanLimitX() / 16 - 1);
-			p.y = Utils::GetRandomNumber(0, GetPanLimitY() / 16 - 1);
+			p.x = Rand::GetRandomNumber(0, GetPanLimitX() / 16 - 1);
+			p.y = Rand::GetRandomNumber(0, GetPanLimitY() / 16 - 1);
 		}
 	}
 }
@@ -259,7 +260,7 @@ void Game_Screen::UpdateSandstorm() {
 	// accounts for the range starting at 1 (not 0) and ending at 127 (not 128).
 
 	constexpr auto epsilon = 1.0f / 128.0f;
-	auto& rng = Utils::GetRNG();
+	auto& rng = Rand::GetRNG();
 	auto dist = std::uniform_real_distribution<float>(epsilon, M_PI - epsilon);
 
 	UpdateFog();
@@ -273,12 +274,12 @@ void Game_Screen::UpdateSandstorm() {
 			p.y += static_cast<int>(p.vy);
 			p.vx += p.ax;
 			p.vy += p.ay;
-		} else if (Utils::PercentChance(10)) {
+		} else if (Rand::PercentChance(10)) {
 			p.t = 80;
 
 			auto c = std::cos(dist(rng));
 			auto s = std::sin(dist(rng));
-			auto d = Utils::GetRandomNumber(16, 95);
+			auto d = Rand::GetRandomNumber(16, 95);
 
 			p.x = static_cast<int>(d * c * 2.0f) * SCREEN_TARGET_WIDTH / 320 + SCREEN_TARGET_WIDTH / 2;
 			p.y = static_cast<int>(d * s) * SCREEN_TARGET_HEIGHT / 240;

--- a/src/game_variables.cpp
+++ b/src/game_variables.cpp
@@ -22,6 +22,7 @@
 #include <lcf/reader_util.h>
 #include <lcf/data.h>
 #include "utils.h"
+#include "rand.h"
 #include <cmath>
 
 constexpr int Game_Variables::max_warnings;
@@ -237,32 +238,32 @@ void Game_Variables::ModRangeVariableIndirect(int first_id, int last_id, int var
 
 void Game_Variables::SetRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
 	PrepareRange(first_id, last_id, "Invalid write var[{},{}] = rand({},{})!", minval, maxval);
-	WriteRange(first_id, last_id, [this,minval,maxval](){ return Utils::GetRandomNumber(minval, maxval); }, VarSet);
+	WriteRange(first_id, last_id, [this,minval,maxval](){ return Rand::GetRandomNumber(minval, maxval); }, VarSet);
 }
 
 void Game_Variables::AddRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
 	PrepareRange(first_id, last_id, "Invalid write var[{},{}] += rand({},{})!", minval, maxval);
-	WriteRange(first_id, last_id, [this,minval,maxval](){ return Utils::GetRandomNumber(minval, maxval); }, VarAdd);
+	WriteRange(first_id, last_id, [this,minval,maxval](){ return Rand::GetRandomNumber(minval, maxval); }, VarAdd);
 }
 
 void Game_Variables::SubRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
 	PrepareRange(first_id, last_id, "Invalid write var[{},{}] -= rand({},{})!", minval, maxval);
-	WriteRange(first_id, last_id, [this,minval,maxval](){ return Utils::GetRandomNumber(minval, maxval); }, VarSub);
+	WriteRange(first_id, last_id, [this,minval,maxval](){ return Rand::GetRandomNumber(minval, maxval); }, VarSub);
 }
 
 void Game_Variables::MultRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
 	PrepareRange(first_id, last_id, "Invalid write var[{},{}] *= rand({},{})!", minval, maxval);
-	WriteRange(first_id, last_id, [this,minval,maxval](){ return Utils::GetRandomNumber(minval, maxval); }, VarMult);
+	WriteRange(first_id, last_id, [this,minval,maxval](){ return Rand::GetRandomNumber(minval, maxval); }, VarMult);
 }
 
 void Game_Variables::DivRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
 	PrepareRange(first_id, last_id, "Invalid write var[{},{}] /= rand({},{})!", minval, maxval);
-	WriteRange(first_id, last_id, [this,minval,maxval](){ return Utils::GetRandomNumber(minval, maxval); }, VarDiv);
+	WriteRange(first_id, last_id, [this,minval,maxval](){ return Rand::GetRandomNumber(minval, maxval); }, VarDiv);
 }
 
 void Game_Variables::ModRangeRandom(int first_id, int last_id, Var_t minval, Var_t maxval) {
 	PrepareRange(first_id, last_id, "Invalid write var[{},{}] %= rand({},{})!", minval, maxval);
-	WriteRange(first_id, last_id, [this,minval,maxval](){ return Utils::GetRandomNumber(minval, maxval); }, VarMod);
+	WriteRange(first_id, last_id, [this,minval,maxval](){ return Rand::GetRandomNumber(minval, maxval); }, VarMod);
 }
 
 StringView Game_Variables::GetName(int _id) const {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -44,6 +44,7 @@
 #include "async_handler.h"
 #include "audio.h"
 #include "cache.h"
+#include "rand.h"
 #include "cmdline_parser.h"
 #include "filefinder.h"
 #include "fileext_guesser.h"
@@ -168,7 +169,7 @@ void Player::Init(int argc, char *argv[]) {
 #endif
 
 	Game_Clock::logClockInfo();
-	Utils::SeedRandomNumberGenerator(time(NULL));
+	Rand::SeedRandomNumberGenerator(time(NULL));
 
 	auto cfg = ParseCommandLine(argc, argv);
 
@@ -544,7 +545,7 @@ Game_Config Player::ParseCommandLine(int argc, char *argv[]) {
 		}*/
 		if (cp.ParseNext(arg, 1, "--seed")) {
 			if (arg.ParseValue(0, li_value)) {
-				Utils::SeedRandomNumberGenerator(li_value);
+				Rand::SeedRandomNumberGenerator(li_value);
 			}
 			continue;
 		}

--- a/src/rand.cpp
+++ b/src/rand.cpp
@@ -1,0 +1,135 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Headers
+#include "rand.h"
+#include "utils.h"
+#include "output.h"
+#include "compiler.h"
+#include <cassert>
+#include <cstdint>
+#include <cinttypes>
+#include <algorithm>
+#include <random>
+
+namespace {
+Rand::RNG rng;
+
+/** Gets a random number uniformly distributed in [0, U32_MAX] */
+uint32_t GetRandomU32() { return rng(); }
+
+int32_t rng_lock_value = 0;
+bool rng_locked= false;
+}
+
+/** Generate a random number in the range [0,max] */
+static uint32_t GetRandomUnsigned(uint32_t max)
+{
+	if (max == 0xffffffffull) return GetRandomU32();
+
+	// Rejection sampling:
+	// 1. Divide the range of uint32 into blocks of max+1
+	//    numbers each, with rem numbers left over.
+	// 2. Generate a random u32. If it belongs to a block,
+	//    mod it into the range [0,max] and accept it.
+	// 3. If it fell into the range of rem leftover numbers,
+	//    reject it and go back to step 2.
+	uint32_t m = max + 1;
+	uint32_t rem = -m % m; // = 2^32 mod m
+	while (true) {
+		uint32_t n = GetRandomU32();
+		if (n >= rem)
+			return n % m;
+	}
+}
+
+int32_t Rand::GetRandomNumber(int32_t from, int32_t to) {
+	assert(from <= to);
+	if (rng_locked) {
+		return Utils::Clamp(rng_lock_value, from, to);
+	}
+	// Don't use uniform_int_distribution--the algorithm used isn't
+	// portable between stdlibs.
+	// We do from + (rand int in [0, to-from]). The miracle of two's
+	// complement let's us do this all in unsigned and then just cast
+	// back.
+	uint32_t ufrom = uint32_t(from);
+	uint32_t uto = uint32_t(to);
+	uint32_t urange = uto - ufrom;
+	uint32_t ures = ufrom + GetRandomUnsigned(urange);
+	return int32_t(ures);
+}
+
+Rand::RNG& Rand::GetRNG() {
+	return rng;
+}
+
+bool Rand::ChanceOf(int32_t n, int32_t m) {
+	assert(n >= 0 && m > 0);
+	return GetRandomNumber(1, m) <= n;
+}
+
+bool Rand::PercentChance(float rate) {
+	constexpr auto scale = 0x1000000;
+	return GetRandomNumber(0, scale-1) < int32_t(rate * scale);
+}
+
+bool Rand::PercentChance(int rate) {
+	return GetRandomNumber(0, 99) < rate;
+}
+
+void Rand::SeedRandomNumberGenerator(int32_t seed) {
+	rng.seed(seed);
+	Output::Debug("Seeded the RNG with {}.", seed);
+}
+
+void Rand::LockRandom(int32_t value) {
+	rng_locked = true;
+	rng_lock_value = value;
+}
+
+void Rand::UnlockRandom() {
+	rng_locked = false;
+}
+
+std::pair<bool,int32_t> Rand::GetRandomLocked() {
+	return { rng_locked, rng_lock_value };
+}
+
+Rand::LockGuard::LockGuard(int32_t lock_value, bool locked) {
+	auto p = GetRandomLocked();
+	_prev_locked = p.first;
+	_prev_lock_value = p.second;
+	_active = true;
+
+	if (locked) {
+		LockRandom(lock_value);
+	} else {
+		UnlockRandom();
+	}
+}
+
+void Rand::LockGuard::Release() noexcept {
+	if (Enabled()) {
+		if (_prev_locked) {
+			LockRandom(_prev_lock_value);
+		} else {
+			UnlockRandom();
+		}
+		Dismiss();
+	}
+}

--- a/src/rand.h
+++ b/src/rand.h
@@ -1,0 +1,165 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_RANDOM_H
+#define EP_RANDOM_H
+
+#include <functional>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <random>
+#include "system.h"
+#include "string_view.h"
+#include "span.h"
+
+namespace Rand {
+/**
+ * The random number generator object to use
+ */
+using RNG = std::mt19937;
+
+/**
+ * Gets a random number in the inclusive range from - to.
+ *
+ * @param from Interval start
+ * @param to Interval end
+ * @return Random number in inclusive interval
+ */
+int32_t GetRandomNumber(int32_t from, int32_t to);
+
+/**
+ * Gets the seeded Random Number Generator (RNG).
+ *
+ * @return the random number generator
+ */
+RNG& GetRNG();
+
+/**
+ * Has an n/m chance of returning true. If n>m, always returns true.
+ *
+ * @param n number of times out of m to return true (non-negative)
+ * @param m denominator of the probability (positive)
+ * @return true with probability n/m, false with probability 1-n/m
+ */
+bool ChanceOf(int32_t n, int32_t m);
+
+/**
+ * Rolls a random number in [0.0f, 1.0f) returns true if it's less than rate.
+ *
+ * @param rate a value in [0.0f, 1.0f]. Values out of this range are clamped.
+ * @return true with probability rate.
+ */
+bool PercentChance(float rate);
+
+/**
+ * Rolls a random number in [0, 99] and returns true if it's less than rate.
+ *
+ * @param rate a value in [0, 100]. Values out of this range are clamped.
+ * @return true with probability rate.
+ */
+bool PercentChance(int rate);
+bool PercentChance(long rate);
+
+/**
+ * Seeds the RNG used by GetRandomNumber and ChanceOf.
+ *
+ * @param seed Seed to use
+ */
+void SeedRandomNumberGenerator(int32_t seed);
+
+/**
+ * Forces GetRandomNumber() and all dervative functions to return a fixed value.
+ * Useful for testing.
+ *
+ * @param lock_value the value to set. A calls to GetRandomNumber(a, b) will return clamp(lock_value, a, b)
+ * @post All calls to GetRandomNumber(a, b) will return clamp(lock_value, a, b)
+ */
+void LockRandom(int32_t lock_value);
+
+/**
+ * Disables locked random number and returns RNG to original state.
+ * @post All calls to GetRandomNumber(a, b) will return random values.
+ */
+void UnlockRandom();
+
+/**
+ * Retrive whether random numbers are locked and if so, which value they are locked to.
+ * @return whether or not random numbers are locked and if so, to what value.
+ */
+std::pair<bool,int32_t> GetRandomLocked();
+
+/** An RAII guard which fixes the rng while active and resets on destruction */
+class LockGuard {
+public:
+	/**
+	 * Store current state and set locked state
+	 * @param lock_value The rng value to fix to
+	 * @param locked Whether to fix or reset
+	 */
+	LockGuard(int32_t lock_value, bool locked = true);
+
+	LockGuard(const LockGuard&) = delete;
+	LockGuard& operator=(const LockGuard&) = delete;
+
+	/** Move other LockGuard to this */
+	LockGuard(LockGuard&& o) noexcept;
+	LockGuard& operator=(LockGuard&&) = delete;
+
+	/** Calls Release() */
+	~LockGuard();
+
+	/** If Enabled(), returns the rng locked state to what it was */
+	void Release() noexcept;
+
+	/** Disables the LockGuard leaving the rng state as is */
+	void Dismiss();
+
+	/** @return whether the guard is enabled and will release on destruction */
+	bool Enabled() const;
+private:
+	int32_t _prev_lock_value = 0;
+	bool _prev_locked = false;
+	bool _active = false;
+};
+
+inline bool PercentChance(long rate) {
+	return PercentChance(static_cast<int>(rate));
+}
+
+inline LockGuard::LockGuard(LockGuard&& o) noexcept {
+	std::swap(_prev_lock_value, o._prev_lock_value);
+	std::swap(_prev_locked, o._prev_locked);
+	std::swap(_active, o._active);
+}
+
+inline LockGuard::~LockGuard() {
+	Release();
+}
+
+inline void LockGuard::Dismiss() {
+	_active = false;
+}
+
+inline bool LockGuard::Enabled() const {
+	return _active;
+}
+
+} // namespace Rand
+
+
+#endif

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -41,6 +41,7 @@
 #include "scene_gameover.h"
 #include "scene_debug.h"
 #include "game_interpreter.h"
+#include "rand.h"
 
 Scene_Battle::Scene_Battle(const BattleArgs& args)
 	: troop_id(args.troop_id),
@@ -116,7 +117,7 @@ void Scene_Battle::InitEscapeChance() {
 }
 
 bool Scene_Battle::TryEscape() {
-	if (first_strike || Utils::PercentChance(escape_chance)) {
+	if (first_strike || Rand::PercentChance(escape_chance)) {
 		return true;
 	}
 	escape_chance += 10;

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -35,6 +35,7 @@
 #include "scene_battle.h"
 #include "scene_gameover.h"
 #include "output.h"
+#include "rand.h"
 
 Scene_Battle_Rpg2k::Scene_Battle_Rpg2k(const BattleArgs& args) :
 	Scene_Battle(args)
@@ -1301,7 +1302,7 @@ void Scene_Battle_Rpg2k::SelectPreviousActor() {
 void Scene_Battle_Rpg2k::CreateExecutionOrder() {
 	// Define random Agility. Must be done outside of the sort function because of the "strict weak ordering" property, so the sort is consistent
 	for (auto battler : battle_actions) {
-		int battle_order = battler->GetAgi() + Utils::GetRandomNumber(0, battler->GetAgi() / 4 + 3);
+		int battle_order = battler->GetAgi() + Rand::GetRandomNumber(0, battler->GetAgi() / 4 + 3);
 		if (battler->GetBattleAlgorithm()->GetType() == Game_BattleAlgorithm::Type::Normal && battler->HasPreemptiveAttack()) {
 			// This is an arbitrarily large number to separate preemptive vs non-preemptive battlers
 			battle_order += 100000;

--- a/src/transition.cpp
+++ b/src/transition.cpp
@@ -33,6 +33,7 @@
 #include "drawable.h"
 #include "drawable_mgr.h"
 #include "output.h"
+#include "rand.h"
 
 int Transition::GetDefaultFrames(Transition::Type type)
 {
@@ -130,7 +131,7 @@ void Transition::SetAttributesTransitions() {
 	case TransitionRandomBlocks:
 		random_block_transition = Bitmap::Create(DisplayUi->GetWidth(), DisplayUi->GetHeight(), true);
 		current_blocks_print = 0;
-		std::shuffle(random_blocks.begin(), random_blocks.end(), Utils::GetRNG());
+		std::shuffle(random_blocks.begin(), random_blocks.end(), Rand::GetRNG());
 		break;
 	case TransitionRandomBlocksDown:
 	case TransitionRandomBlocksUp:
@@ -143,7 +144,7 @@ void Transition::SetAttributesTransitions() {
 		length = 10;
 		for (int i = 0; i < h - 1; i++) {
 			end_i = (i < length ? 2 * i + 1 : i <= h - length ? i + length : (i + h) / 2) * w;
-			std::shuffle(random_blocks.begin() + i * w, random_blocks.begin() + end_i, Utils::GetRNG());
+			std::shuffle(random_blocks.begin() + i * w, random_blocks.begin() + end_i, Rand::GetRNG());
 
 			beg_i = i * w + (i % 2 == 0 ? 0 : 2);
 			mid_i = i * w + (i % 2 == 0 ? 1 : 3) + (i > h * 2 / 3 ? 3 : 0);

--- a/src/utils.h
+++ b/src/utils.h
@@ -220,56 +220,6 @@ namespace Utils {
 	 */
 	void SwapByteOrder(double& d);
 
-	/**
-	 * Gets a random number in the inclusive range from - to.
-	 *
-	 * @param from Interval start
-	 * @param to Interval end
-	 * @return Random number in inclusive interval
-	 */
-	int32_t GetRandomNumber(int32_t from, int32_t to);
-
-	/**
-	 * Gets the seeded Random Number Generator (RNG).
-	 *
-	 * @return the random number generator
-	 */
-	std::mt19937 &GetRNG();
-
-	/**
-	 * Has an n/m chance of returning true. If n>m, always returns true.
-	 *
-	 * @param n number of times out of m to return true (non-negative)
-	 * @param m denominator of the probability (positive)
-	 * @return true with probability n/m, false with probability 1-n/m
-	 */
-	bool ChanceOf(int32_t n, int32_t m);
-
-
-	/**
-	 * Rolls a random number in [0.0f, 1.0f) returns true if it's less than rate.
-	 *
-	 * @param rate a value in [0.0f, 1.0f]. Values out of this range are clamped.
-	 * @return true with probability rate.
-	 */
-	bool PercentChance(float rate);
-
-	/**
-	 * Rolls a random number in [0, 99] and returns true if it's less than rate.
-	 *
-	 * @param rate a value in [0, 100]. Values out of this range are clamped.
-	 * @return true with probability rate.
-	 */
-	bool PercentChance(int rate);
-	bool PercentChance(long rate);
-
-	/**
-	 * Seeds the RNG used by GetRandomNumber and ChanceOf.
-	 *
-	 * @param seed Seed to use
-	 */
-	void SeedRandomNumberGenerator(int32_t seed);
-
 	/** @return -1 if t < 0, 0 if t== 0, 1 if t > 0 */
 	template <typename T>
 		int Signum(const T& val);
@@ -396,10 +346,6 @@ namespace Utils {
 template <typename T>
 constexpr T Utils::Clamp(T value, const T& minv, const T& maxv) {
 	return (value < minv) ? (minv) : ((value > maxv) ? maxv : value);
-}
-
-inline bool Utils::PercentChance(long rate) {
-	return Utils::PercentChance(static_cast<int>(rate));
 }
 
 template <typename F>

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -27,6 +27,7 @@
 #include "drawable_mgr.h"
 #include "player.h"
 #include "output.h"
+#include "rand.h"
 
 Weather::Weather() :
 	Drawable(Priority_Weather, Drawable::Flags::Shared)
@@ -311,7 +312,7 @@ void Weather::CreateFogOverlay() {
 	auto* sand_img = reinterpret_cast<uint32_t*>(sand_bitmap->pixels());
 
 	for (int i = 0; i < w * h; ++i) {
-		int px = Utils::GetRandomNumber(0, num_overlay_colors - 1);
+		int px = Rand::GetRandomNumber(0, num_overlay_colors - 1);
 		// FIXME: This only works for 32bit pixel formats
 		fog_img[i] = fog_pixels[px];
 		sand_img[i] = sand_pixels[px];

--- a/tests/game_character.cpp
+++ b/tests/game_character.cpp
@@ -248,6 +248,7 @@ TEST_CASE("InitEventNoPage") {
 TEST_CASE("InitEventDefaultPage") {
 	lcf::rpg::Event event;
 	event.pages.push_back({});
+	event.pages.back().move_type = lcf::rpg::EventPage::MoveType_stationary;
 	Game_Event ch(0, &event);
 
 	testInit(ch, 64);

--- a/tests/rand.cpp
+++ b/tests/rand.cpp
@@ -1,0 +1,103 @@
+#include "rand.h"
+#include "doctest.h"
+
+static void testGetRandomNumber(int32_t a, int32_t b) {
+	for (int i = 0; i < 1000; ++i) {
+		auto x = Rand::GetRandomNumber(a, b);
+		REQUIRE_GE(x, a);
+		REQUIRE_LE(x, b);
+	}
+}
+
+TEST_SUITE_BEGIN("Rand");
+
+TEST_CASE("GetRandomNumber") {
+	testGetRandomNumber(0, 43);
+	testGetRandomNumber(-21, 31);
+	testGetRandomNumber(0, 0);
+	testGetRandomNumber(5, 5);
+	testGetRandomNumber(-5, -2);
+}
+
+TEST_CASE("Lock") {
+	REQUIRE_FALSE(Rand::GetRandomLocked().first);
+
+	Rand::LockRandom(55);
+
+	REQUIRE(Rand::GetRandomLocked().first);
+	REQUIRE_EQ(Rand::GetRandomLocked().second, 55);
+
+	Rand::UnlockRandom();
+
+	REQUIRE_FALSE(Rand::GetRandomLocked().first);
+}
+
+TEST_CASE("LockGuardNest") {
+	REQUIRE_FALSE(Rand::GetRandomLocked().first);
+	{
+		Rand::LockGuard fg(32);
+		REQUIRE(fg.Enabled());
+
+		REQUIRE(Rand::GetRandomLocked().first);
+		REQUIRE_EQ(Rand::GetRandomLocked().second, 32);
+
+		{
+			Rand::LockGuard fg(0, false);
+			REQUIRE(fg.Enabled());
+
+			REQUIRE_FALSE(Rand::GetRandomLocked().first);
+		}
+
+		REQUIRE(Rand::GetRandomLocked().first);
+		REQUIRE_EQ(Rand::GetRandomLocked().second, 32);
+	}
+	REQUIRE_FALSE(Rand::GetRandomLocked().first);
+}
+
+TEST_CASE("LockGuardRelease") {
+	REQUIRE_FALSE(Rand::GetRandomLocked().first);
+
+	Rand::LockGuard fg(-16);
+	REQUIRE(fg.Enabled());
+
+	REQUIRE(Rand::GetRandomLocked().first);
+	REQUIRE_EQ(Rand::GetRandomLocked().second, -16);
+
+	fg.Release();
+
+	REQUIRE_FALSE(Rand::GetRandomLocked().first);
+	REQUIRE_FALSE(fg.Enabled());
+}
+
+TEST_CASE("LockGuardDismiss") {
+	Rand::LockGuard fg(INT32_MAX);
+	REQUIRE(fg.Enabled());
+
+	REQUIRE(Rand::GetRandomLocked().first);
+	REQUIRE_EQ(Rand::GetRandomLocked().second, INT32_MAX);
+
+	fg.Dismiss();
+
+	REQUIRE(Rand::GetRandomLocked().first);
+	REQUIRE_EQ(Rand::GetRandomLocked().second, INT32_MAX);
+
+	Rand::UnlockRandom();
+}
+
+static void testGetRandomNumberFixed(int32_t a, int32_t b, int32_t fix, int32_t result) {
+	Rand::LockGuard fg(fix);
+	for (int i = 0; i < 10; ++i) {
+		auto x = Rand::GetRandomNumber(a, b);
+		REQUIRE_EQ(x, result);
+	}
+}
+
+TEST_CASE("GetRandomNumberFixed") {
+	testGetRandomNumberFixed(-10, 12, 5, 5);
+	testGetRandomNumberFixed(-10, 12, 12, 12);
+	testGetRandomNumberFixed(-10, 12, 55, 12);
+	testGetRandomNumberFixed(-10, 12, INT32_MIN, -10);
+	testGetRandomNumberFixed(-10, 12, INT32_MAX, 12);
+}
+
+TEST_SUITE_END();


### PR DESCRIPTION
This PR allows you to lock the rng to always return a single value. In order to maintain accurate semantics for callers to random, the value is clamped.

So for example:

```
Rand::LockRandom(5);
assert(Rand::GetRandomNumber(0, 10) == 5);

Rand::LockRandom(65);
assert(Rand::GetRandomNumber(0, 10) == 10);

Rand::LockRandom(-65);
assert(Rand::GetRandomNumber(0, 10) == 0);
```

My use case for this is to be able to accurately unit test battle variance in #2320, but I imagine we can also use this for the regression test system.