### PR TITLE
Add snapcraft recipe

### DIFF
--- a/builds/snap/snapcraft.yaml
+++ b/builds/snap/snapcraft.yaml
@@ -38,6 +38,9 @@ parts:
     plugin: autotools
     source: https://github.com/EasyRPG/liblcf
     source-type: git
+    build-environment:
+      - CXXFLAGS: "$CXXFLAGS -fuse-ld=gold -flto=$(nproc) -ffunction-sections -fdata-sections"
+      - LDFLAGS:  "$LDFLAGS  -fuse-ld=gold -flto=$(nproc) -Wl,--gc-sections"
     autotools-configure-parameters:
       - --prefix=/usr
       - --disable-static
@@ -117,6 +120,9 @@ parts:
     plugin: cmake
     source: https://github.com/Mindwerks/wildmidi
     source-type: git
+    build-environment:
+      - CXXFLAGS: "$CXXFLAGS -fuse-ld=gold -flto=$(nproc) -ffunction-sections -fdata-sections"
+      - LDFLAGS:  "$LDFLAGS  -fuse-ld=gold -flto=$(nproc) -Wl,--gc-sections"
     cmake-parameters:
       - -DCMAKE_BUILD_TYPE=Release
       - -DBUILD_SHARED_LIBS=ON

--- a/builds/snap/snapcraft.yaml
+++ b/builds/snap/snapcraft.yaml
@@ -114,7 +114,6 @@ parts:
       - libwayland-egl1-mesa
       - libwildmidi-config
       - libxmp4
-      - locales-all
 
   libwildmidi:
     plugin: cmake
@@ -135,5 +134,3 @@ parts:
     plugin: make
     build-packages:
       - libglib2.0-dev
-    stage-packages:
-      - libglib2.0-bin

--- a/builds/snap/snapcraft.yaml
+++ b/builds/snap/snapcraft.yaml
@@ -44,11 +44,10 @@ parts:
     autotools-configure-parameters:
       - --prefix=/usr
       - --disable-static
+      - --disable-tools
     override-build: |
       git fetch
       snapcraftctl build
-      strip --strip-all $SNAPCRAFT_PART_INSTALL/usr/bin/lcf2xml
-      strip --strip-all $SNAPCRAFT_PART_INSTALL/usr/bin/lcfstrings
       strip --strip-all $SNAPCRAFT_PART_INSTALL/usr/lib/liblcf.so.0.0.0
     build-packages:
       - libexpat1-dev
@@ -75,7 +74,7 @@ parts:
       if [ "${last_committed_tag}" != "${last_released_tag}" ]; then
         git fetch
         git checkout -f "${last_committed_tag}"
-        snapcraftctl set-version $(git -C ../src tag --list | head -n1)
+        snapcraftctl set-version $(git -C ../src tag --list | tail -n1)
       else
         snapcraftctl set-version $(git describe | sed 's/desc\///')
       fi
@@ -93,7 +92,6 @@ parts:
       - libsndfile1-dev
       - libsdl2-dev
       - libsdl2-mixer-dev
-      - libsdl2-ttf-dev
       - libspeexdsp-dev
       - libvorbis-dev
       - libxmp-dev
@@ -108,9 +106,9 @@ parts:
       - libglu1-mesa
       - libopusfile0
       - libpixman-1-0
+      - libpng16-16
       - libsdl2-2.0-0
       - libsdl2-mixer-2.0-0
-      - libsdl2-ttf-2.0-0
       - libsndfile1
       - libspeexdsp1
       - libvorbis0a

--- a/builds/snap/snapcraft.yaml
+++ b/builds/snap/snapcraft.yaml
@@ -47,6 +47,9 @@ parts:
     override-build: |
       git fetch
       snapcraftctl build
+      strip --strip-all $SNAPCRAFT_PART_INSTALL/usr/bin/lcf2xml
+      strip --strip-all $SNAPCRAFT_PART_INSTALL/usr/bin/lcfstrings
+      strip --strip-all $SNAPCRAFT_PART_INSTALL/usr/lib/liblcf.so.0.0.0
     build-packages:
       - libexpat1-dev
       - libicu-dev
@@ -77,6 +80,7 @@ parts:
         snapcraftctl set-version $(git describe | sed 's/desc\///')
       fi
       snapcraftctl build
+      strip --strip-all $SNAPCRAFT_PART_INSTALL/usr/bin/easyrpg-player
 
     build-packages:
       - libfmt-dev
