### PR TITLE
Maniac Patch: Implement Load, Save, SaveInfo and Mouse input

### DIFF
--- a/src/async_op.h
+++ b/src/async_op.h
@@ -39,6 +39,8 @@ class AsyncOp {
 			eToTitle,
 			eExitGame,
 			eTerminateBattle,
+			eSave,
+			eLoad
 		};
 
 		AsyncOp() = default;
@@ -63,6 +65,12 @@ class AsyncOp {
 
 		/** @return a TerminateBattle async operation */
 		static AsyncOp MakeTerminateBattle(int result);
+
+		/** @return a Save async operation */
+		static AsyncOp MakeSave(int save_slot, int save_result_var);
+
+		/** @return a Load async operation */
+		static AsyncOp MakeLoad(int save_slot);
 
 		/** @return the type of async operation */
 		Type GetType() const;
@@ -99,6 +107,18 @@ class AsyncOp {
 		 * @pre If GetType() is not eTerminateBattle, the return value is undefined.
 		 **/
 		int GetBattleResult() const;
+
+		/**
+		 * @return the desired slot to save or load
+		 * @pre If GetType() is not eSave or eLoad, the return value is undefined.
+		 **/
+		 int GetSaveSlot() const;
+
+		/**
+		 * @return the variable to set to 1 when the save was a success.
+		 * @pre If GetType() is not eSave, the return value is undefined.
+		 **/
+		int GetSaveResultVar() const;
 
 	private:
 		Type _type = eNone;
@@ -142,6 +162,17 @@ inline int AsyncOp::GetBattleResult() const {
 	return _args[0];
 }
 
+inline int AsyncOp::GetSaveSlot() const {
+	assert(GetType() == eSave || GetType() == eLoad);
+	return _args[0];
+}
+
+inline int AsyncOp::GetSaveResultVar() const {
+	assert(GetType() == eSave);
+	return _args[1];
+}
+
+
 template <typename... Args>
 inline AsyncOp::AsyncOp(Type type, Args&&... args)
 	: _type(type), _args{std::forward<Args>(args)...}
@@ -173,6 +204,14 @@ inline AsyncOp AsyncOp::MakeExitGame() {
 
 inline AsyncOp AsyncOp::MakeTerminateBattle(int transition_type) {
 	return AsyncOp(eTerminateBattle, transition_type);
+}
+
+inline AsyncOp AsyncOp::MakeSave(int save_slot, int save_result_var) {
+	return AsyncOp(eSave, save_slot, save_result_var);
+}
+
+inline AsyncOp AsyncOp::MakeLoad(int save_slot) {
+	return AsyncOp(eLoad, save_slot);
 }
 
 #endif

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1642,14 +1642,25 @@ bool Game_Interpreter::CommandChangeLevel(lcf::rpg::EventCommand const& com) { /
 }
 
 int Game_Interpreter::ValueOrVariable(int mode, int val) {
-	switch (mode) {
-		case 0:
-			return val;
-		case 1:
-			return Main_Data::game_variables->Get(val);
-		default:
-			return -1;
+	if (mode == 0) {
+		return val;
+	} else if (mode == 1) {
+		return Main_Data::game_variables->Get(val);
+	} else if (Player::IsPatchManiac()) {
+		// Maniac Patch does not implement all modes for all commands
+		// For simplicity it is enabled for all here
+		if (mode == 2) {
+			// Variable indirect
+			return Main_Data::game_variables->Get(Main_Data::game_variables->Get(val));
+		} else if (mode == 3) {
+			// Switch (F = 0, T = 1)
+			return Main_Data::game_switches->Get(val) ? 1 : 0;
+		} else if (mode == 4) {
+			// Switch through Variable indirect
+			return Main_Data::game_switches->Get(Main_Data::game_variables->Get(val)) ? 1 : 0;
+		}
 	}
+	return -1;
 }
 
 bool Game_Interpreter::CommandChangeParameters(lcf::rpg::EventCommand const& com) { // Code 10430

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1235,17 +1235,17 @@ bool Game_Interpreter::CommandControlVariables(lcf::rpg::EventCommand const& com
 				case 10:
 					// Current date (YYMMDD)
 					if (Player::IsPatchManiac()) {
-						std::time_t t = std::time(0);
+						std::time_t t = std::time(nullptr);
 						std::tm* tm = std::localtime(&t);
-						value = (tm->tm_year - 100) * 10000 + (tm->tm_mon + 1) * 100 + tm->tm_mday;
+						value = atoi(Utils::FormatDate(tm, Utils::DateFormat_YYMMDD).c_str());
 					}
 					break;
 				case 11:
 					// Current time (HHMMSS)
 					if (Player::IsPatchManiac()) {
-						std::time_t t = std::time(0);
+						std::time_t t = std::time(nullptr);
 						std::tm* tm = std::localtime(&t);
-						value = tm->tm_hour * 10000 + tm->tm_min * 100 + tm->tm_sec;
+						value = atoi(Utils::FormatDate(tm, Utils::DateFormat_HHMMSS).c_str());
 					}
 					break;
 				case 12:
@@ -3637,10 +3637,8 @@ bool Game_Interpreter::CommandManiacGetSaveInfo(lcf::rpg::EventCommand const& co
 	std::time_t t = lcf::LSD_Reader::ToUnixTimestamp(save->title.timestamp);
 	std::tm* tm = std::gmtime(&t);
 
-	// YYMMDD
-	Main_Data::game_variables->Set(com.parameters[2], (tm->tm_year - 100) * 10000 + (tm->tm_mon + 1) * 100 + tm->tm_mday);
-	// HHMMSS
-	Main_Data::game_variables->Set(com.parameters[3], tm->tm_hour * 10000 + tm->tm_min * 100 + tm->tm_sec);
+	Main_Data::game_variables->Set(com.parameters[2], atoi(Utils::FormatDate(tm, Utils::DateFormat_YYMMDD).c_str()));
+	Main_Data::game_variables->Set(com.parameters[3], atoi(Utils::FormatDate(tm, Utils::DateFormat_HHMMSS).c_str()));
 	Main_Data::game_variables->Set(com.parameters[4], save->title.hero_level);
 	Main_Data::game_variables->Set(com.parameters[5], save->title.hero_hp);
 	Game_Map::SetNeedRefresh(true);

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1157,6 +1157,7 @@ bool Game_Interpreter::CommandControlVariables(lcf::rpg::EventCommand const& com
 					value = Main_Data::game_party->GetGold();
 					break;
 				case 1:
+					// Timer 1 remaining time
 					value = Main_Data::game_party->GetTimerSeconds(Main_Data::game_party->Timer1);
 					break;
 				case 2:
@@ -1188,7 +1189,37 @@ bool Game_Interpreter::CommandControlVariables(lcf::rpg::EventCommand const& com
 					value = Main_Data::game_ineluki->GetMidiTicks();
 					break;
 				case 9:
+					// Timer 2 remaining time
 					value = Main_Data::game_party->GetTimerSeconds(Main_Data::game_party->Timer2);
+					break;
+				case 10:
+					// Current date (YYMMDD)
+					if (Player::IsPatchManiac()) {
+						std::time_t t = std::time(0);
+						std::tm* tm = std::localtime(&t);
+						value = (tm->tm_year - 100) * 10000 + (tm->tm_mon + 1) * 100 + tm->tm_mday;
+					}
+					break;
+				case 11:
+					// Current time (HHMMSS)
+					if (Player::IsPatchManiac()) {
+						std::time_t t = std::time(0);
+						std::tm* tm = std::localtime(&t);
+						value = tm->tm_hour * 10000 + tm->tm_min * 100 + tm->tm_sec;
+					}
+					break;
+				case 12:
+					// Frames
+					if (Player::IsPatchManiac()) {
+						value = Main_Data::game_system->GetFrameCounter();
+					}
+					break;
+				case 13:
+					// Patch version
+					if (Player::IsPatchManiac()) {
+						// Latest version before the engine rewrite
+						value = 200128;
+					}
 					break;
 			}
 			break;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2911,10 +2911,10 @@ bool Game_Interpreter::CommandKeyInputProc(lcf::rpg::EventCommand const& com) { 
 		} else {
 			// For Rpg2k >=1.50
 			_keyinput.keys[Keys::eShift] = com.parameters[5] != 0;
-			_keyinput.keys[Keys::eDown] = param_size > 6 ? com.parameters[6] != 0 : false;
-			_keyinput.keys[Keys::eLeft] = param_size > 7 ? com.parameters[7] != 0 : false;
-			_keyinput.keys[Keys::eRight] = param_size > 8 ? com.parameters[8] != 0 : false;
-			_keyinput.keys[Keys::eUp] = param_size > 9 ? com.parameters[9] != 0 : false;
+			_keyinput.keys[Keys::eDown] = param_size > 6 && com.parameters[6] != 0;
+			_keyinput.keys[Keys::eLeft] = param_size > 7 && com.parameters[7] != 0;
+			_keyinput.keys[Keys::eRight] = param_size > 8 && com.parameters[8] != 0;
+			_keyinput.keys[Keys::eUp] = param_size > 9 && com.parameters[9] != 0;
 		}
 	} else {
 		if (param_size != 10 || Player::IsRPG2k3Legacy()) {
@@ -2925,17 +2925,17 @@ bool Game_Interpreter::CommandKeyInputProc(lcf::rpg::EventCommand const& com) { 
 				_keyinput.keys[Keys::eRight] = true;
 				_keyinput.keys[Keys::eUp] = true;
 			}
-			_keyinput.keys[Keys::eNumbers] = param_size > 5 ? com.parameters[5] != 0 : false;
-			_keyinput.keys[Keys::eOperators] = param_size > 6 ? com.parameters[6] != 0 : false;
-			_keyinput.time_variable = param_size > 7 ? com.parameters[7] : false;
-			_keyinput.timed = param_size > 8 ? com.parameters[8] != 0 : false;
+			_keyinput.keys[Keys::eNumbers] = param_size > 5 && com.parameters[5] != 0;
+			_keyinput.keys[Keys::eOperators] = param_size > 6 && com.parameters[6] != 0;
+			_keyinput.time_variable = param_size > 7 ? com.parameters[7] : 0; // Attention: int, not bool
+			_keyinput.timed = param_size > 8 && com.parameters[8] != 0;
 			if (param_size > 10 && Player::IsMajorUpdatedVersion()) {
 				// For Rpg2k3 >=1.05
 				_keyinput.keys[Keys::eShift] = com.parameters[9] != 0;
 				_keyinput.keys[Keys::eDown] = com.parameters[10] != 0;
-				_keyinput.keys[Keys::eLeft] = param_size > 11 ? com.parameters[11] != 0 : false;
-				_keyinput.keys[Keys::eRight] = param_size > 12 ? com.parameters[12] != 0 : false;
-				_keyinput.keys[Keys::eUp] = param_size > 13 ? com.parameters[13] != 0 : false;
+				_keyinput.keys[Keys::eLeft] = param_size > 11 && com.parameters[11] != 0;
+				_keyinput.keys[Keys::eRight] = param_size > 12 && com.parameters[12] != 0;
+				_keyinput.keys[Keys::eUp] = param_size > 13 && com.parameters[13] != 0;
 			}
 		} else {
 			// Since RPG2k3 1.05

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -294,7 +294,13 @@ protected:
 		eCancel,
 		eShift,
 		eNumbers,
-		eOperators
+		eOperators,
+		// ManiacPatch
+		eMouseLeft,
+		eMouseRight,
+		eMouseMiddle,
+		eMouseScrollDown,
+		eMouseScrollUp
 	};
 
 	struct KeyInputState {

--- a/src/game_pictures.cpp
+++ b/src/game_pictures.cpp
@@ -299,6 +299,11 @@ void Game_Pictures::Erase(int id) {
 	}
 }
 
+bool Game_Pictures::Picture::Exists() const {
+	// Incompatible with the Yume2kki edge-case that uses empty filenames
+	return !data.name.empty();
+}
+
 void Game_Pictures::RequestPictureSprite(Picture& pic) {
 	const auto& name = pic.data.name;
 	if (name.empty()) {
@@ -448,6 +453,35 @@ void Game_Pictures::Update(bool is_battle) {
 	for (auto& pic: pictures) {
 		pic.Update(is_battle);
 	}
+}
+
+Game_Pictures::ShowParams Game_Pictures::Picture::GetShowParams() const {
+	Game_Pictures::ShowParams params;
+	params.position_x = static_cast<int>(data.finish_x);
+	params.position_y = static_cast<int>(data.finish_y);
+	params.magnify = data.finish_magnify;
+	params.top_trans = data.finish_top_trans;
+	params.bottom_trans = data.finish_bot_trans;
+	params.red = data.finish_red;
+	params.green = data.finish_green;
+	params.blue = data.finish_blue;
+	params.saturation = data.finish_sat;
+	params.effect_mode = data.effect_mode;
+	params.effect_power = data.finish_effect_power;
+	params.name = data.name;
+	params.spritesheet_cols = data.spritesheet_cols;
+	params.spritesheet_rows = data.spritesheet_rows;
+	params.spritesheet_frame = data.spritesheet_frame;
+	params.spritesheet_speed = data.spritesheet_speed;
+	params.map_layer = data.map_layer;
+	params.battle_layer = data.battle_layer;
+	for (size_t i = 0; i < data.flags.flags.size(); ++i) {
+		params.flags |= data.flags.flags[i] << i;
+	}
+	params.spritesheet_play_once = data.spritesheet_play_once;
+	params.use_transparent_color = data.use_transparent_color;
+	params.fixed_to_map = data.fixed_to_map;
+	return params;
 }
 
 void Game_Pictures::Picture::SetNonEffectParams(const Params& params, bool set_positions) {

--- a/src/game_pictures.h
+++ b/src/game_pictures.h
@@ -43,17 +43,17 @@ public:
 	static int GetDefaultNumberOfPictures();
 
 	struct Params {
-		int position_x;
-		int position_y;
-		int magnify;
-		int top_trans;
-		int bottom_trans;
-		int red;
-		int green;
-		int blue;
-		int saturation;
-		int effect_mode;
-		int effect_power;
+		int position_x = 0;
+		int position_y = 0;
+		int magnify = 100;
+		int top_trans = 0;
+		int bottom_trans = 0;
+		int red = 100;
+		int green = 100;
+		int blue = 100;
+		int saturation = 100;
+		int effect_mode = 0;
+		int effect_power = 0;
 	};
 	struct ShowParams : Params {
 		std::string name;
@@ -72,7 +72,7 @@ public:
 	};
 
 	struct MoveParams : Params {
-		int duration;
+		int duration = 0;
 	};
 
 	void Show(int id, const ShowParams& params);
@@ -100,11 +100,13 @@ public:
 		bool IsOnBattle() const;
 		int NumSpriteSheetFrames() const;
 
+		ShowParams GetShowParams() const;
 		void SetNonEffectParams(const Params& params, bool set_positions);
 
 		bool Show(const ShowParams& params);
 		void Move(const MoveParams& params);
 		void Erase();
+		bool Exists() const;
 
 		void OnPictureSpriteReady();
 		void OnMapScrolled(int dx, int dy);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -86,9 +86,7 @@ namespace {
 			init = true;
 		}
 		std::time_t t = std::time(nullptr);
-		char timestr[100];
-		strftime(timestr, 100, "[%Y-%m-%d %H:%M:%S] ", std::localtime(&t));
-		return LOG_FILE << timestr;
+		return LOG_FILE << Utils::FormatDate(std::localtime(&t), "[%Y-%m-%d %H:%M:%S] ");
 	}
 
 	bool ignore_pause = false;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1037,12 +1037,16 @@ static void OnMapSaveFileReady(FileRequestResult*, lcf::rpg::Save save) {
 
 void Player::LoadSavegame(const std::string& save_name, int save_id) {
 	Output::Debug("Loading Save {}", save_name);
-	Main_Data::game_system->BgmFade(800);
 
-	// We erase the screen now before loading the saved game. This prevents an issue where
-	// if the save game has a different system graphic, the load screen would change before
-	// transitioning out.
-	Transition::instance().InitErase(Transition::TransitionFadeOut, Scene::instance.get(), 6);
+	bool load_on_map = Scene::instance->type == Scene::Map;
+
+	if (!load_on_map) {
+		Main_Data::game_system->BgmFade(800);
+		// We erase the screen now before loading the saved game. This prevents an issue where
+		// if the save game has a different system graphic, the load screen would change before
+		// transitioning out.
+		Transition::instance().InitErase(Transition::TransitionFadeOut, Scene::instance.get(), 6);
+	}
 
 	auto title_scene = Scene::Find(Scene::Title);
 	if (title_scene) {
@@ -1094,7 +1098,9 @@ void Player::LoadSavegame(const std::string& save_name, int save_id) {
 		save->airship_location.animation_type = Game_Character::AnimType::AnimType_non_continuous;
 	}
 
-	Scene::PopUntil(Scene::Title);
+	if (!load_on_map) {
+		Scene::PopUntil(Scene::Title);
+	}
 	Game_Map::Dispose();
 
 	Main_Data::game_switches->SetData(std::move(save->system.switches));
@@ -1116,7 +1122,9 @@ void Player::LoadSavegame(const std::string& save_name, int save_id) {
 	Main_Data::game_system->ReloadSystemGraphic();
 
 	map->Start();
-	Scene::Push(std::make_shared<Scene_Map>(save_id));
+	if (!load_on_map) {
+		Scene::Push(std::make_shared<Scene_Map>(save_id));
+	}
 }
 
 static void OnMapFileReady(FileRequestResult*) {

--- a/src/scene_save.h
+++ b/src/scene_save.h
@@ -40,8 +40,8 @@ public:
 	bool IsSlotValid(int index) override;
 
 	static std::string GetSaveFilename(const FilesystemView& tree, int slot_id);
-	static void Save(const FilesystemView& tree, int slot_id, bool prepare_save = true);
-	static void Save(std::ostream& os, int slot_id, bool prepare_save = true);
+	static bool Save(const FilesystemView& tree, int slot_id, bool prepare_save = true);
+	static bool Save(std::ostream& os, int slot_id, bool prepare_save = true);
 };
 
 #endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -623,3 +623,12 @@ std::string Utils::ReplacePlaceholders(StringView text_template, Span<const char
 
 	return str;
 }
+
+std::string Utils::FormatDate(const std::tm *tm, StringView format) {
+	constexpr int buf_size = 128;
+	char buffer[buf_size];
+
+	auto res = strftime(buffer, buf_size, ToString(format).c_str(), tm);
+
+	return std::string(buffer, res);
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,6 +18,7 @@
 #ifndef EP_UTILS_H
 #define EP_UTILS_H
 
+#include <ctime>
 #include <functional>
 #include <string>
 #include <sstream>
@@ -28,6 +29,9 @@
 #include "span.h"
 
 namespace Utils {
+	constexpr StringView DateFormat_YYMMDD = "%y%m%d";
+	constexpr StringView DateFormat_HHMMSS = "%H%M%S";
+
 	/**
 	 * Converts a string to lower case (ASCII only)
 	 *
@@ -326,6 +330,15 @@ namespace Utils {
 	 * @return true when s contains only ASCII
 	 */
 	bool StringIsAscii(std::string& s);
+
+	/**
+	 * Formats a date.
+	 *
+	 * @param tm Time structure
+	 * @param format Format string (See strftime)
+	 * @return formatted date
+	 */
+	std::string FormatDate(const std::tm* tm, StringView format);
 
 	/**
 	 * RPG_RT / Delphi compatible rounding of floating point.


### PR DESCRIPTION
This implements the imo most useful commands of the Maniac Patch (except for String picture, this is also pretty cool!)

_Still have to do careful testing of this again. There shouldn't be regressions as the code is usually in ManiacPatch checks._

Discussion:

### Load

This does a Async Load (yields the interpreter), in Maniac it loads directly, this is incompatible with how our code works.

The parameter for checking whether the save exists is ignored, in RPG_RT loading a non-existant save simply crashes.

### Save

This does a Async save (Yields the interpreter), in Maniac this saves directly resulting in saving at an undefined state because there is stuff in temporaries. So yielding here is safer.

### Get Save Info

In Maniac this is implemented by setting the arguments (or not if the pic exists) and then doing a jump just before the 2k3E picture code that handles layers etc. (so save game pictures shown inherit the attributes of the current picture in the slot)
As we cannot really do this I added a function for retrieving the current Show Params instead.
There will be likely minor incompatibilities here, but when they do not do anything fancy with the picture it should work...

### Key Input Proc (Mouse)

Had to add "& 2"-checks where applicable as Maniac uses bit 1 of certain keys for this:

- Confirm: Mouse left
- Cancel: Mouse right
- Shift: Mouse middle
- Up: Wheel Up
- Down: Wheel Down

To reduce chaos in the code this will only work properly with RPG2k3E, KeyInput is already messy enough, so sorry, no fully Maniac mouse input in Player for 2k ;).

### New return values in Control Variables

Maniacs added tons of stuff here, also new ops like sin and pow. For now I only add the absolute minimum:

- Current Time (Maniac reuses the savegame time function here, I use stdlib time functions)
- Frame counter
- Maniac version: Returns the highest version available before the engine was replaced with this replace

### ValueOrVariable

Maniac Patch adds support for "Variable indirect", "Switch" and "Switch Indirect" to some event commands (and I guess with TPC and the new engine to even more). 

To make this easier for me I simply added this handling to ValueOrVariable which is our resolver for this indirection stuff.

Has the side-effect that all event commands that support indirection got these features now with a minimal code change.

This e.g. implements for **Call Event**:  "Added method to specify common event by variable number variable."