### PR TITLE
Resampler: Fix crackles when looping the audio

### DIFF
--- a/src/audio_decoder_base.h
+++ b/src/audio_decoder_base.h
@@ -88,7 +88,7 @@ public:
 	 *
 	 * @return if looping
 	 */
-	bool GetLooping() const;
+	virtual bool GetLooping() const;
 
 	/**
 	 * Enables/Disables audio stream looping.
@@ -97,14 +97,14 @@ public:
 	 *
 	 * @param enable Enable/Disable looping
 	 */
-	void SetLooping(bool enable);
+	virtual void SetLooping(bool enable);
 
 	/**
 	 * Gets the number of loops
 	 *
 	 * @return loop count
 	 */
-	int GetLoopCount() const;
+	virtual int GetLoopCount() const;
 
 	// Functions to be implemented by the audio decoder
 	/**

--- a/src/audio_resampler.cpp
+++ b/src/audio_resampler.cpp
@@ -309,7 +309,18 @@ bool AudioResampler::Seek(std::streamoff offset, std::ios_base::seekdir origin) 
 		return true;
 	}
 	return false;
+}
 
+bool AudioResampler::GetLooping() const {
+	return wrapped_decoder->GetLooping();
+}
+
+void AudioResampler::SetLooping(bool enable) {
+	wrapped_decoder->SetLooping(enable);
+}
+
+int AudioResampler::GetLoopCount() const {
+	return wrapped_decoder->GetLoopCount();
 }
 
 std::streampos AudioResampler::Tell() const {

--- a/src/audio_resampler.h
+++ b/src/audio_resampler.h
@@ -121,6 +121,29 @@ public:
 	bool Seek(std::streamoff offset, std::ios_base::seekdir origin) override;
 
 	/**
+	 * Gets if the audio stream will loop when the stream finishes.
+	 *
+	 * @return if looping
+	 */
+	bool GetLooping() const override;
+
+	/**
+	 * Enables/Disables audio stream looping.
+	 * When looping is enabled IsFinished will never return true and the stream
+	 * auto-rewinds (assuming Rewind is supported)
+	 *
+	 * @param enable Enable/Disable looping
+	 */
+	void SetLooping(bool enable) override;
+
+	/**
+	 * Gets the number of loops
+	 *
+	 * @return loop count
+	 */
+	int GetLoopCount() const override;
+
+	/**
 	 * Wraps the tell function of the contained decoder
 	 *
 	 * @return Position in the stream
@@ -135,7 +158,7 @@ public:
 	int GetTicks() const override;
 
 	/**
-	 * Returns wheter the resampled audio stream is finished
+	 * Returns whether the resampled is exhausted and the audio stream is finished.
 	 *
 	 * @return true if the stream has reached it's end
 	 */


### PR DESCRIPTION
I "only" needed 4 hours to come up with this solution. Well, after debugging for 4 hours I finally understood how our resampler works. I was also able to simplify the code alot until I discovered where the crackles are coming from: The wrapped_decoder is not looping. 

Refactoring the resampler to get it merged with the decoder will take a while, so I provide here a workaround to get rid of the crackles for now.

------------

For a smooth looping without gaps the wrapped_decoder must be able to loop.

The solution is more of a hack / short-term solution:
All loop-related methods were forwarded to the wrapped_decoder

The better, more complex solution is refactoring the code by merging Decoder+Resampler
to give more control about the decoding process without all this ugly forwarding.

Fix #2666