### PR TITLE
Stub Maniac Patch commands, add --patch cli arg

### DIFF
--- a/resources/easyrpg-player.6.adoc
+++ b/resources/easyrpg-player.6.adoc
@@ -111,6 +111,13 @@ directory!
    - 'RPG_RT'     - The default RPG_RT compatible algo, including RPG_RT bugs
    - 'RPG_RT+'    - The default RPG_RT compatible algo, with bug fixes
 
+*--patch* 'PATCH_A' ['PATCH_B' '...']::
+  Force emulation of engine patches, disabling auto detection.
+  Possible options:
+   - 'none'       - Disable all patches
+   - 'dynrpg'     - DynRPG patch by Cherry
+   - 'maniac'     - Maniac Patch by BingShan
+
 *--start-map-id* 'ID'::
   Overwrite the map used for new games and use Map__ID__.lmu instead ('ID' is
   padded to four digits).

--- a/src/game_ineluki.cpp
+++ b/src/game_ineluki.cpp
@@ -170,7 +170,7 @@ bool Game_Ineluki::Execute(StringView ini_file) {
 			// TODO: automatic (append mouse pos every 500ms) not implemented
 #if !defined(USE_MOUSE) || !defined(SUPPORT_MOUSE)
 			if (mouse_support) {
-				Output::Debug("Ineluki: Mouse input is not supported on this platform");
+				Output::Warning("Ineluki: Mouse input is not supported on this platform");
 			}
 #else
 			if (prev_mouse_support != mouse_support) {

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -726,14 +726,6 @@ bool Game_Interpreter::ExecuteCommand() {
 			return CommandManiacShowStringPicture(com);
 		case Cmd::Maniac_GetPictureInfo:
 			return CommandManiacGetPictureInfo(com);
-		case Cmd::Maniac_ControlBattle:
-			return CommandManiacControlBattle(com);
-		case Cmd::Maniac_ControlAtbGauge:
-			return CommandManiacControlAtbGauge(com);
-		case Cmd::Maniac_ChangeBattleCommandEx:
-			return CommandManiacChangeBattleCommandEx(com);
-		case Cmd::Maniac_GetBattleInfo:
-			return CommandManiacGetBattleInfo(com);
 		case Cmd::Maniac_ControlVarArray:
 			return CommandManiacControlVarArray(com);
 		case Cmd::Maniac_KeyInputProcEx:
@@ -3552,42 +3544,6 @@ bool Game_Interpreter::CommandManiacGetPictureInfo(lcf::rpg::EventCommand const&
 	return true;
 }
 
-bool Game_Interpreter::CommandManiacControlBattle(lcf::rpg::EventCommand const&) {
-	if (!Player::IsPatchManiac()) {
-		return true;
-	}
-
-	Output::Warning("Maniac Patch: Command ControlBattle not supported");
-	return true;
-}
-
-bool Game_Interpreter::CommandManiacControlAtbGauge(lcf::rpg::EventCommand const&) {
-	if (!Player::IsPatchManiac()) {
-		return true;
-	}
-
-	Output::Warning("Maniac Patch: Command ControlAtbGauge not supported");
-	return true;
-}
-
-bool Game_Interpreter::CommandManiacChangeBattleCommandEx(lcf::rpg::EventCommand const&) {
-	if (!Player::IsPatchManiac()) {
-		return true;
-	}
-
-	Output::Warning("Maniac Patch: Command ChangeBattleCommandEx not supported");
-	return true;
-}
-
-bool Game_Interpreter::CommandManiacGetBattleInfo(lcf::rpg::EventCommand const&) {
-	if (!Player::IsPatchManiac()) {
-		return true;
-	}
-
-	Output::Warning("Maniac Patch: Command GetBattleInfo not supported");
-	return true;
-}
-
 bool Game_Interpreter::CommandManiacControlVarArray(lcf::rpg::EventCommand const&) {
 	if (!Player::IsPatchManiac()) {
 		return true;
@@ -3650,7 +3606,6 @@ bool Game_Interpreter::CommandManiacCallCommand(lcf::rpg::EventCommand const&) {
 	Output::Warning("Maniac Patch: Command CallCommand not supported");
 	return true;
 }
-
 
 Game_Interpreter& Game_Interpreter::GetForegroundInterpreter() {
 	return Game_Battle::IsBattleRunning()

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -3505,7 +3505,23 @@ bool Game_Interpreter::CommandManiacGetMousePosition(lcf::rpg::EventCommand cons
 		return true;
 	}
 
-	Output::Warning("Maniac Patch: Command GetMousePosition not supported");
+#if !defined(USE_MOUSE) || !defined(SUPPORT_MOUSE)
+	static bool warned = false;
+	if (!warned) {
+		// This command is polled, prevent excessive spam
+		Output::Warning("Maniac Patch: Mouse input is not supported on this platform");
+		warned = true;
+	}
+	return true;
+#endif
+
+	Point mouse_pos = Input::GetMousePosition();
+
+	Main_Data::game_variables->Set(com.parameters[0], mouse_pos.x);
+	Main_Data::game_variables->Set(com.parameters[1], mouse_pos.y);
+
+	Game_Map::SetNeedRefresh(true);
+
 	return true;
 }
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -710,6 +710,44 @@ bool Game_Interpreter::ExecuteCommand() {
 			return CommandExitGame(com);
 		case Cmd::ToggleFullscreen:
 			return CommandToggleFullscreen(com);
+		case Cmd::Maniac_GetSaveInfo:
+			return CommandManiacGetSaveInfo(com);
+		case Cmd::Maniac_Load:
+			return CommandManiacLoad(com);
+		case Cmd::Maniac_Save:
+			return CommandManiacSave(com);
+		case Cmd::Maniac_EndLoadProcess:
+			return CommandManiacEndLoadProcess(com);
+		case Cmd::Maniac_GetMousePosition:
+			return CommandManiacGetMousePosition(com);
+		case Cmd::Maniac_SetMousePosition:
+			return CommandManiacSetMousePosition(com);
+		case Cmd::Maniac_ShowStringPicture:
+			return CommandManiacShowStringPicture(com);
+		case Cmd::Maniac_GetPictureInfo:
+			return CommandManiacGetPictureInfo(com);
+		case Cmd::Maniac_ControlBattle:
+			return CommandManiacControlBattle(com);
+		case Cmd::Maniac_ControlAtbGauge:
+			return CommandManiacControlAtbGauge(com);
+		case Cmd::Maniac_ChangeBattleCommandEx:
+			return CommandManiacChangeBattleCommandEx(com);
+		case Cmd::Maniac_GetBattleInfo:
+			return CommandManiacGetBattleInfo(com);
+		case Cmd::Maniac_ControlVarArray:
+			return CommandManiacControlVarArray(com);
+		case Cmd::Maniac_KeyInputProcEx:
+			return CommandManiacKeyInputProcEx(com);
+		case Cmd::Maniac_RewriteMap:
+			return CommandManiacRewriteMap(com);
+		case Cmd::Maniac_ControlGlobalSave:
+			return CommandManiacControlGlobalSave(com);
+		case Cmd::Maniac_ChangePictureId:
+			return CommandManiacChangePictureId(com);
+		case Cmd::Maniac_SetGameOption:
+			return CommandManiacSetGameOption(com);
+		case Cmd::Maniac_CallCommand:
+			return CommandManiacCallCommand(com);
 		default:
 			return true;
 	}
@@ -3425,6 +3463,178 @@ bool Game_Interpreter::CommandToggleFullscreen(lcf::rpg::EventCommand const& /* 
 	DisplayUi->ToggleFullscreen();
 	return true;
 }
+
+bool Game_Interpreter::CommandManiacGetSaveInfo(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command GetSaveInfo not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacSave(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command Save not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacLoad(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command Load not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacEndLoadProcess(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command EndLoadProcess not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacGetMousePosition(lcf::rpg::EventCommand const& com) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command GetMousePosition not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacSetMousePosition(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command SetMousePosition not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacShowStringPicture(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command ShowStringPicture not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacGetPictureInfo(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command GetPictureInfo not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacControlBattle(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command ControlBattle not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacControlAtbGauge(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command ControlAtbGauge not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacChangeBattleCommandEx(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command ChangeBattleCommandEx not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacGetBattleInfo(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command GetBattleInfo not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacControlVarArray(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command ControlVarArray not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacKeyInputProcEx(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command KeyInputProcEx not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacRewriteMap(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command RewriteMap not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacControlGlobalSave(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command ControlGlobalSave not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacChangePictureId(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command ChangePictureId not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacSetGameOption(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command SetGameOption not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacCallCommand(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command CallCommand not supported");
+	return true;
+}
+
 
 Game_Interpreter& Game_Interpreter::GetForegroundInterpreter() {
 	return Game_Battle::IsBattleRunning()

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -265,10 +265,6 @@ protected:
 	bool CommandManiacSetMousePosition(lcf::rpg::EventCommand const& com);
 	bool CommandManiacShowStringPicture(lcf::rpg::EventCommand const& com);
 	bool CommandManiacGetPictureInfo(lcf::rpg::EventCommand const& com);
-	bool CommandManiacControlBattle(lcf::rpg::EventCommand const& com);
-	bool CommandManiacControlAtbGauge(lcf::rpg::EventCommand const& com);
-	bool CommandManiacChangeBattleCommandEx(lcf::rpg::EventCommand const& com);
-	bool CommandManiacGetBattleInfo(lcf::rpg::EventCommand const& com);
 	bool CommandManiacControlVarArray(lcf::rpg::EventCommand const& com);
 	bool CommandManiacKeyInputProcEx(lcf::rpg::EventCommand const& com);
 	bool CommandManiacRewriteMap(lcf::rpg::EventCommand const& com);

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -257,6 +257,25 @@ protected:
 	bool CommandChangeBattleCommands(lcf::rpg::EventCommand const& com);
 	bool CommandExitGame(lcf::rpg::EventCommand const& com);
 	bool CommandToggleFullscreen(lcf::rpg::EventCommand const& com);
+	bool CommandManiacGetSaveInfo(lcf::rpg::EventCommand const& com);
+	bool CommandManiacSave(lcf::rpg::EventCommand const& com);
+	bool CommandManiacLoad(lcf::rpg::EventCommand const& com);
+	bool CommandManiacEndLoadProcess(lcf::rpg::EventCommand const& com);
+	bool CommandManiacGetMousePosition(lcf::rpg::EventCommand const& com);
+	bool CommandManiacSetMousePosition(lcf::rpg::EventCommand const& com);
+	bool CommandManiacShowStringPicture(lcf::rpg::EventCommand const& com);
+	bool CommandManiacGetPictureInfo(lcf::rpg::EventCommand const& com);
+	bool CommandManiacControlBattle(lcf::rpg::EventCommand const& com);
+	bool CommandManiacControlAtbGauge(lcf::rpg::EventCommand const& com);
+	bool CommandManiacChangeBattleCommandEx(lcf::rpg::EventCommand const& com);
+	bool CommandManiacGetBattleInfo(lcf::rpg::EventCommand const& com);
+	bool CommandManiacControlVarArray(lcf::rpg::EventCommand const& com);
+	bool CommandManiacKeyInputProcEx(lcf::rpg::EventCommand const& com);
+	bool CommandManiacRewriteMap(lcf::rpg::EventCommand const& com);
+	bool CommandManiacControlGlobalSave(lcf::rpg::EventCommand const& com);
+	bool CommandManiacChangePictureId(lcf::rpg::EventCommand const& com);
+	bool CommandManiacSetGameOption(lcf::rpg::EventCommand const& com);
+	bool CommandManiacCallCommand(lcf::rpg::EventCommand const& com);
 
 	int DecodeInt(lcf::DBArray<int32_t>::const_iterator& it);
 	const std::string DecodeString(lcf::DBArray<int32_t>::const_iterator& it);

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -176,6 +176,14 @@ bool Game_Interpreter_Battle::ExecuteCommand() {
 			return CommandElseBranchBattle(com);
 		case Cmd::EndBranch_B:
 			return CommandEndBranchBattle(com);
+		case Cmd::Maniac_ControlBattle:
+			return CommandManiacControlBattle(com);
+		case Cmd::Maniac_ControlAtbGauge:
+			return CommandManiacControlAtbGauge(com);
+		case Cmd::Maniac_ChangeBattleCommandEx:
+			return CommandManiacChangeBattleCommandEx(com);
+		case Cmd::Maniac_GetBattleInfo:
+			return CommandManiacGetBattleInfo(com);
 		default:
 			return Game_Interpreter::ExecuteCommand();
 	}
@@ -506,6 +514,42 @@ bool Game_Interpreter_Battle::CommandElseBranchBattle(lcf::rpg::EventCommand con
 }
 
 bool Game_Interpreter_Battle::CommandEndBranchBattle(lcf::rpg::EventCommand const& /* com */) { //code 23311
+	return true;
+}
+
+bool Game_Interpreter_Battle::CommandManiacControlBattle(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command ControlBattle not supported");
+	return true;
+}
+
+bool Game_Interpreter_Battle::CommandManiacControlAtbGauge(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command ControlAtbGauge not supported");
+	return true;
+}
+
+bool Game_Interpreter_Battle::CommandManiacChangeBattleCommandEx(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command ChangeBattleCommandEx not supported");
+	return true;
+}
+
+bool Game_Interpreter_Battle::CommandManiacGetBattleInfo(lcf::rpg::EventCommand const&) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	Output::Warning("Maniac Patch: Command GetBattleInfo not supported");
 	return true;
 }
 

--- a/src/game_interpreter_battle.h
+++ b/src/game_interpreter_battle.h
@@ -72,6 +72,12 @@ private:
 	bool CommandConditionalBranchBattle(lcf::rpg::EventCommand const& com);
 	bool CommandElseBranchBattle(lcf::rpg::EventCommand const& com);
 	bool CommandEndBranchBattle(lcf::rpg::EventCommand const& com);
+
+	bool CommandManiacControlBattle(lcf::rpg::EventCommand const& com);
+	bool CommandManiacControlAtbGauge(lcf::rpg::EventCommand const& com);
+	bool CommandManiacChangeBattleCommandEx(lcf::rpg::EventCommand const& com);
+	bool CommandManiacGetBattleInfo(lcf::rpg::EventCommand const& com);
+
 private:
 	Span<const lcf::rpg::TroopPage> pages;
 	std::vector<bool> executed;

--- a/src/player.h
+++ b/src/player.h
@@ -51,7 +51,9 @@ namespace Player {
 		/** DynRPG */
 		PatchDynRpg = 1,
 		/** ManiacPatch */
-		PatchManiac = 2
+		PatchManiac = 1 << 1,
+		/** Patches specified on command line, no autodetect */
+		PatchOverride = 1 << 16
 	};
 
 	/**


### PR DESCRIPTION
This stubs Maniac Patch commands in the interpreter and emits warnings.
Can help in finding problematic games.

Also added a ``--patch`` cli arg because there is currently no way to configure this stuff in emscripten.