### PR TITLE
switch: Rename missing ZL key for new hid api

### DIFF
--- a/src/platform/switch/switch_ui.cpp
+++ b/src/platform/switch/switch_ui.cpp
@@ -363,7 +363,7 @@ void NxUi::ProcessEvents() {
 
 	// cycle through GUI layouts
 	input = padGetButtonsDown(&pad);
-	if (input & KEY_ZL)
+	if (input & HidNpadButton_ZL)
 		ui_mode = (ui_mode + 1) % 3;
 
 	// do not handle touch when not displaying buttons or no touch happened


### PR DESCRIPTION
This was overlooked in #2454.
Latest libnx version finally removes the old enums. Before they have been aliased so this worked.
