### PR TITLE
RPG Maker 2003 English release is always "MajorUpdated" (#2531)

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -782,7 +782,7 @@ void Player::CreateGameObjects() {
 					Output::Debug("Using RPG2k3 Interpreter");
 				}
 			} else {
-				engine |= EngineEnglish;
+				engine |= EngineEnglish | EngineMajorUpdated;
 				Output::Debug("Using RPG2k3 (English release, v1.11) Interpreter");
 			}
 		} else {


### PR DESCRIPTION
RPG Maker 2003 English release is always "MajorUpdated"

In the command line handler the behaviour was already correct.

Fix #2531