### PR TITLE
Android: Opt out of scoped storage nonsense

### DIFF
--- a/builds/android/app/src/main/AndroidManifest.xml
+++ b/builds/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
 
     <application
         android:allowBackup="true"
+        android:requestLegacyExternalStorage="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme">


### PR DESCRIPTION
 (for now, until Google forces us to use API30)

Fix #2415