### PR TITLE
Fix ExFont extraction in Grimm's Hollow

### DIFF
--- a/src/exe_reader.h
+++ b/src/exe_reader.h
@@ -36,7 +36,6 @@ public:
 	// 2. max offset value is this size
 
 	EXEReader(Filesystem_Stream::InputStream& core);
-	~EXEReader();
 
 	// Extracts an EXFONT resource with BMP header if present
 	// and returns exfont buffer on success.

--- a/src/image_bmp.h
+++ b/src/image_bmp.h
@@ -21,8 +21,21 @@
 #include "filesystem_stream.h"
 
 namespace ImageBMP {
+	struct BitmapHeader {
+		int size = 0;
+		int w = 0;
+		int h = 0;
+		int planes = 0;
+		int depth = 0;
+		int compression = 0;
+		int num_colors = 0;
+		int palette_size = 0;
+	};
+
 	bool ReadBMP(const uint8_t* data, unsigned len, bool transparent, int& width, int& height, void*& pixels);
 	bool ReadBMP(Filesystem_Stream::InputStream& stream, bool transparent, int& width, int& height, void*& pixels);
+
+	BitmapHeader ParseHeader(const uint8_t*& ptr, uint8_t const* e);
 }
 
 #endif


### PR DESCRIPTION
... by doing a more sophisticated Bitmap header building. Grimms Hollow used 4 palette entries but we hardcoded it to 256.

I checked the sourcecode of wrestool (line 303) https://fossies.org/linux/icoutils/wrestool/extract.c to ensure that this logic is correct.

Reported via
https://community.easyrpg.org/t/retroarch-easyrpg-bug-grimms-hollow-missing-star-glyph/952