### PR TITLE
Implement (most of) Ineluki Key Patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,8 @@ add_library(${PROJECT_NAME} STATIC
 	src/game_enemyparty.h
 	src/game_event.cpp
 	src/game_event.h
+	src/game_ineluki.cpp
+	src/game_ineluki.h
 	src/game_interpreter_battle.cpp
 	src/game_interpreter_battle.h
 	src/game_interpreter.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -129,6 +129,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/game_enemyparty.h \
 	src/game_event.cpp \
 	src/game_event.h \
+	src/game_ineluki.cpp \
+	src/game_ineluki.h \
 	src/game_interpreter.cpp \
 	src/game_interpreter.h \
 	src/game_interpreter_battle.cpp \

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -755,6 +755,12 @@ bool FileFinder::IsRPG2kProjectWithRenames(DirectoryTree const& dir) {
 }
 
 bool FileFinder::HasSavegame() {
+	return GetSavegames() > 0;
+}
+
+int FileFinder::GetSavegames() {
+	int count = 0;
+
 	std::shared_ptr<FileFinder::DirectoryTree> tree = FileFinder::CreateSaveDirectoryTree();
 
 	for (int i = 1; i <= 15; i++) {
@@ -763,10 +769,10 @@ bool FileFinder::HasSavegame() {
 		std::string filename = FileFinder::FindDefault(*tree, ss.str());
 
 		if (!filename.empty()) {
-			return true;
+			++count;
 		}
 	}
-	return false;
+	return count;
 }
 
 std::string FileFinder::FindMusic(const std::string& name) {

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -302,6 +302,9 @@ namespace FileFinder {
 	 */
 	bool HasSavegame();
 
+	/** @returns Amount of savegames in the save directory */
+	int GetSavegames();
+
 	/**
 	 * Get the size of a file
 	 *

--- a/src/game_ineluki.cpp
+++ b/src/game_ineluki.cpp
@@ -254,14 +254,12 @@ void Game_Ineluki::Update() {
 
 	for (const auto& key : keylist_down) {
 		if (Input::IsRawKeyTriggered(key.key)) {
-			//Output::Debug("Key Down: {}", key.key, key.value);
 			output_list.push_back(key.value);
 		}
 	}
 
 	for (const auto& key : keylist_up) {
 		if (Input::IsRawKeyReleased(key.key)) {
-			//Output::Debug("Key Up: {}", key.key, key.value);
 			output_list.push_back(key.value);
 		}
 	}
@@ -277,7 +275,6 @@ void Game_Ineluki::Update() {
 			++cheat.index;
 			if (cheat.index >= cheat.keys.size()) {
 				output_list.push_back(cheat.value);
-				Output::Debug("Cheat enabled");
 				cheat.index = 0;
 			}
 		}

--- a/src/game_ineluki.cpp
+++ b/src/game_ineluki.cpp
@@ -285,7 +285,7 @@ void Game_Ineluki::Update() {
 		// There is no efficient way to check for wrong keys being pressed (no callback API)
 		if (Input::IsRawKeyPressed(cheat.keys[cheat.index])) {
 			++cheat.index;
-			if (cheat.index >= cheat.keys.size()) {
+			if (cheat.index >= static_cast<int>(cheat.keys.size())) {
 				output_list.push_back(cheat.value);
 				cheat.index = 0;
 			}

--- a/src/game_ineluki.cpp
+++ b/src/game_ineluki.cpp
@@ -54,7 +54,7 @@ bool Game_Ineluki::Execute(const std::string& ini_file) {
 	}
 
 	for (const auto& cmd : functions[ini_file]) {
-		Output::Debug("Ineluki {} {}", cmd.name, cmd.arg);
+		//Output::Debug("Ineluki {} {}", cmd.name, cmd.arg);
 
 		if (cmd.name == "writetolog") {
 			Output::InfoStr(cmd.arg);
@@ -102,8 +102,12 @@ bool Game_Ineluki::Execute(const std::string& ini_file) {
 		} else if (cmd.name == "enablemousesupport") {
 			mouse_support = Utils::LowerCase(cmd.arg) == "true";
 			mouse_id_prefix = atoi(cmd.arg2.c_str());
-			// automatic
+			// TODO: automatic (append mouse pos every 500ms) not implemented
 		} else if (cmd.name == "getmouseposition") {
+			if (!mouse_support) {
+				return true;
+			}
+
 			int mouse_x;
 			int mouse_y;
 
@@ -135,10 +139,11 @@ bool Game_Ineluki::ExecuteAutorunScript() {
 		return false;
 	}
 
+	Output::Debug("Ineluki: Processing autostart script");
+
 	std::string line = Utils::ReadLine(is);
 	while (!is.eof()) {
 		if (!line.empty()) {
-			Output::Debug("Ineluki: Autostart {}", line);
 			Execute(FileFinder::FindDefault(line));
 		}
 		line = Utils::ReadLine(is);
@@ -153,6 +158,8 @@ bool Game_Ineluki::Parse(const std::string& ini_file) {
 	if (ini.ParseError() == -1) {
 		return false;
 	}
+
+	Output::Debug("Ineluki: Parsing script {}", FileFinder::GetPathInsideGamePath(ini_file));
 
 	command_list commands;
 	std::string section = "execute";
@@ -224,16 +231,20 @@ int Game_Ineluki::GetMidiTicks() {
 }
 
 void Game_Ineluki::Update() {
+	if (!key_support) {
+		return;
+	}
+
 	for (const auto& key : keylist_down) {
 		if (Input::IsRawKeyTriggered(key.key)) {
-			Output::Debug("Key Down: {}", key.key, key.value);
+			//Output::Debug("Key Down: {}", key.key, key.value);
 			output_list.push_back(key.value);
 		}
 	}
 
 	for (const auto& key : keylist_up) {
 		if (Input::IsRawKeyReleased(key.key)) {
-			Output::Debug("Key Up: {}", key.key, key.value);
+			//Output::Debug("Key Up: {}", key.key, key.value);
 			output_list.push_back(key.value);
 		}
 	}

--- a/src/game_ineluki.cpp
+++ b/src/game_ineluki.cpp
@@ -343,12 +343,17 @@ void Game_Ineluki::Update() {
 			continue;
 		}
 
-		// FIXME: This does not reset the cheat when the wrong key is pressed
-		// There is no efficient way to check for wrong keys being pressed (no callback API)
 		if (Input::IsRawKeyPressed(cheat.keys[cheat.index])) {
 			++cheat.index;
 			if (cheat.index >= static_cast<int>(cheat.keys.size())) {
 				output_list.push_back(cheat.value);
+				cheat.index = 0;
+			}
+		} else if (cheat.index > 0) {
+			auto pressed = Input::GetAllRawPressed();
+			// Don't reset when the previous cheat key is (still) pressed
+			pressed[cheat.keys[cheat.index - 1]] = false;
+			if (pressed.any()) {
 				cheat.index = 0;
 			}
 		}

--- a/src/game_ineluki.cpp
+++ b/src/game_ineluki.cpp
@@ -1,0 +1,189 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Headers
+#include "game_ineluki.h"
+#include "filefinder.h"
+#include "utils.h"
+#include "output.h"
+#include "audio.h"
+#include "input.h"
+#include "player.h"
+
+#include <lcf/inireader.h>
+
+Game_Ineluki::Game_Ineluki() {
+
+}
+
+bool Game_Ineluki::Execute(const lcf::rpg::Sound& se) {
+	if (Utils::LowerCase(se.name) == "saves.script") {
+		// Support for the script written by SaveCount.dat
+		// It counts the amount of savegames and outputs the result
+		output_mode = OutputMode::Output;
+		// TODO
+		output_list.push_back(1);
+		return true;
+	}
+
+	if (functions.find(se.name) == functions.end()) {
+		if (!Parse(se)) {
+			return false;
+		}
+	}
+
+	for (const auto& cmd : functions[se.name]) {
+		Output::Debug("Ineluki {} {}", cmd.name, cmd.arg);
+
+		if (cmd.name == "writetolog") {
+			Output::InfoStr(cmd.arg);
+		} else if (cmd.name == "execprogram") {
+			// Fake execute some known programs
+			if (Utils::StartsWith(cmd.arg, "exitgame") ||
+					Utils::StartsWith(cmd.arg, "taskkill")) {
+				Player::exit_flag = true;
+			} else if (Utils::StartsWith(cmd.arg, "SaveCount.dat")) {
+				// no-op, detected through saves.script access
+			} else {
+				Output::Warning("Ineluki ExecProgram {}: Not supported", cmd.arg);
+			}
+		} else if (cmd.name == "mcicommand") {
+			Output::Warning("Ineluki MciProgram {}: Not supported", cmd.arg);
+		} else if (cmd.name == "miditickfunction") {
+			std::string arg = Utils::LowerCase(cmd.arg);
+			if (arg == "original") {
+				output_mode = OutputMode::Original;
+			} else if (arg == "output") {
+				output_mode = OutputMode::Output;
+			} else if (arg == "clear") {
+				output_list.clear();
+			}
+		} else if (cmd.name == "addoutput") {
+			output_list.push_back(atoi(cmd.arg.c_str()));
+		} else if (cmd.name == "enablekeysupport") {
+			key_support = Utils::LowerCase(cmd.arg) == "true";
+		} else if (cmd.name == "registerkeydownevent") {
+			// TODO
+		} else if (cmd.name == "registerkeyupevent") {
+			// TODO
+		} else if (cmd.name == "enablemousesupport") {
+			mouse_support = Utils::LowerCase(cmd.arg) == "true";
+			mouse_id_prefix = atoi(cmd.arg2.c_str());
+			// automatic
+		} else if (cmd.name == "getmouseposition") {
+			int mouse_x;
+			int mouse_y;
+
+			Input::GetMousePosition(mouse_x, mouse_y);
+
+			bool left = Input::IsKeyPressed(Input::Keys::MOUSE_LEFT);
+			bool right = Input::IsKeyPressed(Input::Keys::MOUSE_RIGHT);
+
+			int key = left && right ? 3 : right ? 2 : left ? 1 : 0;
+
+			output_list.push_back(key);
+			output_list.push_back(mouse_y);
+			output_list.push_back(mouse_x);
+			output_list.push_back(mouse_id_prefix);
+		} else if (cmd.name == "setdebuglevel") {
+			// no-op
+		}
+	}
+
+	return true;
+}
+
+bool Game_Ineluki::Parse(const lcf::rpg::Sound& se) {
+	std::string ini_file = FileFinder::FindSound(se.name);
+
+	auto is = FileFinder::OpenInputStream(ini_file);
+	lcf::INIReader ini(is);
+	if (ini.ParseError() == -1) {
+		return false;
+	}
+
+	command_list commands;
+	std::string section = "execute";
+
+	do {
+		InelukiCommand cmd;
+		cmd.name = Utils::LowerCase(ini.Get(section, "action", std::string()));
+		bool valid = true;
+
+		if (cmd.name == "writetolog") {
+			cmd.arg = ini.Get(section, "text", std::string());
+		} else if (cmd.name == "execprogram") {
+			cmd.arg = ini.Get(section, "command", std::string());
+		} else if (cmd.name == "mcicommand") {
+			cmd.arg = ini.Get(section, "command", std::string());
+		} else if (cmd.name == "miditickfunction") {
+			cmd.arg = ini.Get(section, "command", std::string());
+			if (cmd.arg.empty()) {
+				cmd.arg = ini.Get(section, "value", std::string());
+			}
+		} else if (cmd.name == "addoutput") {
+			cmd.arg = ini.Get(section, "value", std::string());
+		} else if (cmd.name == "enablekeysupport") {
+			cmd.arg = ini.Get(section, "enable", std::string());
+		} else if (cmd.name == "registerkeydownevent") {
+			cmd.arg = ini.Get(section, "key", std::string());
+			cmd.arg2 = ini.Get(section, "value", std::string());
+		} else if (cmd.name == "registerkeyupevent") {
+			cmd.arg = ini.Get(section, "key", std::string());
+			cmd.arg2 = ini.Get(section, "value", std::string());
+		} else if (cmd.name == "enablemousesupport") {
+			cmd.arg = ini.Get(section, "enable", std::string());
+			cmd.arg2 = ini.Get(section, "id", std::string());
+			cmd.arg3 = ini.Get(section, "automatic", std::string());
+		} else if (cmd.name == "getmouseposition") {
+			// no args
+		} else if (cmd.name == "setdebuglevel") {
+			cmd.arg = ini.Get(section, "level", std::string());
+		} else {
+			valid = false;
+		}
+
+		if (valid) {
+			commands.push_back(cmd);
+		}
+
+		section = ini.Get(section, "next", std::string());
+	} while (!section.empty());
+
+	functions[se.name] = commands;
+
+	return true;
+}
+
+int Game_Ineluki::GetMidiTicks() {
+	if (output_mode == OutputMode::Original) {
+		return Audio().BGM_GetTicks();
+	} else {
+		int val = 0;
+		if (!output_list.empty()) {
+			val = output_list.back();
+			output_list.pop_back();
+		}
+		return val;
+	}
+}
+
+void Game_Ineluki::Update() {
+	if (mouse_support) {
+
+	}
+}

--- a/src/game_ineluki.cpp
+++ b/src/game_ineluki.cpp
@@ -131,14 +131,14 @@ bool Game_Ineluki::Execute(StringView ini_file) {
 	return true;
 }
 
-bool Game_Ineluki::ExecuteAutorunScript() {
-	auto is = FileFinder::OpenInputStream(FileFinder::FindDefault("autorun.script"));
+bool Game_Ineluki::ExecuteScriptList(StringView list_file) {
+	auto is = FileFinder::OpenInputStream(ToString(list_file));
 
 	if (!is) {
 		return false;
 	}
 
-	Output::Debug("Ineluki: Processing autostart script");
+	Output::Debug("Ineluki: Processing script list {}", FileFinder::GetPathInsideGamePath(ToString(list_file)));
 
 	std::string line = Utils::ReadLine(is);
 	while (!is.eof()) {

--- a/src/game_ineluki.cpp
+++ b/src/game_ineluki.cpp
@@ -37,8 +37,7 @@ bool Game_Ineluki::Execute(const lcf::rpg::Sound& se) {
 		// Support for the script written by SaveCount.dat
 		// It counts the amount of savegames and outputs the result
 		output_mode = OutputMode::Output;
-		// TODO
-		output_list.push_back(1);
+		output_list.push_back(FileFinder::GetSavegames());
 		return true;
 	}
 

--- a/src/game_ineluki.cpp
+++ b/src/game_ineluki.cpp
@@ -24,6 +24,7 @@
 #include "audio.h"
 #include "input.h"
 #include "player.h"
+#include "system.h"
 
 #include <lcf/inireader.h>
 
@@ -86,6 +87,11 @@ bool Game_Ineluki::Execute(StringView ini_file) {
 			output_list.push_back(atoi(cmd.arg.c_str()));
 		} else if (cmd.name == "enablekeysupport") {
 			key_support = Utils::LowerCase(cmd.arg) == "true";
+#if !defined(SUPPORT_KEYBOARD)
+			if (key_support) {
+				Output::Warning("Ineluki: Keyboard input is not supported on this platform");
+			}
+#endif
 		} else if (cmd.name == "registerkeydownevent") {
 			std::string arg_lower = Utils::LowerCase(cmd.arg);
 			auto it = std::find_if(key_to_ineluki.begin(), key_to_ineluki.end(), [&](const auto& k) {
@@ -106,7 +112,13 @@ bool Game_Ineluki::Execute(StringView ini_file) {
 			mouse_support = Utils::LowerCase(cmd.arg) == "true";
 			mouse_id_prefix = atoi(cmd.arg2.c_str());
 			// TODO: automatic (append mouse pos every 500ms) not implemented
+#if !defined(USE_MOUSE) || !defined(SUPPORT_MOUSE)
+			if (mouse_support) {
+				Output::Debug("Ineluki: Mouse input is not supported on this platform");
+			}
+#endif
 		} else if (cmd.name == "getmouseposition") {
+#if defined(USE_MOUSE) && defined(SUPPORT_MOUSE)
 			if (!mouse_support) {
 				return true;
 			}
@@ -115,13 +127,13 @@ bool Game_Ineluki::Execute(StringView ini_file) {
 
 			bool left = Input::IsRawKeyPressed(Input::Keys::MOUSE_LEFT);
 			bool right = Input::IsRawKeyPressed(Input::Keys::MOUSE_RIGHT);
-
 			int key = left && right ? 3 : right ? 2 : left ? 1 : 0;
 
 			output_list.push_back(key);
 			output_list.push_back(mouse_pos.y);
 			output_list.push_back(mouse_pos.x);
 			output_list.push_back(mouse_id_prefix);
+#endif
 		} else if (cmd.name == "setdebuglevel") {
 			// no-op
 		} else if (cmd.name == "registercheatevent") {

--- a/src/game_ineluki.h
+++ b/src/game_ineluki.h
@@ -26,6 +26,7 @@
 #include <lcf/rpg/sound.h>
 
 #include "keys.h"
+#include "string_view.h"
 
 /**
  * Implements Ineluki's Key Patch
@@ -33,7 +34,7 @@
 class Game_Ineluki {
 public:
 	bool Execute(const lcf::rpg::Sound& se);
-	bool Execute(const std::string& ini_file);
+	bool Execute(StringView ini_file);
 
 	bool ExecuteAutorunScript();
 
@@ -42,7 +43,7 @@ public:
 	void Update();
 
 private:
-	bool Parse(const std::string& ini_file);
+	bool Parse(StringView ini_file);
 
 	struct InelukiCommand {
 		std::string name;

--- a/src/game_ineluki.h
+++ b/src/game_ineluki.h
@@ -1,0 +1,71 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_GAME_INELUKI_H
+#define EP_GAME_INELUKI_H
+
+// Headers
+#include <string>
+#include <vector>
+#include <map>
+
+#include <lcf/rpg/sound.h>
+
+#include "keys.h"
+
+/**
+ * Implements Ineluki's Key Patch
+ */
+class Game_Ineluki {
+public:
+	Game_Ineluki();
+
+	bool Execute(const lcf::rpg::Sound& se);
+
+	int GetMidiTicks();
+
+	void Update();
+
+private:
+	bool Parse(const lcf::rpg::Sound& se);
+
+	struct InelukiCommand {
+		std::string name;
+		std::string arg;
+		std::string arg2;
+		std::string arg3;
+	};
+
+	using command_list = std::vector<InelukiCommand>;
+
+	std::map<std::string, command_list> functions;
+
+	enum class OutputMode {
+		Original,
+		Output
+	};
+
+	OutputMode output_mode = OutputMode::Original;
+	std::vector<int> output_list;
+	std::vector<Input::Keys::InputKey> keylist;
+
+	bool key_support = false;
+	bool mouse_support = false;
+	int mouse_id_prefix = 0;
+};
+
+#endif

--- a/src/game_ineluki.h
+++ b/src/game_ineluki.h
@@ -32,16 +32,17 @@
  */
 class Game_Ineluki {
 public:
-	Game_Ineluki();
-
 	bool Execute(const lcf::rpg::Sound& se);
+	bool Execute(const std::string& ini_file);
+
+	bool ExecuteAutorunScript();
 
 	int GetMidiTicks();
 
 	void Update();
 
 private:
-	bool Parse(const lcf::rpg::Sound& se);
+	bool Parse(const std::string& ini_file);
 
 	struct InelukiCommand {
 		std::string name;
@@ -79,11 +80,11 @@ private:
 		const char* name;
 	};
 
-	static constexpr std::array<Mapping, 50> key_to_ineluki = {{
+	static constexpr std::array<Mapping, 61> key_to_ineluki = {{
 		{Input::Keys::LEFT, "(links)"},
 		{Input::Keys::RIGHT, "(rechts)"},
 		{Input::Keys::UP, "(oben)"},
-		{Input::Keys::DOWN, "(unten)"},
+		{Input::Keys::DOWN, "(runter)"},
 		{Input::Keys::A, "a"},
 		{Input::Keys::B, "b"},
 		{Input::Keys::C, "c"},
@@ -129,7 +130,19 @@ private:
 		{Input::Keys::HOME, "(pos1)"},
 		{Input::Keys::INSERT, "(einfg)"},
 		{Input::Keys::ESCAPE, "(esc)"},
-		{Input::Keys::RETURN, "(enter)"}
+		{Input::Keys::RETURN, "(enter)"},
+		{Input::Keys::SPACE, "(space)"},
+		{Input::Keys::BACKSPACE, "(backspace)"},
+		{Input::Keys::CTRL, "(strg)"},
+		{Input::Keys::ALT, "(alt)"},
+		{Input::Keys::CAPS_LOCK, "(capslock)"},
+		{Input::Keys::NUM_LOCK, "(numlock)"},
+		{Input::Keys::SCROLL_LOCK, "(scrolllock)"},
+		// FIXME: Why runter (down) and hoch (up)?
+		{Input::Keys::LSHIFT, "(lshift runter)"},
+		{Input::Keys::RSHIFT, "(rshift runter)"},
+		{Input::Keys::LSHIFT, "(lshift hoch)"},
+		{Input::Keys::RSHIFT, "(rshift hoch)"},
 	}};
 };
 

--- a/src/game_ineluki.h
+++ b/src/game_ineluki.h
@@ -20,6 +20,7 @@
 
 // Headers
 #include <string>
+#include <utility>
 #include <vector>
 #include <map>
 
@@ -27,6 +28,7 @@
 
 #include "keys.h"
 #include "string_view.h"
+#include "async_handler.h"
 
 /**
  * Implements Ineluki's Key Patch
@@ -190,6 +192,17 @@ private:
 		{Input::Keys::LSHIFT, "(lshift hoch)"},
 		{Input::Keys::RSHIFT, "(rshift hoch)"},
 	}};
+
+	void OnScriptFileReady(FileRequestResult* result);
+	struct AsyncArgs {
+		FileRequestBinding binding;
+		std::string script_name;
+		bool invoked = false;
+
+		AsyncArgs(FileRequestBinding binding, std::string script_name) :
+			binding(std::move(binding)), script_name(std::move(script_name)) {}
+	};
+	std::vector<AsyncArgs> async_scripts;
 };
 
 #endif

--- a/src/game_ineluki.h
+++ b/src/game_ineluki.h
@@ -33,16 +33,55 @@
  */
 class Game_Ineluki {
 public:
+	/**
+	 * Executes the specified sound effect (which is actually an INI file) as a keypatch script.
+	 * The file is not requested asynchroniously.
+	 *
+	 * @param se Sound Effect (INI file) to execute
+	 * @return Whether the file is a valid script
+	 */
 	bool Execute(const lcf::rpg::Sound& se);
+
+	/**
+	 * Executes the specified INI file as a keypatch script.
+	 * The file is not requested asynchroniously.
+	 *
+	 * @param ini_file INI file to execute
+	 * @return Whether the file is a valid script
+	 */
 	bool Execute(StringView ini_file);
 
-	bool ExecuteAutorunScript();
+	/**
+	 * Executes a file containing a list of script files.
+	 * Usually used for the autorun.script on startup.
+	 * The scripts are requested asynchroniously as important files and executed in
+	 * order but the file itself is not fetched.
+	 *
+	 * @param list_file File to process
+	 * @return Whether the file was found
+	 */
+	bool ExecuteScriptList(StringView list_file);
 
+	/**
+	 * Returns the normal midi ticks or an element from the output list depending
+	 * on the output state
+	 *
+	 * @return Midi Ticks or output list
+	 */
 	int GetMidiTicks();
 
+	/**
+	 * Updates the key up/down list. Must be called once per update frame.
+	 */
 	void Update();
 
 private:
+	/**
+	 * Parses and caches the script.
+	 *
+	 * @param ini_file Script to parse
+	 * @return Whether the file is a valid script
+	 */
 	bool Parse(StringView ini_file);
 
 	struct InelukiCommand {
@@ -53,11 +92,12 @@ private:
 	};
 
 	using command_list = std::vector<InelukiCommand>;
-
 	std::map<std::string, command_list> functions;
 
 	enum class OutputMode {
+		/** GetMidiTicks returns the audio ticks */
 		Original,
+		/** GetMidiTicks returns from the output list */
 		Output
 	};
 
@@ -65,11 +105,15 @@ private:
 	std::vector<int> output_list;
 
 	struct KeyList {
+		/** Key to watch */
 		Input::Keys::InputKey key;
+		/** Value to push when key event occurs */
 		int value;
 	};
 
+	/** List of key down events to watch */
 	std::vector<KeyList> keylist_down;
+	/** List of key up events to watch */
 	std::vector<KeyList> keylist_up;
 
 	bool key_support = false;
@@ -81,6 +125,7 @@ private:
 		const char* name;
 	};
 
+	/** Mapping from input key to Ineluki key (yes, they are German) */
 	static constexpr std::array<Mapping, 61> key_to_ineluki = {{
 		{Input::Keys::LEFT, "(links)"},
 		{Input::Keys::RIGHT, "(rechts)"},
@@ -139,7 +184,7 @@ private:
 		{Input::Keys::CAPS_LOCK, "(capslock)"},
 		{Input::Keys::NUM_LOCK, "(numlock)"},
 		{Input::Keys::SCROLL_LOCK, "(scrolllock)"},
-		// FIXME: Why runter (down) and hoch (up)?
+		// FIXME: Why does Ineluki have runter (down) and hoch (up)?
 		{Input::Keys::LSHIFT, "(lshift runter)"},
 		{Input::Keys::RSHIFT, "(rshift runter)"},
 		{Input::Keys::LSHIFT, "(lshift hoch)"},

--- a/src/game_ineluki.h
+++ b/src/game_ineluki.h
@@ -34,6 +34,8 @@
  */
 class Game_Ineluki {
 public:
+	~Game_Ineluki();
+
 	/**
 	 * Executes the specified sound effect (which is actually an INI file) as a keypatch script.
 	 * The file is not requested asynchroniously.

--- a/src/game_ineluki.h
+++ b/src/game_ineluki.h
@@ -61,11 +61,76 @@ private:
 
 	OutputMode output_mode = OutputMode::Original;
 	std::vector<int> output_list;
-	std::vector<Input::Keys::InputKey> keylist;
+
+	struct KeyList {
+		Input::Keys::InputKey key;
+		int value;
+	};
+
+	std::vector<KeyList> keylist_down;
+	std::vector<KeyList> keylist_up;
 
 	bool key_support = false;
 	bool mouse_support = false;
 	int mouse_id_prefix = 0;
+
+	struct Mapping {
+		Input::Keys::InputKey key;
+		const char* name;
+	};
+
+	static constexpr std::array<Mapping, 50> key_to_ineluki = {{
+		{Input::Keys::LEFT, "(links)"},
+		{Input::Keys::RIGHT, "(rechts)"},
+		{Input::Keys::UP, "(oben)"},
+		{Input::Keys::DOWN, "(unten)"},
+		{Input::Keys::A, "a"},
+		{Input::Keys::B, "b"},
+		{Input::Keys::C, "c"},
+		{Input::Keys::D, "d"},
+		{Input::Keys::E, "e"},
+		{Input::Keys::F, "f"},
+		{Input::Keys::G, "g"},
+		{Input::Keys::H, "h"},
+		{Input::Keys::I, "i"},
+		{Input::Keys::J, "j"},
+		{Input::Keys::K, "k"},
+		{Input::Keys::L, "l"},
+		{Input::Keys::M, "m"},
+		{Input::Keys::N, "n"},
+		{Input::Keys::O, "o"},
+		{Input::Keys::P, "p"},
+		{Input::Keys::Q, "q"},
+		{Input::Keys::R, "r"},
+		{Input::Keys::S, "s"},
+		{Input::Keys::T, "t"},
+		{Input::Keys::U, "u"},
+		{Input::Keys::V, "v"},
+		{Input::Keys::W, "w"},
+		{Input::Keys::X, "x"},
+		{Input::Keys::Y, "y"},
+		{Input::Keys::Z, "z"},
+		{Input::Keys::N0, "0"},
+		{Input::Keys::N1, "1"},
+		{Input::Keys::N2, "2"},
+		{Input::Keys::N3, "3"},
+		{Input::Keys::N4, "4"},
+		{Input::Keys::N5, "5"},
+		{Input::Keys::N6, "6"},
+		{Input::Keys::N7, "7"},
+		{Input::Keys::N8, "8"},
+		{Input::Keys::N9, "9"},
+		{Input::Keys::PERIOD, "."},
+		{Input::Keys::TAB, "(tab)"},
+		{Input::Keys::DEL, "(entf)"},
+		{Input::Keys::ENDS, "(ende)"},
+		{Input::Keys::PGDN, "(bildrunter)"},
+		{Input::Keys::PGUP, "(bildhoch)"},
+		{Input::Keys::HOME, "(pos1)"},
+		{Input::Keys::INSERT, "(einfg)"},
+		{Input::Keys::ESCAPE, "(esc)"},
+		{Input::Keys::RETURN, "(enter)"}
+	}};
 };
 
 #endif

--- a/src/game_ineluki.h
+++ b/src/game_ineluki.h
@@ -20,7 +20,6 @@
 
 // Headers
 #include <string>
-#include <utility>
 #include <vector>
 #include <map>
 
@@ -106,7 +105,7 @@ private:
 	OutputMode output_mode = OutputMode::Original;
 	std::vector<int> output_list;
 
-	struct KeyList {
+	struct KeyItem {
 		/** Key to watch */
 		Input::Keys::InputKey key;
 		/** Value to push when key event occurs */
@@ -114,9 +113,9 @@ private:
 	};
 
 	/** List of key down events to watch */
-	std::vector<KeyList> keylist_down;
+	std::vector<KeyItem> keylist_down;
 	/** List of key up events to watch */
-	std::vector<KeyList> keylist_up;
+	std::vector<KeyItem> keylist_up;
 
 	bool key_support = false;
 	bool mouse_support = false;
@@ -192,6 +191,18 @@ private:
 		{Input::Keys::LSHIFT, "(lshift hoch)"},
 		{Input::Keys::RSHIFT, "(rshift hoch)"},
 	}};
+
+	struct CheatItem {
+		/** Cheat code */
+		std::vector<Input::Keys::InputKey> keys;
+		/** Value to push when cheat was entered */
+		int value = 0;
+		/** Current index in the cheatcode */
+		int index = 0;
+
+		CheatItem(const std::string& code, int value);
+	};
+	std::vector<CheatItem> cheatlist;
 
 	void OnScriptFileReady(FileRequestResult* result);
 	struct AsyncArgs {

--- a/src/game_ineluki.h
+++ b/src/game_ineluki.h
@@ -126,11 +126,14 @@ private:
 		const char* name;
 	};
 
-	/** Mapping from input key to Ineluki key (yes, they are German) */
+	/**
+	 * Mapping from input key to Ineluki key (yes, they are German)
+	 * ä. ö, ü and other German keyboard keys are not supported
+	 */
 	static constexpr std::array<Mapping, 61> key_to_ineluki = {{
 		{Input::Keys::LEFT, "(links)"},
 		{Input::Keys::RIGHT, "(rechts)"},
-		{Input::Keys::UP, "(oben)"},
+		{Input::Keys::UP, "(hoch)"},
 		{Input::Keys::DOWN, "(runter)"},
 		{Input::Keys::A, "a"},
 		{Input::Keys::B, "b"},

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -28,6 +28,7 @@
 #include "game_map.h"
 #include "game_event.h"
 #include "game_enemyparty.h"
+#include "game_ineluki.h"
 #include "game_player.h"
 #include "game_targets.h"
 #include "game_switches.h"
@@ -1151,7 +1152,7 @@ bool Game_Interpreter::CommandControlVariables(lcf::rpg::EventCommand const& com
 					break;
 				case 8:
 					// MIDI play position
-					value = Audio().BGM_GetTicks();
+					value = Main_Data::game_ineluki->GetMidiTicks();
 					break;
 				case 9:
 					value = Main_Data::game_party->GetTimerSeconds(Main_Data::game_party->Timer2);

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -26,6 +26,7 @@
 #include "bitmap.h"
 #include "cache.h"
 #include "output.h"
+#include "game_ineluki.h"
 #include "transition.h"
 #include "main_data.h"
 #include "player.h"
@@ -129,8 +130,6 @@ void Game_System::BgmFade(int duration) {
 }
 
 void Game_System::SePlay(const lcf::rpg::Sound& se, bool stop_sounds) {
-	static bool ineluki_warning_shown = false;
-
 	if (se.name.empty()) {
 		return;
 	} else if (se.name == "(OFF)") {
@@ -143,12 +142,7 @@ void Game_System::SePlay(const lcf::rpg::Sound& se, bool stop_sounds) {
 	std::string end = ".script";
 	if (se.name.length() >= end.length() &&
 		0 == se.name.compare(se.name.length() - end.length(), end.length(), end)) {
-		if (!ineluki_warning_shown) {
-			Output::Warning("This game seems to use Ineluki's key patch to support "
-				"additional keys, mouse or scripts. Such patches are "
-				"unsupported, so this functionality will not work!");
-			ineluki_warning_shown = true;
-		}
+		Main_Data::game_ineluki->Execute(se);
 		return;
 	}
 

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -108,7 +108,7 @@ void Game_System::BgmPlay(lcf::rpg::Music const& bgm) {
 			Audio().BGM_Stop();
 			bgm_pending = true;
 			FileRequestAsync* request = AsyncHandler::RequestFile("Music", bgm.name);
-			music_request_id = request->Bind([this](auto* result) { OnBgmReady(result); });
+			music_request_id = request->Bind(&Game_System::OnBgmReady, this);
 			request->Start();
 		}
 	} else {
@@ -166,7 +166,7 @@ void Game_System::SePlay(const lcf::rpg::Sound& se, bool stop_sounds) {
 	}
 
 	FileRequestAsync* request = AsyncHandler::RequestFile("Sound", se.name);
-	se_request_ids[se.name] = request->Bind([=](auto* result) { OnSeReady(result, volume, tempo, stop_sounds); });
+	se_request_ids[se.name] = request->Bind(&Game_System::OnSeReady, this, volume, tempo, stop_sounds);
 	request->Start();
 }
 
@@ -199,7 +199,7 @@ void Game_System::OnChangeSystemGraphicReady(FileRequestResult* result) {
 
 void Game_System::ReloadSystemGraphic() {
 	FileRequestAsync* request = AsyncHandler::RequestFile("System", GetSystemName());
-	system_request_id = request->Bind([this](auto* result) { OnChangeSystemGraphicReady(result); });
+	system_request_id = request->Bind(&Game_System::OnChangeSystemGraphicReady, this);
 	request->SetImportantFile(true);
 	request->SetGraphicFile(true);
 	request->Start();

--- a/src/game_system.h
+++ b/src/game_system.h
@@ -484,6 +484,7 @@ public:
 	bool GetMessageEventMessageActive();
 private:
 	void OnBgmReady(FileRequestResult* result);
+	void OnBgmInelukiReady(FileRequestResult* result);
 	void OnSeReady(FileRequestResult* result, lcf::rpg::Sound se, bool stop_sounds);
 	void OnChangeSystemGraphicReady(FileRequestResult* result);
 private:

--- a/src/game_system.h
+++ b/src/game_system.h
@@ -484,7 +484,7 @@ public:
 	bool GetMessageEventMessageActive();
 private:
 	void OnBgmReady(FileRequestResult* result);
-	void OnSeReady(FileRequestResult* result, int volume, int tempo, bool stop_sounds);
+	void OnSeReady(FileRequestResult* result, lcf::rpg::Sound se, bool stop_sounds);
 	void OnChangeSystemGraphicReady(FileRequestResult* result);
 private:
 	lcf::rpg::SaveSystem data;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -73,6 +73,8 @@ void Input::Init(
 
 	source = Source::Create(std::move(buttons), std::move(directions), replay_from_path);
 	source->InitRecording(record_to_path);
+
+	ResetMask();
 }
 
 static void UpdateButton(int i, bool pressed) {
@@ -325,4 +327,38 @@ void Input::AddRecordingData(Input::RecordingData type, StringView data) {
 bool Input::IsRecording() {
 	assert(source);
 	return source->IsRecording();
+}
+
+Input::KeyStatus Input::GetMask() {
+	assert(source);
+	return source->GetMask();
+}
+
+void Input::SetMask(Input::KeyStatus new_mask) {
+	auto& old_mask = source->GetMask();
+
+#if defined(USE_MOUSE) && defined(SUPPORT_MOUSE)
+	if (!Player::mouse_flag) {
+		// Mask mouse input when mouse input is not enabled
+		constexpr std::array<Input::Keys::InputKey, 7> mouse_keys = {
+			Input::Keys::MOUSE_LEFT,
+			Input::Keys::MOUSE_RIGHT,
+			Input::Keys::MOUSE_MIDDLE,
+			Input::Keys::MOUSE_XBUTTON1,
+			Input::Keys::MOUSE_XBUTTON2,
+			Input::Keys::MOUSE_SCROLLUP,
+			Input::Keys::MOUSE_SCROLLDOWN
+		};
+		for (auto k: mouse_keys) {
+			new_mask[k] = true;
+		}
+	}
+#endif
+
+	old_mask = new_mask;
+}
+
+void Input::ResetMask() {
+	assert(source);
+	SetMask(source->GetMask());
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -46,7 +46,7 @@ namespace Input {
 
 	std::array<int, BUTTON_COUNT> press_time;
 	std::bitset<BUTTON_COUNT> triggered, repeated, released;
-	std::bitset<Input::Keys::KEYS_COUNT> raw_triggered, raw_pressed, raw_released;
+	Input::KeyStatus raw_triggered, raw_pressed, raw_released;
 	int dir4;
 	int dir8;
 	std::unique_ptr<Source> source;
@@ -313,6 +313,18 @@ bool Input::IsRawKeyTriggered(Input::Keys::InputKey key) {
 
 bool Input::IsRawKeyReleased(Input::Keys::InputKey key) {
 	return raw_released[key];
+}
+
+const Input::KeyStatus& Input::GetAllRawPressed() {
+	return raw_pressed;
+}
+
+const Input::KeyStatus& Input::GetAllRawTriggered() {
+	return raw_triggered;
+}
+
+const Input::KeyStatus& Input::GetAllRawReleased() {
+	return raw_released;
 }
 
 Point Input::GetMousePosition() {

--- a/src/input.h
+++ b/src/input.h
@@ -245,6 +245,27 @@ namespace Input {
 	bool IsRawKeyReleased(Input::Keys::InputKey key);
 
 	/**
+	 * Gets all raw keys being pressed.
+	 *
+	 * @return a vector with the key IDs.
+	 */
+	const Input::KeyStatus& GetAllRawPressed();
+
+	/**
+	 * Gets all raw keys being triggered.
+	 *
+	 * @return a vector with the key IDs.
+	 */
+	const Input::KeyStatus& GetAllRawTriggered();
+
+	/**
+	 * Gets all raw keys being released.
+	 *
+	 * @return a vector with the key IDs.
+	 */
+	const Input::KeyStatus& GetAllRawReleased();
+
+	/**
 	 * @return Position of the mouse cursor relative to the screen
 	 */
 	Point GetMousePosition();

--- a/src/input.h
+++ b/src/input.h
@@ -199,6 +199,24 @@ namespace Input {
 	 */
 	std::vector<InputButton> GetAllReleased();
 
+	/**
+	 * Returns the key mask for manipulation. When a bit is set the key is
+	 * ignored even if it is mapped. Only raw reads will return the key state.
+	 *
+	 * @return key mask
+	 */
+	Input::KeyStatus GetMask();
+
+	/**
+	 * @param new_mask The new key mask to set
+	 */
+	void SetMask(Input::KeyStatus new_mask);
+
+	/**
+	 * Resets the key mask. All keys are reported again.
+	 */
+	void ResetMask();
+
 	/*
 	 * Gets if a key is pressed.
 	 * Low level function accessing keys directly bypassing the button mapping.

--- a/src/input_source.cpp
+++ b/src/input_source.cpp
@@ -56,6 +56,10 @@ void Input::UiSource::DoUpdate(bool system_only) {
 	pressed_buttons = {};
 
 	for (auto& bm: button_mappings) {
+		if (keymask[bm.second]) {
+			continue;
+		}
+
 		if (!system_only || Input::IsSystemButton(bm.first)) {
 			pressed_buttons[bm.first] = pressed_buttons[bm.first] | keystates[bm.second];
 		}

--- a/src/input_source.h
+++ b/src/input_source.h
@@ -26,6 +26,8 @@
 #include "keys.h"
 
 namespace Input {
+	using KeyStatus = std::bitset<Input::Keys::KEYS_COUNT>;
+
 	enum class RecordingData : char {
 		CommandLine = 'C',
 		EventCommand = 'E', // unused - reserved
@@ -95,6 +97,9 @@ namespace Input {
 
 		Point GetMousePosition() const { return mouse_pos; }
 
+		const KeyStatus& GetMask() const { return keymask; }
+		KeyStatus& GetMask() { return keymask; }
+
 	protected:
 		void Record();
 
@@ -103,7 +108,8 @@ namespace Input {
 		DirectionMappingArray direction_mappings;
 		std::unique_ptr<Filesystem_Stream::OutputStream> record_log;
 
-		std::bitset<Input::Keys::KEYS_COUNT> keystates;
+		KeyStatus keystates;
+		KeyStatus keymask;
 		Point mouse_pos;
 
 		int last_written_frame = -1;

--- a/src/main_data.cpp
+++ b/src/main_data.cpp
@@ -22,6 +22,7 @@
 #include "game_actors.h"
 #include "game_party.h"
 #include "game_enemyparty.h"
+#include "game_ineluki.h"
 #include "game_player.h"
 #include "game_screen.h"
 #include "game_pictures.h"
@@ -69,6 +70,7 @@ namespace Main_Data {
 	std::unique_ptr<Game_EnemyParty> game_enemyparty;
 	std::unique_ptr<Game_Targets> game_targets;
 	std::unique_ptr<Game_Quit> game_quit;
+	std::unique_ptr<Game_Ineluki> game_ineluki;
 }
 
 void Main_Data::Init() {
@@ -169,6 +171,7 @@ void Main_Data::Cleanup() {
 	game_targets.reset();
 	game_quit.reset();
 	game_system.reset();
+	game_ineluki.reset();
 }
 
 const std::string& Main_Data::GetProjectPath() {

--- a/src/main_data.h
+++ b/src/main_data.h
@@ -37,6 +37,7 @@ class Game_Switches;
 class Game_Variables;
 class Game_Targets;
 class Game_Quit;
+class Game_Ineluki;
 
 namespace Main_Data {
 	// Dynamic Game lcf::Data
@@ -51,6 +52,7 @@ namespace Main_Data {
 	extern std::unique_ptr<Game_EnemyParty> game_enemyparty;
 	extern std::unique_ptr<Game_Targets> game_targets;
 	extern std::unique_ptr<Game_Quit> game_quit;
+	extern std::unique_ptr<Game_Ineluki> game_ineluki;
 
 	void Init();
 	void Cleanup();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -844,6 +844,8 @@ void Player::ResetGameObjects() {
 	Game_Clock::ResetFrame(Game_Clock::now());
 
 	Main_Data::game_system->ReloadSystemGraphic();
+
+	Input::ResetMask();
 }
 
 static bool DefaultLmuStartFileExists(const FileFinder::DirectoryTree& dir) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -809,7 +809,7 @@ void Player::CreateGameObjects() {
 
 	ResetGameObjects();
 
-	Main_Data::game_ineluki->ExecuteAutorunScript();
+	Main_Data::game_ineluki->ExecuteScriptList(FileFinder::FindDefault("autorun.script"));
 }
 
 void Player::ResetGameObjects() {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -54,6 +54,7 @@
 #include "game_map.h"
 #include "game_message.h"
 #include "game_enemyparty.h"
+#include "game_ineluki.h"
 #include "game_party.h"
 #include "game_player.h"
 #include "game_switches.h"
@@ -830,6 +831,7 @@ void Player::ResetGameObjects() {
 	Main_Data::game_party = std::make_unique<Game_Party>();
 	Main_Data::game_player = std::make_unique<Game_Player>();
 	Main_Data::game_quit = std::make_unique<Game_Quit>();
+	Main_Data::game_ineluki.reset(new Game_Ineluki());
 
 	DynRpg::Reset();
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -372,6 +372,10 @@ void Player::Update(bool update_scene) {
 
 	if (update_scene) {
 		Scene::instance->Update();
+
+		if (Main_Data::game_ineluki) {
+			Main_Data::game_ineluki->Update();
+		}
 	}
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -371,11 +371,11 @@ void Player::Update(bool update_scene) {
 	}
 
 	if (update_scene) {
-		Scene::instance->Update();
-
 		if (Main_Data::game_ineluki) {
 			Main_Data::game_ineluki->Update();
 		}
+
+		Scene::instance->Update();
 	}
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -808,6 +808,8 @@ void Player::CreateGameObjects() {
 	}
 
 	ResetGameObjects();
+
+	Main_Data::game_ineluki->ExecuteAutorunScript();
 }
 
 void Player::ResetGameObjects() {
@@ -835,7 +837,7 @@ void Player::ResetGameObjects() {
 	Main_Data::game_party = std::make_unique<Game_Party>();
 	Main_Data::game_player = std::make_unique<Game_Player>();
 	Main_Data::game_quit = std::make_unique<Game_Quit>();
-	Main_Data::game_ineluki.reset(new Game_Ineluki());
+	Main_Data::game_ineluki = std::make_unique<Game_Ineluki>();
 
 	DynRpg::Reset();
 

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -126,10 +126,13 @@ void Scene_Logo::OnIndexReady(FileRequestResult*) {
 	exfont->SetImportantFile(true);
 	FileRequestAsync* soundfont = AsyncHandler::RequestFile("easyrpg.soundfont");
 	soundfont->SetImportantFile(true);
+	FileRequestAsync* autorun_ineluki = AsyncHandler::RequestFile("autorun.script");
+	autorun_ineluki->SetImportantFile(true);
 
 	db->Start();
 	tree->Start();
 	ini->Start();
 	exfont->Start();
 	soundfont->Start();
+	autorun_ineluki->Start();
 }

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -67,7 +67,7 @@ void Scene_Title::Continue(SceneType prev_scene) {
 		AudioSeCache::Clear();
 
 		Player::ResetGameObjects();
-		Main_Data::game_ineluki->ExecuteAutorunScript();
+		Main_Data::game_ineluki->ExecuteScriptList(FileFinder::FindDefault("autorun.script"));
 
 		Start();
 	} else if (CheckEnableTitleGraphicAndMusic()) {

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -24,6 +24,7 @@
 #include "audio_secache.h"
 #include "cache.h"
 #include "game_battle.h"
+#include "game_ineluki.h"
 #include "game_screen.h"
 #include "game_system.h"
 #include "transition.h"
@@ -66,6 +67,7 @@ void Scene_Title::Continue(SceneType prev_scene) {
 		AudioSeCache::Clear();
 
 		Player::ResetGameObjects();
+		Main_Data::game_ineluki->ExecuteAutorunScript();
 
 		Start();
 	} else if (CheckEnableTitleGraphicAndMusic()) {

--- a/src/sdl2_ui.cpp
+++ b/src/sdl2_ui.cpp
@@ -637,9 +637,6 @@ void Sdl2Ui::ProcessMouseMotionEvent(SDL_Event& evnt) {
 
 void Sdl2Ui::ProcessMouseWheelEvent(SDL_Event& evnt) {
 #if defined(USE_MOUSE) && defined(SUPPORT_MOUSE)
-	if (!Player::mouse_flag)
-		return;
-
 	// Ignore Finger (touch) events here
 	if (evnt.wheel.which == SDL_TOUCH_MOUSEID)
 		return;
@@ -660,9 +657,6 @@ void Sdl2Ui::ProcessMouseWheelEvent(SDL_Event& evnt) {
 
 void Sdl2Ui::ProcessMouseButtonEvent(SDL_Event& evnt) {
 #if defined(USE_MOUSE) && defined(SUPPORT_MOUSE)
-	if (!Player::mouse_flag)
-		return;
-
 	// Ignore Finger (touch) events here
 	if (evnt.button.which == SDL_TOUCH_MOUSEID)
 		return;


### PR DESCRIPTION
Can we agree on that this fixes #1181 and  #1367 even though there are more problems here?
Imo there can be new issues opened when they occur.

For #1181 not all ExecProgram calls are supported.
#1367 also has a patches exe to skip the title screen and load the first save, not related to Ineluki.

Limitations:
- ``ExecProgram`` not supported except for some specific programs that are HLE'ed
- ``MciProgram`` not supported
- Only alphanumeric and some special keys supported. This doesn't map properly to the key codes because Ineluki was written with a German keyboard in mind
- Cheat support does not reset when wrong key is pressed, needs some kind of input callback API, polling is ugly and highly inefficient here.

Problems:
- Mouse support needs ``--enable-mouse`` argument and this binds clicks and wheel to confirm and other stuff. So it conflicts with the patch
- WSAD conflict. We use them for walking but in RPG_RT they are not mapped.

Ideas are welcome about how to resolve the problems.

Tests:
- https://easyrpg.org/play/pr2397/?game=ineluki&enable-mouse
- https://easyrpg.org/play/pr2397/?game=ineluki_autorun&enable-mouse - Tests that the autorun.script is executed on startup
- https://easyrpg.org/play/pr2397/?game=calm_falls MP3 link file support in the web player (vs. before https://easyrpg.org/play/?game=calm_falls )

Best for testing are the two samples at the bottom:
- Diablo-Like Mouse control (click to walk)
- Tasten Test (Key Test) - Prints the Key ID
