### PR TITLE
Battle 2k3: Add CBA single target ranged weapons

### DIFF
--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -330,6 +330,10 @@ const lcf::rpg::BattlerAnimationItemSkill* Game_BattleAlgorithm::AlgorithmBase::
 	return nullptr;
 }
 
+const lcf::rpg::Item* Game_BattleAlgorithm::AlgorithmBase::GetWeaponData() const {
+	return nullptr;
+}
+
 void Game_BattleAlgorithm::AlgorithmBase::Start() {
 	reflect_target = nullptr;
 
@@ -750,6 +754,21 @@ const lcf::rpg::BattlerAnimationItemSkill* Game_BattleAlgorithm::Normal::GetWeap
 			if (static_cast<int>(item->animation_data.size()) > source->GetId() - 1) {
 				return &item->animation_data[source->GetId() - 1];
 			}
+		}
+	}
+
+	return nullptr;
+}
+
+const lcf::rpg::Item* Game_BattleAlgorithm::Normal::GetWeaponData() const {
+	const auto weapon = GetWeapon();
+	auto* source = GetSource();
+	if (source->GetType() == Game_Battler::Type_Ally) {
+		auto* ally = static_cast<Game_Actor*>(source);
+		auto weapons = ally->GetWeapons(weapon);
+		auto* item = weapons[0];
+		if (item) {
+			return item;
 		}
 	}
 

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -376,6 +376,9 @@ public:
 	/** @return the weapon animation data for this action (if applicable) */
 	virtual const lcf::rpg::BattlerAnimationItemSkill* GetWeaponAnimationData() const;
 
+	/** @return the weapon data for this action (if applicable) */
+	virtual const lcf::rpg::Item* GetWeaponData() const;
+
 	/**
 	 * Gets the sound effect that is played when the action is starting.
 	 *
@@ -634,6 +637,7 @@ public:
 	int GetSourcePose() const override;
 	int GetCBAMovement() const override;
 	const lcf::rpg::BattlerAnimationItemSkill* GetWeaponAnimationData() const override;
+	const lcf::rpg::Item* GetWeaponData() const override;
 	const lcf::rpg::Sound* GetStartSe() const override;
 	Game_Battler::Weapon GetWeapon() const;
 	void ApplyComboHitsMultiplier(int hits) override;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -2268,7 +2268,15 @@ Scene_Battle_Rpg2k3::BattleActionReturn Scene_Battle_Rpg2k3::ProcessBattleAction
 
 Scene_Battle_Rpg2k3::BattleActionReturn Scene_Battle_Rpg2k3::ProcessBattleActionCBARangedWeaponMove(Game_BattleAlgorithm::AlgorithmBase* action) {
 	auto* source = action->GetSource();
-	auto* target = action->GetOriginalSingleTarget();
+	Game_Battler* target = nullptr;
+	// The ranged weapon animation targets the original single target
+	// if the weapon has the "Attack All" flag set and the ranged attack
+	// range is set to "Single Enemy"
+	if (action->GetWeaponData()->attack_all) {
+		target = action->GetOriginalSingleTarget();
+	} else {
+		target = action->GetTarget();
+	}
 
 	if (cba_ranged_weapon_move_frame < cba_num_ranged_weapon_move_frames) {
 		cba_ranged_weapon_move_frame++;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1901,8 +1901,17 @@ Scene_Battle_Rpg2k3::BattleActionReturn Scene_Battle_Rpg2k3::ProcessBattleAction
 
 	if (source->GetType() == Game_Battler::Type_Ally) {
 		auto* sprite = static_cast<Game_Actor*>(source)->GetActorBattleSprite();
-		if (sprite && !sprite->IsIdling() && battle_action_state != BattleActionState_CBAMove && battle_action_state != BattleActionState_StartAnimation && battle_action_state != BattleActionState_CBARangedWeaponInit && battle_action_state != BattleActionState_CBARangedWeaponMove && battle_action_state != BattleActionState_Animation) {
-			return BattleActionReturn::eWait;
+		if (sprite && !sprite->IsIdling()) {
+			switch (battle_action_state) {
+				case BattleActionState_CBAMove:
+				case BattleActionState_StartAnimation:
+				case BattleActionState_CBARangedWeaponInit:
+				case BattleActionState_CBARangedWeaponMove:
+				case BattleActionState_Animation:
+					break;
+				default:
+					return BattleActionReturn::eWait;
+			}
 		}
 	}
 

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -67,6 +67,9 @@ public:
 		BattleActionState_StartAlgo,
 		BattleActionState_CBAInit,
 		BattleActionState_CBAMove,
+		BattleActionState_StartAnimation,
+		BattleActionState_CBARangedWeaponInit,
+		BattleActionState_CBARangedWeaponMove,
 		BattleActionState_Animation,
 		BattleActionState_AnimationReflect,
 		BattleActionState_FinishPose,
@@ -192,6 +195,9 @@ protected:
 	BattleActionReturn ProcessBattleActionStartAlgo(Game_BattleAlgorithm::AlgorithmBase* action);
 	BattleActionReturn ProcessBattleActionCBAInit(Game_BattleAlgorithm::AlgorithmBase* action);
 	BattleActionReturn ProcessBattleActionCBAMove(Game_BattleAlgorithm::AlgorithmBase* action);
+	BattleActionReturn ProcessBattleActionStartAnimation(Game_BattleAlgorithm::AlgorithmBase* action);
+	BattleActionReturn ProcessBattleActionCBARangedWeaponInit(Game_BattleAlgorithm::AlgorithmBase* action);
+	BattleActionReturn ProcessBattleActionCBARangedWeaponMove(Game_BattleAlgorithm::AlgorithmBase* action);
 	BattleActionReturn ProcessBattleActionAnimation(Game_BattleAlgorithm::AlgorithmBase* action);
 	BattleActionReturn ProcessBattleActionAnimationReflect(Game_BattleAlgorithm::AlgorithmBase* action);
 	BattleActionReturn ProcessBattleActionFinishPose(Game_BattleAlgorithm::AlgorithmBase* action);
@@ -237,6 +243,10 @@ protected:
 	int cba_move_frame = 0;
 	Point cba_start_pos;
 	Point cba_end_pos;
+
+	std::unique_ptr<Sprite_Weapon> cba_ranged_weapon;
+	int cba_ranged_weapon_move_frame = 0;
+	int cba_num_ranged_weapon_move_frames = 60;
 };
 
 #endif

--- a/src/sprite_weapon.cpp
+++ b/src/sprite_weapon.cpp
@@ -72,6 +72,10 @@ void Sprite_Weapon::SetWeaponAnimation(int nweapon_animation_id) {
 	weapon_animation_id = nweapon_animation_id;
 }
 
+void Sprite_Weapon::SetRanged(bool nranged) {
+	ranged = nranged;
+}
+
 void Sprite_Weapon::StartAttack(bool secondary_weapon) {
 	if ((secondary_weapon && !battler->IsDirectionFlipped()) || (!secondary_weapon && battler->IsDirectionFlipped())) {
 		SetZ(battler->GetBattleSprite()->GetZ() + 1);
@@ -132,8 +136,10 @@ void Sprite_Weapon::Draw(Bitmap& dst) {
 	}
 
 	SetTone(Main_Data::game_screen->GetTone());
-	SetX(battler->GetDisplayX());
-	SetY(battler->GetDisplayY());
+	if (!ranged) {
+		SetX(battler->GetDisplayX());
+		SetY(battler->GetDisplayY());
+	}
 	SetFlashEffect(battler->GetFlashColor());
 
 	Sprite::Draw(dst);

--- a/src/sprite_weapon.h
+++ b/src/sprite_weapon.h
@@ -45,6 +45,8 @@ public:
 
 	void SetWeaponAnimation(int nweapon_animation_id);
 
+	void SetRanged(bool nranged);
+
 	void StartAttack(bool secondary_weapon);
 
 	void StopAttack();
@@ -59,6 +61,7 @@ protected:
 
 	BitmapRef graphic;
 	int weapon_animation_id = 0;
+	bool ranged = false;
 	bool attacking = false;
 	int cycle = 0;
 	int sprite_frame = -1;


### PR DESCRIPTION
This PR adds CBA ranged weapons which target a single enemy and travel straight to it. The following checkboxes from #1269 are handled by it: "Use" checkbox, Dagger "fly in a straight line like a knife", Single Enemy and all Flying speed checkboxes.