### PR TITLE
Change random movement behavior

### DIFF
--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -465,7 +465,8 @@ void Game_Event::UpdateNextMovementAction() {
 
 void Game_Event::SetMaxStopCountForRandom() {
 	auto st = GetMaxStopCountForStep(GetMoveFrequency());
-	st *= (Rand::GetRandomNumber(0, 3) + 3) / 5;
+	st *= Rand::GetRandomNumber(0, 3) + 3;
+	st /= 5;
 	SetMaxStopCount(st);
 }
 


### PR DESCRIPTION
This PR fixes #2424. The cause where an event with movement behavior set the random moves more than one tile at a move frequency below 8 is because the random stop count multiplier sometimes returns a straight zero which means that the event will not wait before the next move. Changing the divisor from 5 (int) to 5.0 (double) stops the random stop count multiplier returning zero, which fixes the issue mentioned above. Move frequency 8 (uninterrupted movement) is not affected by #2424 and this PR because in this case the stop count is always zero regardless of the stop count multiplier.