### PR TITLE
RPG Maker 2003 battle scene changes

### DIFF
--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -302,7 +302,7 @@ void Scene_Battle_Rpg2k3::CreateUi() {
 	}
 
 	if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) {
-		int transp = lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent ? 128 : 255;
+		int transp = lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent ? 160 : 255;
 		options_window->SetBackOpacity(transp);
 		item_window->SetBackOpacity(transp);
 		skill_window->SetBackOpacity(transp);
@@ -506,7 +506,7 @@ void Scene_Battle_Rpg2k3::CreateBattleTargetWindow() {
 	target_window->SetZ(Priority_Window + 10);
 
 	if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) {
-		int transp = lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent ? 128 : 255;
+		int transp = lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent ? 160 : 255;
 		target_window->SetBackOpacity(transp);
 	}
 }
@@ -594,7 +594,7 @@ void Scene_Battle_Rpg2k3::CreateBattleCommandWindow() {
 	command_window->SetZ(Priority_Window + 20);
 
 	if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) {
-		int transp = lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent ? 128 : 255;
+		int transp = lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent ? 160 : 255;
 		command_window->SetBackOpacity(transp);
 	}
 }

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -397,7 +397,7 @@ void Scene_Battle_Rpg2k3::UpdateAnimations() {
 
 				ally_cursor->SetVisible(true);
 				ally_cursor->SetX(actor->GetBattlePosition().x);
-				ally_cursor->SetY(actor->GetBattlePosition().y - sprite->GetHeight() / 2);
+				ally_cursor->SetY(actor->GetBattlePosition().y - 40);
 
 				if (frame_counter % 30 == 0) {
 					SelectionFlash(actor);

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -515,6 +515,9 @@ void Scene_Battle_Rpg2k3::RefreshTargetWindow() {
 	// FIXME: Handle live refresh in traditional when the window is always visible
 	auto commands = GetEnemyTargetNames();
 	target_window->ReplaceCommands(std::move(commands));
+	if (!target_window->GetActive()) {
+		target_window->SetIndex(-1);
+	}
 }
 
 void Scene_Battle_Rpg2k3::CreateBattleStatusWindow() {
@@ -942,6 +945,7 @@ bool Scene_Battle_Rpg2k3::CheckBattleEndAndScheduleEvents(EventTriggerType tt) {
 #else
 	(void)page;
 #endif
+	RefreshTargetWindow();
 
 	return !interp.IsRunning();
 }
@@ -2237,6 +2241,7 @@ Scene_Battle_Rpg2k3::BattleActionReturn Scene_Battle_Rpg2k3::ProcessBattleAction
 		if (!was_dead && enemy->IsDead()) {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_EnemyKill));
 			enemy->SetDeathTimer();
+			RefreshTargetWindow();
 		}
 	}
 

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -302,7 +302,7 @@ void Scene_Battle_Rpg2k3::CreateUi() {
 	}
 
 	if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) {
-		int transp = lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent ? 160 : 255;
+		int transp = IsTransparent() ? 160 : 255;
 		options_window->SetBackOpacity(transp);
 		item_window->SetBackOpacity(transp);
 		skill_window->SetBackOpacity(transp);
@@ -481,6 +481,10 @@ void Scene_Battle_Rpg2k3::DrawFloatText(int x, int y, int color, StringView text
 	floating_texts.push_back(float_text);
 }
 
+bool Scene_Battle_Rpg2k3::IsTransparent() const {
+	return lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent;
+}
+
 static std::vector<std::string> GetEnemyTargetNames() {
 	std::vector<std::string> commands;
 
@@ -506,7 +510,7 @@ void Scene_Battle_Rpg2k3::CreateBattleTargetWindow() {
 	target_window->SetZ(Priority_Window + 10);
 
 	if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) {
-		int transp = lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent ? 160 : 255;
+		int transp = IsTransparent() ? 160 : 255;
 		target_window->SetBackOpacity(transp);
 	}
 }
@@ -597,7 +601,7 @@ void Scene_Battle_Rpg2k3::CreateBattleCommandWindow() {
 	command_window->SetZ(Priority_Window + 20);
 
 	if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) {
-		int transp = lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent ? 160 : 255;
+		int transp = IsTransparent() ? 160 : 255;
 		command_window->SetBackOpacity(transp);
 	}
 }

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1788,11 +1788,7 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionEs
 			for (auto& actor: Main_Data::game_party->GetActors()) {
 				auto* sprite = actor->GetActorBattleSprite();
 				if (sprite) {
-					if (actor->IsDirectionFlipped()) {
-						sprite->SetAnimationState(Sprite_Actor::AnimationState_WalkingLeft);
-					} else {
-						sprite->SetAnimationState(Sprite_Actor::AnimationState_WalkingRight);
-					}
+					sprite->SetAnimationState(Sprite_Actor::AnimationState_WalkingRight);
 				}
 			}
 			running_away = true;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -2024,6 +2024,8 @@ Scene_Battle_Rpg2k3::BattleActionReturn Scene_Battle_Rpg2k3::ProcessBattleAction
 		}
 	}
 
