### PR TITLE
Clear current_music on starting a new game (Fix issue #2411)

### DIFF
--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -123,8 +123,11 @@ void Game_System::BgmStop() {
 	Audio().BGM_Stop();
 }
 
-void Game_System::BgmFade(int duration) {
+void Game_System::BgmFade(int duration, bool clear_current_music) {
 	Audio().BGM_Fade(duration);
+	if (clear_current_music) {
+		data.current_music.name = "(OFF)";
+	}
 	data.music_stopping = true;
 }
 

--- a/src/game_system.h
+++ b/src/game_system.h
@@ -127,8 +127,9 @@ public:
 	 * Fades out the current BGM
 	 *
 	 * @param duration Duration in ms
+	 * @param clear_current_music If true then current_music is set to (OFF). Only needed on starting a new game.
 	 */
-	void BgmFade(int duration);
+	void BgmFade(int duration, bool clear_current_music = false);
 
 	/**
 	 * Plays a Sound.

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1137,7 +1137,7 @@ static void OnMapFileReady(FileRequestResult*) {
 }
 
 void Player::SetupNewGame() {
-	Main_Data::game_system->BgmFade(800);
+	Main_Data::game_system->BgmFade(800, true);
 	Main_Data::game_system->ResetFrameCounter();
 	auto title = Scene::Find(Scene::Title);
 	if (title) {


### PR DESCRIPTION
This PR clears the current_music value when starting a new game. This fixes issue #2411.

Fixes: #2411