### PR TITLE
XMP: Reset stream properly, newlib fixes

### DIFF
--- a/src/decoder_xmp.cpp
+++ b/src/decoder_xmp.cpp
@@ -156,6 +156,7 @@ bool XMPDecoder::SetFormat(int freq, AudioDecoder::Format frmt, int chans) {
 
 bool XMPDecoder::IsModule(Filesystem_Stream::InputStream& stream) {
 	int res = xmp_test_module_from_callbacks(&stream, vio, nullptr);
+	stream.clear();
 	stream.seekg(0, std::ios_base::beg);
 	return res == 0;
 }

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -530,12 +530,12 @@ bool Game_Interpreter_Map::CommandPanScreen(lcf::rpg::EventCommand const& com) {
 		distance = com.parameters[2];
 		// FIXME: For an "instant pan" Yume2kki passes a huge value (53) here
 		// which crashes depending on the hardware
-		speed = Utils::Clamp(com.parameters[3], 1, 6);
+		speed = Utils::Clamp<int>(com.parameters[3], 1, 6);
 		waiting_pan_screen = com.parameters[4] != 0;
 		player.StartPan(direction, distance, speed);
 		break;
 	case 3: // Reset
-		speed = Utils::Clamp(com.parameters[3], 1, 6);
+		speed = Utils::Clamp<int>(com.parameters[3], 1, 6);
 		waiting_pan_screen = com.parameters[4] != 0;
 		player.ResetPan(speed);
 		distance = std::max(


### PR DESCRIPTION
meh

seekg(0) only works when the stream is not in a failed state... Forgot this detail :/ (this breaks the MP3 in the TestGame test, but Witch's Heart and IB title music work without this patch).