### PR TITLE
Battle 2k3: Add CBA multi target ranged weapons

### DIFF
--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -244,7 +244,8 @@ protected:
 	Point cba_start_pos;
 	Point cba_end_pos;
 
-	std::unique_ptr<Sprite_Weapon> cba_ranged_weapon;
+	std::vector<std::pair<Game_Battler&, std::unique_ptr<Sprite_Weapon>>> cba_ranged;
+	Point cba_ranged_center;
 	int cba_ranged_weapon_move_frame = 0;
 	int cba_num_ranged_weapon_move_frames = 60;
 };


### PR DESCRIPTION
This PR adds CBA ranged weapons which targets multiple enemies and travel straight to them. The following checkboxes from #1269 are handled by it: "Center" and "All Enemies" from the "Ranged Attack range" section. Not handled by this PR is the "Attack in Sequence" ranged attack range, because this one is plain insane.