### PR TITLE
Debug scene: Set gold setting back to 6 digits

### DIFF
--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -338,7 +338,7 @@ void Scene_Debug::Update() {
 				if (sz > 1) {
 					DoGold();
 				} else {
-					PushUiNumberInput(Main_Data::game_party->GetGold(), 7, false);
+					PushUiNumberInput(Main_Data::game_party->GetGold(), 6, false);
 					range_index = 0;
 					range_window->SetIndex(range_index);
 				}

--- a/src/scene_menu.cpp
+++ b/src/scene_menu.cpp
@@ -52,6 +52,7 @@ void Scene_Menu::Start() {
 
 void Scene_Menu::Continue(SceneType /* prev_scene */) {
 	menustatus_window->Refresh();
+	gold_window->Refresh();
 }
 
 void Scene_Menu::Update() {


### PR DESCRIPTION
This was fixed in #2214 but got a regression by #2210 (the latter set the gold setting back to 7 digits). This PR "re-fixes" the gold setting digit count. Moreover the gold value in the gold value window in the main menu scene gets updated upon leaving the debug scene now.