### PR TITLE
Add "easyrpg_affected_by_row_modifiers" attribute for skills

### DIFF
--- a/src/algo.h
+++ b/src/algo.h
@@ -88,10 +88,12 @@ int CalcNormalAttackToHit(const Game_Battler& source,
  * @param source The source of the action
  * @param target The target of the action
  * @param skill Which skill to calculate hit rate for
+ * @param cond The current battle condition
+ * @param emulate_2k3_enemy_row_bug Whether or not to emulate 2k3 bug where RPG_RT considers defending enemies in the front row
  *
  * @return Success hit rate
  */
-int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const lcf::rpg::Skill& skill);
+int CalcSkillToHit(const Game_Battler& source, const Game_Battler& target, const lcf::rpg::Skill& skill, lcf::rpg::System::BattleCondition cond, bool emulate_2k3_enemy_row_bug);
 
 /**
  * Compute the critical hit rate if source attacks target.
@@ -150,6 +152,8 @@ int CalcNormalAttackEffect(const Game_Battler& source,
  * @param skill The skill to use
  * @param apply_variance If true, apply variance to the damage
  * @param is_critical_hit If true, apply critical hit bonus
+ * @param cond The current battle condition
+ * @param emulate_2k3_enemy_row_bug Whether or not to emulate 2k3 bug where RPG_RT considers defending enemies in the front row
  *
  * @return effect amount
  */
@@ -157,7 +161,9 @@ int CalcSkillEffect(const Game_Battler& source,
 		const Game_Battler& target,
 		const lcf::rpg::Skill& skill,
 		bool apply_variance,
-		bool is_critical_hit);
+		bool is_critical_hit,
+		lcf::rpg::System::BattleCondition cond,
+		bool emulate_2k3_enemy_row_bug);
 
 /**
  * Compute the base damage for self-destruct

--- a/src/autobattle.h
+++ b/src/autobattle.h
@@ -102,13 +102,14 @@ private:
  * @param source the user of the skill
  * @param target the target of the skill
  * @param skill the skill
+ * @param cond the battle condition
  * @param apply_variance If true, apply variance to the damage
  * @param emulate_bugs Emulate all RPG_RT bugs for accuracy
  *
  * @pre skill Must be a normal or subskill or the result is undefined.
  * @pre skill must target self, ally, or ally party or the result is undefined.
  */
-double CalcSkillHealAutoBattleTargetRank(const Game_Actor& source, const Game_Battler& target, const lcf::rpg::Skill& skill, bool apply_variance, bool emulate_bugs);
+double CalcSkillHealAutoBattleTargetRank(const Game_Actor& source, const Game_Battler& target, const lcf::rpg::Skill& skill, lcf::rpg::System::BattleCondition cond, bool apply_variance, bool emulate_bugs);
 
 /**
  * Calculate the auto battle effectiveness rank of source using damage skill on target.
@@ -116,23 +117,25 @@ double CalcSkillHealAutoBattleTargetRank(const Game_Actor& source, const Game_Ba
  * @param source the user of the skill
  * @param target the target of the skill
  * @param skill the skill
+ * @param cond the battle condition
  * @param apply_variance If true, apply variance to the damage
  * @param emulate_bugs Emulate all RPG_RT bugs for accuracy
  *
  * @pre skill Must be a normal or subskill or the result is undefined.
  * @pre skill must target enemy, or enemy party or the result is undefined.
  */
-double CalcSkillDmgAutoBattleTargetRank(const Game_Actor& source, const Game_Battler& target, const lcf::rpg::Skill& skill, bool apply_variance, bool emulate_bugs);
+double CalcSkillDmgAutoBattleTargetRank(const Game_Actor& source, const Game_Battler& target, const lcf::rpg::Skill& skill, lcf::rpg::System::BattleCondition cond, bool apply_variance, bool emulate_bugs);
 
 /**
  * Calculate the auto battle total effectiveness rank of using a skill.
  *
  * @param source the user of the skill
  * @param skill the skill
+ * @param cond the battle condition
  * @param apply_variance If true, apply variance to the damage
  * @param emulate_bugs Emulate all RPG_RT bugs for accuracy
  */
