### PR TITLE
Equipment scene: Do not show equippable items on fixed equipment

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -817,15 +817,17 @@ bool Game_Actor::IsEquippable(int item_id) const {
 	return IsItemUsable(item_id);
 }
 
-bool Game_Actor::IsEquipmentFixed() const {
+bool Game_Actor::IsEquipmentFixed(bool check_states) const {
 	if (data.lock_equipment) {
 		return true;
 	}
 
-	for (auto state_id: GetInflictedStates()) {
-		auto* state = lcf::ReaderUtil::GetElement(lcf::Data::states, state_id);
-		if (state && state->cursed) {
-			return true;
+	if (check_states) {
+		for (auto state_id: GetInflictedStates()) {
+			auto* state = lcf::ReaderUtil::GetElement(lcf::Data::states, state_id);
+			if (state && state->cursed) {
+				return true;
+			}
 		}
 	}
 	return false;

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -412,9 +412,10 @@ public:
 	/**
 	 * Checks if the actor has a fixed equipped
 	 *
+	 * @param check_states if true also check for states that cause fixed equipment
 	 * @return true if fixed
 	 */
-	bool IsEquipmentFixed() const;
+	bool IsEquipmentFixed(bool check_states) const;
 
 	/**
 	 * Checks if the actors defense skill is stronger the usual.

--- a/src/scene_equip.cpp
+++ b/src/scene_equip.cpp
@@ -145,7 +145,7 @@ void Scene_Equip::UpdateStatusWindow() {
 }
 
 static bool CanRemoveEquipment(const Game_Actor& actor, int index) {
-	if (actor.IsEquipmentFixed()) {
+	if (actor.IsEquipmentFixed(true)) {
 		return false;
 	}
 	auto* item = actor.GetEquipment(index + 1);

--- a/src/window_equipitem.cpp
+++ b/src/window_equipitem.cpp
@@ -38,6 +38,11 @@ Window_EquipItem::Window_EquipItem(int actor_id, int equip_type) :
 }
 
 bool Window_EquipItem::CheckInclude(int item_id) {
+	// Do not show equippable items if the actor has its equipment fixed
+	if (Main_Data::game_actors->GetActor(actor_id)->IsEquipmentFixed()) {
+		return false;
+	}
+
 	// Add the empty element
 	if (item_id == 0) {
 		return true;

--- a/src/window_equipitem.cpp
+++ b/src/window_equipitem.cpp
@@ -39,7 +39,7 @@ Window_EquipItem::Window_EquipItem(int actor_id, int equip_type) :
 
 bool Window_EquipItem::CheckInclude(int item_id) {
 	// Do not show equippable items if the actor has its equipment fixed
-	if (Main_Data::game_actors->GetActor(actor_id)->IsEquipmentFixed()) {
+	if (Main_Data::game_actors->GetActor(actor_id)->IsEquipmentFixed(false)) {
 		return false;
 	}
 

--- a/tests/game_actor.cpp
+++ b/tests/game_actor.cpp
@@ -76,7 +76,7 @@ TEST_CASE("Default") {
 	REQUIRE_EQ(actor.GetHelmet(), nullptr);
 	REQUIRE_EQ(actor.GetAccessory(), nullptr);
 
-	REQUIRE_FALSE(actor.IsEquipmentFixed());
+	REQUIRE_FALSE(actor.IsEquipmentFixed(true));
 	REQUIRE_FALSE(actor.HasStrongDefense());
 	REQUIRE_FALSE(actor.HasTwoWeapons());
 	REQUIRE_FALSE(actor.GetAutoBattle());
@@ -214,7 +214,7 @@ TEST_CASE("ActorFlags") {
 					auto actor = MakeActor(1, 1, 99, 1, 1, 1, 1, 1, 1, two_weapon, lock_equip, auto_battle, super_guard);
 
 					REQUIRE_EQ(actor.HasTwoWeapons(), two_weapon);
-					REQUIRE_EQ(actor.IsEquipmentFixed(), lock_equip);
+					REQUIRE_EQ(actor.IsEquipmentFixed(true), lock_equip);
 					REQUIRE_EQ(actor.GetAutoBattle(), auto_battle);
 					REQUIRE_EQ(actor.HasStrongDefense(), super_guard);
 				}


### PR DESCRIPTION
This PR hides the equippable items in the equipment scene if the selected actor has the fixed equipment flag set (According to [this comment](https://github.com/easyrpg/player/issues/1790#issuecomment-878496741) the equipment scene should behave this way).