### PR TITLE
Change Z-Value calculation in RPG Maker 2003 battles

### DIFF
--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -2877,6 +2877,13 @@ void Scene_Battle_Rpg2k3::CBAMove() {
 			offset_y = (cba_end_pos.y - cba_start_pos.y) * frame / cba_num_move_frames;
 		}
 		source->SetBattlePosition(Point(cba_start_pos.x + offset_x, cba_start_pos.y + offset_y));
+
+		if (source->GetType() == Game_Battler::Type_Ally) {
+			auto* sprite = static_cast<Game_Actor*>(source)->GetActorBattleSprite();
+			if (sprite) {
+				sprite->ResetZ();
+			}
+		}
 	}
 
 	if (cba_move_frame >= cba_num_move_frames) {

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -41,10 +41,11 @@ void Sprite_Battler::ResetZ() {
 	int y = battler->GetBattlePosition().y;
 	if (battler->GetType() == Game_Battler::Type_Enemy && graphic) {
 		y += graphic->GetHeight() / 2;
+	} else if (battler->GetType() == Game_Battler::Type_Ally) {
+		y += 24;
 	}
 
 	int z = battler->GetType();
-	z *= SCREEN_TARGET_HEIGHT * 2;
 	z += y;
 	z *= id_limit;
 	z += id_limit - battle_index;


### PR DESCRIPTION
This PR changes the Z-Value calculation and recalculates the Z-Value on every CBA move frame in RPG Maker 2003 battles.

Fixes: #2539