### PR TITLE
Fix missing alpha when a picture is rotating and the screen fades out

### DIFF
--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -1103,6 +1103,8 @@ void Bitmap::RotateZoomOpacityBlit(int x, int y, int ox, int oy,
 
 	auto mask = CreateMask(opacity, src_rect, &inv);
 
+	// OP_SRC draws a black rectangle around the rotated image making this operator unusable here
+	blend_mode = (blend_mode == BlendMode::Default ? BlendMode::Normal : blend_mode);
 	pixman_image_composite32(GetOperator(mask.get(), blend_mode),
 							 src_img, mask.get(), bitmap.get(),
 							 dst_rect.x, dst_rect.y,


### PR DESCRIPTION
Rotation cannot be done with OP_SRC as it renders a black rectangle.

See also #1077 (surprisingly this issue did not regress)

Fix #2667
