### PR TITLE
SDL2: Add integer scaling support

### DIFF
--- a/src/baseui.cpp
+++ b/src/baseui.cpp
@@ -61,6 +61,7 @@ BaseUi::BaseUi(const Game_ConfigVideo& cfg)
 	fps_render_window = cfg.fps_render_window.Get();
 	fps_limit = cfg.fps_limit.Get();
 	frame_limit = (fps_limit == 0 ? Game_Clock::duration(0) : Game_Clock::TimeStepFromFps(fps_limit));
+	scaling_mode = cfg.scaling_mode.Get();
 }
 
 BitmapRef BaseUi::CaptureScreen() {

--- a/src/baseui.h
+++ b/src/baseui.h
@@ -234,7 +234,7 @@ protected:
 	bool fps_render_window = false;
 
 	/** How to scale the viewport when larger than 320x240 */
-	ScalingMode scaling_mode = ScalingMode::Fractional;
+	ScalingMode scaling_mode = ScalingMode::Bilinear;
 };
 
 /** Global DisplayUi variable. */

--- a/src/baseui.h
+++ b/src/baseui.h
@@ -232,6 +232,9 @@ protected:
 
 	/** If we will render fps on the screen even in windowed mode */
 	bool fps_render_window = false;
+
+	/** How to scale the viewport when larger than 320x240 */
+	ScalingMode scaling_mode = ScalingMode::Fractional;
 };
 
 /** Global DisplayUi variable. */

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -180,6 +180,9 @@ void Game_Config::LoadFromConfig(const std::string& path) {
 	if (ini.HasValue("video", "window-zoom")) {
 		video.window_zoom.Set(ini.GetInteger("video", "window-zoom", 0));
 	}
+	if (ini.HasValue("video", "scaling-mode")) {
+		video.scaling_mode.Set(static_cast<ScalingMode>(ini.GetInteger("video", "scaling-mode", 0)));
+	}
 
 	/** AUDIO SECTION */
 

--- a/src/game_config.h
+++ b/src/game_config.h
@@ -23,6 +23,11 @@
 
 class CmdlineParser;
 
+enum class ScalingMode {
+	Fractional,
+	Integer
+};
+
 struct Game_ConfigPlayer {
 	StringConfigParam autobattle_algo{ "" };
 	StringConfigParam enemyai_algo{ "" };
@@ -35,6 +40,7 @@ struct Game_ConfigVideo {
 	BoolConfigParam fps_render_window{ false };
 	RangeConfigParam<int> fps_limit{ DEFAULT_FPS, 0, std::numeric_limits<int>::max() };
 	RangeConfigParam<int> window_zoom{ 2, 1, std::numeric_limits<int>::max() };
+	EnumConfigParam<ScalingMode> scaling_mode{ ScalingMode::Fractional };
 };
 
 struct Game_ConfigAudio {

--- a/src/game_config.h
+++ b/src/game_config.h
@@ -24,8 +24,12 @@
 class CmdlineParser;
 
 enum class ScalingMode {
-	Fractional,
-	Integer
+	/** Nearest neighbour to fit screen */
+	Nearest,
+	/** Like NN but only scales to integers */
+	Integer,
+	/** Integer followed by Bilinear downscale to fit screen */
+	Bilinear,
 };
 
 struct Game_ConfigPlayer {
@@ -40,7 +44,7 @@ struct Game_ConfigVideo {
 	BoolConfigParam fps_render_window{ false };
 	RangeConfigParam<int> fps_limit{ DEFAULT_FPS, 0, std::numeric_limits<int>::max() };
 	RangeConfigParam<int> window_zoom{ 2, 1, std::numeric_limits<int>::max() };
-	EnumConfigParam<ScalingMode> scaling_mode{ ScalingMode::Fractional };
+	EnumConfigParam<ScalingMode> scaling_mode{ ScalingMode::Bilinear };
 };
 
 struct Game_ConfigAudio {

--- a/src/sdl2_ui.cpp
+++ b/src/sdl2_ui.cpp
@@ -180,8 +180,8 @@ Sdl2Ui::Sdl2Ui(long width, long height, const Game_ConfigVideo& cfg) : BaseUi(cf
 }
 
 Sdl2Ui::~Sdl2Ui() {
-	if (sdl_texture) {
-		SDL_DestroyTexture(sdl_texture);
+	if (sdl_texture_game) {
+		SDL_DestroyTexture(sdl_texture_game);
 	}
 	if (sdl_renderer) {
 		SDL_DestroyRenderer(sdl_renderer);
@@ -344,12 +344,12 @@ bool Sdl2Ui::RefreshDisplayMode() {
 		SDL_RenderClear(sdl_renderer);
 		SDL_RenderPresent(sdl_renderer);
 
-		sdl_texture = SDL_CreateTexture(sdl_renderer,
+		sdl_texture_game = SDL_CreateTexture(sdl_renderer,
 			texture_format,
 			SDL_TEXTUREACCESS_STREAMING,
 			SCREEN_TARGET_WIDTH, SCREEN_TARGET_HEIGHT);
 
-		if (!sdl_texture) {
+		if (!sdl_texture_game) {
 			Output::Debug("SDL_CreateTexture failed : {}", SDL_GetError());
 			return false;
 		}
@@ -381,7 +381,7 @@ bool Sdl2Ui::RefreshDisplayMode() {
 	uint32_t sdl_pixel_fmt = GetDefaultFormat();
 	int a, w, h;
 
-	if (SDL_QueryTexture(sdl_texture, &sdl_pixel_fmt, &a, &w, &h) != 0) {
+	if (SDL_QueryTexture(sdl_texture_game, &sdl_pixel_fmt, &a, &w, &h) != 0) {
 		Output::Debug("SDL_QueryTexture failed : {}", SDL_GetError());
 		return false;
 	}
@@ -460,7 +460,7 @@ void Sdl2Ui::ProcessEvents() {
 
 void Sdl2Ui::UpdateDisplay() {
 	// SDL_UpdateTexture was found to be faster than SDL_LockTexture / SDL_UnlockTexture.
-	SDL_UpdateTexture(sdl_texture, nullptr, main_surface->pixels(), main_surface->pitch());
+	SDL_UpdateTexture(sdl_texture_game, nullptr, main_surface->pixels(), main_surface->pitch());
 
 	if (window.size_changed) {
 		// Based on SDL2 function UpdateLogicalSize
@@ -512,7 +512,7 @@ void Sdl2Ui::UpdateDisplay() {
 	}
 
 	SDL_RenderClear(sdl_renderer);
-	SDL_RenderCopy(sdl_renderer, sdl_texture, nullptr, nullptr);
+	SDL_RenderCopy(sdl_renderer, sdl_texture_game, nullptr, nullptr);
 	SDL_RenderPresent(sdl_renderer);
 }
 

--- a/src/sdl2_ui.h
+++ b/src/sdl2_ui.h
@@ -121,7 +121,7 @@ private:
 	DisplayMode last_display_mode;
 
 	/** Main SDL window. */
-	SDL_Texture* sdl_texture = nullptr;
+	SDL_Texture* sdl_texture_game = nullptr;
 	SDL_Window* sdl_window = nullptr;
 	SDL_Renderer* sdl_renderer = nullptr;
 

--- a/src/sdl2_ui.h
+++ b/src/sdl2_ui.h
@@ -122,6 +122,7 @@ private:
 
 	/** Main SDL window. */
 	SDL_Texture* sdl_texture_game = nullptr;
+	SDL_Texture* sdl_texture_scaled = nullptr;
 	SDL_Window* sdl_window = nullptr;
 	SDL_Renderer* sdl_renderer = nullptr;
 
@@ -129,6 +130,7 @@ private:
 		int width = 0;
 		int height = 0;
 		bool size_changed = true;
+		float scale = 0.f;
 	} window = {};
 
 	uint32_t texture_format = SDL_PIXELFORMAT_UNKNOWN;

--- a/src/sdl2_ui.h
+++ b/src/sdl2_ui.h
@@ -90,7 +90,7 @@ private:
 
 	void ProcessEvent(SDL_Event &sdl_event);
 
-	void ProcessActiveEvent(SDL_Event &evnt);
+	void ProcessWindowEvent(SDL_Event &evnt);
 	void ProcessKeyDownEvent(SDL_Event &evnt);
 	void ProcessKeyUpEvent(SDL_Event &evnt);
 	void ProcessMouseMotionEvent(SDL_Event &evnt);
@@ -124,6 +124,14 @@ private:
 	SDL_Texture* sdl_texture = nullptr;
 	SDL_Window* sdl_window = nullptr;
 	SDL_Renderer* sdl_renderer = nullptr;
+
+	struct {
+		int width = 0;
+		int height = 0;
+		bool size_changed = true;
+	} window = {};
+
+	uint32_t texture_format = SDL_PIXELFORMAT_UNKNOWN;
 
 	std::unique_ptr<AudioInterface> audio_;
 };


### PR DESCRIPTION
Code is based on code from SDL2. I extracted it as this gives more flexibility.

Fix #720
Fix #1366

-----

DONE: ~~Not ready yet. Also want to add a 3rd scaling mode while at it:~~

~~When the viewport is a fractional then scale one higher than would fit and then do a bilinear downscale to the viewport size.~~

(Can somebody find the issue number where this was mentioned???)