-double CalcSkillAutoBattleRank(const Game_Actor& source, const lcf::rpg::Skill& skill, bool apply_variance, bool emulate_bugs);
+double CalcSkillAutoBattleRank(const Game_Actor& source, const lcf::rpg::Skill& skill, lcf::rpg::System::BattleCondition cond, bool apply_variance, bool emulate_bugs);
 
 /**
  * Calculate the auto battle effectiveness rank of source attacking target.

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -904,14 +904,14 @@ bool Game_BattleAlgorithm::Skill::vExecute() {
 
 	SetIsPositive(Algo::SkillTargetsAllies(skill));
 
-	auto to_hit = Algo::CalcSkillToHit(*source, *target, skill);
+	auto to_hit = Algo::CalcSkillToHit(*source, *target, skill, Game_Battle::GetBattleCondition(), true);
 	auto crit_chance = Algo::CalcCriticalHitChance(*source, *target, Game_Battler::WeaponAll, skill.easyrpg_critical_hit_chance);
 
 	if (Rand::PercentChance(crit_chance)) {
 		SetIsCriticalHit(true);
 	}
 
-	auto effect = Algo::CalcSkillEffect(*source, *target, skill, true, IsCriticalHit());
+	auto effect = Algo::CalcSkillEffect(*source, *target, skill, true, IsCriticalHit(), Game_Battle::GetBattleCondition(), treat_enemies_asif_in_front_row);
 	effect = Utils::Clamp(effect, -MaxDamageValue(), MaxDamageValue());
 
 	if (!IsPositive()) {

--- a/src/game_battlealgorithm.h
+++ b/src/game_battlealgorithm.h
@@ -684,12 +684,17 @@ public:
 	const lcf::rpg::Skill& GetSkill() const;
 	const lcf::rpg::Item* GetItem() const;
 
+	// Emulates an RPG_RT bug where whenver an actor attacks an enemy, the hit rate and damage
+	// is adjusted as if the enemy were in the front row.
+	void SetTreatEnemiesAsIfInFrontRow(bool v);
+
 private:
 	void Init();
 	std::string GetFirstStartMessage() const;
 	std::string GetSecondStartMessage() const;
 	const lcf::rpg::Skill& skill;
 	const lcf::rpg::Item* item;
+	bool treat_enemies_asif_in_front_row = false;
 };
 
 class Item : public AlgorithmBase {
@@ -1026,6 +1031,10 @@ inline const lcf::rpg::Skill& Game_BattleAlgorithm::Skill::GetSkill() const {
 
 inline const lcf::rpg::Item* Game_BattleAlgorithm::Skill::GetItem() const {
 	return item;
+}
+
+inline void Game_BattleAlgorithm::Skill::SetTreatEnemiesAsIfInFrontRow(bool v) {
+	treat_enemies_asif_in_front_row = v;
 }
 
 } //namespace Game_BattleAlgorithm

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -237,7 +237,7 @@ bool Game_Battler::UseSkill(int skill_id, const Game_Battler* source) {
 		}
 
 		// Calculate effect:
-		auto effect = Algo::CalcSkillEffect(*source, *this, *skill, true, false);
+		auto effect = Algo::CalcSkillEffect(*source, *this, *skill, true, false, lcf::rpg::System::BattleCondition_none, false);
 
 		// Negative attributes do damage but cannot kill
 		bool negative_effect = false;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -2036,8 +2036,12 @@ Scene_Battle_Rpg2k3::BattleActionReturn Scene_Battle_Rpg2k3::ProcessBattleAction
 
 	// Emulate an RPG_RT bug where whenver actors attack, the damage and evasion calculations are performed
 	// as if the enemies are in the front row.
-	if (source->GetType() == Game_Battler::Type_Ally && action->GetType() == Game_BattleAlgorithm::Type::Normal) {
-		static_cast<Game_BattleAlgorithm::Normal*>(action)->SetTreatEnemiesAsIfInFrontRow(true);
+	if (source->GetType() == Game_Battler::Type_Ally) {
+		if (action->GetType() == Game_BattleAlgorithm::Type::Normal) {
+			static_cast<Game_BattleAlgorithm::Normal*>(action)->SetTreatEnemiesAsIfInFrontRow(true);
+		} else if (action->GetType() == Game_BattleAlgorithm::Type::Skill) {
+			static_cast<Game_BattleAlgorithm::Skill*>(action)->SetTreatEnemiesAsIfInFrontRow(true);
+		}
 	}
 
 	// Setup enemy targets

--- a/tests/algo.cpp
+++ b/tests/algo.cpp
@@ -208,11 +208,11 @@ static void testAgi(int src, int tgt, int res) {
 	auto& target = *MakeAgiEnemy(0, tgt);
 
 	REQUIRE_EQ(res, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, true));
-	REQUIRE_EQ(res, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
-	REQUIRE_EQ(res, Algo::CalcSkillToHit(source, target, lcf::Data::skills[1]));
+	REQUIRE_EQ(res, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0], lcf::rpg::System::BattleCondition_none, false));
+	REQUIRE_EQ(res, Algo::CalcSkillToHit(source, target, lcf::Data::skills[1], lcf::rpg::System::BattleCondition_none, false));
 	for (int i = 2; i < 6; ++i) {
 		CAPTURE(i);
-		REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[i]));
+		REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[i], lcf::rpg::System::BattleCondition_none, false));
 
 	}
 }
@@ -233,14 +233,14 @@ static void testStates(Game_Battler& source, Game_Battler& target, int base) {
 	SUBCASE("Cannot act") {
 		target.AddState(2, true);
 		REQUIRE_EQ(100, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, true));
-		REQUIRE_EQ(100, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+		REQUIRE_EQ(100, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0], lcf::rpg::System::BattleCondition_none, false));
 	}
 
 	SUBCASE("Avoid attacks") {
 		target.AddState(3, true);
 		REQUIRE_EQ(0, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, true));
 		// RPG_RT bug
-		REQUIRE_EQ(base, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+		REQUIRE_EQ(base, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0], lcf::rpg::System::BattleCondition_none, false));
 	}
 
 	SUBCASE("Avoid attacks and cannot act") {
@@ -248,7 +248,7 @@ static void testStates(Game_Battler& source, Game_Battler& target, int base) {
 		target.AddState(3, true);
 		REQUIRE_EQ(0, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, true));
 		// RPG_RT bug
-		REQUIRE_EQ(100, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+		REQUIRE_EQ(100, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0], lcf::rpg::System::BattleCondition_none, false));
 	}
 }
 
@@ -267,7 +267,7 @@ TEST_CASE("HitRateStates") {
 	SUBCASE("source blind50") {
 		source.AddState(4, true);
 		REQUIRE_EQ(45, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponAll, lcf::rpg::System::BattleCondition_none, true));
-		REQUIRE_EQ(45, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+		REQUIRE_EQ(45, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0], lcf::rpg::System::BattleCondition_none, false));
 
 		testStates(source, target, 45);
 	}
@@ -303,7 +303,7 @@ TEST_CASE("HitRateArmorAndRow2k3") {
 			SUBCASE("no armor") {
 				testHitRateRow(source, target, 90, 65, 65, 90, 65, 65);
 
-				REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+				REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0], lcf::rpg::System::BattleCondition_none, false));
 			}
 
 			SUBCASE("phys eva up") {
@@ -312,7 +312,7 @@ TEST_CASE("HitRateArmorAndRow2k3") {
 
 				testHitRateRow(source, target, 65, 40, 40, 65, 40, 40);
 
-				REQUIRE_EQ(65, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+				REQUIRE_EQ(65, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0], lcf::rpg::System::BattleCondition_none, false));
 			}
 		}
 
@@ -322,7 +322,7 @@ TEST_CASE("HitRateArmorAndRow2k3") {
 			SUBCASE("no armor") {
 				testHitRateRow(source, target, 65, 90, 65, 90, 90, 65);
 
-				REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+				REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0], lcf::rpg::System::BattleCondition_none, false));
 			}
 
 			SUBCASE("phys eva up") {
@@ -331,7 +331,7 @@ TEST_CASE("HitRateArmorAndRow2k3") {
 
 				testHitRateRow(source, target, 40, 65, 40, 65, 65, 40);
 
-				REQUIRE_EQ(65, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+				REQUIRE_EQ(65, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0], lcf::rpg::System::BattleCondition_none, false));
 			}
 		}
 	}
@@ -341,7 +341,7 @@ TEST_CASE("HitRateArmorAndRow2k3") {
 
 		testHitRateRow(source, target, 90, 65, 65, 90, 90, 90);
 
-		REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+		REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0], lcf::rpg::System::BattleCondition_none, false));
 	}
 }
 
@@ -362,7 +362,7 @@ TEST_CASE("HitRateArmorAndRow2k") {
 		SUBCASE("no armor") {
 			testHitRateRow2k(source, target, 90);
 
-			REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+			REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0], lcf::rpg::System::BattleCondition_none, false));
 		}
 
 		SUBCASE("phys eva up") {
@@ -371,7 +371,7 @@ TEST_CASE("HitRateArmorAndRow2k") {
 
 			testHitRateRow2k(source, target, 65);
 
-			REQUIRE_EQ(65, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+			REQUIRE_EQ(65, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0], lcf::rpg::System::BattleCondition_none, false));
 		}
 	}
 
@@ -380,7 +380,7 @@ TEST_CASE("HitRateArmorAndRow2k") {
 
 		testHitRateRow2k(source, target, 90);
 
-		REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+		REQUIRE_EQ(90, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0], lcf::rpg::System::BattleCondition_none, false));
 	}
 }
 
@@ -411,7 +411,7 @@ TEST_CASE("HitRateWeapons") {
 	REQUIRE_FALSE(source.AttackIgnoresEvasion(Game_Battler::WeaponSecondary));
 	REQUIRE_EQ(88, Algo::CalcNormalAttackToHit(source, target, Game_Battler::WeaponSecondary, lcf::rpg::System::BattleCondition_none, true));
 
-	REQUIRE_EQ(100, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0]));
+	REQUIRE_EQ(100, Algo::CalcSkillToHit(source, target, lcf::Data::skills[0], lcf::rpg::System::BattleCondition_none, false));
 }
 
 TEST_CASE("CritRate") {
@@ -604,35 +604,35 @@ static void testSkillStats(int power, int phys, int mag, Game_Battler& source, G
 	lcf::Data::skills[19].ignore_defense = true;
 
 	SUBCASE("baseline") {
-		REQUIRE_EQ(dmg, Algo::CalcSkillEffect(source, target, lcf::Data::skills[0], false, false));
-		REQUIRE_EQ(dmg, Algo::CalcSkillEffect(source, target, lcf::Data::skills[1], false, false));
-		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[2], false, false));
-		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[3], false, false));
-		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[4], false, false));
+		REQUIRE_EQ(dmg, Algo::CalcSkillEffect(source, target, lcf::Data::skills[0], false, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(dmg, Algo::CalcSkillEffect(source, target, lcf::Data::skills[1], false, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[2], false, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[3], false, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[4], false, false, lcf::rpg::System::BattleCondition_none, false));
 	}
 
 	SUBCASE("attr2x") {
-		REQUIRE_EQ(dmg * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[5], false, false));
-		REQUIRE_EQ(dmg * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[6], false, false));
-		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[7], false, false));
-		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[8], false, false));
-		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[9], false, false));
+		REQUIRE_EQ(dmg * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[5], false, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(dmg * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[6], false, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[7], false, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[8], false, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[9], false, false, lcf::rpg::System::BattleCondition_none, false));
 	}
 
 	SUBCASE("ignore_defense") {
-		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[10], false, false));
-		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[11], false, false));
-		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[12], false, false));
-		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[13], false, false));
-		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[14], false, false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[10], false, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[11], false, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[12], false, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[13], false, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(heal, Algo::CalcSkillEffect(source, target, lcf::Data::skills[14], false, false, lcf::rpg::System::BattleCondition_none, false));
 	}
 
 	SUBCASE("ignore_defense+attr2x") {
-		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[15], false, false));
-		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[16], false, false));
-		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[17], false, false));
-		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[18], false, false));
-		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[19], false, false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[15], false, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[16], false, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[17], false, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[18], false, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(heal * 2, Algo::CalcSkillEffect(source, target, lcf::Data::skills[19], false, false, lcf::rpg::System::BattleCondition_none, false));
 	}
 }
 
@@ -918,13 +918,13 @@ static void testSkillVar(Game_Battler& source, Game_Battler& target, int var, in
 
 	SUBCASE("max") {
 		Rand::LockGuard lk(INT32_MAX);
-		REQUIRE_EQ(dmg_high, Algo::CalcSkillEffect(source, target, *skill1, true, false));
-		REQUIRE_EQ(heal_high, Algo::CalcSkillEffect(source, target, *skill2, true, false));
+		REQUIRE_EQ(dmg_high, Algo::CalcSkillEffect(source, target, *skill1, true, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(heal_high, Algo::CalcSkillEffect(source, target, *skill2, true, false, lcf::rpg::System::BattleCondition_none, false));
 	}
 	SUBCASE("min") {
 		Rand::LockGuard lk(INT32_MIN);
-		REQUIRE_EQ(dmg_low, Algo::CalcSkillEffect(source, target, *skill1, true, false));
-		REQUIRE_EQ(heal_low, Algo::CalcSkillEffect(source, target, *skill2, true, false));
+		REQUIRE_EQ(dmg_low, Algo::CalcSkillEffect(source, target, *skill1, true, false, lcf::rpg::System::BattleCondition_none, false));
+		REQUIRE_EQ(heal_low, Algo::CalcSkillEffect(source, target, *skill2, true, false, lcf::rpg::System::BattleCondition_none, false));
 	}
 }
 


### PR DESCRIPTION
This PR adds the "easyrpg_affected_by_row_modifiers" attribute for skills. If this attribute is set, then the damage and hit rate is affected by row modifiers. This feature is needed if you want to add skills which should act like normal physical attacks in RPG Maker 2003 games.