### PR TITLE
Fix enemy default state rank

### DIFF
--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -59,7 +59,7 @@ int Game_Enemy::MaxStatBaseValue() const {
 }
 
 int Game_Enemy::GetStateProbability(int state_id) const {
-	int rate = 2; // C - default
+	int rate = 1; // Enemies have only B as the default state rank
 
 	if (state_id <= (int)enemy->state_ranks.size()) {
 		rate = enemy->state_ranks[state_id - 1];


### PR DESCRIPTION
The default state rank of an enemy is only "B" instead of "C". All the other default ranks (enemy attribute rank, player state rank and player attribute rank) are already correct.