### PR TITLE
UI changes (2/2)

### DIFF
--- a/src/scene_file.h
+++ b/src/scene_file.h
@@ -56,9 +56,11 @@ protected:
 	virtual void PopulatePartyFaces(Window_SaveFile& win, int id, lcf::rpg::Save& savegame);
 	virtual void UpdateLatestTimestamp(int id, lcf::rpg::Save& savegame);
 	static std::unique_ptr<Sprite> MakeBorderSprite(int y);
+	static std::unique_ptr<Sprite> MakeArrowSprite(bool down);
 
 	void Refresh();
 	void MoveFileWindows(int dy, int dt);
+	void UpdateArrows();
 
 	int index = 0;
 	int top_index = 0;
@@ -66,12 +68,16 @@ protected:
 	std::vector<std::shared_ptr<Window_SaveFile> > file_windows;
 	std::unique_ptr<Sprite> border_top;
 	std::unique_ptr<Sprite> border_bottom;
+	std::unique_ptr<Sprite> up_arrow;
+	std::unique_ptr<Sprite> down_arrow;
 	std::string message;
 
 	std::unique_ptr<DirectoryTree> tree;
 
 	double latest_time = 0;
 	int latest_slot = 0;
+
+	int arrow_frame = 0;
 };
 
 #endif

--- a/src/scene_skill.cpp
+++ b/src/scene_skill.cpp
@@ -46,6 +46,11 @@ void Scene_Skill::Start() {
 	skill_window->SetHelpWindow(help_window.get());
 }
 
