### PR TITLE
Refactor Skill and Item usability and fix some incompatibilities

### DIFF
--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -18,10 +18,16 @@
 #include "game_battler.h"
 #include "game_actor.h"
 #include "game_enemy.h"
+#include "game_system.h"
+#include "main_data.h"
+#include "game_player.h"
+#include "game_targets.h"
+#include "game_battle.h"
 #include "attribute.h"
 #include "player.h"
 #include "rand.h"
 #include <lcf/rpg/skill.h>
+#include <lcf/reader_util.h>
 
 #include <algorithm>
 
@@ -257,4 +263,50 @@ int CalcSkillCost(const lcf::rpg::Skill& skill, int max_sp, bool half_sp_cost) {
 		? max_sp * skill.sp_percent / 100 / div
 		: (skill.sp_cost + static_cast<int>(half_sp_cost)) / div;
 }
+
+bool IsSkillUsable(const lcf::rpg::Skill& skill,
+		bool require_states_persist)
+{
+	const auto in_battle = Game_Battle::IsBattleRunning();
+
+	if (skill.type == lcf::rpg::Skill::Type_escape) {
+		return !in_battle && Main_Data::game_system->GetAllowEscape() && Main_Data::game_targets->HasEscapeTarget() && !Main_Data::game_player->IsFlying();
+	}
+
+	if (skill.type == lcf::rpg::Skill::Type_teleport) {
+		return !in_battle && Main_Data::game_system->GetAllowTeleport() && Main_Data::game_targets->HasTeleportTargets() && !Main_Data::game_player->IsFlying();
+	}
+
+	if (skill.type == lcf::rpg::Skill::Type_switch) {
+		return in_battle ? skill.occasion_battle : skill.occasion_field;
+	}
+
+	if (in_battle) {
+		return true;
+	}
+
+	if (skill.scope == lcf::rpg::Skill::Scope_enemy
+			|| skill.scope == lcf::rpg::Skill::Scope_enemies) {
+		return false;
+	}
+
+	if (skill.affect_hp || skill.affect_sp) {
+		return true;
+	}
+
+	bool affects_state = false;
+	for (int i = 0; i < static_cast<int>(skill.state_effects.size()); ++i) {
+		const bool inflict = skill.state_effects[i];
+		if (inflict) {
+			const auto* state = lcf::ReaderUtil::GetElement(lcf::Data::states, i + 1);
+			if (state && (!require_states_persist || state->type == lcf::rpg::State::Persistence_persists)) {
+				affects_state = true;
+				break;
+			}
+		}
+	}
+
+	return affects_state;
+}
+
 } // namespace Algo

--- a/src/algo.h
+++ b/src/algo.h
@@ -181,6 +181,16 @@ int CalcSelfDestructEffect(const Game_Battler& source,
  */
 int CalcSkillCost(const lcf::rpg::Skill& skill, int max_sp, bool half_sp_cost);
 
+/*
+ * Determine whether a skill is usable.
+ *
+ * @param skill the skill to check
+ * @param require_states_persist If we should require persistent states for non-battle.
+ * @return Whether the skill can be used.
+ */
+bool IsSkillUsable(const lcf::rpg::Skill& skill,
+		bool require_states_persist);
+
 } // namespace Algo
 
 

--- a/src/algo.h
+++ b/src/algo.h
@@ -21,6 +21,7 @@
 #include <lcf/rpg/fwd.h>
 #include <lcf/rpg/system.h>
 #include <lcf/rpg/saveactor.h>
+#include <lcf/rpg/skill.h>
 #include "game_battler.h"
 
 class Game_Actor;
@@ -190,6 +191,17 @@ int CalcSkillCost(const lcf::rpg::Skill& skill, int max_sp, bool half_sp_cost);
  */
 bool IsSkillUsable(const lcf::rpg::Skill& skill,
 		bool require_states_persist);
+
+/**
+ * Checks if the skill is a normal or subskill type.
+ *
+ * @param skill the skill to check
+ * @return true if a normal skill or a 2k3 subskill.
+ */
+inline bool IsNormalOrSubskill(const lcf::rpg::Skill& skill) {
+	return skill.type == lcf::rpg::Skill::Type_normal
+		|| skill.type >= lcf::rpg::Skill::Type_subskill;
+}
 
 } // namespace Algo
 

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -189,20 +189,22 @@ bool Game_Actor::IsSkillUsable(int skill_id) const {
 		return false;
 	}
 
