### PR TITLE
Fix stat preview with "two handed" non-weapon equipment

### DIFF
--- a/src/scene_equip.cpp
+++ b/src/scene_equip.cpp
@@ -121,7 +121,7 @@ void Scene_Equip::UpdateStatusWindow() {
 		add_item(old_item, -1);
 		// If other hand had a two handed weapon, or we considering a 2 handed weapon, remove the other hand.
 		if (current_item && other_old_item &&
-				(other_old_item->two_handed || current_item->two_handed)) {
+				((other_old_item->type == lcf::rpg::Item::Type_weapon && other_old_item->two_handed) || (current_item->type == lcf::rpg::Item::Type_weapon && current_item->two_handed))) {
 			add_item(other_old_item, -1);
 		}
 		add_item(current_item, 1);

--- a/src/window_shopparty.cpp
+++ b/src/window_shopparty.cpp
@@ -96,7 +96,7 @@ static int CmpEquip(const Game_Actor* actor, const lcf::rpg::Item* new_item) {
 	add_item(old_item, -1);
 	// If other hand had a two handed weapon, or we considering a 2 handed weapon, remove the other hand.
 	if (new_item && other_old_item &&
-			(other_old_item->two_handed || new_item->two_handed)) {
+			((other_old_item->type == lcf::rpg::Item::Type_weapon && other_old_item->two_handed) || (new_item->type == lcf::rpg::Item::Type_weapon && new_item->two_handed))) {
 		add_item(other_old_item, -1);
 	}
 	add_item(new_item, 1);


### PR DESCRIPTION
This PR should make the stat preview work correctly now even with non-weapon equipment which has the "two handed" flag set.