### PR TITLE
Improve ALSA, workaround issues

### DIFF
--- a/src/audio_decoder_midi.cpp
+++ b/src/audio_decoder_midi.cpp
@@ -155,8 +155,7 @@ int AudioDecoderMidi::GetVolume() const {
 		return static_cast<int>(volume * 100);
 	}
 
-	// Lie about the volume as this is handled by the Midi messages internally
-	return 100;
+	return static_cast<int>(volume * 100);
 }
 
 void AudioDecoderMidi::SetVolume(int new_volume) {

--- a/src/audio_decoder_midi.cpp
+++ b/src/audio_decoder_midi.cpp
@@ -237,8 +237,10 @@ void AudioDecoderMidi::UpdateMidi(std::chrono::microseconds delta) {
 	if (paused) {
 		return;
 	}
-	seq->play(mtime, this);
+
 	mtime += std::chrono::microseconds(static_cast<int>(delta.count() * pitch / 100));
+	Update(delta);
+	seq->play(mtime, this);
 
 	if (IsFinished() && looping) {
 		mtime = seq->rewind_to_loop()->time;

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -528,12 +528,14 @@ bool Game_Interpreter_Map::CommandPanScreen(lcf::rpg::EventCommand const& com) {
 	case 2: // Pan
 		direction = com.parameters[1];
 		distance = com.parameters[2];
-		speed = com.parameters[3];
+		// FIXME: For an "instant pan" Yume2kki passes a huge value (53) here
+		// which crashes depending on the hardware
+		speed = Utils::Clamp(com.parameters[3], 1, 6);
 		waiting_pan_screen = com.parameters[4] != 0;
 		player.StartPan(direction, distance, speed);
 		break;
 	case 3: // Reset
-		speed = com.parameters[3];
+		speed = Utils::Clamp(com.parameters[3], 1, 6);
 		waiting_pan_screen = com.parameters[4] != 0;
 		player.ResetPan(speed);
 		distance = std::max(

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -103,7 +103,7 @@ void Game_System::BgmPlay(lcf::rpg::Music const& bgm) {
 		if (!data.music_stopping && previous_music.name == bgm.name) {
 			if (previous_music.volume != data.current_music.volume) {
 				if (!bgm_pending) { // Delay if not ready
-					Audio().BGM_Volume(AdjustVolume(data.current_music.volume));
+					Audio().BGM_Volume(data.current_music.volume);
 				}
 			}
 			if (previous_music.tempo != data.current_music.tempo) {
@@ -538,12 +538,12 @@ void Game_System::OnBgmReady(FileRequestResult* result) {
 		return;
 	}
 
-	Audio().BGM_Play(std::move(stream), AdjustVolume(data.current_music.volume), data.current_music.tempo, data.current_music.fadein);
+	Audio().BGM_Play(std::move(stream), data.current_music.volume, data.current_music.tempo, data.current_music.fadein);
 }
 
 void Game_System::OnBgmInelukiReady(FileRequestResult* result) {
 	bgm_pending = false;
-	Audio().BGM_Play(FileFinder::Game().OpenFile(result->file), AdjustVolume(data.current_music.volume), data.current_music.tempo, data.current_music.fadein);
+	Audio().BGM_Play(FileFinder::Game().OpenFile(result->file), data.current_music.volume, data.current_music.tempo, data.current_music.fadein);
 }
 
 void Game_System::OnSeReady(FileRequestResult* result, lcf::rpg::Sound se, bool stop_sounds) {


### PR DESCRIPTION
This PR workarounds a crash in Yume2kki by clamping values (this is incorrect but better than crashing).

Also it removes all the volume adjustment code. There are multiple issues in here, especially when combined with "Fade".

Another problem is that MIDI volume messages are already logarithmic, so they are adjusted twice making MIDI almost silent when volume != 100.

So the logic varies depending on whether it is MIDI or Sampled and we did not expect this when adding AdjustVolume... And seems nobody tested MIDI with volumes != 100 so this was completely missed in the Midi PR. (so also only 100 -> 0 fade was tested which worked as expected.)

Fixing this properly needs at least a day and I'm on vacation by next week so I cannot fix this properly now. But I also do not want this broken code for 1 month in the continuous build...

But you can decide what you prefer. Then I remove the last commit. I will fix this properly in September.
