### PR TITLE
Battle 2k3: Battle animation sprites changes

### DIFF
--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -73,7 +73,8 @@ void BattleAnimation::Update() {
 	UpdateScreenFlash();
 	UpdateTargetFlash();
 
-	SetFlashEffect(Main_Data::game_screen->GetFlashColor());
+	Color screenflash = Main_Data::game_screen->GetFlashColor();
+	if (screenflash.red > 0 || screenflash.green > 0 || screenflash.blue > 0 || screenflash.alpha > 0) SetFlashEffect(Main_Data::game_screen->GetFlashColor());
 
 	frame++;
 }
@@ -209,7 +210,7 @@ void BattleAnimation::UpdateScreenFlash() {
 void BattleAnimation::UpdateTargetFlash() {
 	int r, g, b, p;
 	UpdateFlashGeneric(target_flash_timing, r, g, b, p);
-	FlashTargets(r, g, b, p);
+	if (r > 0 || g > 0 || b > 0 || p > 0) FlashTargets(r, g, b, p);
 }
 
 // For handling the vertical position.

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -204,13 +204,13 @@ void BattleAnimation::UpdateFlashGeneric(int timing_idx, int& r, int& g, int& b,
 void BattleAnimation::UpdateScreenFlash() {
 	int r, g, b, p;
 	UpdateFlashGeneric(screen_flash_timing, r, g, b, p);
-	if (r > 0 || g > 0 || b > 0 || p > 0) Main_Data::game_screen->FlashOnce(r, g, b, p, 0);
+	if (!overwrite_screen_effects) Main_Data::game_screen->FlashOnce(r, g, b, p, 0);
 }
 
 void BattleAnimation::UpdateTargetFlash() {
 	int r, g, b, p;
 	UpdateFlashGeneric(target_flash_timing, r, g, b, p);
-	if (r > 0 || g > 0 || b > 0 || p > 0) FlashTargets(r, g, b, p);
+	if (!overwrite_screen_effects) FlashTargets(r, g, b, p);
 }
 
 // For handling the vertical position.
@@ -333,4 +333,8 @@ void BattleAnimation::SetIgnoreYOffset(bool ignoreyoffset) {
 
 void BattleAnimation::SetInvert(bool inverted) {
 	invert = inverted;
+}
+
+void BattleAnimation::SetOverwriteScreenEffects(bool overwrite) {
+	overwrite_screen_effects = overwrite;
 }

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -330,3 +330,7 @@ void BattleAnimation::SetFrame(int frame) {
 void BattleAnimation::SetIgnoreYOffset(bool ignoreyoffset) {
 	ignore_y_offset = ignoreyoffset;
 }
+
+void BattleAnimation::SetInvert(bool inverted) {
+	invert = inverted;
+}

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -203,7 +203,7 @@ void BattleAnimation::UpdateFlashGeneric(int timing_idx, int& r, int& g, int& b,
 void BattleAnimation::UpdateScreenFlash() {
 	int r, g, b, p;
 	UpdateFlashGeneric(screen_flash_timing, r, g, b, p);
-	Main_Data::game_screen->FlashOnce(r, g, b, p, 0);
+	if (r > 0 || g > 0 || b > 0 || p > 0) Main_Data::game_screen->FlashOnce(r, g, b, p, 0);
 }
 
 void BattleAnimation::UpdateTargetFlash() {

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -294,7 +294,7 @@ void BattleAnimationBattle::Draw(Bitmap& dst) {
 	for (auto* battler: battlers) {
 		const Sprite_Battler* sprite = Game_Battle::GetSpriteset().FindBattler(battler);
 		int offset = 0;
-		if (sprite && sprite->GetBitmap()) {
+		if (sprite && (sprite->GetBitmap() || (sprite->IsUsingAnimationAsSprite() && !ignore_y_offset))) {
 			offset = CalculateOffset(animation.position, sprite->GetHeight());
 		}
 		DrawAt(dst, battler->GetBattlePosition().x, battler->GetBattlePosition().y + offset);
@@ -327,3 +327,6 @@ void BattleAnimation::SetFrame(int frame) {
 	this->frame = frame;
 }
 
+void BattleAnimation::SetIgnoreYOffset(bool ignoreyoffset) {
+	ignore_y_offset = ignoreyoffset;
+}

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -86,6 +86,13 @@ public:
 	 **/
 	void SetIgnoreYOffset(bool ignoreyoffset);
 
+	/**
+	 * Set if the animation overwrites screen effects
+	 *
+	 * @param overwrite if the animation overwrites screen effects
+	 **/
+	void SetOverwriteScreenEffects(bool overwrite);
+
 protected:
 	BattleAnimation(const lcf::rpg::Animation& anim, bool only_sound = false, int cutoff = -1);
 
@@ -110,6 +117,7 @@ protected:
 	bool only_sound = false;
 	bool invert = false;
 	bool ignore_y_offset = false;
+	bool overwrite_screen_effects = false;
 };
 
 // For playing animations on the map.

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -73,6 +73,13 @@ public:
 	int GetAnimationCellHeight() const;
 
 	/**
+	 * Set if the animation is inverted
+	 *
+	 * @param inverted if the animation is inverted
+	 **/
+	void SetInvert(bool inverted);
+
+	/**
 	 * Set if the animation ignores vertical offset
 	 *
 	 * @param ignoreyoffset if the animation ignores vertical offset

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -62,6 +62,16 @@ public:
 	/** @return true if the animation only plays audio and doesn't display **/
 	bool IsOnlySound() const;
 
+	/**
+	 * @return the animation cell width
+	 */
+	int GetAnimationCellWidth() const;
+
+	/**
+	 * @return the animation cell height
+	 */
+	int GetAnimationCellHeight() const;
+
 protected:
 	BattleAnimation(const lcf::rpg::Animation& anim, bool only_sound = false, int cutoff = -1);
 
@@ -137,6 +147,12 @@ inline bool BattleAnimation::IsOnlySound() const {
 	return only_sound;
 }
 
+inline int BattleAnimation::GetAnimationCellWidth() const {
+	return 96;
+}
 
+inline int BattleAnimation::GetAnimationCellHeight() const {
+	return 96;
+}
 
 #endif

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -72,6 +72,13 @@ public:
 	 */
 	int GetAnimationCellHeight() const;
 
+	/**
+	 * Set if the animation ignores vertical offset
+	 *
+	 * @param ignoreyoffset if the animation ignores vertical offset
+	 **/
+	void SetIgnoreYOffset(bool ignoreyoffset);
+
 protected:
 	BattleAnimation(const lcf::rpg::Animation& anim, bool only_sound = false, int cutoff = -1);
 
@@ -95,6 +102,7 @@ protected:
 	FileRequestBinding request_id;
 	bool only_sound = false;
 	bool invert = false;
+	bool ignore_y_offset = false;
 };
 
 // For playing animations on the map.

--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -649,9 +649,11 @@ Point Game_Battle::Calculate2k3BattlePosition(const Game_Actor& actor) {
 
 	int half_height = 0;
 	int half_width = 0;
+	bool animation_as_sprite = false;
 	if (sprite) {
 		half_height = sprite->GetHeight() / 2;
 		half_width = sprite->GetWidth() / 2;
+		animation_as_sprite = sprite->IsUsingAnimationAsSprite();
 	}
 
 	int row_x_offset = 0;
@@ -706,7 +708,8 @@ Point Game_Battle::Calculate2k3BattlePosition(const Game_Actor& actor) {
 	position.y = grid.y - half_height;
 
 	// RPG_RT doesn't clamp Y for actors
-	position.x = Utils::Clamp(position.x, half_width, 320 - half_width);
+	// Clamping is only used if not battle animations are used as sprites
+	if (!animation_as_sprite) position.x = Utils::Clamp(position.x, half_width, 320 - half_width);
 
 	return position;
 }

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -400,6 +400,15 @@ void Scene_Battle_Rpg2k3::CreateUi() {
 	} else {
 		SetupSystem2Graphics();
 	}
+
+	std::vector<Game_Battler*> battlers;
+	Main_Data::game_party->GetActiveBattlers(battlers);
+	for (Game_Battler* battler : battlers) {
+		Sprite_Battler* sprite = Game_Battle::GetSpriteset().FindBattler(battler);
+		if (sprite) {
+			sprite->DetectStateChange();
+		}
+	}
 }
 
 void Scene_Battle_Rpg2k3::UpdateCursors() {

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -236,6 +236,7 @@ void Sprite_Battler::SetAnimationState(int state, LoopState loop) {
 				} else {
 					animation.reset(new BattleAnimationBattle(*battle_anim, { battler }));
 					animation->SetIgnoreYOffset(true);
+					animation->SetOverwriteScreenEffects(true);
 					animation->SetZ(GetZ());
 				}
 			}

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -112,6 +112,7 @@ void Sprite_Battler::Update() {
 		if (Player::IsRPG2k3()) {
 			if (animation) {
 				// Is a battle animation
+				animation->SetInvert(battler->IsDirectionFlipped());
 				animation->SetFlashEffect(battler->GetFlashColor());
 				animation->Update();
 
@@ -189,7 +190,7 @@ void Sprite_Battler::Update() {
 	const bool flip = battler->IsDirectionFlipped();
 	SetFlipX(flip);
 	if (animation) {
-		SetFlipX(flip);
+		animation->SetInvert(flip);
 	}
 }
 

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -265,16 +265,20 @@ bool Sprite_Battler::IsIdling() {
 
 int Sprite_Battler::GetWidth() const {
 	if (animation) {
-		return animation->GetWidth();
+		return animation->GetAnimationCellWidth() / 2;
 	}
 	return Sprite::GetWidth();
 }
 
 int Sprite_Battler::GetHeight() const {
 	if (animation) {
-		return animation->GetHeight();
+		return animation->GetAnimationCellHeight() / 2;
 	}
 	return Sprite::GetHeight();
+}
+
+bool Sprite_Battler::IsUsingAnimationAsSprite() {
+	return animation != nullptr;
 }
 
 void Sprite_Battler::ResetZ() {

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -234,6 +234,7 @@ void Sprite_Battler::SetAnimationState(int state, LoopState loop) {
 					animation.reset();
 				} else {
 					animation.reset(new BattleAnimationBattle(*battle_anim, { battler }));
+					animation->SetIgnoreYOffset(true);
 					animation->SetZ(GetZ());
 				}
 			}
@@ -278,7 +279,7 @@ int Sprite_Battler::GetHeight() const {
 	return Sprite::GetHeight();
 }
 
-bool Sprite_Battler::IsUsingAnimationAsSprite() {
+bool Sprite_Battler::IsUsingAnimationAsSprite() const {
 	return animation != nullptr;
 }
 

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -112,6 +112,7 @@ void Sprite_Battler::Update() {
 		if (Player::IsRPG2k3()) {
 			if (animation) {
 				// Is a battle animation
+				animation->SetFlashEffect(battler->GetFlashColor());
 				animation->Update();
 
 				if (animation->IsDone()) {

--- a/src/sprite_battler.h
+++ b/src/sprite_battler.h
@@ -91,6 +91,8 @@ public:
 	int GetWidth() const override;
 	int GetHeight() const override;
 
+	bool IsUsingAnimationAsSprite();
+
 	/**
 	 * A hack for 2k battle system. Treat the sprite as not dead
 	 * even if the battler is dead. This is needed because battler "dies"

--- a/src/sprite_battler.h
+++ b/src/sprite_battler.h
@@ -91,7 +91,7 @@ public:
 	int GetWidth() const override;
 	int GetHeight() const override;
 
-	bool IsUsingAnimationAsSprite();
+	bool IsUsingAnimationAsSprite() const;
 
 	/**
 	 * A hack for 2k battle system. Treat the sprite as not dead


### PR DESCRIPTION
This PR will be updated as soon as #2399 is merged into master. The planned changes are in [rueter37:battleanimation-sprites-new](https://github.com/rueter37/Player/tree/battleanimation-sprites-new).

Depends on: #2399 because of the new sprite_actor class and changes in the sprite_battler class made there.

This PR does the following fixes (after the update):
- Placement of battlers: The battlers were placed wrong (too much distance between each other and partially and full off-screen placing starting with the third party member) if battle animation sprites were used. BattleCharset sprites are working fine.
- Displaying state afflictions: While BattleCharset sprites are showing its state afflictions at the beginning of the battle, the battle animation sprite battlers did so not until their first turn.
- Battle animation sprites are flipped now if the flip flag is set.
- BattleAnimation height: Battle animations are displayed on the right height if the target is a battle animation sprite.
- Battler flashes: The battler flashes didn't work if battle animation sprites were used. Again BattleCharset sprites fully work here.
- Battler shake effects: The battler shake effects didn't work if battle animation sprites were used. Again BattleCharset sprites fully work here.
- ~~Screen flashes: The screen flashes didn't work if battle animation sprites were used. Again BattleCharset sprites fully work here.~~ (#2399 fixes this)