@@ -99,7 +103,6 @@ parts:
       - libfreetype6
       - libharfbuzz0b
       - libmpg123-0
-      - libstdc++6
       - libgl1-mesa-dri
       - libgl1-mesa-glx
       - libglu1-mesa

--- a/builds/snap/snapcraft.yaml
+++ b/builds/snap/snapcraft.yaml
@@ -40,6 +40,7 @@ parts:
     source-type: git
     autotools-configure-parameters:
       - --prefix=/usr
+      - --disable-static
     override-build: |
       git fetch
       snapcraftctl build
@@ -55,18 +56,20 @@ parts:
     after: [libwildmidi,liblcf,desktop-glib-only]
     source: https://github.com/EasyRPG/Player
     source-type: git
+    build-environment:
+      - CXXFLAGS: "$CXXFLAGS -fuse-ld=gold -flto=$(nproc) -ffunction-sections -fdata-sections"
+      - LDFLAGS:  "$LDFLAGS  -fuse-ld=gold -flto=$(nproc) -Wl,--gc-sections"
     autotools-configure-parameters:
       - --prefix=/usr
     override-build: |
-      last_committed_tag="$(git tag --list | tac | head -n1)"
-      trimmed_tag="$(echo $last_committed_tag | sed 's/desc\///' | sed 's/git//' | sed 's/^v//')"
+      last_committed_tag="$(git tag --list | tail -n1)"
       last_released_tag="$(snap info easyrpg-player | awk '$1 == "latest/beta:" { print $2 }')"
       # If the latest tag from the upstream project has not been released to
       # beta, build that tag instead of master.
-      if [ "${trimmed_tag}" != "${last_released_tag}" ]; then
+      if [ "${last_committed_tag}" != "${last_released_tag}" ]; then
         git fetch
         git checkout -f "${last_committed_tag}"
-        snapcraftctl set-version $(git -C ../src tag --list | tac | head -n1 | sed 's/desc\///' | sed 's/git//' | sed 's/^v//')
+        snapcraftctl set-version $(git -C ../src tag --list | head -n1)
       else
         snapcraftctl set-version $(git describe | sed 's/desc\///')
       fi
@@ -80,10 +83,10 @@ parts:
       - libopusfile-dev
       - libpixman-1-dev
       - libpng-dev
+      - libsndfile1-dev
       - libsdl2-dev
       - libsdl2-mixer-dev
       - libsdl2-ttf-dev
-      - libsndfile1-dev
       - libspeexdsp-dev
       - libvorbis-dev
       - libxmp-dev
@@ -92,14 +95,13 @@ parts:
       - freepats
       - libfreetype6
       - libharfbuzz0b
-      - libmpg123-dev
+      - libmpg123-0
       - libstdc++6
       - libgl1-mesa-dri
       - libgl1-mesa-glx
       - libglu1-mesa
       - libopusfile0
       - libpixman-1-0
-      - libpng16-16
       - libsdl2-2.0-0
       - libsdl2-mixer-2.0-0
       - libsdl2-ttf-2.0-0
@@ -117,12 +119,10 @@ parts:
     source-type: git
     cmake-parameters:
       - -DCMAKE_BUILD_TYPE=Release
-      - -DBUILD_SHARED_LIBS=OFF
-      - -DWANT_PLAYER=ON
-      - -DWANT_STATIC=ON
-    stage-packages:
-      - libasound2
- 
+      - -DBUILD_SHARED_LIBS=ON
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DWANT_PLAYER=OFF
+
   desktop-glib-only:
     source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
     source-subdir: glib-only

