### PR TITLE
Fix EXP table on actors with changed classes on savegame loading

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -106,6 +106,7 @@ void Game_Actor::SetSaveData(lcf::rpg::SaveActor save) {
 		data.super_guard = dbActor->super_guard;
 	}
 
+	MakeExpList();
 	Fixup();
 }
 


### PR DESCRIPTION
This PR fixes a regression in relation to savegame loading: If a RPG Maker 2003 savegame gets loaded then any actors with changed classes used the default EXP table instead of the EXP table of the current class. Adding the `MakeExpList()` function fixes this.