### PR TITLE
Implement auto battle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ add_library(${PROJECT_NAME} STATIC
 	src/audio_sdl_mixer.h
 	src/audio_secache.cpp
 	src/audio_secache.h
+	src/autobattle.cpp
+	src/autobattle.h
 	src/background.cpp
 	src/background.h
 	src/baseui.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/audio_sdl_mixer.h \
 	src/audio_secache.cpp \
 	src/audio_secache.h \
+	src/autobattle.cpp \
+	src/autobattle.h \
 	src/background.cpp \
 	src/background.h \
 	src/baseui.cpp \

--- a/resources/easyrpg-player.6.adoc
+++ b/resources/easyrpg-player.6.adoc
@@ -104,6 +104,12 @@ directory!
   Overwrite the map used for new games and use Map__ID__.lmu instead ('ID' is
   padded to four digits).
 
+*--autobattle-algo* 'ALGO'::
+  Which AutoBattle algorithm to use. Possible options:
+   - 'RPG_RT'     - The default RPG_RT compatible algo, including RPG_RT bugs
+   - 'RPG_RT+'    - The default RPG_RT compatible algo, with bug fixes
+   - 'ATTACK'     - RPG_RT+ but only physical attacks, no skills
+
 NOTE: Incompatible with *--load-game-id*.
 
 *--start-position* 'X' 'Y'::

--- a/resources/unix/bash-completion/easyrpg-player
+++ b/resources/unix/bash-completion/easyrpg-player
@@ -35,7 +35,7 @@ _easyrpg-player ()
       #_filedir '@(lmu|emu)'
       return
       ;;
-    # load map files
+    # Select autobattle algorithm
     --autobattle-algos)
       COMPREPLY=($(compgen -W "$autobattle_algos" -- $cur))
       return

--- a/resources/unix/bash-completion/easyrpg-player
+++ b/resources/unix/bash-completion/easyrpg-player
@@ -13,13 +13,14 @@ _easyrpg-player ()
   prev=${COMP_WORDS[COMP_CWORD-1]}
 
   # all possible options
-  ouropts='--battle-test --disable-audio --disable-rtp --enable-mouse --enable-touch \
+  ouropts='--autobattle-algo --battle-test --disable-audio --disable-rtp --enable-mouse --enable-touch \
            --encoding --engine --fps-limit --fps-render-window --fullscreen -h --help \
            --hide-title --load-game-id --new-game --no-vsync --project-path --record-input \
            --replay-input --save-path --seed --show-fps --start-map-id --start-party \
            --start-position --test-play --window -v --version'
   rpgrtopts='BattleTest battletest HideTitle hidetitle TestPlay testplay Window window'
   engines='rpg2k rpg2kv150 rpg2ke rpg2k3 rpg2k3v105 rpg2k3e'
+  autobattle_algos='RPG_RT RPG_RT+ ATTACK'
 
   # first list all special cases
   case $prev in
@@ -32,6 +33,11 @@ _easyrpg-player ()
     --start-map-id)
       # broken, disabled for now
       #_filedir '@(lmu|emu)'
+      return
+      ;;
+    # load map files
+    --autobattle-algos)
+      COMPREPLY=($(compgen -W "$autobattle_algos" -- $cur))
       return
       ;;
     # load save files

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -251,4 +251,10 @@ int CalcSelfDestructEffect(const Game_Battler& source,
 	return effect;
 }
 
+int CalcSkillCost(const lcf::rpg::Skill& skill, int max_sp, bool half_sp_cost) {
+	const auto div = half_sp_cost ? 2 : 1;
+	return (Player::IsRPG2k3() && skill.sp_type == lcf::rpg::Skill::SpType_percent)
+		? max_sp * skill.sp_percent / 100 / div
+		: (skill.sp_cost + static_cast<int>(half_sp_cost)) / div;
+}
 } // namespace Algo

--- a/src/algo.h
+++ b/src/algo.h
@@ -168,6 +168,19 @@ int CalcSelfDestructEffect(const Game_Battler& source,
 		const Game_Battler& target,
 		bool apply_variance);
 
+/**
+ * Calculate the sp cost for a skill.
+ * This includes: power, source atk, target def, variance
+ * It does not include: hit rate, target defend adjustment, value clamping
+ *
+ * @param skill The skill to compute
+ * @param max_sp the max sp of the user
+ * @param half_sp_cost if user has half_sp_cost modifier
+ *
+ * @return sp cost
+ */
+int CalcSkillCost(const lcf::rpg::Skill& skill, int max_sp, bool half_sp_cost);
+
 } // namespace Algo
 
 

