### PR TITLE
Fix title graphic disappearing too early (#2337)

### DIFF
--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -133,6 +133,7 @@ std::shared_ptr<Scene> Graphics::UpdateSceneCallback() {
 
 	if (current_scene) {
 		if (prev_scene) {
+			prev_scene->Suspend(current_scene->type);
 			current_scene->TransferDrawablesFrom(*prev_scene);
 		}
 		DrawableMgr::SetLocalList(&current_scene->GetDrawableList());

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -194,7 +194,7 @@ void Scene::MainFunction() {
 		Graphics::Update();
 
 		auto next_scene = instance ? instance->type : Null;
-		Suspend(next_scene);
+
 		// Scene could have manually triggered transition earlier
 		if (!Transition::instance().IsActive()) {
 			TransitionOut(next_scene);
@@ -210,15 +210,15 @@ void Scene::Start() {
 void Scene::Continue(SceneType /* prev_scene */) {
 }
 
-void Scene::Suspend(SceneType /* next_scene */) {
-}
-
 void Scene::TransitionIn(SceneType) {
 	Transition::instance().InitShow(Transition::TransitionFadeIn, this, 6);
 }
 
 void Scene::TransitionOut(SceneType) {
 	Transition::instance().InitErase(Transition::TransitionFadeOut, this, 6);
+}
+
+void Scene::Suspend(SceneType /* next_scene */) {
 }
 
 void Scene::OnFinishAsync() {

--- a/src/scene.h
+++ b/src/scene.h
@@ -102,30 +102,30 @@ public:
 	virtual void Continue(SceneType prev_scene);
 
 	/**
-	 * Suspend processing.
-	 * This function is executed before the fade out for
-	 * the scene change, either when terminating the scene
-	 * or switching to a nested scene
-	 *
-	 * @param next_scene the scene we will transition to
-	 */
-	virtual void Suspend(SceneType next_scene);
-
-	/**
-	 * Does the transition upon starting or resuming
-	 * the scene
+	 * Used to configure the transition upon starting or resuming
+	 * the scene.
 	 *
 	 * @param prev_scene the scene we transitioned from
 	 */
 	virtual void TransitionIn(SceneType prev_scene);
 
 	/**
-	 * Does the transition upon ending or suspending
-	 * the scene
+	 * Used to configure the transition upon ending or suspending
+	 * the scene.
 	 *
 	 * @param next_scene the scene we will transition to
 	 */
 	virtual void TransitionOut(SceneType next_scene);
+
+	/**
+	 * This function is executed after the fade out transition is finished.
+	 * Use this for clean up before terminating the scene or switching to
+	 * a nested scene.
+	 * In case of termination this is called right before the destructor.
+	 *
+	 * @param next_scene the scene we will transition to
+	 */
+	virtual void Suspend(SceneType next_scene);
 
 	/**
 	 * Called when a transition or async load is finished.

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -169,12 +169,6 @@ void Scene_Map::TransitionIn(SceneType prev_scene) {
 	Scene::TransitionIn(prev_scene);
 }
 
-void Scene_Map::Suspend(SceneType next_scene) {
-	if (next_scene == Scene::Title) {
-		Main_Data::game_system->BgmStop();
-	}
-}
-
 void Scene_Map::TransitionOut(SceneType next_scene) {
 	auto& transition = Transition::instance();
 
@@ -204,10 +198,16 @@ void Scene_Map::TransitionOut(SceneType next_scene) {
 		}
 		return;
 	}
+
 	if (next_scene == Scene::Gameover) {
 		transition.InitErase(Transition::TransitionFadeOut, this);
 		return;
 	}
+
+	if (next_scene == Scene::Title) {
+		Main_Data::game_system->BgmStop();
+	}
+
 	Scene::TransitionOut(next_scene);
 }
 

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -39,7 +39,6 @@ public:
 
 	void Start() override;
 	void Continue(SceneType prev_scene) override;
-	void Suspend(SceneType next_scene) override;
 	void Update() override;
 	void TransitionIn(SceneType prev_scene) override;
 	void TransitionOut(SceneType next_scene) override;

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -101,9 +101,7 @@ void Scene_Title::TransitionIn(SceneType prev_scene) {
 	Transition::instance().InitShow(Transition::TransitionFadeIn, this);
 }
 
-void Scene_Title::TransitionOut(Scene::SceneType next_scene) {
-	Scene::TransitionOut(next_scene);
-
+void Scene_Title::Suspend(Scene::SceneType next_scene) {
 	// Unload title graphic to save memory
 	title.reset();
 }

--- a/src/scene_title.h
+++ b/src/scene_title.h
@@ -38,7 +38,7 @@ public:
 	void Start() override;
 	void Continue(SceneType prev_scene) override;
 	void TransitionIn(SceneType prev_scene) override;
-	void TransitionOut(SceneType next_scene) override;
+	void Suspend(SceneType next_scene) override;
 	void Update() override;
 
 	/**


### PR DESCRIPTION
Invoke Scene::Suspend after the transition out before transfering drawables

There was no way before for scenes to execute any cleanup code here.

For cleanup before transitioning Scene::TransitionOut can be overwritten.

Only two classes used Suspend:
- Scene_Map to disable the BGM, this was moved to TransitionOut
- Scene_Shop for a callback that notifies if anything was bought. Here it does not matter.

Fix #2337