### PR TITLE
Enemy AI changes: Change weighting of priorities and add special check

### DIFF
--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -184,6 +184,14 @@ public:
 	const lcf::rpg::EnemyAction* ChooseRandomAction();
 	bool IsInParty() const override;
 
+        /**
+         * Checks if the AI wants to use the skill.
+         *
+         * @param skill_id ID of skill to check.
+         * @return true if the AI wants to use that skill.
+         */
+        bool IsSkillUsableForAI(int skill_id) const;
+
 protected:
 	const lcf::rpg::Enemy* enemy = nullptr;
 	const lcf::rpg::TroopMember* troop_member = nullptr;


### PR DESCRIPTION
This PR tries to fix #1831.

This one changes the weighting of the priorities: The action with the highest priority always gets a weight of 10 and actions with a priority of (highest priority - 9) gets a weight of 1. The scaling between is linear. This means if we have two actions, one with a
priority of 50 and one with a priority of 45, the first action gets a 10/15 chance and the second action a 5/15 chance to get selected. Moreover a special check has been added if the enemy uses a skill which only heals states without affecting anything else: He actually checks if there is an ally which is affected by at least one state which get healed by the skill. If this is not the case, then the action gets discarded.