--- a/src/autobattle.cpp
+++ b/src/autobattle.cpp
@@ -45,13 +45,13 @@ constexpr decltype(AttackOnly::name) AttackOnly::name;
 constexpr decltype(RpgRtImproved::name) RpgRtImproved::name;
 
 std::unique_ptr<AlgorithmBase> CreateAlgorithm(StringView name) {
-	if (name == RpgRtImproved::name) {
+	if (Utils::StrICmp(name, RpgRtImproved::name) == 0) {
 		return std::make_unique<RpgRtImproved>();
 	}
-	if (name == AttackOnly::name) {
+	if (Utils::StrICmp(name, AttackOnly::name) == 0) {
 		return std::make_unique<AttackOnly>();
 	}
-	if (name != RpgRtCompat::name) {
+	if (Utils::StrICmp(name, RpgRtCompat::name) != 0) {
 		static bool warned = false;
 		if (!warned) {
 			Output::Debug("Invalid AutoBattle algo name `{}' falling back to {} ...", name, RpgRtCompat::name);

--- a/src/autobattle.cpp
+++ b/src/autobattle.cpp
@@ -1,0 +1,376 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "autobattle.h"
+#include "game_actor.h"
+#include "game_enemy.h"
+#include "game_enemyparty.h"
+#include "game_party.h"
+#include "game_battlealgorithm.h"
+#include "game_battle.h"
+#include "algo.h"
+#include "player.h"
+#include "output.h"
+#include "rand.h"
+#include <lcf/reader_util.h>
+#include <lcf/data.h>
+
+namespace AutoBattle {
+
+#ifdef EP_DEBUG_AUTOBATTLE
+template <typename... Args>
+static void DebugLog(const char* fmt, Args&&... args) {
+	Output::Debug(fmt, std::forward<Args>(args)...);
+}
+#else
+template <typename... Args>
+static void DebugLog(const char*, Args&&...) {}
+#endif
+
+constexpr decltype(RpgRtCompat::name) RpgRtCompat::name;
+constexpr decltype(AttackOnly::name) AttackOnly::name;
+constexpr decltype(RpgRtImproved::name) RpgRtImproved::name;
+
+std::unique_ptr<AlgorithmBase> CreateAlgorithm(StringView name) {
+	if (name == RpgRtImproved::name) {
+		return std::make_unique<RpgRtImproved>();
+	}
+	if (name == AttackOnly::name) {
+		return std::make_unique<AttackOnly>();
+	}
+	if (name != RpgRtCompat::name) {
+		static bool warned = false;
+		if (!warned) {
+			Output::Debug("Invalid AutoBattle algo name `{}' falling back to {} ...", name, RpgRtCompat::name);
+			warned = true;
+		}
+	}
+	return std::make_unique<RpgRtCompat>();
+}
+
+void AlgorithmBase::SetAutoBattleAction(Game_Actor& source) {
+	vSetAutoBattleAction(source);
+	if (source.GetBattleAlgorithm() == nullptr) {
+		source.SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(&source));
+	}
+}
+
+void RpgRtCompat::vSetAutoBattleAction(Game_Actor& source) {
+	SelectAutoBattleActionRpgRtCompat(source, Game_Battle::GetBattleCondition());
+}
+
+void AttackOnly::vSetAutoBattleAction(Game_Actor& source) {
+	SelectAutoBattleAction(source, Game_Battler::WeaponAll, Game_Battle::GetBattleCondition(), false, false, false, false);
+}
+
+void RpgRtImproved::vSetAutoBattleAction(Game_Actor& source) {
+	SelectAutoBattleAction(source, Game_Battler::WeaponAll, Game_Battle::GetBattleCondition(), true, false, false, false);
+}
+
+double CalcSkillHealAutoBattleTargetRank(const Game_Actor& source, const Game_Battler& target, const lcf::rpg::Skill& skill, bool apply_variance, bool emulate_bugs) {
+	assert(skill.type == lcf::rpg::Skill::Type_normal || skill.type >= lcf::rpg::Skill::Type_subskill);
+	assert(skill.scope == lcf::rpg::Skill::Scope_self || skill.scope == lcf::rpg::Skill::Scope_ally || skill.scope == lcf::rpg::Skill::Scope_party);
+
+	const double src_max_sp = source.GetMaxSp();
+	const double tgt_max_hp = target.GetMaxHp();
+	const double tgt_hp = target.GetHp();
+
+	if (target.GetHp() > 0) {
+		// Can the skill can heal the target?
+		if (!skill.affect_hp) {
+			return 0.0;
+		}
+
+		const double base_effect = Algo::CalcSkillEffect(source, target, skill, apply_variance);
+		const double max_effect = std::min(base_effect, tgt_max_hp - tgt_hp);
+
+		auto rank = static_cast<double>(max_effect) / static_cast<double>(tgt_max_hp);
+		if (src_max_sp > 0) {
+			const double cost = source.CalculateSkillCost(skill.ID);
+			// Note: RPG_RT 2ke only uses integer division for cost / src_max_sp here.
+			rank -= cost / src_max_sp / 8.0;
+			rank = std::max(rank, 0.0);
+		}
+		return rank;
+	}
+
+	// Can the skill revive the target?
+	if (skill.state_effects.size() > 1 && skill.state_effects[0]) {
+		// BUG: RPG_RT does not check the reverse_state_effect flag to skip skills which would kill party members
+		if (emulate_bugs || !skill.reverse_state_effect) {
+			return static_cast<double>(skill.power) / 1000.0 + 1.0;
+		}
+	}
+	return 0.0;
+}
+
+double CalcSkillDmgAutoBattleTargetRank(const Game_Actor& source, const Game_Battler& target, const lcf::rpg::Skill& skill, bool apply_variance, bool emulate_bugs) {
+	assert(skill.type == lcf::rpg::Skill::Type_normal || skill.type >= lcf::rpg::Skill::Type_subskill);
+	assert(skill.scope == lcf::rpg::Skill::Scope_enemy || skill.scope == lcf::rpg::Skill::Scope_enemies);
+	(void)emulate_bugs;
+
+	if (!(skill.affect_hp && target.Exists())) {
+		return 0.0;
+	}
+
+	double rank = 0.0;
+	const double src_max_sp = source.GetMaxSp();
+	const double tgt_hp = target.GetHp();
+
+	const double base_effect = Algo::CalcSkillEffect(source, target, skill, apply_variance);
+	// Note: RPG_RT 2ke only uses integer division for effect / tgt_hp here.
+	rank = std::min(base_effect, tgt_hp) / tgt_hp;
+	if (rank == 1.0) {
+		rank = 1.5;
+	}
+	if (src_max_sp > 0) {
+		const double cost = source.CalculateSkillCost(skill.ID);
+		// Note: RPG_RT 2ke only uses integer division for cost / src_max_sp here.
+		rank -= cost / src_max_sp / 4.0;
+		rank = std::max(rank, 0.0);
+	}
+
+	// Bonus if the target is the first existing enemy?
+	for (auto* enemy: Main_Data::game_enemyparty->GetEnemies()) {
+		if (enemy->Exists()) {
+			if (enemy == &target) {
+				rank = rank * 1.5 + 0.5;
+			}
+			break;
+		}
+	}
+
+	return rank;
+}
+
+double CalcSkillAutoBattleRank(const Game_Actor& source, const lcf::rpg::Skill& skill, bool apply_variance, bool emulate_bugs) {
+	if (!source.IsSkillUsable(skill.ID)) {
+		return 0.0;
+	}
+	if (skill.type != lcf::rpg::Skill::Type_normal && skill.type < lcf::rpg::Skill::Type_subskill) {
+		return 0.0;
+	}
+
+	double rank = 0.0;
+	switch (skill.scope) {
+		case lcf::rpg::Skill::Scope_ally:
+			for (auto* target: Main_Data::game_party->GetActors()) {
+				auto target_rank = CalcSkillHealAutoBattleTargetRank(source, *target, skill, apply_variance, emulate_bugs);
+				rank = std::max(rank, target_rank);
+				DebugLog("AUTOBATTLE: Actor {} Check Skill Single Ally {} Rank : {}({}): {} -> {}", source.GetName(), target->GetName(), skill.name, skill.ID, rank, target_rank);
+			}
+			break;
+		case lcf::rpg::Skill::Scope_party:
+			for (auto* target: Main_Data::game_party->GetActors()) {
+				auto target_rank = CalcSkillHealAutoBattleTargetRank(source, *target, skill, apply_variance, emulate_bugs);
+				rank += target_rank;
+				DebugLog("AUTOBATTLE: Actor {} Check Skill Party Ally {} Rank : {}({}): {} -> {}", source.GetName(), target->GetName(), skill.name, skill.ID, rank, target_rank);
+			}
+			break;
+		case lcf::rpg::Skill::Scope_enemy:
+			for (auto* target: Main_Data::game_enemyparty->GetEnemies()) {
+				auto target_rank = CalcSkillDmgAutoBattleTargetRank(source, *target, skill, apply_variance, emulate_bugs);
+				rank = std::max(rank, target_rank);
+				DebugLog("AUTOBATTLE: Actor {} Check Skill Single Enemy {} Rank : {}({}): {} -> {}", source.GetName(), target->GetName(), skill.name, skill.ID, rank, target_rank);
+			}
+			break;
+		case lcf::rpg::Skill::Scope_enemies:
+			for (auto* target: Main_Data::game_enemyparty->GetEnemies()) {
+				auto target_rank = CalcSkillDmgAutoBattleTargetRank(source, *target, skill, apply_variance, emulate_bugs);
+				rank += target_rank;
+				DebugLog("AUTOBATTLE: Actor {} Check Skill Party Enemy {} Rank : {}({}): {} -> {}", source.GetName(), target->GetName(), skill.name, skill.ID, rank, target_rank);
+			}
+			break;
+		case lcf::rpg::Skill::Scope_self:
+			rank = CalcSkillHealAutoBattleTargetRank(source, source, skill, apply_variance, emulate_bugs);
+			DebugLog("AUTOBATTLE: Actor {} Check Skill Self Rank : {}({}): {}", source.GetName(), skill.name, skill.ID, rank);
+			break;
+	}
+	if (rank > 0.0) {
+		rank += Rand::GetRandomNumber(0, 99) / 100.0;
+	}
+	return rank;
+}
+
+double CalcNormalAttackAutoBattleTargetRank(const Game_Actor& source,
+		const Game_Battler& target,
+		Game_Battler::Weapon weapon,
+		lcf::rpg::System::BattleCondition cond,
+		bool apply_variance,
+		bool emulate_bugs)
+{
+	if (!target.Exists()) {
+		return 0.0;
+	}
+	const bool is_critical_hit = false;
+
+	// RPG_RT BUG: Normal damage variance is not used
+	// Note: RPG_RT does not do the "2k3_enemy_row_bug" when computing autobattle ranks.
+	double base_effect = Algo::CalcNormalAttackEffect(source, target, weapon, is_critical_hit, apply_variance, cond, false);
+	// RPG_RT BUG: Dual Attack is ignored
+	if (!emulate_bugs && source.HasDualAttack(weapon)) {
+		base_effect *= 2;
+	}
+	const double tgt_hp = target.GetHp();
+
+	// Note: RPG_RT 2ke only uses integer division for effect / tgt_hp here.
+	auto rank = std::min(base_effect, tgt_hp) / tgt_hp;
+	if (rank == 1.0) {
+		rank = 1.5;
+	}
+	if (!emulate_bugs) {
+		// EasyRPG customization - include sp cost of weapon attack using same logic as skill attack
+		const auto cost = std::min(source.CalculateWeaponSpCost(weapon), source.GetSp());
+		if (cost > 0) {
+			const double src_max_sp = source.GetMaxSp();
+			rank -= static_cast<double>(cost) / src_max_sp / 4.0;
+			rank = std::max(rank, 0.0);
+		}
+	}
+
+	// Bonus if the target is the first existing enemy?
+	for (auto* enemy: Main_Data::game_enemyparty->GetEnemies()) {
+		if (enemy->Exists()) {
+			if (enemy == &target) {
+				rank = rank * 1.5 + 0.5;
+			}
+			break;
+		}
+	}
+	if (rank > 0.0) {
+		rank = Rand::GetRandomNumber(0, 99) / 100.0 + rank * 1.5;
+	}
+	return rank;
+}
+
+double CalcNormalAttackAutoBattleRank(const Game_Actor& source, Game_Battler::Weapon weapon, const lcf::rpg::System::BattleCondition cond, bool apply_variance, bool emulate_bugs) {
+	double rank = 0.0;
+	std::vector<Game_Battler*> targets;
+	Main_Data::game_enemyparty->GetBattlers(targets);
+
+	if (!emulate_bugs && source.HasAttackAll(weapon)) {
+		for (auto* target: targets) {
+			auto target_rank = CalcNormalAttackAutoBattleTargetRank(source, *target, weapon, cond, apply_variance, emulate_bugs);
+			rank += target_rank;
+			DebugLog("AUTOBATTLE: Actor {} Check Attack Party Enemy {} Rank : {} -> {}", source.GetName(), target->GetName(), rank, target_rank);
+		}
+	} else {
+		for (auto* target: targets) {
+			auto target_rank = CalcNormalAttackAutoBattleTargetRank(source, *target, weapon, cond, apply_variance, emulate_bugs);
+			rank = std::max(rank, target_rank);
+			DebugLog("AUTOBATTLE: Actor {} Check Attack Single Enemy {} Rank : {} -> {}", source.GetName(), target->GetName(), rank, target_rank);
+		}
+	}
+	return rank;
+}
+
+void SelectAutoBattleAction(Game_Actor& source,
+		Game_Battler::Weapon weapon,
+		lcf::rpg::System::BattleCondition cond,
+		bool do_skills,
+		bool attack_variance,
+		bool skill_variance,
+		bool emulate_bugs)
+{
+	double skill_rank = 0.0;
+	lcf::rpg::Skill* skill = nullptr;
+
+	// Find the highest ranking skill
+	if (do_skills) {
+		for (auto& skill_id: source.GetSkills()) {
+			auto* candidate_skill = lcf::ReaderUtil::GetElement(lcf::Data::skills, skill_id);
+			if (candidate_skill) {
+				const auto rank = CalcSkillAutoBattleRank(source, *candidate_skill, skill_variance, emulate_bugs);
+				DebugLog("AUTOBATTLE: Actor {} Check Skill Rank : {}({}): {}", source.GetName(), candidate_skill->name, candidate_skill->ID, rank);
+				if (rank > skill_rank) {
+					skill_rank = rank;
+					skill = candidate_skill;
+				}
+			}
+		}
+		DebugLog("AUTOBATTLE: Actor {} Best Skill Rank : {}({}): {}", source.GetName(), skill->name, skill->ID, skill_rank);
+	}
+
+	double normal_attack_rank = CalcNormalAttackAutoBattleRank(source, weapon, cond, attack_variance, emulate_bugs);
+	DebugLog("AUTOBATTLE: Actor {} Normal Attack Rank : {}", source.GetName(), normal_attack_rank);
+
+	auto best_target_rank = 0.0;
+	Game_Battler* best_target = nullptr;
+	std::vector<Game_Battler*> targets;
+
+	if (skill != nullptr && normal_attack_rank < skill_rank) {
+		// Choose Skill Target
+		switch (skill->scope) {
+			case lcf::rpg::Skill::Scope_enemies:
+				DebugLog("AUTOBATTLE: Actor {} Select Skill Target : ALL ENEMIES", source.GetName());
+				source.SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::Skill>(&source, Main_Data::game_enemyparty.get(), *skill));
+				return;
+			case lcf::rpg::Skill::Scope_party:
+				DebugLog("AUTOBATTLE: Actor {} Select Skill Target : ALL ALLIES", source.GetName());
+				source.SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::Skill>(&source, Main_Data::game_party.get(), *skill));
+				return;
+			case lcf::rpg::Skill::Scope_enemy:
+				for (auto* target: Main_Data::game_enemyparty->GetEnemies()) {
+					const auto target_rank = CalcSkillDmgAutoBattleTargetRank(source, *target, *skill, skill_variance, emulate_bugs);
+					if (target_rank > best_target_rank) {
+						best_target_rank = target_rank;
+						best_target = target;
+					}
+				}
+				break;
+			case lcf::rpg::Skill::Scope_ally:
+				for (auto* target: Main_Data::game_party->GetActors()) {
+					const auto target_rank = CalcSkillHealAutoBattleTargetRank(source, *target, *skill, skill_variance, emulate_bugs);
+					if (target_rank > best_target_rank) {
+						best_target_rank = target_rank;
+						best_target = target;
+					}
+				}
+				break;
+			case lcf::rpg::Skill::Scope_self:
+				best_target = &source;
+				break;
+		}
+		if (best_target) {
+			DebugLog("AUTOBATTLE: Actor {} Select Skill Target : {}", source.GetName(), best_target->GetName());
+			source.SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::Skill>(&source, best_target, *skill));
+		}
+		return;
+	}
+	// Choose normal attack
+	if (source.HasAttackAll(weapon)) {
+		DebugLog("AUTOBATTLE: Actor {} Select Attack Target : ALL ENEMIES", source.GetName());
+		source.SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::Normal>(&source, Main_Data::game_enemyparty.get()));
+		return;
+	}
+
+	for (auto* target: Main_Data::game_enemyparty->GetEnemies()) {
+		const auto target_rank = CalcNormalAttackAutoBattleTargetRank(source, *target, weapon, cond, attack_variance, emulate_bugs);
+		// On case of ==, prefer the first enemy
+		if (target_rank > best_target_rank) {
+			best_target_rank = target_rank;
+			best_target = target;
+		}
+	}
+
+	if (best_target != nullptr) {
+		DebugLog("AUTOBATTLE: Actor {} Select Attack Target : {}", source.GetName(), best_target->GetName());
+		source.SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::Normal>(&source, best_target));
+		return;
+	}
+}
+
+} // namespace AutoBattle

