### PR TITLE
Battle 2k3: Add CBA movement

### DIFF
--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -726,10 +726,8 @@ int Game_BattleAlgorithm::Normal::GetCBAMovement() const {
 		auto weapons = ally->GetWeapons(weapon);
 		auto* item = weapons[0];
 		if (item) {
-			if (item->animation_id > 0) {
-				if (static_cast<int>(item->animation_data.size()) > source->GetId() - 1) {
-					return item->animation_data[source->GetId() - 1].movement;
-				}
+			if (static_cast<int>(item->animation_data.size()) > source->GetId() - 1) {
+				return item->animation_data[source->GetId() - 1].movement;
 			}
 		}
 	}
@@ -1041,7 +1039,7 @@ std::string Game_BattleAlgorithm::Skill::GetStartMessage(int line) const {
 
 int Game_BattleAlgorithm::Skill::GetSourcePose() const {
 	auto* source = GetSource();
-	if (source->GetType() == Game_Battler::Type_Ally && skill.animation_id > 0) {
+	if (source->GetType() == Game_Battler::Type_Ally) {
 		if (static_cast<int>(skill.battler_animation_data.size()) > source->GetId() - 1) {
 			return skill.battler_animation_data[source->GetId() - 1].pose;
 		}
@@ -1052,7 +1050,7 @@ int Game_BattleAlgorithm::Skill::GetSourcePose() const {
 
 int Game_BattleAlgorithm::Skill::GetCBAMovement() const {
 	auto* source = GetSource();
-	if (source->GetType() == Game_Battler::Type_Ally && skill.animation_id > 0) {
+	if (source->GetType() == Game_Battler::Type_Ally) {
 		if (static_cast<int>(skill.battler_animation_data.size()) > source->GetId() - 1) {
 			return skill.battler_animation_data[source->GetId() - 1].movement;
 		}
@@ -1193,7 +1191,7 @@ int Game_BattleAlgorithm::Item::GetSourcePose() const {
 
 int Game_BattleAlgorithm::Item::GetCBAMovement() const {
 	auto* source = GetSource();
-	if (source->GetType() == Game_Battler::Type_Ally && item.animation_id > 0) {
+	if (source->GetType() == Game_Battler::Type_Ally) {
 		if (static_cast<int>(item.animation_data.size()) > source->GetId() - 1) {
 			return item.animation_data[source->GetId() - 1].movement;
 		}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -322,6 +322,10 @@ int Game_BattleAlgorithm::AlgorithmBase::GetSourcePose() const {
 	return lcf::rpg::BattlerAnimation::Pose_Idle;
 }
 
+int Game_BattleAlgorithm::AlgorithmBase::GetCBAMovement() const {
+	return lcf::rpg::BattlerAnimationItemSkill::Movement_none;
+}
+
 void Game_BattleAlgorithm::AlgorithmBase::Start() {
 	reflect_target = nullptr;
 
@@ -714,6 +718,25 @@ int Game_BattleAlgorithm::Normal::GetSourcePose() const {
 		: lcf::rpg::BattlerAnimation::Pose_AttackRight;
 }
 
+int Game_BattleAlgorithm::Normal::GetCBAMovement() const {
+	const auto weapon = GetWeapon();
+	auto* source = GetSource();
+	if (source->GetType() == Game_Battler::Type_Ally) {
+		auto* ally = static_cast<Game_Actor*>(source);
+		auto weapons = ally->GetWeapons(weapon);
+		auto* item = weapons[0];
+		if (item) {
+			if (item->animation_id > 0) {
+				if (static_cast<int>(item->animation_data.size()) > source->GetId() - 1) {
+					return item->animation_data[source->GetId() - 1].movement;
+				}
+			}
+		}
+	}
+
+	return lcf::rpg::BattlerAnimationItemSkill::Movement_none;
+}
+
 const lcf::rpg::Sound* Game_BattleAlgorithm::Normal::GetStartSe() const {
 	if (Player::IsRPG2k() && GetSource()->GetType() == Game_Battler::Type_Enemy) {
 		return &Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_EnemyAttacks);
@@ -1027,6 +1050,17 @@ int Game_BattleAlgorithm::Skill::GetSourcePose() const {
 	return lcf::rpg::BattlerAnimation::Pose_Skill;
 }
 
+int Game_BattleAlgorithm::Skill::GetCBAMovement() const {
+	auto* source = GetSource();
+	if (source->GetType() == Game_Battler::Type_Ally && skill.animation_id > 0) {
+		if (static_cast<int>(skill.battler_animation_data.size()) > source->GetId() - 1) {
+			return skill.battler_animation_data[source->GetId() - 1].movement;
+		}
+	}
+
+	return lcf::rpg::BattlerAnimationItemSkill::Movement_none;
+}
+
 const lcf::rpg::Sound* Game_BattleAlgorithm::Skill::GetStartSe() const {
 	if (skill.type == lcf::rpg::Skill::Type_switch) {
 		return &skill.sound_effect;
@@ -1155,6 +1189,17 @@ std::string Game_BattleAlgorithm::Item::GetStartMessage(int line) const {
 
 int Game_BattleAlgorithm::Item::GetSourcePose() const {
 	return lcf::rpg::BattlerAnimation::Pose_Item;
+}
+
+int Game_BattleAlgorithm::Item::GetCBAMovement() const {
+	auto* source = GetSource();
+	if (source->GetType() == Game_Battler::Type_Ally && item.animation_id > 0) {
+		if (static_cast<int>(item.animation_data.size()) > source->GetId() - 1) {
+			return item.animation_data[source->GetId() - 1].movement;
+		}
+	}
+
+	return lcf::rpg::BattlerAnimationItemSkill::Movement_none;
 }
 
 const lcf::rpg::Sound* Game_BattleAlgorithm::Item::GetStartSe() const {

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -367,6 +367,9 @@ public:
 	/** @return the pose the source should be in when performing the action */
 	virtual int GetSourcePose() const;
 
+	/** @return the CBA movement to use when performing the action */
+	virtual int GetCBAMovement() const;
+
 	/** @return true if it is still possible to perform this action now.  */
 	virtual bool ActionIsPossible() const;
 
@@ -626,6 +629,7 @@ public:
 	int GetAnimationId(int i) const override;
 	std::string GetStartMessage(int line) const override;
 	int GetSourcePose() const override;
+	int GetCBAMovement() const override;
 	const lcf::rpg::Sound* GetStartSe() const override;
 	Game_Battler::Weapon GetWeapon() const;
 	void ApplyComboHitsMultiplier(int hits) override;
@@ -657,6 +661,7 @@ public:
 	int GetAnimationId(int i) const override;
 	std::string GetStartMessage(int line) const override;
 	int GetSourcePose() const override;
+	int GetCBAMovement() const override;
 	const lcf::rpg::Sound* GetStartSe() const override;
 	const lcf::rpg::Sound* GetFailureSe() const override;
 	std::string GetFailureMessage() const override;
@@ -686,6 +691,7 @@ public:
 
 	std::string GetStartMessage(int line) const override;
 	int GetSourcePose() const override;
+	int GetCBAMovement() const override;
 	const lcf::rpg::Sound* GetStartSe() const override;
 	bool ActionIsPossible() const override;
 

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -108,7 +108,13 @@ void Game_Party::SetupBattleTest() {
 		Game_Actor* actor = Main_Data::game_actors->GetActor(btdata.actor_id);
 
 		// Filter garbage btdata inserted by the editor
-		std::array<int, 5> ids = {{ btdata.weapon_id, btdata.shield_id, btdata.armor_id, btdata.helmet_id, btdata.accessory_id }};
+		// The upper 16 bit look like uninitialized data
+		std::array<int, 5> ids = {{
+			btdata.weapon_id & 0xFFFF,
+			btdata.shield_id & 0xFFFF,
+			btdata.armor_id & 0xFFFF,
+			btdata.helmet_id & 0xFFFF,
+			btdata.accessory_id & 0xFFFF }};
 		std::replace_if(ids.begin(), ids.end(), [] (const int& item_id) {
 			return lcf::ReaderUtil::GetElement(lcf::Data::items, item_id) == nullptr;
 		}, 0);

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -2603,7 +2603,7 @@ void Scene_Battle_Rpg2k3::CBAInit() {
 		}
 	} else {
 		if (sprite) {
-			if (cba_action->GetCBAMovement() == lcf::rpg::BattlerAnimationItemSkill::Movement_jump || cba_action->GetCBAMovement() == lcf::rpg::BattlerAnimationItemSkill::Movement_move) {
+			if (cba_action->GetType() == Game_BattleAlgorithm::Type::Normal || cba_action->GetCBAMovement() == lcf::rpg::BattlerAnimationItemSkill::Movement_move) {
 				sprite->SetAnimationState(Sprite_Actor::AnimationState_WalkingRight);
 			} else {
 				sprite->SetAnimationState(Sprite_Actor::AnimationState_WalkingLeft);

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -23,6 +23,12 @@
 #include "async_handler.h"
 #include "window_actorsp.h"
 
+// CBA constants
+// FIXME: How many CBA move frames does RPG_RT actually use?
+constexpr int cba_num_move_frames_step = 15;
+constexpr int cba_num_move_frames_jump = 15;
+constexpr int cba_num_move_frames_move = 10;
+
 /**
  * Scene_Battle class.
  * Manages the battles.
@@ -60,6 +66,9 @@ public:
 		BattleActionState_Notify,
 		BattleActionState_Combo,
 		BattleActionState_StartAlgo,
+		BattleActionState_CBAInit,
+		BattleActionState_CBAMove,
+		BattleActionState_Animation,
 		BattleActionState_AnimationReflect,
 		BattleActionState_FinishPose,
 		BattleActionState_Execute,
@@ -180,6 +189,9 @@ protected:
 	BattleActionReturn ProcessBattleActionNotify(Game_BattleAlgorithm::AlgorithmBase* action);
 	BattleActionReturn ProcessBattleActionCombo(Game_BattleAlgorithm::AlgorithmBase* action);
 	BattleActionReturn ProcessBattleActionStartAlgo(Game_BattleAlgorithm::AlgorithmBase* action);
+	BattleActionReturn ProcessBattleActionCBAInit(Game_BattleAlgorithm::AlgorithmBase* action);
+	BattleActionReturn ProcessBattleActionCBAMove(Game_BattleAlgorithm::AlgorithmBase* action);
+	BattleActionReturn ProcessBattleActionAnimation(Game_BattleAlgorithm::AlgorithmBase* action);
 	BattleActionReturn ProcessBattleActionAnimationReflect(Game_BattleAlgorithm::AlgorithmBase* action);
 	BattleActionReturn ProcessBattleActionFinishPose(Game_BattleAlgorithm::AlgorithmBase* action);
 	BattleActionReturn ProcessBattleActionExecute(Game_BattleAlgorithm::AlgorithmBase* action);
@@ -214,6 +226,17 @@ protected:
 	bool running_away = false;
 	bool resume_from_debug_scene = false;
 	bool auto_battle = false;
+
+	// CBA stuff
+	void CBAInit();
+	void CBAMove();
+
+	Game_BattleAlgorithm::AlgorithmBase* cba_action;
+	bool cba_direction_back = false;
+	int cba_move_frame = 0;
+	int cba_num_move_frames = 1;
+	Point cba_start_pos;
+	Point cba_end_pos;
 };
 
 #endif

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -23,11 +23,10 @@
 #include "async_handler.h"
 #include "window_actorsp.h"
 
-// CBA constants
-// FIXME: How many CBA move frames does RPG_RT actually use?
-constexpr int cba_num_move_frames_step = 15;
-constexpr int cba_num_move_frames_jump = 15;
-constexpr int cba_num_move_frames_move = 10;
+// CBA constant
+// The CBA move frame counter is incremented twice per frame in RPG_RT,
+// so the effective frame count is 13
+constexpr int cba_num_move_frames = 25;
 
 /**
  * Scene_Battle class.
@@ -234,7 +233,6 @@ protected:
 	Game_BattleAlgorithm::AlgorithmBase* cba_action;
 	bool cba_direction_back = false;
 	int cba_move_frame = 0;
-	int cba_num_move_frames = 1;
 	Point cba_start_pos;
 	Point cba_end_pos;
 };

--- a/src/sprite_actor.cpp
+++ b/src/sprite_actor.cpp
@@ -79,7 +79,7 @@ void Sprite_Actor::Update() {
 			// Is a battle charset animation
 
 			static const int frames[] = {0,1,2,1,0};
-			int frame = frames[cycle / 10];
+			int frame = (battler->IsDefending() ? 0 : frames[cycle / 10]);
 			if (frame == sprite_frame)
 				return;
 
@@ -97,11 +97,10 @@ void Sprite_Actor::Update() {
 
 			SetSrcRect(Rect(frame * 48, ext->battler_index * 48, 48, 48));
 
-			if (cycle == 40) {
+			if (cycle == ((idling || anim_state == AnimationState_WalkingLeft || anim_state == AnimationState_WalkingRight || anim_state == AnimationState_Victory) ? 40 : 30)) {
 				switch (loop_state) {
 					case LoopState_DefaultAnimationAfterFinish:
-						cycle = 0;
-						idling = true;
+						DoIdleAnimation();
 						break;
 					case LoopState_WaitAfterFinish:
 						--cycle; // incremented to last cycle next update
@@ -113,10 +112,6 @@ void Sprite_Actor::Update() {
 					default:
 						assert(false && "Bad loop state");
 				}
-			}
-
-			if (idling) {
-				DoIdleAnimation();
 			}
 		}
 	}
@@ -165,6 +160,7 @@ void Sprite_Actor::SetAnimationState(int state, LoopState loop) {
 		StringView sprite_file = ext->battler_name;
 
 		if (ext->animation_type == lcf::rpg::BattlerAnimationPose::AnimType_battle) {
+			do_not_draw = false;
 			SetBitmap(BitmapRef());
 			lcf::rpg::Animation* battle_anim = lcf::ReaderUtil::GetElement(lcf::Data::animations, ext->battle_animation_id);
 			if (!battle_anim) {
@@ -176,6 +172,7 @@ void Sprite_Actor::SetAnimationState(int state, LoopState loop) {
 			}
 		}
 		else {
+			do_not_draw = sprite_file.empty();
 			animation.reset();
 			if (!sprite_file.empty()) {
 				FileRequestAsync* request = AsyncHandler::RequestFile("BattleCharSet", sprite_file);
@@ -267,7 +264,9 @@ void Sprite_Actor::OnBattlercharsetReady(FileRequestResult* result, int32_t batt
 
 void Sprite_Actor::Draw(Bitmap& dst) {
 	auto* battler = GetBattler();
-	if (battler->IsHidden()) {
+	// "do_not_draw" is set to true if the CBA battler name is empty, this
+	// makes the sprite not being drawn. This fixes issue #1708.
+	if (battler->IsHidden() || do_not_draw) {
 		return;
 	}
 

--- a/src/sprite_actor.h
+++ b/src/sprite_actor.h
@@ -83,6 +83,8 @@ public:
 	 */
 	bool IsIdling();
 
+	void DoIdleAnimation();
+
 	int GetWidth() const override;
 	int GetHeight() const override;
 
@@ -92,7 +94,6 @@ public:
 
 protected:
 	void CreateSprite();
-	void DoIdleAnimation();
 	void OnMonsterSpriteReady(FileRequestResult* result);
 	void OnBattlercharsetReady(FileRequestResult* result, int32_t battler_index);
 
@@ -107,6 +108,8 @@ protected:
 	bool idling = true;
 
 	FileRequestBinding request_id;
+
+	bool do_not_draw = false;
 };
 
 


### PR DESCRIPTION
This PR implements the CBA movement in RPG Maker 2003 battles.

Fixes: #1277
Fixes: #1708

All movement related checkboxes in #1269 are handled by this PR.

Addressing review comments will be handled now in subsequent commits unless stated otherwise by the reviewers in order to avoid confusion.