-	// Actor must have all attributes of the skill equipped as weapons
-	const lcf::rpg::Item* item = GetEquipment(lcf::rpg::Item::Type_weapon);
-	const lcf::rpg::Item* item2 = HasTwoWeapons() ? GetEquipment(lcf::rpg::Item::Type_weapon + 1) : nullptr;
+	if (!skill->affect_attr_defence) {
+		// Actor must have all attributes of the skill equipped as weapons
+		const auto* w1 = GetWeapon();
+		const auto* w2 = Get2ndWeapon();
 
-	for (size_t i = 0; i < skill->attribute_effects.size(); ++i) {
-		bool required = skill->attribute_effects[i] && lcf::Data::attributes[i].type == lcf::rpg::Attribute::Type_physical;
-		if (required) {
-			if (item && i < item->attribute_set.size() && item->attribute_set[i]) {
-				continue;
+		for (size_t i = 0; i < skill->attribute_effects.size(); ++i) {
+			bool required = skill->attribute_effects[i] && lcf::Data::attributes[i].type == lcf::rpg::Attribute::Type_physical;
+			if (required) {
+				if (w1 && i < w1->attribute_set.size() && w1->attribute_set[i]) {
+					continue;
+				}
+				if (w2 && i < w2->attribute_set.size() && w2->attribute_set[i]) {
+					continue;
+				}
+				return false;
 			}
-			if (item2 && i < item2->attribute_set.size() && item2->attribute_set[i]) {
-				continue;
-			}
-			return false;
 		}
 	}
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1154,7 +1154,6 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 
 	if (!(skill.type == lcf::rpg::Skill::Type_normal ||
 				skill.type >= lcf::rpg::Skill::Type_subskill)) {
-		assert(false && "Unsupported skill type");
 		this->success = false;
 		return this->success;
 	}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1152,8 +1152,7 @@ bool Game_BattleAlgorithm::Skill::Execute() {
 		return this->success;
 	}
 
-	if (!(skill.type == lcf::rpg::Skill::Type_normal ||
-				skill.type >= lcf::rpg::Skill::Type_subskill)) {
+	if (!Algo::IsNormalOrSubskill(skill)) {
 		this->success = false;
 		return this->success;
 	}

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -227,7 +227,7 @@ bool Game_Battler::UseSkill(int skill_id, const Game_Battler* source) {
 	bool was_used = false;
 	int revived = 0;
 
-	if (skill->type == lcf::rpg::Skill::Type_normal || skill->type >= lcf::rpg::Skill::Type_subskill) {
+	if (Algo::IsNormalOrSubskill(*skill)) {
 		// Only takes care of healing skills outside of battle,
 		// the other skill logic is in Game_BattleAlgorithm
 

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -374,8 +374,7 @@ bool Game_Party::IsSkillUsable(int skill_id, const Game_Actor* target, bool from
 		return !Game_Battle::IsBattleRunning() && Main_Data::game_system->GetAllowEscape() && Main_Data::game_targets->HasEscapeTarget() && !Main_Data::game_player->IsFlying();
 	} else if (skill->type == lcf::rpg::Skill::Type_teleport) {
 		return !Game_Battle::IsBattleRunning() && Main_Data::game_system->GetAllowTeleport() && Main_Data::game_targets->HasTeleportTargets() && !Main_Data::game_player->IsFlying();
-	} else if (skill->type == lcf::rpg::Skill::Type_normal ||
-		skill->type >= lcf::rpg::Skill::Type_subskill) {
+	} else if (Algo::IsNormalOrSubskill(*skill)) {
 		int scope = skill->scope;
 
 		if (Game_Battle::IsBattleRunning()) {

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -439,8 +439,6 @@ void Scene_Battle::AssignSkill(const lcf::rpg::Skill* skill, const lcf::rpg::Ite
 			ActionSelectedCallback(active_actor);
 			return;
 		}
-		case lcf::rpg::Skill::Type_normal:
-		case lcf::rpg::Skill::Type_subskill:
 		default:
 			break;
 	}

--- a/src/scene_skill.cpp
+++ b/src/scene_skill.cpp
@@ -17,6 +17,7 @@
 
 // Headers
 #include "scene_skill.h"
+#include "algo.h"
 #include "game_map.h"
 #include "game_party.h"
 #include "game_player.h"
@@ -65,7 +66,7 @@ void Scene_Skill::Update() {
 				Main_Data::game_party->UseSkill(skill_id, actor, actor);
 				Scene::PopUntil(Scene::Map);
 				Game_Map::SetNeedRefresh(true);
-			} else if (skill->type == lcf::rpg::Skill::Type_normal || skill->type >= lcf::rpg::Skill::Type_subskill) {
+			} else if (Algo::IsNormalOrSubskill(*skill)) {
 				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 				Scene::Push(std::make_shared<Scene_ActorTarget>(skill_id, actor_index));
 				skill_index = skill_window->GetIndex();

--- a/src/window_skill.cpp
+++ b/src/window_skill.cpp
@@ -121,7 +121,7 @@ bool Window_Skill::CheckInclude(int skill_id) {
 bool Window_Skill::CheckEnable(int skill_id) {
 	const Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
 
-	return actor->IsSkillLearned(skill_id) && Main_Data::game_party->IsSkillUsable(skill_id, actor);
+	return actor->IsSkillLearned(skill_id) && actor->IsSkillUsable(skill_id);
 }
 
 void Window_Skill::SetSubsetFilter(int subset) {


### PR DESCRIPTION
Taken from RE disassembly, which is a bit messy and hard to read here. Needs to be tested to verify.

Tests
-----------

Skill Usability Tests
- [x] Test all 3 Escape conditions
- [x] Test all 3 teleport conditions
- [x] Test switch skill + field and battle flags
- [x] Test states which limit physical and magical rate
- [x] Test all 5 scopes
- [x] Test affect none, hp only, mp only, both hp and mp
- [x] Test heals state which persists after battle
- [x] Test heals state which ends after battle
- [x] Test skill which has 1 physical attribute with and w/o equipment
- [x] Test skill which has 2 physical attribute with and w/o equipment
- [x] Test skill which shifts physical attribute with and w/o equipment
- [x] Test all above as skill in map / menu
- [x] Test all above as skill in battle
- [x] Test all above as skill item in map / menu
- [x] Test all above as skill item in battle
- [x] Test all above as equipment invoke skill item in map / menu
- [x] Test all above as equipment invoke skill item in battle

Item Usability Tests:
- [x] Medicine usability
- [x] Common and Equipment usability
- [x] Skill book
- [x] Seed
- [x] Switch item - with field and battle activiation flags
- [x] Live party member which can use item required for normal and subskill item skills but not escape, teleport, or switch

RPG_RT bugs ❗ 
--------------

See here: https://github.com/EasyRPG/Player/issues/1486#issuecomment-703376641