### PR TITLE
Remove SaveSystem Setup and Fixup - depends on liblcf #396

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1961,7 +1961,7 @@ bool Game_Interpreter::CommandChangeSystemBGM(lcf::rpg::EventCommand const& com)
 	music.volume = com.parameters[2];
 	music.tempo = com.parameters[3];
 	music.balance = com.parameters[4];
-	Game_System::SetSystemBGM(context, music);
+	Game_System::SetSystemBGM(context, std::move(music));
 	return true;
 }
 
@@ -1972,7 +1972,7 @@ bool Game_Interpreter::CommandChangeSystemSFX(lcf::rpg::EventCommand const& com)
 	sound.volume = com.parameters[1];
 	sound.tempo = com.parameters[2];
 	sound.balance = com.parameters[3];
-	Game_System::SetSystemSE(context, sound);
+	Game_System::SetSystemSE(context, std::move(sound));
 	return true;
 }
 

--- a/src/game_switches.cpp
+++ b/src/game_switches.cpp
@@ -19,8 +19,13 @@
 #include "game_switches.h"
 #include "output.h"
 #include <lcf/reader_util.h>
+#include <lcf/data.h>
 
 constexpr int Game_Switches::kMaxWarnings;
+
+Game_Switches::Game_Switches() {
+	_switches.reserve(lcf::Data::switches.size());
+}
 
 void Game_Switches::WarnGet(int variable_id) const {
 	Output::Debug("Invalid read sw[{}]!", variable_id);

--- a/src/game_switches.h
+++ b/src/game_switches.h
@@ -33,7 +33,7 @@ public:
 	using Switches_t = std::vector<bool>;
 	static constexpr int kMaxWarnings = 10;
 
-	Game_Switches() = default;
+	Game_Switches();
 
 	void SetData(Switches_t s);
 	const Switches_t& GetData() const;

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -39,7 +39,8 @@ namespace {
 	Color bg_color = Color{ 0, 0, 0, 255 };
 }
 
-static lcf::rpg::SaveSystem& data = Main_Data::game_data.system;
+static auto& data = Main_Data::game_data.system;
+static auto& dbsys = lcf::Data::system;
 
 bool bgm_pending = false;
 
@@ -244,26 +245,8 @@ StringView Game_System::GetSystem2Name() {
 	return lcf::Data::system.system2_name;
 }
 
-lcf::rpg::Music& Game_System::GetSystemBGM(int which) {
-	switch (which) {
-		case BGM_Battle:		return data.battle_music;
-		case BGM_Victory:		return data.battle_end_music;
-		case BGM_Inn:			return data.inn_music;
-		case BGM_Boat:			return data.boat_music;
-		case BGM_Ship:			return data.ship_music;
-		case BGM_Airship:		return data.airship_music;
-		case BGM_GameOver:		return data.gameover_music;
-	}
-
-	return data.battle_music; // keep the compiler happy
-}
-
-lcf::rpg::Music& Game_System::GetCurrentBGM() {
+const lcf::rpg::Music& Game_System::GetCurrentBGM() {
 	return data.current_music;
-}
-
-void Game_System::SetSystemBGM(int which, const lcf::rpg::Music& bgm) {
-	GetSystemBGM(which) = bgm;
 }
 
 void Game_System::MemorizeBGM() {
@@ -274,26 +257,141 @@ void Game_System::PlayMemorizedBGM() {
 	BgmPlay(data.stored_music);
 }
 
-lcf::rpg::Sound& Game_System::GetSystemSE(int which) {
-	switch (which) {
-		case SFX_Cursor:		return data.cursor_se;
-		case SFX_Decision:		return data.decision_se;
-		case SFX_Cancel:		return data.cancel_se;
-		case SFX_Buzzer:		return data.buzzer_se;
-		case SFX_BeginBattle:	return data.battle_se;
-		case SFX_Escape:		return data.escape_se;
-		case SFX_EnemyAttacks:	return data.enemy_attack_se;
-		case SFX_EnemyDamage:	return data.enemy_damaged_se;
-		case SFX_AllyDamage:	return data.actor_damaged_se;
-		case SFX_Evasion:		return data.dodge_se;
-		case SFX_EnemyKill:		return data.enemy_death_se;
-		case SFX_UseItem:		return data.item_se;
-	}
-	return data.cursor_se; // keep the compiler happy
+
+template <typename T>
+static const T& GetAudio(const T& save, const T& db) {
+	return save.name.empty() ? db : save;
 }
 
-void Game_System::SetSystemSE(int which, const lcf::rpg::Sound& sfx) {
-	GetSystemSE(which) = sfx;
+template <typename T>
+static void SetAudio(T& save, const T& db, T update) {
+	if (update == db) {
+		save = {};
+		save.name.clear();
+	} else {
+		save = std::move(update);
+	}
+}
+
+const lcf::rpg::Music& Game_System::GetSystemBGM(int which) {
+	switch (which) {
+		case BGM_Battle:
+			return GetAudio(data.battle_music, dbsys.battle_music);
+		case BGM_Victory:
+			return GetAudio(data.battle_end_music, dbsys.battle_end_music);
+		case BGM_Inn:
+			return GetAudio(data.inn_music, dbsys.inn_music);
+		case BGM_Boat:
+			return GetAudio(data.boat_music, dbsys.boat_music);
+		case BGM_Ship:
+			return GetAudio(data.ship_music, dbsys.ship_music);
+		case BGM_Airship:
+			return GetAudio(data.airship_music, dbsys.airship_music);
+		case BGM_GameOver:
+			return GetAudio(data.gameover_music, dbsys.gameover_music);
+	}
+
+	static lcf::rpg::Music empty;
+	return empty;
+}
+
+void Game_System::SetSystemBGM(int which, lcf::rpg::Music bgm) {
+	switch (which) {
+		case BGM_Battle:
+			SetAudio(data.battle_music, dbsys.battle_music, std::move(bgm));
+			break;
+		case BGM_Victory:
+			SetAudio(data.battle_end_music, dbsys.battle_end_music, std::move(bgm));
+			break;
+		case BGM_Inn:
+			SetAudio(data.inn_music, dbsys.inn_music, std::move(bgm));
+			break;
+		case BGM_Boat:
+			SetAudio(data.boat_music, dbsys.boat_music, std::move(bgm));
+			break;
+		case BGM_Ship:
+			SetAudio(data.ship_music, dbsys.ship_music, std::move(bgm));
+			break;
+		case BGM_Airship:
+			SetAudio(data.airship_music, dbsys.airship_music, std::move(bgm));
+			break;
+		case BGM_GameOver:
+			SetAudio(data.gameover_music, dbsys.gameover_music, std::move(bgm));
+			break;
+	}
+}
+
+const lcf::rpg::Sound& Game_System::GetSystemSE(int which) {
+	switch (which) {
+		case SFX_Cursor:
+			return GetAudio(data.cursor_se, dbsys.cursor_se);
+		case SFX_Decision:
+			return GetAudio(data.decision_se, dbsys.decision_se);
+		case SFX_Cancel:
+			return GetAudio(data.cancel_se, dbsys.cancel_se);
+		case SFX_Buzzer:
+			return GetAudio(data.buzzer_se, dbsys.buzzer_se);
+		case SFX_BeginBattle:
+			return GetAudio(data.battle_se, dbsys.battle_se);
+		case SFX_Escape:
+			return GetAudio(data.escape_se, dbsys.escape_se);
+		case SFX_EnemyAttacks:
+			return GetAudio(data.enemy_attack_se, dbsys.enemy_attack_se);
+		case SFX_EnemyDamage:
+			return GetAudio(data.enemy_damaged_se, dbsys.enemy_damaged_se);
+		case SFX_AllyDamage:
+			return GetAudio(data.actor_damaged_se, dbsys.actor_damaged_se);
+		case SFX_Evasion:
+			return GetAudio(data.dodge_se, dbsys.dodge_se);
+		case SFX_EnemyKill:
+			return GetAudio(data.enemy_death_se, dbsys.enemy_death_se);
+		case SFX_UseItem:
+			return GetAudio(data.item_se, dbsys.item_se);
+	}
+
+	static lcf::rpg::Sound empty;
+	return empty;
+}
+
+void Game_System::SetSystemSE(int which, lcf::rpg::Sound sfx) {
+	switch (which) {
+		case SFX_Cursor:
+			SetAudio(data.cursor_se, dbsys.cursor_se, std::move(sfx));
+			break;
+		case SFX_Decision:
+			SetAudio(data.decision_se, dbsys.decision_se, std::move(sfx));
+			break;
+		case SFX_Cancel:
+			SetAudio(data.cancel_se, dbsys.cancel_se, std::move(sfx));
+			break;
+		case SFX_Buzzer:
+			SetAudio(data.buzzer_se, dbsys.buzzer_se, std::move(sfx));
+			break;
+		case SFX_BeginBattle:
+			SetAudio(data.battle_se, dbsys.battle_se, std::move(sfx));
+			break;
+		case SFX_Escape:
+			SetAudio(data.escape_se, dbsys.escape_se, std::move(sfx));
+			break;
+		case SFX_EnemyAttacks:
+			SetAudio(data.enemy_attack_se, dbsys.enemy_attack_se, std::move(sfx));
+			break;
+		case SFX_EnemyDamage:
+			SetAudio(data.enemy_damaged_se, dbsys.enemy_damaged_se, std::move(sfx));
+			break;
+		case SFX_AllyDamage:
+			SetAudio(data.actor_damaged_se, dbsys.actor_damaged_se, std::move(sfx));
+			break;
+		case SFX_Evasion:
+			SetAudio(data.dodge_se, dbsys.dodge_se, std::move(sfx));
+			break;
+		case SFX_EnemyKill:
+			SetAudio(data.enemy_death_se, dbsys.enemy_death_se, std::move(sfx));
+			break;
+		case SFX_UseItem:
+			SetAudio(data.item_se, dbsys.item_se, std::move(sfx));
+			break;
+	}
 }
 
 void Game_System::SetAllowTeleport(bool allow) {

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -266,8 +266,8 @@ static const T& GetAudio(const T& save, const T& db) {
 template <typename T>
 static void SetAudio(T& save, const T& db, T update) {
 	if (update == db) {
-		save = {};
-		save.name.clear();
+		// RPG_RT only clears the name, but leaves the rest of the values alone
+		save.name = {};
 	} else {
 		save = std::move(update);
 	}

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -45,7 +45,7 @@ static auto& dbsys = lcf::Data::system;
 bool bgm_pending = false;
 
 void Game_System::Init() {
-	data.Setup();
+	data = {};
 }
 
 bool Game_System::IsStopFilename(const std::string& name, std::string (*find_func) (const std::string&), std::string& found_name) {

--- a/src/game_system.h
+++ b/src/game_system.h
@@ -173,7 +173,7 @@ namespace Game_System {
 	 * @param which which "context" to set the music for.
 	 * @return the music.
 	 */
-	lcf::rpg::Music& GetSystemBGM(int which);
+	const lcf::rpg::Music& GetSystemBGM(int which);
 
 	/**
 	 * Sets the system music.
@@ -181,7 +181,7 @@ namespace Game_System {
 	 * @param which which "context" to set the music for.
 	 * @param bgm the music.
 	 */
-	void SetSystemBGM(int which, lcf::rpg::Music const& bgm);
+	void SetSystemBGM(int which, lcf::rpg::Music bgm);
 
 	/**
 	 * Gets the system sound effects.
@@ -189,7 +189,7 @@ namespace Game_System {
 	 * @param which which "context" to set the music for.
 	 * @return the sound.
 	 */
-	lcf::rpg::Sound& GetSystemSE(int which);
+	const lcf::rpg::Sound& GetSystemSE(int which);
 
 	/**
 	 * Sets a system sound effect.
@@ -197,7 +197,7 @@ namespace Game_System {
 	 * @param which which "context" to set the effect for.
 	 * @param sfx the sound effect.
 	 */
-	void SetSystemSE(int which, lcf::rpg::Sound const& sfx);
+	void SetSystemSE(int which, lcf::rpg::Sound sfx);
 
 	/**
 	 * Gets the system transitions.
@@ -268,7 +268,7 @@ namespace Game_System {
 
 	int GetSaveCount();
 
-	lcf::rpg::Music& GetCurrentBGM();
+	const lcf::rpg::Music& GetCurrentBGM();
 	void MemorizeBGM();
 	void PlayMemorizedBGM();
 

--- a/src/game_variables.cpp
+++ b/src/game_variables.cpp
@@ -20,6 +20,7 @@
 #include "game_variables.h"
 #include "output.h"
 #include <lcf/reader_util.h>
+#include <lcf/data.h>
 #include "utils.h"
 #include <cmath>
 
@@ -56,6 +57,12 @@ constexpr Var_t VarDiv(Var_t n, Var_t d) {
 constexpr Var_t VarMod(Var_t n, Var_t d) {
 	return EP_LIKELY(d != 0) ? n % d : 0;
 };
+}
+
+Game_Variables::Game_Variables(Var_t minval, Var_t maxval)
+	: _min(minval), _max(maxval)
+{
+	_variables.reserve(lcf::Data::variables.size());
 }
 
 void Game_Variables::WarnGet(int variable_id) const {

--- a/src/game_variables.h
+++ b/src/game_variables.h
@@ -110,10 +110,6 @@ private:
 	mutable int _warnings = max_warnings;
 };
 
-inline Game_Variables::Game_Variables(Var_t minval, Var_t maxval)
-	: _min(minval), _max(maxval)
-{ }
-
 inline void Game_Variables::SetData(Variables_t v) {
 	_variables = std::move(v);
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -985,7 +985,6 @@ void Player::LoadSavegame(const std::string& save_name) {
 	Game_Map::Dispose();
 
 	Main_Data::game_data = *save.get();
-	Main_Data::game_data.system.Fixup();
 
 	Main_Data::game_actors->SetSaveData(std::move(Main_Data::game_data.actors));
 	Main_Data::game_party->SetupFromSave(std::move(Main_Data::game_data.inventory));

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -311,7 +311,6 @@ void Weather::CreateFogOverlay() {
 	auto* sand_img = reinterpret_cast<uint32_t*>(sand_bitmap->pixels());
 
 	for (int i = 0; i < w * h; ++i) {
-		// FIXME: How well does this match RPG_RT textures?
 		int px = Utils::GetRandomNumber(0, num_overlay_colors - 1);
 		// FIXME: This only works for 32bit pixel formats
 		fog_img[i] = fog_pixels[px];


### PR DESCRIPTION
Depends on https://github.com/EasyRPG/liblcf/pull/396

This PR changes Player to behave more like RPG_RT.

An empty name string in `SaveSystem` is used to tell the game to use the default `System` audio. When the BGM or SE is changed, if the thing changed to matches the default, then empty string is put back in.

This also means if a custom patch were to put empty string in the name, it would also tell RPG_RT to use the default system audio.

DynRPG Addresses:
----------------------


| Address | Class | Function | Comment |
| -- | -- | -- | -- |
| 004AE0D8 | RPG_Interpreter | CommandChangeSystemSE | |
| 004ADF90 | RPG_Interpreter | CommandChangeSystemBGM | |
| 0048B5BC | RPG_System | GetTitleBGM | * see next section | |
| 0048B5FC | RPG_System | SetBattleBGM | |
| 0048B5DC | RPG_System | GetBattleBGM | |
| 0048B868 | RPG_System | SetCursorSE | |

* All the BGM and SE getters and setters are located right next to each other. Simply search for `GetBattleBGM` and go down in disassembly to see all the others.

Title BGM
-----------

RPG_RT actually stores the title BGM in the system save data, and the title scene calls `RPG_System::GetTitleBGM()` which works like all the other bgm getter functions. However since there is never a saved game loaded on the title screen, this always ends up getting the database bgm instead.

This appears to be a half implemented feature. There is no `SetTitleBGM` function and you cannot change it from the events `CommandChangeSystemBGM`.

Despite the chunk existing, it should never be a non-empty music object in any RPG_RT save.

Sound Caching
-------------

For the cursor, decision, cancel, and buzzer sounds. RPG_RT caches the sound files immediately whenever you change these. For the other sound effects, no caching is done.

Testing
-------

I've already tested this with a few games. This PR is ready for review

Future Work
-------------

* Remove Actor Setup and Fixup - depends on #2320 
* Remove Map Setup and Fixup - depends on #2208 