### PR TITLE
Battle 2k3: Consider acting battler for certain page conditions

### DIFF
--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -68,13 +68,21 @@ bool Game_Interpreter_Battle::AreConditionsMet(const lcf::rpg::TroopPageConditio
 	if (condition.flags.turn && !Game_Battle::CheckTurns(Game_Battle::GetTurn(), condition.turn_b, condition.turn_a))
 		return false;
 
-	if (condition.flags.turn_enemy &&
-		!Game_Battle::CheckTurns((*Main_Data::game_enemyparty)[condition.turn_enemy_id].GetBattleTurn(),	condition.turn_enemy_b, condition.turn_enemy_a))
-		return false;
+	if (condition.flags.turn_enemy) {
+		const auto& enemy = (*Main_Data::game_enemyparty)[condition.turn_enemy_id];
+		if (source && source != &enemy)
+			return false;
+		if (!Game_Battle::CheckTurns(enemy.GetBattleTurn(), condition.turn_enemy_b, condition.turn_enemy_a))
+			return false;
+	}
 
-	if (condition.flags.turn_actor &&
-		!Game_Battle::CheckTurns(Main_Data::game_actors->GetActor(condition.turn_actor_id)->GetBattleTurn(), condition.turn_actor_b, condition.turn_actor_a))
-		return false;
+	if (condition.flags.turn_actor) {
+		const auto* actor = Main_Data::game_actors->GetActor(condition.turn_actor_id);
+		if (source && source != actor)
+			return false;
+		if (!Game_Battle::CheckTurns(actor->GetBattleTurn(), condition.turn_actor_b, condition.turn_actor_a))
+			return false;
+	}
 
 	if (condition.flags.fatigue) {
 		int fatigue = Main_Data::game_party->GetFatigue();

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -40,7 +40,7 @@ Game_Interpreter_Battle::Game_Interpreter_Battle(Span<const lcf::rpg::TroopPage>
 {
 }
 
-bool Game_Interpreter_Battle::AreConditionsMet(const lcf::rpg::TroopPageCondition& condition) {
+bool Game_Interpreter_Battle::AreConditionsMet(const lcf::rpg::TroopPageCondition& condition, Game_Battler* source) {
 	if (!condition.flags.switch_a &&
 		!condition.flags.switch_b &&
 		!condition.flags.variable &&
@@ -100,19 +100,24 @@ bool Game_Interpreter_Battle::AreConditionsMet(const lcf::rpg::TroopPageConditio
 			return false;
 	}
 
-	// FIXME: This also requires current acting hero db id
-	if (condition.flags.command_actor &&
-		condition.command_id != Main_Data::game_actors->GetActor(condition.command_actor_id)->GetLastBattleAction())
-		return false;
+	if (condition.flags.command_actor) {
+		if (!source)
+			return false;
+		const auto* actor = Main_Data::game_actors->GetActor(condition.command_actor_id);
+		if (source != actor)
+			return false;
+		if (condition.command_id != actor->GetLastBattleAction())
+			return false;
+	}
 
 	return true;
 }
 
-int Game_Interpreter_Battle::ScheduleNextPage() {
+int Game_Interpreter_Battle::ScheduleNextPage(Game_Battler* source) {
 	lcf::rpg::TroopPageCondition::Flags f;
 	for (auto& ff: f.flags) ff = true;
 
-	return ScheduleNextPage(f);
+	return ScheduleNextPage(f, source);
 }
 
 static bool HasRequiredCondition(lcf::rpg::TroopPageCondition::Flags page, lcf::rpg::TroopPageCondition::Flags required) {
@@ -124,7 +129,7 @@ static bool HasRequiredCondition(lcf::rpg::TroopPageCondition::Flags page, lcf::
 	return false;
 }
 
-int Game_Interpreter_Battle::ScheduleNextPage(lcf::rpg::TroopPageCondition::Flags required_conditions) {
+int Game_Interpreter_Battle::ScheduleNextPage(lcf::rpg::TroopPageCondition::Flags required_conditions, Game_Battler* source) {
 	if (IsRunning()) {
 		return 0;
 	}
@@ -133,7 +138,7 @@ int Game_Interpreter_Battle::ScheduleNextPage(lcf::rpg::TroopPageCondition::Flag
 		auto& page = pages[i];
 		if (executed[i]
 				|| !HasRequiredCondition(page.condition.flags, required_conditions)
-				|| !AreConditionsMet(page.condition)) {
+				|| !AreConditionsMet(page.condition, source)) {
 			continue;
 		}
 		Clear();

--- a/src/game_interpreter_battle.h
+++ b/src/game_interpreter_battle.h
@@ -45,10 +45,10 @@ public:
 	bool IsValidPage(int page_id) const;
 	bool HasPageExecuted(int page_id) const;
 
-	static bool AreConditionsMet(const lcf::rpg::TroopPageCondition& condition);
+	static bool AreConditionsMet(const lcf::rpg::TroopPageCondition& condition, Game_Battler* source);
 
-	int ScheduleNextPage();
-	int ScheduleNextPage(lcf::rpg::TroopPageCondition::Flags required_conditions);
+	int ScheduleNextPage(Game_Battler* source);
+	int ScheduleNextPage(lcf::rpg::TroopPageCondition::Flags required_conditions, Game_Battler* source);
 	void ResetPagesExecuted();
 
 	void SetCurrentEnemyTargetIndex(int idx);

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -212,7 +212,7 @@ bool Scene_Battle_Rpg2k::CheckBattleEndAndScheduleEvents() {
 
 	auto& interp = Game_Battle::GetInterpreterBattle();
 
-	int page = interp.ScheduleNextPage();
+	int page = interp.ScheduleNextPage(nullptr);
 #ifdef EP_DEBUG_BATTLE2K_STATE_MACHINE
 	if (page) {
 		Output::Debug("Battle2k ScheduleNextEventPage Scheduled Page {} frame={}", page, Main_Data::game_system->GetFrameCounter());

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -917,7 +917,7 @@ bool Scene_Battle_Rpg2k3::CheckBattleEndConditions() {
 }
 
 
-bool Scene_Battle_Rpg2k3::CheckBattleEndAndScheduleEvents(EventTriggerType tt) {
+bool Scene_Battle_Rpg2k3::CheckBattleEndAndScheduleEvents(EventTriggerType tt, Game_Battler* source) {
 	auto& interp = Game_Battle::GetInterpreterBattle();
 
 	if (interp.IsRunning()) {
@@ -946,7 +946,7 @@ bool Scene_Battle_Rpg2k3::CheckBattleEndAndScheduleEvents(EventTriggerType tt) {
 			break;
 	}
 
-	int page = interp.ScheduleNextPage(flags);
+	int page = interp.ScheduleNextPage(flags, source);
 #ifdef EP_DEBUG_BATTLE2K3_STATE_MACHINE
 	if (page) {
 		Output::Debug("Battle2k3 ScheduleNextEventPage Scheduled Page {} frame={}", page, Main_Data::game_system->GetFrameCounter());
@@ -1059,7 +1059,7 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionSt
 	}
 
 	if (scene_action_substate == eUpdateEvents) {
-		if (!CheckBattleEndAndScheduleEvents(EventTriggerType::eAll)) {
+		if (!CheckBattleEndAndScheduleEvents(EventTriggerType::eAll, nullptr)) {
 			return SceneActionReturn::eContinueThisFrame;
 		}
 
@@ -2044,7 +2044,7 @@ Scene_Battle_Rpg2k3::BattleActionReturn Scene_Battle_Rpg2k3::ProcessBattleAction
 	auto* source = action->GetSource();
 
 	// RPG_RT always runs the interpreter before starting the action.
-	if (!CheckBattleEndAndScheduleEvents(EventTriggerType::eBeforeBattleAction)) {
+	if (!CheckBattleEndAndScheduleEvents(EventTriggerType::eBeforeBattleAction, source)) {
 		return BattleActionReturn::eContinue;
 	}
 
@@ -2444,9 +2444,8 @@ Scene_Battle_Rpg2k3::BattleActionReturn Scene_Battle_Rpg2k3::ProcessBattleAction
 }
 
 Scene_Battle_Rpg2k3::BattleActionReturn Scene_Battle_Rpg2k3::ProcessBattleActionSwitchEvents(Game_BattleAlgorithm::AlgorithmBase* action) {
-	(void)action;
 	// RPG_RT always runs the interpreter before starting the action.
-	if (!CheckBattleEndAndScheduleEvents(EventTriggerType::eAfterBattleAction)) {
+	if (!CheckBattleEndAndScheduleEvents(EventTriggerType::eAfterBattleAction, action->GetSource())) {
 		return BattleActionReturn::eContinue;
 	}
 
@@ -2618,9 +2617,8 @@ Scene_Battle_Rpg2k3::BattleActionReturn Scene_Battle_Rpg2k3::ProcessBattleAction
 }
 
 Scene_Battle_Rpg2k3::BattleActionReturn Scene_Battle_Rpg2k3::ProcessBattleActionPostEvents(Game_BattleAlgorithm::AlgorithmBase* action) {
-	(void)action;
 	// RPG_RT always runs the interpreter before starting the action.
-	if (!CheckBattleEndAndScheduleEvents(EventTriggerType::eAfterBattleAction)) {
+	if (!CheckBattleEndAndScheduleEvents(EventTriggerType::eAfterBattleAction, action->GetSource())) {
 		return BattleActionReturn::eContinue;
 	}
 

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -178,7 +178,7 @@ protected:
 	SceneActionReturn ProcessSceneActionEscape();
 
 	void NextTurn(Game_Battler* battler);
-	bool CheckBattleEndAndScheduleEvents(EventTriggerType tt);
+	bool CheckBattleEndAndScheduleEvents(EventTriggerType tt, Game_Battler* source);
 	bool CheckBattleEndConditions();
 
 	void SetBattleActionState(BattleActionState state);


### PR DESCRIPTION
fmatthew missed something ;) (well partially, there was a FIXME in the code but only for ``command_actor``)

When evaluating conditions RPG Maker 2003 passes the current active battler. This battler is evaluated for the page conditions:

- Battle Command: checked battler == current_battler (NULL-check missing because it makes no sense here)
- Actor / Enemy turn: battler is NULL (battle start) or checked battler == current battler

Test cases:

- Battle Command: #2535 . A page has run condition "Hero uses Attack". When the enemy attacks this page was activated again. This is _wrong_. It is only activated when the hero acts. **Works now**
- Actor / Enemy turn: Create two pages, one with "Actor 1 Turn Count x1" and one with "Enemy 1 Turn Count x1" (= run page everytime)
  - When battle starts: Both pages run (good, thats the NULL case)
  - When Actor attacks: Before: Both pages run. **wrong**. Now: Only actor page runs. **Works**
  - When Enemy attacks: Before: Both pages run. **wrong**. Now: Only enemy page runs. **Works**

(The 3 affected conditions are 2k3 exclusive, so this one-line change in 2k is completely harmless.)

Fix #2535