### PR TITLE
Savegame window system graphic fix

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -973,11 +973,6 @@ void Player::LoadSavegame(const std::string& save_name, int save_id) {
 	Output::Debug("Loading Save {}", FileFinder::GetPathInsidePath(Main_Data::GetSavePath(), save_name));
 	Main_Data::game_system->BgmFade(800);
 
-	// We erase the screen now before loading the saved game. This prevents an issue where
-	// if the save game has a different system graphic, the load screen would change before
-	// transitioning out.
-	Transition::instance().InitErase(Transition::TransitionFadeOut, Scene::instance.get(), 6);
-
 	auto title_scene = Scene::Find(Scene::Title);
 	if (title_scene) {
 		static_cast<Scene_Title*>(title_scene.get())->OnGameStart();

--- a/src/window_savefile.cpp
+++ b/src/window_savefile.cpp
@@ -142,6 +142,7 @@ void Window_SaveFile::Refresh() {
 }
 
 void Window_SaveFile::Update() {
-	Window_Base::Update();
+	Window::Update();
+	Window_Base::UpdateMovement();
 	UpdateCursorRect();
 }


### PR DESCRIPTION
The system graphic is no longer changed in the load menu before the fadeout happens. This fixes the second bug mentioned in #2337.