### PR TITLE
Battle 2k3: Battle animation sprites changes

### DIFF
--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -293,8 +293,12 @@ void BattleAnimationBattle::Draw(Bitmap& dst) {
 	for (auto* battler: battlers) {
 		const Sprite_Battler* sprite = battler->GetBattleSprite();
 		int offset = 0;
-		if (sprite && sprite->GetBitmap()) {
-			offset = CalculateOffset(animation.position, sprite->GetHeight());
+		if (sprite) {
+			if (sprite->GetBitmap()) {
+				offset = CalculateOffset(animation.position, sprite->GetHeight());
+			} else {
+				offset = CalculateOffset(animation.position, GetAnimationCellHeight() / 2);
+			}
 		}
 		DrawAt(dst, battler->GetBattlePosition().x, battler->GetBattlePosition().y + offset);
 	}
@@ -306,6 +310,37 @@ void BattleAnimationBattle::FlashTargets(int r, int g, int b, int p) {
 }
 
 void BattleAnimationBattle::ShakeTargets(int str, int spd, int time) {
+	for (auto& battler: battlers) {
+		battler->ShakeOnce(str, spd, time);
+	}
+}
+
+BattleAnimationBattler::BattleAnimationBattler(const lcf::rpg::Animation& anim, std::vector<Game_Battler*> battlers, bool only_sound, int cutoff_frame, bool set_invert) :
+	BattleAnimation(anim, only_sound, cutoff_frame), battlers(std::move(battlers))
+{
+	invert = set_invert;
+}
+
+void BattleAnimationBattler::Draw(Bitmap& dst) {
+	if (IsOnlySound())
+		return;
+	if (animation.scope == lcf::rpg::Animation::Scope_screen) {
+		DrawAt(dst, SCREEN_TARGET_WIDTH / 2, SCREEN_TARGET_HEIGHT / 3);
+		return;
+	}
+
+	for (auto* battler: battlers) {
+		DrawAt(dst, battler->GetBattlePosition().x, battler->GetBattlePosition().y);
+	}
+}
+
+void BattleAnimationBattler::FlashTargets(int r, int g, int b, int p) {
+	for (auto& battler: battlers) {
+		battler->Flash(r, g, b, p, 0);
+	}
+}
+
+void BattleAnimationBattler::ShakeTargets(int str, int spd, int time) {
 	for (auto& battler: battlers) {
 		battler->ShakeOnce(str, spd, time);
 	}

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -326,3 +326,6 @@ void BattleAnimation::SetFrame(int frame) {
 	this->frame = frame;
 }
 
+void BattleAnimation::SetInvert(bool inverted) {
+	invert = inverted;
+}

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -130,6 +130,16 @@ protected:
 	std::vector<Game_Battler*> battlers;
 };
 
+class BattleAnimationBattler : public BattleAnimation {
+public:
+	BattleAnimationBattler(const lcf::rpg::Animation& anim, std::vector<Game_Battler*> battlers, bool only_sound = false, int cutoff_frame = -1, bool set_invert = false);
+	void Draw(Bitmap& dst) override;
+protected:
+	void FlashTargets(int r, int g, int b, int p) override;
+	void ShakeTargets(int str, int spd, int time) override;
+	std::vector<Game_Battler*> battlers;
+};
+
 inline int BattleAnimation::GetFrame() const {
 	return frame;
 }

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -72,6 +72,13 @@ public:
 	 */
 	int GetAnimationCellHeight() const;
 
+	/**
+	 * Set if the animation is inverted
+	 *
+	 * @param inverted if the animation is inverted
+	 **/
+	void SetInvert(bool inverted);
+
 protected:
 	BattleAnimation(const lcf::rpg::Animation& anim, bool only_sound = false, int cutoff = -1);
 

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -62,6 +62,16 @@ public:
 	/** @return true if the animation only plays audio and doesn't display **/
 	bool IsOnlySound() const;
 
+	/**
+	 * @return the animation cell width
+	 */
+	int GetAnimationCellWidth() const;
+
+	/**
+	 * @return the animation cell height
+	 */
+	int GetAnimationCellHeight() const;
+
 protected:
 	BattleAnimation(const lcf::rpg::Animation& anim, bool only_sound = false, int cutoff = -1);
 
@@ -137,6 +147,12 @@ inline bool BattleAnimation::IsOnlySound() const {
 	return only_sound;
 }
 
+inline int BattleAnimation::GetAnimationCellWidth() const {
+	return (animation.large ? 128 : 96);
+}
 
+inline int BattleAnimation::GetAnimationCellHeight() const {
+	return (animation.large ? 128 : 96);
+}
 
 #endif

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -342,9 +342,10 @@ void Scene_Battle_Rpg2k3::ResetAllBattlerZ() {
 	}
 
 	for (auto* actor: Main_Data::game_party->GetActors()) {
-		auto* sprite = actor->GetBattleSprite();
+		auto* sprite = actor->GetActorBattleSprite();
 		if (sprite) {
 			sprite->ResetZ();
+			sprite->DetectStateChange();
 		}
 	}
 }

--- a/src/sprite_actor.cpp
+++ b/src/sprite_actor.cpp
@@ -59,6 +59,7 @@ void Sprite_Actor::Update() {
 		if (Player::IsRPG2k3()) {
 			if (animation) {
 				// Is a battle animation
+				animation->SetInvert(battler->IsDirectionFlipped());
 				animation->Update();
 
 				if (animation->IsDone()) {
@@ -127,9 +128,6 @@ void Sprite_Actor::Update() {
 
 	const bool flip = battler->IsDirectionFlipped();
 	SetFlipX(flip);
-	if (animation) {
-		SetFlipX(flip);
-	}
 }
 
 void Sprite_Actor::SetAnimationState(int state, LoopState loop) {
@@ -174,6 +172,7 @@ void Sprite_Actor::SetAnimationState(int state, LoopState loop) {
 				animation.reset(new BattleAnimationBattle(*battle_anim, { battler }));
 				animation->SetZ(GetZ());
 			}
+			animation->SetInvert(battler->IsDirectionFlipped());
 		}
 		else {
 			animation.reset();

--- a/src/sprite_actor.cpp
+++ b/src/sprite_actor.cpp
@@ -277,3 +277,10 @@ void Sprite_Actor::Draw(Bitmap& dst) {
 
 	Sprite_Battler::Draw(dst);
 }
+
+void Sprite_Actor::ResetZ() {
+	Sprite_Battler::ResetZ();
+	if (animation) {
+		animation->SetZ(GetZ());
+	}
+}

--- a/src/sprite_actor.cpp
+++ b/src/sprite_actor.cpp
@@ -169,7 +169,7 @@ void Sprite_Actor::SetAnimationState(int state, LoopState loop) {
 				Output::Warning("Invalid battle animation ID {}", ext->battle_animation_id);
 				animation.reset();
 			} else {
-				animation.reset(new BattleAnimationBattle(*battle_anim, { battler }));
+				animation.reset(new BattleAnimationBattler(*battle_anim, { battler }));
 				animation->SetZ(GetZ());
 			}
 			animation->SetInvert(battler->IsDirectionFlipped());

--- a/src/sprite_actor.cpp
+++ b/src/sprite_actor.cpp
@@ -203,14 +203,14 @@ bool Sprite_Actor::IsIdling() {
 
 int Sprite_Actor::GetWidth() const {
 	if (animation) {
-		return animation->GetWidth();
+		return animation->GetAnimationCellWidth() / 2;
 	}
 	return Sprite::GetWidth();
 }
 
 int Sprite_Actor::GetHeight() const {
 	if (animation) {
-		return animation->GetHeight();
+		return animation->GetAnimationCellHeight() / 2;
 	}
 	return Sprite::GetHeight();
 }

--- a/src/sprite_actor.h
+++ b/src/sprite_actor.h
@@ -90,6 +90,8 @@ public:
 
 	Game_Actor* GetBattler() const;
 
+	void ResetZ() override;
+
 protected:
 	void CreateSprite();
 	void DoIdleAnimation();

--- a/src/sprite_actor.h
+++ b/src/sprite_actor.h
@@ -90,7 +90,7 @@ public:
 
 	Game_Actor* GetBattler() const;
 
-	void ResetZ() override;
+	void ResetZ() final;
 
 protected:
 	void CreateSprite();

--- a/src/sprite_battler.h
+++ b/src/sprite_battler.h
@@ -47,7 +47,7 @@ public:
 	/**
 	 * Recompute the Z value for the sprite from it's Y coordinate.
 	 */
-	void ResetZ();
+	virtual void ResetZ();
 
 protected:
 	Game_Battler* battler = nullptr;

--- a/src/sprite_enemy.cpp
+++ b/src/sprite_enemy.cpp
@@ -129,3 +129,7 @@ void Sprite_Enemy::Refresh() {
 		CreateSprite();
 	}
 }
+
+void Sprite_Enemy::ResetZ() {
+	Sprite_Battler::ResetZ();
+}

--- a/src/sprite_enemy.h
+++ b/src/sprite_enemy.h
@@ -46,6 +46,8 @@ public:
 
 	void Refresh();
 
+	void ResetZ() final;
+
 protected:
 	void CreateSprite();
 	void OnMonsterSpriteReady(FileRequestResult* result);


### PR DESCRIPTION
This PR intends to do the following fixes:

- Placement of battlers: The battlers were placed wrong (too much distance between each other and partially and full off-screen placing starting with the third party member) if battle animation sprites were used. BattleCharset sprites are working fine.
- Displaying state afflictions: While BattleCharset sprites are showing its state afflictions at the beginning of the battle, the battle animation sprite battlers did so not until their first turn.
- Battle animation sprites are flipped now if the flip flag is set.
- BattleAnimation height: Battle animations are displayed on the right height if the target is a battle animation sprite.