### PR TITLE
Fix broken check for "All directions" for RPG2k3 <1.05

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2856,7 +2856,7 @@ bool Game_Interpreter::CommandKeyInputProc(lcf::rpg::EventCommand const& com) { 
 	// length of the parameter list
 	if (Player::IsRPG2k()) {
 		if (param_size < 6 || Player::IsRPG2kLegacy()) {
-			// For Rpg2k <1.50
+			// For Rpg2k <1.50 (later versions got individual key checks)
 			if (com.parameters[2] != 0) {
 				_keyinput.keys[Keys::eDown] = true;
 				_keyinput.keys[Keys::eLeft] = true;
@@ -2873,7 +2873,7 @@ bool Game_Interpreter::CommandKeyInputProc(lcf::rpg::EventCommand const& com) { 
 		}
 	} else {
 		if (param_size != 10 || Player::IsRPG2k3Legacy()) {
-			if (param_size < 10 && com.parameters[2] != 0) {
+			if ((param_size < 10 || Player::IsRPG2k3Legacy()) && com.parameters[2] != 0) {
 				// For RPG2k3 <1.05 (later versions got individual key checks)
 				_keyinput.keys[Keys::eDown] = true;
 				_keyinput.keys[Keys::eLeft] = true;


### PR DESCRIPTION
Fix #2546

-----

Discussion that the other code was already fine:

I'm pretty sure the KeyInputProc code was already based on reverse engeniered code.

(code pasted here https://github.com/EasyRPG/Player/issues/2546#issuecomment-917435613)

- RPG2k compat mode is executed for cmd_len <= 10 and cmd_len > 9. So the only option is "10" here making our "param_size != 10" check correct (also no support for "all directions here", correct)
- Between legacy 2k3 and updated 2k3 the parameter 5, 6, 7, 8 are the same. this is unified in our code
- When param_size > 10, shift and arrow keys are enabled for updated (correct)
- When param_size > 10, "all direction" is unavailable (Correct)
- **Fixed**: For legacy "all directions" is always available, this param_size > 10 check broke it