### PR TITLE
Emscripten: Improve engine and patch detection.

### DIFF
--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -135,6 +135,20 @@ void AsyncHandler::CreateRequestMapping(const std::string& file) {
 		if (cache.is<picojson::object>()) {
 			parse(cache.get<picojson::object>(), "");
 		}
+
+		// Create some empty DLL files. Engine & patch detection depend on them.
+		bool file_added = false;
+		for (const auto& s : {"ultimate_rt_eb.dll", "dynloader.dll", "accord.dll"}) {
+			auto it = file_mapping.find(s);
+			if (it != file_mapping.end()) {
+				FileFinder::OpenOutputStream(FileFinder::MakePath(Main_Data::GetProjectPath(), s));
+				file_added = true;
+			}
+		}
+		if (file_added) {
+			// Update directory structure (new files were added)
+			FileFinder::SetDirectoryTree(FileFinder::CreateDirectoryTree(Main_Data::GetProjectPath()));
+		}
 	}
 #else
 	// no-op

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -182,14 +182,10 @@ void Player::Init(int argc, char *argv[]) {
 #ifdef EMSCRIPTEN
 	Output::IgnorePause(true);
 
-	// Create initial directory structure in our private area
 	// Retrieve save directory from persistent storage
 	EM_ASM(({
-		var dirs = ['Backdrop', 'Battle', 'Battle2', 'BattleCharSet', 'BattleWeapon', 'CharSet', 'ChipSet', 'FaceSet', 'Frame', 'GameOver', 'Monster', 'Movie', 'Music', 'Panorama', 'Picture', 'Sound', 'System', 'System2', 'Title', 'Save'];
-		dirs.forEach(function(dir) { FS.mkdir(dir) });
-
+		FS.mkdir("Save");
 		FS.mount(Module.EASYRPG_FS, {}, 'Save');
-
 		FS.syncfs(true, function(err) {
 		});
 	}));


### PR DESCRIPTION
Check for certain files in the index.json and create empty versions of them.

This ensures that RPG Maker 2003 English, DynRPG Patch and Maniacs Patch are detected properly.

------

Yeah I know this solution is kinda hacky (like many parts of the Web Player :P). But it works.

(This conflicts with the VFS branch but this change is so minimal that adopting it is no huge problem)

------

Before: https://easyrpg.org/play/master/?game=frozen_triggers
After: https://easyrpg.org/play/pr2520/?game=frozen_triggers

Fix #2526