### PR TITLE
Cancel battle action if getting restriction state added by an event

### DIFF
--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -370,6 +370,9 @@ bool Game_Battler::AddState(int state_id, bool allow_battle_states) {
 	if (GetSignificantRestriction() != lcf::rpg::State::Restriction_normal) {
 		SetIsDefending(false);
 		SetCharged(false);
+		if (GetBattleAlgorithm() != nullptr) {
+			this->SetBattleAlgorithm(std::make_shared<Game_BattleAlgorithm::NoMove>(this));
+		}
 	}
 
 	return was_added;


### PR DESCRIPTION
This PR fixes #2169.

If a battler gets a restriction state added by an event his battle action gets canceled.