### PR TITLE
Battle 2k3: Add negative attribute modifiers and allow state infliction by skills outside of battles

### DIFF
--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -629,7 +629,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		int hp = GetAffectedHp();
 		int target_hp = target->GetHp();
 		target->ChangeHp(IsPositive() ? hp : -hp);
-		if (IsAbsorb()) {
+		if (IsAbsorb() && !IsPositive()) {
 			// Only absorb the hp that were left
 			int src_hp = std::min(target_hp, hp);
 			source->ChangeHp(src_hp);
@@ -640,7 +640,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		int sp = GetAffectedSp();
 		int target_sp = target->GetSp();
 		target->SetSp(target->GetSp() + (IsPositive() ? sp : -sp));
-		if (IsAbsorb()) {
+		if (IsAbsorb() && !IsPositive()) {
 			int src_sp = std::min(target_sp, sp);
 			source->ChangeSp(src_sp);
 		}
@@ -649,7 +649,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedAttack() != -1) {
 		int atk = GetAffectedAttack();
 		target->ChangeAtkModifier(IsPositive() ? atk : -atk);
-		if (IsAbsorb() && Player::IsRPG2k3Updated()) {
+		if (IsAbsorb() && !IsPositive() && Player::IsRPG2k3Updated()) {
 			atk = std::max<int>(0, std::min<int>(atk, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk()));
 			source->ChangeAtkModifier(atk);
 		}
@@ -658,8 +658,8 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedDefense() != -1) {
 		int def = GetAffectedDefense();
 		target->ChangeDefModifier(IsPositive() ? def : -def);
-		if (IsAbsorb() && Player::IsRPG2k3Updated()) {
-			def = std::max<int>(0, std::min<int>(def, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk()));
+		if (IsAbsorb() && !IsPositive() && Player::IsRPG2k3Updated()) {
+			def = std::max<int>(0, std::min<int>(def, std::min<int>(source->MaxStatBattleValue(), source->GetBaseDef() * 2) - source->GetDef()));
 			source->ChangeDefModifier(def);
 		}
 	}
@@ -667,8 +667,8 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedSpirit() != -1) {
 		int spi = GetAffectedSpirit();
 		target->ChangeSpiModifier(IsPositive() ? spi : -spi);
-		if (IsAbsorb() && Player::IsRPG2k3Updated()) {
-			spi = std::max<int>(0, std::min<int>(spi, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk()));
+		if (IsAbsorb() && !IsPositive() && Player::IsRPG2k3Updated()) {
+			spi = std::max<int>(0, std::min<int>(spi, std::min<int>(source->MaxStatBattleValue(), source->GetBaseSpi() * 2) - source->GetSpi()));
 			source->ChangeSpiModifier(spi);
 		}
 	}
@@ -676,8 +676,8 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 	if (GetAffectedAgility() != -1) {
 		int agi = GetAffectedAgility();
 		target->ChangeAgiModifier(IsPositive() ? agi : -agi);
-		if (IsAbsorb() && Player::IsRPG2k3Updated()) {
-			agi = std::max<int>(0, std::min<int>(agi, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk()));
+		if (IsAbsorb() && !IsPositive() && Player::IsRPG2k3Updated()) {
+			agi = std::max<int>(0, std::min<int>(agi, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAgi() * 2) - source->GetAgi()));
 			source->ChangeAgiModifier(agi);
 		}
 	}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1186,7 +1186,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 					this->hp *= 2;
 				}
 
-				if (IsAbsorb())
+				if (IsAbsorb() && !this->negative_effect)
 					this->hp = std::min<int>(hp, GetTarget()->GetHp());
 
 				if (!this->negative_effect && GetTarget()->GetHp() - this->hp <= 0) {
@@ -1209,7 +1209,11 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 
 		if (skill.affect_sp && Rand::PercentChance(to_hit)) {
 			if (IsNegativeSkill()) {
-				this->sp = std::min<int>(effect, GetTarget()->GetSp());
+				if (!this->negative_effect) {
+					this->sp = std::min<int>(effect, GetTarget()->GetSp());
+				} else {
+					this->sp = effect;
+				}
 			} else {
 				int sp_cost = GetSource() == GetTarget() ? source->CalculateSkillCost(skill.ID) : 0;
 				if (!this->negative_effect) {

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -650,7 +650,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		int atk = GetAffectedAttack();
 		target->ChangeAtkModifier(IsPositive() ? atk : -atk);
 		if (IsAbsorb() && !IsPositive() && Player::IsRPG2k3Updated()) {
-			atk = Utils::Clamp(std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk(), 0, atk);
+			atk = Utils::Clamp(atk, 0, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAtk() * 2) - source->GetAtk());
 			source->ChangeAtkModifier(atk);
 		}
 	}
@@ -659,7 +659,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		int def = GetAffectedDefense();
 		target->ChangeDefModifier(IsPositive() ? def : -def);
 		if (IsAbsorb() && !IsPositive() && Player::IsRPG2k3Updated()) {
-			def = Utils::Clamp(std::min<int>(source->MaxStatBattleValue(), source->GetBaseDef() * 2) - source->GetDef(), 0, def);
+			def = Utils::Clamp(def, 0, std::min<int>(source->MaxStatBattleValue(), source->GetBaseDef() * 2) - source->GetDef());
 			source->ChangeDefModifier(def);
 		}
 	}
@@ -668,7 +668,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		int spi = GetAffectedSpirit();
 		target->ChangeSpiModifier(IsPositive() ? spi : -spi);
 		if (IsAbsorb() && !IsPositive() && Player::IsRPG2k3Updated()) {
-			spi = Utils::Clamp(std::min<int>(source->MaxStatBattleValue(), source->GetBaseSpi() * 2) - source->GetSpi(), 0, spi);
+			spi = Utils::Clamp(spi, 0, std::min<int>(source->MaxStatBattleValue(), source->GetBaseSpi() * 2) - source->GetSpi());
 			source->ChangeSpiModifier(spi);
 		}
 	}
@@ -677,7 +677,7 @@ void Game_BattleAlgorithm::AlgorithmBase::Apply() {
 		int agi = GetAffectedAgility();
 		target->ChangeAgiModifier(IsPositive() ? agi : -agi);
 		if (IsAbsorb() && !IsPositive() && Player::IsRPG2k3Updated()) {
-			agi = Utils::Clamp(std::min<int>(source->MaxStatBattleValue(), source->GetBaseAgi() * 2) - source->GetAgi(), 0, agi);
+			agi = Utils::Clamp(agi, 0, std::min<int>(source->MaxStatBattleValue(), source->GetBaseAgi() * 2) - source->GetAgi());
 			source->ChangeAgiModifier(agi);
 		}
 	}
@@ -1199,10 +1199,10 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 					if (Player::IsRPG2k3()) {
 						this->hp = effect;
 					} else {
-						this->hp = Utils::Clamp(GetTarget()->GetMaxHp() - GetTarget()->GetHp(), 0, effect);
+						this->hp = Utils::Clamp(effect, 0, GetTarget()->GetMaxHp() - GetTarget()->GetHp());
 					}
 				} else {
-					this->hp = Utils::Clamp(GetTarget()->GetHp() - 1, 0, effect);
+					this->hp = Utils::Clamp(effect, 0, GetTarget()->GetHp() - 1);
 				}
 			}
 		}
