### PR TITLE
Remove SaveActor Fixup and Setup - depends on liblcf #399

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -76,7 +76,11 @@ Game_Actor::Game_Actor(int actor_id) {
 	MakeExpList();
 	SetBattlePosition(GetOriginalPosition());
 
-	ChangeLevel(dbActor->initial_level, nullptr);
+	data.level = 0;
+	if (dbActor->initial_level > 0) {
+		// For games like COLORS: Lost Memories which use level 0, don't change level because it'll clamp to 1.
+		ChangeLevel(dbActor->initial_level, nullptr);
+	}
 	SetHp(GetMaxHp());
 	SetSp(GetMaxSp());
 
@@ -705,7 +709,7 @@ void Game_Actor::ChangeExp(int exp, PendingMessage* pm) {
 }
 
 void Game_Actor::SetLevel(int _level) {
-	data.level = min(max(_level, 1), GetMaxLevel());
+	data.level = Utils::Clamp(_level, 1, GetMaxLevel());
 	// Ensure current HP/SP remain clamped if new Max HP/SP is less.
 	SetHp(GetHp());
 	SetSp(GetSp());

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -258,8 +258,13 @@ void Game_Actor::UnlearnAllSkills() {
 }
 
 void Game_Actor::SetFace(const std::string& file_name, int index) {
-	data.face_name.assign(file_name);
-	data.face_id = index;
+	if (file_name == dbActor->face_name && index == dbActor->face_index) {
+		data.face_name = "";
+		data.face_id = 0;
+	} else {
+		data.face_name.assign(file_name);
+		data.face_id = index;
+	}
 }
 
 const lcf::rpg::Item* Game_Actor::GetEquipment(int equip_type) const {
@@ -823,9 +828,17 @@ StringView Game_Actor::GetSkillName() const {
 }
 
 void Game_Actor::SetSprite(const std::string &file, int index, bool transparent) {
-	data.sprite_name = file;
-	data.sprite_id = index;
-	data.transparency = transparent ? 3 : 0;
+	if (file == dbActor->character_name
+			&& index == dbActor->character_index
+			&& transparent == dbActor->transparent) {
+		data.sprite_name = "";
+		data.sprite_id = 0;
+		data.transparency = 0;
+	} else {
+		data.sprite_name = file;
+		data.sprite_id = index;
+		data.transparency = transparent ? 3 : 0;
+	}
 }
 
 void Game_Actor::ChangeBattleCommands(bool add, int id) {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -103,7 +103,6 @@ void Game_Actor::Init() {
 }
 
 void Game_Actor::Fixup() {
-	data.Fixup(GetId());
 	if (Player::IsRPG2k()) {
 		data.two_weapon = dbActor->two_weapon;
 		data.lock_equipment = dbActor->lock_equipment;

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -46,7 +46,7 @@ public:
 	Game_Actor(int actor_id);
 
 	void SetSaveData(lcf::rpg::SaveActor save);
-	const lcf::rpg::SaveActor& GetSaveData() const;
+	lcf::rpg::SaveActor GetSaveData() const;
 
 	int MaxHpValue() const override;
 
@@ -57,24 +57,6 @@ public:
 	virtual PermanentStates GetPermanentStates() const override;
 
 	Point GetOriginalPosition() const override;
-
-	/**
-	 * Sets up the game actor
-	 * This is automatically called in the constructor.
-	 */
-	void Setup();
-
-	/**
-	 * Initializes the game actor to the database state.
-	 * Sets the skills, HP, SP and experience.
-	 */
-	void Init();
-
-	/**
-	 * Used after savegame loading to replace savegame default values with
-	 * database ones.
-	 */
-	void Fixup();
 
 	/**
 	 * Applies the effects of an item.
@@ -904,6 +886,7 @@ public:
 
 private:
 	void AdjustEquipmentStates(const lcf::rpg::Item* item, bool add, bool allow_battle_states);
+	void Fixup();
 
 	/**
 	 * Removes invalid data from the actor.

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <lcf/rpg/fwd.h>
 #include <lcf/rpg/saveactor.h>
+#include <lcf/rpg/actor.h>
 #include <lcf/rpg/learning.h>
 #include "game_battler.h"
 #include "string_view.h"
@@ -284,7 +285,7 @@ public:
 	 *
 	 * @return title.
 	 */
-	const std::string& GetTitle() const;
+	StringView GetTitle() const;
 
 	/**
 	 * Gets actor equipped weapon ID.
@@ -919,39 +920,57 @@ inline Game_Battler::BattlerType Game_Actor::GetType() const {
 }
 
 inline void Game_Actor::SetName(const std::string &new_name) {
-	data.name = new_name;
+	data.name = (new_name != dbActor->name)
+		? new_name
+		: lcf::rpg::SaveActor::kEmptyName;
 }
 
 inline StringView Game_Actor::GetName() const {
-	return data.name;
+	return data.name != lcf::rpg::SaveActor::kEmptyName
+		? StringView(data.name)
+		: StringView(dbActor->name);
 }
 
 inline void Game_Actor::SetTitle(const std::string &new_title) {
-	data.title = new_title;
+	data.title = (new_title != dbActor->title)
+		? new_title
+		: lcf::rpg::SaveActor::kEmptyName;
 }
 
-inline const std::string& Game_Actor::GetTitle() const {
-	return data.title;
+inline StringView Game_Actor::GetTitle() const {
+	return data.title != lcf::rpg::SaveActor::kEmptyName
+		? StringView(data.title)
+		: StringView(dbActor->title);
 }
 
 inline StringView Game_Actor::GetSpriteName() const {
-	return data.sprite_name;
+	return (!data.sprite_name.empty())
+		? StringView(data.sprite_name)
+		: StringView(dbActor->character_name);
 }
 
 inline int Game_Actor::GetSpriteIndex() const {
-	return data.sprite_id;
+	return (!data.sprite_name.empty())
+		? data.sprite_id
+		: dbActor->character_index;
 }
 
 inline int Game_Actor::GetSpriteTransparency() const {
-	return data.transparency;
+	return (!data.sprite_name.empty())
+		? data.transparency
+		: (dbActor->transparent ? 3 : 0);
 }
 
 inline StringView Game_Actor::GetFaceName() const {
-	return data.face_name;
+	return (!data.face_name.empty())
+		? StringView(data.face_name)
+		: StringView(dbActor->face_name);
 }
 
 inline int Game_Actor::GetFaceIndex() const {
-	return data.face_id;
+	return (!data.face_name.empty())
+		? data.face_id
+		: dbActor->face_index;
 }
 
 inline int Game_Actor::GetLevel() const {

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -905,16 +905,12 @@ private:
 	void AdjustEquipmentStates(const lcf::rpg::Item* item, bool add, bool allow_battle_states);
 
 	/**
-	 * @return Reference to the Actor data of the LDB
-	 */
-	const lcf::rpg::Actor& GetActor() const;
-
-	/**
 	 * Removes invalid data from the actor.
 	 */
 	void RemoveInvalidData();
 
 	lcf::rpg::SaveActor data;
+	const lcf::rpg::Actor* dbActor = nullptr;
 	std::vector<int> exp_list;
 };
 

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -35,6 +35,8 @@ Game_Party::Game_Party() {
 }
 
 void Game_Party::SetupNewGame() {
+	Clear();
+
 	data.party = lcf::Data::system.party;
 	RemoveInvalidData();
 }
@@ -96,7 +98,7 @@ int Game_Party::GetVisibleBattlerCount() const {
 	return visible;
 }
 
-void Game_Party::SetupBattleTestMembers() {
+void Game_Party::SetupBattleTest() {
 	Clear();
 
 	for (auto& btdata : lcf::Data::system.battletest_data) {
@@ -118,8 +120,6 @@ void Game_Party::SetupBattleTestMembers() {
 		actor->SetHp(actor->GetMaxHp());
 		actor->SetSp(actor->GetMaxSp());
 	}
-
-	Main_Data::game_player->ResetGraphic();
 }
 
 void Game_Party::GetItems(std::vector<int>& item_list) {

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -32,11 +32,10 @@
 #include "output.h"
 
 Game_Party::Game_Party() {
-	SetupNewGame();
 }
 
 void Game_Party::SetupNewGame() {
-	data.Setup();
+	data.party = lcf::Data::system.party;
 	RemoveInvalidData();
 }
 

--- a/src/game_party.h
+++ b/src/game_party.h
@@ -36,6 +36,9 @@ public:
 	/** Initialize for new game */
 	void SetupNewGame();
 
+	/** Setups battle test party */
+	void SetupBattleTest();
+
 	/** Initialize from save game */
 	void SetupFromSave(lcf::rpg::SaveInventory save);
 
@@ -47,10 +50,6 @@ public:
 	int GetBattlerCount() const override;
 	int GetVisibleBattlerCount() const override;
 
-	/**
-	 * Setups battle test party.
-	 */
-	void SetupBattleTestMembers();
 
 	/**
 	 * Adds an actor to the party.

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1046,6 +1046,40 @@ void Player::SetupPlayerSpawn() {
 	request->Start();
 }
 
+void Player::SetupBattleTest() {
+	BattleArgs args;
+	args.troop_id = Game_Battle::battle_test.troop_id;
+	args.first_strike = false;
+	args.allow_escape = true;
+	args.background = ToString(lcf::Data::system.battletest_background);
+	args.terrain_id = 1; //Not used in 2k, for 2k3 only used to determine grid layout if formation == terrain.
+
+	if (Player::IsRPG2k3()) {
+		args.formation = Game_Battle::battle_test.formation;
+		args.condition = Game_Battle::battle_test.condition;
+
+		if (args.formation == lcf::rpg::System::BattleFormation_terrain) {
+			args.terrain_id = Game_Battle::battle_test.terrain_id;
+		}
+
+		Output::Debug("BattleTest Mode 2k3 troop=({}) background=({}) formation=({}) condition=({}) terrain=({})",
+				args.troop_id, args.background.c_str(), args.formation, args.condition, args.terrain_id);
+	} else {
+		Output::Debug("BattleTest Mode 2k troop=({}) background=({})", args.troop_id, args.background);
+	}
+
+	auto* troop = lcf::ReaderUtil::GetElement(lcf::Data::troops, args.troop_id);
+	if (troop == nullptr) {
+		Output::Error("BattleTest: Invalid Monster Party ID {}", args.troop_id);
+	}
+
+	if (Game_Battle::battle_test.enabled) {
+		Main_Data::game_party->SetupBattleTest();
+	}
+
+	Scene::Push(Scene_Battle::Create(std::move(args)), true);
+}
+
 std::string Player::GetEncoding() {
 	encoding = forced_encoding;
 

--- a/src/player.h
+++ b/src/player.h
@@ -153,6 +153,11 @@ namespace Player {
 	void SetupNewGame();
 
 	/**
+	 * Starts a new game
+	 */
+	void SetupBattleTest();
+
+	/**
 	 * Moves the player to the start map.
 	 */
 	void SetupPlayerSpawn();

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -91,10 +91,6 @@ void Scene_Battle::Start() {
 
 	Output::Debug("Starting battle {} ({})", troop_id, troop->name);
 
-	if (Game_Battle::battle_test.enabled) {
-		Main_Data::game_party->SetupBattleTestMembers();
-	}
-
 	Game_Battle::Init(troop_id);
 
 	cycle = 0;

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -127,16 +127,6 @@ void Scene_Save::Save(std::ostream& os, int slot_id, bool prepare_save) {
 	}
 
 	auto data_copy = lcf::LSD_Reader::ClearDefaults(Main_Data::game_data, Game_Map::GetMapInfo(), Game_Map::GetMap());
-	// RPG_RT doesn't save these chunks in rm2k as they are meaningless
-	if (Player::IsRPG2k()) {
-		for (auto& actor: data_copy.actors) {
-			actor.two_weapon = 0;
-			actor.lock_equipment = 0;
-			actor.auto_battle = 0;
-			actor.super_guard = 0;
-		}
-	}
-
 	data_copy.targets = Main_Data::game_targets->GetSaveData();
 	data_copy.system.switches = Main_Data::game_switches->GetData();
 	data_copy.system.variables = Main_Data::game_variables->GetData();

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -97,7 +97,7 @@ void Scene_Title::TransitionOut(Scene::SceneType next_scene) {
 
 void Scene_Title::Update() {
 	if (Game_Battle::battle_test.enabled) {
-		PrepareBattleTest();
+		Player::SetupBattleTest();
 		return;
 	}
 
@@ -198,36 +198,6 @@ bool Scene_Title::CheckEnableTitleGraphicAndMusic() {
 
 bool Scene_Title::CheckValidPlayerLocation() {
 	return (lcf::Data::treemap.start.party_map_id > 0);
-}
-
-void Scene_Title::PrepareBattleTest() {
-	BattleArgs args;
-	args.troop_id = Game_Battle::battle_test.troop_id;
-	args.first_strike = false;
-	args.allow_escape = true;
-	args.background = ToString(lcf::Data::system.battletest_background);
-	args.terrain_id = 1; //Not used in 2k, for 2k3 only used to determine grid layout if formation == terrain.
-
-	if (Player::IsRPG2k3()) {
-		args.formation = Game_Battle::battle_test.formation;
-		args.condition = Game_Battle::battle_test.condition;
-
-		if (args.formation == lcf::rpg::System::BattleFormation_terrain) {
-			args.terrain_id = Game_Battle::battle_test.terrain_id;
-		}
-
-		Output::Debug("BattleTest Mode 2k3 troop=({}) background=({}) formation=({}) condition=({}) terrain=({})",
-				args.troop_id, args.background.c_str(), args.formation, args.condition, args.terrain_id);
-	} else {
-		Output::Debug("BattleTest Mode 2k troop=({}) background=({})", args.troop_id, args.background);
-	}
-
-	auto* troop = lcf::ReaderUtil::GetElement(lcf::Data::troops, args.troop_id);
-	if (troop == nullptr) {
-		Output::Error("BattleTest: Invalid Monster Party ID {}", args.troop_id);
-	}
-
-	Scene::Push(Scene_Battle::Create(std::move(args)), true);
 }
 
 void Scene_Title::CommandNewGame() {

--- a/src/scene_title.h
+++ b/src/scene_title.h
@@ -72,11 +72,6 @@ public:
 	bool CheckValidPlayerLocation();
 
 	/**
-	 * Initializes a battle test session.
-	 */
-	void PrepareBattleTest();
-
-	/**
 	 * Option New Game.
 	 * Starts a new game.
 	 */


### PR DESCRIPTION
Depends on: https://github.com/EasyRPG/liblcf/pull/399


DynRPG Addresses
---------------------


| Address | Class | Function | Comment |
| -- | -- | -- | -- |
| 004B5330 | Actor | Reset | Resets all fields to default values |
| 004B6DD8 | Actor | SetTitle |
| 004B7004 | Actor | SetFace |
| 004B6D34 | Actor | SetName |
| 004B6E58 | Actor | GetCharset |
| 004B6E94 | Actor | GetCharsetId |
| 004B6EBC | Actor | GetCharsetTransparency |
| 004B6D88 | Actor | GetTitle |
| 004B6FDC | Actor | GetFaceId |
| 004B6FA0 | Actor | GetFaceName |
| 004B6CE4 | Actor | GetName |
| 004B5A48 | Actor | InitSaveChunk | Maps save chunk ids to fields 