### PR TITLE
Add more custom game settings in the database

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,8 @@ add_library(${PROJECT_NAME} STATIC
 	src/exe_reader.cpp
 	src/exe_reader.h
 	src/exfont.h
+	src/feature.cpp
+	src/feature.h
 	src/filefinder.cpp
 	src/filefinder.h
 	src/filefinder_rtp.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -97,6 +97,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/exe_reader.cpp \
 	src/exe_reader.h \
 	src/exfont.h \
+	src/feature.cpp \
+	src/feature.h \
 	src/filefinder.cpp \
 	src/filefinder.h \
 	src/filefinder_rtp.cpp \

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -84,8 +84,7 @@ int CalcNormalAttackToHit(const Game_Battler &source,
 	to_hit = (to_hit * source.GetHitChanceModifierFromStates()) / 100;
 
 	// Stop here if attacker ignores evasion.
-	if (source.GetType() == Game_Battler::Type_Ally
-		&& static_cast<const Game_Actor&>(source).AttackIgnoresEvasion(weapon)) {
+	if (source.AttackIgnoresEvasion(weapon)) {
 		return to_hit;
 	}
 
@@ -130,8 +129,7 @@ int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const
 	to_hit = (to_hit * source.GetHitChanceModifierFromStates()) / 100;
 
 	// Stop here if attacker ignores evasion.
-	if (source.GetType() == Game_Battler::Type_Ally
-		&& static_cast<const Game_Actor&>(source).AttackIgnoresEvasion(Game_Battler::WeaponAll)) {
+	if (source.AttackIgnoresEvasion(Game_Battler::WeaponAll)) {
 		return to_hit;
 	}
 

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -107,7 +107,7 @@ int CalcNormalAttackToHit(const Game_Battler &source,
 
 
 int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const lcf::rpg::Skill& skill) {
-	auto to_hit = skill.hit;
+	auto to_hit = (skill.hit < 0 ? source.GetHitChance(Game_Battler::WeaponAll) : skill.hit);
 
 	if (!SkillTargetsAllies(skill) && skill.easyrpg_affected_by_avoid_attacks && target.EvadesAllPhysicalAttacks()) {
 		return 0;

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -99,7 +99,7 @@ int CalcNormalAttackToHit(const Game_Battler &source,
 	}
 
 	// Defender row adjustment
-	if (Player::IsRPG2k3() && IsRowAdjusted(target, cond, false, emulate_2k3_enemy_row_bug)) {
+	if ((Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system) && IsRowAdjusted(target, cond, false, emulate_2k3_enemy_row_bug)) {
 		to_hit -= 25;
 	}
 
@@ -190,7 +190,7 @@ int CalcNormalAttackEffect(const Game_Battler& source,
 	auto dmg = std::max(0, atk / 2 - def / 4);
 
 	// Attacker row adjustment
-	if (Player::IsRPG2k3() && IsRowAdjusted(source, cond, true, false)) {
+	if ((Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system) && IsRowAdjusted(source, cond, true, false)) {
 		dmg = 125 * dmg / 100;
 	}
 
@@ -198,7 +198,7 @@ int CalcNormalAttackEffect(const Game_Battler& source,
 	dmg = Attribute::ApplyAttributeNormalAttackMultiplier(dmg, source, target, weapon);
 
 	// Defender row adjustment
-	if (Player::IsRPG2k3() && IsRowAdjusted(target, cond, false, emulate_2k3_enemy_row_bug)) {
+	if ((Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system) && IsRowAdjusted(target, cond, false, emulate_2k3_enemy_row_bug)) {
 		dmg = 75 * dmg / 100;
 	}
 

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -267,6 +267,12 @@ int CalcSkillCost(const lcf::rpg::Skill& skill, int max_sp, bool half_sp_cost) {
 		: (skill.sp_cost + static_cast<int>(half_sp_cost)) / div;
 }
 
+int CalcSkillHpCost(const lcf::rpg::Skill& skill, int max_hp) {
+	return (Player::IsRPG2k3() && skill.easyrpg_hp_type == lcf::rpg::Skill::HpType_percent)
+		? std::min(max_hp - 1, max_hp * skill.easyrpg_hp_percent / 100)
+		: skill.easyrpg_hp_cost;
+}
+
 bool IsSkillUsable(const lcf::rpg::Skill& skill,
 		bool require_states_persist)
 {

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -93,8 +93,7 @@ int CalcNormalAttackToHit(const Game_Battler &source,
 	to_hit = CalcToHitAgiAdjustment(to_hit, source, target, weapon);
 
 	// If target has physical dodge evasion:
-	if (target.GetType() == Game_Battler::Type_Ally
-			&& static_cast<const Game_Actor&>(target).HasPhysicalEvasionUp()) {
+	if (target.HasPhysicalEvasionUp()) {
 		to_hit -= 25;
 	}
 
@@ -140,8 +139,7 @@ int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const
 	to_hit = CalcToHitAgiAdjustment(to_hit, source, target, Game_Battler::WeaponAll);
 
 	// If target has physical dodge evasion:
-	if (target.GetType() == Game_Battler::Type_Ally
-			&& static_cast<const Game_Actor&>(target).HasPhysicalEvasionUp()) {
+	if (target.HasPhysicalEvasionUp()) {
 		to_hit -= 25;
 	}
 

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -28,6 +28,7 @@
 #include "rand.h"
 #include <lcf/rpg/skill.h>
 #include <lcf/reader_util.h>
+#include "feature.h"
 
 #include <algorithm>
 
@@ -97,7 +98,7 @@ int CalcNormalAttackToHit(const Game_Battler &source,
 	}
 
 	// Defender row adjustment
-	if ((Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system && !lcf::Data::battlecommands.easyrpg_disable_row_feature) && IsRowAdjusted(target, cond, false, emulate_2k3_enemy_row_bug)) {
+	if (Feature::HasRow() && IsRowAdjusted(target, cond, false, emulate_2k3_enemy_row_bug)) {
 		to_hit -= 25;
 	}
 
@@ -190,7 +191,7 @@ int CalcNormalAttackEffect(const Game_Battler& source,
 	auto dmg = std::max(0, atk / 2 - def / 4);
 
 	// Attacker row adjustment
-	if ((Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system && !lcf::Data::battlecommands.easyrpg_disable_row_feature) && IsRowAdjusted(source, cond, true, false)) {
+	if (Feature::HasRow() && IsRowAdjusted(source, cond, true, false)) {
 		dmg = 125 * dmg / 100;
 	}
 
@@ -198,7 +199,7 @@ int CalcNormalAttackEffect(const Game_Battler& source,
 	dmg = Attribute::ApplyAttributeNormalAttackMultiplier(dmg, source, target, weapon);
 
 	// Defender row adjustment
-	if ((Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system && !lcf::Data::battlecommands.easyrpg_disable_row_feature) && IsRowAdjusted(target, cond, false, emulate_2k3_enemy_row_bug)) {
+	if (Feature::HasRow() && IsRowAdjusted(target, cond, false, emulate_2k3_enemy_row_bug)) {
 		dmg = 75 * dmg / 100;
 	}
 

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -99,7 +99,7 @@ int CalcNormalAttackToHit(const Game_Battler &source,
 	}
 
 	// Defender row adjustment
-	if ((Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system) && IsRowAdjusted(target, cond, false, emulate_2k3_enemy_row_bug)) {
+	if ((Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system && !lcf::Data::battlecommands.easyrpg_disable_row_feature) && IsRowAdjusted(target, cond, false, emulate_2k3_enemy_row_bug)) {
 		to_hit -= 25;
 	}
 
@@ -190,7 +190,7 @@ int CalcNormalAttackEffect(const Game_Battler& source,
 	auto dmg = std::max(0, atk / 2 - def / 4);
 
 	// Attacker row adjustment
-	if ((Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system) && IsRowAdjusted(source, cond, true, false)) {
+	if ((Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system && !lcf::Data::battlecommands.easyrpg_disable_row_feature) && IsRowAdjusted(source, cond, true, false)) {
 		dmg = 125 * dmg / 100;
 	}
 
@@ -198,7 +198,7 @@ int CalcNormalAttackEffect(const Game_Battler& source,
 	dmg = Attribute::ApplyAttributeNormalAttackMultiplier(dmg, source, target, weapon);
 
 	// Defender row adjustment
-	if ((Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system) && IsRowAdjusted(target, cond, false, emulate_2k3_enemy_row_bug)) {
+	if ((Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system && !lcf::Data::battlecommands.easyrpg_disable_row_feature) && IsRowAdjusted(target, cond, false, emulate_2k3_enemy_row_bug)) {
 		dmg = 75 * dmg / 100;
 	}
 

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -107,9 +107,9 @@ int CalcNormalAttackToHit(const Game_Battler &source,
 
 
 int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const lcf::rpg::Skill& skill) {
-	auto to_hit = (skill.hit < 0 ? source.GetHitChance(Game_Battler::WeaponAll) : skill.hit);
+	auto to_hit = (skill.hit == -1 ? source.GetHitChance(Game_Battler::WeaponAll) : skill.hit);
 
-	if (!SkillTargetsAllies(skill) && skill.easyrpg_affected_by_avoid_attacks && target.EvadesAllPhysicalAttacks()) {
+	if (!SkillTargetsAllies(skill) && skill.easyrpg_affected_by_evade_all_physical_attacks && target.EvadesAllPhysicalAttacks()) {
 		return 0;
 	}
 

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -146,8 +146,8 @@ int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const
 	return to_hit;
 }
 
-int CalcCriticalHitChance(const Game_Battler& source, const Game_Battler& target, Game_Battler::Weapon weapon) {
-	auto crit_chance = static_cast<int>(source.GetCriticalHitChance(weapon) * 100.0);
+int CalcCriticalHitChance(const Game_Battler& source, const Game_Battler& target, Game_Battler::Weapon weapon, int fixed_chance) {
+	auto crit_chance = (fixed_chance < 0 ? static_cast<int>(source.GetCriticalHitChance(weapon) * 100.0) : fixed_chance);
 	if (target.PreventsCritical()) {
 		crit_chance = 0;
 	}
@@ -221,7 +221,8 @@ int CalcNormalAttackEffect(const Game_Battler& source,
 int CalcSkillEffect(const Game_Battler& source,
 		const Game_Battler& target,
 		const lcf::rpg::Skill& skill,
-		bool apply_variance) {
+		bool apply_variance,
+		bool is_critical_hit) {
 
 	auto effect = skill.power;
 	effect += skill.physical_rate * source.GetAtk() / 20;
@@ -235,6 +236,10 @@ int CalcSkillEffect(const Game_Battler& source,
 	effect = std::max<int>(0, effect);
 
 	effect = Attribute::ApplyAttributeSkillMultiplier(effect, target, skill);
+
+	if (is_critical_hit) {
+		effect *= 3;
+	}
 
 	if (apply_variance) {
 		effect = VarianceAdjustEffect(effect, skill.variance);

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -110,6 +110,10 @@ int CalcNormalAttackToHit(const Game_Battler &source,
 int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const lcf::rpg::Skill& skill) {
 	auto to_hit = skill.hit;
 
+	if (!SkillTargetsAllies(skill) && skill.easyrpg_affected_by_avoid_attacks && target.EvadesAllPhysicalAttacks()) {
+		return 0;
+	}
+
 	// RPG_RT BUG: rm2k3 editor doesn't let you set the failure message for skills, and so you can't make them physical type anymore.
 	// Despite that, RPG_RT still checks the flag and run the below code?
 	if (skill.failure_message != 3 || SkillTargetsAllies(skill)) {

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -150,7 +150,7 @@ int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const
 
 int CalcCriticalHitChance(const Game_Battler& source, const Game_Battler& target, Game_Battler::Weapon weapon) {
 	auto crit_chance = static_cast<int>(source.GetCriticalHitChance(weapon) * 100.0);
-	if (target.GetType() == Game_Battler::Type_Ally && static_cast<const Game_Actor&>(target).PreventsCritical()) {
+	if (target.PreventsCritical()) {
 		crit_chance = 0;
 	}
 	if (source.GetType() == target.GetType()) {

--- a/src/algo.h
+++ b/src/algo.h
@@ -187,6 +187,16 @@ int CalcSelfDestructEffect(const Game_Battler& source,
  */
 int CalcSkillCost(const lcf::rpg::Skill& skill, int max_sp, bool half_sp_cost);
 
+/**
+ * Calculates the hp cost for a skill.
+ *
+ * @param skill The skill to compute
+ * @param max_sp the max hp of the user
+ *
+ * @return hp cost
+ */
+int CalcSkillHpCost(const lcf::rpg::Skill& skill, int max_hp);
+
 /*
  * Determine whether a skill is usable.
  *

--- a/src/algo.h
+++ b/src/algo.h
@@ -99,10 +99,11 @@ int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const
  * @param source The attacker
  * @param target The defender
  * @param weapon Which weapon to use or kWeaponAll for combined
+ * @param fixed_chance Fixed critical hit rate percentage
  *
  * @return Critical hit rate.
  */
-int CalcCriticalHitChance(const Game_Battler& source, const Game_Battler& target, Game_Battler::Weapon weapon);
+int CalcCriticalHitChance(const Game_Battler& source, const Game_Battler& target, Game_Battler::Weapon weapon, int fixed_chance);
 
 /**
  * Check if target is defending and perform damage adjustment if so.
@@ -148,13 +149,15 @@ int CalcNormalAttackEffect(const Game_Battler& source,
  * @param target The target of the action
  * @param skill The skill to use
  * @param apply_variance If true, apply variance to the damage
+ * @param is_critical_hit If true, apply critical hit bonus
  *
  * @return effect amount
  */
 int CalcSkillEffect(const Game_Battler& source,
 		const Game_Battler& target,
 		const lcf::rpg::Skill& skill,
-		bool apply_variance);
+		bool apply_variance,
+		bool is_critical_hit);
 
 /**
  * Compute the base damage for self-destruct

--- a/src/autobattle.cpp
+++ b/src/autobattle.cpp
@@ -101,7 +101,7 @@ double CalcSkillHealAutoBattleTargetRank(const Game_Actor& source, const Game_Ba
 			return 0.0;
 		}
 
-		const double base_effect = Algo::CalcSkillEffect(source, target, skill, apply_variance);
+		const double base_effect = Algo::CalcSkillEffect(source, target, skill, apply_variance, false);
 		const double max_effect = std::min(base_effect, tgt_max_hp - tgt_hp);
 
 		auto rank = static_cast<double>(max_effect) / static_cast<double>(tgt_max_hp);
@@ -136,7 +136,7 @@ double CalcSkillDmgAutoBattleTargetRank(const Game_Actor& source, const Game_Bat
 	const double src_max_sp = source.GetMaxSp();
 	const double tgt_hp = target.GetHp();
 
-	const double base_effect = Algo::CalcSkillEffect(source, target, skill, apply_variance);
+	const double base_effect = Algo::CalcSkillEffect(source, target, skill, apply_variance, false);
 	rank = std::min(base_effect, tgt_hp) / tgt_hp;
 	if (rank == 1.0) {
 		rank = 1.5;

--- a/src/battle_message.cpp
+++ b/src/battle_message.cpp
@@ -22,11 +22,12 @@
 #include <lcf/rpg/state.h>
 #include <lcf/data.h>
 #include <lcf/reader_util.h>
+#include "feature.h"
 
 namespace BattleMessage {
 
 static std::string GetStateMessage(StringView target_name, StringView message) {
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		return Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S'),
@@ -69,7 +70,7 @@ std::string GetDeathMessage(const Game_Battler& target) {
 }
 
 static std::string GetActionFailureMessage(StringView source, StringView target, StringView message) {
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		return Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S', 'O'),
@@ -112,7 +113,7 @@ std::string GetUndamagedMessage(const Game_Battler& target) {
 		? StringView(lcf::Data::terms.actor_undamaged)
 		: StringView(lcf::Data::terms.enemy_undamaged);
 
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		return Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S'),
@@ -129,7 +130,7 @@ std::string GetCriticalHitMessage(const Game_Battler& source, const Game_Battler
 		? StringView(lcf::Data::terms.actor_critical)
 		: StringView(lcf::Data::terms.enemy_critical);
 
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		return Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S', 'O'),
@@ -142,7 +143,7 @@ std::string GetCriticalHitMessage(const Game_Battler& source, const Game_Battler
 }
 
 static std::string GetHpSpRecoveredMessage(const Game_Battler& target, int value, StringView points) {
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		return Utils::ReplacePlaceholders(
 			lcf::Data::terms.hp_recovery,
 			Utils::MakeArray('S', 'V', 'U'),
@@ -180,7 +181,7 @@ std::string GetParameterAbsorbedMessage(const Game_Battler& source, const Game_B
 		? StringView(lcf::Data::terms.actor_hp_absorbed)
 		: StringView(lcf::Data::terms.enemy_hp_absorbed);
 
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		return Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S', 'O', 'V', 'U'),
@@ -235,7 +236,7 @@ std::string GetDamagedMessage(const Game_Battler& target, int value) {
 		? StringView(lcf::Data::terms.actor_damaged)
 		: StringView(lcf::Data::terms.enemy_damaged);
 
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		return Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S', 'V', 'U'),
@@ -268,7 +269,7 @@ std::string GetParameterChangeMessage(const Game_Battler& target, int value, Str
 	   	: StringView(lcf::Data::terms.parameter_decrease);
 
 
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		return Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S', 'V', 'U'),
@@ -324,7 +325,7 @@ std::string GetAttributeShiftMessage(const Game_Battler& target, int value, cons
 		: StringView(lcf::Data::terms.resistance_decrease);
 	std::stringstream ss;
 
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		return Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S', 'O'),
@@ -348,7 +349,7 @@ std::string GetAttributeShiftMessage(const Game_Battler& target, int value, cons
 }
 
 static std::string GetBasicStartMessage2k(const Game_Battler& source, StringView term) {
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		return Utils::ReplacePlaceholders(
 			term,
 			Utils::MakeArray('S'),
@@ -383,7 +384,7 @@ std::string GetEscapeStartMessage2k(const Game_Battler& source) {
 }
 
 std::string GetTransformStartMessage(const Game_Battler& source, const lcf::rpg::Enemy& new_enemy) {
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		return Utils::ReplacePlaceholders(
 			lcf::Data::terms.enemy_transform,
 			Utils::MakeArray('S', 'O'),
@@ -398,7 +399,7 @@ static std::string GetSkillStartMessageGeneric(const Game_Battler& source, const
 	if (target && Algo::IsNormalOrSubskill(skill) && Algo::SkillTargetsOne(skill)) {
 		target_name = target->GetName();
 	}
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		return Utils::ReplacePlaceholders(
 				usage,
 				Utils::MakeArray('S', 'O', 'U'),
@@ -429,7 +430,7 @@ std::string GetItemStartMessage2k(const Game_Battler& source, const lcf::rpg::It
 		);
 	}
 
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		return Utils::ReplacePlaceholders(
 			lcf::Data::terms.use_item,
 			Utils::MakeArray('S', 'O'),

--- a/src/battle_message.cpp
+++ b/src/battle_message.cpp
@@ -26,7 +26,7 @@
 namespace BattleMessage {
 
 static std::string GetStateMessage(StringView target_name, StringView message) {
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		return Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S'),
@@ -69,7 +69,7 @@ std::string GetDeathMessage(const Game_Battler& target) {
 }
 
 static std::string GetActionFailureMessage(StringView source, StringView target, StringView message) {
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		return Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S', 'O'),
@@ -112,7 +112,7 @@ std::string GetUndamagedMessage(const Game_Battler& target) {
 		? StringView(lcf::Data::terms.actor_undamaged)
 		: StringView(lcf::Data::terms.enemy_undamaged);
 
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		return Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S'),
@@ -129,7 +129,7 @@ std::string GetCriticalHitMessage(const Game_Battler& source, const Game_Battler
 		? StringView(lcf::Data::terms.actor_critical)
 		: StringView(lcf::Data::terms.enemy_critical);
 
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		return Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S', 'O'),
@@ -142,7 +142,7 @@ std::string GetCriticalHitMessage(const Game_Battler& source, const Game_Battler
 }
 
 static std::string GetHpSpRecoveredMessage(const Game_Battler& target, int value, StringView points) {
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		return Utils::ReplacePlaceholders(
 			lcf::Data::terms.hp_recovery,
 			Utils::MakeArray('S', 'V', 'U'),
@@ -180,7 +180,7 @@ std::string GetParameterAbsorbedMessage(const Game_Battler& source, const Game_B
 		? StringView(lcf::Data::terms.actor_hp_absorbed)
 		: StringView(lcf::Data::terms.enemy_hp_absorbed);
 
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		return Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S', 'O', 'V', 'U'),
@@ -235,7 +235,7 @@ std::string GetDamagedMessage(const Game_Battler& target, int value) {
 		? StringView(lcf::Data::terms.actor_damaged)
 		: StringView(lcf::Data::terms.enemy_damaged);
 
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		return Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S', 'V', 'U'),
@@ -268,7 +268,7 @@ std::string GetParameterChangeMessage(const Game_Battler& target, int value, Str
 	   	: StringView(lcf::Data::terms.parameter_decrease);
 
 
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		return Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S', 'V', 'U'),
@@ -324,7 +324,7 @@ std::string GetAttributeShiftMessage(const Game_Battler& target, int value, cons
 		: StringView(lcf::Data::terms.resistance_decrease);
 	std::stringstream ss;
 
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		return Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S', 'O'),
@@ -348,7 +348,7 @@ std::string GetAttributeShiftMessage(const Game_Battler& target, int value, cons
 }
 
 static std::string GetBasicStartMessage2k(const Game_Battler& source, StringView term) {
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		return Utils::ReplacePlaceholders(
 			term,
 			Utils::MakeArray('S'),
@@ -383,7 +383,7 @@ std::string GetEscapeStartMessage2k(const Game_Battler& source) {
 }
 
 std::string GetTransformStartMessage(const Game_Battler& source, const lcf::rpg::Enemy& new_enemy) {
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		return Utils::ReplacePlaceholders(
 			lcf::Data::terms.enemy_transform,
 			Utils::MakeArray('S', 'O'),
@@ -398,7 +398,7 @@ static std::string GetSkillStartMessageGeneric(const Game_Battler& source, const
 	if (target && Algo::IsNormalOrSubskill(skill) && Algo::SkillTargetsOne(skill)) {
 		target_name = target->GetName();
 	}
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		return Utils::ReplacePlaceholders(
 				usage,
 				Utils::MakeArray('S', 'O', 'U'),
@@ -429,7 +429,7 @@ std::string GetItemStartMessage2k(const Game_Battler& source, const lcf::rpg::It
 		);
 	}
 
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		return Utils::ReplacePlaceholders(
 			lcf::Data::terms.use_item,
 			Utils::MakeArray('S', 'O'),

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -1,0 +1,49 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Headers
+#include "feature.h"
+#include "player.h"
+#include <lcf/data.h>
+
+bool Feature::HasRpg2kBattleSystem() {
+	if (Player::IsRPG2k()) {
+		return true;
+	}
+
+	return lcf::Data::system.easyrpg_use_rpg2k_battle_system;
+}
+
+bool Feature::HasRpg2k3BattleSystem() {
+	return !HasRpg2kBattleSystem();
+}
+
+bool Feature::HasRow() {
+	if (HasRpg2k3BattleSystem() && !lcf::Data::battlecommands.easyrpg_disable_row_feature) {
+		return true;
+	}
+
+	return false;
+}
+
+bool Feature::HasPlaceholders() {
+	if (Player::IsRPG2kE()) {
+		return true;
+	}
+
+	return Player::IsRPG2k3() && HasRpg2kBattleSystem() && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings;
+}

--- a/src/feature.h
+++ b/src/feature.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_FEATURE_H
+#define EP_FEATURE_H
+
+/**
+ * Feature namespace.
+ */
+namespace Feature {
+	/**
+	 * @return true if the RPG Maker 2000 battle system is used
+	 */
+	bool HasRpg2kBattleSystem();
+
+	/**
+	 * @return true if the RPG Maker 2003 battle system is used
+	 */
+	bool HasRpg2k3BattleSystem();
+
+	/**
+	 * @return true if the row feature is enabled
+	 */
+	bool HasRow();
+
+	/**
+	 * @return true if text placeholders are used
+	 */
+	bool HasPlaceholders();
+}
+
+#endif

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1419,6 +1419,9 @@ bool Game_Actor::PreventsTerrainDamage() const {
 }
 
 bool Game_Actor::HasPhysicalEvasionUp() const {
+	if (dbActor->easyrpg_raise_evasion) {
+		return true;
+	}
 	bool rc = false;
 	ForEachEquipment<false, true>(GetWholeEquipment(), [&](auto& item) { rc |= item.raise_evasion; });
 	return rc;

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1402,6 +1402,9 @@ bool Game_Actor::HasAttackAll(Weapon weapon) const {
 }
 
 bool Game_Actor::AttackIgnoresEvasion(Weapon weapon) const {
+	if (GetWeapon() == nullptr && Get2ndWeapon() == nullptr) {
+		return dbActor->easyrpg_ignore_evasion;
+	}
 	bool rc = false;
 	ForEachEquipment<true, false>(GetWholeEquipment(), [&](auto& item) { rc |= item.ignore_evasion; }, weapon);
 	return rc;

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1407,6 +1407,9 @@ int Game_Actor::GetNumberOfAttacks(Weapon weapon) const {
 }
 
 bool Game_Actor::HasAttackAll(Weapon weapon) const {
+	if (GetWeapon() == nullptr && Get2ndWeapon() == nullptr) {
+		return dbActor->easyrpg_attack_all;
+	}
 	bool rc = false;
 	ForEachEquipment<true, false>(GetWholeEquipment(), [&](auto& item) { rc |= item.attack_all; }, weapon);
 	return rc;

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1404,6 +1404,9 @@ bool Game_Actor::AttackIgnoresEvasion(Weapon weapon) const {
 }
 
 bool Game_Actor::PreventsCritical() const {
+	if (dbActor->easyrpg_prevent_critical) {
+		return true;
+	}
 	bool rc = false;
 	ForEachEquipment<false, true>(GetWholeEquipment(), [&](auto& item) { rc |= item.prevent_critical; });
 	return rc;

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1398,6 +1398,9 @@ bool Game_Actor::HasPreemptiveAttack(Weapon weapon) const {
 }
 
 int Game_Actor::GetNumberOfAttacks(Weapon weapon) const {
+	if (GetWeapon() == nullptr && Get2ndWeapon() == nullptr && dbActor->easyrpg_dual_attack) {
+		return 2;
+	}
 	int hits = 1;
 	ForEachEquipment<true, false>(GetWholeEquipment(), [&](auto& item) { hits = std::max(hits, Algo::GetNumberOfAttacks(GetId(), item)); }, weapon);
 	return hits;

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -695,6 +695,10 @@ int Game_Actor::GetBaseAttributeRate(int attribute_id) const {
 	return Utils::Clamp(rate, 0, 4);
 }
 
+bool Game_Actor::IsImmuneToAttributeDownshifts() const {
+	return dbActor->easyrpg_immune_to_attribute_downshifts;
+}
+
 int Game_Actor::GetWeaponId() const {
 	int item_id = GetWholeEquipment()[0];
 	return item_id <= (int)lcf::Data::items.size() ? item_id : 0;

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -1238,7 +1238,15 @@ int Game_Actor::GetHitChance(Weapon weapon) const {
 	int hit = INT_MIN;
 	ForEachEquipment<true, false>(GetWholeEquipment(), [&](auto& item) { hit = std::max(hit, static_cast<int>(item.hit)); }, weapon);
 
-	return hit != INT_MIN ? hit : 90;
+	if (hit != INT_MIN) {
+		return hit;
+	} else {
+		if (dbActor->easyrpg_unarmed_hit != -1) {
+			return dbActor->easyrpg_unarmed_hit;
+		} else {
+			return 90;
+		}
+	}
 }
 
 float Game_Actor::GetCriticalHitChance(Weapon weapon) const {

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -843,12 +843,12 @@ public:
 	bool HasAttackAll(Weapon weapon = WeaponAll) const override;
 
 	/**
-	 * Tests if the battler has a weapon which ignores evasion.
+	 * Tests if the actor has a weapon which ignores evasion.
 	 *
 	 * @param weapon Which weapons to include in calculating result.
 	 * @return If the actor has weapon that ignores evasion
 	 */
-	bool AttackIgnoresEvasion(Weapon weapon = WeaponAll) const;
+	bool AttackIgnoresEvasion(Weapon weapon = WeaponAll) const override;
 
 	/**
 	 * @return If the actor has equipment that protects against terrain damage.

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -854,9 +854,9 @@ public:
 	bool PreventsCritical() const override;
 
 	/**
-	 * @return If the actor has an equipment that with physical evasion up.
+	 * @return If the actor has an increased physical evasion rate.
 	 */
-	bool HasPhysicalEvasionUp() const;
+	bool HasPhysicalEvasionUp() const override;
 
 	/**
 	 * @return If the actor has an equipment with half sp cost.

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -849,9 +849,9 @@ public:
 	bool PreventsTerrainDamage() const;
 
 	/**
-	 * @return If the actor has an equipment that protects against critical hits.
+	 * @return If the actor is protected against critical hits.
 	 */
-	bool PreventsCritical() const;
+	bool PreventsCritical() const override;
 
 	/**
 	 * @return If the actor has an equipment that with physical evasion up.

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -228,6 +228,13 @@ public:
 	int GetBaseAttributeRate(int attribute_id) const override;
 
 	/**
+	 * Checks if the actor is immune to attribute downshifts.
+	 *
+	 * @return if the actor is immune to attribute downshifts.
+	 */
+	bool IsImmuneToAttributeDownshifts() const override;
+
+	/**
 	 * Gets actor name.
 	 *
 	 * @return name.

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -49,6 +49,7 @@
 #include "algo.h"
 #include "attribute.h"
 #include "spriteset_battle.h"
+#include "feature.h"
 
 static inline int MaxDamageValue() {
 	return lcf::Data::system.easyrpg_max_damage == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_damage;
@@ -544,7 +545,7 @@ Game_BattleAlgorithm::Normal::Normal(Game_Battler* source, Game_Party_Base* targ
 }
 
 Game_BattleAlgorithm::Normal::Style Game_BattleAlgorithm::Normal::GetDefaultStyle() {
-	return (Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system) ? Style_MultiHit : Style_Combined;
+	return Feature::HasRpg2k3BattleSystem() ? Style_MultiHit : Style_Combined;
 }
 
 Game_Battler::Weapon Game_BattleAlgorithm::Normal::GetWeapon() const {
@@ -610,7 +611,7 @@ int Game_BattleAlgorithm::Normal::GetAnimationId(int idx) const {
 		return 0;
 	}
 	if (source->GetType() == Game_Battler::Type_Enemy
-			&& (Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system)
+			&& Feature::HasRpg2k3BattleSystem()
 			&& !lcf::Data::animations.empty()) {
 		Game_Enemy* enemy = static_cast<Game_Enemy*>(source);
 		return enemy->GetUnarmedBattleAnimationId();
@@ -754,7 +755,7 @@ bool Game_BattleAlgorithm::Normal::vExecute() {
 
 std::string Game_BattleAlgorithm::Normal::GetStartMessage(int line) const {
 	if (line == 0) {
-		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+		if (Feature::HasRpg2kBattleSystem()) {
 			return BattleMessage::GetNormalAttackStartMessage2k(*GetSource());
 		}
 		if (GetSource()->GetType() == Game_Battler::Type_Enemy && hits_multiplier == 2) {
@@ -838,7 +839,7 @@ const lcf::rpg::Item* Game_BattleAlgorithm::Normal::GetWeaponData() const {
 }
 
 const lcf::rpg::Sound* Game_BattleAlgorithm::Normal::GetStartSe() const {
-	if ((Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) && GetSource()->GetType() == Game_Battler::Type_Enemy) {
+	if (Feature::HasRpg2kBattleSystem() && GetSource()->GetType() == Game_Battler::Type_Enemy) {
 		return &Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_EnemyAttacks);
 	}
 	return nullptr;
@@ -1136,7 +1137,7 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 std::string Game_BattleAlgorithm::Skill::GetStartMessage(int line) const {
 	if (item && item->using_message == 0) {
 		if (line == 0) {
-			if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+			if (Feature::HasRpg2kBattleSystem()) {
 				return BattleMessage::GetItemStartMessage2k(*GetSource(), *item);
 			} else {
 				return BattleMessage::GetItemStartMessage2k3(*GetSource(), *item);
@@ -1147,7 +1148,7 @@ std::string Game_BattleAlgorithm::Skill::GetStartMessage(int line) const {
 
 	const auto* target = GetOriginalSingleTarget();
 	if (line == 0) {
-		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+		if (Feature::HasRpg2kBattleSystem()) {
 			if (!skill.using_message1.empty()) {
 				return BattleMessage::GetSkillFirstStartMessage2k(*GetSource(), target, skill);
 			} else {
@@ -1157,7 +1158,7 @@ std::string Game_BattleAlgorithm::Skill::GetStartMessage(int line) const {
 			return BattleMessage::GetSkillStartMessage2k3(*GetSource(), target, skill);
 		}
 	}
-	if (line == 1 && (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) && !skill.using_message2.empty()) {
+	if (line == 1 && Feature::HasRpg2kBattleSystem() && !skill.using_message2.empty()) {
 		return BattleMessage::GetSkillSecondStartMessage2k(*GetSource(), target, skill);
 	}
 	return "";
@@ -1312,7 +1313,7 @@ bool Game_BattleAlgorithm::Item::vExecute() {
 
 std::string Game_BattleAlgorithm::Item::GetStartMessage(int line) const {
 	if (line == 0) {
-		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+		if (Feature::HasRpg2kBattleSystem()) {
 			return BattleMessage::GetItemStartMessage2k(*GetSource(), item);
 		} else {
 			return BattleMessage::GetItemStartMessage2k3(*GetSource(), item);
@@ -1354,7 +1355,7 @@ Game_BattleAlgorithm::Defend::Defend(Game_Battler* source) :
 
 std::string Game_BattleAlgorithm::Defend::GetStartMessage(int line) const {
 	if (line == 0) {
-		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+		if (Feature::HasRpg2kBattleSystem()) {
 			return BattleMessage::GetDefendStartMessage2k(*GetSource());
 		} else if (GetSource()->GetType() == Game_Battler::Type_Enemy) {
 			return BattleMessage::GetDefendStartMessage2k3(*GetSource());
@@ -1374,7 +1375,7 @@ AlgorithmBase(Type::Observe, source, source) {
 
 std::string Game_BattleAlgorithm::Observe::GetStartMessage(int line) const {
 	if (line == 0) {
-		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+		if (Feature::HasRpg2kBattleSystem()) {
 			return BattleMessage::GetObserveStartMessage2k(*GetSource());
 		} else if (GetSource()->GetType() == Game_Battler::Type_Enemy) {
 			return BattleMessage::GetObserveStartMessage2k3(*GetSource());
@@ -1390,7 +1391,7 @@ AlgorithmBase(Type::Charge, source, source) {
 
 std::string Game_BattleAlgorithm::Charge::GetStartMessage(int line) const {
 	if (line == 0) {
-		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+		if (Feature::HasRpg2kBattleSystem()) {
 			return BattleMessage::GetChargeUpStartMessage2k(*GetSource());
 		} else if (GetSource()->GetType() == Game_Battler::Type_Enemy) {
 			return BattleMessage::GetChargeUpStartMessage2k3(*GetSource());
@@ -1410,7 +1411,7 @@ AlgorithmBase(Type::SelfDestruct, source, target) {
 
 std::string Game_BattleAlgorithm::SelfDestruct::GetStartMessage(int line) const {
 	if (line == 0) {
-		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+		if (Feature::HasRpg2kBattleSystem()) {
 			return BattleMessage::GetSelfDestructStartMessage2k(*GetSource());
 		} else if (GetSource()->GetType() == Game_Battler::Type_Enemy) {
 			return BattleMessage::GetSelfDestructStartMessage2k3(*GetSource());
@@ -1464,7 +1465,7 @@ Game_BattleAlgorithm::Escape::Escape(Game_Battler* source) :
 
 std::string Game_BattleAlgorithm::Escape::GetStartMessage(int line) const {
 	if (line == 0) {
-		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+		if (Feature::HasRpg2kBattleSystem()) {
 			return BattleMessage::GetEscapeStartMessage2k(*GetSource());
 		} else if (GetSource()->GetType() == Game_Battler::Type_Enemy) {
 			return BattleMessage::GetEscapeStartMessage2k3(*GetSource());
@@ -1500,7 +1501,7 @@ AlgorithmBase(Type::Transform, source, source), new_monster_id(new_monster_id) {
 }
 
 std::string Game_BattleAlgorithm::Transform::GetStartMessage(int line) const {
-	if (line == 0 && (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system)) {
+	if (line == 0 && Feature::HasRpg2kBattleSystem()) {
 		auto* enemy = lcf::ReaderUtil::GetElement(lcf::Data::enemies, new_monster_id);
 		return BattleMessage::GetTransformStartMessage(*GetSource(), *enemy);
 	}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -544,7 +544,7 @@ Game_BattleAlgorithm::Normal::Normal(Game_Battler* source, Game_Party_Base* targ
 }
 
 Game_BattleAlgorithm::Normal::Style Game_BattleAlgorithm::Normal::GetDefaultStyle() {
-	return Player::IsRPG2k3() ? Style_MultiHit : Style_Combined;
+	return (Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system) ? Style_MultiHit : Style_Combined;
 }
 
 Game_Battler::Weapon Game_BattleAlgorithm::Normal::GetWeapon() const {
@@ -610,7 +610,7 @@ int Game_BattleAlgorithm::Normal::GetAnimationId(int idx) const {
 		return 0;
 	}
 	if (source->GetType() == Game_Battler::Type_Enemy
-			&& Player::IsRPG2k3()
+			&& (Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system)
 			&& !lcf::Data::animations.empty()) {
 		Game_Enemy* enemy = static_cast<Game_Enemy*>(source);
 		return enemy->GetUnarmedBattleAnimationId();
@@ -713,7 +713,7 @@ bool Game_BattleAlgorithm::Normal::vExecute() {
 
 std::string Game_BattleAlgorithm::Normal::GetStartMessage(int line) const {
 	if (line == 0) {
-		if (Player::IsRPG2k()) {
+		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
 			return BattleMessage::GetNormalAttackStartMessage2k(*GetSource());
 		}
 		if (GetSource()->GetType() == Game_Battler::Type_Enemy && hits_multiplier == 2) {
@@ -797,7 +797,7 @@ const lcf::rpg::Item* Game_BattleAlgorithm::Normal::GetWeaponData() const {
 }
 
 const lcf::rpg::Sound* Game_BattleAlgorithm::Normal::GetStartSe() const {
-	if (Player::IsRPG2k() && GetSource()->GetType() == Game_Battler::Type_Enemy) {
+	if ((Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) && GetSource()->GetType() == Game_Battler::Type_Enemy) {
 		return &Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_EnemyAttacks);
 	}
 	return nullptr;
@@ -1085,7 +1085,7 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 std::string Game_BattleAlgorithm::Skill::GetStartMessage(int line) const {
 	if (item && item->using_message == 0) {
 		if (line == 0) {
-			if (Player::IsRPG2k()) {
+			if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
 				return BattleMessage::GetItemStartMessage2k(*GetSource(), *item);
 			} else {
 				return BattleMessage::GetItemStartMessage2k3(*GetSource(), *item);
@@ -1096,7 +1096,7 @@ std::string Game_BattleAlgorithm::Skill::GetStartMessage(int line) const {
 
 	const auto* target = GetOriginalSingleTarget();
 	if (line == 0) {
-		if (Player::IsRPG2k()) {
+		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
 			if (!skill.using_message1.empty()) {
 				return BattleMessage::GetSkillFirstStartMessage2k(*GetSource(), target, skill);
 			} else {
@@ -1106,7 +1106,7 @@ std::string Game_BattleAlgorithm::Skill::GetStartMessage(int line) const {
 			return BattleMessage::GetSkillStartMessage2k3(*GetSource(), target, skill);
 		}
 	}
-	if (line == 1 && Player::IsRPG2k() && !skill.using_message2.empty()) {
+	if (line == 1 && (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) && !skill.using_message2.empty()) {
 		return BattleMessage::GetSkillSecondStartMessage2k(*GetSource(), target, skill);
 	}
 	return "";
@@ -1261,7 +1261,7 @@ bool Game_BattleAlgorithm::Item::vExecute() {
 
 std::string Game_BattleAlgorithm::Item::GetStartMessage(int line) const {
 	if (line == 0) {
-		if (Player::IsRPG2k()) {
+		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
 			return BattleMessage::GetItemStartMessage2k(*GetSource(), item);
 		} else {
 			return BattleMessage::GetItemStartMessage2k3(*GetSource(), item);
@@ -1303,7 +1303,7 @@ Game_BattleAlgorithm::Defend::Defend(Game_Battler* source) :
 
 std::string Game_BattleAlgorithm::Defend::GetStartMessage(int line) const {
 	if (line == 0) {
-		if (Player::IsRPG2k()) {
+		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
 			return BattleMessage::GetDefendStartMessage2k(*GetSource());
 		} else if (GetSource()->GetType() == Game_Battler::Type_Enemy) {
 			return BattleMessage::GetDefendStartMessage2k3(*GetSource());
@@ -1323,7 +1323,7 @@ AlgorithmBase(Type::Observe, source, source) {
 
 std::string Game_BattleAlgorithm::Observe::GetStartMessage(int line) const {
 	if (line == 0) {
-		if (Player::IsRPG2k()) {
+		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
 			return BattleMessage::GetObserveStartMessage2k(*GetSource());
 		} else if (GetSource()->GetType() == Game_Battler::Type_Enemy) {
 			return BattleMessage::GetObserveStartMessage2k3(*GetSource());
@@ -1339,7 +1339,7 @@ AlgorithmBase(Type::Charge, source, source) {
 
 std::string Game_BattleAlgorithm::Charge::GetStartMessage(int line) const {
 	if (line == 0) {
-		if (Player::IsRPG2k()) {
+		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
 			return BattleMessage::GetChargeUpStartMessage2k(*GetSource());
 		} else if (GetSource()->GetType() == Game_Battler::Type_Enemy) {
 			return BattleMessage::GetChargeUpStartMessage2k3(*GetSource());
@@ -1359,7 +1359,7 @@ AlgorithmBase(Type::SelfDestruct, source, target) {
 
 std::string Game_BattleAlgorithm::SelfDestruct::GetStartMessage(int line) const {
 	if (line == 0) {
-		if (Player::IsRPG2k()) {
+		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
 			return BattleMessage::GetSelfDestructStartMessage2k(*GetSource());
 		} else if (GetSource()->GetType() == Game_Battler::Type_Enemy) {
 			return BattleMessage::GetSelfDestructStartMessage2k3(*GetSource());
@@ -1413,7 +1413,7 @@ Game_BattleAlgorithm::Escape::Escape(Game_Battler* source) :
 
 std::string Game_BattleAlgorithm::Escape::GetStartMessage(int line) const {
 	if (line == 0) {
-		if (Player::IsRPG2k()) {
+		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
 			return BattleMessage::GetEscapeStartMessage2k(*GetSource());
 		} else if (GetSource()->GetType() == Game_Battler::Type_Enemy) {
 			return BattleMessage::GetEscapeStartMessage2k3(*GetSource());
@@ -1449,7 +1449,7 @@ AlgorithmBase(Type::Transform, source, source), new_monster_id(new_monster_id) {
 }
 
 std::string Game_BattleAlgorithm::Transform::GetStartMessage(int line) const {
-	if (line == 0 && Player::IsRPG2k()) {
+	if (line == 0 && (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system)) {
 		auto* enemy = lcf::ReaderUtil::GetElement(lcf::Data::enemies, new_monster_id);
 		return BattleMessage::GetTransformStartMessage(*GetSource(), *enemy);
 	}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -1072,15 +1072,17 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 	int to_hit_attribute_shift = (skill.easyrpg_attribute_hit != -1 ? skill.easyrpg_attribute_hit : to_hit);
 	if (skill.affect_attr_defence) {
 		auto shift = IsPositive() ? 1 : -1;
-		for (int i = 0; i < static_cast<int>(skill.attribute_effects.size()); i++) {
-			auto id = i + 1;
-			if (skill.attribute_effects[i]
-					&& GetTarget()->CanShiftAttributeRate(id, shift)
-					&& Rand::PercentChance(to_hit_attribute_shift)
-					)
-			{
-				AddAffectedAttribute({ id, shift});
-				SetIsSuccess();
+		if (shift >= 0 || !GetTarget()->IsImmuneToAttributeDownshifts()) {
+			for (int i = 0; i < static_cast<int>(skill.attribute_effects.size()); i++) {
+				auto id = i + 1;
+				if (skill.attribute_effects[i]
+						&& GetTarget()->CanShiftAttributeRate(id, shift)
+						&& Rand::PercentChance(to_hit_attribute_shift)
+						)
+				{
+					AddAffectedAttribute({ id, shift});
+					SetIsSuccess();
+				}
 			}
 		}
 	}

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -870,6 +870,7 @@ bool Game_BattleAlgorithm::Skill::vStart() {
 		Main_Data::game_party->ConsumeItemUse(item->ID);
 	} else {
 		source->ChangeSp(-source->CalculateSkillCost(skill.ID));
+		source->ChangeHp(-source->CalculateSkillHpCost(skill.ID), false);
 	}
 	return true;
 }
@@ -952,7 +953,8 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 			? effect
 			: Algo::AdjustDamageForDefend(effect, *target);
 
-		const auto cur_hp = target->GetHp();
+		const auto hp_cost = (source == target) ? source->CalculateSkillHpCost(skill.ID) : 0;
+		const auto cur_hp = target->GetHp() - hp_cost;
 
 		if (absorb) {
 			// Cannot aborb more hp than the target has.

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -655,6 +655,27 @@ bool Game_BattleAlgorithm::Normal::vExecute() {
 	// Conditions healed by physical attack:
 	BattlePhysicalStateHeal(100, target_states, target_perm_states);
 
+	auto easyrpg_state_set = [&](const auto& state_set, const auto& state_chance) {
+		int num_states = static_cast<int>(state_set.size());
+		for (int i = 0; i < num_states; ++i) {
+			int inflict_pct = 0;
+			if (i < static_cast<int>(num_states) && state_set[i]) {
+				inflict_pct = static_cast<int>(state_chance);
+			}
+			auto state_id = (i + 1);
+
+			if (inflict_pct > 0) {
+				inflict_pct = inflict_pct * target.GetStateProbability(state_id) / 100;
+				if (Rand::PercentChance(inflict_pct)) {
+					if (!State::Has(state_id, target_states) && State::Add(state_id, target_states, target_perm_states, true)) {
+						AddAffectedState(StateEffect{state_id, StateEffect::Inflicted});
+					}
+				}
+				inflict_pct = 0;
+			}
+		}
+	};
+
 	// Conditions caused / healed by weapon.
 	if (source.GetType() == Game_Battler::Type_Ally) {
 		auto& ally = static_cast<Game_Actor&>(source);
@@ -708,46 +729,12 @@ bool Game_BattleAlgorithm::Normal::vExecute() {
 			}
 		} else {
 			lcf::rpg::Actor* allydata = lcf::ReaderUtil::GetElement(lcf::Data::actors, ally.GetId());
-			int num_states = allydata->easyrpg_unarmed_state_set.size();
-			for (int i = 0; i < num_states; ++i) {
-				int inflict_pct = 0;
-				if (i < static_cast<int>(allydata->easyrpg_unarmed_state_set.size()) && allydata->easyrpg_unarmed_state_set[i]) {
-					inflict_pct = static_cast<int>(allydata->easyrpg_unarmed_state_chance);
-				}
-				auto state_id = (i + 1);
-
-				if (inflict_pct > 0) {
-					inflict_pct = inflict_pct * target.GetStateProbability(state_id) / 100;
-					if (Rand::PercentChance(inflict_pct)) {
-						if (!State::Has(state_id, target_states) && State::Add(state_id, target_states, target_perm_states, true)) {
-							AddAffectedState(StateEffect{state_id, StateEffect::Inflicted});
-						}
-					}
-					inflict_pct = 0;
-				}
-			}
+			easyrpg_state_set(allydata->easyrpg_unarmed_state_set, allydata->easyrpg_unarmed_state_chance);
 		}
 	} else if (source.GetType() == Game_Battler::Type_Enemy) {
 		auto& enemy = static_cast<Game_Enemy&>(source);
 		lcf::rpg::Enemy* enemydata = lcf::ReaderUtil::GetElement(lcf::Data::enemies, enemy.GetId());
-		int num_states = enemydata->easyrpg_state_set.size();
-		for (int i = 0; i < num_states; ++i) {
-			int inflict_pct = 0;
-			if (i < static_cast<int>(enemydata->easyrpg_state_set.size()) && enemydata->easyrpg_state_set[i]) {
-				inflict_pct = static_cast<int>(enemydata->easyrpg_state_chance);
-			}
-			auto state_id = (i + 1);
-
-			if (inflict_pct > 0) {
-				inflict_pct = inflict_pct * target.GetStateProbability(state_id) / 100;
-				if (Rand::PercentChance(inflict_pct)) {
-					if (!State::Has(state_id, target_states) && State::Add(state_id, target_states, target_perm_states, true)) {
-						AddAffectedState(StateEffect{state_id, StateEffect::Inflicted});
-					}
-				}
-				inflict_pct = 0;
-			}
-		}
+		easyrpg_state_set(enemydata->easyrpg_state_set, enemydata->easyrpg_state_chance);
 	}
 
 	return SetIsSuccess();

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -705,6 +705,47 @@ bool Game_BattleAlgorithm::Normal::vExecute() {
 					}
 				}
 			}
+		} else {
+			lcf::rpg::Actor* allydata = lcf::ReaderUtil::GetElement(lcf::Data::actors, ally.GetId());
+			int num_states = allydata->easyrpg_unarmed_state_set.size();
+			for (int i = 0; i < num_states; ++i) {
+				int inflict_pct = 0;
+				if (i < static_cast<int>(allydata->easyrpg_unarmed_state_set.size()) && allydata->easyrpg_unarmed_state_set[i]) {
+					inflict_pct = static_cast<int>(allydata->easyrpg_unarmed_state_chance);
+				}
+				auto state_id = (i + 1);
+
+				if (inflict_pct > 0) {
+					inflict_pct = inflict_pct * target.GetStateProbability(state_id) / 100;
+					if (Rand::PercentChance(inflict_pct)) {
+						if (!State::Has(state_id, target_states) && State::Add(state_id, target_states, target_perm_states, true)) {
+							AddAffectedState(StateEffect{state_id, StateEffect::Inflicted});
+						}
+					}
+					inflict_pct = 0;
+				}
+			}
+		}
+	} else if (source.GetType() == Game_Battler::Type_Enemy) {
+		auto& enemy = static_cast<Game_Enemy&>(source);
+		lcf::rpg::Enemy* enemydata = lcf::ReaderUtil::GetElement(lcf::Data::enemies, enemy.GetId());
+		int num_states = enemydata->easyrpg_state_set.size();
+		for (int i = 0; i < num_states; ++i) {
+			int inflict_pct = 0;
+			if (i < static_cast<int>(enemydata->easyrpg_state_set.size()) && enemydata->easyrpg_state_set[i]) {
+				inflict_pct = static_cast<int>(enemydata->easyrpg_state_chance);
+			}
+			auto state_id = (i + 1);
+
+			if (inflict_pct > 0) {
+				inflict_pct = inflict_pct * target.GetStateProbability(state_id) / 100;
+				if (Rand::PercentChance(inflict_pct)) {
+					if (!State::Has(state_id, target_states) && State::Add(state_id, target_states, target_perm_states, true)) {
+						AddAffectedState(StateEffect{state_id, StateEffect::Inflicted});
+					}
+				}
+				inflict_pct = 0;
+			}
 		}
 	}
 

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -624,7 +624,7 @@ bool Game_BattleAlgorithm::Normal::vExecute() {
 	auto& target = *GetTarget();
 
 	auto to_hit = Algo::CalcNormalAttackToHit(source, target, weapon, Game_Battle::GetBattleCondition(), true);
-	auto crit_chance = Algo::CalcCriticalHitChance(source, target, weapon);
+	auto crit_chance = Algo::CalcCriticalHitChance(source, target, weapon, -1);
 
 	// Damage calculation
 	if (!Rand::PercentChance(to_hit)) {
@@ -875,7 +875,13 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 	SetIsPositive(Algo::SkillTargetsAllies(skill));
 
 	auto to_hit = Algo::CalcSkillToHit(*source, *target, skill);
-	auto effect = Algo::CalcSkillEffect(*source, *target, skill, true);
+	auto crit_chance = Algo::CalcCriticalHitChance(*source, *target, Game_Battler::WeaponAll, skill.easyrpg_critical_hit_chance);
+
+	if (Rand::PercentChance(crit_chance)) {
+		SetIsCriticalHit(true);
+	}
+
+	auto effect = Algo::CalcSkillEffect(*source, *target, skill, true, IsCriticalHit());
 	effect = Utils::Clamp(effect, -MaxDamageValue(), MaxDamageValue());
 
 	if (!IsPositive()) {

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -125,7 +125,7 @@ bool Game_Battler::IsSkillUsable(int skill_id) const {
 		return false;
 	}
 
-	if (CalculateSkillCost(skill_id) > GetSp()) {
+	if (CalculateSkillCost(skill_id) > GetSp() || CalculateSkillHpCost(skill_id) >= GetHp()) {
 		return false;
 	}
 
@@ -315,6 +315,15 @@ int Game_Battler::CalculateSkillCost(int skill_id) const {
 		return 0;
 	}
 	return Algo::CalcSkillCost(*skill, GetMaxSp(), false);
+}
+
+int Game_Battler::CalculateSkillHpCost(int skill_id) const {
+	const lcf::rpg::Skill* skill = lcf::ReaderUtil::GetElement(lcf::Data::skills, skill_id);
+	if (!skill) {
+		Output::Warning("CalculateSkillHpCost: Invalid skill ID {}", skill_id);
+		return 0;
+	}
+	return Algo::CalcSkillHpCost(*skill, GetMaxHp());
 }
 
 bool Game_Battler::AddState(int state_id, bool allow_battle_states) {

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -237,7 +237,7 @@ bool Game_Battler::UseSkill(int skill_id, const Game_Battler* source) {
 		}
 
 		// Calculate effect:
-		auto effect = Algo::CalcSkillEffect(*source, *this, *skill, true);
+		auto effect = Algo::CalcSkillEffect(*source, *this, *skill, true, false);
 
 		// Negative attributes do damage but cannot kill
 		bool negative_effect = false;

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -711,6 +711,11 @@ public:
 	 */
 	virtual bool HasAttackAll(Weapon weapon = WeaponAll) const;
 
+	/**
+	 * @return If the battler is protected against critical hits.
+	 */
+	virtual bool PreventsCritical() const = 0;
+
 
 	enum BattlerType {
 		Type_Ally,

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -716,6 +716,11 @@ public:
 	 */
 	virtual bool PreventsCritical() const = 0;
 
+	/**
+	 * @return If the battler has an increased physical evasion rate.
+	 */
+	virtual bool HasPhysicalEvasionUp() const = 0;
+
 
 	enum BattlerType {
 		Type_Ally,

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -491,6 +491,14 @@ public:
 	virtual int CalculateSkillCost(int skill_id) const;
 
 	/**
+	 * Calculates the Skill hp costs including all modifiers.
+	 *
+	 * @param skill_id ID of skill to calculate.
+	 * @return needed skill hp cost.
+	 */
+	virtual int CalculateSkillHpCost(int skill_id) const;
+
+	/**
 	 * Calculates the Sp cost for attacking with a weapon.
 	 *
 	 * @param weapon which weapons to include in calculating result.

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -214,6 +214,13 @@ public:
 	int GetAttributeRateShift(int attribute_id) const;
 
 	/**
+	 * Checks if the battler is immune to attribute downshifts.
+	 *
+	 * @return if the battler is immune to attribute downshifts.
+	 */
+	virtual bool IsImmuneToAttributeDownshifts() const = 0;
+
+	/**
 	 * Gets probability that a state can be inflicted on this actor.
 	 *
 	 * @param state_id State to test

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -719,6 +719,14 @@ public:
 	virtual bool HasAttackAll(Weapon weapon = WeaponAll) const;
 
 	/**
+	 * Tests if the battler has a weapon which ignores evasion.
+	 *
+	 * @param weapon Which weapons to include in calculating result.
+	 * @return If the actor has weapon that ignores evasion
+	 */
+	virtual bool AttackIgnoresEvasion(Weapon weapon = WeaponAll) const = 0;
+
+	/**
 	 * @return If the battler is protected against critical hits.
 	 */
 	virtual bool PreventsCritical() const = 0;

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -724,7 +724,7 @@ public:
 	 * @param weapon Which weapons to include in calculating result.
 	 * @return true if a weapon is having attack all attribute
 	 */
-	virtual bool HasAttackAll(Weapon weapon = WeaponAll) const;
+	virtual bool HasAttackAll(Weapon weapon = WeaponAll) const = 0;
 
 	/**
 	 * Tests if the battler has a weapon which ignores evasion.

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -144,7 +144,11 @@ void Game_Enemy::Transform(int new_enemy_id) {
 }
 
 int Game_Enemy::GetHitChance(Weapon) const {
-	return enemy->miss ? 70 : 90;
+	if (enemy->easyrpg_hit != -1) {
+		return enemy->easyrpg_hit;
+	} else {
+		return enemy->miss ? 70 : 90;
+	}
 }
 
 float Game_Enemy::GetCriticalHitChance(Weapon) const {

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -151,6 +151,10 @@ float Game_Enemy::GetCriticalHitChance(Weapon) const {
 	return enemy->critical_hit ? (1.0f / enemy->critical_hit_chance) : 0.0f;
 }
 
+bool Game_Enemy::AttackIgnoresEvasion(Weapon weapon) const {
+	return enemy->easyrpg_ignore_evasion;
+}
+
 bool Game_Enemy::PreventsCritical() const {
 	return enemy->easyrpg_prevent_critical;
 }

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -155,6 +155,10 @@ float Game_Enemy::GetCriticalHitChance(Weapon) const {
 	return enemy->critical_hit ? (1.0f / enemy->critical_hit_chance) : 0.0f;
 }
 
+bool Game_Enemy::HasAttackAll(Weapon weapon) const {
+	return enemy->easyrpg_attack_all;
+}
+
 bool Game_Enemy::AttackIgnoresEvasion(Weapon weapon) const {
 	return enemy->easyrpg_ignore_evasion;
 }

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -147,6 +147,10 @@ float Game_Enemy::GetCriticalHitChance(Weapon) const {
 	return enemy->critical_hit ? (1.0f / enemy->critical_hit_chance) : 0.0f;
 }
 
+bool Game_Enemy::PreventsCritical() const {
+	return enemy->easyrpg_prevent_critical;
+}
+
 int Game_Enemy::GetFlyingOffset() const {
 	// 2k does not support flying, albeit mentioned in the help file
 	if (!Player::IsRPG2k3() || !IsFlying()) {

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -100,6 +100,10 @@ int Game_Enemy::GetBaseAttributeRate(int attribute_id) const {
 	return rate;
 }
 
+bool Game_Enemy::IsImmuneToAttributeDownshifts() const {
+	return enemy->easyrpg_immune_to_attribute_downshifts;
+}
+
 int Game_Enemy::SetHp(int _hp) {
 	hp = Utils::Clamp(_hp, 0, GetMaxHp());
 	return hp;

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -151,6 +151,10 @@ bool Game_Enemy::PreventsCritical() const {
 	return enemy->easyrpg_prevent_critical;
 }
 
+bool Game_Enemy::HasPhysicalEvasionUp() const {
+	return enemy->easyrpg_raise_evasion;
+}
+
 int Game_Enemy::GetFlyingOffset() const {
 	// 2k does not support flying, albeit mentioned in the help file
 	if (!Player::IsRPG2k3() || !IsFlying()) {

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -166,6 +166,11 @@ public:
 	 */
 	bool PreventsCritical() const override;
 
+	/**
+	 * @return If the enemy has an increased physical evasion rate.
+	 */
+	bool HasPhysicalEvasionUp() const override;
+
 	int GetBattleAnimationId() const override;
 
 	int GetExp() const;

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -66,6 +66,13 @@ public:
 	int GetBaseAttributeRate(int attribute_id) const override;
 
 	/**
+	 * Checks if the enemy is immune to attribute downshifts.
+	 *
+	 * @return if the enemy is immune to attribute downshifts.
+	 */
+	bool IsImmuneToAttributeDownshifts() const override;
+
+	/**
 	 * Gets the enemy ID.
 	 *
 	 * @return Enemy ID

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -160,6 +160,12 @@ public:
 	 * @return hit rate. [0-100]
 	 */
 	float GetCriticalHitChance(Weapon = WeaponAll) const override;
+
+	/**
+	 * @return If the enemy is protected against critical hits.
+	 */
+	bool PreventsCritical() const override;
+
 	int GetBattleAnimationId() const override;
 
 	int GetExp() const;

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -395,7 +395,7 @@ inline bool Game_Enemy::IsFlying() const {
 }
 
 inline int Game_Enemy::GetUnarmedBattleAnimationId() const {
-        return (Player::IsPatchManiac() ? enemy->maniac_unarmed_animation : 1);
+	return enemy->maniac_unarmed_animation;
 }
 
 inline Sprite_Enemy* Game_Enemy::GetEnemyBattleSprite() const {

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -169,6 +169,14 @@ public:
 	float GetCriticalHitChance(Weapon = WeaponAll) const override;
 
 	/**
+	 * Tests if the enemy has a weapon that grants attack all
+	 *
+	 * @param weapon Which weapons to include in calculating result.
+	 * @return true if a weapon is having attack all attribute
+	 */
+	bool HasAttackAll(Weapon weapon = WeaponAll) const override;
+
+	/**
 	 * Tests if the enemy has a weapon which ignores evasion.
 	 *
 	 * @param weapon Which weapons to include in calculating result.

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -258,6 +258,15 @@ public:
 
 	Sprite_Enemy* GetEnemyBattleSprite() const;
 
+	int GetEnemyAi() const;
+
+	/**
+	 * Checks if the enemies defense skill is stronger the usual.
+	 *
+	 * @return true if strong defense
+	 */
+	bool HasStrongDefense() const override;
+
 protected:
 	const lcf::rpg::Enemy* enemy = nullptr;
 	const lcf::rpg::TroopMember* troop_member = nullptr;
@@ -402,5 +411,9 @@ inline Sprite_Enemy* Game_Enemy::GetEnemyBattleSprite() const {
 	return static_cast<Sprite_Enemy*>(Game_Battler::GetBattleSprite());
 }
 
+
+inline bool Game_Enemy::HasStrongDefense() const {
+	return enemy->easyrpg_super_guard;
+}
 
 #endif

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -169,6 +169,14 @@ public:
 	float GetCriticalHitChance(Weapon = WeaponAll) const override;
 
 	/**
+	 * Tests if the enemy has a weapon which ignores evasion.
+	 *
+	 * @param weapon Which weapons to include in calculating result.
+	 * @return If the actor has weapon that ignores evasion
+	 */
+	bool AttackIgnoresEvasion(Weapon weapon = WeaponAll) const override;
+
+	/**
 	 * @return If the enemy is protected against critical hits.
 	 */
 	bool PreventsCritical() const override;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -51,6 +51,7 @@
 #include <lcf/scope_guard.h>
 #include <lcf/rpg/save.h>
 #include "scene_gameover.h"
+#include "feature.h"
 
 namespace {
 	lcf::rpg::SaveMapInfo map_info;
@@ -1271,7 +1272,7 @@ bool Game_Map::PrepareEncounter(BattleArgs& args) {
 
 	args.troop_id = encounters[Rand::GetRandomNumber(0, encounters.size() - 1)];
 
-	if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+	if (Feature::HasRpg2kBattleSystem()) {
 		if (Rand::ChanceOf(1, 32)) {
 			args.first_strike = true;
 		}

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1271,7 +1271,7 @@ bool Game_Map::PrepareEncounter(BattleArgs& args) {
 
 	args.troop_id = encounters[Rand::GetRandomNumber(0, encounters.size() - 1)];
 
-	if (Player::IsRPG2k()) {
+	if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
 		if (Rand::ChanceOf(1, 32)) {
 			args.first_strike = true;
 		}

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -30,6 +30,7 @@
 #include <lcf/data.h>
 #include <lcf/reader_util.h>
 #include "output.h"
+#include "feature.h"
 
 #include <cctype>
 
@@ -45,7 +46,7 @@ Window_Message* Game_Message::GetWindow() {
 
 int Game_Message::GetRealPosition() {
 	if (Game_Battle::IsBattleRunning()) {
-		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+		if (Feature::HasRpg2kBattleSystem()) {
 			return 2;
 		}
 		else {

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -45,7 +45,7 @@ Window_Message* Game_Message::GetWindow() {
 
 int Game_Message::GetRealPosition() {
 	if (Game_Battle::IsBattleRunning()) {
-		if (Player::IsRPG2k()) {
+		if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
 			return 2;
 		}
 		else {

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -451,6 +451,7 @@ bool Game_Party::UseSkill(int skill_id, Game_Actor* source, Game_Actor* target) 
 
 	if (was_used) {
 		source->SetSp(source->GetSp() - source->CalculateSkillCost(skill_id));
+		source->SetHp(source->GetHp() - source->CalculateSkillHpCost(skill_id));
 	}
 
 	return was_used;

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -40,6 +40,7 @@
 #include <lcf/rpg/savetarget.h>
 #include <algorithm>
 #include <cmath>
+#include "scene_gameover.h"
 
 Game_Player::Game_Player(): Game_PlayerBase(Player)
 {
@@ -632,7 +633,18 @@ bool Game_Player::Move(int dir) {
 					if (terrain->damage > 0) {
 						red_flash = true;
 					}
-					hero->ChangeHp(-terrain->damage, false);
+					if (terrain->easyrpg_damage_in_percent) {
+						int value = std::max(1, std::abs(hero->GetMaxHp() * terrain->damage / 100));
+						hero->ChangeHp((terrain->damage > 0 ? -value : value), terrain->easyrpg_damage_can_kill);
+					} else {
+						hero->ChangeHp(-terrain->damage, terrain->easyrpg_damage_can_kill);
+					}
+				}
+			}
+			if (terrain->damage > 0 && terrain->easyrpg_damage_can_kill) {
+				if (!Main_Data::game_party->IsAnyActive() && Main_Data::game_party->GetBattlerCount() > 0) {
+					Scene::instance->SetRequestedScene(std::make_shared<Scene_Gameover>());
+					return true;
 				}
 			}
 		}

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -35,6 +35,7 @@
 #include "scene_map.h"
 #include "utils.h"
 #include "audio_secache.h"
+#include "feature.h"
 
 Game_System::Game_System()
 	: dbsys(&lcf::Data::system)
@@ -578,7 +579,7 @@ void Game_System::OnSeReady(FileRequestResult* result, lcf::rpg::Sound se, bool 
 }
 
 bool Game_System::IsMessageTransparent() {
-	if ((Player::IsRPG2k() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system)) && Game_Battle::IsBattleRunning()) {
+	if (Feature::HasRpg2kBattleSystem() && Game_Battle::IsBattleRunning()) {
 		return false;
 	}
 

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -578,7 +578,7 @@ void Game_System::OnSeReady(FileRequestResult* result, lcf::rpg::Sound se, bool 
 }
 
 bool Game_System::IsMessageTransparent() {
-	if (Player::IsRPG2k() && Game_Battle::IsBattleRunning()) {
+	if ((Player::IsRPG2k() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system)) && Game_Battle::IsBattleRunning()) {
 		return false;
 	}
 

--- a/src/scene_actortarget.cpp
+++ b/src/scene_actortarget.cpp
@@ -153,7 +153,7 @@ void Scene_ActorTarget::UpdateSkill() {
 	if (Input::IsTriggered(Input::DECISION)) {
 		Game_Actor* actor = &(*Main_Data::game_party)[actor_index];
 
-		if (actor->GetSp() < actor->CalculateSkillCost(id)) {
+		if (actor->GetSp() < actor->CalculateSkillCost(id) || actor->GetHp() <= actor->CalculateSkillHpCost(id)) {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 			return;
 		}

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -473,7 +473,7 @@ void Scene_Battle::AssignSkill(const lcf::rpg::Skill* skill, const lcf::rpg::Ite
 
 std::shared_ptr<Scene_Battle> Scene_Battle::Create(const BattleArgs& args)
 {
-	if (Player::IsRPG2k()) {
+	if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
 		return std::make_shared<Scene_Battle_Rpg2k>(args);
 	}
 	else {

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -45,6 +45,7 @@
 #include "rand.h"
 #include "autobattle.h"
 #include "enemyai.h"
+#include "feature.h"
 
 Scene_Battle::Scene_Battle(const BattleArgs& args)
 	: troop_id(args.troop_id),
@@ -473,7 +474,7 @@ void Scene_Battle::AssignSkill(const lcf::rpg::Skill* skill, const lcf::rpg::Ite
 
 std::shared_ptr<Scene_Battle> Scene_Battle::Create(const BattleArgs& args)
 {
-	if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+	if (Feature::HasRpg2kBattleSystem()) {
 		return std::make_shared<Scene_Battle_Rpg2k>(args);
 	}
 	else {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -41,6 +41,7 @@
 #include "autobattle.h"
 #include "enemyai.h"
 #include "battle_message.h"
+#include "feature.h"
 
 Scene_Battle_Rpg2k::Scene_Battle_Rpg2k(const BattleArgs& args) :
 	Scene_Battle(args)
@@ -780,7 +781,7 @@ Scene_Battle_Rpg2k::SceneActionReturn Scene_Battle_Rpg2k::ProcessSceneActionVict
 		auto pm = PendingMessage();
 		pm.SetEnableFace(false);
 
-		pm.SetWordWrapped(Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings));
+		pm.SetWordWrapped(Feature::HasPlaceholders());
 		pm.PushLine(ToString(lcf::Data::terms.victory) + Player::escape_symbol + "|");
 
 		std::stringstream ss;
@@ -837,7 +838,7 @@ Scene_Battle_Rpg2k::SceneActionReturn Scene_Battle_Rpg2k::ProcessSceneActionDefe
 		auto pm = PendingMessage();
 		pm.SetEnableFace(false);
 
-		pm.SetWordWrapped(Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings));
+		pm.SetWordWrapped(Feature::HasPlaceholders());
 
 		pm.PushLine(ToString(lcf::Data::terms.defeat));
 
@@ -1825,7 +1826,7 @@ bool Scene_Battle_Rpg2k::CheckWait() {
 }
 
 void Scene_Battle_Rpg2k::PushExperienceGainedMessage(PendingMessage& pm, int exp) {
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		pm.PushLine(
 			Utils::ReplacePlaceholders(
 				lcf::Data::terms.exp_received,
@@ -1843,7 +1844,7 @@ void Scene_Battle_Rpg2k::PushExperienceGainedMessage(PendingMessage& pm, int exp
 
 void Scene_Battle_Rpg2k::PushGoldReceivedMessage(PendingMessage& pm, int money) {
 
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		pm.PushLine(
 			Utils::ReplacePlaceholders(
 				lcf::Data::terms.gold_recieved_a,
@@ -1867,7 +1868,7 @@ void Scene_Battle_Rpg2k::PushItemRecievedMessages(PendingMessage& pm, std::vecto
 		// No Output::Warning needed here, reported later when the item is added
 		StringView item_name = item ? StringView(item->name) : StringView("??? BAD ITEM ???");
 
-		if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+		if (Feature::HasPlaceholders()) {
 			pm.PushLine(
 				Utils::ReplacePlaceholders(
 					lcf::Data::terms.item_recieved,

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -780,7 +780,7 @@ Scene_Battle_Rpg2k::SceneActionReturn Scene_Battle_Rpg2k::ProcessSceneActionVict
 		auto pm = PendingMessage();
 		pm.SetEnableFace(false);
 
-		pm.SetWordWrapped(Player::IsRPG2kE());
+		pm.SetWordWrapped(Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings));
 		pm.PushLine(ToString(lcf::Data::terms.victory) + Player::escape_symbol + "|");
 
 		std::stringstream ss;
@@ -837,7 +837,7 @@ Scene_Battle_Rpg2k::SceneActionReturn Scene_Battle_Rpg2k::ProcessSceneActionDefe
 		auto pm = PendingMessage();
 		pm.SetEnableFace(false);
 
-		pm.SetWordWrapped(Player::IsRPG2kE());
+		pm.SetWordWrapped(Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings));
 
 		pm.PushLine(ToString(lcf::Data::terms.defeat));
 
@@ -1822,7 +1822,7 @@ bool Scene_Battle_Rpg2k::CheckWait() {
 }
 
 void Scene_Battle_Rpg2k::PushExperienceGainedMessage(PendingMessage& pm, int exp) {
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		pm.PushLine(
 			Utils::ReplacePlaceholders(
 				lcf::Data::terms.exp_received,
@@ -1840,7 +1840,7 @@ void Scene_Battle_Rpg2k::PushExperienceGainedMessage(PendingMessage& pm, int exp
 
 void Scene_Battle_Rpg2k::PushGoldReceivedMessage(PendingMessage& pm, int money) {
 
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		pm.PushLine(
 			Utils::ReplacePlaceholders(
 				lcf::Data::terms.gold_recieved_a,
@@ -1864,7 +1864,7 @@ void Scene_Battle_Rpg2k::PushItemRecievedMessages(PendingMessage& pm, std::vecto
 		// No Output::Warning needed here, reported later when the item is added
 		StringView item_name = item ? StringView(item->name) : StringView("??? BAD ITEM ???");
 
-		if (Player::IsRPG2kE()) {
+		if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 			pm.PushLine(
 				Utils::ReplacePlaceholders(
 					lcf::Data::terms.item_recieved,

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -1144,8 +1144,11 @@ Scene_Battle_Rpg2k::BattleActionReturn Scene_Battle_Rpg2k::ProcessBattleActionAn
 Scene_Battle_Rpg2k::BattleActionReturn Scene_Battle_Rpg2k::ProcessBattleActionExecute(Game_BattleAlgorithm::AlgorithmBase* action) {
 	action->Execute();
 	if (action->GetType() == Game_BattleAlgorithm::Type::Normal
+			|| action->GetType() == Game_BattleAlgorithm::Type::Skill
 			|| action->GetType() == Game_BattleAlgorithm::Type::SelfDestruct) {
-		SetWait(4,4);
+		if (action->GetType() != Game_BattleAlgorithm::Type::Skill) {
+			SetWait(4,4);
+		}
 		if (action->IsSuccess() && action->IsCriticalHit()) {
 			SetBattleActionState(BattleActionState_Critical);
 			return BattleActionReturn::eContinue;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -592,7 +592,7 @@ std::vector<std::string> Scene_Battle_Rpg2k3::GetBattleCommandNames(const Game_A
 			commands.push_back(ToString(cmd->name));
 		}
 	}
-	if (lcf::Data::battlecommands.easyrpg_enable_battle_row_command) {
+	if (lcf::Data::battlecommands.easyrpg_enable_battle_row_command && !lcf::Data::battlecommands.easyrpg_disable_row_feature) {
 		commands.push_back(ToString(lcf::Data::terms.row));
 	}
 
@@ -1356,7 +1356,7 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionCo
 		if (Input::IsTriggered(Input::DECISION)) {
 			int index = command_window->GetIndex();
 			// Row command always uses the last index
-			if (!lcf::Data::battlecommands.easyrpg_enable_battle_row_command || index < command_window->GetRowMax() - 1) {
+			if (!lcf::Data::battlecommands.easyrpg_enable_battle_row_command || lcf::Data::battlecommands.easyrpg_disable_row_feature || index < command_window->GetRowMax() - 1) {
 				const auto* command = active_actor->GetBattleCommand(index);
 
 				if (command) {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -49,6 +49,7 @@
 #include "enemyai.h"
 #include <algorithm>
 #include <memory>
+#include "feature.h"
 
 Scene_Battle_Rpg2k3::Scene_Battle_Rpg2k3(const BattleArgs& args) :
 	Scene_Battle(args),
@@ -592,7 +593,7 @@ std::vector<std::string> Scene_Battle_Rpg2k3::GetBattleCommandNames(const Game_A
 			commands.push_back(ToString(cmd->name));
 		}
 	}
-	if (lcf::Data::battlecommands.easyrpg_enable_battle_row_command && !lcf::Data::battlecommands.easyrpg_disable_row_feature) {
+	if (Feature::HasRow() && lcf::Data::battlecommands.easyrpg_enable_battle_row_command) {
 		commands.push_back(ToString(lcf::Data::terms.row));
 	}
 
@@ -1356,7 +1357,7 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionCo
 		if (Input::IsTriggered(Input::DECISION)) {
 			int index = command_window->GetIndex();
 			// Row command always uses the last index
-			if (!lcf::Data::battlecommands.easyrpg_enable_battle_row_command || lcf::Data::battlecommands.easyrpg_disable_row_feature || index < command_window->GetRowMax() - 1) {
+			if (!Feature::HasRow() || !lcf::Data::battlecommands.easyrpg_enable_battle_row_command || index < command_window->GetRowMax() - 1) {
 				const auto* command = active_actor->GetBattleCommand(index);
 
 				if (command) {

--- a/src/scene_menu.cpp
+++ b/src/scene_menu.cpp
@@ -84,7 +84,17 @@ void Scene_Menu::CreateCommandWindow() {
 	} else {
 		for (std::vector<int16_t>::iterator it = lcf::Data::system.menu_commands.begin();
 			it != lcf::Data::system.menu_commands.end(); ++it) {
-				command_options.push_back((CommandOptionType)*it);
+				switch (*it) {
+				case Row:
+				case Wait:
+					if (!lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+						command_options.push_back((CommandOptionType)*it);
+					}
+					break;
+				default:
+					command_options.push_back((CommandOptionType)*it);
+					break;
+				}
 		}
 		if (Player::debug_flag) {
 			command_options.push_back(Debug);

--- a/src/scene_menu.cpp
+++ b/src/scene_menu.cpp
@@ -86,6 +86,10 @@ void Scene_Menu::CreateCommandWindow() {
 			it != lcf::Data::system.menu_commands.end(); ++it) {
 				switch (*it) {
 				case Row:
+					if (!lcf::Data::system.easyrpg_use_rpg2k_battle_system && !lcf::Data::battlecommands.easyrpg_disable_row_feature) {
+						command_options.push_back((CommandOptionType)*it);
+					}
+					break;
 				case Wait:
 					if (!lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
 						command_options.push_back((CommandOptionType)*it);

--- a/src/scene_menu.cpp
+++ b/src/scene_menu.cpp
@@ -33,6 +33,7 @@
 #include "scene_save.h"
 #include "scene_status.h"
 #include "bitmap.h"
+#include "feature.h"
 
 Scene_Menu::Scene_Menu(int menu_index) :
 	menu_index(menu_index) {
@@ -86,12 +87,12 @@ void Scene_Menu::CreateCommandWindow() {
 			it != lcf::Data::system.menu_commands.end(); ++it) {
 				switch (*it) {
 				case Row:
-					if (!lcf::Data::system.easyrpg_use_rpg2k_battle_system && !lcf::Data::battlecommands.easyrpg_disable_row_feature) {
+					if (Feature::HasRow()) {
 						command_options.push_back((CommandOptionType)*it);
 					}
 					break;
 				case Wait:
-					if (!lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+					if (Feature::HasRpg2k3BattleSystem()) {
 						command_options.push_back((CommandOptionType)*it);
 					}
 					break;

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -48,6 +48,13 @@ bool Add(int state_id, StateVec& states, const PermanentStates& ps, bool allow_b
 		if (lcf::Data::states[i].priority <= sig_state->priority - 10 && !ps.Has(i + 1)) {
 			states[i] = 0;
 		}
+		if (states[i]) {
+			for (int j = 0; j < (int)lcf::Data::states[i].easyrpg_clear_states.size(); ++j) {
+				if (lcf::Data::states[i].easyrpg_clear_states[j] && !ps.Has(j + 1)) {
+					states[j] = 0;
+				}
+			}
+		}
 	}
 
 	return states[state_id - 1] != 0;

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -49,8 +49,8 @@ bool Add(int state_id, StateVec& states, const PermanentStates& ps, bool allow_b
 			states[i] = 0;
 		}
 		if (states[i]) {
-			for (int j = 0; j < (int)lcf::Data::states[i].easyrpg_clear_states.size(); ++j) {
-				if (lcf::Data::states[i].easyrpg_clear_states[j] && !ps.Has(j + 1)) {
+			for (int j = 0; j < (int)lcf::Data::states[i].easyrpg_immune_states.size(); ++j) {
+				if (lcf::Data::states[i].easyrpg_immune_states[j] && !ps.Has(j + 1)) {
 					states[j] = 0;
 				}
 			}

--- a/src/window_actorinfo.cpp
+++ b/src/window_actorinfo.cpp
@@ -40,9 +40,11 @@ void Window_ActorInfo::Refresh() {
 }
 
 void Window_ActorInfo::DrawInfo() {
-	// Draw Row formation.
-	std::string battle_row = Main_Data::game_actors->GetActor(actor_id)->GetBattleRow() == Game_Actor::RowType::RowType_back ? lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_back, "Back") : lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_front, "Front");
-	contents->TextDraw(contents->GetWidth(), 2, Font::ColorDefault, battle_row, Text::AlignRight);
+	if (!lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+		// Draw Row formation.
+		std::string battle_row = Main_Data::game_actors->GetActor(actor_id)->GetBattleRow() == Game_Actor::RowType::RowType_back ? lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_back, "Back") : lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_front, "Front");
+		contents->TextDraw(contents->GetWidth(), 2, Font::ColorDefault, battle_row, Text::AlignRight);
+	}
 
 	const Game_Actor& actor = *Main_Data::game_actors->GetActor(actor_id);
 

--- a/src/window_actorinfo.cpp
+++ b/src/window_actorinfo.cpp
@@ -23,6 +23,7 @@
 #include "game_party.h"
 #include "bitmap.h"
 #include "font.h"
+#include "feature.h"
 
 Window_ActorInfo::Window_ActorInfo(int ix, int iy, int iwidth, int iheight, int actor_id) :
 	Window_Base(ix, iy, iwidth, iheight),
@@ -40,7 +41,7 @@ void Window_ActorInfo::Refresh() {
 }
 
 void Window_ActorInfo::DrawInfo() {
-	if (!lcf::Data::system.easyrpg_use_rpg2k_battle_system && !lcf::Data::battlecommands.easyrpg_disable_row_feature) {
+	if (Feature::HasRow()) {
 		// Draw Row formation.
 		std::string battle_row = Main_Data::game_actors->GetActor(actor_id)->GetBattleRow() == Game_Actor::RowType::RowType_back ? lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_back, "Back") : lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_front, "Front");
 		contents->TextDraw(contents->GetWidth(), 2, Font::ColorDefault, battle_row, Text::AlignRight);

--- a/src/window_actorinfo.cpp
+++ b/src/window_actorinfo.cpp
@@ -40,7 +40,7 @@ void Window_ActorInfo::Refresh() {
 }
 
 void Window_ActorInfo::DrawInfo() {
-	if (!lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+	if (!lcf::Data::system.easyrpg_use_rpg2k_battle_system && !lcf::Data::battlecommands.easyrpg_disable_row_feature) {
 		// Draw Row formation.
 		std::string battle_row = Main_Data::game_actors->GetActor(actor_id)->GetBattleRow() == Game_Actor::RowType::RowType_back ? lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_back, "Back") : lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_front, "Front");
 		contents->TextDraw(contents->GetWidth(), 2, Font::ColorDefault, battle_row, Text::AlignRight);

--- a/src/window_battlecommand.cpp
+++ b/src/window_battlecommand.cpp
@@ -25,6 +25,7 @@
 #include "game_actors.h"
 #include "window_battlecommand.h"
 #include "bitmap.h"
+#include "feature.h"
 
 Window_BattleCommand::Window_BattleCommand(int x, int y, int width, int height) :
 	Window_Base(x, y, width, height) {
@@ -133,7 +134,7 @@ void Window_BattleCommand::SetIndex(int _index) {
 }
 
 void Window_BattleCommand::SetActor(int _actor_id) {
-	actor_id = (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) ? 0 : _actor_id;
+	actor_id = Feature::HasRpg2kBattleSystem() ? 0 : _actor_id;
 	commands.clear();
 
 	if (actor_id == 0) {

--- a/src/window_battlecommand.cpp
+++ b/src/window_battlecommand.cpp
@@ -133,7 +133,7 @@ void Window_BattleCommand::SetIndex(int _index) {
 }
 
 void Window_BattleCommand::SetActor(int _actor_id) {
-	actor_id = (Player::IsRPG2k()) ? 0 : _actor_id;
+	actor_id = (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) ? 0 : _actor_id;
 	commands.clear();
 
 	if (actor_id == 0) {

--- a/src/window_battlemessage.cpp
+++ b/src/window_battlemessage.cpp
@@ -24,6 +24,7 @@
 #include "font.h"
 #include "utils.h"
 #include "output.h"
+#include "feature.h"
 
 Window_BattleMessage::Window_BattleMessage(int ix, int iy, int iwidth, int iheight) :
 	Window_Base(ix, iy, iwidth, iheight)
@@ -44,7 +45,7 @@ void Window_BattleMessage::Push(StringView message) {
 }
 
 void Window_BattleMessage::PushLine(StringView line) {
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		Game_Message::WordWrap(
 				line,
 				GetWidth() - 20,
@@ -61,7 +62,7 @@ void Window_BattleMessage::PushLine(StringView line) {
 }
 
 void Window_BattleMessage::PushWithSubject(StringView message, StringView subject) {
-	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
+	if (Feature::HasPlaceholders()) {
 		Push(Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S'),

--- a/src/window_battlemessage.cpp
+++ b/src/window_battlemessage.cpp
@@ -44,7 +44,7 @@ void Window_BattleMessage::Push(StringView message) {
 }
 
 void Window_BattleMessage::PushLine(StringView line) {
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		Game_Message::WordWrap(
 				line,
 				GetWidth() - 20,
@@ -61,7 +61,7 @@ void Window_BattleMessage::PushLine(StringView line) {
 }
 
 void Window_BattleMessage::PushWithSubject(StringView message, StringView subject) {
-	if (Player::IsRPG2kE()) {
+	if (Player::IsRPG2kE() || (Player::IsRPG2k3() && lcf::Data::system.easyrpg_use_rpg2k_battle_system && lcf::Data::system.easyrpg_battle_use_rpg2ke_strings)) {
 		Push(Utils::ReplacePlaceholders(
 			message,
 			Utils::MakeArray('S'),

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -89,7 +89,7 @@ void Window_BattleStatus::Refresh() {
 			int y = menu_item_height / 8 + i * menu_item_height;
 
 			DrawActorName(*actor, 4, y);
-			if (Player::IsRPG2k()) {
+			if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
 				int hpdigits = (actor->MaxHpValue() >= 1000) ? 4 : 3;
 				int spdigits = (actor->MaxSpValue() >= 1000) ? 4 : 3;
 				DrawActorState(*actor, (hpdigits < 4 && spdigits < 4) ? 86 : 80, y);
@@ -110,7 +110,7 @@ void Window_BattleStatus::Refresh() {
 }
 
 void Window_BattleStatus::RefreshGauge() {
-	if (Player::IsRPG2k3()) {
+	if (Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
 		if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_alternative) {
 			if (lcf::Data::battlecommands.window_size == lcf::rpg::BattleCommands::WindowSize_small) {
 				contents->ClearRect(Rect(192, 0, 45, 58));
@@ -277,7 +277,7 @@ void Window_BattleStatus::Update() {
 
 	if (item_max != old_item_max) {
 		Refresh();
-	} else if (Player::IsRPG2k3()) {
+	} else if (Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
 		RefreshGauge();
 	}
 

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -29,6 +29,7 @@
 #include "font.h"
 #include "output.h"
 #include "window_battlestatus.h"
+#include "feature.h"
 
 Window_BattleStatus::Window_BattleStatus(int ix, int iy, int iwidth, int iheight, bool enemy) :
 	Window_Selectable(ix, iy, iwidth, iheight), mode(ChoiceMode_All), enemy(enemy) {
@@ -89,7 +90,7 @@ void Window_BattleStatus::Refresh() {
 			int y = menu_item_height / 8 + i * menu_item_height;
 
 			DrawActorName(*actor, 4, y);
-			if (Player::IsRPG2k() || lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+			if (Feature::HasRpg2kBattleSystem()) {
 				int hpdigits = (actor->MaxHpValue() >= 1000) ? 4 : 3;
 				int spdigits = (actor->MaxSpValue() >= 1000) ? 4 : 3;
 				DrawActorState(*actor, (hpdigits < 4 && spdigits < 4) ? 86 : 80, y);
@@ -110,7 +111,7 @@ void Window_BattleStatus::Refresh() {
 }
 
 void Window_BattleStatus::RefreshGauge() {
-	if (Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+	if (Feature::HasRpg2k3BattleSystem()) {
 		if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_alternative) {
 			if (lcf::Data::battlecommands.window_size == lcf::rpg::BattleCommands::WindowSize_small) {
 				contents->ClearRect(Rect(192, 0, 45, 58));
@@ -277,7 +278,7 @@ void Window_BattleStatus::Update() {
 
 	if (item_max != old_item_max) {
 		Refresh();
-	} else if (Player::IsRPG2k3() && !lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+	} else if (Feature::HasRpg2k3BattleSystem()) {
 		RefreshGauge();
 	}
 

--- a/src/window_menustatus.cpp
+++ b/src/window_menustatus.cpp
@@ -21,6 +21,7 @@
 #include "game_party.h"
 #include "player.h"
 #include "bitmap.h"
+#include "feature.h"
 
 Window_MenuStatus::Window_MenuStatus(int ix, int iy, int iwidth, int iheight) :
 	Window_Selectable(ix, iy, iwidth, iheight) {
@@ -48,7 +49,7 @@ void Window_MenuStatus::Refresh() {
 
 		int face_x = 0;
 		if (Player::IsRPG2k3()) {
-			if (lcf::Data::system.easyrpg_use_rpg2k_battle_system || lcf::Data::battlecommands.easyrpg_disable_row_feature) {
+			if (!Feature::HasRow()) {
 				face_x = 4;
 			} else {
 				face_x = actor.GetBattleRow() == Game_Actor::RowType::RowType_back ? 8 : 0;

--- a/src/window_menustatus.cpp
+++ b/src/window_menustatus.cpp
@@ -48,7 +48,7 @@ void Window_MenuStatus::Refresh() {
 
 		int face_x = 0;
 		if (Player::IsRPG2k3()) {
-			if (lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+			if (lcf::Data::system.easyrpg_use_rpg2k_battle_system || lcf::Data::battlecommands.easyrpg_disable_row_feature) {
 				face_x = 4;
 			} else {
 				face_x = actor.GetBattleRow() == Game_Actor::RowType::RowType_back ? 8 : 0;

--- a/src/window_menustatus.cpp
+++ b/src/window_menustatus.cpp
@@ -48,7 +48,11 @@ void Window_MenuStatus::Refresh() {
 
 		int face_x = 0;
 		if (Player::IsRPG2k3()) {
-			face_x = actor.GetBattleRow() == Game_Actor::RowType::RowType_back ? 8 : 0;
+			if (lcf::Data::system.easyrpg_use_rpg2k_battle_system) {
+				face_x = 4;
+			} else {
+				face_x = actor.GetBattleRow() == Game_Actor::RowType::RowType_back ? 8 : 0;
+			}
 		}
 		DrawActorFace(actor, face_x, i*48 + y);
 

--- a/tests/algo.cpp
+++ b/tests/algo.cpp
@@ -430,7 +430,7 @@ TEST_CASE("CritRate") {
 
 		REQUIRE_GT(source.GetCriticalHitChance(), 0.0f);
 
-		REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll));
+		REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll, -1));
 	}
 
 	SUBCASE("enemy -> enemy - always fails") {
@@ -439,7 +439,7 @@ TEST_CASE("CritRate") {
 
 		REQUIRE_GT(source.GetCriticalHitChance(), 0.0f);
 
-		REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll));
+		REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll, -1));
 	}
 
 	SUBCASE("actor -> enemy") {
@@ -449,20 +449,20 @@ TEST_CASE("CritRate") {
 		REQUIRE_GT(source.GetCriticalHitChance(), 0.0f);
 
 		SUBCASE("baseline") {
-			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll));
-			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponNone));
-			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponPrimary));
-			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponSecondary));
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll, -1));
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponNone, -1));
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponPrimary, -1));
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponSecondary, -1));
 		}
 
 		SUBCASE("weapons") {
 			source.SetEquipment(1, 1);
 			source.SetEquipment(2, 2);
 
-			REQUIRE_EQ(83, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll));
-			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponNone));
-			REQUIRE_EQ(53, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponPrimary));
-			REQUIRE_EQ(83, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponSecondary));
+			REQUIRE_EQ(83, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll, -1));
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponNone, -1));
+			REQUIRE_EQ(53, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponPrimary, -1));
+			REQUIRE_EQ(83, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponSecondary, -1));
 		}
 	}
 
@@ -473,19 +473,19 @@ TEST_CASE("CritRate") {
 		REQUIRE_GT(source.GetCriticalHitChance(), 0.0f);
 
 		SUBCASE("baseline") {
-			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll));
-			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponNone));
-			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponPrimary));
-			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponSecondary));
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll, -1));
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponNone, -1));
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponPrimary, -1));
+			REQUIRE_EQ(3, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponSecondary, -1));
 		}
 
 		SUBCASE("armor prevents critical") {
 			target.SetEquipment(3, 3);
 
-			REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll));
-			REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponNone));
-			REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponPrimary));
-			REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponSecondary));
+			REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponAll, -1));
+			REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponNone, -1));
+			REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponPrimary, -1));
+			REQUIRE_EQ(0, Algo::CalcCriticalHitChance(source, target, Game_Battler::WeaponSecondary, -1));
 		}
 	}
 }
@@ -604,35 +604,35 @@ static void testSkillStats(int power, int phys, int mag, Game_Battler& source, G
 	lcf::Data::skills[19].ignore_defense = true;
 
 	SUBCASE("baseline") {
-		REQUIRE_EQ(dmg, Algo::CalcSkillEffect(source, target, lcf::Data::skills[0], false));
-		REQUIRE_EQ(dmg, Algo::CalcSkillEffect(source, target, lcf::Data::skills[1], false));
-		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[2], false));
-		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[3], false));
-		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[4], false));
+		REQUIRE_EQ(dmg, Algo::CalcSkillEffect(source, target, lcf::Data::skills[0], false, false));
+		REQUIRE_EQ(dmg, Algo::CalcSkillEffect(source, target, lcf::Data::skills[1], false, false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[2], false, false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[3], false, false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[4], false, false));
 	}
 
 	SUBCASE("attr2x") {
-		REQUIRE_EQ(dmg * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[5], false));
-		REQUIRE_EQ(dmg * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[6], false));
-		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[7], false));
-		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[8], false));
-		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[9], false));
+		REQUIRE_EQ(dmg * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[5], false, false));
+		REQUIRE_EQ(dmg * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[6], false, false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[7], false, false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[8], false, false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[9], false, false));
 	}
 
 	SUBCASE("ignore_defense") {
-		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[10], false));
-		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[11], false));
-		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[12], false));
-		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[13], false));
-		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[14], false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[10], false, false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[11], false, false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[12], false, false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[13], false, false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[14], false, false));
 	}
 
 	SUBCASE("ignore_defense+attr2x") {
-		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[15], false));
-		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[16], false));
-		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[17], false));
-		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[18], false));
-		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[19], false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[15], false, false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[16], false, false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[17], false, false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[18], false, false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[19], false, false));
 	}
 }
 
@@ -918,13 +918,13 @@ static void testSkillVar(Game_Battler& source, Game_Battler& target, int var, in
 
 	SUBCASE("max") {
 		Rand::LockGuard lk(INT32_MAX);
-		REQUIRE_EQ(dmg_high, Algo::CalcSkillEffect(source, target, *skill1, true));
-		REQUIRE_EQ(heal_high, Algo::CalcSkillEffect(source, target, *skill2, true));
+		REQUIRE_EQ(dmg_high, Algo::CalcSkillEffect(source, target, *skill1, true, false));
+		REQUIRE_EQ(heal_high, Algo::CalcSkillEffect(source, target, *skill2, true, false));
 	}
 	SUBCASE("min") {
 		Rand::LockGuard lk(INT32_MIN);
-		REQUIRE_EQ(dmg_low, Algo::CalcSkillEffect(source, target, *skill1, true));
-		REQUIRE_EQ(heal_low, Algo::CalcSkillEffect(source, target, *skill2, true));
+		REQUIRE_EQ(dmg_low, Algo::CalcSkillEffect(source, target, *skill1, true, false));
+		REQUIRE_EQ(heal_low, Algo::CalcSkillEffect(source, target, *skill2, true, false));
 	}
 }
 


### PR DESCRIPTION
This PR adds the following game settings which can be set in the game database:

- BattleCommands: Disable RPG Maker 2003 row feature
- Actors: Protected against critical hits
- Actors: Increased physical attack evasion rate
- Actors: Immune to attribute downshifts
- Actors: Ignore enemy evasion on physical attacks
- Actors: Unarmed attack hit rate
- Actors: States inflicted by unarmed normal attacks
- Actors: State infliction probability by unarmed normal attacks
- Actors: Attributes used by unarmed normal attacks
- Actors: Unarmed attack dual attack
- Actors: Unarmed attack targets entire enemy party
- Enemies: Protected against critical hits
- Enemies: Increased physical attack evasion rate
- Enemies: Immune to attribute downshifts
- Enemies: Ignore enemy evasion on physical attacks
- Enemies: Normal attack hit rate
- Enemies: States inflicted by normal attacks
- Enemies: State infliction probability by normal attacks
- Enemies: Attributes used by normal attacks
- Enemies: Quarter instead of half damage on defend action
- Enemies: Normal attack targets entire player party
- Skills: Affected by avoid attack states
- Skills: Critical hit rate percentage
- Skills: Affected by row modifiers
- Skills: Skill HP cost type
- Skills: Skill HP cost in percent of the maximum HP
- Skills: Skill fixed value HP cost
- States: Clear certain states on infliction by this state
- Terrains: Damage in percent of the actor HP
- Terrains: Damage can kill the actor
- System: Use RPG Maker 2000 battle system in RPG Maker 2003 games
- System: Use RPG2kE strings in RPG Maker 2000 battles in RPG Maker 2003 games