@@ -1217,7 +1217,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 			} else {
 				int sp_cost = GetSource() == GetTarget() ? source->CalculateSkillCost(skill.ID) : 0;
 				if (!this->negative_effect) {
-					this->sp = Utils::Clamp(GetTarget()->GetMaxSp() - GetTarget()->GetSp() + sp_cost, 0, effect);
+					this->sp = Utils::Clamp(effect, 0, GetTarget()->GetMaxSp() - GetTarget()->GetSp() + sp_cost);
 				} else {
 					this->sp = effect;
 				}
@@ -1226,30 +1226,30 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 
 		if (skill.affect_attack && Rand::PercentChance(to_hit)) {
 			if (!this->healing) {
-				this->attack = Utils::Clamp(GetTarget()->GetAtk() - (GetTarget()->GetBaseAtk() + 1) / 2, 0, effect);
+				this->attack = Utils::Clamp(effect, 0, GetTarget()->GetAtk() - (GetTarget()->GetBaseAtk() + 1) / 2);
 			} else {
-				this->attack = Utils::Clamp(std::min<int>(GetTarget()->MaxStatBattleValue(), GetTarget()->GetBaseAtk() * 2) - GetTarget()->GetAtk(), 0, effect);
+				this->attack = Utils::Clamp(effect, 0, std::min<int>(GetTarget()->MaxStatBattleValue(), GetTarget()->GetBaseAtk() * 2) - GetTarget()->GetAtk());
 			}
 		}
 		if (skill.affect_defense && Rand::PercentChance(to_hit)) {
 			if (!this->healing) {
-				this->defense = Utils::Clamp(GetTarget()->GetDef() - (GetTarget()->GetBaseDef() + 1) / 2, 0, effect);
+				this->defense = Utils::Clamp(effect, 0, GetTarget()->GetDef() - (GetTarget()->GetBaseDef() + 1) / 2);
 			} else {
-				this->defense = Utils::Clamp(std::min<int>(GetTarget()->MaxStatBattleValue(), GetTarget()->GetBaseDef() * 2) - GetTarget()->GetDef(), 0, effect);
+				this->defense = Utils::Clamp(effect, 0, std::min<int>(GetTarget()->MaxStatBattleValue(), GetTarget()->GetBaseDef() * 2) - GetTarget()->GetDef());
 			}
 		}
 		if (skill.affect_spirit && Rand::PercentChance(to_hit)) {
 			if (!this->healing) {
-				this->spirit = Utils::Clamp(GetTarget()->GetSpi() - (GetTarget()->GetBaseSpi() + 1) / 2, 0, effect);
+				this->spirit = Utils::Clamp(effect, 0, GetTarget()->GetSpi() - (GetTarget()->GetBaseSpi() + 1) / 2);
 			} else {
-				this->spirit = Utils::Clamp(std::min<int>(GetTarget()->MaxStatBattleValue(), GetTarget()->GetBaseSpi() * 2) - GetTarget()->GetSpi(), 0, effect);
+				this->spirit = Utils::Clamp(effect, 0, std::min<int>(GetTarget()->MaxStatBattleValue(), GetTarget()->GetBaseSpi() * 2) - GetTarget()->GetSpi());
 			}
 		}
 		if (skill.affect_agility && Rand::PercentChance(to_hit)) {
 			if (!this->healing) {
-				this->agility = Utils::Clamp(GetTarget()->GetAgi() - (GetTarget()->GetBaseAgi() + 1) / 2, 0, effect);
+				this->agility = Utils::Clamp(effect, 0, GetTarget()->GetAgi() - (GetTarget()->GetBaseAgi() + 1) / 2);
 			} else {
-				this->agility = Utils::Clamp(std::min<int>(GetTarget()->MaxStatBattleValue(), GetTarget()->GetBaseAgi() * 2) - GetTarget()->GetAgi(), 0, effect);
+				this->agility = Utils::Clamp(effect, 0, std::min<int>(GetTarget()->MaxStatBattleValue(), GetTarget()->GetBaseAgi() * 2) - GetTarget()->GetAgi());
 			}
 		}
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -946,7 +946,8 @@ bool Game_BattleAlgorithm::Normal::Execute() {
 		// Handle negative effect from attributes
 		if (effect < 0) {
 			this->healing = true;
-			effect = -effect;
+			// RPG_RT bug: Negative effects have double strength
+			effect = -effect * 2;
 		}
 
 		effect = Utils::Clamp(effect, 0, MaxDamageValue());
@@ -1163,7 +1164,8 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 		if (effect < 0) {
 			this->negative_effect = true;
 			this->healing = !this->healing;
-			effect = -effect;
+			// RPG_RT bug: Negative effects have double strength
+			effect = -effect * 2;
 		}
 
 		effect = Utils::Clamp(effect, 0, MaxDamageValue());

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1181,7 +1181,8 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 				this->hp = Algo::AdjustDamageForDefend(effect, *GetTarget());
 
 				// RPG_RT bug: Negative effects affect HP double
-				if (this->negative_effect) {
+				// HP absorbing is not affected by this bug
+				if (this->negative_effect && !IsAbsorb()) {
 					this->hp *= 2;
 				}
 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -478,6 +478,7 @@ protected:
 
 	mutable bool first_attack;
 	bool healing;
+	bool negative_effect;
 	bool success;
 	bool lethal = false;
 	bool killed_by_dmg = false;

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -427,6 +427,16 @@ public:
 	Game_Battler* GetFirstOriginalTarget() const;
 
 	/**
+	 * If the skill is negative before applying attribute modifiers.
+	 */
+	bool IsNegativeSkill() const;
+
+	/**
+	 * If the skill is positive before applying attribute modifiers.
+	 */
+	bool IsPositiveSkill() const;
+
+	/**
 	 * @return the critical hit message
 	 */
 	std::string GetCriticalHitMessage() const;
@@ -668,6 +678,14 @@ inline const std::vector<StateEffect>& AlgorithmBase::GetStateEffects() const {
 
 inline bool AlgorithmBase::IsTargetingParty() const {
 	return party_target != nullptr;
+}
+
+inline bool AlgorithmBase::IsNegativeSkill() const {
+	return !healing ^ negative_effect;
+}
+
+inline bool AlgorithmBase::IsPositiveSkill() const {
+	return healing ^ negative_effect;
 }
 
 } //namespace Game_BattleAlgorithm


### PR DESCRIPTION
This PR implements the negative attribute modifiers used in RPG Maker 2003 which allows for damage absorbing (e.g. dragons absorbing fire-type skills) and the possibility for skills to inflict states outside of battles (this makes the "Regenerationstrank" in "Vampires Dawn II" work outside of battles). By the way, negative attribute modifiers even allow for "funny" things like taking damage through healing skills (but you cannot get killed this way, 1 HP remain - tested with RPG_RT). This is probably my "most insane" PR so I expect many changes needed. Feedback is very appreciated!