### PR TITLE
Disallow canceling in command menu in traditional type battles

### DIFF
--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1407,11 +1407,13 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionCo
 			}
 			return SceneActionReturn::eWaitTillNextFrame;
 		}
-		if (Input::IsTriggered(Input::CANCEL)) {
-			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
-			SetState(State_SelectOption);
+		if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) {
+			if (Input::IsTriggered(Input::CANCEL)) {
+				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
+				SetState(State_SelectOption);
 
-			return SceneActionReturn::eWaitTillNextFrame;
+				return SceneActionReturn::eWaitTillNextFrame;
+			}
 		}
 		return SceneActionReturn::eWaitTillNextFrame;
 	}


### PR DESCRIPTION
This PR no longer allows canceling in the command menu if the RPG Maker 2003 battle type is traditional. This fixes the flicker mentioned in issue #2775.