### PR TITLE
Limit max item count on buying based on current inventory

### DIFF
--- a/src/scene_shop.cpp
+++ b/src/scene_shop.cpp
@@ -253,11 +253,9 @@ void Scene_Shop::UpdateBuySelection() {
 			// Items are guaranteed to be valid
 			const lcf::rpg::Item* item = lcf::ReaderUtil::GetElement(lcf::Data::items, item_id);
 
-			int max;
-			if (item->price == 0) {
-				max = 99;
-			} else {
-				max = Main_Data::game_party->GetGold() / item->price;
+			int max = 99 - Main_Data::game_party->GetItemCount(item_id);
+			if (item->price > 0) {
+				max = std::min(max, Main_Data::game_party->GetGold() / item->price);
 			}
 			number_window->SetData(item_id, max, item->price);
 

--- a/src/window_shopbuy.cpp
+++ b/src/window_shopbuy.cpp
@@ -68,7 +68,7 @@ void Window_ShopBuy::DrawItem(int index) {
 	if (!item) {
 		Output::Warning("Window ShopBuy: Invalid item ID {}", item_id);
 	} else {
-		enabled = item->price <= Main_Data::game_party->GetGold();
+		enabled = item->price <= Main_Data::game_party->GetGold() && Main_Data::game_party->GetItemCount(item_id) < 99;
 		price = item->price;
 	}
 


### PR DESCRIPTION
In RPG_RT the player is not able to buy more items of a kind if the current amount in the player inventory would exceed 99 after
the transaction. Moreover the corresponding shop menu item gets disabled if you have got 99 from that item.