+	status_window->Refresh();
+
 	SetBattleActionState(BattleActionState_Notify);
 	return BattleActionReturn::eContinue;
 }

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -425,8 +425,8 @@ void Scene_Battle_Rpg2k3::UpdateAnimations() {
 					enemy_cursor->SetSrcRect(Rect(sprite_frame * 16, 0, 16, 16));
 
 					enemy_cursor->SetVisible(true);
-					enemy_cursor->SetX(enemy->GetBattlePosition().x + sprite->GetWidth() / 2 + 2);
-					enemy_cursor->SetY(enemy->GetBattlePosition().y - enemy_cursor->GetHeight() / 2);
+					enemy_cursor->SetX(enemy->GetBattlePosition().x + sprite->GetWidth() / 2);
+					enemy_cursor->SetY(enemy->GetBattlePosition().y);
 
 					std::vector<lcf::rpg::State*> ordered_states = enemy->GetInflictedStatesOrderedByPriority();
 					if (ordered_states.size() > 0) {

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -114,6 +114,8 @@ protected:
 
 	void DrawFloatText(int x, int y, int color, StringView text);
 
+	bool IsTransparent() const;
+
 
 	void SetState(Scene_Battle::State new_state) override;
 

--- a/src/window_actorsp.cpp
+++ b/src/window_actorsp.cpp
@@ -36,6 +36,8 @@ void Window_ActorSp::SetBattler(const Game_Battler& battler) {
 		color = Font::ColorCritical;
 	}
 
+	contents->Clear();
+
 	// Draw current Sp
 	contents->TextDraw(cx + 3 * 6, 2, color, std::to_string(battler.GetSp()), Text::AlignRight);
 

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -337,3 +337,21 @@ void Window_Base::DrawGauge(const Game_Battler& actor, int cx, int cy, int alpha
 		contents->StretchBlit(bar_rect, *system2, gauge_bar, alpha);
 	}
 }
+
+void Window_Base::DrawActorHpValue(const Game_Battler& actor, int cx, int cy) const {
+	int color = Font::ColorDefault;
+	if (actor.GetHp() == 0) {
+		color = Font::ColorKnockout;
+	} else if (actor.GetHp() <= actor.GetMaxHp() / 4) {
+		color = Font::ColorCritical;
+	}
+	contents->TextDraw(cx, cy, color, std::to_string(actor.GetHp()), Text::AlignRight);
+}
+
+void Window_Base::DrawActorSpValue(const Game_Battler& actor, int cx, int cy) const {
+	int color = Font::ColorDefault;
+	if (actor.GetSp() <= actor.GetMaxSp() / 4) {
+		color = Font::ColorCritical;
+	}
+	contents->TextDraw(cx, cy, color, std::to_string(actor.GetSp()), Text::AlignRight);
+}

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -173,12 +173,7 @@ void Window_Base::DrawActorHp(const Game_Battler& actor, int cx, int cy, int dig
 	// Draw Current HP of the Actor
 	cx += 12;
 	// Color: 0 okay, 4 critical, 5 dead
-	int color = Font::ColorDefault;
-	if (actor.GetHp() == 0) {
-		color = Font::ColorKnockout;
-	} else if (actor.GetHp() <= actor.GetMaxHp() / 4) {
-		color = Font::ColorCritical;
-	}
+	int color = GetValueFontColor(actor.GetHp(), actor.GetMaxHp(), true);
 	auto dx = digits * 6;
 	contents->TextDraw(cx + dx, cy, color, std::to_string(actor.GetHp()), Text::AlignRight);
 
@@ -201,10 +196,7 @@ void Window_Base::DrawActorSp(const Game_Battler& actor, int cx, int cy, int dig
 	// Draw Current SP of the Actor
 	cx += 12;
 	// Color: 0 okay, 4 critical/empty
-	int color = Font::ColorDefault;
-	if (actor.GetMaxSp() != 0 && actor.GetSp() <= actor.GetMaxSp() / 4) {
-		color = Font::ColorCritical;
-	}
+	int color = GetValueFontColor(actor.GetSp(), actor.GetMaxSp(), false);
 	auto dx = digits * 6;
 	contents->TextDraw(cx + dx, cy, color, std::to_string(actor.GetSp()), Text::AlignRight);
 
@@ -339,19 +331,15 @@ void Window_Base::DrawGauge(const Game_Battler& actor, int cx, int cy, int alpha
 }
 
 void Window_Base::DrawActorHpValue(const Game_Battler& actor, int cx, int cy) const {
-	int color = Font::ColorDefault;
-	if (actor.GetHp() == 0) {
-		color = Font::ColorKnockout;
-	} else if (actor.GetHp() <= actor.GetMaxHp() / 4) {
-		color = Font::ColorCritical;
-	}
-	contents->TextDraw(cx, cy, color, std::to_string(actor.GetHp()), Text::AlignRight);
+	contents->TextDraw(cx, cy, GetValueFontColor(actor.GetHp(), actor.GetMaxHp(), true), std::to_string(actor.GetHp()), Text::AlignRight);
 }
 
 void Window_Base::DrawActorSpValue(const Game_Battler& actor, int cx, int cy) const {
-	int color = Font::ColorDefault;
-	if (actor.GetSp() <= actor.GetMaxSp() / 4) {
-		color = Font::ColorCritical;
-	}
-	contents->TextDraw(cx, cy, color, std::to_string(actor.GetSp()), Text::AlignRight);
+	contents->TextDraw(cx, cy, GetValueFontColor(actor.GetSp(), actor.GetMaxSp(), false), std::to_string(actor.GetSp()), Text::AlignRight);
+}
+
+int Window_Base::GetValueFontColor(int have, int max, bool can_knockout) const {
+	if (can_knockout && have == 0) return Font::ColorKnockout;
+	if (max > 0 && (have <= max / 4)) return Font::ColorCritical;
+	return Font::ColorDefault;
 }

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -306,7 +306,7 @@ void Window_Base::DrawCurrencyValue(int money, int cx, int cy) const {
 	contents->TextDraw(cx - gold_text_size.width, cy, Font::ColorDefault, gold.str(), Text::AlignRight);
 }
 
-void Window_Base::DrawGauge(const Game_Battler& actor, int cx, int cy) const {
+void Window_Base::DrawGauge(const Game_Battler& actor, int cx, int cy, int alpha) const {
 	BitmapRef system2 = Cache::System2();
 	if (!system2) {
 		return;
@@ -324,9 +324,9 @@ void Window_Base::DrawGauge(const Game_Battler& actor, int cx, int cy) const {
 
 	Rect dst_rect(cx + 16, cy, 25, 16);
 
-	contents->Blit(cx + 0, cy, *system2, gauge_left, 255);
-	contents->Blit(cx + 16 + 25, cy, *system2, gauge_right, 255);
-	contents->StretchBlit(dst_rect, *system2, gauge_center, 255);
+	contents->Blit(cx + 0, cy, *system2, gauge_left, alpha);
+	contents->Blit(cx + 16 + 25, cy, *system2, gauge_right, alpha);
+	contents->StretchBlit(dst_rect, *system2, gauge_center, alpha);
 
 	const auto atb = actor.GetAtbGauge();
 	const auto gauge_w = 25 * atb / actor.GetMaxAtbGauge();
@@ -334,6 +334,6 @@ void Window_Base::DrawGauge(const Game_Battler& actor, int cx, int cy) const {
 		// Full or not full bar
 		Rect gauge_bar(full ? 64 : 48, gauge_y, 16, 16);
 		Rect bar_rect(cx + 16, cy, gauge_w, 16);
-		contents->StretchBlit(bar_rect, *system2, gauge_bar, 255);
+		contents->StretchBlit(bar_rect, *system2, gauge_bar, alpha);
 	}
 }

--- a/src/window_base.h
+++ b/src/window_base.h
@@ -67,7 +67,7 @@ public:
 	void DrawItemName(const lcf::rpg::Item& item, int cx, int cy, bool enabled = true) const;
 	void DrawSkillName(const lcf::rpg::Skill& skill, int cx, int cy, bool enabled = true) const;
 	void DrawCurrencyValue(int money, int cx, int cy) const;
-	void DrawGauge(const Game_Battler& actor, int cx, int cy) const;
+	void DrawGauge(const Game_Battler& actor, int cx, int cy, int alpha = 255) const;
 	/** @} */
 
 	/**

--- a/src/window_base.h
+++ b/src/window_base.h
@@ -68,6 +68,8 @@ public:
 	void DrawSkillName(const lcf::rpg::Skill& skill, int cx, int cy, bool enabled = true) const;
 	void DrawCurrencyValue(int money, int cx, int cy) const;
 	void DrawGauge(const Game_Battler& actor, int cx, int cy, int alpha = 255) const;
+	void DrawActorHpValue(const Game_Battler& actor, int cx, int cy) const;
+	void DrawActorSpValue(const Game_Battler& actor, int cx, int cy) const;
 	/** @} */
 
 	/**

--- a/src/window_base.h
+++ b/src/window_base.h
@@ -70,6 +70,7 @@ public:
 	void DrawGauge(const Game_Battler& actor, int cx, int cy, int alpha = 255) const;
 	void DrawActorHpValue(const Game_Battler& actor, int cx, int cy) const;
 	void DrawActorSpValue(const Game_Battler& actor, int cx, int cy) const;
+	int GetValueFontColor(int have, int max, bool can_knockout) const;
 	/** @} */
 
 	/**

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -101,6 +101,10 @@ void Window_BattleStatus::Refresh() {
 
 void Window_BattleStatus::RefreshGauge() {
 	if (Player::IsRPG2k3()) {
+		if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_alternative) {
+			contents->ClearRect(Rect(192, 0, 45, 64));
+		}
+
 		for (int i = 0; i < item_max; ++i) {
 			// The party always contains valid battlers
 			Game_Battler* actor;
@@ -154,7 +158,10 @@ void Window_BattleStatus::RefreshGauge() {
 				int y = 2 + i * 16;
 
 				if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_alternative) {
-					DrawGauge(*actor, 202 - 10, y - 2);
+					// RPG_RT Bug (?): Gauge hidden when selected due to transparency (wrong color when rendering)
+					if (lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_opaque || (2 + index * 16 != y)) {
+						DrawGauge(*actor, 202 - 10, y - 2, lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_opaque ? 96 : 255);
+					}
 					DrawActorHp(*actor, 136, y, 4, true);
 					DrawActorSp(*actor, 202, y, 3, false);
 				} else {

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -81,13 +81,17 @@ void Window_BattleStatus::Refresh() {
 			int y = 2 + i * 16;
 
 			DrawActorName(*actor, 4, y);
-			DrawActorState(*actor, 84 + (Player::IsRPG2k() ? 2 : 0), y);
-			if (Player::IsRPG2k3() && lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional) {
-				contents->TextDraw(132 + 4 * 6, y, Font::ColorDefault, std::to_string(actor->GetHp()), Text::AlignRight);
+			if (Player::IsRPG2k()) {
+				DrawActorState(*actor, 86, y);
+				DrawActorHp(*actor, 142, y, 3, true);
+				DrawActorSp(*actor, 202, y, 3, false);
 			} else {
-				int digits = Player::IsRPG2k() ? 3 : 4;
-				DrawActorHp(*actor, 126 + (Player::IsRPG2k() ? 16 : 0), y, digits, true);
-				DrawActorSp(*actor, 198 + (Player::IsRPG2k() ? 4 : 0), y, 3, false);
+				if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional) {
+					DrawActorState(*actor, 84, y);
+					contents->TextDraw(126 + 42 + 4 * 6, y, Font::ColorDefault, std::to_string(actor->GetHp()), Text::AlignRight);
+				} else {
+					DrawActorState(*actor, 80, y);
+				}
 			}
 		}
 	}
@@ -97,11 +101,6 @@ void Window_BattleStatus::Refresh() {
 
 void Window_BattleStatus::RefreshGauge() {
 	if (Player::IsRPG2k3()) {
-		int gauge_x = contents->GetWidth() - 48;
-		if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_gauge) {
-			contents->ClearRect(Rect(gauge_x + 10, 0, 25 + 16, 15 * item_max));
-		}
-
 		for (int i = 0; i < item_max; ++i) {
 			// The party always contains valid battlers
 			Game_Battler* actor;
@@ -154,9 +153,10 @@ void Window_BattleStatus::RefreshGauge() {
 			else {
 				int y = 2 + i * 16;
 
-				DrawGauge(*actor, gauge_x, y - 2);
+				DrawGauge(*actor, 202 - 10, y - 2);
 				if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_alternative) {
-					DrawActorSp(*actor, 198, y, 3, false);
+					DrawActorHp(*actor, 136, y, 4, true);
+					DrawActorSp(*actor, 202, y, 3, false);
 				}
 			}
 		}

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -88,7 +88,7 @@ void Window_BattleStatus::Refresh() {
 			} else {
 				if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional) {
 					DrawActorState(*actor, 84, y);
-					contents->TextDraw(136 + 4 * 6, y, Font::ColorDefault, std::to_string(actor->GetHp()), Text::AlignRight);
+					contents->TextDraw(136 + 4 * 6, y, actor->GetHp() == 0 ? Font::ColorKnockout : actor->GetHp() <= actor->GetMaxHp() / 4 ? Font::ColorCritical : Font::ColorDefault, std::to_string(actor->GetHp()), Text::AlignRight);
 				} else {
 					DrawActorState(*actor, 80, y);
 				}

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -88,7 +88,7 @@ void Window_BattleStatus::Refresh() {
 			} else {
 				if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional) {
 					DrawActorState(*actor, 84, y);
-					contents->TextDraw(126 + 42 + 4 * 6, y, Font::ColorDefault, std::to_string(actor->GetHp()), Text::AlignRight);
+					contents->TextDraw(136 + 4 * 6, y, Font::ColorDefault, std::to_string(actor->GetHp()), Text::AlignRight);
 				} else {
 					DrawActorState(*actor, 80, y);
 				}
@@ -153,10 +153,12 @@ void Window_BattleStatus::RefreshGauge() {
 			else {
 				int y = 2 + i * 16;
 
-				DrawGauge(*actor, 202 - 10, y - 2);
 				if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_alternative) {
+					DrawGauge(*actor, 202 - 10, y - 2);
 					DrawActorHp(*actor, 136, y, 4, true);
 					DrawActorSp(*actor, 202, y, 3, false);
+				} else {
+					DrawGauge(*actor, 156, y - 2);
 				}
 			}
 		}

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -88,7 +88,7 @@ void Window_BattleStatus::Refresh() {
 			} else {
 				if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional) {
 					DrawActorState(*actor, 84, y);
-					contents->TextDraw(136 + 4 * 6, y, actor->GetHp() == 0 ? Font::ColorKnockout : actor->GetHp() <= actor->GetMaxHp() / 4 ? Font::ColorCritical : Font::ColorDefault, std::to_string(actor->GetHp()), Text::AlignRight);
+					DrawActorHpValue(*actor, 136 + 4 * 6, y);
 				} else {
 					DrawActorState(*actor, 80, y);
 				}


### PR DESCRIPTION
This PR does the following changes:

- The status window components have been rearranged to match the RPG_RT style.
- The transparent windows use an alpha of 160 instead of 128 now (tested with truecolor RPG_RT).
- In traditional style battles two bugs have been fixed: The SP window got printed over when a skill which costs SP has been used and the HP value didn't change its color if the HP reached critical or zero.
- In alternative style battles the gauges are now shown transparent if the window is opaque.
- The ally cursor is always drawn 40 pixels above the Y-Position of the battler.
- The enemy cursor is always drawn on the same height as the Y-Position of the enemy.
- Flipped actors use now the correct walking animation on escaping.
- The battle status window gets refreshed on applying state effects. This stops the HP value "lagging" behind on traditional battle mode.
- The enemy target window gets refreshed as soon as an enemy dies.