### PR TITLE
Set battleanim_active to false on map change

### DIFF
--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -86,6 +86,7 @@ void Game_Screen::OnMapChange() {
 	movie_res_x = 0;
 	movie_res_y = 0;
 
+	data.battleanim_active = false;
 	animation.reset();
 }
 


### PR DESCRIPTION
This PR makes sets the `battleanim_active` flag to false on map change. This change should avoid RPG_RT crashes with savegames made with EasyRPG which have an active battle animation which targets an invalid event because of a map change.

Fixes: #2597