### PR TITLE
Fix BGM play upon returning to the title screen from load screen

### DIFF
--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -79,6 +79,8 @@ void Scene_Title::Continue(SceneType prev_scene) {
 		Main_Data::game_ineluki->ExecuteScriptList(FileFinder::Game().FindFile("autorun.script"));
 
 		Start();
+
+		restart_title_cache = false;
 	} else if (CheckEnableTitleGraphicAndMusic()) {
 		CreateTitleGraphic();
 	}


### PR DESCRIPTION
This PR makes the BGM no longer being restarted upon returning to the title screen from the load screen.

Fixes: #2589