### PR TITLE
SDL mixer: Do not leak handles

### DIFF
--- a/src/audio_sdl_mixer.cpp
+++ b/src/audio_sdl_mixer.cpp
@@ -318,12 +318,7 @@ void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int
 		return;
 	}
 
-	filestream = FileFinder::OpenInputStream(file);
-	if (!filestream) {
-		// Unlikely, just in case
-		Output::Warning("Music not readable: {}", FileFinder::GetPathInsideGamePath(file));
-		return;
-	}
+	filestream.seekg(0, std::ios_base::beg);
 	SDL_RWops* rw = create_StreamRWOps(std::move(filestream));
 
 	bgm_stop = false;

--- a/src/audio_sdl_mixer.cpp
+++ b/src/audio_sdl_mixer.cpp
@@ -326,7 +326,7 @@ void SdlMixerAudio::BGM_Play(std::string const& file, int volume, int pitch, int
 
 	// rw will be freed in Mix_FreeMusic
 #if SDL_MIXER_MAJOR_VERSION>1
-	bgm.reset(Mix_LoadMUS_RW(rw, 0), &Mix_FreeMusic);
+	bgm.reset(Mix_LoadMUS_RW(rw, 1), &Mix_FreeMusic);
 #else
 	bgm.reset(Mix_LoadMUS_RW(rw), &Mix_FreeMusic);
 #endif

--- a/src/decoder_midigeneric.cpp
+++ b/src/decoder_midigeneric.cpp
@@ -158,7 +158,7 @@ int GenericMidiDecoder::FillBuffer(uint8_t* buffer, int length) {
 
 	// Advance the MIDI playback in smaller steps to achieve a 1ms message resolution
 	// Otherwise the MIDI sounds off because messages are processed too late.
-	for (;;) {
+	while (samples_max > 0) {
 		// Process MIDI messages
 		size_t samples = std::min(samples_per_play, samples_max);
 		float delta = (float)samples / (frequency * 100.0f / pitch);


### PR DESCRIPTION
This one is interesting and very old :(.

- [x] Test Native MIDI on Windows

The good news: This only affects SDL Mixer (not SDL) and in June 2016 we added the Audio Decoder classes which resulted in this codepath being almost never used anymore (except for Native MIDI playback).

First: ``Load_MUS_RW`` of SDL Mixer 1.2 _never_ closes handles. So for SDL1.2 we leak them since June 2014:
https://github.com/EasyRPG/Player/commit/a441cbc16e7ca9fee42a9527536d824e657deaef
(I will not fix this, we do not use Mixer 1.2 anywhere anymore)

For SDL2 the bug was introduced here in Feb 2016:
https://github.com/EasyRPG/Player/commit/4f2b8c9cb5beb109c65e7838f71b986c3e6a2892
The commit messages links to #710 which discusses a fix for a double free in the SDL ADPCM loader.

I also think that this comment here is wrong "The crash can be worked around by passing 0 instead of 1 to SDL_LoadMUS_RW() and the free call is already done from the shared_ptr reset deleter parameter.". The shared_ptr deleter only applied to SE, not to BGM.

_I simply set the "free_src" param to 1, I do not really care that this breaks ADPCM, we use libsndfile for this. SDL mixer can die once the native Midi PR is in_

Fix: #2494

--------

I also noticed that BGS_Play does use filenames directly, so this is also broken with my VFS-PR... Not going to fix this.


