### PR TITLE
Fixes for NovemberJoy's remaining battle issues

### DIFF
--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -2214,10 +2214,15 @@ Scene_Battle_Rpg2k3::BattleActionReturn Scene_Battle_Rpg2k3::ProcessBattleAction
 			auto* enemy = static_cast<Game_Enemy*>(target);
 			enemy->SetBlinkTimer();
 		} else if (action->GetAffectedHp() < 0) {
-			target_sprite->SetAnimationState(Sprite_Actor::AnimationState_Damage, Sprite_Actor::LoopState_DefaultAnimationAfterFinish);
+			if (!target->IsDead()) {
+				target_sprite->SetAnimationState(Sprite_Actor::AnimationState_Damage, Sprite_Actor::LoopState_DefaultAnimationAfterFinish);
+			}
 		}
 	}
 
+	if (!was_dead && target->GetType() == Game_Battler::Type_Ally && target->IsDead()) {
+		target_sprite->SetAnimationState(Sprite_Actor::AnimationState_Dead, Sprite_Actor::LoopState_WaitAfterFinish);
+	}
 
 	if (action->IsSuccess() && target->GetType() == Game_Battler::Type_Enemy) {
 		auto* enemy = static_cast<Game_Enemy*>(target);

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1844,7 +1844,7 @@ Scene_Battle_Rpg2k3::BattleActionReturn Scene_Battle_Rpg2k3::ProcessBattleAction
 		return BattleActionReturn::eFinished;
 	}
 
-	if (Game_Battle::IsBattleAnimationWaiting()) {
+	if (Game_Battle::IsBattleAnimationWaiting() && !(action->GetType() == Game_BattleAlgorithm::Type::Normal && source->GetType() == Game_Battler::Type_Enemy)) {
 		return BattleActionReturn::eWait;
 	}
 

--- a/src/sprite_actor.cpp
+++ b/src/sprite_actor.cpp
@@ -255,7 +255,7 @@ void Sprite_Actor::DoIdleAnimation() {
 		idling_anim = 7;
 
 	if (idling_anim != anim_state || loop_state == LoopState_DefaultAnimationAfterFinish)
-		SetAnimationState(idling_anim);
+		SetAnimationState(idling_anim, idling_anim == AnimationState_Dead ? LoopState_WaitAfterFinish : LoopState_LoopAnimation);
 
 	idling = true;
 }


### PR DESCRIPTION
This PR fixes the death animation loop by playing death animations only once (RPG_RT does this as well) and normal enemy attacks do not longer wait for the battle animation (you will see the animation and the damage number at the same time like in RPG_RT). This affects RPG Maker 2003 battles.

Fixes: #1681
Fixes: #2335