### PR TITLE
States: Allow states simultaneously with death

### DIFF
--- a/src/state.cpp
+++ b/src/state.cpp
@@ -30,16 +30,8 @@ bool Add(int state_id, StateVec& states, const PermanentStates& ps, bool allow_b
 		return false;
 	}
 
-	if (Has(lcf::rpg::State::kDeathID, states)) {
-		return false;
-	}
-
 	if (!allow_battle_states && state->type == lcf::rpg::State::Persistence_ends) {
 		return false;
-	}
-
-	if (state_id == lcf::rpg::State::kDeathID) {
-		RemoveAll(states, ps);
 	}
 
 	if (state_id > static_cast<int>(states.size())) {


### PR DESCRIPTION
This PR fixes #2327. If an actor gets the death state every already inflicted state with a priority of >= 91 no longer gets removed. Moreover skills and weapons adds states only if the target does not get killed by the damage and weapons can remove states in RPG Maker 2003 now.