### PR TITLE
URL encode +

### DIFF
--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -253,9 +253,10 @@ void FileRequestAsync::Start() {
 		request_path += path;
 	}
 
-	// URL encode % and #
+	// URL encode % and # and +
 	request_path = std::regex_replace(request_path, std::regex("%"), "%25");
 	request_path = std::regex_replace(request_path, std::regex("#"), "%23");
+	request_path = std::regex_replace(request_path, std::regex("+"), "%2B");
 
 	emscripten_async_wget2(
 		request_path.c_str(),


### PR DESCRIPTION
Some servers (e.g. CloudFront) will not respond properly if the file name contains `+`, such as `a+b.png`.

Therefore, URL encoding is helpful. (See also #894)