### PR TITLE
Unequip shield on equipping a two-handed weapon and vice versa

### DIFF
--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -355,7 +355,10 @@ void Game_Actor::ChangeEquipment(int equip_type, int item_id) {
 	// In case you have a two_handed weapon equipped, the other weapon is removed.
 	const lcf::rpg::Item* item = GetWeapon();
 	const lcf::rpg::Item* item2 = Get2ndWeapon();
-	if (item && item2 && (item->two_handed || item2->two_handed)) {
+	if (item2 == nullptr) {
+		item2 = GetShield();
+	}
+	if (item && item2 && ((item->type == lcf::rpg::Item::Type_weapon && item->two_handed) || (item2->type == lcf::rpg::Item::Type_weapon && item2->two_handed))) {
 		ChangeEquipment(equip_type == lcf::rpg::Item::Type_weapon ? equip_type + 1 : equip_type - 1, 0);
 	}
 }


### PR DESCRIPTION
The shield is unequipped now upon equipping a two-handed weapon and vice versa. While the unequip check worked on actors which can wield two weapons, it did not work on actors which can wield a weapon and a shield.