### PR TITLE
Make the number of level digits dependent on the global maximum level

### DIFF
--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -132,7 +132,7 @@ void Window_Base::DrawActorLevel(const Game_Actor& actor, int cx, int cy) const 
 	contents->TextDraw(cx, cy, 1, lcf::Data::terms.lvl_short);
 
 	// Draw Level of the Actor
-	contents->TextDraw(cx + (actor.GetMaxLevel() >= 100 ? 30 : 24), cy, Font::ColorDefault, std::to_string(actor.GetLevel()), Text::AlignRight);
+	contents->TextDraw(cx + (lcf::Data::system.easyrpg_max_level >= 100 ? 30 : 24), cy, Font::ColorDefault, std::to_string(actor.GetLevel()), Text::AlignRight);
 }
 
 void Window_Base::DrawActorState(const Game_Battler& actor, int cx, int cy) const {


### PR DESCRIPTION
This PR makes the number of level digits dependent on the global maximum level setting instead of the maximum level of the actor. This fixes a small optical issue with the level indent if you have actors in the party which can reach level 100 or greater and actors which can reach at most level 99.