### PR TITLE
Switch: Change Applet handling

### DIFF
--- a/src/platform/switch/switch_ui.h
+++ b/src/platform/switch/switch_ui.h
@@ -65,8 +65,8 @@ public:
 
 private:
 	BitmapRef touch_ui;
-	bool update_ui = true;
-	int ui_mode = 0;
+	PadState pad;
+	HidTouchScreenState touch = {0};
 
 #ifdef SUPPORT_AUDIO
 	std::unique_ptr<AudioInterface> audio_;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -94,6 +94,8 @@
 #include "exe_reader.h"
 #endif
 
+using namespace std::chrono_literals;
+
 namespace Player {
 	bool exit_flag;
 	bool reset_flag;
@@ -237,8 +239,13 @@ void Player::Run() {
 		if (!aptMainLoop())
 			Exit();
 #  elif defined(__SWITCH__)
-		if(!appletMainLoop())
-			Exit();
+		// handle events
+		appletMainLoop();
+		// skipping our main loop, when out of focus
+		if(appletGetFocusState() != AppletFocusState_InFocus) {
+			Game_Clock::SleepFor(10ms);
+			continue;
+		}
 #  endif
 		MainLoop();
 	}
@@ -418,7 +425,6 @@ void Player::Exit() {
 	Text::Draw(*surface, 84, DisplayUi->GetHeight() / 2 - 30, *Font::Default(), Color(221, 123, 64, 255), message);
 	DisplayUi->UpdateDisplay();
 #endif
-
 	Player::ResetGameObjects();
 	Font::Dispose();
 	DynRpg::Reset();


### PR DESCRIPTION
- Lock closing to allow cleanup
- manually pause and resume on focus lost
- do not check for docking/undocking anymore, use hook
- log firmware version


Trying to fix the first issue from the forum post: https://community.easyrpg.org/t/easy-rpg-switch-port-0-7/1038