### PR TITLE
Fix skill start second message

### DIFF
--- a/src/battle_message.cpp
+++ b/src/battle_message.cpp
@@ -393,7 +393,7 @@ std::string GetTransformStartMessage(const Game_Battler& source, const lcf::rpg:
 	return ToString(source.GetName()) + ToString(lcf::Data::terms.enemy_transform);
 }
 
-static std::string GetSkillStartMessageGeneric(const Game_Battler& source, const Game_Battler* target, const lcf::rpg::Skill& skill, StringView usage) {
+static std::string GetSkillStartMessageGeneric(const Game_Battler& source, const Game_Battler* target, const lcf::rpg::Skill& skill, StringView usage, bool second_message = false) {
 	StringView target_name = "???";
 	if (target && Algo::IsNormalOrSubskill(skill) && Algo::SkillTargetsOne(skill)) {
 		target_name = target->GetName();
@@ -405,7 +405,11 @@ static std::string GetSkillStartMessageGeneric(const Game_Battler& source, const
 				Utils::MakeSvArray(source.GetName(), target_name, skill.name)
 				);
 	}
-	return ToString(source.GetName()) + ToString(usage);
+	if (second_message) {
+		return ToString(usage);
+	} else {
+		return ToString(source.GetName()) + ToString(usage);
+	}
 }
 
 std::string GetSkillFirstStartMessage2k(const Game_Battler& source, const Game_Battler* target, const lcf::rpg::Skill& skill) {
@@ -413,7 +417,7 @@ std::string GetSkillFirstStartMessage2k(const Game_Battler& source, const Game_B
 }
 
 std::string GetSkillSecondStartMessage2k(const Game_Battler& source, const Game_Battler* target, const lcf::rpg::Skill& skill) {
-	return GetSkillStartMessageGeneric(source, target, skill, skill.using_message2);
+	return GetSkillStartMessageGeneric(source, target, skill, skill.using_message2, true);
 }
 
 std::string GetItemStartMessage2k(const Game_Battler& source, const lcf::rpg::Item& item) {


### PR DESCRIPTION
In RPG_RT the name of the user of the skill is not displayed in the second start message of a skill (unless you use placeholders, versions 1.60+ only). But in EasyRPG you receive an output like (tested with "Unterwegs in Düsterburg", Dankwart using the skill "Stossgebet"):
`Dankwart stimmt einen heiligen`
`DankwartChoral an`

Expected output:
`Dankwart stimmt einen heiligen`
`Choral an`

The name of the user of the skill is displayed twice while in RPG_RT the name is only displayed in the first message. This PR fixes this.