### PR TITLE
Improve ZIP handling

### DIFF
--- a/src/filesystem_zip.h
+++ b/src/filesystem_zip.h
@@ -30,7 +30,6 @@
  */
 class ZipFilesystem : public Filesystem {
 public:
-
 	/**
 	 * Initializes a filesystem inside the given ZIP File
 	 *
@@ -62,15 +61,16 @@ private:
 		bool is_directory;
 	};
 
-	ZipFilesystem() = delete;
-
-	static bool FindCentralDirectory(std::istream& stream, uint32_t& offset, uint32_t& size, uint16_t& num_entries);
-	static bool ReadCentralDirectoryEntry(std::istream& zipfile, std::vector<char>& filepath, uint32_t& offset, uint32_t& uncompressed_size);
-	static bool ReadLocalHeader(std::istream& zipfile, uint32_t& offset, StorageMethod& method, uint32_t& compressed_size);
+	bool FindCentralDirectory(std::istream& stream, uint32_t& offset, uint32_t& size, uint16_t& num_entries) const;
+	bool ReadCentralDirectoryEntry(std::istream& zipfile, std::string& filepath, uint32_t& offset, uint32_t& uncompressed_size, bool& is_utf8) const;
+	bool ReadLocalHeader(std::istream& zipfile, uint32_t& offset, StorageMethod& method, uint32_t& compressed_size) const;
+	const ZipEntry* Find(StringView what) const;
 
 	mutable std::unordered_map<std::string, std::vector<uint8_t>> input_pool;
-	std::unordered_map<std::string, ZipEntry> zip_entries;
+	std::vector<std::pair<std::string, ZipEntry>> zip_entries;
+	std::vector<std::pair<std::string, ZipEntry>> zip_entries_cp437;
 	std::string encoding;
+	mutable std::vector<char> filename_buffer;
 };
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -320,6 +320,14 @@ namespace Utils {
 	bool IsControlCharacter(T ch);
 
 	/**
+	 * Determines if a passed string contains only ASCII characters
+	 * (0x00 to 0x7F)
+	 * @param s
+	 * @return true when s contains only ASCII
+	 */
+	bool StringIsAscii(std::string& s);
+
+	/**
 	 * RPG_RT / Delphi compatible rounding of floating point.
 	 *
 	 * @param v the float value to convert
@@ -397,6 +405,12 @@ inline void Utils::ForEachLine(StringView line, F&& f) {
 template <typename T>
 inline bool Utils::IsControlCharacter(T ch) {
 	return (ch >= 0x0 && ch <= 0x1F) || ch == 0x7F;
+}
+
+inline bool Utils::StringIsAscii(std::string &s) {
+	return std::all_of(s.begin(), s.end(), [](char c) {
+		return isascii(static_cast<int>(c));
+	});
 }
 
 template <typename Dest, typename Src>


### PR DESCRIPTION
1. The language flag (Bit 11) is now respected for UTF-8
This is used by all zip programs except the Windows "compressed folder"

2. All files that are not ASCII and do not have Bit 11 are considered for encoding detection
The encoding detection will be only needed for Windows "compressed folder"

3. When the file is considered for encoding it is also stored in Codepage 437
7zip uses CP437 for Western European filenames

Fix #2562

----------

Umlauts in folder names won't work properly when 7zip created the archive. But this doesn't really matter as game directories do not contain umlauts.

When an upper folder contains umlauts (e.g. the Game directory itself "Unterwegs in Düsterburg") this doesn't matter.