### PR TITLE
RPG Maker 2003 battle scene changes

### DIFF
--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -268,6 +268,12 @@ void Scene_Battle_Rpg2k3::Update() {
 					Game_Battle::UpdateAtbGauges();
 				}
 
+				if (state == State_SelectCommand) {
+					if (active_actor->GetSignificantRestriction() != lcf::rpg::State::Restriction_normal) {
+						SetState(State_SelectActor);
+					}
+				}
+
 				if (state != State_SelectEnemyTarget) {
 					int old_state = state;
 
@@ -1645,7 +1651,7 @@ void Scene_Battle_Rpg2k3::SelectNextActor() {
 
 	int i = 0;
 	for (auto* battler: actors) {
-		if (battler->IsAtbGaugeFull() && !battler->GetBattleAlgorithm() && battle_actions.empty()) {
+		if (battler->IsAtbGaugeFull() && !battler->GetBattleAlgorithm() && battle_actions.empty() && battler->GetSignificantRestriction() != lcf::rpg::State::Restriction_do_nothing) {
 			actor_index = i;
 			active_actor = static_cast<Game_Actor*>(battler);
 

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1850,7 +1850,7 @@ void Scene_Battle_Rpg2k3::ShowNotification(std::string text) {
 		return;
 	}
 	help_window->SetVisible(true);
-	help_window->SetText(std::move(text));
+	help_window->SetText(std::move(text), Text::AlignLeft, false);
 }
 
 bool Scene_Battle_Rpg2k3::CheckAnimFlip(Game_Battler* battler) {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -858,6 +858,11 @@ void Scene_Battle_Rpg2k3::ProcessActions() {
 			UpdateActorsDirection();
 			SetState(State_SelectOption);
 			break;
+		case State_SelectOption:
+			if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional) {
+				SetState(State_SelectActor);
+				break;
+			}
 		case State_SelectActor:
 		case State_AutoBattle:
 		case State_Battle:
@@ -1207,11 +1212,15 @@ void Scene_Battle_Rpg2k3::ProcessInput() {
 			break;
 		case State_SelectActor:
 		case State_AutoBattle:
-			SetState(State_SelectOption);
+			if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) {
+				SetState(State_SelectOption);
+			}
 			break;
 		case State_SelectCommand:
-			active_actor->SetLastBattleAction(-1);
-			SetState(State_SelectOption);
+			if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) {
+				active_actor->SetLastBattleAction(-1);
+				SetState(State_SelectOption);
+			}
 			break;
 		case State_SelectItem:
 		case State_SelectSkill:

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -688,6 +688,8 @@ void Scene_Battle_Rpg2k3::SetState(Scene_Battle::State new_state) {
 			target_window->SetIndex(-1);
 			target_window->SetZ(Priority_Window - 10);
 			target_window->SetVisible(true);
+		} else {
+			status_window->SetIndex(-1);
 		}
 		if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_alternative) {
 			command_window->SetX(SCREEN_TARGET_WIDTH);
@@ -716,6 +718,7 @@ void Scene_Battle_Rpg2k3::SetState(Scene_Battle::State new_state) {
 	case State_SelectCommand:
 		if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) {
 			options_window->SetVisible(true);
+			status_window->SetIndex(-1);
 		}
 		status_window->SetVisible(true);
 		if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional) {
@@ -745,6 +748,8 @@ void Scene_Battle_Rpg2k3::SetState(Scene_Battle::State new_state) {
 			status_window->SetZ(Priority_Window - 10);
 			target_window->SetZ(Priority_Window + 10);
 			target_window->SetVisible(true);
+		} else {
+			status_window->SetIndex(-1);
 		}
 		break;
 	case State_SelectAllyTarget:
@@ -763,6 +768,7 @@ void Scene_Battle_Rpg2k3::SetState(Scene_Battle::State new_state) {
 			target_window->SetZ(Priority_Window - 10);
 			target_window->SetVisible(true);
 		}
+		status_window->SetIndex(0);
 		command_window->SetVisible(true);
 		break;
 	case State_Battle:
@@ -790,6 +796,8 @@ void Scene_Battle_Rpg2k3::SetState(Scene_Battle::State new_state) {
 			target_window->SetZ(Priority_Window - 10);
 			target_window->SetVisible(true);
 			command_window->SetVisible(false);
+		} else {
+			status_window->SetIndex(-1);
 		}
 		if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_alternative) {
 			command_window->SetVisible(true);
@@ -804,6 +812,8 @@ void Scene_Battle_Rpg2k3::SetState(Scene_Battle::State new_state) {
 			target_window->SetZ(Priority_Window - 10);
 			target_window->SetVisible(true);
 			command_window->SetVisible(false);
+		} else {
+			status_window->SetIndex(-1);
 		}
 		if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_alternative) {
 			command_window->SetVisible(true);

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -418,18 +418,18 @@ void Scene_Battle_Rpg2k3::UpdateCursors() {
 
 		std::vector<Game_Battler*> actors;
 
-		if (ally_index >= 0 && lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) {
+		if (ally_index >= 0 && (state == State_SelectActor || state == State_SelectAllyTarget)) {
 			ally_cursor->SetVisible(true);
 			Main_Data::game_party->GetBattlers(actors);
 			Game_Battler* actor = actors[ally_index];
 			Sprite_Battler* sprite = Game_Battle::GetSpriteset().FindBattler(actor);
 			ally_cursor->SetX(actor->GetBattlePosition().x);
-			ally_cursor->SetY(actor->GetBattlePosition().y - sprite->GetHeight() / 2);
+			ally_cursor->SetY(actor->GetBattlePosition().y - 40);
 			static const int frames[] = { 0, 1, 2, 1 };
 			int frame = frames[(cycle / 15) % 4];
 			ally_cursor->SetSrcRect(Rect(frame * 16, 16, 16, 16));
 
-			if (cycle % 30 == 0) {
+			if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional && cycle % 30 == 0) {
 				SelectionFlash(actor);
 			}
 		}

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -383,7 +383,7 @@ void Scene_Battle_Rpg2k3::CreateUi() {
 	}
 
 	if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) {
-		int transp = lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent ? 128 : 255;
+		int transp = lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent ? 160 : 255;
 		options_window->SetBackOpacity(transp);
 		item_window->SetBackOpacity(transp);
 		skill_window->SetBackOpacity(transp);
@@ -514,7 +514,7 @@ void Scene_Battle_Rpg2k3::CreateBattleTargetWindow() {
 	target_window->SetZ(Priority_Window + 10);
 
 	if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) {
-		int transp = lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent ? 128 : 255;
+		int transp = lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent ? 160 : 255;
 		target_window->SetBackOpacity(transp);
 	}
 }
@@ -563,7 +563,7 @@ void Scene_Battle_Rpg2k3::CreateBattleCommandWindow() {
 	}
 
 	if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) {
-		int transp = lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent ? 128 : 255;
+		int transp = lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent ? 160 : 255;
 		command_window->SetBackOpacity(transp);
 	}
 }

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -162,6 +162,8 @@ protected:
 	bool escape_initiated = false;
 	bool win_wait_elapsed = false;
 	bool lose_wait_elapsed = false;
+
+	int selected_actor_index = -1;
 };
 
 #endif

--- a/src/window_actorsp.cpp
+++ b/src/window_actorsp.cpp
@@ -36,6 +36,8 @@ void Window_ActorSp::SetBattler(const Game_Battler& battler) {
 		color = Font::ColorCritical;
 	}
 
+	contents->Clear();
+
 	// Draw current Sp
 	contents->TextDraw(cx + 3 * 6, 2, color, std::to_string(battler.GetSp()), Text::AlignRight);
 

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -299,7 +299,7 @@ void Window_Base::DrawCurrencyValue(int money, int cx, int cy) const {
 	contents->TextDraw(cx - gold_text_size.width, cy, Font::ColorDefault, gold.str(), Text::AlignRight);
 }
 
-void Window_Base::DrawGauge(const Game_Battler& actor, int cx, int cy) const {
+void Window_Base::DrawGauge(const Game_Battler& actor, int cx, int cy, int alpha) const {
 	BitmapRef system2 = Cache::System2();
 	if (!system2) {
 		return;
@@ -319,10 +319,10 @@ void Window_Base::DrawGauge(const Game_Battler& actor, int cx, int cy) const {
 	Rect dst_rect1(cx + 16, cy, 13, 16);
 	Rect dst_rect2(cx + 16 + 13, cy, 12, 16);
 
-	contents->Blit(cx + 0, cy, *system2, gauge_left, 255);
-	contents->Blit(cx + 16 + 25, cy, *system2, gauge_right, 255);
-	contents->StretchBlit(dst_rect1, *system2, gauge_center1, 255);
-	contents->StretchBlit(dst_rect2, *system2, gauge_center2, 255);
+	contents->Blit(cx + 0, cy, *system2, gauge_left, alpha);
+	contents->Blit(cx + 16 + 25, cy, *system2, gauge_right, alpha);
+	contents->StretchBlit(dst_rect1, *system2, gauge_center1, alpha);
+	contents->StretchBlit(dst_rect2, *system2, gauge_center2, alpha);
 
 	const auto atb = actor.GetAtbGauge();
 	const auto gauge_w = 25 * atb / actor.GetMaxAtbGauge();
@@ -333,11 +333,11 @@ void Window_Base::DrawGauge(const Game_Battler& actor, int cx, int cy) const {
 		if (gauge_w >= 13) {
 			Rect bar_rect1(cx + 16, cy, 13, 16);
 			Rect bar_rect2(cx + 16 + 13, cy, gauge_w - 13, 16);
-			contents->StretchBlit(bar_rect1, *system2, gauge_bar1, 255);
-			contents->StretchBlit(bar_rect2, *system2, gauge_bar2, 255);
+			contents->StretchBlit(bar_rect1, *system2, gauge_bar1, alpha);
+			contents->StretchBlit(bar_rect2, *system2, gauge_bar2, alpha);
 		} else {
 			Rect bar_rect(cx + 16, cy, gauge_w, 16);
-			contents->StretchBlit(bar_rect, *system2, gauge_bar1, 255);
+			contents->StretchBlit(bar_rect, *system2, gauge_bar1, alpha);
 		}
 	}
 }

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -312,21 +312,32 @@ void Window_Base::DrawGauge(const Game_Battler& actor, int cx, int cy) const {
 
 	// Three components of the gauge
 	Rect gauge_left(0, gauge_y, 16, 16);
-	Rect gauge_center(16, gauge_y, 16, 16);
+	Rect gauge_center1(16, gauge_y, 8, 16);
+	Rect gauge_center2(16 + 8, gauge_y, 8, 16);
 	Rect gauge_right(32, gauge_y, 16, 16);
 
-	Rect dst_rect(cx + 16, cy, 25, 16);
+	Rect dst_rect1(cx + 16, cy, 13, 16);
+	Rect dst_rect2(cx + 16 + 13, cy, 12, 16);
 
 	contents->Blit(cx + 0, cy, *system2, gauge_left, 255);
 	contents->Blit(cx + 16 + 25, cy, *system2, gauge_right, 255);
-	contents->StretchBlit(dst_rect, *system2, gauge_center, 255);
+	contents->StretchBlit(dst_rect1, *system2, gauge_center1, 255);
+	contents->StretchBlit(dst_rect2, *system2, gauge_center2, 255);
 
 	const auto atb = actor.GetAtbGauge();
 	const auto gauge_w = 25 * atb / actor.GetMaxAtbGauge();
 	if (gauge_w > 0) {
 		// Full or not full bar
-		Rect gauge_bar(full ? 64 : 48, gauge_y, 16, 16);
-		Rect bar_rect(cx + 16, cy, gauge_w, 16);
-		contents->StretchBlit(bar_rect, *system2, gauge_bar, 255);
+		Rect gauge_bar1(full ? 64 : 48, gauge_y, 8, 16);
+		Rect gauge_bar2(full ? 64 + 8: 48 + 8, gauge_y, 8, 16);
+		if (gauge_w >= 13) {
+			Rect bar_rect1(cx + 16, cy, 13, 16);
+			Rect bar_rect2(cx + 16 + 13, cy, gauge_w - 13, 16);
+			contents->StretchBlit(bar_rect1, *system2, gauge_bar1, 255);
+			contents->StretchBlit(bar_rect2, *system2, gauge_bar2, 255);
+		} else {
+			Rect bar_rect(cx + 16, cy, gauge_w, 16);
+			contents->StretchBlit(bar_rect, *system2, gauge_bar1, 255);
+		}
 	}
 }

--- a/src/window_base.h
+++ b/src/window_base.h
@@ -67,7 +67,7 @@ public:
 	void DrawItemName(const lcf::rpg::Item& item, int cx, int cy, bool enabled = true) const;
 	void DrawSkillName(const lcf::rpg::Skill& skill, int cx, int cy, bool enabled = true) const;
 	void DrawCurrencyValue(int money, int cx, int cy) const;
-	void DrawGauge(const Game_Battler& actor, int cx, int cy) const;
+	void DrawGauge(const Game_Battler& actor, int cx, int cy, int alpha = 255) const;
 	/** @} */
 
 	/**

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -286,7 +286,7 @@ void Window_BattleStatus::Update() {
 }
 
 void Window_BattleStatus::UpdateCursorRect() {
-	if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) {
+	if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_gauge) {
 		SetCursorRect(Rect());
 		return;
 	}

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -80,13 +80,17 @@ void Window_BattleStatus::Refresh() {
 			int y = 2 + i * 16;
 
 			DrawActorName(*actor, 4, y);
-			DrawActorState(*actor, 84, y);
-			if (Player::IsRPG2k3() && lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional) {
-				contents->TextDraw(126 + 42 + 4 * 6, y, Font::ColorDefault, std::to_string(actor->GetHp()), Text::AlignRight);
+			if (Player::IsRPG2k()) {
+				DrawActorState(*actor, 86, y);
+				DrawActorHp(*actor, 142, y, 3, true);
+				DrawActorSp(*actor, 202, y, 3, false);
 			} else {
-				int digits = Player::IsRPG2k() ? 3 : 4;
-				DrawActorHp(*actor, 126, y, digits, true);
-				DrawActorSp(*actor, 198, y, 3, false);
+				if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional) {
+					DrawActorState(*actor, 84, y);
+					contents->TextDraw(126 + 42 + 4 * 6, y, Font::ColorDefault, std::to_string(actor->GetHp()), Text::AlignRight);
+				} else {
+					DrawActorState(*actor, 80, y);
+				}
 			}
 		}
 	}
@@ -96,10 +100,6 @@ void Window_BattleStatus::Refresh() {
 
 void Window_BattleStatus::RefreshGauge() {
 	if (Player::IsRPG2k3()) {
-		if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_gauge) {
-			contents->ClearRect(Rect(198, 0, 25 + 16, 15 * item_max));
-		}
-
 		for (int i = 0; i < item_max; ++i) {
 			// The party always contains valid battlers
 			Game_Battler* actor;
@@ -152,9 +152,10 @@ void Window_BattleStatus::RefreshGauge() {
 			else {
 				int y = 2 + i * 16;
 
-				DrawGauge(*actor, 198 - 10, y - 2);
+				DrawGauge(*actor, 202 - 10, y - 2);
 				if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_alternative) {
-					DrawActorSp(*actor, 198, y, 3, false);
+					DrawActorHp(*actor, 136, y, 4, true);
+					DrawActorSp(*actor, 202, y, 3, false);
 				}
 			}
 		}

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -87,7 +87,7 @@ void Window_BattleStatus::Refresh() {
 			} else {
 				if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional) {
 					DrawActorState(*actor, 84, y);
-					contents->TextDraw(126 + 42 + 4 * 6, y, Font::ColorDefault, std::to_string(actor->GetHp()), Text::AlignRight);
+					contents->TextDraw(136 + 4 * 6, y, Font::ColorDefault, std::to_string(actor->GetHp()), Text::AlignRight);
 				} else {
 					DrawActorState(*actor, 80, y);
 				}
@@ -153,10 +153,12 @@ void Window_BattleStatus::RefreshGauge() {
 			else {
 				int y = 2 + i * 16;
 
-				DrawGauge(*actor, 202 - 10, y - 2);
 				if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_alternative) {
+					DrawGauge(*actor, 202 - 10, y - 2);
 					DrawActorHp(*actor, 136, y, 4, true);
 					DrawActorSp(*actor, 202, y, 3, false);
+				} else {
+					DrawGauge(*actor, 156, y - 2);
 				}
 			}
 		}

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -100,6 +100,10 @@ void Window_BattleStatus::Refresh() {
 
 void Window_BattleStatus::RefreshGauge() {
 	if (Player::IsRPG2k3()) {
+		if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_alternative) {
+			contents->ClearRect(Rect(192, 0, 45, 64));
+		}
+
 		for (int i = 0; i < item_max; ++i) {
 			// The party always contains valid battlers
 			Game_Battler* actor;
@@ -154,9 +158,17 @@ void Window_BattleStatus::RefreshGauge() {
 				int y = 2 + i * 16;
 
 				if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_alternative) {
-					DrawGauge(*actor, 202 - 10, y - 2);
-					DrawActorHp(*actor, 136, y, 4, true);
-					DrawActorSp(*actor, 202, y, 3, false);
+					if (lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_opaque) {
+						DrawActorHp(*actor, 136, y, 4, true);
+						DrawActorSp(*actor, 202, y, 3, false);
+						DrawGauge(*actor, 202 - 10, y - 2, 96);
+					} else {
+						if (2 + index * 16 != y) {
+							DrawGauge(*actor, 202 - 10, y - 2, 255);
+						}
+						DrawActorHp(*actor, 136, y, 4, true);
+						DrawActorSp(*actor, 202, y, 3, false);
+					}
 				} else {
 					DrawGauge(*actor, 156, y - 2);
 				}

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -87,7 +87,7 @@ void Window_BattleStatus::Refresh() {
 			} else {
 				if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional) {
 					DrawActorState(*actor, 84, y);
-					contents->TextDraw(136 + 4 * 6, y, Font::ColorDefault, std::to_string(actor->GetHp()), Text::AlignRight);
+					contents->TextDraw(136 + 4 * 6, y, actor->GetHp() == 0 ? Font::ColorKnockout : actor->GetHp() <= actor->GetMaxHp() / 4 ? Font::ColorCritical : Font::ColorDefault, std::to_string(actor->GetHp()), Text::AlignRight);
 				} else {
 					DrawActorState(*actor, 80, y);
 				}

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -130,7 +130,8 @@ void Window_BattleStatus::RefreshGauge() {
 
 					// Center
 					const auto fill_x = x;
-					contents->StretchBlit(Rect(x, y, 25, 48), *system2, Rect(16, 32, 16, 48), Opacity::Opaque());
+					contents->StretchBlit(Rect(x, y, 13, 48), *system2, Rect(16, 32, 8, 48), Opacity::Opaque());
+					contents->StretchBlit(Rect(x + 13, y, 12, 48), *system2, Rect(24, 32, 8, 48), Opacity::Opaque());
 					x += 25;
 
 					// Right
@@ -180,7 +181,12 @@ void Window_BattleStatus::DrawGaugeSystem2(int x, int y, int cur_value, int max_
 		gauge_width = 25 * cur_value / max_value;
 	}
 
-	contents->StretchBlit(Rect(x, y, gauge_width, 16), *system2, Rect(48 + gauge_x, 32 + 16 * which, 16, 16), Opacity::Opaque());
+	if (gauge_width >= 13) {
+		contents->StretchBlit(Rect(x, y, 13, 16), *system2, Rect(48 + gauge_x, 32 + 16 * which, 8, 16), Opacity::Opaque());
+		contents->StretchBlit(Rect(x + 13, y, gauge_width - 13, 16), *system2, Rect(56 + gauge_x, 32 + 16 * which, 8, 16), Opacity::Opaque());
+	} else {
+		contents->StretchBlit(Rect(x, y, gauge_width, 16), *system2, Rect(48 + gauge_x, 32 + 16 * which, 8, 16), Opacity::Opaque());
+	}
 }
 
 void Window_BattleStatus::DrawNumberSystem2(int x, int y, int value) {

--- a/src/window_help.cpp
+++ b/src/window_help.cpp
@@ -29,7 +29,7 @@ Window_Help::Window_Help(int ix, int iy, int iwidth, int iheight, Drawable::Flag
 	contents->Clear();
 }
 
-void Window_Help::SetText(std::string text,	Text::Alignment align) {
+void Window_Help::SetText(std::string text,	Text::Alignment align, bool halfwidthspace) {
 	if (this->text != text || this->align != align) {
 		contents->Clear();
 
@@ -43,7 +43,11 @@ void Window_Help::SetText(std::string text,	Text::Alignment align) {
 			x += Font::Default()->GetSize(segment).width;
 
 			if (nextpos != decltype(text)::npos) {
-				x += Font::Default()->GetSize(" ").width / 2;
+				if (halfwidthspace) {
+					x += Font::Default()->GetSize(" ").width / 2;
+				} else {
+					x += Font::Default()->GetSize(" ").width;
+				}
 				pos = nextpos + 1;
 			}
 		}

--- a/src/window_help.h
+++ b/src/window_help.h
@@ -40,7 +40,7 @@ public:
 	 * @param text text to show.
 	 * @param align text alignment.
 	 */
-	void SetText(std::string text, Text::Alignment align = Text::AlignLeft);
+	void SetText(std::string text, Text::Alignment align = Text::AlignLeft, bool halfwidthspace = true);
 
 	/**
 	 * Clears the window


### PR DESCRIPTION
This PR will be updated as soon as #2399 and #2361 are merged into master. The planned changes are in [rueter37:scene-battle2k3-changes-new](https://github.com/rueter37/Player/tree/scene-battle2k3-changes-new).

Depends on: #2399 because #2361 depends on it and #2361 because of changes in the battle window made there.

This PR does the following changes (after the update):

- The status window components have been rearranged to match the RPG_RT style.
- The transparent windows use an alpha of 160 instead of 128 now.
- The gauge display is more accurate now but still needs work. Getting this to 100% accuracy requires a pixman expert. Picture scaling is a general problem as stated in #446.
- In traditional style battles two bugs have been fixed: The SP window got printed over when a skill which costs SP has been used and the HP value didn't change its color if the HP reached critical or zero.
- In alternative style battles the gauges are now shown transparent if the window is opaque.
- The ally cursor is always drawn 40 pixels above the Y-Position of the battler. (Tested with RPG_RT, but correct me if this is wrong nevertheless)
- ~~In the alternative and gauge battle types it is now possible to switch between actors with full ATB gauge.~~ (Fixed in #2399)
- ~~In the traditional battle type the player is forced to battle manually now.~~ (Fixed in #2399)
- ~~The ally cursor is only shown in the "Select_Actor" and "Select_AllyTarget" states.~~ (Fixed in #2399)
- ~~Actors with a "do nothing" restriction due to a state cannot do an action with full ATB anymore.~~ (Fixed in #2399)