### PR TITLE
Add --rtp-path command line option

### DIFF
--- a/resources/easyrpg-player.6.adoc
+++ b/resources/easyrpg-player.6.adoc
@@ -81,6 +81,10 @@ for some additional binary patches.
 *--project-path* 'PATH'::
   Instead of using the working directory the game in 'PATH' is used.
 
+*--rtp-path* 'PATH'::
+  Adds 'PATH' to the RTP directory list and use this one with highest
+  precedence.
+
 *--record-input* 'PATH'::
   Records all button input to a log file at 'PATH'.
 
@@ -176,7 +180,8 @@ arguments are supported:
 
 NOTE: All '*_RTP_PATH' variables support directory lists, using colon (':') or
 semicolon (';') as separator. Useful when you have multiple translated RTP
-versions or directories with extra files.
+versions or directories with extra files. The '--rtp-path' command line
+option supports directory lists as well.
 
 
 == FILES
@@ -199,7 +204,7 @@ https://github.com/EasyRPG/Player/issues
 
 
 == COPYRIGHT / AUTHORS
-EasyRPG Player is Copyright (C) 2007-2017 the EasyRPG authors, see file
+EasyRPG Player is Copyright (C) 2007-2021 the EasyRPG authors, see file
 AUTHORS.md for details.
 
 This program is free software; you can redistribute it and/or modify it under

--- a/resources/unix/bash-completion/easyrpg-player
+++ b/resources/unix/bash-completion/easyrpg-player
@@ -15,7 +15,7 @@ _easyrpg-player ()
   # all possible options
   ouropts='--autobattle-algo --battle-test --disable-audio --disable-rtp --enable-mouse --enable-touch \
            --encoding --enemyai-algo --engine --fps-limit --fps-render-window --fullscreen -h --help \
-           --hide-title --load-game-id --new-game --no-vsync --project-path --record-input \
+           --hide-title --load-game-id --new-game --no-vsync --project-path --rtp-path --record-input \
            --replay-input --save-path --seed --show-fps --start-map-id --start-party \
            --start-position --test-play --window -v --version'
   rpgrtopts='BattleTest battletest HideTitle hidetitle TestPlay testplay Window window'
@@ -54,6 +54,11 @@ _easyrpg-player ()
       ;;
     # set game directory
     --@(project-path|save-path))
+      _filedir -d
+      return
+      ;;
+    # add rtp directory
+    --rtp-path)
       _filedir -d
       return
       ;;

--- a/src/filefinder_rtp.cpp
+++ b/src/filefinder_rtp.cpp
@@ -31,7 +31,7 @@
 #   include <SDL_system.h>
 #endif
 
-FileFinder_RTP::FileFinder_RTP(bool no_rtp, bool no_rtp_warnings) {
+FileFinder_RTP::FileFinder_RTP(bool no_rtp, bool no_rtp_warnings, std::string rtp_path) {
 #ifdef EMSCRIPTEN
 	// No RTP support for emscripten at the moment.
 	disable_rtp = true;
@@ -129,6 +129,12 @@ FileFinder_RTP::FileFinder_RTP(bool no_rtp, bool no_rtp_warnings) {
 	if (getenv("RPG_RTP_PATH")) {
 		std::vector<std::string> tmp = Utils::Tokenize(getenv("RPG_RTP_PATH"), f);
 		env_paths.insert(env_paths.end(), tmp.begin(), tmp.end());
+	}
+
+	// If custom RTP paths are set, use these with highest precedence
+	if (!rtp_path.empty()) {
+		std::vector<std::string> tmp = Utils::Tokenize(rtp_path, f);
+		env_paths.insert(env_paths.begin(), tmp.begin(), tmp.end());
 	}
 
 #ifdef USE_XDG_RTP

--- a/src/filefinder_rtp.h
+++ b/src/filefinder_rtp.h
@@ -29,8 +29,9 @@ public:
 	 *
 	 * @param no_rtp If true disables RTP support completely
 	 * @param no_rtp_warnings If true disables warnings when a RTP asset is used
+	 * @param rtp_path Custom RTP path to use
 	 */
-	FileFinder_RTP(bool no_rtp, bool no_rtp_warnings);
+	FileFinder_RTP(bool no_rtp, bool no_rtp_warnings, std::string rtp_path);
 
 	/**
 	 * Looks up a file in the list of RTPs

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -106,6 +106,7 @@ namespace Player {
 	std::vector<int> party_members;
 	int start_map_id;
 	bool no_rtp_flag;
+	std::string rtp_path;
 	bool no_audio_flag;
 	bool is_easyrpg_project;
 	bool mouse_flag;
@@ -632,6 +633,12 @@ Game_Config Player::ParseCommandLine(int argc, char *argv[]) {
 			no_rtp_flag = true;
 			continue;
 		}
+		if (cp.ParseNext(arg, 1, "--rtp-path")) {
+			if (arg.NumValues() > 0) {
+				rtp_path = arg.Value(0);
+			}
+			continue;
+		}
 		if (cp.ParseNext(arg, 2, "--patch")) {
 			patch |= PatchOverride;
 			for (int i = 0; i < arg.NumValues(); ++i) {
@@ -776,7 +783,7 @@ void Player::CreateGameObjects() {
 	}
 	Output::Debug("Engine configured as: 2k={} 2k3={} MajorUpdated={} Eng={}", Player::IsRPG2k(), Player::IsRPG2k3(), Player::IsMajorUpdatedVersion(), Player::IsEnglish());
 
-	Main_Data::filefinder_rtp = std::make_unique<FileFinder_RTP>(no_rtp_flag, no_rtp_warning_flag);
+	Main_Data::filefinder_rtp = std::make_unique<FileFinder_RTP>(no_rtp_flag, no_rtp_warning_flag, rtp_path);
 
 	if ((patch & PatchOverride) == 0) {
 		if (!FileFinder::Game().FindFile("dynloader.dll").empty()) {


### PR DESCRIPTION
This PR adds a command line option which allows the user to add a custom RTP path. This path will be used with highest precedence.

Fixes: #2448