### PR TITLE
Midi: Reset loop_count when calling Open. Now it is reset for MidiOut.

### DIFF
--- a/src/audio_decoder_midi.cpp
+++ b/src/audio_decoder_midi.cpp
@@ -109,6 +109,7 @@ bool AudioDecoderMidi::Open(Filesystem_Stream::InputStream stream) {
 
 	file_buffer_pos = 0;
 	file_buffer = Utils::ReadStream(stream);
+	loop_count = 0;
 
 	if (!seq->load(this, read_func)) {
 		error_message = "Midi: Error reading file";


### PR DESCRIPTION
Fixes Inn music only playing once

Fix #2689
