### PR TITLE
Battle: Fix output text of item drops

### DIFF
--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -1496,7 +1496,7 @@ void Scene_Battle_Rpg2k::PushItemRecievedMessages(PendingMessage& pm, std::vecto
 	for (std::vector<int>::iterator it = drops.begin(); it != drops.end(); ++it) {
 		const lcf::rpg::Item* item = lcf::ReaderUtil::GetElement(lcf::Data::items, *it);
 		// No Output::Warning needed here, reported later when the item is added
-		StringView item_name = item ? item->name : "??? BAD ITEM ???";
+		StringView item_name = item ? StringView(item->name) : StringView("??? BAD ITEM ???");
 
 		if (Player::IsRPG2kE()) {
 			pm.PushLine(

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1361,7 +1361,7 @@ bool Scene_Battle_Rpg2k3::CheckWin() {
 		for (std::vector<int>::iterator it = drops.begin(); it != drops.end(); ++it) {
 			const lcf::rpg::Item* item = lcf::ReaderUtil::GetElement(lcf::Data::items, *it);
 			// No Output::Warning needed here, reported later when the item is added
-			StringView item_name = item ? item->name : "??? BAD ITEM ???";
+			StringView item_name = item ? StringView(item->name) : StringView("??? BAD ITEM ???");
 
 			ss.str("");
 			ss << item_name << space << lcf::Data::terms.item_recieved;


### PR DESCRIPTION
I stumbled upon an oddity in relation with the output text of enemy item drops: After the enemy party gets defeated and they drop items the output says funny things like "U received!" instead of the actual item name. Changing `item->name` to `item->name.c_str()` fixes the output but I would like to hear your opinions if this is the right way to fix this.