### PR TITLE
Input: Rebind key used for fast forward x10 on desktop versions

### DIFF
--- a/src/input_buttons.h
+++ b/src/input_buttons.h
@@ -70,6 +70,7 @@ namespace Input {
 		SCROLL_UP,
 		SCROLL_DOWN,
 		FAST_FORWARD,
+		FAST_FORWARD_PLUS,
 		TOGGLE_FULLSCREEN,
 		TOGGLE_ZOOM,
 		BUTTON_COUNT
@@ -110,6 +111,7 @@ namespace Input {
 		"SCROLL_UP",
 		"SCROLL_DOWN",
 		"FAST_FORWARD",
+		"FAST_FORWARD_PLUS",
 		"TOGGLE_FULLSCREEN",
 		"TOGGLE_ZOOM",
 		"BUTTON_COUNT");
@@ -150,6 +152,7 @@ namespace Input {
 		"Scroll up key",
 		"Scroll down key",
 		"Fast forward key",
+		"Fast forward plus key",
 		"Toggle Fullscreen mode",
 		"Toggle Window Zoom level",
 		"Total Button Count");
@@ -166,6 +169,7 @@ namespace Input {
 			case SHOW_LOG:
 			case TOGGLE_ZOOM:
 			case FAST_FORWARD:
+			case FAST_FORWARD_PLUS:
 				return true;
 			default:
 				return false;

--- a/src/input_buttons_desktop.cpp
+++ b/src/input_buttons_desktop.cpp
@@ -82,6 +82,7 @@ Input::ButtonMappingArray Input::GetDefaultButtonMappings() {
 		{PAGE_DOWN, Keys::PGDN},
 		{RESET, Keys::F12},
 		{FAST_FORWARD, Keys::F},
+		{FAST_FORWARD_PLUS, Keys::G},
 
 #if defined(USE_MOUSE) && defined(SUPPORT_MOUSE)
 		{DECISION, Keys::MOUSE_LEFT},

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -123,6 +123,7 @@ namespace Player {
 	std::string record_input_path;
 	std::string command_line;
 	int speed_modifier = 3;
+	int speed_modifier_plus = 10;
 	Game_ConfigPlayer player_config;
 #ifdef EMSCRIPTEN
 	std::string emscripten_game_name;
@@ -314,7 +315,10 @@ void Player::UpdateInput() {
 	}
 	float speed = 1.0;
 	if (Input::IsSystemPressed(Input::FAST_FORWARD)) {
-		speed = Input::IsPressed(Input::PLUS) ? 10 : speed_modifier;
+		speed = speed_modifier;
+	}
+	if (Input::IsSystemPressed(Input::FAST_FORWARD_PLUS)) {
+		speed = speed_modifier_plus;
 	}
 	Game_Clock::SetGameSpeedFactor(speed);
 


### PR DESCRIPTION
This PR rebinds the fast forward x10 function from the `F` and `NumPlus` keys to the `G` key on desktop versions. This feature was suggested by rpgguest4188 and supported by Fran[e]1 on March 8, 2021 according to the [IRC chatlog](https://easyrpg.org/irc/log/2021/2021-03-08.html#msg-19:22:33). I'm supporting this feature request myself, because it is much more convenient not having to use two hands for the fast forward x10 function. One more advantage is that the change stops interferences with some RPG Maker 2003 games which use the `NumPlus` key for certain events. This change doesn't interfere with the current input scheme as the `G` key is currently unused.