### PR TITLE
Change character Z-Index calculation

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -116,8 +116,7 @@ int Game_Character::GetScreenZ(bool apply_shift) const {
 		z = Priority_EventsAbove;
 	}
 
-	// For events on the screen, this should be inside a 0-40 range
-	z += GetScreenY(apply_shift, false) >> 3;
+	z += GetScreenY(apply_shift, false);
 
 	return z;
 }


### PR DESCRIPTION
This PR changes the map characters Z-Index calculation to fix character overlapping.

Fixes: #2550