### PR TITLE
Change sound volume scaling

### DIFF
--- a/builds/cmake/Modules/FindSDL2.cmake
+++ b/builds/cmake/Modules/FindSDL2.cmake
@@ -250,12 +250,13 @@ if(SDL2_FOUND)
 			find_library(AUDIOTOOLBOX AudioToolbox)
 			find_library(AUDIOUNIT AudioUnit)
 			find_library(METAL Metal)
+			find_library(GAMECONTROLLER GameController)
 			find_library(ICONV_LIBRARY iconv)
 			set_property(TARGET SDL2::SDL2 APPEND_STRING PROPERTY
 				INTERFACE_LINK_LIBRARIES ${COREVIDEO} ${COCOA_LIBRARY}
 					${IOKIT} ${FORCEFEEDBACK} ${CARBON_LIBRARY}
 					${COREAUDIO} ${AUDIOTOOLBOX} ${AUDIOUNIT} ${METAL}
-					${ICONV_LIBRARY})
+					${GAMECONTROLLER} ${ICONV_LIBRARY})
 		elseif(ANDROID)
 			find_library(HIDAPI hidapi)
 			set_property(TARGET SDL2::SDL2 APPEND_STRING PROPERTY

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -89,6 +89,11 @@ void Game_System::BgmPlay(lcf::rpg::Music const& bgm) {
 		Output::Debug("BGM {} has invalid tempo {}", bgm.name, bgm.tempo);
 	}
 
+	// Adjust to RPG_RT (Direct Sound) volume scale
+	if (bgm.volume > 0) {
+		data.current_music.volume = (int)(100 * std::pow(10, (-100 + bgm.volume) / 60.0));
+	}
+
 	// (OFF) means play nothing
 	if (!bgm.name.empty() && bgm.name != "(OFF)") {
 		// Same music: Only adjust volume and speed
@@ -150,6 +155,11 @@ void Game_System::SePlay(const lcf::rpg::Sound& se, bool stop_sounds) {
 	if (se.volume < 0 || se.volume > 100) {
 		Output::Debug("SE {} has invalid volume {}", se.name, se.volume);
 		volume = Utils::Clamp<int32_t>(se.volume, 0, 100);
+	}
+
+	// Adjust to RPG_RT (Direct Sound) volume scale
+	if (volume > 0) {
+		volume = (int)(100 * std::pow(10, (-100 + volume) / 60.0));
 	}
 
 	if (se.tempo < 50 || se.tempo > 200) {

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -39,6 +39,12 @@ Game_System::Game_System()
 	: dbsys(&lcf::Data::system)
 { }
 
+static void AdjustVolume(int& volume) {
+	if (volume > 0) {
+		volume = (int)(100 * std::pow(10, (-100 + volume) / 60.0));
+	}
+}
+
 void Game_System::SetupFromSave(lcf::rpg::SaveSystem save) {
 	data = std::move(save);
 }
@@ -90,9 +96,7 @@ void Game_System::BgmPlay(lcf::rpg::Music const& bgm) {
 	}
 
 	// Adjust to RPG_RT (Direct Sound) volume scale
-	if (bgm.volume > 0) {
-		data.current_music.volume = (int)(100 * std::pow(10, (-100 + bgm.volume) / 60.0));
-	}
+	AdjustVolume(data.current_music.volume);
 
 	// (OFF) means play nothing
 	if (!bgm.name.empty() && bgm.name != "(OFF)") {
@@ -158,9 +162,7 @@ void Game_System::SePlay(const lcf::rpg::Sound& se, bool stop_sounds) {
 	}
 
 	// Adjust to RPG_RT (Direct Sound) volume scale
-	if (volume > 0) {
-		volume = (int)(100 * std::pow(10, (-100 + volume) / 60.0));
-	}
+	AdjustVolume(volume);
 
 	if (se.tempo < 50 || se.tempo > 200) {
 		Output::Debug("SE {} has invalid tempo {}", se.name, se.tempo);


### PR DESCRIPTION
This PR changes the volume scaling method of the sound and music effects from linear to a [logarithmic scale](https://github.com/easyrpg/player/issues/2236#issuecomment-803439029). This aims to fix some sound volume issues reported in #2236.

Related: #2236