### PR TITLE
Battle 2k3: Process enemy actions first

### DIFF
--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -281,9 +281,6 @@ void Scene_Battle_Rpg2k3::Update() {
 
 				if (state != State_SelectEnemyTarget) {
 					int old_state = state;
-					if (state == State_SelectActor || state == State_AutoBattle) {
-						SelectNextActor();
-					}
 
 					if (old_state == state && battle_actions.empty()) {
 						// No actor got the turn
@@ -300,6 +297,10 @@ void Scene_Battle_Rpg2k3::Update() {
 								//FIXME: Do we need to handle invalid actions or empty action list here?
 							}
 						}
+					}
+
+					if (state == State_SelectActor || state == State_AutoBattle) {
+						SelectNextActor();
 					}
 				}
 			}


### PR DESCRIPTION
The enemy actions are processed first in RPG Maker 2003 battles now. This is crucial if the actor and the enemy have the same agility, in this case the enemy goes first. This fixes the first bullet point of #2147.