### PR TITLE
Make RPG Maker 2003 battle hardcoded terms customizable

### DIFF
--- a/src/battle_message.cpp
+++ b/src/battle_message.cpp
@@ -432,8 +432,15 @@ std::string GetItemStartMessage2k(const Game_Battler& source, const lcf::rpg::It
 	return ToString(source.GetName()) + particle + ToString(item.name) + ToString(lcf::Data::terms.use_item);
 }
 
-std::string GetDoubleAttackStartMessage2k3() {
-	return "Double Attack";
+std::string GetDoubleAttackStartMessage2k3(const Game_Battler& source) {
+	if (lcf::Data::terms.easyrpg_battle2k3_double_attack == lcf::Data::terms.kDefaultTerm) {
+		return "Double Attack";
+	}
+	return Utils::ReplacePlaceholders(
+		lcf::Data::terms.easyrpg_battle2k3_double_attack,
+		Utils::MakeArray('S'),
+		Utils::MakeSvArray(source.GetName())
+	);
 }
 
 std::string GetSkillStartMessage2k3(const lcf::rpg::Skill& skill) {
@@ -444,24 +451,59 @@ std::string GetItemStartMessage2k3(const lcf::rpg::Item& item) {
 	return ToString(item.name);
 }
 
-std::string GetObserveStartMessage2k3() {
-	return "Observe";
+std::string GetObserveStartMessage2k3(const Game_Battler& source) {
+	if (lcf::Data::terms.easyrpg_battle2k3_observe == lcf::Data::terms.kDefaultTerm) {
+		return "Observe";
+	}
+	return Utils::ReplacePlaceholders(
+		lcf::Data::terms.easyrpg_battle2k3_observe,
+		Utils::MakeArray('S'),
+		Utils::MakeSvArray(source.GetName())
+	);
 }
 
-std::string GetDefendStartMessage2k3() {
-	return "Defend";
+std::string GetDefendStartMessage2k3(const Game_Battler& source) {
+	if (lcf::Data::terms.easyrpg_battle2k3_defend == lcf::Data::terms.kDefaultTerm) {
+		return "Defend";
+	}
+	return Utils::ReplacePlaceholders(
+		lcf::Data::terms.easyrpg_battle2k3_defend,
+		Utils::MakeArray('S'),
+		Utils::MakeSvArray(source.GetName())
+	);
 }
 
-std::string GetChargeUpStartMessage2k3() {
-	return "Charge Up";
+std::string GetChargeUpStartMessage2k3(const Game_Battler& source) {
+	if (lcf::Data::terms.easyrpg_battle2k3_charge == lcf::Data::terms.kDefaultTerm) {
+		return "Charge Up";
+	}
+	return Utils::ReplacePlaceholders(
+		lcf::Data::terms.easyrpg_battle2k3_charge,
+		Utils::MakeArray('S'),
+		Utils::MakeSvArray(source.GetName())
+	);
 }
 
-std::string GetSelfDestructStartMessage2k3() {
-	return "Self-Destruct";
+std::string GetSelfDestructStartMessage2k3(const Game_Battler& source) {
+	if (lcf::Data::terms.easyrpg_battle2k3_selfdestruct == lcf::Data::terms.kDefaultTerm) {
+		return "Self-Destruct";
+	}
+	return Utils::ReplacePlaceholders(
+		lcf::Data::terms.easyrpg_battle2k3_selfdestruct,
+		Utils::MakeArray('S'),
+		Utils::MakeSvArray(source.GetName())
+	);
 }
 
-std::string GetEscapeStartMessage2k3() {
-	return "Escape";
+std::string GetEscapeStartMessage2k3(const Game_Battler& source) {
+	if (lcf::Data::terms.easyrpg_battle2k3_escape == lcf::Data::terms.kDefaultTerm) {
+		return "Escape";
+	}
+	return Utils::ReplacePlaceholders(
+		lcf::Data::terms.easyrpg_battle2k3_escape,
+		Utils::MakeArray('S'),
+		Utils::MakeSvArray(source.GetName())
+	);
 }
 
 } // namespace BattleMessage

--- a/src/battle_message.cpp
+++ b/src/battle_message.cpp
@@ -417,6 +417,14 @@ std::string GetSkillSecondStartMessage2k(const Game_Battler& source, const Game_
 }
 
 std::string GetItemStartMessage2k(const Game_Battler& source, const lcf::rpg::Item& item) {
+	if (item.easyrpg_using_message != lcf::rpg::Item::kDefaultMessage) {
+		return Utils::ReplacePlaceholders(
+			item.easyrpg_using_message,
+			Utils::MakeArray('S', 'O'),
+			Utils::MakeSvArray(source.GetName(), item.name)
+		);
+	}
+
 	if (Player::IsRPG2kE()) {
 		return Utils::ReplacePlaceholders(
 			lcf::Data::terms.use_item,
@@ -443,12 +451,44 @@ std::string GetDoubleAttackStartMessage2k3(const Game_Battler& source) {
 	);
 }
 
-std::string GetSkillStartMessage2k3(const lcf::rpg::Skill& skill) {
-	return ToString(skill.name);
+std::string GetSkillStartMessage2k3(const Game_Battler& source, const Game_Battler* target, const lcf::rpg::Skill& skill) {
+	StringView target_name = "???";
+	if (target && Algo::IsNormalOrSubskill(skill) && Algo::SkillTargetsOne(skill)) {
+		target_name = target->GetName();
+	}
+	if (skill.easyrpg_battle2k3_message == lcf::rpg::Skill::kDefaultMessage) {
+		if (lcf::Data::terms.easyrpg_battle2k3_skill == lcf::Data::terms.kDefaultTerm) {
+			return ToString(skill.name);
+		}
+		return Utils::ReplacePlaceholders(
+			lcf::Data::terms.easyrpg_battle2k3_skill,
+			Utils::MakeArray('S', 'O', 'U'),
+			Utils::MakeSvArray(source.GetName(), target_name, skill.name)
+		);
+	}
+	return Utils::ReplacePlaceholders(
+		skill.easyrpg_battle2k3_message,
+		Utils::MakeArray('S', 'O', 'U'),
+		Utils::MakeSvArray(source.GetName(), target_name, skill.name)
+	);
 }
 
-std::string GetItemStartMessage2k3(const lcf::rpg::Item& item) {
-	return ToString(item.name);
+std::string GetItemStartMessage2k3(const Game_Battler& source, const lcf::rpg::Item& item) {
+	if (item.easyrpg_using_message == lcf::rpg::Item::kDefaultMessage) {
+		if (lcf::Data::terms.easyrpg_battle2k3_item == lcf::Data::terms.kDefaultTerm) {
+			return ToString(item.name);
+		}
+		return Utils::ReplacePlaceholders(
+			lcf::Data::terms.easyrpg_battle2k3_item,
+			Utils::MakeArray('S', 'O'),
+			Utils::MakeSvArray(source.GetName(), item.name)
+		);
+	}
+	return Utils::ReplacePlaceholders(
+		item.easyrpg_using_message,
+		Utils::MakeArray('S', 'O'),
+		Utils::MakeSvArray(source.GetName(), item.name)
+	);
 }
 
 std::string GetObserveStartMessage2k3(const Game_Battler& source) {

--- a/src/battle_message.h
+++ b/src/battle_message.h
@@ -98,21 +98,21 @@ std::string GetSkillSecondStartMessage2k(const Game_Battler& source, const Game_
 
 std::string GetItemStartMessage2k(const Game_Battler& source, const lcf::rpg::Item& item);
 
-std::string GetDoubleAttackStartMessage2k3();
+std::string GetDoubleAttackStartMessage2k3(const Game_Battler& source);
 
 std::string GetSkillStartMessage2k3(const lcf::rpg::Skill& skill);
 
 std::string GetItemStartMessage2k3(const lcf::rpg::Item& item);
 
-std::string GetObserveStartMessage2k3();
+std::string GetObserveStartMessage2k3(const Game_Battler& source);
 
-std::string GetDefendStartMessage2k3();
+std::string GetDefendStartMessage2k3(const Game_Battler& source);
 
-std::string GetChargeUpStartMessage2k3();
+std::string GetChargeUpStartMessage2k3(const Game_Battler& source);
 
-std::string GetSelfDestructStartMessage2k3();
+std::string GetSelfDestructStartMessage2k3(const Game_Battler& source);
 
-std::string GetEscapeStartMessage2k3();
+std::string GetEscapeStartMessage2k3(const Game_Battler& source);
 
 } // namespace BattleMessage
 

--- a/src/battle_message.h
+++ b/src/battle_message.h
@@ -100,9 +100,9 @@ std::string GetItemStartMessage2k(const Game_Battler& source, const lcf::rpg::It
 
 std::string GetDoubleAttackStartMessage2k3(const Game_Battler& source);
 
-std::string GetSkillStartMessage2k3(const lcf::rpg::Skill& skill);
+std::string GetSkillStartMessage2k3(const Game_Battler& source, const Game_Battler* target, const lcf::rpg::Skill& skill);
 
-std::string GetItemStartMessage2k3(const lcf::rpg::Item& item);
+std::string GetItemStartMessage2k3(const Game_Battler& source, const lcf::rpg::Item& item);
 
 std::string GetObserveStartMessage2k3(const Game_Battler& source);
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -701,7 +701,7 @@ std::string Game_BattleAlgorithm::Normal::GetStartMessage(int line) const {
 			return BattleMessage::GetNormalAttackStartMessage2k(*GetSource());
 		}
 		if (GetSource()->GetType() == Game_Battler::Type_Enemy && hits_multiplier == 2) {
-			return BattleMessage::GetDoubleAttackStartMessage2k3();
+			return BattleMessage::GetDoubleAttackStartMessage2k3(*GetSource());
 		}
 	}
 	return "";
@@ -1178,7 +1178,7 @@ std::string Game_BattleAlgorithm::Defend::GetStartMessage(int line) const {
 		if (Player::IsRPG2k()) {
 			return BattleMessage::GetDefendStartMessage2k(*GetSource());
 		} else if (GetSource()->GetType() == Game_Battler::Type_Enemy) {
-			return BattleMessage::GetDefendStartMessage2k3();
+			return BattleMessage::GetDefendStartMessage2k3(*GetSource());
 		}
 	}
 	return "";
@@ -1198,7 +1198,7 @@ std::string Game_BattleAlgorithm::Observe::GetStartMessage(int line) const {
 		if (Player::IsRPG2k()) {
 			return BattleMessage::GetObserveStartMessage2k(*GetSource());
 		} else if (GetSource()->GetType() == Game_Battler::Type_Enemy) {
-			return BattleMessage::GetObserveStartMessage2k3();
+			return BattleMessage::GetObserveStartMessage2k3(*GetSource());
 		}
 	}
 	return "";
@@ -1214,7 +1214,7 @@ std::string Game_BattleAlgorithm::Charge::GetStartMessage(int line) const {
 		if (Player::IsRPG2k()) {
 			return BattleMessage::GetChargeUpStartMessage2k(*GetSource());
 		} else if (GetSource()->GetType() == Game_Battler::Type_Enemy) {
-			return BattleMessage::GetChargeUpStartMessage2k3();
+			return BattleMessage::GetChargeUpStartMessage2k3(*GetSource());
 		}
 	}
 	return "";
@@ -1234,7 +1234,7 @@ std::string Game_BattleAlgorithm::SelfDestruct::GetStartMessage(int line) const 
 		if (Player::IsRPG2k()) {
 			return BattleMessage::GetSelfDestructStartMessage2k(*GetSource());
 		} else if (GetSource()->GetType() == Game_Battler::Type_Enemy) {
-			return BattleMessage::GetSelfDestructStartMessage2k3();
+			return BattleMessage::GetSelfDestructStartMessage2k3(*GetSource());
 		}
 	}
 	return "";
@@ -1288,7 +1288,7 @@ std::string Game_BattleAlgorithm::Escape::GetStartMessage(int line) const {
 		if (Player::IsRPG2k()) {
 			return BattleMessage::GetEscapeStartMessage2k(*GetSource());
 		} else if (GetSource()->GetType() == Game_Battler::Type_Enemy) {
-			return BattleMessage::GetEscapeStartMessage2k3();
+			return BattleMessage::GetEscapeStartMessage2k3(*GetSource());
 		}
 	}
 	return "";

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -992,7 +992,7 @@ std::string Game_BattleAlgorithm::Skill::GetStartMessage(int line) const {
 			if (Player::IsRPG2k()) {
 				return BattleMessage::GetItemStartMessage2k(*GetSource(), *item);
 			} else {
-				return BattleMessage::GetItemStartMessage2k3(*item);
+				return BattleMessage::GetItemStartMessage2k3(*GetSource(), *item);
 			}
 		}
 		return "";
@@ -1007,7 +1007,7 @@ std::string Game_BattleAlgorithm::Skill::GetStartMessage(int line) const {
 				return BattleMessage::GetSkillSecondStartMessage2k(*GetSource(), target, skill);
 			}
 		} else {
-			return BattleMessage::GetSkillStartMessage2k3(skill);
+			return BattleMessage::GetSkillStartMessage2k3(*GetSource(), target, skill);
 		}
 	}
 	if (line == 1 && Player::IsRPG2k() && !skill.using_message2.empty()) {
@@ -1147,7 +1147,7 @@ std::string Game_BattleAlgorithm::Item::GetStartMessage(int line) const {
 		if (Player::IsRPG2k()) {
 			return BattleMessage::GetItemStartMessage2k(*GetSource(), item);
 		} else {
-			return BattleMessage::GetItemStartMessage2k3(item);
+			return BattleMessage::GetItemStartMessage2k3(*GetSource(), item);
 		}
 	}
 	return "";

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1022,9 +1022,12 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionSt
 	if (scene_action_substate == eSpecialMessage) {
 		EndNotification();
 		const auto cond = Game_Battle::GetBattleCondition();
-		if (!lcf::Data::terms.special_combat.empty() && (cond != lcf::rpg::System::BattleCondition_none || first_strike)) {
-			if (cond == lcf::rpg::System::BattleCondition_initiative || cond == lcf::rpg::System::BattleCondition_surround || (cond == lcf::rpg::System::BattleCondition_none && first_strike)) {
+		if ((!lcf::Data::terms.special_combat.empty() || !lcf::Data::terms.easyrpg_battle2k3_special_combat_back.empty()) && (cond != lcf::rpg::System::BattleCondition_none || first_strike)) {
+			if (!lcf::Data::terms.special_combat.empty() && (cond == lcf::rpg::System::BattleCondition_initiative || cond == lcf::rpg::System::BattleCondition_surround || (cond == lcf::rpg::System::BattleCondition_none && first_strike))) {
 				ShowNotification(ToString(lcf::Data::terms.special_combat));
+			}
+			if (!lcf::Data::terms.easyrpg_battle2k3_special_combat_back.empty() && (cond == lcf::rpg::System::BattleCondition_back || cond == lcf::rpg::System::BattleCondition_pincers)) {
+				ShowNotification(ToString(lcf::Data::terms.easyrpg_battle2k3_special_combat_back));
 			}
 			SetWait(30, 70);
 		}


### PR DESCRIPTION
This PR makes the hardcoded terms in RPG Maker 2003 battle customizable and adds skill and item start messages in RPG Maker 2003 battles.

Fixes: #2362