--- a/builds/snap/snapcraft.yaml
+++ b/builds/snap/snapcraft.yaml
@@ -1,0 +1,134 @@
+name: easyrpg-player
+base: core20
+adopt-info: easyrpg-player
+summary: easyrpg-player
+description: |
+    EasyRPG Player is a program that allows to play games created with RPG Maker 2000 and 2003.
+    EasyRPG is developed by the amazing people running the [EasyRPG project](https://easyrpg.org/).
+
+    It aims to be a free (as in freedom) cross-platform RPG Maker 2000/2003 interpreter.
+    The main goal is to play all games created with them as the original game interpreter (RPG_RT) does.
+confinement: strict
+grade: stable
+
+apps:
+  easyrpg-player:
+    command: bin/desktop-launch $SNAP/usr/bin/easyrpg-player
+    plugs:
+      - x11
+      - wayland
+      - unity7
+      - opengl
+      - audio-playback
+      - joystick
+      - home
+
+    environment:
+      XDG_DATA_HOME: $SNAP_USER_COMMON/
+      DBUS_FATAL_WARNINGS: 0
+
+layout:
+  /etc/wildmidi:
+    bind: $SNAP/etc/wildmidi
+  /usr/share/midi/freepats:
+    bind: $SNAP/usr/share/midi/freepats
+
+parts:
+  liblcf:
+    plugin: autotools
+    source: https://github.com/EasyRPG/liblcf
+    source-type: git
+    autotools-configure-parameters:
+      - --prefix=/usr
+    override-build: |
+      git fetch
+      git checkout 0.6.2
+      snapcraftctl build
+    build-packages:
+      - libexpat1-dev
+      - libicu-dev
+      - icu-devtools
+    stage-packages:
+      - libicu66
+
+  easyrpg-player:   
+    plugin: autotools
+    after: [libwildmidi,liblcf,desktop-glib-only]
+    source: https://github.com/EasyRPG/Player
+    source-type: git
+    autotools-configure-parameters:
+      - --prefix=/usr
+    override-build: |
+      last_committed_tag="$(git tag --list | tac | head -n1)"
+      trimmed_tag="$(echo $last_committed_tag | sed 's/desc\///' | sed 's/git//' | sed 's/^v//')"
+      last_released_tag="$(snap info easyrpg-player | awk '$1 == "latest/beta:" { print $2 }')"
+      # If the latest tag from the upstream project has not been released to
+      # beta, build that tag instead of master.
+      if [ "${trimmed_tag}" != "${last_released_tag}" ]; then
+        git fetch
+        git checkout -f "${last_committed_tag}"
+        snapcraftctl set-version $(git -C ../src tag --list | tac | head -n1 | sed 's/desc\///' | sed 's/git//' | sed 's/^v//')
+      else
+        snapcraftctl set-version $(git describe | sed 's/desc\///')
+      fi
+      snapcraftctl build
+
+    build-packages:
+      - libfmt-dev
+      - libfreetype6-dev
+      - libharfbuzz-dev
+      - libmpg123-dev
+      - libopusfile-dev
+      - libpixman-1-dev
+      - libpng-dev
+      - libsdl2-dev
+      - libsdl2-mixer-dev
+      - libsdl2-ttf-dev
+      - libsndfile1-dev
+      - libspeexdsp-dev
+      - libvorbis-dev
+      - libxmp-dev
+
+    stage-packages:
+      - freepats
+      - libfreetype6
+      - libharfbuzz0b
+      - libmpg123-dev
+      - libstdc++6
+      - libgl1-mesa-dri
+      - libgl1-mesa-glx
+      - libglu1-mesa
+      - libopusfile0
+      - libpixman-1-0
+      - libpng16-16
+      - libsdl2-2.0-0
+      - libsdl2-mixer-2.0-0
+      - libsdl2-ttf-2.0-0
+      - libsndfile1
+      - libspeexdsp1
+      - libvorbis0a
+      - libwayland-egl1-mesa
+      - libwildmidi-config
+      - libxmp4
+      - locales-all
+
+  libwildmidi:
+    plugin: cmake
+    source: https://github.com/Mindwerks/wildmidi
+    source-type: git
+    cmake-parameters:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=OFF
+      - -DWANT_PLAYER=ON
+      - -DWANT_STATIC=ON
+    stage-packages:
+      - libasound2
+ 
+  desktop-glib-only:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: glib-only
+    plugin: make
+    build-packages:
+      - libglib2.0-dev
+    stage-packages:
+      - libglib2.0-bin

--- a/builds/snap/snapcraft.yaml
+++ b/builds/snap/snapcraft.yaml
@@ -42,7 +42,6 @@ parts:
       - --prefix=/usr
     override-build: |
       git fetch
-      git checkout 0.6.2
       snapcraftctl build
     build-packages:
       - libexpat1-dev


### PR DESCRIPTION
Last weekend, I added the EasyRPG Player to the Snap Store (https://snapcraft.io/easyrpg-player) in order to make current EasyRPG Player easily available on Ubuntu and other Linux distributions.

For reference, this is the recipe used to build the snap package.

I'm planning to keep this package up-to-date in the future (since I really like the EasyRPG player) and backport all changes into this repository.

However, if you prefer to publish this under your own name/organisation, please ping me and I'll arrange a transfer of the Snap ownership (yes, it's a bit unfortunate that the Snap Store calls me "Developer" rather than "Publisher").