### PR TITLE
Disallow system updates on closing windows

### DIFF
--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -381,7 +381,7 @@ void Window_Message::Update() {
 
 	const bool was_closing = IsClosing();
 
-	Window_Selectable::Update();
+	Window_Selectable::Update(IsClosing());
 	number_input_window->Update();
 	gold_window->Update();
 

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -123,8 +123,13 @@ void Window_Selectable::UpdateArrows() {
 }
 
 // Update
-void Window_Selectable::Update() {
-	Window_Base::Update();
+void Window_Selectable::Update(bool block_system_change) {
+	if (block_system_change) {
+		Window::Update();
+		Window_Base::UpdateMovement();
+	} else {
+		Window_Base::Update();
+	}
 	if (active && item_max > 0 && index >= 0) {
 		if (Input::IsRepeated(Input::DOWN) || Input::IsTriggered(Input::SCROLL_DOWN)) {
 			if (index < item_max - column_max || column_max == 1) {

--- a/src/window_selectable.h
+++ b/src/window_selectable.h
@@ -69,7 +69,7 @@ public:
 	 */
 	void SetHelpWindow(Window_Help* nhelp_window);
 	virtual void UpdateCursorRect();
-	void Update() override;
+	void Update(bool block_system_change = false);
 
 	virtual void UpdateHelp();
 


### PR DESCRIPTION
System changes are applied now after the window has been closed. This fixes a cosmetic bug in "Vampires Dawn" when you interact with the graves in the graveyard in "Asgars Schloss", the message window uses a different system graphic. But as soon as the window starts closing, the system graphic switches back to the default system graphic which looks a bit awkward. This PR fixes this by applying the change after the window has been closed. You can reproduce the bug and confirm the fix with this savegame: [Save01.zip](https://github.com/EasyRPG/Player/files/5939146/Save01.zip).
