### PR TITLE
Support RPG Maker 2003 battle commands in RPG Maker 2000 battles

### DIFF
--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -270,7 +270,7 @@ int CalcSkillCost(const lcf::rpg::Skill& skill, int max_sp, bool half_sp_cost) {
 
 int CalcSkillHpCost(const lcf::rpg::Skill& skill, int max_hp) {
 	return (Player::IsRPG2k3() && skill.easyrpg_hp_type == lcf::rpg::Skill::HpType_percent)
-		? std::min(max_hp - 1, max_hp * skill.easyrpg_hp_percent / 100)
+		? std::min<int>(max_hp - 1, max_hp * skill.easyrpg_hp_percent / 100)
 		: skill.easyrpg_hp_cost;
 }
 

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -634,7 +634,7 @@ bool Game_Player::Move(int dir) {
 						red_flash = true;
 					}
 					if (terrain->easyrpg_damage_in_percent) {
-						int value = std::max(1, std::abs(hero->GetMaxHp() * terrain->damage / 100));
+						int value = std::max<int>(1, std::abs(hero->GetMaxHp() * terrain->damage / 100));
 						hero->ChangeHp((terrain->damage > 0 ? -value : value), terrain->easyrpg_damage_can_kill);
 					} else {
 						hero->ChangeHp(-terrain->damage, terrain->easyrpg_damage_can_kill);

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -186,6 +186,8 @@ protected:
 
 	void OptionSelected();
 	void CommandSelected();
+	void SubskillSelected2k3(int command);
+	void SpecialSelected2k3();
 
 	void SelectNextActor(bool auto_battle);
 	void SelectPreviousActor();
@@ -236,6 +238,8 @@ protected:
 	BattleActionReturn ProcessBattleActionStateEffects(Game_BattleAlgorithm::AlgorithmBase* action);
 	BattleActionReturn ProcessBattleActionAttributeEffects(Game_BattleAlgorithm::AlgorithmBase* action);
 	BattleActionReturn ProcessBattleActionFinished(Game_BattleAlgorithm::AlgorithmBase* action);
+
+	std::vector<std::string> GetBattleCommandNames2k3(const Game_Actor* actor);
 
 	void ProcessBattleActionDeath(Game_BattleAlgorithm::AlgorithmBase* action);
 


### PR DESCRIPTION
This PR enables the usage of the RPG Maker 2003 battle command feature in RPG Maker 2003 games, even if the RPG Maker 2000 battle system feature is enabled.