### PR TITLE
Fix WildMidi becoming stuck

### DIFF
--- a/src/decoder_midigeneric.cpp
+++ b/src/decoder_midigeneric.cpp
@@ -132,7 +132,7 @@ bool GenericMidiDecoder::SetPitch(int pitch) {
 		return false;
 	}
 
-	this->pitch = 100.0f / pitch;
+	this->pitch = static_cast<float>(pitch);
 
 	return true;
 }
@@ -151,7 +151,7 @@ int GenericMidiDecoder::FillBuffer(uint8_t* buffer, int length) {
 
 	size_t samples = (size_t)length / sizeof(int_least16_t) / 2;
 
-	float delta = (float)samples / (frequency * pitch);
+	float delta = (float)samples / (frequency * pitch / 100.0f);
 
 	seq->play(mtime, this);
 	int res = mididec->FillBuffer(buffer, length);


### PR DESCRIPTION
Was a bug in the pitch calculation.

Note that the looping is not seemless at the end, I don't consider this a bug, is just really hard to get the timing right because the midi messages and Wildmidi are independent of each other (sample based as you know...). So this is a gigantic hack that kinda works.

For gapless playback use FluidLite or FmMidi.