--- a/src/autobattle.cpp
+++ b/src/autobattle.cpp
@@ -80,6 +80,13 @@ void RpgRtImproved::vSetAutoBattleAction(Game_Actor& source) {
 	SelectAutoBattleAction(source, Game_Battler::WeaponAll, Game_Battle::GetBattleCondition(), true, false, false, false);
 }
 
+static int CalcSkillCostAutoBattle(const Game_Actor& source, const lcf::rpg::Skill& skill, bool emulate_bugs) {
+	// RPG_RT autobattle ignores half sp cost modifier
+	return emulate_bugs
+		? Algo::CalcSkillCost(skill, source.GetMaxSp(), false)
+		: source.CalculateSkillCost(skill.ID);
+}
+
 double CalcSkillHealAutoBattleTargetRank(const Game_Actor& source, const Game_Battler& target, const lcf::rpg::Skill& skill, bool apply_variance, bool emulate_bugs) {
 	assert(skill.type == lcf::rpg::Skill::Type_normal || skill.type >= lcf::rpg::Skill::Type_subskill);
 	assert(skill.scope == lcf::rpg::Skill::Scope_self || skill.scope == lcf::rpg::Skill::Scope_ally || skill.scope == lcf::rpg::Skill::Scope_party);
@@ -99,7 +106,7 @@ double CalcSkillHealAutoBattleTargetRank(const Game_Actor& source, const Game_Ba
 
 		auto rank = static_cast<double>(max_effect) / static_cast<double>(tgt_max_hp);
 		if (src_max_sp > 0) {
-			const double cost = source.CalculateSkillCost(skill.ID);
+			const double cost = CalcSkillCostAutoBattle(source, skill, emulate_bugs);
 			rank -= cost / src_max_sp / 8.0;
 			rank = std::max(rank, 0.0);
 		}
@@ -135,7 +142,7 @@ double CalcSkillDmgAutoBattleTargetRank(const Game_Actor& source, const Game_Bat
 		rank = 1.5;
 	}
 	if (src_max_sp > 0) {
-		const double cost = source.CalculateSkillCost(skill.ID);
+		const double cost = CalcSkillCostAutoBattle(source, skill, emulate_bugs);
 		rank -= cost / src_max_sp / 4.0;
 		rank = std::max(rank, 0.0);
 	}

--- a/src/autobattle.cpp
+++ b/src/autobattle.cpp
@@ -89,7 +89,7 @@ double CalcSkillHealAutoBattleTargetRank(const Game_Actor& source, const Game_Ba
 	const double tgt_hp = target.GetHp();
 
 	if (target.GetHp() > 0) {
-		// Can the skill can heal the target?
+		// Can the skill heal the target?
 		if (!skill.affect_hp) {
 			return 0.0;
 		}
@@ -100,7 +100,6 @@ double CalcSkillHealAutoBattleTargetRank(const Game_Actor& source, const Game_Ba
 		auto rank = static_cast<double>(max_effect) / static_cast<double>(tgt_max_hp);
 		if (src_max_sp > 0) {
 			const double cost = source.CalculateSkillCost(skill.ID);
-			// Note: RPG_RT 2ke only uses integer division for cost / src_max_sp here.
 			rank -= cost / src_max_sp / 8.0;
 			rank = std::max(rank, 0.0);
 		}
@@ -131,14 +130,12 @@ double CalcSkillDmgAutoBattleTargetRank(const Game_Actor& source, const Game_Bat
 	const double tgt_hp = target.GetHp();
 
 	const double base_effect = Algo::CalcSkillEffect(source, target, skill, apply_variance);
-	// Note: RPG_RT 2ke only uses integer division for effect / tgt_hp here.
 	rank = std::min(base_effect, tgt_hp) / tgt_hp;
 	if (rank == 1.0) {
 		rank = 1.5;
 	}
 	if (src_max_sp > 0) {
 		const double cost = source.CalculateSkillCost(skill.ID);
-		// Note: RPG_RT 2ke only uses integer division for cost / src_max_sp here.
 		rank -= cost / src_max_sp / 4.0;
 		rank = std::max(rank, 0.0);
 	}
@@ -226,7 +223,6 @@ double CalcNormalAttackAutoBattleTargetRank(const Game_Actor& source,
 	}
 	const double tgt_hp = target.GetHp();
 
-	// Note: RPG_RT 2ke only uses integer division for effect / tgt_hp here.
 	auto rank = std::min(base_effect, tgt_hp) / tgt_hp;
 	if (rank == 1.0) {
 		rank = 1.5;

--- a/src/autobattle.h
+++ b/src/autobattle.h
@@ -1,0 +1,192 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef EP_AUTOBATTLE_H
+#define EP_AUTOBATTLE_H
+
+#include <lcf/rpg/fwd.h>
+#include <lcf/rpg/system.h>
+#include <lcf/rpg/saveactor.h>
+#include <game_battler.h>
+#include <memory>
+
+class Game_Actor;
+class Game_Enemy;
+
+namespace AutoBattle {
+class AlgorithmBase;
+
+/**
+ * Auto battle algorithm factory function which creates auto battle algorithm from the given name
+ *
+ * @param name of the algo.
+ * @return An auto battle algorithm to be used in battles.
+ */
+std::unique_ptr<AlgorithmBase> CreateAlgorithm(StringView name);
+
+/**
+ * Base class for auto battle algorithm implementations.
+ */
+class AlgorithmBase {
+public:
+	virtual ~AlgorithmBase() {}
+
+	/** @return the name of this algorithm */
+	virtual StringView GetName() const = 0;
+
+	/**
+	 * Calculates the auto battle algorithm and sets the algorithm on source.
+	 * This computation ignores states on the actor, it is  the resposibility of the caller
+	 * to handle death, confuse, provoke, etc..
+	 *
+	 * @param source The source actor to set the action for.
+	 * @post source will have a BattleAlgorithm set.
+	 */
+	void SetAutoBattleAction(Game_Actor& source);
+private:
+	virtual void vSetAutoBattleAction(Game_Actor& source) = 0;
+};
+
+/**
+ * The default autobattle algorithm which is strictly compatible with RPG_RT, bugs included.
+ */
+class RpgRtCompat: public AlgorithmBase {
+public:
+	static constexpr auto name = "RPG_RT";
+
+	StringView GetName() const override { return name; }
+private:
+	void vSetAutoBattleAction(Game_Actor& source) override;
+};
+
+/**
+ * An autobattle algorithm which only does physical attacks.
+ */
+class AttackOnly: public AlgorithmBase {
+public:
+	static constexpr auto name = "ATTACK";
+
+	StringView GetName() const override { return name; }
+private:
+	void vSetAutoBattleAction(Game_Actor& source) override;
+};
+
+/**
+ * A custom autobattle algorithm which is similar to RPG_RT but fixes bugs and has improved logic.
+ */
+class RpgRtImproved: public AlgorithmBase {
+public:
+	static constexpr auto name = "RPG_RT+";
+
+	StringView GetName() const override { return name; }
+private:
+	void vSetAutoBattleAction(Game_Actor& source) override;
+};
+
+/**
+ * Calculate the auto battle effectiveness rank of source using healing skill on target.
+ *
+ * @param source the user of the skill
+ * @param target the target of the skill
+ * @param skill the skill
+ * @param apply_variance If true, apply variance to the damage
+ * @param emulate_bugs Emulate all RPG_RT bugs for accuracy
+ *
+ * @pre skill Must be a normal or subskill or the result is undefined.
+ * @pre skill must target self, ally, or ally party or the result is undefined.
+ */
+double CalcSkillHealAutoBattleTargetRank(const Game_Actor& source, const Game_Battler& target, const lcf::rpg::Skill& skill, bool apply_variance, bool emulate_bugs);
+
+/**
+ * Calculate the auto battle effectiveness rank of source using damage skill on target.
+ *
+ * @param source the user of the skill
+ * @param target the target of the skill
+ * @param skill the skill
+ * @param apply_variance If true, apply variance to the damage
+ * @param emulate_bugs Emulate all RPG_RT bugs for accuracy
+ *
+ * @pre skill Must be a normal or subskill or the result is undefined.
+ * @pre skill must target enemy, or enemy party or the result is undefined.
+ */
+double CalcSkillDmgAutoBattleTargetRank(const Game_Actor& source, const Game_Battler& target, const lcf::rpg::Skill& skill, bool apply_variance, bool emulate_bugs);
+
+/**
+ * Calculate the auto battle total effectiveness rank of using a skill.
+ *
+ * @param source the user of the skill
+ * @param skill the skill
+ * @param apply_variance If true, apply variance to the damage
+ * @param emulate_bugs Emulate all RPG_RT bugs for accuracy
+ */
+double CalcSkillAutoBattleRank(const Game_Actor& source, const lcf::rpg::Skill& skill, bool apply_variance, bool emulate_bugs);
+
+/**
+ * Calculate the auto battle effectiveness rank of source attacking target.
+ *
+ * @param source the user of the skill
+ * @param target the target of the skill
+ * @param cond the battle condition
+ * @param apply_variance If true, apply variance to the damage
+ * @param emulate_bugs Emulate all RPG_RT bugs for accuracy
+ */
+double CalcNormalAttackAutoBattleTargetRank(const Game_Actor& source, const Game_Battler& target, Game_Battler::Weapon weapon, lcf::rpg::System::BattleCondition cond, bool apply_variance, bool emulate_bugs);
+
+/**
+ * Calculate the auto battle total effectiveness rank of using a normal attack.
+ *
+ * @param source the user of the skill
+ * @param weapon Which weapon to use in the calculation
+ * @param cond the battle condition
+ * @param apply_variance If true, apply variance to the damage
+ * @param emulate_bugs Emulate all RPG_RT bugs for accuracy
+ */
+double CalcNormalAttackAutoBattleRank(const Game_Actor& source, Game_Battler::Weapon weapon, lcf::rpg::System::BattleCondition cond, bool apply_variance, bool emulate_bugs);
+
+/**
+ * Runs the RPG_RT auto battle algorithm and sets a Game_BattlerAlgorithm on the source.
+ *
+ * @param actor Which actor to select auto battle action for
+ * @param weapon Which weapon to use in the calculation
+ * @param cond the battle condition
+ * @param do_skills Whether to include skills or not
+ * @param attack_variance Whether to include variance in normal attack ranking
+ * @param skill_variance Whether to include variance in skill ranking
+ * @param emulate_bugs Emulate all RPG_RT bugs for accuracy
+ * @post actor may have a battle algorithm set, unless an error occured.
+ */
+void SelectAutoBattleAction(Game_Actor& source,
+		Game_Battler::Weapon weapon,
+		lcf::rpg::System::BattleCondition cond,
+		bool do_skills,
+		bool attack_variance,
+		bool skill_variance,
+		bool emulate_bugs);
+
+/**
+ * Calls SelectAutoBattleAction() with RPG_RT strictly compatible flags.
+ *
+ * @param actor Which actor to select auto battle action for
+ * @param cond the battle condition
+ * @post actor may have a battle algorithm set, unless an error occured.
+ */
+inline void SelectAutoBattleActionRpgRtCompat(Game_Actor& source, lcf::rpg::System::BattleCondition cond) {
+	SelectAutoBattleAction(source, Game_Battler::WeaponAll, cond, true, false, true, true);
+}
+
+} // namespace AutoBattle
+
+#endif

--- a/src/cmdline_parser.cpp
+++ b/src/cmdline_parser.cpp
@@ -23,6 +23,14 @@
 #include <iostream>
 #include <sstream>
 
+bool CmdlineArg::ParseValue(int i, std::string& value) const {
+	if (i >= NumValues()) {
+		return false;
+	}
+	value = Value(i);
+	return true;
+}
+
 bool CmdlineArg::ParseValue(int i, long& value) const {
 	if (i >= NumValues()) {
 		return false;

--- a/src/cmdline_parser.h
+++ b/src/cmdline_parser.h
@@ -72,6 +72,15 @@ public:
 	 * @return true if i < NumValues() and the string value was able to be parsed to an integer.
 	 */
 	bool ParseValue(int i, long& value) const;
+
+	/**
+	 * Gets an argument value to a string
+	 *
+	 * @param i the index to the value.
+	 * @param value the value to write to. If the function returns true, this parameter is written, if returns false, this parameter is not touched.
+	 * @return true if i < NumValues()
+	 */
+	bool ParseValue(int i, std::string& value) const;
 private:
 	const std::string* ptr = nullptr;
 	int num_values = 0;

--- a/src/config_param.h
+++ b/src/config_param.h
@@ -44,7 +44,7 @@ public:
 		return false;
 	}
 
-	bool IsValid(const T& value) const {
+	bool IsValid(const T&) const {
 		return true;
 	}
 

--- a/src/dynrpg.cpp
+++ b/src/dynrpg.cpp
@@ -61,7 +61,7 @@ bool DynRpg::HasFunction(const std::string& name) {
 // Var arg referenced by $n
 std::string DynRpg::ParseVarArg(StringView func_name, dyn_arg_list args, int index, bool& parse_okay) {
 	parse_okay = true;
-	if (index >= args.size()) {
+	if (index >= static_cast<int>(args.size())) {
 		parse_okay = false;
 		Output::Warning("{}: Vararg {} out of range", func_name, index);
 		return "";
@@ -89,7 +89,7 @@ std::string DynRpg::ParseVarArg(StringView func_name, dyn_arg_list args, int ind
 			} else if (n >= '1' && n <= '9') {
 				int i = (int)(n - '0');
 
-				if (i + index < args.size()) {
+				if (i + index < static_cast<int>(args.size())) {
 					msg << args[i + index];
 				}
 				else {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -34,6 +34,7 @@
 #include "compiler.h"
 #include "attribute.h"
 #include "rand.h"
+#include "algo.h"
 
 constexpr int max_level_2k = 50;
 constexpr int max_level_2k3 = 99;
@@ -209,11 +210,12 @@ bool Game_Actor::IsSkillUsable(int skill_id) const {
 }
 
 int Game_Actor::CalculateSkillCost(int skill_id) const {
-	int cost = Game_Battler::CalculateSkillCost(skill_id);
-	if (HasHalfSpCost()) {
-		cost = (cost + 1) / 2;
+	const lcf::rpg::Skill* skill = lcf::ReaderUtil::GetElement(lcf::Data::skills, skill_id);
+	if (!skill) {
+		Output::Warning("CalculateSkillCost: Invalid skill ID {}", skill_id);
+		return 0;
 	}
-	return cost;
+	return Algo::CalcSkillCost(*skill, GetMaxSp(), HasHalfSpCost());
 }
 
 bool Game_Actor::LearnSkill(int skill_id, PendingMessage* pm) {

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -344,10 +344,7 @@ int Game_Battler::CalculateSkillCost(int skill_id) const {
 		Output::Warning("CalculateSkillCost: Invalid skill ID {}", skill_id);
 		return 0;
 	}
-
-	return (Player::IsRPG2k3() && skill->sp_type == lcf::rpg::Skill::SpType_percent)
-		? GetMaxSp() * skill->sp_percent / 100
-		: skill->sp_cost;
+	return Algo::CalcSkillCost(*skill, GetMaxSp(), false);
 }
 
 bool Game_Battler::AddState(int state_id, bool allow_battle_states) {

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -116,6 +116,13 @@ void Game_Config::LoadFromArgs(CmdlineParser& cp) {
 			}
 			continue;
 		}
+		if (cp.ParseNext(arg, 1, "--autobattle-algo")) {
+			std::string svalue;
+			if (arg.ParseValue(0, svalue)) {
+				player.autobattle_algo.Set(std::move(svalue));
+			}
+			continue;
+		}
 
 		cp.SkipNext();
 	}
@@ -131,6 +138,14 @@ void Game_Config::LoadFromConfig(const std::string& path) {
 		Output::Debug("Failed to parse ini config file {}", path);
 		return;
 	}
+
+	/** PLAYER SECTION */
+
+	if (ini.HasValue("player", "autobattle-algo")) {
+		player.autobattle_algo.Set(ini.GetString("player", "autobattle-algo", "RPG_RT"));
+	}
+
+	/** VIDEO SECTION */
 
 	if (ini.HasValue("video", "vsync")) {
 		video.vsync.Set(ini.GetBoolean("video", "vsync", false));
@@ -150,6 +165,10 @@ void Game_Config::LoadFromConfig(const std::string& path) {
 	if (ini.HasValue("video", "window-zoom")) {
 		video.window_zoom.Set(ini.GetInteger("video", "window-zoom", 0));
 	}
+
+	/** AUDIO SECTION */
+
+	/** INPUT SECTION */
 }
 
 void Game_Config::WriteToConfig(const std::string& path) const {
@@ -159,6 +178,13 @@ void Game_Config::WriteToConfig(const std::string& path) const {
 		Output::Debug("Failed to open {} for writing: {}", path, strerror(errno));
 		return;
 	}
+
+	/** PLAYER SECTION */
+	of << "[player]\n";
+	of << "autobattle-algo=" << player.autobattle_algo.Get() << "\n";
+	of << "\n";
+
+	/** VIDEO SECTION */
 
 	of << "[video]\n";
 	if (video.vsync.Enabled()) {
@@ -180,5 +206,9 @@ void Game_Config::WriteToConfig(const std::string& path) const {
 		of << "window-zoom=" << video.window_zoom.Get() << "\n";
 	}
 	of << "\n";
+
+	/** AUDIO SECTION */
+
+	/** INPUT SECTION */
 }
 

--- a/src/game_config.h
+++ b/src/game_config.h
@@ -23,6 +23,10 @@
 
 class CmdlineParser;
 
+struct Game_ConfigPlayer {
+	StringConfigParam autobattle_algo{ "RPG_RT" };
+};
+
 struct Game_ConfigVideo {
 	BoolConfigParam vsync{ true };
 	BoolConfigParam fullscreen{ true };
@@ -41,6 +45,9 @@ struct Game_ConfigInput {
 struct Game_Config {
 	/** Path to last config file we read from */
 	std::string config_path;
+
+	/** Gameplay subsystem options */
+	Game_ConfigPlayer player;
 
 	/** Video subsystem options */
 	Game_ConfigVideo video;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -120,6 +120,7 @@ namespace Player {
 	std::string record_input_path;
 	std::string command_line;
 	int speed_modifier = 3;
+	Game_ConfigPlayer player_config;
 #ifdef EMSCRIPTEN
 	std::string emscripten_game_name;
 #endif
@@ -204,6 +205,8 @@ void Player::Init(int argc, char *argv[]) {
 
 	Input::Init(std::move(buttons), std::move(directions), replay_input_path, record_input_path);
 	Input::AddRecordingData(Input::RecordingData::CommandLine, command_line);
+
+	player_config = std::move(cfg.player);
 }
 
 void Player::Run() {
@@ -1212,6 +1215,11 @@ Options:
       --start-map-id N     Overwrite the map used for new games and use.
                            MapN.lmu instead (N is padded to four digits).
                            Incompatible with --load-game-id.
+      --autobattle-algo A  Which AutoBattle algorithm to use.
+                           Possible options:
+                            RPG_RT     - The default RPG_RT compatible algo, including RPG_RT bugs
+                            RPG_RT+    - The default RPG_RT compatible algo, with bug fixes
+                            ATTACK     - RPG_RT+ but only physical attacks, no skills
       --start-position X Y Overwrite the party start position and move the
                            party to position (X, Y).
                            Incompatible with --load-game-id.

--- a/src/player.h
+++ b/src/player.h
@@ -355,6 +355,11 @@ namespace Player {
 	 */
 	extern int speed_modifier;
 
+	/**
+	 * The game logic configuration
+	 */
+	extern Game_ConfigPlayer player_config;
+
 #ifdef EMSCRIPTEN
 	/** Name of game emscripten uses */
 	extern std::string emscripten_game_name;

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -92,7 +92,7 @@ void Scene_Battle::Start() {
 
 	autobattle_algo = AutoBattle::CreateAlgorithm(Player::player_config.autobattle_algo.Get());
 
-	Output::Debug("Starting battle {} ({}) : autobattle={}", troop_id, troop->name, autobattle_algo->GetName());
+	Output::Debug("Starting battle {} ({}): autobattle={}", troop_id, troop->name, autobattle_algo->GetName());
 
 	Game_Battle::Init(troop_id);
 

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -42,6 +42,7 @@
 #include "scene_debug.h"
 #include "game_interpreter.h"
 #include "rand.h"
+#include "autobattle.h"
 
 Scene_Battle::Scene_Battle(const BattleArgs& args)
 	: troop_id(args.troop_id),
@@ -89,7 +90,9 @@ void Scene_Battle::Start() {
 		return;
 	}
 
-	Output::Debug("Starting battle {} ({})", troop_id, troop->name);
+	autobattle_algo = AutoBattle::CreateAlgorithm(Player::player_config.autobattle_algo.Get());
+
+	Output::Debug("Starting battle {} ({}) : autobattle={}", troop_id, troop->name, autobattle_algo->GetName());
 
 	Game_Battle::Init(troop_id);
 

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -44,6 +44,10 @@ class Action;
 class SpriteAction;
 }
 
+namespace AutoBattle {
+class AlgorithmBase;
+}
+
 class Game_Battler;
 
 using BattleContinuation = std::function<void(BattleResult)>;
@@ -205,6 +209,7 @@ protected:
 	std::unique_ptr<Window_Message> message_window;
 
 	std::deque<Game_Battler*> battle_actions;
+	std::unique_ptr<AutoBattle::AlgorithmBase> autobattle_algo;
 
 	BattleContinuation on_battle_end;
 };

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -36,6 +36,7 @@
 #include "scene_gameover.h"
 #include "output.h"
 #include "rand.h"
+#include "autobattle.h"
 
 Scene_Battle_Rpg2k::Scene_Battle_Rpg2k(const BattleArgs& args) :
 	Scene_Battle(args)
@@ -1260,13 +1261,8 @@ void Scene_Battle_Rpg2k::SelectNextActor() {
 	}
 
 	if (auto_battle || active_actor->GetAutoBattle()) {
-		if (active_actor->HasAttackAll()) {
-			active_actor->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::Normal>(active_actor,
-						Main_Data::game_enemyparty.get()));
-		} else {
-			active_actor->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::Normal>(active_actor,
-						Main_Data::game_enemyparty->GetRandomActiveBattler()));
-		}
+		this->autobattle_algo->SetAutoBattleAction(*active_actor);
+		assert(active_actor->GetBattleAlgorithm() != nullptr);
 		battle_actions.push_back(active_actor);
 
 		SelectNextActor();

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -35,6 +35,7 @@
 #include "utils.h"
 #include "font.h"
 #include "output.h"
+#include "autobattle.h"
 
 Scene_Battle_Rpg2k3::Scene_Battle_Rpg2k3(const BattleArgs& args) :
 	Scene_Battle(args),
@@ -1467,18 +1468,19 @@ void Scene_Battle_Rpg2k3::SelectNextActor() {
 				default:
 					break;
 				}
+				if (random_target) {
+					active_actor->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::Normal>(active_actor, random_target));
+					battle_actions.push_back(active_actor);
+					active_actor->SetAtbGauge(0);
+					return;
+				}
 			}
 
-			if (random_target || auto_battle || active_actor->GetAutoBattle()) {
-				if (!random_target) {
-					random_target = Main_Data::game_enemyparty->GetRandomActiveBattler();
-				}
-
-				// ToDo: Auto battle logic is dumb
-				active_actor->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::Normal>(active_actor, random_target));
+			if (auto_battle || active_actor->GetAutoBattle()) {
+				this->autobattle_algo->SetAutoBattleAction(*active_actor);
+				assert(active_actor->GetBattleAlgorithm() != nullptr);
 				battle_actions.push_back(active_actor);
 				active_actor->SetAtbGauge(0);
-
 				return;
 			}
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -83,6 +83,16 @@ int Utils::StrICmp(const char* l, const char* r) {
 	return *l - *r;
 }
 
+int Utils::StrICmp(StringView l, StringView r) {
+	for (size_t i = 0; i < std::min(l.size(), r.size()); ++i) {
+		auto d = Lower(l[i]) - Lower(r[i]);
+		if (d != 0) {
+			return d;
+		}
+	}
+	return l.size() - r.size();
+}
+
 std::u16string Utils::DecodeUTF16(StringView str) {
 	std::u16string result;
 	for (auto it = str.begin(), str_end = str.end(); it < str_end; ++it) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -579,7 +579,7 @@ uint32_t Utils::CRC32(std::istream& stream) {
 	do {
 		stream.read(reinterpret_cast<char*>(buffer.data()), buffer.size());
 		crc = crc32(crc, buffer.data(), stream.gcount());
-	} while (stream.gcount() == buffer.size());
+	} while (stream.gcount() == static_cast<std::streamsize>(buffer.size()));
 	return crc;
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -71,6 +71,16 @@ namespace Utils {
 	int StrICmp(const char* l, const char* r);
 
 	/**
+	 * Case insensitive (ascii only) lexicographical compare of 2 strings.
+	 *
+	 * @param l left string
+	 * @param r right string
+	 *
+	 * @return < 0 if l is before r, 0 if equal, > 0 l is after r
+	 */
+	int StrICmp(StringView l, StringView r);
+
+	/**
 	 * Converts Utf8 to UTF-16.
 	 *
 	 * @param str string to convert.

--- a/tests/algo.cpp
+++ b/tests/algo.cpp
@@ -975,4 +975,38 @@ TEST_CASE("SelfDestructVariance") {
 }
 
 
+TEST_CASE("SkillCost") {
+	const MockActor m;
+
+	auto* skill = MakeDBSkill(1, 90, 0, 0, 0, 0);
+
+	SUBCASE("9") {
+		skill->sp_cost = 9;
+		skill->sp_type = lcf::rpg::Skill::SpType_cost;
+		REQUIRE_EQ(9, Algo::CalcSkillCost(*skill, 100, false));
+		REQUIRE_EQ(5, Algo::CalcSkillCost(*skill, 100, true));
+	}
+
+	SUBCASE("10") {
+		skill->sp_cost = 10;
+		skill->sp_type = lcf::rpg::Skill::SpType_cost;
+		REQUIRE_EQ(10, Algo::CalcSkillCost(*skill, 100, false));
+		REQUIRE_EQ(5, Algo::CalcSkillCost(*skill, 100, true));
+	}
+
+	SUBCASE("49%") {
+		skill->sp_percent = 49;
+		skill->sp_type = lcf::rpg::Skill::SpType_percent;
+		REQUIRE_EQ(49, Algo::CalcSkillCost(*skill, 100, false));
+		REQUIRE_EQ(24, Algo::CalcSkillCost(*skill, 100, true));
+	}
+
+	SUBCASE("50%") {
+		skill->sp_percent = 50;
+		skill->sp_type = lcf::rpg::Skill::SpType_percent;
+		REQUIRE_EQ(50, Algo::CalcSkillCost(*skill, 100, false));
+		REQUIRE_EQ(25, Algo::CalcSkillCost(*skill, 100, true));
+	}
+}
+
 TEST_SUITE_END();

--- a/tests/autobattle.cpp
+++ b/tests/autobattle.cpp
@@ -1,0 +1,61 @@
+#include "test_mock_actor.h"
+#include "autobattle.h"
+#include "rand.h"
+#include "doctest.h"
+
+static Game_Enemy MakeEnemy(int id, int hp, int sp, int atk, int def, int spi, int agi) {
+	MakeDBEnemy(id, hp, sp, atk, def, spi, agi);
+	auto& tp = lcf::Data::troops[0];
+	tp.members.resize(8);
+	tp.members[id - 1].enemy_id = id;
+	Main_Data::game_enemyparty->ResetBattle(1);
+	auto& enemy = (*Main_Data::game_enemyparty)[id - 1];
+	return enemy;
+}
+
+decltype(auto) MakeActor(int id, int hp, int sp, int atk, int def, int spi, int agi) {
+	auto actor = Game_Actor(id);
+	actor.SetBaseMaxHp(hp);
+	actor.SetHp(actor.GetMaxHp());
+	actor.SetBaseMaxSp(sp);
+	actor.SetSp(actor.GetMaxSp());
+	actor.SetBaseAtk(atk);
+	actor.SetBaseDef(def);
+	actor.SetBaseSpi(spi);
+	actor.SetBaseAgi(agi);
+	return actor;
+}
+
+TEST_SUITE_BEGIN("Autobattle");
+
+static void testNormalAttack(const Game_Actor& source, const Game_Battler& target, double v0, double v1, double v2, double v3) {
+	REQUIRE(doctest::Approx(v0) == AutoBattle::CalcNormalAttackAutoBattleTargetRank(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, false, true));
+	REQUIRE(doctest::Approx(v1) == AutoBattle::CalcNormalAttackAutoBattleTargetRank(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, false, false));
+	REQUIRE(doctest::Approx(v2) == AutoBattle::CalcNormalAttackAutoBattleTargetRank(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, true, true));
+	REQUIRE(doctest::Approx(v3) == AutoBattle::CalcNormalAttackAutoBattleTargetRank(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, true, false));
+}
+
+TEST_CASE("NormalAttackTargetRank") {
+	const MockActor m;
+
+	SUBCASE("actor 120/0 -> enemy 0/90") {
+		auto source = MakeActor(1, 500, 500, 120, 0, 0, 0);
+		auto target = MakeEnemy(2, 500, 500, 0, 90, 0, 0);
+
+		REQUIRE_EQ(source.GetAtk(), 120);
+		REQUIRE_EQ(target.GetDef(), 90);
+
+		SUBCASE("max") {
+			Rand::LockGuard lk(INT32_MAX);
+			testNormalAttack(source, target, 1.131, 1.131, 1.158, 1.158);
+		}
+		SUBCASE("min") {
+			Rand::LockGuard lk(INT32_MIN);
+			testNormalAttack(source, target, 0.141, 0.141, 0.114, 0.114);
+		}
+	}
+}
+
+
+
+TEST_SUITE_END();

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -17,26 +17,38 @@ TEST_CASE("Upper") {
 	REQUIRE_EQ(Utils::UpperCase("!A/b"), "!A/B");
 }
 
+template <typename T>
+static void testStrICmp() {
+	REQUIRE_EQ(Utils::StrICmp(T("easyrpg"), T("easyrpg")), 0);
+	REQUIRE_EQ(Utils::StrICmp(T("easyrpg"), T("EASYRPG")), 0);
+	REQUIRE_EQ(Utils::StrICmp(T("EASYRPG"), T("easyrpg")), 0);
+
+	REQUIRE_LT(Utils::StrICmp(T("A"), T("B")), 0);
+	REQUIRE_LT(Utils::StrICmp(T("a"), T("B")), 0);
+	REQUIRE_LT(Utils::StrICmp(T("A"), T("b")), 0);
+
+	REQUIRE_GT(Utils::StrICmp(T("B"), T("A")), 0);
+	REQUIRE_GT(Utils::StrICmp(T("b"), T("A")), 0);
+	REQUIRE_GT(Utils::StrICmp(T("B"), T("a")), 0);
+
+	REQUIRE_GT(Utils::StrICmp(T("AA"), T("A")), 0);
+	REQUIRE_GT(Utils::StrICmp(T("aa"), T("A")), 0);
+	REQUIRE_GT(Utils::StrICmp(T("AA"), T("a")), 0);
+
+	REQUIRE_LT(Utils::StrICmp(T("A"), T("AA")), 0);
+	REQUIRE_LT(Utils::StrICmp(T("a"), T("AA")), 0);
+	REQUIRE_LT(Utils::StrICmp(T("A"), T("aa")), 0);
+}
+
 TEST_CASE("StrICmp") {
-	REQUIRE_EQ(Utils::StrICmp("easyrpg", "easyrpg"), 0);
-	REQUIRE_EQ(Utils::StrICmp("easyrpg", "EASYRPG"), 0);
-	REQUIRE_EQ(Utils::StrICmp("EASYRPG", "easyrpg"), 0);
 
-	REQUIRE_LT(Utils::StrICmp("A", "B"), 0);
-	REQUIRE_LT(Utils::StrICmp("a", "B"), 0);
-	REQUIRE_LT(Utils::StrICmp("A", "b"), 0);
+	SUBCASE("cstr") {
+		testStrICmp<const char*>();
+	}
 
-	REQUIRE_GT(Utils::StrICmp("B", "A"), 0);
-	REQUIRE_GT(Utils::StrICmp("b", "A"), 0);
-	REQUIRE_GT(Utils::StrICmp("B", "a"), 0);
-
-	REQUIRE_GT(Utils::StrICmp("AA", "A"), 0);
-	REQUIRE_GT(Utils::StrICmp("aa", "A"), 0);
-	REQUIRE_GT(Utils::StrICmp("AA", "a"), 0);
-
-	REQUIRE_LT(Utils::StrICmp("A", "AA"), 0);
-	REQUIRE_LT(Utils::StrICmp("a", "AA"), 0);
-	REQUIRE_LT(Utils::StrICmp("A", "aa"), 0);
+	SUBCASE("sv") {
+		testStrICmp<StringView>();
+	}
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
Fix: #1586 


This implements RPG_RT compatible auto battle. I've designed auto battle to support different auto battle algorithms. The end goal will be Player ships a few algos that you can choose from. Game developers customizing player could also add their own to the `AutoBattle::CreateAlgorithm` factory function.

This PR provides 3 algorithms:
* `RPG_RT` - RPG_RT compatible including bugs - this is the default
* `ATTACK` - RPG_RT, only physical attacks, bug fixes included
* `RPG_RT+` - RPG_RT with bug fixes - Also open to further improvements

For now I just added a `--autobattle-algo` command line parameter to select the algo, later this can probably be part of `Scene_Settings` etc.. Or maybe even a custom save chunk.

TODO
-------

- [x] More game play testing
- [x] Unit tests
- [x] Verify 2k3 dynrpg
- [x] Verify 2k3 legacy
- [x] Verify 2ke
- [x] Verify 2k updated
- [x] Verify 2k legacy
- [x] A better algo selection mechanism? Or punt till later?


DynRPG Addresses
-------------------


| Address | Class | Name | Comment |
| -- | -- | -- | -- |
| 004BA518 | Actor | SelectAutoBattleAction | Virtual function which runs the whole auto battle algorithm, everything is here |
| 004B9EF0 | Actor | GetAutoBattleSkillRank | Computes best ranking of skill against all possible targets |
| 004BA384 | Actor | GetAutoBattleAttackRank | Computes best rank of normal attack against all possible targets |
| 004BA0B8 | Actor | GetAutoBattleSkillEffectRank | Computes the rank of a skill against a single target |
| 004BA3E8 | Actor | GetAutoBattleAttackEffectRank | Computes the rank of a normal attack against a single target |


RPG_RT bugs ❗ 
------------------

* Normal attack ranking does not consider attack all. It should sum the ranks of all enemies
* Normal attack ranking does not consider dual attack
* Normal attack ranking doesn't accurately consider dual wield for 2k3
* Normal attack ranked does not consider sp cost of weapons
* Skill ranking uses variance, normal attack does not
* Revive skill ranking does not check for the `reverse_state` flag, and so a skill which inflicts death on an ally would be highly ranked and probably used on a dead ally.