### PR TITLE
Help window space width changes

### DIFF
--- a/src/scene_actortarget.cpp
+++ b/src/scene_actortarget.cpp
@@ -71,7 +71,7 @@ void Scene_ActorTarget::Start() {
 			}
 		}
 		status_window->SetData(id, true, 0);
-		help_window->SetText(ToString(item->name));
+		help_window->SetText(ToString(item->name), Font::ColorDefault, Text::AlignLeft, false);
 		return;
 	} else {
 		const lcf::rpg::Skill* skill = lcf::ReaderUtil::GetElement(lcf::Data::skills, id);
@@ -88,7 +88,7 @@ void Scene_ActorTarget::Start() {
 		}
 
 		status_window->SetData(id, false, actor_index);
-		help_window->SetText(ToString(skill->name));
+		help_window->SetText(ToString(skill->name), Font::ColorDefault, Text::AlignLeft, false);
 	}
 }
 

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -2436,7 +2436,7 @@ void Scene_Battle_Rpg2k3::ShowNotification(std::string text) {
 		return;
 	}
 	help_window->SetVisible(true);
-	help_window->SetText(std::move(text));
+	help_window->SetText(std::move(text), Font::ColorDefault, Text::AlignLeft, false);
 }
 
 void Scene_Battle_Rpg2k3::EndNotification() {

--- a/src/scene_end.cpp
+++ b/src/scene_end.cpp
@@ -74,7 +74,7 @@ void Scene_End::CreateHelpWindow() {
 
 	help_window.reset(new Window_Help((SCREEN_TARGET_WIDTH/2) - (text_size + 16)/ 2,
 									  72, text_size + 16, 32));
-	help_window->SetText(ToString(lcf::Data::terms.exit_game_message));
+	help_window->SetText(ToString(lcf::Data::terms.exit_game_message), Font::ColorDefault, Text::AlignLeft, false);
 
 	command_window->SetHelpWindow(help_window.get());
 }

--- a/src/window_help.cpp
+++ b/src/window_help.cpp
@@ -29,7 +29,7 @@ Window_Help::Window_Help(int ix, int iy, int iwidth, int iheight, Drawable::Flag
 	contents->Clear();
 }
 
-void Window_Help::SetText(std::string text, int color, Text::Alignment align) {
+void Window_Help::SetText(std::string text, int color, Text::Alignment align, bool halfwidthspace) {
 	if (this->text != text || this->color != color || this->align != align) {
 		contents->Clear();
 
@@ -43,7 +43,11 @@ void Window_Help::SetText(std::string text, int color, Text::Alignment align) {
 			x += Font::Default()->GetSize(segment).width;
 
 			if (nextpos != decltype(text)::npos) {
-				x += Font::Default()->GetSize(" ").width / 2;
+				if (halfwidthspace) {
+					x += Font::Default()->GetSize(" ").width / 2;
+				} else {
+					x += Font::Default()->GetSize(" ").width;
+				}
 				pos = nextpos + 1;
 			}
 		}

--- a/src/window_help.h
+++ b/src/window_help.h
@@ -40,8 +40,9 @@ public:
 	 *
 	 * @param text text to show.
 	 * @param align text alignment.
+	 * @param halfwidthspace if half width spaces should be used.
 	 */
-	void SetText(std::string text, int color = Font::ColorDefault, Text::Alignment align = Text::AlignLeft);
+	void SetText(std::string text, int color = Font::ColorDefault, Text::Alignment align = Text::AlignLeft, bool halfwidthspace = true);
 
 	/**
 	 * Clears the window


### PR DESCRIPTION
Depends on #2399 because of the help window changes made there.

The target status window and end game window and the RPG Maker 2003 battle notifications use full width spaces instead of half width spaces in RPG_RT. This PR does these changes.

Fixes the bug reported of the end screen in #2264.