### PR TITLE
Show more than one state in help window

### DIFF
--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -678,6 +678,11 @@ void Game_Battler::Flash(int r, int g, int b, int power, int frames) {
 	flash.time_left = frames;
 }
 
+const std::vector<lcf::rpg::State*> Game_Battler::GetInflictedStatesOrderedByPriority() const {
+	std::vector<lcf::rpg::State*> state_list = State::GetObjects(GetStates());
+	return State::SortedByPriority(state_list);
+}
+
 int Game_Battler::CanChangeAtkModifier(int modifier) const {
 	const auto prev = atk_modifier;
 	const auto base = GetBaseAtk();

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -875,6 +875,9 @@ public:
 	/** @return battle frame counter */
 	int GetBattleFrameCounter() const;
 
+	/** @return inflicted states as state objects ordered by priority */
+	const std::vector<lcf::rpg::State*> GetInflictedStatesOrderedByPriority() const;
+
 protected:
 	/** Gauge for RPG2k3 Battle */
 	int gauge = 0;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -44,6 +44,7 @@
 #include "output.h"
 #include "autobattle.h"
 #include "enemyai.h"
+#include <algorithm>
 
 Scene_Battle_Rpg2k3::Scene_Battle_Rpg2k3(const BattleArgs& args) :
 	Scene_Battle(args),
@@ -427,9 +428,15 @@ void Scene_Battle_Rpg2k3::UpdateAnimations() {
 					enemy_cursor->SetX(enemy->GetBattlePosition().x + sprite->GetWidth() / 2 + 2);
 					enemy_cursor->SetY(enemy->GetBattlePosition().y - enemy_cursor->GetHeight() / 2);
 
-					auto* state = enemy->GetSignificantState();
-					if (state) {
-						help_window->SetText(ToString(state->name), state->color);
+					std::vector<lcf::rpg::State*> ordered_states = enemy->GetInflictedStatesOrderedByPriority();
+					if (ordered_states.size() > 0) {
+						help_window->Clear();
+						int state_counter = 0;
+						for (lcf::rpg::State* state : ordered_states) {
+							std::string state_name = fmt::format("{:9s}", state->name);
+							help_window->AddText(state_name, state->color, Text::AlignLeft, false);
+							if (++state_counter >= 5) break;
+						}
 						help_window->SetVisible(true);
 					} else {
 						help_window->SetVisible(false);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -203,4 +203,23 @@ int GetStateRate(int state_id, int rate) {
 
 }
 
+const std::vector<lcf::rpg::State*> GetObjects(const StateVec& states) {
+	std::vector<lcf::rpg::State*> state_list;
+	for (size_t i = 0; i < states.size(); ++i) {
+		if (states[i] > 0) {
+			lcf::rpg::State* state = lcf::ReaderUtil::GetElement(lcf::Data::states, i + 1);
+			state_list.push_back(state);
+		}
+	}
+	return state_list;
+}
+
+const std::vector<lcf::rpg::State*> SortedByPriority(const std::vector<lcf::rpg::State*>& states) {
+	std::vector<lcf::rpg::State*> state_list = states;
+	std::sort(state_list.begin(), state_list.end(), [](lcf::rpg::State* lhs, lcf::rpg::State* rhs) {
+		return std::tie(lhs->priority, lhs->ID) > std::tie(rhs->priority, rhs->ID);
+	});
+	return state_list;
+}
+
 } //namspace State

--- a/src/state.h
+++ b/src/state.h
@@ -109,6 +109,22 @@ const lcf::rpg::State* GetSignificantState(const StateVec& states);
  */
 int GetStateRate(int state_id, int rate);
 
+/**
+ * Return vector with state objects.
+ *
+ * @param vector of states
+ * @return vector which contains the given states as state objects
+ */
+const std::vector<lcf::rpg::State*> GetObjects(const StateVec& states);
+
+/**
+ * Return vector with state objects which are sorted by priority.
+ *
+ * @param vector of state objects
+ * @return vector which contains the given state objects sorted by priority
+ */
+const std::vector<lcf::rpg::State*> SortedByPriority(const std::vector<lcf::rpg::State*>& states);
+
 } //namespace State
 
 inline bool State::Has(int state_id, const StateVec& states) {

--- a/src/window_help.cpp
+++ b/src/window_help.cpp
@@ -33,24 +33,8 @@ void Window_Help::SetText(std::string text, int color, Text::Alignment align, bo
 	if (this->text != text || this->color != color || this->align != align) {
 		contents->Clear();
 
-		int x = 0;
-		std::string::size_type pos = 0;
-		std::string::size_type nextpos = 0;
-		while (nextpos != std::string::npos) {
-			nextpos = text.find(' ', pos);
-			auto segment = ToStringView(text).substr(pos, nextpos - pos);
-			contents->TextDraw(x, 2, color, segment, align);
-			x += Font::Default()->GetSize(segment).width;
-
-			if (nextpos != decltype(text)::npos) {
-				if (halfwidthspace) {
-					x += Font::Default()->GetSize(" ").width / 2;
-				} else {
-					x += Font::Default()->GetSize(" ").width;
-				}
-				pos = nextpos + 1;
-			}
-		}
+		text_x_offset = 0;
+		AddText(text, color, align, halfwidthspace);
 
 		this->text = std::move(text);
 		this->align = align;
@@ -62,5 +46,26 @@ void Window_Help::Clear() {
 	this->text = "";
 	this->color = Font::ColorDefault;
 	this->align = Text::AlignLeft;
+	text_x_offset = 0;
 	contents->Clear();
+}
+
+void Window_Help::AddText(std::string text, int color, Text::Alignment align, bool halfwidthspace) {
+	std::string::size_type pos = 0;
+	std::string::size_type nextpos = 0;
+	while (nextpos != std::string::npos) {
+		nextpos = text.find(' ', pos);
+		auto segment = ToStringView(text).substr(pos, nextpos - pos);
+		contents->TextDraw(text_x_offset, 2, color, segment, align);
+		text_x_offset += Font::Default()->GetSize(segment).width;
+
+		if (nextpos != decltype(text)::npos) {
+			if (halfwidthspace) {
+				text_x_offset += Font::Default()->GetSize(" ").width / 2;
+			} else {
+				text_x_offset += Font::Default()->GetSize(" ").width;
+			}
+			pos = nextpos + 1;
+		}
+	}
 }

--- a/src/window_help.h
+++ b/src/window_help.h
@@ -49,6 +49,16 @@ public:
 	 */
 	void Clear();
 
+	/**
+	 * Adds text to the help window. This does not overwrite the old content.
+	 *
+	 * @param text text to add.
+	 * @param color text color.
+	 * @param align text alignment.
+	 * @param halfwidthspace if half width spaces should be used.
+	 */
+	void AddText(std::string text, int color = Font::ColorDefault, Text::Alignment align = Text::AlignLeft, bool halfwidthspace = true);
+
 private:
 	/** Text to draw. */
 	std::string text;
@@ -56,6 +66,8 @@ private:
 	int color = Font::ColorDefault;
 	/** Alignment of text. */
 	Text::Alignment align;
+	/** Current text position */
+	int text_x_offset = 0;
 };
 
 #endif


### PR DESCRIPTION
This PR makes the help window in RPG Maker 2003 battles show more than one state if you target an enemy. Up to 5 states are shown ordered by priority.

Fixes: #2487