### PR TITLE
Maniac Patch: Fix out of bounds read in Move Picture

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2886,7 +2886,7 @@ bool Game_Interpreter::CommandMovePicture(lcf::rpg::EventCommand const& com) { /
 		// RPG2k and RPG2k3 1.10 do not support this option
 		params.bottom_trans = params.top_trans;
 
-		if (Player::IsPatchManiac()) {
+		if (Player::IsPatchManiac() && param_size > 16) {
 			int flags = com.parameters[16] >> 8;
 			int blend_mode = flags & 3;
 			if (blend_mode == 1) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -831,7 +831,6 @@ void Player::CreateGameObjects() {
 
 		if (!FileFinder::Game().FindFile("accord.dll").empty()) {
 			patch |= PatchManiac;
-			Output::Warning("This game uses the Maniac Patch and will not run properly.");
 		}
 	}
 


### PR DESCRIPTION
Reported by Soeufans, thanks.

Forgot a size check in Move Picture event. Show picture is unaffected because the code is structured different.

Also disabled the warning on startup as there is enough maniac support by now to consider it usable.