### PR TITLE
Fix random movement behavior on locked face direction

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -497,15 +497,15 @@ bool Game_Character::Move(int dir) {
 }
 
 void Game_Character::Turn90DegreeLeft() {
-	SetDirection(GetDirection90DegreeLeft(GetFacing()));
+	SetDirection(GetDirection90DegreeLeft(GetDirection()));
 }
 
 void Game_Character::Turn90DegreeRight() {
-	SetDirection(GetDirection90DegreeRight(GetFacing()));
+	SetDirection(GetDirection90DegreeRight(GetDirection()));
 }
 
 void Game_Character::Turn180Degree() {
-	SetDirection(GetDirection180Degree(GetFacing()));
+	SetDirection(GetDirection180Degree(GetDirection()));
 }
 
 void Game_Character::Turn90DegreeLeftOrRight() {


### PR DESCRIPTION
The random movement behavior uses the current move direction instead of the current face direction now if the face direction is locked. This fixes the bug which disallows the event moving towards the direction he is facing if the face direction is locked and the
movement type is set random movement.

Fixes: #2436