### PR TITLE
Maniac Pictures: Support Origin, Fixed Angle and Frames for duration

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2910,7 +2910,7 @@ bool Game_Interpreter::CommandMovePicture(lcf::rpg::EventCommand const& com) { /
 	params.magnify = std::max(0, std::min(params.magnify, 2000));
 	params.top_trans = std::max(0, std::min(params.top_trans, 100));
 	params.bottom_trans = std::max(0, std::min(params.bottom_trans, 100));
-	params.duration = std::max(0, std::min(params.duration, 10000));
+	params.duration = std::max(Player::IsPatchManiac() ? -10000 : 0, std::min(params.duration, 10000));
 
 	if (pic_id <= 0) {
 		Output::Error("MovePicture: Requested invalid picture id ({})", pic_id);

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2807,13 +2807,13 @@ bool Game_Interpreter::CommandShowPicture(lcf::rpg::EventCommand const& com) { /
 			params.flip_x = (flags & 16) == 16;
 			params.flip_y = (flags & 32) == 32;
 
-			if ((com.parameters[1] >> 8) != 0) {
-				Output::Warning("Maniac ShowPicture: X/Y origin not supported");
-			}
-
 			if (params.effect_mode == lcf::rpg::SavePicture::Effect_maniac_fixed_angle) {
-				Output::Warning("Maniac ShowPicture: Fixed angle not supported");
-				params.effect_mode = lcf::rpg::SavePicture::Effect_none;
+				params.effect_power = ValueOrVariable(com.parameters[16] & 0xF, params.effect_power);
+				int divisor = ValueOrVariable((com.parameters[16] & 0xF0) >> 4, com.parameters[15]);
+				if (divisor == 0) {
+					divisor = 1;
+				}
+				params.effect_power /= divisor;
 			}
 		}
 	}
@@ -2890,13 +2890,13 @@ bool Game_Interpreter::CommandMovePicture(lcf::rpg::EventCommand const& com) { /
 			params.flip_x = (flags & 16) == 16;
 			params.flip_y = (flags & 32) == 32;
 
-			if ((com.parameters[1] >> 8) != 0) {
-				Output::Warning("Maniac MovePicture: X/Y origin not supported");
-			}
-
 			if (params.effect_mode == lcf::rpg::SavePicture::Effect_maniac_fixed_angle) {
-				Output::Warning("Maniac MovePicture: Fixed angle not supported");
-				params.effect_mode = lcf::rpg::SavePicture::Effect_none;
+				params.effect_power = ValueOrVariable(com.parameters[16] & 0xF, params.effect_power);
+				int divisor = ValueOrVariable((com.parameters[16] & 0xF0) >> 4, com.parameters[15]);
+				if (divisor == 0) {
+					divisor = 1;
+				}
+				params.effect_power /= divisor;
 			}
 		}
 	} else {

--- a/src/game_pictures.cpp
+++ b/src/game_pictures.cpp
@@ -251,7 +251,11 @@ void Game_Pictures::Picture::Move(const MoveParams& params) {
 	const bool ignore_position = Player::IsLegacy() && data.fixed_to_map;
 
 	SetNonEffectParams(params, !ignore_position);
-	data.time_left = params.duration * DEFAULT_FPS / 10;
+	if (params.duration < 0) {
+		data.time_left = -params.duration;
+	} else {
+		data.time_left = params.duration * DEFAULT_FPS / 10;
+	}
 
 	// Note that data.effect_mode doesn't necessarily reflect the
 	// last effect set. Possible states are:

--- a/src/game_pictures.cpp
+++ b/src/game_pictures.cpp
@@ -189,7 +189,11 @@ bool Game_Pictures::Picture::Show(const ShowParams& params) {
 	SyncCurrentToFinish<true>(data);
 	data.start_x = data.current_x;
 	data.start_y = data.current_y;
-	data.current_rotation = 0.0;
+	if (data.effect_mode == lcf::rpg::SavePicture::Effect_maniac_fixed_angle) {
+		data.current_rotation = data.finish_effect_power;
+	} else {
+		data.current_rotation = 0.0;
+	}
 	data.current_waver = 0;
 	data.time_left = 0;
 
@@ -456,6 +460,11 @@ void Game_Pictures::Picture::Update(bool is_battle) {
 	// Update waver phase
 	if (data.effect_mode == lcf::rpg::SavePicture::Effect_wave) {
 		data.current_waver += 8;
+	}
+
+	// Update fixed angle
+	if (data.effect_mode == lcf::rpg::SavePicture::Effect_maniac_fixed_angle) {
+		data.current_rotation = data.current_effect_power;
 	}
 
 	// RPG Maker 2k3 1.12: Animated spritesheets

--- a/src/game_pictures.h
+++ b/src/game_pictures.h
@@ -58,6 +58,7 @@ public:
 		bool flip_x = false;
 		bool flip_y = false;
 		int blend_mode = 0;
+		int origin = 0;
 	};
 	struct ShowParams : Params {
 		std::string name;
@@ -79,7 +80,7 @@ public:
 		int duration = 0;
 	};
 
-	void Show(int id, const ShowParams& params);
+	bool Show(int id, const ShowParams& params);
 	void Move(int id, const MoveParams& params);
 	void Erase(int id);
 	void EraseAll();
@@ -98,6 +99,7 @@ public:
 		lcf::rpg::SavePicture data;
 		FileRequestBinding request_id;
 		bool needs_update = false;
+		int origin = 0;
 
 		void Update(bool is_battle);
 
@@ -116,7 +118,8 @@ public:
 		bool IsRequestPending() const;
 		void MakeRequestImportant() const;
 
-		void OnPictureSpriteReady() const;
+		void OnPictureSpriteReady();
+		void ApplyOrigin(bool is_move);
 		void OnMapScrolled(int dx, int dy);
 	};
 
@@ -125,7 +128,7 @@ public:
 
 private:
 	void RequestPictureSprite(Picture& pic);
-	void OnPictureSpriteReady(int id);
+	void OnPictureSpriteReady(FileRequestResult*, int id);
 
 	std::vector<Picture> pictures;
 	std::deque<Sprite_Picture> sprites;

--- a/src/sprite_picture.cpp
+++ b/src/sprite_picture.cpp
@@ -110,7 +110,13 @@ void Sprite_Picture::Draw(Bitmap& dst) {
 	SetOx(sr.width / 2);
 	SetOy(sr.height / 2);
 
-	SetAngle(data.effect_mode != lcf::rpg::SavePicture::Effect_wave ? data.current_rotation * (2 * M_PI) / 256 : 0.0);
+	if (data.effect_mode == lcf::rpg::SavePicture::Effect_maniac_fixed_angle) {
+		SetAngle(data.current_rotation * (2 * M_PI) / 360);
+	} else if (data.effect_mode != lcf::rpg::SavePicture::Effect_wave) {
+		SetAngle(data.current_rotation * (2 * M_PI) / 256);
+	} else {
+		SetAngle(0.0);
+	}
 	SetWaverPhase(data.effect_mode == lcf::rpg::SavePicture::Effect_wave ? data.current_waver * (2 * M_PI) / 256 : 0.0);
 	SetWaverDepth(data.effect_mode == lcf::rpg::SavePicture::Effect_wave ? data.current_effect_power * 2 : 0);
 


### PR DESCRIPTION
Okay kinda clickbait. Origin is not supported yet because I cannot figure out some rounding errors.
But it will come this week ;)

Wanted an issue number already for the metabug (#1818)

- [x] Fixed Angle standalone
- [x] Switching from Fixed Angle to other effects (this looks bad because maniac uses 360°, rest 256°, not my fault)
- [x] How many frames Move picture lasts
- [x] Origin  
