### PR TITLE
Add support for negative terrain damage

### DIFF
--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -610,16 +610,18 @@ bool Game_Player::Move(int dir) {
 	bool red_flash = false;
 
 	if (terrain) {
-		if (!terrain->on_damage_se || (terrain->on_damage_se && (terrain->damage > 0))) {
-			Main_Data::game_system->SePlay(terrain->footstep);
-		}
-		if (terrain->damage > 0) {
+		if (terrain->damage != 0) {
 			for (auto hero : Main_Data::game_party->GetActors()) {
-				if (!hero->PreventsTerrainDamage()) {
-					red_flash = true;
+				if (terrain->damage < 0 || !hero->PreventsTerrainDamage()) {
+					if (terrain->damage > 0) {
+						red_flash = true;
+					}
 					hero->ChangeHp(-terrain->damage, false);
 				}
 			}
+		}
+		if (!terrain->on_damage_se || red_flash) {
+			Main_Data::game_system->SePlay(terrain->footstep);
 		}
 	} else {
 		Output::Warning("Player BeginMove: Invalid terrain ID {} at ({}, {})", terrain_id, GetX(), GetY());


### PR DESCRIPTION
This PR adds support for negative terrain damage. RPG_RT supports this and the RPG Maker 2003 documentation says that the
editor allows setting negative terrain damage values.