### PR TITLE
Add custom game settings

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -57,7 +57,7 @@ int Game_Actor::MaxStatBattleValue() const {
 }
 
 int Game_Actor::MaxStatBaseValue() const {
-	return 999;
+	return lcf::Data::system.easyrpg_max_stat_base_value == -1 ? 999 : lcf::Data::system.easyrpg_max_stat_base_value;
 }
 
 Game_Actor::Game_Actor(int actor_id) {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -41,7 +41,7 @@ constexpr int max_level_2k = 50;
 constexpr int max_level_2k3 = 99;
 
 static int max_exp_value() {
-	return Player::IsRPG2k() ? 999999 : 9999999;
+	return lcf::Data::system.easyrpg_max_exp == -1 ? (Player::IsRPG2k() ? 999999 : 9999999) : lcf::Data::system.easyrpg_max_exp;
 }
 
 int Game_Actor::MaxHpValue() const {
@@ -588,16 +588,16 @@ void Game_Actor::MakeExpList() {
 	}
 }
 
-std::string Game_Actor::GetExpString() const {
+std::string Game_Actor::GetExpString(bool status_scene) const {
 	// RPG_RT displays dashes for max level. As a customization
 	// we always display the amount of EXP.
-	// if (GetNextExp() == -1) { return Player::IsRPG2k3() ? "-------" : "------"; }
+	// if (GetNextExp() == -1) { return (max_exp_value() >= 1000000 || status_scene) ? "-------" : "------"; }
 	return std::to_string(GetExp());
 }
 
-std::string Game_Actor::GetNextExpString() const {
+std::string Game_Actor::GetNextExpString(bool status_scene) const {
 	if (GetNextExp() == -1) {
-		return Player::IsRPG2k3() ? "-------" : "------";
+		return (max_exp_value() >= 1000000 || status_scene) ? "-------" : "------";
 	}
 	return std::to_string(GetNextExp());
 }

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -545,6 +545,8 @@ int Game_Actor::GetBaseAgi(Weapon weapon) const {
 int Game_Actor::CalculateExp(int level) const {
 	const lcf::rpg::Class* klass = lcf::ReaderUtil::GetElement(lcf::Data::classes, data.class_id);
 
+	int exp_curve = (lcf::Data::system.easyrpg_alternative_exp == 0 ? (Player::IsRPG2k() ? 1 : 2) : lcf::Data::system.easyrpg_alternative_exp);
+
 	double base, inflation, correction;
 	if (klass) {
 		base = klass->exp_base;
@@ -559,7 +561,7 @@ int Game_Actor::CalculateExp(int level) const {
 	}
 
 	int result = 0;
-	if (Player::IsRPG2k()) {
+	if (exp_curve == 1) {
 		inflation = 1.5 + (inflation * 0.01);
 
 		for (int i = level; i >= 1; i--)

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -45,7 +45,7 @@ static int max_exp_value() {
 }
 
 int Game_Actor::MaxHpValue() const {
-	return Player::IsRPG2k() ? 999 : 9999;
+	return lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp;
 }
 
 int Game_Actor::MaxStatBattleValue() const {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -691,7 +691,7 @@ int Game_Actor::GetAccessoryId() const {
 }
 
 int Game_Actor::GetMaxLevel() const {
-	return std::max<int32_t>(1, std::min<int32_t>(dbActor->final_level, Player::IsRPG2k() ? max_level_2k : max_level_2k3));
+	return std::max<int32_t>(1, std::min<int32_t>(dbActor->final_level, lcf::Data::system.easyrpg_max_level == -1 ? (Player::IsRPG2k() ? max_level_2k : max_level_2k3) : lcf::Data::system.easyrpg_max_level));
 }
 
 void Game_Actor::SetExp(int _exp) {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -53,7 +53,7 @@ int Game_Actor::MaxSpValue() const {
 }
 
 int Game_Actor::MaxStatBattleValue() const {
-	return 9999;
+	return lcf::Data::system.easyrpg_max_stat_battle_value == -1 ? 9999 : lcf::Data::system.easyrpg_max_stat_battle_value;
 }
 
 int Game_Actor::MaxStatBaseValue() const {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -718,16 +718,20 @@ int Game_Actor::GetAccessoryId() const {
 }
 
 int Game_Actor::GetMaxLevel() const {
-	return std::max<int32_t>(1, std::min<int32_t>(dbActor->final_level, lcf::Data::system.easyrpg_max_level == -1 ? (Player::IsRPG2k() ? max_level_2k : max_level_2k3) : lcf::Data::system.easyrpg_max_level));
+	int max_level = Player::IsRPG2k() ? max_level_2k : max_level_2k3;
+	if (lcf::Data::system.easyrpg_max_level > -1) {
+		max_level = lcf::Data::system.easyrpg_max_level;
+	}
+	return Utils::Clamp<int32_t>(max_level, 1, dbActor->final_level);
 }
 
 void Game_Actor::SetExp(int _exp) {
-	data.exp = min(max(_exp, 0), MaxExpValue());
+	data.exp = Utils::Clamp<int32_t>(_exp, 0, MaxExpValue());
 }
 
 void Game_Actor::ChangeExp(int exp, PendingMessage* pm) {
 	int new_level = GetLevel();
-	int new_exp = min(max(exp, 0), MaxExpValue());
+	int new_exp = Utils::Clamp<int>(exp, 0, MaxExpValue());
 
 	if (new_exp > GetExp()) {
 		for (int i = GetLevel() + 1; i <= GetMaxLevel(); ++i) {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -40,24 +40,44 @@
 constexpr int max_level_2k = 50;
 constexpr int max_level_2k3 = 99;
 
-static int max_exp_value() {
-	return lcf::Data::system.easyrpg_max_exp == -1 ? (Player::IsRPG2k() ? 999999 : 9999999) : lcf::Data::system.easyrpg_max_exp;
-}
-
 int Game_Actor::MaxHpValue() const {
-	return lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp;
+	auto& val = lcf::Data::system.easyrpg_max_actor_hp;
+	if (val == -1) {
+		return Player::IsRPG2k() ? 999 : 9999;
+	}
+	return val;
 }
 
 int Game_Actor::MaxSpValue() const {
-	return lcf::Data::system.easyrpg_max_actor_sp == -1 ? 999 : lcf::Data::system.easyrpg_max_actor_sp;
+	auto& val = lcf::Data::system.easyrpg_max_actor_sp;
+	if (val == -1) {
+		return 999;
+	}
+	return val;
 }
 
 int Game_Actor::MaxStatBattleValue() const {
-	return lcf::Data::system.easyrpg_max_stat_battle_value == -1 ? 9999 : lcf::Data::system.easyrpg_max_stat_battle_value;
+	auto& val = lcf::Data::system.easyrpg_max_stat_battle_value;
+	if (val == -1) {
+		return 9999;
+	}
+	return val;
 }
 
 int Game_Actor::MaxStatBaseValue() const {
-	return lcf::Data::system.easyrpg_max_stat_base_value == -1 ? 999 : lcf::Data::system.easyrpg_max_stat_base_value;
+	auto& val = lcf::Data::system.easyrpg_max_stat_base_value;
+	if (val == -1) {
+		return 999;
+	}
+	return val;
+}
+
+int Game_Actor::MaxExpValue() const {
+	auto& val = lcf::Data::system.easyrpg_max_exp;
+	if (val == -1) {
+		return Player::IsRPG2k() ? 999999 : 9999999;
+	}
+	return val;
 }
 
 Game_Actor::Game_Actor(int actor_id) {
@@ -549,7 +569,10 @@ int Game_Actor::GetBaseAgi(Weapon weapon) const {
 int Game_Actor::CalculateExp(int level) const {
 	const lcf::rpg::Class* klass = lcf::ReaderUtil::GetElement(lcf::Data::classes, data.class_id);
 
-	int exp_curve = (lcf::Data::system.easyrpg_alternative_exp == 0 ? (Player::IsRPG2k() ? 1 : 2) : lcf::Data::system.easyrpg_alternative_exp);
+	int exp_curve = Player::IsRPG2k() ? 1 : 2;
+	if (lcf::Data::system.easyrpg_alternative_exp > 0) {
+		exp_curve = lcf::Data::system.easyrpg_alternative_exp;
+	}
 
 	double base, inflation, correction;
 	if (klass) {
@@ -582,7 +605,7 @@ int Game_Actor::CalculateExp(int level) const {
 			result += (int)correction;
 		}
 	}
-	return min(result, max_exp_value());
+	return min(result, MaxExpValue());
 }
 
 void Game_Actor::MakeExpList() {
@@ -595,13 +618,13 @@ void Game_Actor::MakeExpList() {
 std::string Game_Actor::GetExpString(bool status_scene) const {
 	// RPG_RT displays dashes for max level. As a customization
 	// we always display the amount of EXP.
-	// if (GetNextExp() == -1) { return (max_exp_value() >= 1000000 || status_scene) ? "-------" : "------"; }
+	// if (GetNextExp() == -1) { return (MaxExpValue() >= 1000000 || status_scene) ? "-------" : "------"; }
 	return std::to_string(GetExp());
 }
 
 std::string Game_Actor::GetNextExpString(bool status_scene) const {
 	if (GetNextExp() == -1) {
-		return (max_exp_value() >= 1000000 || status_scene) ? "-------" : "------";
+		return (MaxExpValue() >= 1000000 || status_scene) ? "-------" : "------";
 	}
 	return std::to_string(GetNextExp());
 }
@@ -699,12 +722,12 @@ int Game_Actor::GetMaxLevel() const {
 }
 
 void Game_Actor::SetExp(int _exp) {
-	data.exp = min(max(_exp, 0), max_exp_value());
+	data.exp = min(max(_exp, 0), MaxExpValue());
 }
 
 void Game_Actor::ChangeExp(int exp, PendingMessage* pm) {
 	int new_level = GetLevel();
-	int new_exp = min(max(exp, 0), max_exp_value());
+	int new_exp = min(max(exp, 0), MaxExpValue());
 
 	if (new_exp > GetExp()) {
 		for (int i = GetLevel() + 1; i <= GetMaxLevel(); ++i) {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -48,6 +48,10 @@ int Game_Actor::MaxHpValue() const {
 	return lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp;
 }
 
+int Game_Actor::MaxSpValue() const {
+	return lcf::Data::system.easyrpg_max_actor_sp == -1 ? 999 : lcf::Data::system.easyrpg_max_actor_sp;
+}
+
 int Game_Actor::MaxStatBattleValue() const {
 	return 9999;
 }
@@ -407,7 +411,7 @@ int Game_Actor::GetBaseMaxSp(bool mod) const {
 	if (mod)
 		n += data.sp_mod;
 
-	return Utils::Clamp(n, 0, MaxStatBaseValue());
+	return Utils::Clamp(n, 0, MaxSpValue());
 }
 
 int Game_Actor::GetBaseMaxSp() const {
@@ -1100,6 +1104,11 @@ static int ClampMaxHpMod(int hp, const Game_Actor* actor) {
 	return Utils::Clamp(hp, -limit, limit);
 }
 
+static int ClampMaxSpMod(int sp, const Game_Actor* actor) {
+	auto limit = actor->MaxSpValue();
+	return Utils::Clamp(sp, -limit, limit);
+}
+
 static int ClampStatMod(int value, const Game_Actor* actor) {
 	auto limit = actor->MaxStatBaseValue();
 	return Utils::Clamp(value, -limit, limit);
@@ -1114,7 +1123,7 @@ void Game_Actor::SetBaseMaxHp(int maxhp) {
 
 void Game_Actor::SetBaseMaxSp(int maxsp) {
 	int new_sp_mod = data.sp_mod + (maxsp - GetBaseMaxSp());
-	data.sp_mod = ClampStatMod(new_sp_mod, this);
+	data.sp_mod = ClampMaxSpMod(new_sp_mod, this);
 
 	SetSp(data.current_sp);
 }

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -51,6 +51,8 @@ public:
 
 	int MaxHpValue() const override;
 
+	int MaxSpValue() const override;
+
 	int MaxStatBattleValue() const override;
 
 	int MaxStatBaseValue() const override;

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -167,14 +167,14 @@ public:
 	 *
 	 * @return Exp-String or ------ if Level is max.
 	 */
-	std::string GetExpString() const;
+	std::string GetExpString(bool status_scene = false) const;
 
 	/**
 	 * Converts the Exp for the next LV to a string.
 	 *
 	 * @return Exp-String or ------ if Level is max.
 	 */
-	std::string GetNextExpString() const;
+	std::string GetNextExpString(bool status_scene = false) const;
 
 	/**
 	 * Returns how many Exp are minimum for current level.

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -57,6 +57,8 @@ public:
 
 	int MaxStatBaseValue() const override;
 
+	int MaxExpValue() const;
+
 	virtual PermanentStates GetPermanentStates() const override;
 
 	Point GetOriginalPosition() const override;
@@ -219,7 +221,7 @@ public:
 
 	/**
 	 * Gets the base attribute rate when actor is damaged.
-	 * 
+	 *
 	 * @param attribute_id Attribute to query
 	 * @return Attribute rate
 	 */
@@ -889,7 +891,7 @@ public:
 	 */
 	int IsControllable() const;
 
-	/** 
+	/**
 	 * Reset all equipment inflicted states
 	 *
 	 * @param allow_battle_states allow battle states to be added.

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1149,8 +1149,9 @@ std::string Game_BattleAlgorithm::Skill::GetFailureMessage() const {
 }
 
 bool Game_BattleAlgorithm::Skill::IsReflected(const Game_Battler& target) const {
-	// Skills invoked by items ignore reflect
-	if (item) {
+	// Skills invoked by items and skills with the attribute
+        // "easyrpg_ignore_reflect" set ignore reflect
+	if (item || skill.easyrpg_ignore_reflect) {
 		return false;
 	}
 	return IsTargetValid(target) && target.HasReflectState() && target.GetType() != GetSource()->GetType();

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -51,7 +51,7 @@
 #include "spriteset_battle.h"
 
 static inline int MaxDamageValue() {
-	return Player::IsRPG2k() ? 999 : 9999;
+	return lcf::Data::system.easyrpg_max_damage == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_damage;
 }
 
 Game_BattleAlgorithm::AlgorithmBase::AlgorithmBase(Type ty, Game_Battler* source, Game_Battler* target) :

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1004,6 +1004,7 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 
 	bool heals_states = IsPositive() ^ (Player::IsRPG2k3() && skill.reverse_state_effect);
 	bool affected_death = false;
+	int to_hit_states = (skill.easyrpg_state_hit != -1 ? skill.easyrpg_state_hit : to_hit);
 	for (int i = 0; i < static_cast<int>(skill.state_effects.size()); i++) {
 		if (!skill.state_effects[i])
 			continue;
@@ -1017,7 +1018,7 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 			continue;
 		}
 
-		if (!Rand::PercentChance(to_hit)) {
+		if (!Rand::PercentChance(to_hit_states)) {
 			continue;
 		}
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -973,6 +973,7 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 		const auto atk = target->CanChangeAtkModifier(effect);
 		if (atk != 0) {
 			SetAffectedAtk(atk);
+			if (lcf::Data::system.easyrpg_enable_stat_absorbing) SetIsAbsorbAtk(absorb);
 			SetIsSuccess();
 		}
 	}
@@ -980,6 +981,7 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 		const auto def = target->CanChangeDefModifier(effect);
 		if (def != 0) {
 			SetAffectedDef(def);
+			if (lcf::Data::system.easyrpg_enable_stat_absorbing) SetIsAbsorbDef(absorb);
 			SetIsSuccess();
 		}
 	}
@@ -987,6 +989,7 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 		const auto spi = target->CanChangeSpiModifier(effect);
 		if (spi != 0) {
 			SetAffectedSpi(spi);
+			if (lcf::Data::system.easyrpg_enable_stat_absorbing) SetIsAbsorbSpi(absorb);
 			SetIsSuccess();
 		}
 	}
@@ -994,6 +997,7 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 		const auto agi = target->CanChangeAgiModifier(effect);
 		if (agi != 0) {
 			SetAffectedAgi(agi);
+			if (lcf::Data::system.easyrpg_enable_stat_absorbing) SetIsAbsorbAgi(absorb);
 			SetIsSuccess();
 		}
 	}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1055,13 +1055,14 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 	}
 
 	// Attribute resistance / weakness + an attribute selected + can be modified
+	int to_hit_attribute_shift = (skill.easyrpg_attribute_hit != -1 ? skill.easyrpg_attribute_hit : to_hit);
 	if (skill.affect_attr_defence) {
 		auto shift = IsPositive() ? 1 : -1;
 		for (int i = 0; i < static_cast<int>(skill.attribute_effects.size()); i++) {
 			auto id = i + 1;
 			if (skill.attribute_effects[i]
 					&& GetTarget()->CanShiftAttributeRate(id, shift)
-					&& Rand::PercentChance(to_hit)
+					&& Rand::PercentChance(to_hit_attribute_shift)
 					)
 			{
 				AddAffectedAttribute({ id, shift});

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -973,7 +973,7 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 		const auto atk = target->CanChangeAtkModifier(effect);
 		if (atk != 0) {
 			SetAffectedAtk(atk);
-			if (lcf::Data::system.easyrpg_enable_stat_absorbing) {
+			if (skill.easyrpg_enable_stat_absorbing) {
 				SetIsAbsorbAtk(absorb);
 			}
 			SetIsSuccess();
@@ -983,7 +983,7 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 		const auto def = target->CanChangeDefModifier(effect);
 		if (def != 0) {
 			SetAffectedDef(def);
-			if (lcf::Data::system.easyrpg_enable_stat_absorbing) {
+			if (skill.easyrpg_enable_stat_absorbing) {
 				SetIsAbsorbDef(absorb);
 			}
 			SetIsSuccess();
@@ -993,7 +993,7 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 		const auto spi = target->CanChangeSpiModifier(effect);
 		if (spi != 0) {
 			SetAffectedSpi(spi);
-			if (lcf::Data::system.easyrpg_enable_stat_absorbing) {
+			if (skill.easyrpg_enable_stat_absorbing) {
 				SetIsAbsorbSpi(absorb);
 			}
 			SetIsSuccess();
@@ -1003,7 +1003,7 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 		const auto agi = target->CanChangeAgiModifier(effect);
 		if (agi != 0) {
 			SetAffectedAgi(agi);
-			if (lcf::Data::system.easyrpg_enable_stat_absorbing) {
+			if (skill.easyrpg_enable_stat_absorbing) {
 				SetIsAbsorbAgi(absorb);
 			}
 			SetIsSuccess();

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -973,7 +973,9 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 		const auto atk = target->CanChangeAtkModifier(effect);
 		if (atk != 0) {
 			SetAffectedAtk(atk);
-			if (lcf::Data::system.easyrpg_enable_stat_absorbing) SetIsAbsorbAtk(absorb);
+			if (lcf::Data::system.easyrpg_enable_stat_absorbing) {
+				SetIsAbsorbAtk(absorb);
+			}
 			SetIsSuccess();
 		}
 	}
@@ -981,7 +983,9 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 		const auto def = target->CanChangeDefModifier(effect);
 		if (def != 0) {
 			SetAffectedDef(def);
-			if (lcf::Data::system.easyrpg_enable_stat_absorbing) SetIsAbsorbDef(absorb);
+			if (lcf::Data::system.easyrpg_enable_stat_absorbing) {
+				SetIsAbsorbDef(absorb);
+			}
 			SetIsSuccess();
 		}
 	}
@@ -989,7 +993,9 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 		const auto spi = target->CanChangeSpiModifier(effect);
 		if (spi != 0) {
 			SetAffectedSpi(spi);
-			if (lcf::Data::system.easyrpg_enable_stat_absorbing) SetIsAbsorbSpi(absorb);
+			if (lcf::Data::system.easyrpg_enable_stat_absorbing) {
+				SetIsAbsorbSpi(absorb);
+			}
 			SetIsSuccess();
 		}
 	}
@@ -997,7 +1003,9 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 		const auto agi = target->CanChangeAgiModifier(effect);
 		if (agi != 0) {
 			SetAffectedAgi(agi);
-			if (lcf::Data::system.easyrpg_enable_stat_absorbing) SetIsAbsorbAgi(absorb);
+			if (lcf::Data::system.easyrpg_enable_stat_absorbing) {
+				SetIsAbsorbAgi(absorb);
+			}
 			SetIsSuccess();
 		}
 	}
@@ -1155,8 +1163,6 @@ std::string Game_BattleAlgorithm::Skill::GetFailureMessage() const {
 }
 
 bool Game_BattleAlgorithm::Skill::IsReflected(const Game_Battler& target) const {
-	// Skills invoked by items and skills with the attribute
-        // "easyrpg_ignore_reflect" set ignore reflect
 	if (item || skill.easyrpg_ignore_reflect) {
 		return false;
 	}

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -132,7 +132,7 @@ bool Game_Battler::IsSkillUsable(int skill_id) const {
 	for (auto state_id: GetInflictedStates()) {
 		const auto* state = lcf::ReaderUtil::GetElement(lcf::Data::states, state_id);
 		if (state) {
-			if (state->restrict_skill && skill->physical_rate >= state->restrict_skill_level) {
+			if (state->restrict_skill && skill->physical_rate >= state->restrict_skill_level && !skill->easyrpg_ignore_restrict_skill) {
 				return false;
 			}
 			if (state->restrict_magic && skill->magical_rate >= state->restrict_magic_level) {

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -135,7 +135,7 @@ bool Game_Battler::IsSkillUsable(int skill_id) const {
 			if (state->restrict_skill && skill->physical_rate >= state->restrict_skill_level && !skill->easyrpg_ignore_restrict_skill) {
 				return false;
 			}
-			if (state->restrict_magic && skill->magical_rate >= state->restrict_magic_level) {
+			if (state->restrict_magic && skill->magical_rate >= state->restrict_magic_level && !skill->easyrpg_ignore_restrict_magic) {
 				return false;
 			}
 		}

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -74,6 +74,8 @@ public:
 
 	virtual int MaxHpValue() const = 0;
 
+	virtual int MaxSpValue() const = 0;
+
 	virtual int MaxStatBattleValue() const = 0;
 
 	virtual int MaxStatBaseValue() const = 0;

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -49,7 +49,7 @@ Game_Enemy::Game_Enemy(const lcf::rpg::TroopMember* member)
 }
 
 int Game_Enemy::MaxHpValue() const {
-	return Player::IsRPG2k() ? 9999 : 99999;
+	return lcf::Data::system.easyrpg_max_enemy_hp == -1 ? (Player::IsRPG2k() ? 9999 : 99999) : lcf::Data::system.easyrpg_max_enemy_hp;
 }
 
 int Game_Enemy::MaxStatBattleValue() const {

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -61,7 +61,7 @@ int Game_Enemy::MaxStatBattleValue() const {
 }
 
 int Game_Enemy::MaxStatBaseValue() const {
-	return 999;
+	return lcf::Data::system.easyrpg_max_stat_base_value == -1 ? 999 : lcf::Data::system.easyrpg_max_stat_base_value;
 }
 
 int Game_Enemy::GetStateProbability(int state_id) const {

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -57,7 +57,7 @@ int Game_Enemy::MaxSpValue() const {
 }
 
 int Game_Enemy::MaxStatBattleValue() const {
-	return 9999;
+	return lcf::Data::system.easyrpg_max_stat_battle_value == -1 ? 9999 : lcf::Data::system.easyrpg_max_stat_battle_value;
 }
 
 int Game_Enemy::MaxStatBaseValue() const {

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -53,7 +53,7 @@ int Game_Enemy::MaxHpValue() const {
 }
 
 int Game_Enemy::MaxSpValue() const {
-	return 9999;
+	return lcf::Data::system.easyrpg_max_enemy_sp == -1 ? 9999 : lcf::Data::system.easyrpg_max_enemy_sp;
 }
 
 int Game_Enemy::MaxStatBattleValue() const {

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -52,6 +52,10 @@ int Game_Enemy::MaxHpValue() const {
 	return lcf::Data::system.easyrpg_max_enemy_hp == -1 ? (Player::IsRPG2k() ? 9999 : 99999) : lcf::Data::system.easyrpg_max_enemy_hp;
 }
 
+int Game_Enemy::MaxSpValue() const {
+	return 9999;
+}
+
 int Game_Enemy::MaxStatBattleValue() const {
 	return 9999;
 }

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -49,19 +49,35 @@ Game_Enemy::Game_Enemy(const lcf::rpg::TroopMember* member)
 }
 
 int Game_Enemy::MaxHpValue() const {
-	return lcf::Data::system.easyrpg_max_enemy_hp == -1 ? (Player::IsRPG2k() ? 9999 : 99999) : lcf::Data::system.easyrpg_max_enemy_hp;
+	auto& val = lcf::Data::system.easyrpg_max_enemy_hp;
+	if (val == -1) {
+		return Player::IsRPG2k() ? 9999 : 99999;
+	}
+	return val;
 }
 
 int Game_Enemy::MaxSpValue() const {
-	return lcf::Data::system.easyrpg_max_enemy_sp == -1 ? 9999 : lcf::Data::system.easyrpg_max_enemy_sp;
+	auto& val = lcf::Data::system.easyrpg_max_enemy_sp;
+	if (val == -1) {
+		return 9999;
+	}
+	return val;
 }
 
 int Game_Enemy::MaxStatBattleValue() const {
-	return lcf::Data::system.easyrpg_max_stat_battle_value == -1 ? 9999 : lcf::Data::system.easyrpg_max_stat_battle_value;
+	auto& val = lcf::Data::system.easyrpg_max_stat_battle_value;
+	if (val == -1) {
+		return 9999;
+	}
+	return val;
 }
 
 int Game_Enemy::MaxStatBaseValue() const {
-	return lcf::Data::system.easyrpg_max_stat_base_value == -1 ? 999 : lcf::Data::system.easyrpg_max_stat_base_value;
+	auto& val = lcf::Data::system.easyrpg_max_stat_base_value;
+	if (val == -1) {
+		return 999;
+	}
+	return val;
 }
 
 int Game_Enemy::GetStateProbability(int state_id) const {

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -39,6 +39,8 @@ public:
 
 	int MaxHpValue() const override;
 
+	int MaxSpValue() const override;
+
 	int MaxStatBattleValue() const override;
 
 	int MaxStatBaseValue() const override;

--- a/src/game_party.h
+++ b/src/game_party.h
@@ -133,6 +133,14 @@ public:
 	int GetItemTotalCount(int item_id) const;
 
 	/**
+	 * Gets maximum number of item allowed in inventory.
+	 *
+	 * @param item_id database item ID.
+	 * @return maximum number of items.
+	 */
+	int GetMaxItemCount(int item_id) const;
+
+	/**
 	 * Gains an amount of items.
 	 *
 	 * @param item_id database item ID.

--- a/src/game_variables.cpp
+++ b/src/game_variables.cpp
@@ -63,6 +63,9 @@ constexpr Var_t VarMod(Var_t n, Var_t d) {
 Game_Variables::Game_Variables(Var_t minval, Var_t maxval)
 	: _min(minval), _max(maxval)
 {
+	if (minval >= maxval) {
+		Output::Error("Variables: Invalid var range: [{}, {}]", minval, maxval);
+	}
 	_variables.reserve(lcf::Data::variables.size());
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1138,6 +1138,8 @@ void Player::SetupNewGame() {
 		static_cast<Scene_Title*>(title.get())->OnGameStart();
 	}
 
+	Main_Data::game_system->SetAtbMode(static_cast<Game_System::AtbMode>(lcf::Data::battlecommands.easyrpg_default_atb_mode));
+
 	Main_Data::game_party->SetupNewGame();
 	SetupPlayerSpawn();
 	Scene::Push(std::make_shared<Scene_Map>(0));

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -859,8 +859,14 @@ void Player::ResetGameObjects() {
 
 	Main_Data::game_switches = std::make_unique<Game_Switches>();
 
-	auto min_var = Player::IsRPG2k3() ? Game_Variables::min_2k3 : Game_Variables::min_2k;
-	auto max_var = Player::IsRPG2k3() ? Game_Variables::max_2k3 : Game_Variables::max_2k;
+	auto min_var = lcf::Data::system.easyrpg_variable_min_value;
+	if (min_var == 0) {
+		min_var = Player::IsRPG2k3() ? Game_Variables::min_2k3 : Game_Variables::min_2k;
+	}
+	auto max_var = lcf::Data::system.easyrpg_variable_max_value;
+	if (max_var == 0) {
+		max_var = Player::IsRPG2k3() ? Game_Variables::max_2k3 : Game_Variables::max_2k;
+	}
 	Main_Data::game_variables = std::make_unique<Game_Variables>(min_var, max_var);
 
 	// Prevent a crash when Game_Map wants to reset the screen content

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -160,15 +160,13 @@ void Scene_Battle::DrawBackground(Bitmap& dst) {
 void Scene_Battle::CreateUi() {
 	std::vector<std::string> commands;
 
-	for (std::vector<int16_t>::iterator it = lcf::Data::system.easyrpg_battle_options.begin();
-		it != lcf::Data::system.easyrpg_battle_options.end(); ++it) {
-			battle_options.push_back((BattleOptionType)*it);
+	for (auto option: lcf::Data::system.easyrpg_battle_options) {
+		battle_options.push_back((BattleOptionType)option);
 	}
 
 	// Add all menu items
-	std::vector<BattleOptionType>::iterator it;
-	for (it = battle_options.begin(); it != battle_options.end(); ++it) {
-		switch(*it) {
+	for (auto option: battle_options) {
+		switch(option) {
 		case Battle:
 			commands.push_back(ToString(lcf::Data::terms.battle_fight));
 			break;

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -159,9 +159,28 @@ void Scene_Battle::DrawBackground(Bitmap& dst) {
 
 void Scene_Battle::CreateUi() {
 	std::vector<std::string> commands;
-	commands.push_back(ToString(lcf::Data::terms.battle_fight));
-	commands.push_back(ToString(lcf::Data::terms.battle_auto));
-	commands.push_back(ToString(lcf::Data::terms.battle_escape));
+
+	for (std::vector<int16_t>::iterator it = lcf::Data::system.easyrpg_battle_options.begin();
+		it != lcf::Data::system.easyrpg_battle_options.end(); ++it) {
+			battle_options.push_back((BattleOptionType)*it);
+	}
+
+	// Add all menu items
+	std::vector<BattleOptionType>::iterator it;
+	for (it = battle_options.begin(); it != battle_options.end(); ++it) {
+		switch(*it) {
+		case Battle:
+			commands.push_back(ToString(lcf::Data::terms.battle_fight));
+			break;
+		case AutoBattle:
+			commands.push_back(ToString(lcf::Data::terms.battle_auto));
+			break;
+		case Escape:
+			commands.push_back(ToString(lcf::Data::terms.battle_escape));
+			break;
+		}
+	}
+
 	options_window.reset(new Window_Command(commands, option_command_mov));
 	options_window->SetHeight(80);
 	options_window->SetY(SCREEN_TARGET_HEIGHT - 80);

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -119,6 +119,13 @@ public:
 		State_Escape
 	};
 
+	/** Options available in a battle option menu. */
+	enum BattleOptionType {
+		Battle,
+		AutoBattle,
+		Escape
+	};
+
 	static void SelectionFlash(Game_Battler* battler);
 
 protected:
@@ -188,6 +195,9 @@ protected:
 	std::unique_ptr<EnemyAi::AlgorithmBase> enemyai_algo;
 
 	BattleContinuation on_battle_end;
+
+	/** Options available in the menu. */
+	std::vector<BattleOptionType> battle_options;
 };
 
 inline bool Scene_Battle::IsEscapeAllowed() const {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -65,6 +65,10 @@ void Scene_Battle_Rpg2k::CreateUi() {
 
 	battle_message_window.reset(new Window_BattleMessage(0, (SCREEN_TARGET_HEIGHT - 80), SCREEN_TARGET_WIDTH, 80));
 
+	if (!lcf::Data::system.easyrpg_enable_auto_battle) {
+		options_window->DisableItem(1);
+	}
+
 	if (!IsEscapeAllowed()) {
 		options_window->DisableItem(2);
 	}
@@ -451,8 +455,13 @@ Scene_Battle_Rpg2k::SceneActionReturn Scene_Battle_Rpg2k::ProcessSceneActionFigh
 						SetState(State_SelectActor);
 						break;
 					case 1: // Auto Battle
-						SetState(State_AutoBattle);
-						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
+						if (!lcf::Data::system.easyrpg_enable_auto_battle) {
+							Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
+						}
+						else {
+							SetState(State_AutoBattle);
+							Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
+						}
 						break;
 					case 2: // Escape
 						if (!IsEscapeAllowed()) {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -65,12 +65,11 @@ void Scene_Battle_Rpg2k::CreateUi() {
 
 	battle_message_window.reset(new Window_BattleMessage(0, (SCREEN_TARGET_HEIGHT - 80), SCREEN_TARGET_WIDTH, 80));
 
-	if (!lcf::Data::system.easyrpg_enable_auto_battle) {
-		options_window->DisableItem(1);
-	}
-
 	if (!IsEscapeAllowed()) {
-		options_window->DisableItem(2);
+		auto it = std::find(battle_options.begin(), battle_options.end(), Escape);
+		if (it != battle_options.end()) {
+			options_window->DisableItem(std::distance(battle_options.begin(), it));
+		}
 	}
 
 	SetCommandWindows(0);
@@ -447,23 +446,18 @@ Scene_Battle_Rpg2k::SceneActionReturn Scene_Battle_Rpg2k::ProcessSceneActionFigh
 
 		if (Input::IsTriggered(Input::DECISION)) {
 			if (!message_window->IsVisible()) {
-				switch (options_window->GetIndex()) {
-					case 0: // Battle
+				switch (battle_options[options_window->GetIndex()]) {
+					case Battle: // Battle
 						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 						RefreshTargetWindow();
 						target_window->SetVisible(false);
 						SetState(State_SelectActor);
 						break;
-					case 1: // Auto Battle
-						if (!lcf::Data::system.easyrpg_enable_auto_battle) {
-							Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
-						}
-						else {
-							SetState(State_AutoBattle);
-							Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
-						}
+					case AutoBattle: // Auto Battle
+						SetState(State_AutoBattle);
+						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 						break;
-					case 2: // Escape
+					case Escape: // Escape
 						if (!IsEscapeAllowed()) {
 							Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 						}

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -564,7 +564,9 @@ std::vector<std::string> Scene_Battle_Rpg2k3::GetBattleCommandNames(const Game_A
 			commands.push_back(ToString(cmd->name));
 		}
 	}
-	if (lcf::Data::battlecommands.easyrpg_enable_battle_row_command) commands.push_back(ToString(lcf::Data::terms.row));
+	if (lcf::Data::battlecommands.easyrpg_enable_battle_row_command) {
+		commands.push_back(ToString(lcf::Data::terms.row));
+	}
 
 	return commands;
 }

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -563,7 +563,7 @@ std::vector<std::string> Scene_Battle_Rpg2k3::GetBattleCommandNames(const Game_A
 			commands.push_back(ToString(cmd->name));
 		}
 	}
-	commands.push_back(ToString(lcf::Data::terms.row));
+	if (lcf::Data::battlecommands.easyrpg_enable_battle_row_command) commands.push_back(ToString(lcf::Data::terms.row));
 
 	return commands;
 }
@@ -1303,7 +1303,7 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionCo
 		if (Input::IsTriggered(Input::DECISION)) {
 			int index = command_window->GetIndex();
 			// Row command always uses the last index
-			if (index < command_window->GetRowMax() - 1) {
+			if (!lcf::Data::battlecommands.easyrpg_enable_battle_row_command || index < command_window->GetRowMax() - 1) {
 				const auto* command = active_actor->GetBattleCommand(index);
 
 				if (command) {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1170,6 +1170,11 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionAc
 			command_window->SetVisible(true);
 		}
 
+		if (lcf::Data::battlecommands.easyrpg_sequential_order) {
+			SetSceneActionSubState(eWaitActor);
+			return SceneActionReturn::eContinueThisFrame;
+		}
+
 		SetSceneActionSubState(eWaitInput);
 	}
 
@@ -1224,6 +1229,15 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionAc
 			command_window->SetIndex(0);
 			SetState(State_SelectCommand);
 			return SceneActionReturn::eWaitTillNextFrame;
+		}
+
+		if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) {
+			if (Input::IsTriggered(Input::CANCEL)) {
+				SetActiveActor(-1);
+				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
+				SetState(State_SelectOption);
+				return SceneActionReturn::eWaitTillNextFrame;
+			}
 		}
 
 		return SceneActionReturn::eWaitTillNextFrame;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1080,12 +1080,19 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionFi
 		ResetWindows(true);
 		target_window->SetIndex(-1);
 
-		if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional) {
+		if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional || (!lcf::Data::system.easyrpg_enable_auto_battle && !IsEscapeAllowedFromOptionWindow())) {
+			if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) MoveCommandWindows(-options_window->GetWidth(), 1);
 			SetState(State_SelectActor);
 			return SceneActionReturn::eContinueThisFrame;
 		}
 
 		options_window->SetActive(true);
+		if (lcf::Data::system.easyrpg_enable_auto_battle) {
+			options_window->EnableItem(1);
+		} else {
+			options_window->DisableItem(1);
+		}
+
 		if (IsEscapeAllowedFromOptionWindow()) {
 			options_window->EnableItem(2);
 		} else {
@@ -1122,9 +1129,13 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionFi
 					SetState(State_SelectActor);
 					break;
 				case 1: // Auto Battle
-					MoveCommandWindows(-options_window->GetWidth(), 8);
-					SetState(State_AutoBattle);
-					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
+					if (lcf::Data::system.easyrpg_enable_auto_battle) {
+						MoveCommandWindows(-options_window->GetWidth(), 8);
+						SetState(State_AutoBattle);
+						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
+					} else {
+						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
+					}
 					break;
 				case 2: // Escape
 					if (IsEscapeAllowedFromOptionWindow()) {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -292,7 +292,8 @@ void Scene_Battle_Rpg2k3::CreateUi() {
 	CreateBattleStatusWindow();
 	CreateBattleCommandWindow();
 
-	sp_window.reset(new Window_ActorSp(SCREEN_TARGET_WIDTH - 60, 136, 60, 32));
+	int spwindow_size = (lcf::Data::system.easyrpg_max_actor_sp == -1 ? 999 : lcf::Data::system.easyrpg_max_actor_sp) >= 1000 ? 72 : 60;
+	sp_window.reset(new Window_ActorSp(SCREEN_TARGET_WIDTH - spwindow_size, 136, spwindow_size, 32));
 	sp_window->SetVisible(false);
 	sp_window->SetZ(Priority_Window + 2);
 
@@ -1772,6 +1773,8 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionVi
 		message_window->SetHeight(32);
 		message_window->SetMaxLinesPerPage(1);
 		Game_Message::SetPendingMessage(std::move(pm));
+
+		status_window->Refresh();
 
 		SetSceneActionSubState(eEnd);
 		return SceneActionReturn::eContinueThisFrame;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1083,23 +1083,24 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionFi
 		ResetWindows(true);
 		target_window->SetIndex(-1);
 
-		if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional || (!lcf::Data::system.easyrpg_enable_auto_battle && !IsEscapeAllowedFromOptionWindow())) {
+		if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional || ((std::find(battle_options.begin(), battle_options.end(), AutoBattle) == battle_options.end()) && !IsEscapeAllowedFromOptionWindow())) {
 			if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) MoveCommandWindows(-options_window->GetWidth(), 1);
 			SetState(State_SelectActor);
 			return SceneActionReturn::eContinueThisFrame;
 		}
 
 		options_window->SetActive(true);
-		if (lcf::Data::system.easyrpg_enable_auto_battle) {
-			options_window->EnableItem(1);
-		} else {
-			options_window->DisableItem(1);
-		}
 
 		if (IsEscapeAllowedFromOptionWindow()) {
-			options_window->EnableItem(2);
+			auto it = std::find(battle_options.begin(), battle_options.end(), Escape);
+			if (it != battle_options.end()) {
+				options_window->EnableItem(std::distance(battle_options.begin(), it));
+			}
 		} else {
-			options_window->DisableItem(2);
+			auto it = std::find(battle_options.begin(), battle_options.end(), Escape);
+			if (it != battle_options.end()) {
+				options_window->DisableItem(std::distance(battle_options.begin(), it));
+			}
 		}
 
 		options_window->SetVisible(true);
@@ -1125,22 +1126,18 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionFi
 			if (message_window->IsVisible()) {
 				return SceneActionReturn::eWaitTillNextFrame;
 			}
-			switch (options_window->GetIndex()) {
-				case 0: // Battle
+			switch (battle_options[options_window->GetIndex()]) {
+				case Battle: // Battle
 					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 					MoveCommandWindows(-options_window->GetWidth(), 8);
 					SetState(State_SelectActor);
 					break;
-				case 1: // Auto Battle
-					if (lcf::Data::system.easyrpg_enable_auto_battle) {
-						MoveCommandWindows(-options_window->GetWidth(), 8);
-						SetState(State_AutoBattle);
-						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
-					} else {
-						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
-					}
+				case AutoBattle: // Auto Battle
+					MoveCommandWindows(-options_window->GetWidth(), 8);
+					SetState(State_AutoBattle);
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 					break;
-				case 2: // Escape
+				case Escape: // Escape
 					if (IsEscapeAllowedFromOptionWindow()) {
 						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 						SetState(State_Escape);

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -2811,7 +2811,7 @@ void Scene_Battle_Rpg2k3::RecreateSpWindow(Game_Battler* battler) {
 	if (battler && battler->MaxSpValue() >= 1000) {
 		spwindow_size = 72;
 	}
-	sp_window = std::make_unique<Window_ActorSp>(SCREEN_TARGET_WIDTH - spwindow_size, 136, 60, 32);
+	sp_window = std::make_unique<Window_ActorSp>(SCREEN_TARGET_WIDTH - spwindow_size, 136, spwindow_size, 32);
 	sp_window->SetVisible(false);
 	sp_window->SetZ(Priority_Window + 2);
 	if (battler) {

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -226,6 +226,7 @@ protected:
 	int battle_end_timer = 0;
 
 	std::unique_ptr<Window_ActorSp> sp_window;
+	void RecreateSpWindow(Game_Battler* battler);
 
 	FileRequestBinding request_id;
 	std::shared_ptr<Game_BattleAlgorithm::AlgorithmBase> pending_battle_action = {};

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -348,7 +348,7 @@ void Scene_Debug::Update() {
 					DoItem();
 				} else if (sz > 2) {
 					if (frame.value <= static_cast<int>(lcf::Data::items.size())) {
-						PushUiNumberInput(Main_Data::game_party->GetItemCount(frame.value), 2, false);
+						PushUiNumberInput(Main_Data::game_party->GetItemCount(frame.value), Main_Data::game_party->GetMaxItemCount(frame.value) >= 100 ? 3 : 2, false);
 					}
 				} else if (sz > 1) {
 					PushUiVarList();

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -589,8 +589,8 @@ void Scene_Debug::CreateVarListWindow() {
 }
 
 void Scene_Debug::CreateNumberInputWindow() {
-	numberinput_window.reset(new Window_NumberInput(105, 104,
-		Player::IsRPG2k() ? 12 * 7 + 16 : 12 * 8 + 16, 32));
+	numberinput_window.reset(new Window_NumberInput(160 - (Main_Data::game_variables->GetMaxDigits() + 1) * 6 - 8, 104,
+		(Main_Data::game_variables->GetMaxDigits() + 1) * 12 + 16, 32));
 	numberinput_window->SetVisible(false);
 	numberinput_window->SetOpacity(255);
 	numberinput_window->SetShowOperator(true);

--- a/src/scene_equip.cpp
+++ b/src/scene_equip.cpp
@@ -126,10 +126,12 @@ void Scene_Equip::UpdateStatusWindow() {
 		}
 		add_item(current_item, 1);
 
-		atk = Utils::Clamp(atk, 1, 999);
-		def = Utils::Clamp(def, 1, 999);
-		spi = Utils::Clamp(spi, 1, 999);
-		agi = Utils::Clamp(agi, 1, 999);
+		int limit = lcf::Data::system.easyrpg_max_stat_base_value == -1 ? 999 : lcf::Data::system.easyrpg_max_stat_base_value;
+
+		atk = Utils::Clamp(atk, 1, limit);
+		def = Utils::Clamp(def, 1, limit);
+		spi = Utils::Clamp(spi, 1, limit);
+		agi = Utils::Clamp(agi, 1, limit);
 
 		atk = actor.CalcValueAfterAtkStates(atk);
 		def = actor.CalcValueAfterDefStates(def);

--- a/src/scene_equip.cpp
+++ b/src/scene_equip.cpp
@@ -126,7 +126,7 @@ void Scene_Equip::UpdateStatusWindow() {
 		}
 		add_item(current_item, 1);
 
-		int limit = lcf::Data::system.easyrpg_max_stat_base_value == -1 ? 999 : lcf::Data::system.easyrpg_max_stat_base_value;
+		int limit = actor.MaxStatBaseValue();
 
 		atk = Utils::Clamp(atk, 1, limit);
 		def = Utils::Clamp(def, 1, limit);

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -114,7 +114,7 @@ void Scene_File::Start() {
 	// Refresh File Finder Save Folder
 	fs = FileFinder::Save();
 
-	for (int i = 0; i < 15; i++) {
+	for (int i = 0; i < Utils::Clamp(lcf::Data::system.easyrpg_max_savefiles, 3, 99); i++) {
 		std::shared_ptr<Window_SaveFile>
 			w(new Window_SaveFile(0, 40 + i * 64, SCREEN_TARGET_WIDTH, 64));
 		w->SetIndex(i);

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -114,7 +114,7 @@ void Scene_File::Start() {
 	// Refresh File Finder Save Folder
 	fs = FileFinder::Save();
 
-	for (int i = 0; i < Utils::Clamp(lcf::Data::system.easyrpg_max_savefiles, 3, 99); i++) {
+	for (int i = 0; i < Utils::Clamp<int32_t>(lcf::Data::system.easyrpg_max_savefiles, 3, 99); i++) {
 		std::shared_ptr<Window_SaveFile>
 			w(new Window_SaveFile(0, 40 + i * 64, SCREEN_TARGET_WIDTH, 64));
 		w->SetIndex(i);

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -50,7 +50,7 @@ Scene_Save::Scene_Save() :
 void Scene_Save::Start() {
 	Scene_File::Start();
 
-	for (int i = 0; i < 15; i++) {
+	for (int i = 0; i < Utils::Clamp(lcf::Data::system.easyrpg_max_savefiles, 3, 99); i++) {
 		file_windows[i]->SetHasSave(true);
 		file_windows[i]->Refresh();
 	}

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -50,7 +50,7 @@ Scene_Save::Scene_Save() :
 void Scene_Save::Start() {
 	Scene_File::Start();
 
-	for (int i = 0; i < Utils::Clamp(lcf::Data::system.easyrpg_max_savefiles, 3, 99); i++) {
+	for (int i = 0; i < Utils::Clamp<int32_t>(lcf::Data::system.easyrpg_max_savefiles, 3, 99); i++) {
 		file_windows[i]->SetHasSave(true);
 		file_windows[i]->Refresh();
 	}

--- a/src/scene_shop.cpp
+++ b/src/scene_shop.cpp
@@ -253,7 +253,7 @@ void Scene_Shop::UpdateBuySelection() {
 			// Items are guaranteed to be valid
 			const lcf::rpg::Item* item = lcf::ReaderUtil::GetElement(lcf::Data::items, item_id);
 
-			int max = 99 - Main_Data::game_party->GetItemCount(item_id);
+			int max = Main_Data::game_party->GetMaxItemCount(item_id) - Main_Data::game_party->GetItemCount(item_id);
 			if (item->price > 0) {
 				max = std::min<int>(max, Main_Data::game_party->GetGold() / item->price);
 			}

--- a/src/window_actorsp.cpp
+++ b/src/window_actorsp.cpp
@@ -31,6 +31,8 @@ Window_ActorSp::Window_ActorSp(int ix, int iy, int iwidth, int iheight) :
 void Window_ActorSp::SetBattler(const Game_Battler& battler) {
 	int cx = 0;
 
+	int digits = (lcf::Data::system.easyrpg_max_actor_sp == -1 ? 999 : lcf::Data::system.easyrpg_max_actor_sp) >= 1000 ? 4 : 3;
+
 	int color = Font::ColorDefault;
 	if (battler.GetMaxSp() != 0 && battler.GetSp() <= battler.GetMaxSp() / 4) {
 		color = Font::ColorCritical;
@@ -39,13 +41,13 @@ void Window_ActorSp::SetBattler(const Game_Battler& battler) {
 	contents->Clear();
 
 	// Draw current Sp
-	contents->TextDraw(cx + 3 * 6, 2, color, std::to_string(battler.GetSp()), Text::AlignRight);
+	contents->TextDraw(cx + digits * 6, 2, color, std::to_string(battler.GetSp()), Text::AlignRight);
 
 	// Draw /
-	cx += 3 * 6;
+	cx += digits * 6;
 	contents->TextDraw(cx, 2, Font::ColorDefault, "/");
 
 	// Draw Max Sp
 	cx += 6;
-	contents->TextDraw(cx + 3 * 6, 2, Font::ColorDefault, std::to_string(battler.GetMaxSp()), Text::AlignRight);
+	contents->TextDraw(cx + digits * 6, 2, Font::ColorDefault, std::to_string(battler.GetMaxSp()), Text::AlignRight);
 }

--- a/src/window_actorsp.cpp
+++ b/src/window_actorsp.cpp
@@ -31,7 +31,7 @@ Window_ActorSp::Window_ActorSp(int ix, int iy, int iwidth, int iheight) :
 void Window_ActorSp::SetBattler(const Game_Battler& battler) {
 	int cx = 0;
 
-	int digits = (lcf::Data::system.easyrpg_max_actor_sp == -1 ? 999 : lcf::Data::system.easyrpg_max_actor_sp) >= 1000 ? 4 : 3;
+	int digits = (battler.MaxSpValue() >= 1000) ? 4 : 3;
 
 	int color = Font::ColorDefault;
 	if (battler.GetMaxSp() != 0 && battler.GetSp() <= battler.GetMaxSp() / 4) {

--- a/src/window_actorstatus.cpp
+++ b/src/window_actorstatus.cpp
@@ -72,13 +72,13 @@ void Window_ActorStatus::DrawMinMax(int cx, int cy, int min, int max, int color)
 	if (max >= 0)
 		ss << min;
 	else
-		ss << Main_Data::game_actors->GetActor(actor_id)->GetExpString();
+		ss << Main_Data::game_actors->GetActor(actor_id)->GetExpString(true);
 	contents->TextDraw(cx, cy, color, ss.str(), Text::AlignRight);
 	contents->TextDraw(cx, cy, Font::ColorDefault, "/");
 	ss.str("");
 	if (max >= 0)
 		ss << max;
 	else
-		ss << Main_Data::game_actors->GetActor(actor_id)->GetNextExpString();
+		ss << Main_Data::game_actors->GetActor(actor_id)->GetNextExpString(true);
 	contents->TextDraw(cx + 48, cy, Font::ColorDefault, ss.str(), Text::AlignRight);
 }

--- a/src/window_actortarget.cpp
+++ b/src/window_actortarget.cpp
@@ -43,8 +43,8 @@ void Window_ActorTarget::Refresh() {
 		DrawActorName(actor, 48 + 8, i * 48 + 2 + y);
 		DrawActorLevel(actor, 48 + 8, i * 48 + 2 + 16 + y);
 		DrawActorState(actor, 48 + 8, i * 48 + 2 + 16 + 16 + y);
-		int x_offset = 48 + 8 + 46 + (Player::IsRPG2k() ? 12 : 0);
-		int digits = (Player::IsRPG2k() ? 3 : 4);
+		int digits = (lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 ? 4 : 3;
+		int x_offset = 48 + 8 + 46 + (digits == 3 ? 12 : 0);
 		DrawActorHp(actor, x_offset, i * 48 + 2 + 16 + y, digits);
 		DrawActorSp(actor, x_offset, i * 48 + 2 + 16 + 16 + y, digits);
 

--- a/src/window_actortarget.cpp
+++ b/src/window_actortarget.cpp
@@ -43,7 +43,7 @@ void Window_ActorTarget::Refresh() {
 		DrawActorName(actor, 48 + 8, i * 48 + 2 + y);
 		DrawActorLevel(actor, 48 + 8, i * 48 + 2 + 16 + y);
 		DrawActorState(actor, 48 + 8, i * 48 + 2 + 16 + 16 + y);
-		int digits = (lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 ? 4 : 3;
+		int digits = ((lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 || (lcf::Data::system.easyrpg_max_actor_sp == -1 ? 999 : lcf::Data::system.easyrpg_max_actor_sp) >= 1000) ? 4 : 3;
 		int x_offset = 48 + 8 + 46 + (digits == 3 ? 12 : 0);
 		DrawActorHp(actor, x_offset, i * 48 + 2 + 16 + y, digits);
 		DrawActorSp(actor, x_offset, i * 48 + 2 + 16 + 16 + y, digits);

--- a/src/window_actortarget.cpp
+++ b/src/window_actortarget.cpp
@@ -43,7 +43,7 @@ void Window_ActorTarget::Refresh() {
 		DrawActorName(actor, 48 + 8, i * 48 + 2 + y);
 		DrawActorLevel(actor, 48 + 8, i * 48 + 2 + 16 + y);
 		DrawActorState(actor, 48 + 8, i * 48 + 2 + 16 + 16 + y);
-		int digits = ((lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 || (lcf::Data::system.easyrpg_max_actor_sp == -1 ? 999 : lcf::Data::system.easyrpg_max_actor_sp) >= 1000) ? 4 : 3;
+		int digits = (actor.MaxHpValue() >= 1000 || actor.MaxSpValue() >= 1000) ? 4 : 3;
 		int x_offset = 48 + 8 + 46 + (digits == 3 ? 12 : 0);
 		DrawActorHp(actor, x_offset, i * 48 + 2 + 16 + y, digits);
 		DrawActorSp(actor, x_offset, i * 48 + 2 + 16 + 16 + y, digits);
@@ -68,7 +68,7 @@ Game_Actor* Window_ActorTarget::GetActor() {
 		ind = -ind - 1;
 	}
 	else if (ind == -100) {
-		return NULL;
+		return nullptr;
 	}
 
 	return &(*Main_Data::game_party)[ind];

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -132,7 +132,7 @@ void Window_Base::DrawActorLevel(const Game_Actor& actor, int cx, int cy) const 
 	contents->TextDraw(cx, cy, 1, lcf::Data::terms.lvl_short);
 
 	// Draw Level of the Actor
-	contents->TextDraw(cx + 24, cy, Font::ColorDefault, std::to_string(actor.GetLevel()), Text::AlignRight);
+	contents->TextDraw(cx + (lcf::Data::system.easyrpg_max_level >= 100 ? 30 : 24), cy, Font::ColorDefault, std::to_string(actor.GetLevel()), Text::AlignRight);
 }
 
 void Window_Base::DrawActorState(const Game_Battler& actor, int cx, int cy) const {

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -148,7 +148,7 @@ void Window_Base::DrawActorState(const Game_Battler& actor, int cx, int cy) cons
 void Window_Base::DrawActorExp(const Game_Actor& actor, int cx, int cy) const {
 	// Draw EXP-String
 	int width = 7;
-	if (Player::IsRPG2k()) {
+	if ((lcf::Data::system.easyrpg_max_exp == -1 ? (Player::IsRPG2k() ? 999999 : 9999999) : lcf::Data::system.easyrpg_max_exp) < 1000000) {
 		width = 6;
 		contents->TextDraw(cx, cy, 1, lcf::Data::terms.exp_short);
 	}
@@ -163,7 +163,7 @@ void Window_Base::DrawActorExp(const Game_Actor& actor, int cx, int cy) const {
 
 	// Exp for Level up
 	ss << std::setfill(' ') << std::setw(width) << actor.GetNextExpString();
-	contents->TextDraw(cx + (Player::IsRPG2k() ? 12 : 0), cy, Font::ColorDefault, ss.str(), Text::AlignLeft);
+	contents->TextDraw(cx + (width == 6 ? 12 : 0), cy, Font::ColorDefault, ss.str(), Text::AlignLeft);
 }
 
 void Window_Base::DrawActorHp(const Game_Battler& actor, int cx, int cy, int digits, bool draw_max) const {

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -148,7 +148,7 @@ void Window_Base::DrawActorState(const Game_Battler& actor, int cx, int cy) cons
 void Window_Base::DrawActorExp(const Game_Actor& actor, int cx, int cy) const {
 	// Draw EXP-String
 	int width = 7;
-	if ((lcf::Data::system.easyrpg_max_exp == -1 ? (Player::IsRPG2k() ? 999999 : 9999999) : lcf::Data::system.easyrpg_max_exp) < 1000000) {
+	if (actor.MaxExpValue() < 1000000) {
 		width = 6;
 		contents->TextDraw(cx, cy, 1, lcf::Data::terms.exp_short);
 	}

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -132,7 +132,7 @@ void Window_Base::DrawActorLevel(const Game_Actor& actor, int cx, int cy) const 
 	contents->TextDraw(cx, cy, 1, lcf::Data::terms.lvl_short);
 
 	// Draw Level of the Actor
-	contents->TextDraw(cx + (lcf::Data::system.easyrpg_max_level >= 100 ? 30 : 24), cy, Font::ColorDefault, std::to_string(actor.GetLevel()), Text::AlignRight);
+	contents->TextDraw(cx + (actor.GetMaxLevel() >= 100 ? 30 : 24), cy, Font::ColorDefault, std::to_string(actor.GetLevel()), Text::AlignRight);
 }
 
 void Window_Base::DrawActorState(const Game_Battler& actor, int cx, int cy) const {

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -82,8 +82,9 @@ void Window_BattleStatus::Refresh() {
 
 			DrawActorName(*actor, 4, y);
 			if (Player::IsRPG2k()) {
-				DrawActorState(*actor, 86, y);
-				DrawActorHp(*actor, 142, y, 3, true);
+				int digits = (lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 ? 4 : 3;
+				DrawActorState(*actor, digits == 3 ? 86 : 80, y);
+				DrawActorHp(*actor, digits == 3 ? 142 : 136, y, digits, true);
 				DrawActorSp(*actor, 202, y, 3, false);
 			} else {
 				if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional) {
@@ -162,7 +163,8 @@ void Window_BattleStatus::RefreshGauge() {
 					if (lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_opaque || (2 + index * 16 != y)) {
 						DrawGauge(*actor, 202 - 10, y - 2, lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_opaque ? 96 : 255);
 					}
-					DrawActorHp(*actor, 136, y, 4, true);
+					int digits = (lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 ? 4 : 3;
+					DrawActorHp(*actor, digits == 3 ? 142 : 136, y, digits, true);
 					DrawActorSp(*actor, 202, y, 3, false);
 				} else {
 					DrawGauge(*actor, 156, y - 2);

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -82,8 +82,8 @@ void Window_BattleStatus::Refresh() {
 
 			DrawActorName(*actor, 4, y);
 			if (Player::IsRPG2k()) {
-				int hpdigits = (actor->GetMaxHp() >= 1000) ? 4 : 3;
-				int spdigits = (actor->GetMaxSp() >= 1000) ? 4 : 3;
+				int hpdigits = (actor->MaxHpValue() >= 1000) ? 4 : 3;
+				int spdigits = (actor->MaxSpValue() >= 1000) ? 4 : 3;
 				DrawActorState(*actor, (hpdigits < 4 && spdigits < 4) ? 86 : 80, y);
 				DrawActorHp(*actor, 178 - hpdigits * 6 - spdigits * 6, y, hpdigits, true);
 				DrawActorSp(*actor, 220 - spdigits * 6, y, spdigits, false);

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -82,8 +82,8 @@ void Window_BattleStatus::Refresh() {
 
 			DrawActorName(*actor, 4, y);
 			if (Player::IsRPG2k()) {
-				int hpdigits = (lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 ? 4 : 3;
-				int spdigits = (lcf::Data::system.easyrpg_max_actor_sp == -1 ? 999 : lcf::Data::system.easyrpg_max_actor_sp) >= 1000 ? 4 : 3;
+				int hpdigits = (actor->GetMaxHp() >= 1000) ? 4 : 3;
+				int spdigits = (actor->GetMaxSp() >= 1000) ? 4 : 3;
 				DrawActorState(*actor, (hpdigits < 4 && spdigits < 4) ? 86 : 80, y);
 				DrawActorHp(*actor, 178 - hpdigits * 6 - spdigits * 6, y, hpdigits, true);
 				DrawActorSp(*actor, 220 - spdigits * 6, y, spdigits, false);
@@ -164,8 +164,8 @@ void Window_BattleStatus::RefreshGauge() {
 					if (lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_opaque || (2 + index * 16 != y)) {
 						DrawGauge(*actor, 202 - 10, y - 2, lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_opaque ? 96 : 255);
 					}
-					int hpdigits = (lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 ? 4 : 3;
-					int spdigits = (lcf::Data::system.easyrpg_max_actor_sp == -1 ? 999 : lcf::Data::system.easyrpg_max_actor_sp) >= 1000 ? 4 : 3;
+					int hpdigits = (actor->MaxHpValue() >= 1000) ? 4 : 3;
+					int spdigits = (actor->MaxSpValue() >= 1000) ? 4 : 3;
 					DrawActorHp(*actor, 178 - hpdigits * 6 - spdigits * 6, y, hpdigits, true);
 					DrawActorSp(*actor, 220 - spdigits * 6, y, spdigits, false);
 				} else {

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -82,10 +82,11 @@ void Window_BattleStatus::Refresh() {
 
 			DrawActorName(*actor, 4, y);
 			if (Player::IsRPG2k()) {
-				int digits = (lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 ? 4 : 3;
-				DrawActorState(*actor, digits == 3 ? 86 : 80, y);
-				DrawActorHp(*actor, digits == 3 ? 142 : 136, y, digits, true);
-				DrawActorSp(*actor, 202, y, 3, false);
+				int hpdigits = (lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 ? 4 : 3;
+				int spdigits = (lcf::Data::system.easyrpg_max_actor_sp == -1 ? 999 : lcf::Data::system.easyrpg_max_actor_sp) >= 1000 ? 4 : 3;
+				DrawActorState(*actor, (hpdigits < 4 && spdigits < 4) ? 86 : 80, y);
+				DrawActorHp(*actor, 178 - hpdigits * 6 - spdigits * 6, y, hpdigits, true);
+				DrawActorSp(*actor, 220 - spdigits * 6, y, spdigits, false);
 			} else {
 				if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional) {
 					DrawActorState(*actor, 84, y);
@@ -163,9 +164,10 @@ void Window_BattleStatus::RefreshGauge() {
 					if (lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_opaque || (2 + index * 16 != y)) {
 						DrawGauge(*actor, 202 - 10, y - 2, lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_opaque ? 96 : 255);
 					}
-					int digits = (lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 ? 4 : 3;
-					DrawActorHp(*actor, digits == 3 ? 142 : 136, y, digits, true);
-					DrawActorSp(*actor, 202, y, 3, false);
+					int hpdigits = (lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 ? 4 : 3;
+					int spdigits = (lcf::Data::system.easyrpg_max_actor_sp == -1 ? 999 : lcf::Data::system.easyrpg_max_actor_sp) >= 1000 ? 4 : 3;
+					DrawActorHp(*actor, 178 - hpdigits * 6 - spdigits * 6, y, hpdigits, true);
+					DrawActorSp(*actor, 220 - spdigits * 6, y, spdigits, false);
 				} else {
 					DrawGauge(*actor, 156, y - 2);
 				}

--- a/src/window_equipstatus.cpp
+++ b/src/window_equipstatus.cpp
@@ -113,11 +113,15 @@ void Window_EquipStatus::DrawParameter(int cx, int cy, int type) {
 		return;
 	}
 
+	// Check if 4 digits are needed instead of 3
+	int limit = lcf::Data::system.easyrpg_max_stat_base_value == -1 ? 999 : lcf::Data::system.easyrpg_max_stat_base_value;
+	bool more_space_needed = (Player::IsRPG2k3() && limit >= 500) || limit >= 1000;
+
 	// Draw Term
 	contents->TextDraw(cx, cy, 1, name);
 
 	// Draw Value
-	cx += (Player::IsRPG2k3() ? (8 * 6 + 6 * 4) : (10 * 6 + 6 * 3));
+	cx += (more_space_needed ? (8 * 6 + 6 * 4) : (10 * 6 + 6 * 3));
 	contents->TextDraw(cx, cy, Font::ColorDefault, std::to_string(value), Text::AlignRight);
 
 	if (draw_params) {
@@ -136,7 +140,7 @@ void Window_EquipStatus::DrawParameter(int cx, int cy, int type) {
 		}
 
 		// Draw New Value
-		cx += 6 * 2 + (Player::IsRPG2k3() ? (6 * 4) : (6 * 3));
+		cx += 6 * 2 + (more_space_needed ? (6 * 4) : (6 * 3));
 		int color = GetNewParameterColor(value, new_value);
 		contents->TextDraw(cx, cy, color, std::to_string(new_value), Text::AlignRight);
 	}

--- a/src/window_equipstatus.cpp
+++ b/src/window_equipstatus.cpp
@@ -87,26 +87,27 @@ void Window_EquipStatus::DrawParameter(int cx, int cy, int type) {
 	StringView name;
 	int value;
 	int new_value;
+	Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
 
 	switch (type) {
 	case 0:
 		name = lcf::Data::terms.attack;
-		value = Main_Data::game_actors->GetActor(actor_id)->GetAtk();
+		value = actor->GetAtk();
 		new_value = atk;
 		break;
 	case 1:
 		name = lcf::Data::terms.defense;
-		value = Main_Data::game_actors->GetActor(actor_id)->GetDef();
+		value = actor->GetDef();
 		new_value = def;
 		break;
 	case 2:
 		name = lcf::Data::terms.spirit;
-		value = Main_Data::game_actors->GetActor(actor_id)->GetSpi();
+		value = actor->GetSpi();
 		new_value = spi;
 		break;
 	case 3:
 		name = lcf::Data::terms.agility;
-		value = Main_Data::game_actors->GetActor(actor_id)->GetAgi();
+		value = actor->GetAgi();
 		new_value = agi;
 		break;
 	default:
@@ -114,7 +115,7 @@ void Window_EquipStatus::DrawParameter(int cx, int cy, int type) {
 	}
 
 	// Check if 4 digits are needed instead of 3
-	int limit = lcf::Data::system.easyrpg_max_stat_base_value == -1 ? 999 : lcf::Data::system.easyrpg_max_stat_base_value;
+	int limit = actor->MaxStatBaseValue();
 	bool more_space_needed = (Player::IsRPG2k3() && limit >= 500) || limit >= 1000;
 
 	// Draw Term

--- a/src/window_menustatus.cpp
+++ b/src/window_menustatus.cpp
@@ -57,7 +57,7 @@ void Window_MenuStatus::Refresh() {
 		DrawActorLevel(actor, 48 + 8 + text_offset, i*48 + 2 + 16 + y);
 		DrawActorState(actor, 48 + 8 + 42 + text_offset, i*48 + 2 + 16 + y);
 		DrawActorExp(actor, 48 + 8 + text_offset, i*48 + 2 + 16 + 16 + y);
-		int digits = (lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 ? 4 : 3;
+		int digits = ((lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 || (lcf::Data::system.easyrpg_max_actor_sp == -1 ? 999 : lcf::Data::system.easyrpg_max_actor_sp) >= 1000) ? 4 : 3;
 		DrawActorHp(actor, 48 + 8 + 106 + text_offset - (digits == 3 ? 0 : 12), i * 48 + 2 + 16 + y, digits);
 		DrawActorSp(actor, 48 + 8 + 106 + text_offset - (digits == 3 ? 0 : 12), i * 48 + 2 + 16 + 16 + y, digits);
 

--- a/src/window_menustatus.cpp
+++ b/src/window_menustatus.cpp
@@ -57,9 +57,9 @@ void Window_MenuStatus::Refresh() {
 		DrawActorLevel(actor, 48 + 8 + text_offset, i*48 + 2 + 16 + y);
 		DrawActorState(actor, 48 + 8 + 42 + text_offset, i*48 + 2 + 16 + y);
 		DrawActorExp(actor, 48 + 8 + text_offset, i*48 + 2 + 16 + 16 + y);
-		int digits = (Player::IsRPG2k() ? 3 : 4);
-		DrawActorHp(actor, 48 + 8 + 106 + text_offset - (Player::IsRPG2k() ? 0 : 12), i * 48 + 2 + 16 + y, digits);
-		DrawActorSp(actor, 48 + 8 + 106 + text_offset - (Player::IsRPG2k() ? 0 : 12), i * 48 + 2 + 16 + 16 + y, digits);
+		int digits = (lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 ? 4 : 3;
+		DrawActorHp(actor, 48 + 8 + 106 + text_offset - (digits == 3 ? 0 : 12), i * 48 + 2 + 16 + y, digits);
+		DrawActorSp(actor, 48 + 8 + 106 + text_offset - (digits == 3 ? 0 : 12), i * 48 + 2 + 16 + 16 + y, digits);
 
 		y += 10;
 	}

--- a/src/window_menustatus.cpp
+++ b/src/window_menustatus.cpp
@@ -57,7 +57,7 @@ void Window_MenuStatus::Refresh() {
 		DrawActorLevel(actor, 48 + 8 + text_offset, i*48 + 2 + 16 + y);
 		DrawActorState(actor, 48 + 8 + 42 + text_offset, i*48 + 2 + 16 + y);
 		DrawActorExp(actor, 48 + 8 + text_offset, i*48 + 2 + 16 + 16 + y);
-		int digits = ((lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 || (lcf::Data::system.easyrpg_max_actor_sp == -1 ? 999 : lcf::Data::system.easyrpg_max_actor_sp) >= 1000) ? 4 : 3;
+		int digits = (actor.MaxHpValue() >= 1000 || actor.MaxSpValue() >= 1000) ? 4 : 3;
 		DrawActorHp(actor, 48 + 8 + 106 + text_offset - (digits == 3 ? 0 : 12), i * 48 + 2 + 16 + y, digits);
 		DrawActorSp(actor, 48 + 8 + 106 + text_offset - (digits == 3 ? 0 : 12), i * 48 + 2 + 16 + 16 + y, digits);
 

--- a/src/window_numberinput.cpp
+++ b/src/window_numberinput.cpp
@@ -17,6 +17,7 @@
 
 // Headers
 #include "window_numberinput.h"
+#include "game_variables.h"
 #include "game_system.h"
 #include "input.h"
 #include "main_data.h"
@@ -30,7 +31,7 @@
 
 Window_NumberInput::Window_NumberInput(int ix, int iy, int iwidth, int iheight) :
 	Window_Selectable(ix, iy, iwidth, iheight),
-	digits_max(Player::IsRPG2k() ? 6 : 7) {
+	digits_max(Main_Data::game_variables->GetMaxDigits()) {
 	number = 0;
 	plus = true;
 
@@ -84,8 +85,9 @@ int Window_NumberInput::GetMaxDigits() {
 }
 
 void Window_NumberInput::SetMaxDigits(int idigits_max) {
-	// Only accepts values between 1 and 6 (or 7) as RPG2K (or RPG2k3)
-	int top = Player::IsRPG2k() ? 6 : 7;
+	// At least 7 digits because of gold input in debug scene
+	// (free space and 6 digits for the gold value)
+	int top = std::max(7, digits_max);
 	digits_max =
 		(idigits_max > top) ? top :
 		(idigits_max <= 0) ? 1 :

--- a/src/window_numberinput.cpp
+++ b/src/window_numberinput.cpp
@@ -87,7 +87,7 @@ int Window_NumberInput::GetMaxDigits() {
 void Window_NumberInput::SetMaxDigits(int idigits_max) {
 	// At least 7 digits because of gold input in debug scene
 	// (free space and 6 digits for the gold value)
-	int top = std::max(7, digits_max);
+	int top = std::max(7, idigits_max);
 	digits_max =
 		(idigits_max > top) ? top :
 		(idigits_max <= 0) ? 1 :

--- a/src/window_shopbuy.cpp
+++ b/src/window_shopbuy.cpp
@@ -68,7 +68,7 @@ void Window_ShopBuy::DrawItem(int index) {
 	if (!item) {
 		Output::Warning("Window ShopBuy: Invalid item ID {}", item_id);
 	} else {
-		enabled = item->price <= Main_Data::game_party->GetGold() && Main_Data::game_party->GetItemCount(item_id) < 99;
+		enabled = item->price <= Main_Data::game_party->GetGold() && Main_Data::game_party->GetItemCount(item_id) < Main_Data::game_party->GetMaxItemCount(item_id);
 		price = item->price;
 	}
 
@@ -101,5 +101,5 @@ bool Window_ShopBuy::CheckEnable(int item_id) {
 	}
 
 	return (item->price <= Main_Data::game_party->GetGold() &&
-		Main_Data::game_party->GetItemCount(item_id) < 99);
+		Main_Data::game_party->GetItemCount(item_id) < Main_Data::game_party->GetMaxItemCount(item_id));
 }

--- a/src/window_shopnumber.cpp
+++ b/src/window_shopnumber.cpp
@@ -35,7 +35,7 @@ Window_ShopNumber::Window_ShopNumber(int ix, int iy, int iwidth, int iheight) :
 
 void Window_ShopNumber::SetData(int item_id, int item_max, int price) {
 	this->item_id = item_id;
-	this->item_max = min(item_max, 99);
+	this->item_max = item_max;
 	this->price = price;
 	number = 1;
 }
@@ -52,7 +52,11 @@ void Window_ShopNumber::Refresh() {
 
 	contents->TextDraw(132, y, Font::ColorDefault, "x");
 	contents->TextDraw(132 + 30, y, Font::ColorDefault, ss.str(), Text::AlignRight);
-	SetCursorRect(Rect(132 + 14, y - 2, 20, 16));
+	if (item_max >= 100) {
+		SetCursorRect(Rect(132 + 8, y - 2, 26, 16));
+	} else {
+		SetCursorRect(Rect(132 + 14, y - 2, 20, 16));
+	}
 
 	DrawCurrencyValue(GetTotal(), contents->GetWidth(), y + 32);
 }

--- a/src/window_shopparty.cpp
+++ b/src/window_shopparty.cpp
@@ -101,10 +101,12 @@ static int CmpEquip(const Game_Actor* actor, const lcf::rpg::Item* new_item) {
 	}
 	add_item(new_item, 1);
 
-	atk = Utils::Clamp(atk, 1, 999);
-	def = Utils::Clamp(def, 1, 999);
-	spi = Utils::Clamp(spi, 1, 999);
-	agi = Utils::Clamp(agi, 1, 999);
+	int limit = lcf::Data::system.easyrpg_max_stat_base_value == -1 ? 999 : lcf::Data::system.easyrpg_max_stat_base_value;
+
+	atk = Utils::Clamp(atk, 1, limit);
+	def = Utils::Clamp(def, 1, limit);
+	spi = Utils::Clamp(spi, 1, limit);
+	agi = Utils::Clamp(agi, 1, limit);
 
 	int new_score = atk + def + spi + agi;
 

--- a/src/window_shopparty.cpp
+++ b/src/window_shopparty.cpp
@@ -101,7 +101,7 @@ static int CmpEquip(const Game_Actor* actor, const lcf::rpg::Item* new_item) {
 	}
 	add_item(new_item, 1);
 
-	int limit = lcf::Data::system.easyrpg_max_stat_base_value == -1 ? 999 : lcf::Data::system.easyrpg_max_stat_base_value;
+	int limit = actor->MaxStatBaseValue();
 
 	atk = Utils::Clamp(atk, 1, limit);
 	def = Utils::Clamp(def, 1, limit);

--- a/src/window_skillstatus.cpp
+++ b/src/window_skillstatus.cpp
@@ -48,7 +48,8 @@ void Window_SkillStatus::Refresh() {
 	x += 44;
 	DrawActorState(actor, x, y);
 	x += 54;
-	DrawActorHp(actor, x + (Player::IsRPG2k() ? 6 : 0), y, (Player::IsRPG2k() ? 3 : 4));
+	int digits = (lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 ? 4 : 3;
+	DrawActorHp(actor, x + (digits == 3 ? 6 : 0), y, digits);
 	x += 72;
 	DrawActorSp(actor, x, y, 3);
 }

--- a/src/window_skillstatus.cpp
+++ b/src/window_skillstatus.cpp
@@ -47,9 +47,10 @@ void Window_SkillStatus::Refresh() {
 	DrawActorLevel(actor, x, y);
 	x += 44;
 	DrawActorState(actor, x, y);
-	x += 54;
-	int digits = (lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 ? 4 : 3;
-	DrawActorHp(actor, x + (digits == 3 ? 6 : 0), y, digits);
-	x += 72;
-	DrawActorSp(actor, x, y, 3);
+	int hpdigits = (lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 ? 4 : 3;
+	int spdigits = (lcf::Data::system.easyrpg_max_actor_sp == -1 ? 999 : lcf::Data::system.easyrpg_max_actor_sp) >= 1000 ? 4 : 3;
+	x += (96 - hpdigits * 6 - spdigits * 6);
+	DrawActorHp(actor, x, y, hpdigits);
+	x += (66 + hpdigits * 6 - spdigits * 6);
+	DrawActorSp(actor, x, y, spdigits);
 }

--- a/src/window_skillstatus.cpp
+++ b/src/window_skillstatus.cpp
@@ -47,8 +47,8 @@ void Window_SkillStatus::Refresh() {
 	DrawActorLevel(actor, x, y);
 	x += 44;
 	DrawActorState(actor, x, y);
-	int hpdigits = (lcf::Data::system.easyrpg_max_actor_hp == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_actor_hp) >= 1000 ? 4 : 3;
-	int spdigits = (lcf::Data::system.easyrpg_max_actor_sp == -1 ? 999 : lcf::Data::system.easyrpg_max_actor_sp) >= 1000 ? 4 : 3;
+	int hpdigits = (actor.MaxHpValue() >= 1000) ? 4 : 3;
+	int spdigits = (actor.MaxSpValue() >= 1000) ? 4 : 3;
 	x += (96 - hpdigits * 6 - spdigits * 6);
 	DrawActorHp(actor, x, y, hpdigits);
 	x += (66 + hpdigits * 6 - spdigits * 6);


### PR DESCRIPTION
Depends on [liblcf#421](https://github.com/easyrpg/liblcf/pull/421)

This PR adds the following game settings which can be set in the game database:

- BattleCommands: Default ATB mode
- BattleCommands: Enable in-battle row command
- BattleCommands: Sequential order battling
- Skills: Ignore reflect state
- Skills: State infliction hit rate
- Skills: Attribute shift hit rate
- Skills: Ignore physical rate restriction by states
- Skills: Ignore magical rate restriction by states
- Items: Maximum item count in inventory
- System: Alternative EXP curve
- System: Battle options
- System: Maximum actor HP value
- System: Maximum enemy HP value
- System: Maximum damage value
- System: Maximum EXP value
- System: Maximum level
- System: Enable stat absorbing
- System: Maximum number of savegame slots
- System: Default maximum item count in inventory
- System: Minimum variable value
- System: Maximum variable value
- System: Maximum actor SP value
- System: Maximum enemy SP value
- System: Maximum base stat value
- System: Maximum battle stat value
