### PR TITLE
Proper overflow handling

### DIFF
--- a/src/game_variables.cpp
+++ b/src/game_variables.cpp
@@ -616,6 +616,6 @@ StringView Game_Variables::GetName(int _id) const {
 }
 
 int Game_Variables::GetMaxDigits() const {
-	auto val = std::max(std::abs(_max), std::abs(_min));
+	auto val = std::max(std::llabs(_max), std::llabs(_min));
 	return static_cast<int>(std::log10(val) + 1);
 }

--- a/src/game_variables.cpp
+++ b/src/game_variables.cpp
@@ -617,5 +617,5 @@ StringView Game_Variables::GetName(int _id) const {
 
 int Game_Variables::GetMaxDigits() const {
 	auto val = std::max(std::abs(_max), std::abs(_min));
-	return std::log10(val) + 1;
+	return static_cast<int>(std::log10(val) + 1);
 }

--- a/src/game_variables.cpp
+++ b/src/game_variables.cpp
@@ -40,15 +40,71 @@ constexpr Var_t VarSet(Var_t o, Var_t n) {
 }
 
 constexpr Var_t VarAdd(Var_t l, Var_t r) {
-	return l + r;
+	Var_t res = 0;
+
+#ifdef _MSC_VER
+	res = l + r;
+	if (res < 0 && l > 0 && r > 0) {
+		return std::numeric_limits<Var_t>::max();
+	} else if (res > 0 && l < 0 && r < 0) {
+		return std::numeric_limits<Var_t>::min();
+	}
+#else
+	if (EP_UNLIKELY(__builtin_add_overflow(l, r, &res))) {
+		if (l >= 0 && r >= 0) {
+			return std::numeric_limits<Var_t>::max();
+		}
+		return std::numeric_limits<Var_t>::min();
+	}
+#endif
+
+	return res;
 }
 
 constexpr Var_t VarSub(Var_t l, Var_t r) {
-	return l - r;
+	Var_t res = 0;
+
+#ifdef _MSC_VER
+	res = l - r;
+	if (res < 0 && l > 0 && r < 0) {
+		return std::numeric_limits<Var_t>::max();
+	} else if (res > 0 && l < 0 && r > 0) {
+		return std::numeric_limits<Var_t>::min();
+	}
+#else
+	if (EP_UNLIKELY(__builtin_sub_overflow(l, r, &res))) {
+		if (r < 0) {
+			return std::numeric_limits<Var_t>::max();
+		}
+		return std::numeric_limits<Var_t>::min();
+	}
+#endif
+
+	return res;
 }
 
 constexpr Var_t VarMult(Var_t l, Var_t r) {
-	return l * r;
+	Var_t res = 0;
+
+#ifdef _MSC_VER
+	res = l * r;
+	if (l != 0 && res / l != r) {
+		if ((l > 0 && r > 0) || (l < 0 && r < 0)) {
+			return std::numeric_limits<Var_t>::max();
+		} else {
+			return std::numeric_limits<Var_t>::min();
+		}
+	}
+#else
+	if (EP_UNLIKELY(__builtin_mul_overflow(l, r, &res))) {
+		if ((l > 0 && r > 0) || (l < 0 && r < 0)) {
+			return std::numeric_limits<Var_t>::max();
+		}
+		return std::numeric_limits<Var_t>::min();
+	}
+#endif
+
+	return res;
 }
 
 constexpr Var_t VarDiv(Var_t n, Var_t d) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -885,11 +885,19 @@ void Player::ResetGameObjects() {
 
 	auto min_var = lcf::Data::system.easyrpg_variable_min_value;
 	if (min_var == 0) {
-		min_var = Player::IsRPG2k3() ? Game_Variables::min_2k3 : Game_Variables::min_2k;
+		if (Player::IsPatchManiac()) {
+			min_var = std::numeric_limits<Game_Variables::Var_t>::min();
+		} else {
+			min_var = Player::IsRPG2k3() ? Game_Variables::min_2k3 : Game_Variables::min_2k;
+		}
 	}
 	auto max_var = lcf::Data::system.easyrpg_variable_max_value;
 	if (max_var == 0) {
-		max_var = Player::IsRPG2k3() ? Game_Variables::max_2k3 : Game_Variables::max_2k;
+		if (Player::IsPatchManiac()) {
+			max_var = std::numeric_limits<Game_Variables::Var_t>::max();
+		} else {
+			max_var = Player::IsRPG2k3() ? Game_Variables::max_2k3 : Game_Variables::max_2k;
+		}
 	}
 	Main_Data::game_variables = std::make_unique<Game_Variables>(min_var, max_var);
 

--- a/src/window_numberinput.cpp
+++ b/src/window_numberinput.cpp
@@ -79,11 +79,11 @@ int Window_NumberInput::GetNumber() const {
 }
 
 void Window_NumberInput::SetNumber(int inumber) {
-	int num = 1;
+	int64_t num = 1;
 	for (int i = 0; i < digits_max; ++i) {
 		num *= 10;
 	}
-	number = min(max(abs(inumber), 0), num - 1);
+	number = Utils::Clamp<int64_t>(std::llabs(inumber), 0, num - 1);
 	ResetIndex();
 
 	plus = inumber >= 0;

--- a/src/window_numberinput.cpp
+++ b/src/window_numberinput.cpp
@@ -92,7 +92,7 @@ void Window_NumberInput::SetNumber(int inumber) {
 	Refresh();
 }
 
-int Window_NumberInput::GetMaxDigits() {
+int Window_NumberInput::GetMaxDigits() const {
 	return digits_max;
 }
 
@@ -108,7 +108,7 @@ void Window_NumberInput::SetMaxDigits(int idigits_max) {
 	Refresh();
 }
 
-bool Window_NumberInput::GetShowOperator() {
+bool Window_NumberInput::GetShowOperator() const {
 	return show_operator;
 }
 

--- a/src/window_numberinput.cpp
+++ b/src/window_numberinput.cpp
@@ -62,8 +62,20 @@ void Window_NumberInput::Refresh() {
 	}
 }
 
-int Window_NumberInput::GetNumber() {
-	return number * (plus ? 1 : -1);
+int Window_NumberInput::GetNumber() const {
+	if (plus) {
+		if (number > std::numeric_limits<int>::max()) {
+			return std::numeric_limits<int>::max();
+		} else {
+			return static_cast<int>(number);
+		}
+	} else {
+		if (number * -1 < std::numeric_limits<int>::min()) {
+			return std::numeric_limits<int>::min();
+		} else {
+			return static_cast<int>(-number);
+		}
+	}
 }
 
 void Window_NumberInput::SetNumber(int inumber) {
@@ -85,9 +97,8 @@ int Window_NumberInput::GetMaxDigits() {
 }
 
 void Window_NumberInput::SetMaxDigits(int idigits_max) {
-	// At least 7 digits because of gold input in debug scene
-	// (free space and 6 digits for the gold value)
-	int top = std::max(7, idigits_max);
+	// Up to 10 digits (highest 32 bit number)
+	int top = std::max(10, idigits_max);
 	digits_max =
 		(idigits_max > top) ? top :
 		(idigits_max <= 0) ? 1 :
@@ -122,7 +133,7 @@ void Window_NumberInput::Update() {
 				for (int i = 0; i < (digits_max - 1 - (int)index + (int)show_operator); ++i) {
 					place *= 10;
 				}
-				int n = number / place % 10;
+				int64_t n = number / place % 10;
 				number -= n * place;
 				if (Input::IsRepeated(Input::UP)) {
 					n = (n + 1) % 10;

--- a/src/window_numberinput.cpp
+++ b/src/window_numberinput.cpp
@@ -161,6 +161,26 @@ void Window_NumberInput::Update() {
 			index = (index + digits_max - 1 + (int)show_operator) % (digits_max + (int)show_operator);
 		}
 
+		// Extension: Allow number input through numpad
+		if (!show_operator || index > 0) {
+			for (int btn = static_cast<int>(Input::N0); btn <= static_cast<int>(Input::N9); ++btn) {
+				if (Input::IsTriggered(static_cast<Input::InputButton>(btn))) {
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+
+					int place = 1;
+					for (int i = 0; i < (digits_max - 1 - (int)index + (int)show_operator); ++i) {
+						place *= 10;
+					}
+					int64_t n = number / place % 10;
+					number -= n * place;
+					number += (btn - static_cast<int>(Input::N0)) * static_cast<int64_t>(place);
+					index = (index + 1) % (digits_max + (int)show_operator);
+					Refresh();
+					break;
+				}
+			}
+		}
+
 		UpdateCursorRect();
 	}
 }

--- a/src/window_numberinput.h
+++ b/src/window_numberinput.h
@@ -47,7 +47,7 @@ public:
 	 *
 	 * @return the currently input number.
 	 */
-	int GetNumber();
+	int GetNumber() const;
 
 	/**
 	 * Sets a new number value.
@@ -61,7 +61,7 @@ public:
 	 *
 	 * @return number of displayed digits.
 	 */
-	int GetMaxDigits();
+	int GetMaxDigits() const;
 
 	/**
 	 * Sets the maximal displayed digits.
@@ -76,7 +76,7 @@ public:
 	 *
 	 * @return the current operator state
 	 */
-	bool GetShowOperator();
+	bool GetShowOperator() const;
 
 	/**
 	 * Enables or Disables the +- operator before the numbers.

--- a/src/window_numberinput.h
+++ b/src/window_numberinput.h
@@ -97,7 +97,7 @@ public:
 	void Update() override;
 
 protected:
-	int number;
+	int64_t number;
 	int digits_max;
 	int cursor_width;
 	int index;

--- a/tests/variables.cpp
+++ b/tests/variables.cpp
@@ -494,6 +494,48 @@ TEST_CASE("RangeRandom") {
 	REQUIRE_NE(first_diff, 0);
 }
 
+TEST_CASE("Overflow/Underflow") {
+	lcf::Data::variables.resize(max_vars);
+
+	auto _min = std::numeric_limits<Game_Variables::Var_t>::min();
+	auto _max = std::numeric_limits<Game_Variables::Var_t>::max();
+
+	Game_Variables v(_min, _max);
+	v.SetWarning(0);
+
+	v.Set(1, _max);
+	v.Add(1, 1);
+	REQUIRE(v.Get(1) == _max);
+
+	v.Set(1, _min);
+	v.Add(1, -1);
+	REQUIRE(v.Get(1) == _min);
+
+	v.Set(1, _max);
+	v.Sub(1, -1);
+	REQUIRE(v.Get(1) == _max);
+
+	v.Set(1, _min);
+	v.Sub(1, 1);
+	REQUIRE(v.Get(1) == _min);
+
+	v.Set(1, _max);
+	v.Mult(1, 2);
+	REQUIRE(v.Get(1) == _max);
+
+	v.Set(1, _min);
+	v.Mult(1, -2);
+	REQUIRE(v.Get(1) == _max);
+
+	v.Set(1, _max);
+	v.Mult(1, -2);
+	REQUIRE(v.Get(1) == _min);
+
+	v.Set(1, _min);
+	v.Mult(1, 2);
+	REQUIRE(v.Get(1) == _min);
+}
+
 TEST_CASE("Enumerate") {
 	auto s = make();
 


### PR DESCRIPTION
When variables overflow the value is now correctly clamped.

Mostly required by Maniac Patch because it uses the entire integer range but also broke with multiply in normal maker (see fixed issue).

Also implemented the "Input numbers via numpad" extension from newer Maniac versions.

Fix #2650