### PR TITLE
Fix save count incrementing on game save

### DIFF
--- a/src/game_system.h
+++ b/src/game_system.h
@@ -276,6 +276,7 @@ public:
 	void SetAllowMenu(bool allow);
 
 	int GetSaveCount();
+	void IncSaveCount();
 
 	const lcf::rpg::Music& GetCurrentBGM();
 	void MemorizeBGM();
@@ -646,6 +647,10 @@ inline bool Game_System::GetInvertAnimations() {
 
 inline int Game_System::GetSaveCount() {
 	return data.save_count;
+}
+
+inline void Game_System::IncSaveCount() {
+	++data.save_count;
 }
 
 inline StringView Game_System::GetSystem2Name() {

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -120,6 +120,7 @@ void Scene_Save::Save(std::ostream& os, int slot_id, bool prepare_save) {
 
 	if (prepare_save) {
 		lcf::LSD_Reader::PrepareSave(save, PLAYER_SAVEGAME_VERSION);
+		Main_Data::game_system->IncSaveCount();
 	}
 
 	save.targets = Main_Data::game_targets->GetSaveData();


### PR DESCRIPTION
The PR aims to fix the save count incrementing on game save. For some reason the [save count increment in liblcf](https://github.com/EasyRPG/liblcf/blob/master/src/lsd_reader.cpp#L37) is no longer working some commits after the 0.6.2 release.

Fixes: #2450 