### PR TITLE
Change menu cursor scrolling speed

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -35,14 +35,14 @@ namespace Input {
 	 * to be maintained pressed before being
 	 * repeated for fist time.
 	 */
-	constexpr int start_repeat_time = 20;
+	constexpr int start_repeat_time = 23;
 
 	/**
 	 * Repeat time (in frames) a key has to be
 	 * maintained pressed after the start repeat time
 	 * has passed for being repeated again.
 	 */
-	constexpr int repeat_time = 5;
+	constexpr int repeat_time = 4;
 
 	std::array<int, BUTTON_COUNT> press_time;
 	std::bitset<BUTTON_COUNT> triggered, repeated, released;


### PR DESCRIPTION
This PR decreases the interval between two menu cursor scrolls to 4 frames and increases the initial delay to 23 frames.

This is a partial fix for #2574. Still missing is the "smooth scrolling" stuff in the shop window.