### PR TITLE
Fix #2509

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -101,8 +101,15 @@ namespace {
 				continue;
 			}
 
-			if (cache_size <= cache_limit && cur_ticks - it->second.last_access < 3s) {
-				// Below memory limit and last access < 3s
+			auto last_access = cur_ticks - it->second.last_access;
+			bool cache_exhausted = cache_size > cache_limit;
+			if (cache_exhausted) {
+				if (last_access <= 50ms) {
+					// Used during the last 3 frames, must be important, keep it.
+					++it;
+					continue;
+				}
+			} else if (last_access <= 3s) {
 				++it;
 				continue;
 			}


### PR DESCRIPTION
When the cache is exhausted do not delete unreferenced assets that were used during the last 50ms.

The current behaviour (flush everything unreferenced when cache is full) was added to workaround out-of-memory issues on systems with limited RAM but this direct unload made some use cases like face rendering in the Battle scene with Gauge style really slow (face was deleted and reloaded from disk each frame).

I hope that 50ms is a good compromise here.

Fix #2509