### PR TITLE
States: Damage and recovery is rounded down instead of up

### DIFF
--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -384,8 +384,8 @@ int Game_Battler::ApplyConditions() {
 	for (int16_t inflicted : GetInflictedStates()) {
 		// States are guaranteed to be valid
 		lcf::rpg::State& state = *lcf::ReaderUtil::GetElement(lcf::Data::states, inflicted);
-		int hp = state.hp_change_val + (int)(std::ceil(GetMaxHp() * state.hp_change_max / 100.0));
-		int sp = state.sp_change_val + (int)(std::ceil(GetMaxHp() * state.sp_change_max / 100.0));
+		int hp = state.hp_change_val + (GetMaxHp() * state.hp_change_max / 100);
+		int sp = state.sp_change_val + (GetMaxSp() * state.sp_change_max / 100);
 		int source_hp = this->GetHp();
 		int source_sp = this->GetSp();
 		int src_hp = 0;


### PR DESCRIPTION
If an actor get damaged or recovered due to a state, the damage/recovery value is rounded down instead of up. This means that the damage/recovery value can even be zero if the damage/recovery percentage is set to a low value. Moreover a bug got fixed in SP damage/recovery: The SP damage/recovery percentage uses now the maximum SP instead of the maximum HP for the calculation.