### PR TITLE
Filesystem [2.5/3]: Fix regressions

### DIFF
--- a/src/directory_tree.cpp
+++ b/src/directory_tree.cpp
@@ -190,25 +190,25 @@ std::string DirectoryTree::FindFile(const DirectoryTree::Args& args) const {
 
 	auto* entries = ListDirectory(dir);
 	if (entries) {
-        std::string dir_key = make_key(dir);
-        auto dir_it = dir_cache.find(dir_key);
-        assert(dir_it != dir_cache.end());
+		std::string dir_key = make_key(dir);
+		auto dir_it = dir_cache.find(dir_key);
+		assert(dir_it != dir_cache.end());
 
-        std::string name_key = make_key(name);
-        if (args.exts.empty()) {
-            auto entry_it = entries->find(name_key);
-            if (entry_it != entries->end() && entry_it->second.type == FileType::Regular) {
-                return MakePath(FileFinder::MakePath(dir_it->second, entry_it->second.name));
-            }
-        } else {
-            for (const auto& ext : args.exts) {
-                auto full_name_key = name_key + ToString(ext);
-                auto entry_it = entries->find(full_name_key);
-                if (entry_it != entries->end() && entry_it->second.type == FileType::Regular) {
-                    return MakePath(FileFinder::MakePath(dir_it->second, entry_it->second.name));
-                }
-            }
-        }
+		std::string name_key = make_key(name);
+		if (args.exts.empty()) {
+			auto entry_it = entries->find(name_key);
+			if (entry_it != entries->end() && entry_it->second.type == FileType::Regular) {
+				return MakePath(FileFinder::MakePath(dir_it->second, entry_it->second.name));
+			}
+		} else {
+			for (const auto& ext : args.exts) {
+				auto full_name_key = name_key + ToString(ext);
+				auto entry_it = entries->find(full_name_key);
+				if (entry_it != entries->end() && entry_it->second.type == FileType::Regular) {
+					return MakePath(FileFinder::MakePath(dir_it->second, entry_it->second.name));
+				}
+			}
+		}
 	}
 
 	if (args.use_rtp && Main_Data::filefinder_rtp) {
@@ -234,9 +234,10 @@ StringView DirectoryTree::GetRootPath() const {
 	return root;
 }
 
-DirectoryTreeView::DirectoryTreeView(const DirectoryTree* tree, std::string sub_path) :
-	tree(tree), sub_path(std::move(sub_path)) {
-	valid = (tree->ListDirectory(this->sub_path) != nullptr);
+DirectoryTreeView::DirectoryTreeView(const DirectoryTree* tree, std::string subdir) :
+	tree(tree), sub_path(std::move(subdir)) {
+	full_path = tree->MakePath(sub_path);
+	valid = (tree->ListDirectory(sub_path) != nullptr);
 }
 
 std::string DirectoryTreeView::FindFile(StringView name, Span<StringView> exts) const {
@@ -252,7 +253,7 @@ std::string DirectoryTreeView::FindFile(StringView dir, StringView name, Span<St
 }
 
 std::string DirectoryTreeView::FindFile(const DirectoryTree::Args& args) const {
-    assert(tree);
+	assert(tree);
 	auto args_cp = args;
 	std::string path = MakeSubPath(args.path);
 	args_cp.path = path;
@@ -261,7 +262,7 @@ std::string DirectoryTreeView::FindFile(const DirectoryTree::Args& args) const {
 
 StringView DirectoryTreeView::GetRootPath() const {
 	assert(tree);
-	return tree->MakePath(sub_path);
+	return full_path;
 }
 
 std::string DirectoryTreeView::MakePath(StringView subdir) const {
@@ -270,16 +271,16 @@ std::string DirectoryTreeView::MakePath(StringView subdir) const {
 }
 
 std::string DirectoryTreeView::MakeSubPath(StringView subdir) const {
-    assert(tree);
-    return FileFinder::MakePath(sub_path, subdir);
+	assert(tree);
+	return FileFinder::MakePath(sub_path, subdir);
 }
 
-DirectoryTree::DirectoryListType* DirectoryTreeView::ListDirectory(StringView path) const {
-    assert(tree);
-	return tree->ListDirectory(MakeSubPath(sub_path));
+DirectoryTree::DirectoryListType* DirectoryTreeView::ListDirectory(StringView subdir) const {
+	assert(tree);
+	return tree->ListDirectory(MakeSubPath(subdir));
 }
 
-DirectoryTreeView DirectoryTreeView::Subtree(const std::string& sub_path) {
-    assert(tree);
-	return DirectoryTreeView(tree, MakeSubPath(sub_path));
+DirectoryTreeView DirectoryTreeView::Subtree(const std::string& subdir) {
+	assert(tree);
+	return DirectoryTreeView(tree, MakeSubPath(subdir));
 }

--- a/src/directory_tree.cpp
+++ b/src/directory_tree.cpp
@@ -242,18 +242,19 @@ DirectoryTreeView::DirectoryTreeView(const DirectoryTree* tree, std::string sub_
 std::string DirectoryTreeView::FindFile(StringView name, Span<StringView> exts) const {
 	assert(tree);
 	DebugLog("TreeView FindFile: {}", name);
-	return tree->FindFile(MakePath(name), exts);
+	return tree->FindFile(MakeSubPath(name), exts);
 }
 
 std::string DirectoryTreeView::FindFile(StringView dir, StringView name, Span<StringView> exts) const {
 	assert(tree);
 	DebugLog("TreeView FindFile: {} {}", dir, name);
-	return tree->FindFile(MakePath(dir), name, exts);
+	return tree->FindFile(MakeSubPath(dir), name, exts);
 }
 
 std::string DirectoryTreeView::FindFile(const DirectoryTree::Args& args) const {
+    assert(tree);
 	auto args_cp = args;
-	std::string path = MakePath(args.path);
+	std::string path = MakeSubPath(args.path);
 	args_cp.path = path;
 	return tree->FindFile(args_cp);
 }
@@ -265,13 +266,20 @@ StringView DirectoryTreeView::GetRootPath() const {
 
 std::string DirectoryTreeView::MakePath(StringView subdir) const {
 	assert(tree);
-	return FileFinder::MakePath(sub_path, subdir);
+	return FileFinder::MakePath(GetRootPath(), subdir);
+}
+
+std::string DirectoryTreeView::MakeSubPath(StringView subdir) const {
+    assert(tree);
+    return FileFinder::MakePath(sub_path, subdir);
 }
 
 DirectoryTree::DirectoryListType* DirectoryTreeView::ListDirectory(StringView path) const {
-	return tree->ListDirectory(MakePath(path));
+    assert(tree);
+	return tree->ListDirectory(MakeSubPath(sub_path));
 }
 
 DirectoryTreeView DirectoryTreeView::Subtree(const std::string& sub_path) {
-	return DirectoryTreeView(tree, MakePath(sub_path));
+    assert(tree);
+	return DirectoryTreeView(tree, MakeSubPath(sub_path));
 }

--- a/src/directory_tree.cpp
+++ b/src/directory_tree.cpp
@@ -189,31 +189,26 @@ std::string DirectoryTree::FindFile(const DirectoryTree::Args& args) const {
 	DebugLog("FindFile: {} | {} | {}", canonical_path, dir, name);
 
 	auto* entries = ListDirectory(dir);
-	if (!entries) {
-		if (args.file_not_found_warning) {
-			Output::Debug("Cannot find: {}/{}", dir, name);
-		}
-		return "";
-	}
+	if (entries) {
+        std::string dir_key = make_key(dir);
+        auto dir_it = dir_cache.find(dir_key);
+        assert(dir_it != dir_cache.end());
 
-	std::string dir_key = make_key(dir);
-	auto dir_it = dir_cache.find(dir_key);
-	assert(dir_it != dir_cache.end());
-
-	std::string name_key = make_key(name);
-	if (args.exts.empty()) {
-		auto entry_it = entries->find(name_key);
-		if (entry_it != entries->end() && entry_it->second.type == FileType::Regular) {
-			return MakePath(FileFinder::MakePath(dir_it->second, entry_it->second.name));
-		}
-	} else {
-		for (const auto& ext : args.exts) {
-			auto full_name_key = name_key + ToString(ext);
-			auto entry_it = entries->find(full_name_key);
-			if (entry_it != entries->end() && entry_it->second.type == FileType::Regular) {
-				return MakePath(FileFinder::MakePath(dir_it->second, entry_it->second.name));
-			}
-		}
+        std::string name_key = make_key(name);
+        if (args.exts.empty()) {
+            auto entry_it = entries->find(name_key);
+            if (entry_it != entries->end() && entry_it->second.type == FileType::Regular) {
+                return MakePath(FileFinder::MakePath(dir_it->second, entry_it->second.name));
+            }
+        } else {
+            for (const auto& ext : args.exts) {
+                auto full_name_key = name_key + ToString(ext);
+                auto entry_it = entries->find(full_name_key);
+                if (entry_it != entries->end() && entry_it->second.type == FileType::Regular) {
+                    return MakePath(FileFinder::MakePath(dir_it->second, entry_it->second.name));
+                }
+            }
+        }
 	}
 
 	if (args.use_rtp && Main_Data::filefinder_rtp) {

--- a/src/directory_tree.h
+++ b/src/directory_tree.h
@@ -128,7 +128,7 @@ public:
 	/**
 	 * Does a case insensitive search for a file.
 	 * Advanced version for special purposes searches. Usually not needed.
-	 * 
+	 *
 	 * @see DirectoryTree::Args
 	 * @param args See documentation of DirectoryTree::Args
 	 * @return Path to file or empty string when not found
@@ -138,7 +138,7 @@ public:
 	/** @return root path of the tree */
 	StringView GetRootPath() const;
 
-	/** 
+	/**
 	 * @param subpath Path to append to the root
 	 * @return Combined path
 	 */
@@ -203,7 +203,7 @@ public:
 	/**
 	 * Does a case insensitive search for a file.
 	 * Advanced version for special purposes searches. Usually not needed.
-	 * 
+	 *
 	 * @see DirectoryTree::Args
 	 * @param args See documentation of DirectoryTree::Args
 	 * @return Path to file or empty string when not found
@@ -248,6 +248,7 @@ public:
 
 private:
 	const DirectoryTree* tree = nullptr;
+	std::string full_path;
 	std::string sub_path;
 	bool valid = false;
 };

--- a/src/directory_tree.h
+++ b/src/directory_tree.h
@@ -213,11 +213,19 @@ public:
 	/** @return root path of the subtree */
 	StringView GetRootPath() const;
 
-	/** 
+	/**
+	 * Creates path consisting of root + subtree + subdir
 	 * @param subpath Path to append to the subtree root
 	 * @return Combined path
 	 */
 	std::string MakePath(StringView subdir) const;
+
+    /**
+     * Creates a path consisting of subtree + subdir
+     * @param subpath Path to append to the subtree
+     * @return Combined path
+     */
+    std::string MakeSubPath(StringView subdir) const;
 
 	/**
 	 * Enumerates a directory.


### PR DESCRIPTION
@rueter37 can you confirm?

- RTP lookup: Reordered the logic, fixes RTP assets not found when game lacks folder
- Saving: The save scene constructed a path that lacked the root path. This is fixed by accident in #2455 because the stream opening is now handled by the VFS, not by FileFinder.