### PR TITLE
Raise the priority of WQY when encoding is Chinese Simplified.

### DIFF
--- a/src/font.cpp
+++ b/src/font.cpp
@@ -71,11 +71,23 @@ namespace {
 	}
 
 	BitmapFontGlyph const* find_gothic_glyph(char32_t code) {
+		if (Player::IsCP936()) {
+			auto* wqy = find_glyph(BITMAPFONT_WQY, code);
+			if (wqy != NULL) {
+				return wqy;
+			}
+		}		
 		auto* gothic = find_glyph(SHINONOME_GOTHIC, code);
 		return gothic != NULL ? gothic : find_fallback_glyph(code);
 	}
 
 	BitmapFontGlyph const* find_mincho_glyph(char32_t code) {
+		if (Player::IsCP936()) {
+			auto* wqy = find_glyph(BITMAPFONT_WQY, code);
+			if (wqy != NULL) {
+				return wqy;
+			}
+		}		
 		auto* mincho = find_glyph(SHINONOME_MINCHO, code);
 		return mincho == NULL ? find_gothic_glyph(code) : mincho;
 	}


### PR DESCRIPTION
As mentioned in https://github.com/EasyRPG/Player/issues/2724, this is not a perfect solution, but do solve the problem.
(Anyway it costs no side effect for other encoding) Note that some punctuations don't exist in WQY, so we still need to check Mincho when there is no code in WQY.

Tested passed in [webplayer](https://easyrpg.org/player/guide/webplayer/).

Fix #2724 