+void Scene_Skill::Continue(SceneType) {
+	skillstatus_window->Refresh();
+	skill_window->Refresh();
+}
+
 void Scene_Skill::Update() {
 	help_window->Update();
 	skillstatus_window->Update();

--- a/src/scene_skill.h
+++ b/src/scene_skill.h
@@ -36,6 +36,7 @@ public:
 	Scene_Skill(int actor_index, int skill_index = 0);
 
 	void Start() override;
+	void Continue(SceneType prev_scene) override;
 	void Update() override;
 	void TransitionOut(SceneType next_scene) override;
 

--- a/src/window_actorstatus.cpp
+++ b/src/window_actorstatus.cpp
@@ -43,15 +43,24 @@ void Window_ActorStatus::DrawStatus() {
 
 	Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
 
+	int have, max;
+	auto fontcolor = [&have, &max](bool can_knockout) {
+		if (can_knockout && have == 0) return Font::ColorKnockout;
+		if (max > 0 && (have <= max / 4)) return Font::ColorCritical;
+		return Font::ColorDefault;
+	};
+
 	// Draw Hp
 	contents->TextDraw(1, 2, 1, lcf::Data::terms.health_points);
-	int color = (actor->GetHp() == 0 ? Font::ColorKnockout : (actor->GetHp() <= actor->GetMaxHp() / 4 ? Font::ColorCritical : Font::ColorDefault));
-	DrawMinMax(90, 2, actor->GetHp(), actor->GetMaxHp(), color);
+	have = actor->GetHp();
+	max = actor->GetMaxHp();
+	DrawMinMax(90, 2, have, max, fontcolor(true));
 
 	// Draw Sp
 	contents->TextDraw(1, 18, 1, lcf::Data::terms.spirit_points);
-	color = (actor->GetMaxSp() > 0 && actor->GetSp() <= actor->GetMaxSp() / 4 ? Font::ColorCritical : Font::ColorDefault);
-	DrawMinMax(90, 18, actor->GetSp(), actor->GetMaxSp(), color);
+	have = actor->GetSp();
+	max = actor->GetMaxSp();
+	DrawMinMax(90, 18, have, max, fontcolor(false));
 
 	// Draw Exp
 	contents->TextDraw(1, 34, 1, lcf::Data::terms.exp_short);

--- a/src/window_actorstatus.cpp
+++ b/src/window_actorstatus.cpp
@@ -39,35 +39,37 @@ void Window_ActorStatus::Refresh() {
 	DrawStatus();
 }
 
-void Window_ActorStatus::DrawStatus(){
+void Window_ActorStatus::DrawStatus() {
 
 	Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
 
 	// Draw Hp
 	contents->TextDraw(1, 2, 1, lcf::Data::terms.health_points);
-	DrawMinMax(90,2,actor->GetHp(), actor->GetMaxHp());
+	int color = (actor->GetHp() == 0 ? Font::ColorKnockout : (actor->GetHp() <= actor->GetMaxHp() / 4 ? Font::ColorCritical : Font::ColorDefault));
+	DrawMinMax(90, 2, actor->GetHp(), actor->GetMaxHp(), color);
 
 	// Draw Sp
 	contents->TextDraw(1, 18, 1, lcf::Data::terms.spirit_points);
-	DrawMinMax(90,18,actor->GetSp(), actor->GetMaxSp());
+	color = (actor->GetMaxSp() > 0 && actor->GetSp() <= actor->GetMaxSp() / 4 ? Font::ColorCritical : Font::ColorDefault);
+	DrawMinMax(90, 18, actor->GetSp(), actor->GetMaxSp(), color);
 
 	// Draw Exp
-	contents->TextDraw(1, 32, 1, lcf::Data::terms.exp_short);
-	DrawMinMax(90,34, -1, -1);
+	contents->TextDraw(1, 34, 1, lcf::Data::terms.exp_short);
+	DrawMinMax(90, 34, -1, -1);
 }
 
-void Window_ActorStatus::DrawMinMax(int cx, int cy, int min, int max){
+void Window_ActorStatus::DrawMinMax(int cx, int cy, int min, int max, int color) {
 	std::stringstream ss;
 	if (max >= 0)
 		ss << min;
 	else
 		ss << Main_Data::game_actors->GetActor(actor_id)->GetExpString();
-	contents->TextDraw(cx, cy, Font::ColorDefault, ss.str(), Text::AlignRight);
+	contents->TextDraw(cx, cy, color, ss.str(), Text::AlignRight);
 	contents->TextDraw(cx, cy, Font::ColorDefault, "/");
 	ss.str("");
 	if (max >= 0)
 		ss << max;
 	else
 		ss << Main_Data::game_actors->GetActor(actor_id)->GetNextExpString();
-	contents->TextDraw(cx+48, cy, Font::ColorDefault, ss.str(), Text::AlignRight);
+	contents->TextDraw(cx + 48, cy, Font::ColorDefault, ss.str(), Text::AlignRight);
 }

--- a/src/window_actorstatus.h
+++ b/src/window_actorstatus.h
@@ -20,6 +20,7 @@
 
 // Headers
 #include "window_base.h"
+#include "font.h"
 
 /**
  * Window ActorStatus Class.
@@ -42,11 +43,11 @@ public:
 	 * Draws the actor status
 	 */
 	void DrawStatus();
-	
+
 	/**
 	 * Draws min and max separated by a "/" in cx, cy
 	 */
-	void DrawMinMax(int cx, int cy, int min, int max);
+	void DrawMinMax(int cx, int cy, int min, int max, int color = Font::ColorDefault);
 
 private:
 	int actor_id;

--- a/src/window_actortarget.cpp
+++ b/src/window_actortarget.cpp
@@ -43,7 +43,7 @@ void Window_ActorTarget::Refresh() {
 		DrawActorName(actor, 48 + 8, i * 48 + 2 + y);
 		DrawActorLevel(actor, 48 + 8, i * 48 + 2 + 16 + y);
 		DrawActorState(actor, 48 + 8, i * 48 + 2 + 16 + 16 + y);
-		int x_offset = 48 + 8 + 42 + (Player::IsRPG2k() ? 16 : 0);
+		int x_offset = 48 + 8 + 46 + (Player::IsRPG2k() ? 12 : 0);
 		int digits = (Player::IsRPG2k() ? 3 : 4);
 		DrawActorHp(actor, x_offset, i * 48 + 2 + 16 + y, digits);
 		DrawActorSp(actor, x_offset, i * 48 + 2 + 16 + 16 + y, digits);

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -81,13 +81,13 @@ void Window_BattleStatus::Refresh() {
 			int y = 2 + i * 16;
 
 			DrawActorName(*actor, 4, y);
-			DrawActorState(*actor, 84, y);
+			DrawActorState(*actor, 84 + (Player::IsRPG2k() ? 2 : 0), y);
 			if (Player::IsRPG2k3() && lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional) {
 				contents->TextDraw(132 + 4 * 6, y, Font::ColorDefault, std::to_string(actor->GetHp()), Text::AlignRight);
 			} else {
 				int digits = Player::IsRPG2k() ? 3 : 4;
-				DrawActorHp(*actor, 126, y, digits, true);
-				DrawActorSp(*actor, 198, y, 3, false);
+				DrawActorHp(*actor, 126 + (Player::IsRPG2k() ? 16 : 0), y, digits, true);
+				DrawActorSp(*actor, 198 + (Player::IsRPG2k() ? 4 : 0), y, 3, false);
 			}
 		}
 	}

--- a/src/window_menustatus.cpp
+++ b/src/window_menustatus.cpp
@@ -25,7 +25,13 @@
 Window_MenuStatus::Window_MenuStatus(int ix, int iy, int iwidth, int iheight) :
 	Window_Selectable(ix, iy, iwidth, iheight) {
 
-	SetContents(Bitmap::Create(width - 16, height - 16));
+	if (Player::IsRPG2k3()) {
+		SetContents(Bitmap::Create(width - 12, height - 16));
+		SetBorderX(4);
+		text_offset = 4;
+	} else {
+		SetContents(Bitmap::Create(width - 16, height - 16));
+	}
 
 	Refresh();
 }
@@ -42,18 +48,18 @@ void Window_MenuStatus::Refresh() {
 
 		int face_x = 0;
 		if (Player::IsRPG2k3()) {
-			face_x = actor.GetBattleRow() == Game_Actor::RowType::RowType_back ? 5 : 0;
+			face_x = actor.GetBattleRow() == Game_Actor::RowType::RowType_back ? 8 : 0;
 		}
 		DrawActorFace(actor, face_x, i*48 + y);
 
-		DrawActorName(actor, 48 + 8, i*48 + 2 + y);
-		DrawActorTitle(actor, 48 + 8 + 88, i*48 + 2 + y);
-		DrawActorLevel(actor, 48 + 8, i*48 + 2 + 16 + y);
-		DrawActorState(actor, 48 + 8 + 42, i*48 + 2 + 16 + y);
-		DrawActorExp(actor, 48 + 8, i*48 + 2 + 16 + 16 + y);
+		DrawActorName(actor, 48 + 8 + text_offset, i*48 + 2 + y);
+		DrawActorTitle(actor, 48 + 8 + 88 + text_offset, i*48 + 2 + y);
+		DrawActorLevel(actor, 48 + 8 + text_offset, i*48 + 2 + 16 + y);
+		DrawActorState(actor, 48 + 8 + 42 + text_offset, i*48 + 2 + 16 + y);
+		DrawActorExp(actor, 48 + 8 + text_offset, i*48 + 2 + 16 + 16 + y);
 		int digits = (Player::IsRPG2k() ? 3 : 4);
-		DrawActorHp(actor, 48 + 8 + 106 - (Player::IsRPG2k() ? 0 : 12), i * 48 + 2 + 16 + y, digits);
-		DrawActorSp(actor, 48 + 8 + 106 - (Player::IsRPG2k() ? 0 : 12), i * 48 + 2 + 16 + 16 + y, digits);
+		DrawActorHp(actor, 48 + 8 + 106 + text_offset - (Player::IsRPG2k() ? 0 : 12), i * 48 + 2 + 16 + y, digits);
+		DrawActorSp(actor, 48 + 8 + 106 + text_offset - (Player::IsRPG2k() ? 0 : 12), i * 48 + 2 + 16 + 16 + y, digits);
 
 		y += 10;
 	}
@@ -64,7 +70,7 @@ void Window_MenuStatus::UpdateCursorRect()
 	if (index < 0) {
 		cursor_rect = { 0, 0, 0, 0 };
 	} else {
-		cursor_rect = { 48 + 4, index * (48 + 10), 168, 48 };
+		cursor_rect = { 48 + 4 + text_offset, index * (48 + 10), 168, 48 };
 	}
 }
 

--- a/src/window_menustatus.h
+++ b/src/window_menustatus.h
@@ -31,6 +31,9 @@ public:
 	void UpdateCursorRect() override;
 
 	Game_Actor* GetActor() const;
+
+protected:
+	int text_offset = 0;
 };
 
 #endif

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -669,18 +669,18 @@ void Window_Message::UpdateCursorRect() {
 	if (index >= 0) {
 		int x_pos = 2;
 		int y_pos = (pending_message.GetChoiceStartLine() + index) * 16;
-		int width = contents->GetWidth();
+		int width = contents->GetWidth() - 4;
 
 		if (IsFaceEnabled()) {
 			if (!Main_Data::game_system->IsMessageFaceRightPosition()) {
 				x_pos += LeftMargin + FaceSize + RightFaceMargin;
 			}
-			width = width - LeftMargin - FaceSize - RightFaceMargin - 4;
+			width = width - LeftMargin - FaceSize - RightFaceMargin;
 		}
 
-		cursor_rect = { x_pos, y_pos, width, 16 };
+		SetCursorRect(Rect(x_pos, y_pos, width, 16));
 	} else {
-		cursor_rect = { 0, 0, 0, 0 };
+		SetCursorRect(Rect());
 	}
 }
 

--- a/src/window_savefile.cpp
+++ b/src/window_savefile.cpp
@@ -40,7 +40,11 @@ void Window_SaveFile::UpdateCursorRect() {
 	Rect rect = Rect();
 
 	if (GetActive()) {
-		rect = Rect(0, 0, Font::Default()->GetSize(GetSaveFileName()).width + 6, 16);
+		if (override_index > 0) {
+			rect = Rect(0, 0, Font::Default()->GetSize(GetSaveFileName()).width + 6, 16);
+		} else {
+			rect = Rect(0, 0, Font::Default()->GetSize(GetSaveFileName()).width + Font::Default()->GetSize(" ").width * 5 / 2 + 8, 16);
+		}
 	}
 
 	SetCursorRect(rect);
@@ -55,7 +59,7 @@ std::string Window_SaveFile::GetSaveFileName() const {
 			out << override_name;
 		}
 	} else {
-		out << lcf::Data::terms.file << std::setw(2) << std::setfill(' ') << index + 1;
+		out << lcf::Data::terms.file;
 	}
 	return out.str();
 }
@@ -92,6 +96,11 @@ void Window_SaveFile::Refresh() {
 	Font::SystemColor fc = has_save ? Font::ColorDefault : Font::ColorDisabled;
 
 	contents->TextDraw(4, 2, fc, GetSaveFileName());
+	contents->TextDraw(4 + Font::Default()->GetSize(GetSaveFileName()).width, 2, fc, " ");
+
+	std::stringstream out;
+	out << std::setw(2) << std::setfill(' ') << index + 1;
+	contents->TextDraw(4 + Font::Default()->GetSize(GetSaveFileName()).width + Font::Default()->GetSize(" ").width / 2, 2, fc, out.str());
 
 	if (corrupted) {
 		contents->TextDraw(4, 16 + 2, Font::ColorKnockout, "Savegame corrupted");
@@ -102,9 +111,9 @@ void Window_SaveFile::Refresh() {
 		return;
 	}
 
-	std::stringstream out;
+	out.str("");
 	if (override_index > 0) {
-		out << lcf::Data::terms.file << std::setw(2) << std::setfill(' ') << override_index;
+		out << lcf::Data::terms.file << std::setw(3) << std::setfill(' ') << override_index;
 		contents->TextDraw(4, 16+2, fc, out.str());
 	} else {
 		contents->TextDraw(4, 16 + 2, fc, data.hero_name);

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -126,18 +126,34 @@ void Window_Selectable::UpdateArrows() {
 void Window_Selectable::Update() {
 	Window_Base::Update();
 	if (active && item_max > 0 && index >= 0) {
-		if (Input::IsRepeated(Input::DOWN) || Input::IsTriggered(Input::SCROLL_DOWN)) {
-			if (index < item_max - column_max || column_max == 1) {
+		auto move_down = [&]() {
+			if (index < item_max - column_max || column_max == 1 ) {
 				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 				index = (index + column_max) % item_max;
 			}
+		};
+		if (Input::IsTriggered(Input::DOWN) || Input::IsTriggered(Input::SCROLL_DOWN)) {
+			move_down();
+		} else if (Input::IsRepeated(Input::DOWN)) {
+			if (endless_scrolling || (index + column_max) % item_max > index) {
+				move_down();
+			}
 		}
-		if (Input::IsRepeated(Input::UP) || Input::IsTriggered(Input::SCROLL_UP)) {
+
+		auto move_up = [&]() {
 			if (index >= column_max || column_max == 1) {
 				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 				index = (index - column_max + item_max) % item_max;
 			}
+		};
+		if (Input::IsTriggered(Input::UP) || Input::IsTriggered(Input::SCROLL_UP)) {
+			move_up();
+		} else if (Input::IsRepeated(Input::UP)) {
+			if (endless_scrolling || (index - column_max + item_max) % item_max < index) {
+				move_up();
+			}
 		}
+
 		// page up/down is limited to selectables with one column
 		if (column_max == 1) {
 			if (Input::IsRepeated(Input::PAGE_DOWN) && index < item_max - 1) {
@@ -169,4 +185,9 @@ void Window_Selectable::Update() {
 	}
 	UpdateCursorRect();
 	UpdateArrows();
+}
+
+// Set endless scrolling state
+void Window_Selectable::SetEndlessScrolling(bool state) {
+	endless_scrolling = state;
 }

--- a/src/window_selectable.h
+++ b/src/window_selectable.h
@@ -73,6 +73,13 @@ public:
 
 	virtual void UpdateHelp();
 
+	/**
+	 * Sets if endless scrolling is enabled.
+	 *
+	 * @param state true to enable (default), false to disable.
+	 */
+	void SetEndlessScrolling(bool state);
+
 protected:
 	void UpdateArrows();
 
@@ -81,6 +88,8 @@ protected:
 	int column_max = 1;
 	int index = -1;
 	int arrow_frame = 0;
+
+	bool endless_scrolling = true;
 };
 
 #endif

--- a/src/window_skillstatus.cpp
+++ b/src/window_skillstatus.cpp
@@ -48,7 +48,7 @@ void Window_SkillStatus::Refresh() {
 	x += 44;
 	DrawActorState(actor, x, y);
 	x += 54;
-	DrawActorHp(actor, x, y, (Player::IsRPG2k() ? 3 : 4));
+	DrawActorHp(actor, x + (Player::IsRPG2k() ? 6 : 0), y, (Player::IsRPG2k() ? 3 : 4));
 	x += 72;
 	DrawActorSp(actor, x, y, 3);
 }

--- a/src/window_targetstatus.cpp
+++ b/src/window_targetstatus.cpp
@@ -37,9 +37,9 @@ void Window_TargetStatus::Refresh() {
 	}
 
 	if (use_item) {
-		contents->TextDraw(0, 0, 1, lcf::Data::terms.possessed_items);
+		contents->TextDraw(0, 2, 1, lcf::Data::terms.possessed_items);
 	} else {
-		contents->TextDraw(0, 0, 1, lcf::Data::terms.sp_cost);
+		contents->TextDraw(0, 2, 1, lcf::Data::terms.sp_cost);
 	}
 
 	// Scene_ActorTarget validates items and skills
@@ -51,7 +51,7 @@ void Window_TargetStatus::Refresh() {
 	}
 
 	FontRef font = Font::Default();
-	contents->TextDraw(contents->GetWidth() - font->GetSize(str).width, 0, Font::ColorDefault, str, Text::AlignRight);
+	contents->TextDraw(contents->GetWidth(), 2, Font::ColorDefault, str, Text::AlignRight);
 }
 
 void Window_TargetStatus::SetData(int id, bool is_item, int actor_index) {


### PR DESCRIPTION
This PR does the following changes:
- Fix positioning of the item count/skill cost in the Targetstatus window.
- The stats in the skill selection scene are updated now if the user leaves the ActorTarget scene.
- Change spacing and add arrows in the Savegame window.
- Moved HP a bit to the right in the Battlestatus and Skillstatus window.
- Some labels have been realigned in the RPG Maker 2003 ActorInfo window.
- Faces have been moved left in the RPG Maker 2003 main menu window.
- Fix cropped selection boxes in message windows.

Fixes: #2216
Fixes: #1617