### PR TITLE
Make some hardcoded terms customizable

### DIFF
--- a/src/scene_order.cpp
+++ b/src/scene_order.cpp
@@ -109,9 +109,8 @@ void Scene_Order::CreateCommandWindow() {
 		options_right.push_back("");
 	}
 
-	// Are they stored anywhere in terms?
-	options_confirm.push_back("Confirm");
-	options_confirm.push_back("Redo");
+	options_confirm.push_back(lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_order_scene_confirm, "Confirm"));
+	options_confirm.push_back(lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_order_scene_redo, "Redo"));
 
 	window_left.reset(new Window_Command(options_left, 88, 4));
 	window_left->SetX(68);

--- a/src/window_actorinfo.cpp
+++ b/src/window_actorinfo.cpp
@@ -41,7 +41,7 @@ void Window_ActorInfo::Refresh() {
 
 void Window_ActorInfo::DrawInfo() {
 	// Draw Row formation.
-	std::string battle_row = Main_Data::game_actors->GetActor(actor_id)->GetBattleRow() == Game_Actor::RowType::RowType_back ? "Back" : "Front";
+	std::string battle_row = Main_Data::game_actors->GetActor(actor_id)->GetBattleRow() == Game_Actor::RowType::RowType_back ? lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_back, "Back") : lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_front, "Front");
 	contents->TextDraw(contents->GetWidth(), 2, Font::ColorDefault, battle_row, Text::AlignRight);
 
 	const Game_Actor& actor = *Main_Data::game_actors->GetActor(actor_id);
@@ -50,19 +50,19 @@ void Window_ActorInfo::DrawInfo() {
 	DrawActorFace(actor, 0, 0);
 
 	// Draw Name
-	contents->TextDraw(0, 50, 1, "Name");
+	contents->TextDraw(0, 50, 1, lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_name, "Name"));
 	DrawActorName(actor, 36, 66);
 
 	// Draw Profession
-	contents->TextDraw(3, 80, 1, "Class");
+	contents->TextDraw(0, 82, 1, lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_class, "Class"));
 	DrawActorClass(actor, 36, 98);
 
 	// Draw Rank
-	contents->TextDraw(3, 110, 1, "Nickname");
+	contents->TextDraw(0, 114, 1, lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_title, "Title"));
 	DrawActorTitle(actor, 36, 130);
 
 	// Draw Status
-	contents->TextDraw(3, 140, 1, "State");
+	contents->TextDraw(0, 146, 1, lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_condition, "State"));
 	DrawActorState(actor, 36, 162);
 
 	//Draw Level

--- a/src/window_equipstatus.cpp
+++ b/src/window_equipstatus.cpp
@@ -121,12 +121,18 @@ void Window_EquipStatus::DrawParameter(int cx, int cy, int type) {
 	contents->TextDraw(cx, cy, Font::ColorDefault, std::to_string(value), Text::AlignRight);
 
 	if (draw_params) {
-		if (Player::IsCP932()) {
-			// Draw fullwidth arrow
-			contents->TextDraw(cx, cy, 1, "→");
+		if (lcf::Data::terms.easyrpg_equipment_arrow == lcf::Data::terms.kDefaultTerm) {
+			if (Player::IsCP932()) {
+				// Draw fullwidth arrow
+				contents->TextDraw(cx, cy, 1, "→");
+			} else {
+				// Draw arrow (+3 for center between the two numbers)
+				contents->TextDraw(cx + 3, cy, 1, ">");
+			}
 		} else {
-			// Draw arrow (+3 for center between the two numbers)
-			contents->TextDraw(cx + 3, cy, 1, ">");
+			// Draw arrow
+			int offset = (12 - Font::Default()->GetSize(lcf::Data::terms.easyrpg_equipment_arrow).width) / 2;
+			contents->TextDraw(cx + offset, cy, 1, lcf::Data::terms.easyrpg_equipment_arrow);
 		}
 
 		// Draw New Value

--- a/src/window_item.cpp
+++ b/src/window_item.cpp
@@ -124,7 +124,7 @@ void Window_Item::DrawItem(int index) {
 		DrawItemName(*item, rect.x, rect.y, enabled);
 
 		Font::SystemColor color = enabled ? Font::ColorDefault : Font::ColorDisabled;
-		contents->TextDraw(rect.x + rect.width - 24, rect.y, color, fmt::format(":{:3d}", number));
+		contents->TextDraw(rect.x + rect.width - 24, rect.y, color, fmt::format("{}{:3d}", lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_item_number_separator, ":"), number));
 	}
 }
 

--- a/src/window_skill.cpp
+++ b/src/window_skill.cpp
@@ -84,7 +84,7 @@ void Window_Skill::DrawItem(int index) {
 		bool enabled = CheckEnable(skill_id);
 		int color = !enabled ? Font::ColorDisabled : Font::ColorDefault;
 
-		contents->TextDraw(rect.x + rect.width - 24, rect.y, color, fmt::format("-{:3d}", costs));
+		contents->TextDraw(rect.x + rect.width - 24, rect.y, color, fmt::format("{}{:3d}", lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_skill_cost_separator, "-"), costs));
 
 		// Skills are guaranteed to be valid
 		DrawSkillName(*lcf::ReaderUtil::GetElement(lcf::Data::skills, skill_id), rect.x, rect.y, enabled);


### PR DESCRIPTION
This PR makes the following hardcoded terms customizable:
- Item number separator
- Skill cost separator
- Equipment window arrow
- Status scene Name
- Status scene Class
- Status scene Title
- Status scene Condition
- Status scene Front
- Status scene Back
- Order scene Confirm
- Order scene Redo

Related: #2362