### PR TITLE
Equipment scene: Use 4 digits for stat values in RPG Maker 2003

### DIFF
--- a/src/window_equipstatus.cpp
+++ b/src/window_equipstatus.cpp
@@ -117,7 +117,7 @@ void Window_EquipStatus::DrawParameter(int cx, int cy, int type) {
 	contents->TextDraw(cx, cy, 1, name);
 
 	// Draw Value
-	cx += 10 * 6 + 6 * 3;
+	cx += (Player::IsRPG2k3() ? (8 * 6 + 6 * 4) : (10 * 6 + 6 * 3));
 	contents->TextDraw(cx, cy, Font::ColorDefault, std::to_string(value), Text::AlignRight);
 
 	if (draw_params) {
@@ -136,7 +136,7 @@ void Window_EquipStatus::DrawParameter(int cx, int cy, int type) {
 		}
 
 		// Draw New Value
-		cx += 6 * 2 + 6 * 3;
+		cx += 6 * 2 + (Player::IsRPG2k3() ? (6 * 4) : (6 * 3));
 		int color = GetNewParameterColor(value, new_value);
 		contents->TextDraw(cx, cy, color, std::to_string(new_value), Text::AlignRight);
 	}


### PR DESCRIPTION
This PR reserves 4 digits for the stat values in the equipment scene in RPG Maker 2003 games. RPG Maker 2000 games reserves 3 digits for the stat values. Tested and confirmed with RPG_RT, this is probably meant to handle the display of the stat values if they go beyond 999 because of positive states.