### PR TITLE
Shop window: Fix item price position regression from #2313

### DIFF
--- a/src/window_shopbuy.cpp
+++ b/src/window_shopbuy.cpp
@@ -77,7 +77,7 @@ void Window_ShopBuy::DrawItem(int index) {
 	DrawItemName(*item, rect.x, rect.y, enabled);
 
 	std::string str = std::to_string(price);
-	contents->TextDraw(rect.width + 8, rect.y, enabled ? Font::ColorDefault : Font::ColorDisabled, str, Text::AlignRight);
+	contents->TextDraw(rect.width, rect.y, enabled ? Font::ColorDefault : Font::ColorDisabled, str, Text::AlignRight);
 }
 
 void Window_ShopBuy::UpdateHelp() {


### PR DESCRIPTION
In #2313 the item prices were repositioned because the prices were too far left. This was supposed to be fixed but I forgot to recheck the positioning after #2313 was rebased for the menu cursor changes so the prices got too far right and cropped. This PR fixes this.