### PR TITLE
Emscripten: basic Web Gamepad support

### DIFF
--- a/resources/emscripten/emscripten-shell.html
+++ b/resources/emscripten/emscripten-shell.html
@@ -115,13 +115,6 @@
       opacity: 0.4;
     }
 
-    @media (hover: hover) and (pointer: fine) {
-      #apad,
-      #dpad {
-        display: none;
-      }
-    }
-
     @media (min-width: 320px) and (min-height: 240px) { #canvas { width: 320px; height: 240px; } }
     @media (min-width: 640px) and (min-height: 480px) { #canvas { width: 640px; height: 480px; } }
     @media (min-width: 960px) and (min-height: 720px) { #canvas { width: 960px; height: 720px; } }
@@ -249,7 +242,7 @@ function bindKey(node, key, keyCode) {
 
     keysDown.delete(event.target.id);
     node.classList.remove('active');
-  
+
     if (lastTouchedId) {
       document.getElementById(lastTouchedId).classList.remove('active');
     }
@@ -279,6 +272,203 @@ function bindKey(node, key, keyCode) {
   })
 }
 
+/** @type {{[key: number]: Gamepad}} */
+let gamepads = {};
+const haveEvents = 'ongamepadonnected' in window;
+
+let buttonMapping = {
+  0: {
+    key: "Escape",
+    code: "27"
+  },
+  1: {
+    key: "Enter",
+    code: "13"
+  },
+  12: {
+    key: "ArrowUp",
+    code: "38"
+  },
+  13: {
+    key: "ArrowDown",
+    code: "40"
+  },
+  14: {
+    key: "ArrowLeft",
+    code: "37"
+  },
+  15: {
+    key: "ArrowRight",
+    code: "39"
+  }
+};
+
+let axisMapping = {
+  0: {
+    threshold: 0.55,
+    negative: {
+      button: 14
+    },
+    positive: {
+      button: 15
+    }
+  },
+  1: {
+    threshold: 0.55,
+    negative: {
+      button: 12
+    },
+    positive: {
+      button: 13
+    }
+  }
+};
+
+let virtualKeyState = new Map();
+// Set all the keys in the state to "up"
+for (const k in buttonMapping) {
+  const keyMap = buttonMapping[k];
+  virtualKeyState.set(keyMap.key, 'up');
+}
+
+function addGamepad(gamepad) {
+  gamepads[gamepad.index] = gamepad;
+  requestAnimationFrame(updateGamepadStatus);
+  updateTouchControlsVisibility();
+}
+
+function removeGamepad(gamepad) {
+  delete gamepads[gamepad.index];
+  updateTouchControlsVisibility();
+}
+
+/** @returns {Gamepad[]} */
+function getGamepads() {
+  var pads = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : []);
+  return pads;
+}
+
+function scanGamePads() {
+  var pads = getGamepads();
+  for (var i = 0; i < pads.length; i++) {
+    if (pads[i]) {
+      if (pads[i].index in gamepads) {
+        gamepads[pads[i].index] = pads[i];
+      } else {
+        addGamepad(pads[i]);
+      }
+    }
+  }
+}
+
+/**
+ * @param buttonId {number}
+ * @param button {GamepadButton}
+ */
+function updateButtonState(buttonId, button) {
+  const mapping = buttonMapping[buttonId];
+  if (button.pressed && virtualKeyState.get(mapping.key) === 'up') {
+    simulateKeyboardEvent('keydown', mapping.key, mapping.code);
+    virtualKeyState.set(mapping.key, 'down');
+  } else if (!button.pressed && virtualKeyState.get(mapping.key) === 'down') {
+    simulateKeyboardEvent('keyup', mapping.key, mapping.code);
+    virtualKeyState.set(mapping.key, 'up');
+  }
+}
+
+/**
+ * @param buttonId {number}
+ * @param axisValue {number}
+ * @param gamepad {Gamepad}
+ */
+function updateAxisState(axisId, axisValue, gamepad) {
+  const mapping = axisMapping[axisId];
+  const positiveButton = gamepad.buttons[mapping.positive.button];
+  const negativeButton = gamepad.buttons[mapping.negative.button];
+  const positiveMap = buttonMapping[mapping.positive.button];
+  const negativeMap = buttonMapping[mapping.negative.button];
+  let button;
+  let buttonMap;
+  if (axisValue > mapping.threshold) {
+    button = positiveButton;
+    buttonMap = positiveMap;
+  } else if (axisValue < (mapping.threshold * -1)) {
+    button = negativeButton;
+    buttonMap = negativeMap;
+  } else {
+    // Handle axis returning to a neutral position
+    if (!positiveButton.pressed && virtualKeyState.get(positiveMap.key) === 'down') {
+      simulateKeyboardEvent('keyup', positiveMap.key, positiveMap.code);
+      virtualKeyState.set(positiveMap.key, 'up');
+    } else if (!negativeButton.pressed && virtualKeyState.get(negativeMap.key) === 'down') {
+      simulateKeyboardEvent('keyup', negativeMap.key, negativeMap.code);
+      virtualKeyState.set(negativeMap.key, 'up');
+    }
+    return;
+  }
+
+  if (button.pressed === false && virtualKeyState.get(buttonMap.key) === 'up') {
+    simulateKeyboardEvent('keydown', buttonMap.key, buttonMap.code);
+    virtualKeyState.set(buttonMap.key, 'down');
+  }
+}
+
+function updateGamepadStatus() {
+  if (!haveEvents) {
+    scanGamePads();
+  }
+
+  for (const index in gamepads) {
+    /** @type {Gamepad} */
+    const gamepad = gamepads[index];
+    if (gamepad.mapping !== 'standard') {
+      // Skip this controller, we only support "standard" (i.e Xbox/PS-like controllers)
+      continue;
+    }
+    for (let i = 0; i < gamepad.buttons.length; i++) {
+      if (!buttonMapping[i]) {
+        // Unmapped button -- skip it.
+        continue;
+      }
+      updateButtonState(i, gamepad.buttons[i]);
+    }
+    for (let i = 0; i < gamepad.axes.length; i++) {
+      if (!axisMapping[i]) {
+        // Unmapped analog stick -- skip it.
+        continue;
+      }
+      updateAxisState(i, gamepad.axes[i], gamepad);
+    }
+  }
+  requestAnimationFrame(updateGamepadStatus);
+}
+
+if (!haveEvents) {
+  setInterval(scanGamePads, 500);
+}
+
+window.addEventListener('gamepadconnected', function(e) {
+  addGamepad(e.gamepad);
+});
+
+window.addEventListener('gamepaddisconnected', function(e) {
+  removeGamepad(e.gamepad);
+})
+
+function updateTouchControlsVisibility() {
+  if (hasTouchscreen && getGamepads().length === 0) {
+    for (const elem of document.querySelectorAll('#dpad, #apad')) {
+      elem.style.display = '';
+    }
+  } else {
+    // If we don't have a touch screen, OR any gamepads are connected...
+    for (const elem of document.querySelectorAll('#dpad, #apad')) {
+      // Hide the touch controls
+      elem.style.display = 'none';
+    }
+  }
+}
+
 // Bind all elements providing a `data-key` attribute with the
 // given key on touch-based devices
 if (hasTouchscreen) {
@@ -302,6 +492,8 @@ if (hasTouchscreen) {
   //   simulateKeyboardInput('Enter', 13);
   // });
 }
+
+updateTouchControlsVisibility();
 </script>
 
 </body>

--- a/resources/emscripten/emscripten-shell.html
+++ b/resources/emscripten/emscripten-shell.html
@@ -276,64 +276,8 @@ function bindKey(node, key, keyCode) {
 let gamepads = {};
 const haveEvents = 'ongamepadonnected' in window;
 
-let buttonMapping = {
-  0: {
-    key: "Escape",
-    code: "27"
-  },
-  1: {
-    key: "Enter",
-    code: "13"
-  },
-  12: {
-    key: "ArrowUp",
-    code: "38"
-  },
-  13: {
-    key: "ArrowDown",
-    code: "40"
-  },
-  14: {
-    key: "ArrowLeft",
-    code: "37"
-  },
-  15: {
-    key: "ArrowRight",
-    code: "39"
-  }
-};
-
-let axisMapping = {
-  0: {
-    threshold: 0.55,
-    negative: {
-      button: 14
-    },
-    positive: {
-      button: 15
-    }
-  },
-  1: {
-    threshold: 0.55,
-    negative: {
-      button: 12
-    },
-    positive: {
-      button: 13
-    }
-  }
-};
-
-let virtualKeyState = new Map();
-// Set all the keys in the state to "up"
-for (const k in buttonMapping) {
-  const keyMap = buttonMapping[k];
-  virtualKeyState.set(keyMap.key, 'up');
-}
-
 function addGamepad(gamepad) {
   gamepads[gamepad.index] = gamepad;
-  requestAnimationFrame(updateGamepadStatus);
   updateTouchControlsVisibility();
 }
 
@@ -361,88 +305,6 @@ function scanGamePads() {
   }
 }
 
-/**
- * @param buttonId {number}
- * @param button {GamepadButton}
- */
-function updateButtonState(buttonId, button) {
-  const mapping = buttonMapping[buttonId];
-  if (button.pressed && virtualKeyState.get(mapping.key) === 'up') {
-    simulateKeyboardEvent('keydown', mapping.key, mapping.code);
-    virtualKeyState.set(mapping.key, 'down');
-  } else if (!button.pressed && virtualKeyState.get(mapping.key) === 'down') {
-    simulateKeyboardEvent('keyup', mapping.key, mapping.code);
-    virtualKeyState.set(mapping.key, 'up');
-  }
-}
-
-/**
- * @param buttonId {number}
- * @param axisValue {number}
- * @param gamepad {Gamepad}
- */
-function updateAxisState(axisId, axisValue, gamepad) {
-  const mapping = axisMapping[axisId];
-  const positiveButton = gamepad.buttons[mapping.positive.button];
-  const negativeButton = gamepad.buttons[mapping.negative.button];
-  const positiveMap = buttonMapping[mapping.positive.button];
-  const negativeMap = buttonMapping[mapping.negative.button];
-  let button;
-  let buttonMap;
-  if (axisValue > mapping.threshold) {
-    button = positiveButton;
-    buttonMap = positiveMap;
-  } else if (axisValue < (mapping.threshold * -1)) {
-    button = negativeButton;
-    buttonMap = negativeMap;
-  } else {
-    // Handle axis returning to a neutral position
-    if (!positiveButton.pressed && virtualKeyState.get(positiveMap.key) === 'down') {
-      simulateKeyboardEvent('keyup', positiveMap.key, positiveMap.code);
-      virtualKeyState.set(positiveMap.key, 'up');
-    } else if (!negativeButton.pressed && virtualKeyState.get(negativeMap.key) === 'down') {
-      simulateKeyboardEvent('keyup', negativeMap.key, negativeMap.code);
-      virtualKeyState.set(negativeMap.key, 'up');
-    }
-    return;
-  }
-
-  if (button.pressed === false && virtualKeyState.get(buttonMap.key) === 'up') {
-    simulateKeyboardEvent('keydown', buttonMap.key, buttonMap.code);
-    virtualKeyState.set(buttonMap.key, 'down');
-  }
-}
-
-function updateGamepadStatus() {
-  if (!haveEvents) {
-    scanGamePads();
-  }
-
-  for (const index in gamepads) {
-    /** @type {Gamepad} */
-    const gamepad = gamepads[index];
-    if (gamepad.mapping !== 'standard') {
-      // Skip this controller, we only support "standard" (i.e Xbox/PS-like controllers)
-      continue;
-    }
-    for (let i = 0; i < gamepad.buttons.length; i++) {
-      if (!buttonMapping[i]) {
-        // Unmapped button -- skip it.
-        continue;
-      }
-      updateButtonState(i, gamepad.buttons[i]);
-    }
-    for (let i = 0; i < gamepad.axes.length; i++) {
-      if (!axisMapping[i]) {
-        // Unmapped analog stick -- skip it.
-        continue;
-      }
-      updateAxisState(i, gamepad.axes[i], gamepad);
-    }
-  }
-  requestAnimationFrame(updateGamepadStatus);
-}
-
 if (!haveEvents) {
   setInterval(scanGamePads, 500);
 }
@@ -456,7 +318,7 @@ window.addEventListener('gamepaddisconnected', function(e) {
 })
 
 function updateTouchControlsVisibility() {
-  if (hasTouchscreen && getGamepads().length === 0) {
+  if (hasTouchscreen && Object.keys(gamepads).length === 0) {
     for (const elem of document.querySelectorAll('#dpad, #apad')) {
       elem.style.display = '';
     }

--- a/src/sdl2_ui.cpp
+++ b/src/sdl2_ui.cpp
@@ -159,7 +159,7 @@ Sdl2Ui::Sdl2Ui(long width, long height, const Game_ConfigVideo& cfg) : BaseUi(cf
 		Output::Warning("Couldn't initialize joystick. {}", SDL_GetError());
 	}
 
-	SDL_JoystickEventState(1);
+	SDL_JoystickEventState(SDL_ENABLE);
 	SDL_JoystickOpen(0);
 #endif
 
@@ -515,6 +515,14 @@ void Sdl2Ui::ProcessEvent(SDL_Event &evnt) {
 			ProcessMouseButtonEvent(evnt);
 			return;
 
+		case SDL_JOYDEVICEADDED:
+			ProcessJoystickAdded(evnt);
+			return;
+
+		case SDL_JOYDEVICEREMOVED:
+			ProcessJoystickRemoved(evnt);
+			return;
+
 		case SDL_JOYBUTTONDOWN:
 		case SDL_JOYBUTTONUP:
 			ProcessJoystickButtonEvent(evnt);
@@ -656,6 +664,19 @@ void Sdl2Ui::ProcessMouseButtonEvent(SDL_Event& evnt) {
 #else
 	/* unused */
 	(void) evnt;
+#endif
+}
+
+void Sdl2Ui::ProcessJoystickAdded(SDL_Event &evnt) {
+#if defined(USE_JOYSTICK) && defined(SUPPORT_JOYSTICK)
+	SDL_JoystickOpen(evnt.jdevice.which);
+#endif
+}
+
+void Sdl2Ui::ProcessJoystickRemoved(SDL_Event &evnt) {
+#if defined(USE_JOYSTICK) && defined(SUPPORT_JOYSTICK)
+	SDL_Joystick *joystick = SDL_JoystickFromInstanceID(evnt.jdevice.which);
+	SDL_JoystickClose(joystick);
 #endif
 }
 

--- a/src/sdl2_ui.h
+++ b/src/sdl2_ui.h
@@ -95,6 +95,8 @@ private:
 	void ProcessKeyUpEvent(SDL_Event &evnt);
 	void ProcessMouseMotionEvent(SDL_Event &evnt);
 	void ProcessMouseButtonEvent(SDL_Event &evnt);
+	void ProcessJoystickAdded(SDL_Event &evnt);
+	void ProcessJoystickRemoved(SDL_Event &evnt);
 	void ProcessJoystickButtonEvent(SDL_Event &evnt);
 	void ProcessJoystickHatEvent(SDL_Event &evnt);
 	void ProcessJoystickAxisEvent(SDL_Event &evnt);


### PR DESCRIPTION
This PR adds _very_ rudimentary Web Gamepad support.

Some notes:
- It seems like Joystick support was broken because `SDL_JoystickOpen(0)` at init time doesn't work when running in emscripten.
- I haven't touched any of the button maps, but it's not great right now. The dpad is completely nonfunctional, and the X button on the Xbox is mapped to arrow down, Y is Esc, B is Enter, and so on. The left stick does work as expected though. I think we'll need to have a special default button map for when `#ifdef EMSCRIPTEN`...
- If there's any gamepad connected and active in the browser window, the on-screen touch controls will immediately disappear. They should reappear when the gamepad disconnects. I moved the logic for displaying the touch controls into JS since the logic is now more complicated than what can be expressed by a simple media query.

The motivation for this change is obviously supporting game controllers out of the box for web deployments of EasyRPG Player, but it's particularly notable since web is the only way to deploy to iOS users, who'll for the first time be able to use MFi controllers instead of clunky touch controls, and stopping those touch controls getting in the way of the game UI.

Fixes #1156