### PR TITLE
Unset system2_name on game exit

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -518,6 +518,8 @@ void Cache::Clear() {
 	}
 
 	cache_tiles.clear();
+
+	system2_name.clear();
 }
 
 void Cache::SetSystemName(std::string filename) {


### PR DESCRIPTION
This PR fixes an [issue mentioned in #1524](https://github.com/EasyRPG/Player/issues/1524#issuecomment-707856405). The change here is that `system2_name` is cleared after exiting a game. This is necessary because as soon as you enter a RPG Maker 2003 battle, the `system2_name` will be set and "locked". This means the `system2_name` is only being set if the `system2_name` is not set when you enter a RPG Maker 2003 battle which leads to the bug mentioned in the link. Unsetting `system2_name` on game exit fixes this.