### PR TITLE
Battle 2k: Disable enemy flashing on no move restriction

### DIFF
--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -511,7 +511,9 @@ bool Scene_Battle_Rpg2k::ProcessActionBegin(Game_BattleAlgorithm::AlgorithmBase*
 		}
 
 		if (action->GetType() != Game_BattleAlgorithm::Type::Null || show_message) {
-			SelectionFlash(action->GetSource());
+			if (action->GetSource()->CanAct()) {
+				SelectionFlash(action->GetSource());
+			}
 		}
 
 		if (show_message) {


### PR DESCRIPTION
This PR fixes #2388.

If it is an enemy's turn in a RPG Maker 2000 battle and he has a state with a no move restriction, then he no longer flashes.