### PR TITLE
Equip and shop window: Fix display errors on edge cases

### DIFF
--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -489,6 +489,22 @@ static int AdjustParam(int base, int mod, int maxval, Span<const int16_t> states
 	return value;
 }
 
+int Game_Battler::CalcValueAfterAtkStates(int value) const {
+	return AdjustParam(value, 0, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_attack);
+}
+
+int Game_Battler::CalcValueAfterDefStates(int value) const {
+	return AdjustParam(value, 0, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_defense);
+}
+
+int Game_Battler::CalcValueAfterSpiStates(int value) const {
+	return AdjustParam(value, 0, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_spirit);
+}
+
+int Game_Battler::CalcValueAfterAgiStates(int value) const {
+	return AdjustParam(value, 0, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_agility);
+}
+
 int Game_Battler::GetAtk(Weapon weapon) const {
 	return AdjustParam(GetBaseAtk(weapon), atk_modifier, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_attack);
 }

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -299,6 +299,38 @@ public:
 	virtual bool HasFullSp() const;
 
 	/**
+	 * Calculates a value after considering the inflicted states
+	 * which influence attack.
+	 *
+	 * @return the value after considering the inflicted states.
+	 */
+	int CalcValueAfterAtkStates(int value) const;
+
+	/**
+	 * Calculates a value after considering the inflicted states
+	 * which influence defense.
+	 *
+	 * @return the value after considering the inflicted states.
+	 */
+	int CalcValueAfterDefStates(int value) const;
+
+	/**
+	 * Calculates a value after considering the inflicted states
+	 * which influence spirit.
+	 *
+	 * @return the value after considering the inflicted states.
+	 */
+	int CalcValueAfterSpiStates(int value) const;
+
+	/**
+	 * Calculates a value after considering the inflicted states
+	 * which influence agility.
+	 *
+	 * @return the value after considering the inflicted states.
+	 */
+	int CalcValueAfterAgiStates(int value) const;
+
+	/**
 	 * Gets the current battler attack.
 	 *
 	 * @param weapon Which weapons to include in calculating result.

--- a/src/scene_equip.cpp
+++ b/src/scene_equip.cpp
@@ -90,10 +90,10 @@ void Scene_Equip::UpdateStatusWindow() {
 
 		const auto eidx = equip_window->GetIndex();
 
-		auto atk = actor.GetAtk();
-		auto def = actor.GetDef();
-		auto spi = actor.GetSpi();
-		auto agi = actor.GetAgi();
+		auto atk = actor.GetBaseAtk(Game_Battler::WeaponAll, true, false);
+		auto def = actor.GetBaseDef(Game_Battler::WeaponAll, true, false);
+		auto spi = actor.GetBaseSpi(Game_Battler::WeaponAll, true, false);
+		auto agi = actor.GetBaseAgi(Game_Battler::WeaponAll, true, false);
 
 		auto add_item = [&](const lcf::rpg::Item* item, int mod = 1) {
 			if (item) {
@@ -103,6 +103,11 @@ void Scene_Equip::UpdateStatusWindow() {
 				agi += item->agi_points1 * mod;
 			}
 		};
+
+		for (int i = 1; i <= 5; i++) {
+			auto* count_item = actor.GetEquipment(i);
+			add_item(count_item, 1);
+		}
 
 		auto* old_item = actor.GetEquipment(eidx + 1);
 		// If its a weapon or shield, get the other hand
@@ -125,6 +130,11 @@ void Scene_Equip::UpdateStatusWindow() {
 		def = Utils::Clamp(def, 1, 999);
 		spi = Utils::Clamp(spi, 1, 999);
 		agi = Utils::Clamp(agi, 1, 999);
+
+		atk = actor.CalcValueAfterAtkStates(atk);
+		def = actor.CalcValueAfterDefStates(def);
+		spi = actor.CalcValueAfterSpiStates(spi);
+		agi = actor.CalcValueAfterAgiStates(agi);
 
 		equipstatus_window->SetNewParameters(atk, def, spi, agi);
 


### PR DESCRIPTION
This PR handles some edge cases in the equip value window and the shop window: In the equip value window, if you have equipped items which makes stats go above 999 (or below 1), then the new stat value is displayed wrong if you change equipment which affects stats which are "out of bounds". The shop window comparison indicators are affected as well. This one is hard to explain so I come up with an example in "Vampires Dawn II" with this savegame: [Save01.zip](https://github.com/EasyRPG/Player/files/5939178/Save01.zip). Take a look at Valnar's equipment: The defense stat sums up to 1090 with the equipment and the game clamps it to 999, which is correct. But if you want to equip the "Spiegelring", which gives a penalty of 30 to all stats, the preview shows a defense stat of 969. The expected value is 999 here because the stat will drop to 1060 which clamps to 999. In the shop window you have the following issue: Talk to the shopkeeper and buy things. Move the cursor to the armors or helmets and you will notice that the comparison indicator says that Valnar's stats will go down despite the defense stat remaining at 999. This PR intends to fix the mentioned issues.
