### PR TITLE
Implement customizable enemy unarmed battle animation

### DIFF
--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -596,7 +596,8 @@ int Game_BattleAlgorithm::Normal::GetAnimationId(int idx) const {
 	if (source->GetType() == Game_Battler::Type_Enemy
 			&& Player::IsRPG2k3()
 			&& !lcf::Data::animations.empty()) {
-		return 1;
+		Game_Enemy* enemy = static_cast<Game_Enemy*>(source);
+		return enemy->GetUnarmedBattleAnimationId();
 	}
 	return 0;
 }

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -21,6 +21,7 @@
 // Headers
 #include "game_battler.h"
 #include "sprite_enemy.h"
+#include "player.h"
 #include <lcf/rpg/enemy.h>
 #include <lcf/rpg/enemyaction.h>
 #include <lcf/rpg/troopmember.h>
@@ -224,6 +225,9 @@ public:
 	/** @return true if enemy is flying */
 	bool IsFlying() const;
 
+	/** @return the id of the enemy's unarmed battle animation */
+	int GetUnarmedBattleAnimationId() const;
+
 	Sprite_Enemy* GetEnemyBattleSprite() const;
 
 protected:
@@ -360,6 +364,10 @@ inline void Game_Enemy::SetDeathTimer(int t) {
 
 inline bool Game_Enemy::IsFlying() const {
 	return enemy->levitate;
+}
+
+inline int Game_Enemy::GetUnarmedBattleAnimationId() const {
+        return (Player::IsPatchManiac() ? enemy->maniac_unarmed_animation : 1);
 }
 
 inline Sprite_Enemy* Game_Enemy::GetEnemyBattleSprite() const {


### PR DESCRIPTION
This PR allows to set the unarmed battle animation of an enemy via the "maniac_unarmed_animation" setting in the LCF database. This fixes the first bullet point in #2497.