### PR TITLE
Yume2kki: Fix Panorama handling

### DIFF
--- a/src/async_op.h
+++ b/src/async_op.h
@@ -40,7 +40,8 @@ class AsyncOp {
 			eExitGame,
 			eTerminateBattle,
 			eSave,
-			eLoad
+			eLoad,
+			eYield
 		};
 
 		AsyncOp() = default;
@@ -71,6 +72,9 @@ class AsyncOp {
 
 		/** @return a Load async operation */
 		static AsyncOp MakeLoad(int save_slot);
+
+		/** @return a Yield for one frame to e.g. fetch an important asset */
+		static AsyncOp MakeYield();
 
 		/** @return the type of async operation */
 		Type GetType() const;
@@ -214,5 +218,8 @@ inline AsyncOp AsyncOp::MakeLoad(int save_slot) {
 	return AsyncOp(eLoad, save_slot);
 }
 
-#endif
+inline AsyncOp AsyncOp::MakeYield() {
+	return AsyncOp(eYield);
+}
 
+#endif

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -3201,6 +3201,10 @@ bool Game_Interpreter::CommandChangePBG(lcf::rpg::EventCommand const& com) { // 
 
 	Game_Map::Parallax::ChangeBG(params);
 
+	if (!params.name.empty()) {
+		_async_op = AsyncOp::MakeYield();
+	}
+
 	return true;
 }
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -134,10 +134,8 @@ void Game_Map::Setup(std::unique_ptr<lcf::rpg::Map> map_in) {
 	map = std::move(map_in);
 
 	SetupCommon();
-	panorama_on_map_init = true;
-	reset_panorama_x_on_next_init = true;
-	reset_panorama_y_on_next_init = true;
 
+	panorama_on_map_init = true;
 	Parallax::ClearChangedBG();
 
 	SetEncounterRate(GetMapInfo().encounter_steps);
@@ -1629,11 +1627,6 @@ void Game_Map::Parallax::Initialize(int width, int height) {
 
 	Params params = GetParallaxParams();
 
-	if (panorama_on_map_init) {
-		AddPositionX(map_info.position_x);
-		AddPositionY(map_info.position_y);
-	}
-
 	if (reset_panorama_x_on_next_init) {
 		ResetPositionX();
 	}
@@ -1792,7 +1785,6 @@ void Game_Map::Parallax::ChangeBG(const Params& params) {
 	map_info.parallax_vert_auto = params.scroll_vert_auto;
 	map_info.parallax_vert_speed = params.scroll_vert_speed;
 
-	panorama_on_map_init = false;
 	reset_panorama_x_on_next_init = !Game_Map::LoopHorizontal() && !map_info.parallax_horz;
 	reset_panorama_y_on_next_init = !Game_Map::LoopVertical() && !map_info.parallax_vert;
 
@@ -1805,4 +1797,5 @@ void Game_Map::Parallax::ChangeBG(const Params& params) {
 void Game_Map::Parallax::ClearChangedBG() {
 	Params params {}; // default Param indicates no override
 	ChangeBG(params);
+	panorama_on_map_init = false;
 }

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1625,7 +1625,10 @@ void Game_Map::Parallax::Initialize(int width, int height) {
 	parallax_width = width;
 	parallax_height = height;
 
-	Params params = GetParallaxParams();
+	if (panorama_on_map_init) {
+		Parallax::SetPositionX(map_info.position_x);
+		Parallax::SetPositionY(map_info.position_y);
+	}
 
 	if (reset_panorama_x_on_next_init) {
 		ResetPositionX();
@@ -1638,6 +1641,8 @@ void Game_Map::Parallax::Initialize(int width, int height) {
 		SetPositionX(panorama.pan_x);
 		SetPositionY(panorama.pan_y);
 	}
+
+	panorama_on_map_init = false;
 }
 
 void Game_Map::Parallax::AddPositionX(int off_x) {
@@ -1651,7 +1656,7 @@ void Game_Map::Parallax::AddPositionY(int off_y) {
 void Game_Map::Parallax::SetPositionX(int x) {
 	// FIXME: Fixes a crash with ChangeBG commands in events, but not correct.
 	// Real fix TBD
-	if (parallax_width != 0) {
+	if (parallax_width) {
 		const int w = parallax_width * TILE_SIZE * 2;
 		panorama.pan_x = (x + w) % w;
 	}
@@ -1797,5 +1802,4 @@ void Game_Map::Parallax::ChangeBG(const Params& params) {
 void Game_Map::Parallax::ClearChangedBG() {
 	Params params {}; // default Param indicates no override
 	ChangeBG(params);
-	panorama_on_map_init = false;
 }

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -35,6 +35,7 @@
 #include "game_screen.h"
 #include "game_pictures.h"
 #include "scene_battle.h"
+#include "scene_map.h"
 #include <lcf/lmu/reader.h>
 #include <lcf/reader_lcf.h>
 #include "map_data.h"
@@ -1761,6 +1762,11 @@ void Game_Map::Parallax::ChangeBG(const Params& params) {
 
 	reset_panorama_x_on_next_init = !Game_Map::LoopHorizontal() && !map_info.parallax_horz;
 	reset_panorama_y_on_next_init = !Game_Map::LoopVertical() && !map_info.parallax_vert;
+
+	Scene_Map* scene = (Scene_Map*)Scene::Find(Scene::Map).get();
+	if (!scene || !scene->spriteset)
+		return;
+	scene->spriteset->ParallaxUpdated();
 }
 
 void Game_Map::Parallax::ClearChangedBG() {

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -649,17 +649,23 @@ namespace Game_Map {
 		/** Call this when you find out the width and height of the BG. */
 		void Initialize(int width, int height);
 
-		/**
-		 * Reset the x position of the BG.
-		 * @param did_teleport When true does additional repositioning required after a teleport
-		 */
-		void ResetPositionX(bool did_teleport);
+		/** Adds x to the panorama x-position MOD parallax_width * TILE_SIZE * 2 */
+		void AddPositionX(int x);
 
-		/**
-		 * Reset the x position of the BG.
-		 * @param did_teleport When true does additional repositioning required after a teleport
-		 */
-		void ResetPositionY(bool did_teleport);
+		/** Adds y to the panorama y-position MOD parallax_width * TILE_SIZE * 2 */
+		void AddPositionY(int y);
+
+		/** Sets the panorama x-position MOD parallax_width * TILE_SIZE * 2 */
+		void SetPositionX(int x);
+
+		/** Sets the panorama y-position MOD parallax_width * TILE_SIZE * 2 */
+		void SetPositionY(int y);
+
+		/** Reset the x position of the BG. */
+		void ResetPositionX();
+
+		/** Reset the x position of the BG. */
+		void ResetPositionY();
 
 		/**
 		 * To be called when the map scrolls right.

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -649,11 +649,17 @@ namespace Game_Map {
 		/** Call this when you find out the width and height of the BG. */
 		void Initialize(int width, int height);
 
-		/** Reset the x position of the BG. */
-		void ResetPositionX();
+		/**
+		 * Reset the x position of the BG.
+		 * @param did_teleport When true does additional repositioning required after a teleport
+		 */
+		void ResetPositionX(bool did_teleport);
 
-		/** Reset the y position of the BG. */
-		void ResetPositionY();
+		/**
+		 * Reset the x position of the BG.
+		 * @param did_teleport When true does additional repositioning required after a teleport
+		 */
+		void ResetPositionY(bool did_teleport);
 
 		/**
 		 * To be called when the map scrolls right.

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -195,10 +195,8 @@ void Game_System::OnChangeSystemGraphicReady(FileRequestResult* result) {
 	bg_color = Cache::SystemOrBlack()->GetBackgroundColor();
 
 	Scene_Map* scene = (Scene_Map*)Scene::Find(Scene::Map).get();
-
-	if (!scene)
+	if (!scene || !scene->spriteset)
 		return;
-
 	scene->spriteset->SystemGraphicUpdated();
 }
 

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -319,7 +319,7 @@ void Scene_Map::FinishPendingTeleport(TeleportParams tp) {
 	Main_Data::game_player->PerformTeleport();
 
 	if (Game_Map::GetMapId() != old_map_id) {
-		spriteset.reset(new Spriteset_Map());
+		spriteset->Refresh();
 	}
 	FinishPendingTeleport2(MapUpdateAsyncContext(), tp);
 }
@@ -384,7 +384,7 @@ void Scene_Map::PerformAsyncTeleport(TeleportTarget original_tt) {
 	Main_Data::game_player->PerformTeleport();
 	Main_Data::game_player->ResetTeleportTarget(original_tt);
 
-	spriteset.reset(new Spriteset_Map());
+	spriteset->Refresh();
 
 	AsyncNext(std::move(map_async_continuation));
 }

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -33,12 +33,29 @@
 
 // Constructor
 Spriteset_Map::Spriteset_Map() {
+	panorama.reset(new Plane());
+	panorama->SetZ(Priority_Background);
+
+	timer1.reset(new Sprite_Timer(0));
+	timer2.reset(new Sprite_Timer(1));
+
+	screen.reset(new Screen());
+	frame.reset(new Frame());
+
+	ParallaxUpdated();
+
+	Refresh();
+
+	Update();
+}
+
+void Spriteset_Map::Refresh() {
 	tilemap.reset(new Tilemap());
 	tilemap->SetWidth(Game_Map::GetWidth());
 	tilemap->SetHeight(Game_Map::GetHeight());
 
-	panorama.reset(new Plane());
-	panorama->SetZ(Priority_Background);
+	airship_shadows.clear();
+	character_sprites.clear();
 
 	ChipsetUpdated();
 
@@ -52,14 +69,6 @@ Spriteset_Map::Spriteset_Map() {
 	CreateAirshipShadowSprite(need_x_clone, need_y_clone);
 
 	CreateSprite(Main_Data::game_player.get(), need_x_clone, need_y_clone);
-
-	timer1.reset(new Sprite_Timer(0));
-	timer2.reset(new Sprite_Timer(1));
-
-	screen.reset(new Screen());
-	frame.reset(new Frame());
-
-	Update();
 }
 
 // Update
@@ -75,18 +84,6 @@ void Spriteset_Map::Update() {
 		character_sprites[i]->SetTone(new_tone);
 	}
 
-	std::string name = Game_Map::Parallax::GetName();
-	if (name != panorama_name) {
-		panorama_name = name;
-		if (name.empty()) {
-			panorama->SetBitmap(BitmapRef());
-		} else {
-			FileRequestAsync *request = AsyncHandler::RequestFile("Panorama", panorama_name);
-			request->SetGraphicFile(true);
-			panorama_request_id = request->Bind(&Spriteset_Map::OnPanoramaSpriteReady, this);
-			request->Start();
-		}
-	}
 	panorama->SetOx(Game_Map::Parallax::GetX());
 	panorama->SetOy(Game_Map::Parallax::GetY());
 	panorama->SetTone(new_tone);
@@ -136,6 +133,23 @@ void Spriteset_Map::ChipsetUpdated() {
 
 	for (auto& sprite: character_sprites) {
 		sprite->ChipsetUpdated();
+	}
+}
+
+void Spriteset_Map::ParallaxUpdated() {
+	std::string name = Game_Map::Parallax::GetName();
+	if (name != panorama_name) {
+		panorama_name = name;
+		if (name.empty()) {
+			panorama->SetBitmap(BitmapRef());
+		}
+		else {
+			FileRequestAsync* request = AsyncHandler::RequestFile("Panorama", panorama_name);
+			request->SetGraphicFile(true);
+			request->SetImportantFile(true);
+			panorama_request_id = request->Bind(&Spriteset_Map::OnPanoramaSpriteReady, this);
+			request->Start();
+		}
 	}
 }
 

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -142,6 +142,7 @@ void Spriteset_Map::ParallaxUpdated() {
 		panorama_name = name;
 		if (name.empty()) {
 			panorama->SetBitmap(BitmapRef());
+			Game_Map::Parallax::Initialize(0, 0);
 		}
 		else {
 			FileRequestAsync* request = AsyncHandler::RequestFile("Panorama", panorama_name);

--- a/src/spriteset_map.h
+++ b/src/spriteset_map.h
@@ -42,6 +42,8 @@ class Spriteset_Map {
 public:
 	Spriteset_Map();
 
+	void Refresh();
+
 	void Update();
 
 	/**
@@ -53,6 +55,11 @@ public:
 	 * Notifies that the map's chipset has changed.
 	 */
 	void ChipsetUpdated();
+
+	/**
+	 * Notifies that the map's parallax has changed.
+	 */
+	void ParallaxUpdated();
 
 	/**
 	 * Notifies that the System graphic has changed.


### PR DESCRIPTION
Panorama positioning depends on width and height of the panorama. 

In some cases (not scrolling or looping) the position is reset after loading the panorama.
Here was the bug: Multiple ChangePanorama commands overwrote the reset indicator.

Added a async yield op to the event and made the panorama image important to ensure that the image is loaded.

Refactored Spriteset_Map to prevent deletion as the panorama change is otherwise a dangling reference.

Fix #2195