### PR TITLE
ZipFs: Disable built-in cache

### DIFF
--- a/src/filesystem_stream.cpp
+++ b/src/filesystem_stream.cpp
@@ -84,26 +84,31 @@ void Filesystem_Stream::OutputStream::Close() {
 	set_rdbuf(nullptr);
 }
 
-Filesystem_Stream::InputMemoryStreamBuf::InputMemoryStreamBuf(Span<uint8_t> buffer)
-		: std::streambuf(), buffer(buffer) {
-	char* cbuffer = reinterpret_cast<char*>(buffer.data());
-	setg(cbuffer, cbuffer, cbuffer + buffer.size());
+Filesystem_Stream::InputMemoryStreamBufView::InputMemoryStreamBufView(Span<uint8_t> buffer_view)
+		: std::streambuf(), buffer_view(buffer_view) {
+	char* cbuffer = reinterpret_cast<char*>(buffer_view.data());
+	setg(cbuffer, cbuffer, cbuffer + buffer_view.size());
 }
 
-std::streambuf::pos_type Filesystem_Stream::InputMemoryStreamBuf::seekoff(std::streambuf::off_type offset, std::ios_base::seekdir dir, std::ios_base::openmode mode) {
+std::streambuf::pos_type Filesystem_Stream::InputMemoryStreamBufView::seekoff(std::streambuf::off_type offset, std::ios_base::seekdir dir, std::ios_base::openmode mode) {
 	std::streambuf::pos_type off;
 	if (dir == std::ios_base::beg) {
 		off = offset;
 	} else if (dir == std::ios_base::cur) {
 		off = gptr() - eback() + offset;
 	} else {
-		off = buffer.size() + offset;
+		off = buffer_view.size() + offset;
 	}
 	return seekpos(off, mode);
 }
 
-std::streambuf::pos_type Filesystem_Stream::InputMemoryStreamBuf::seekpos(std::streambuf::pos_type pos, std::ios_base::openmode) {
-	auto off = Utils::Clamp<std::streambuf::pos_type>(pos, 0, buffer.size());
+std::streambuf::pos_type Filesystem_Stream::InputMemoryStreamBufView::seekpos(std::streambuf::pos_type pos, std::ios_base::openmode) {
+	auto off = Utils::Clamp<std::streambuf::pos_type>(pos, 0, buffer_view.size());
 	setg(eback(), eback() + off, egptr());
 	return off;
+}
+
+Filesystem_Stream::InputMemoryStreamBuf::InputMemoryStreamBuf(std::vector<uint8_t> buffer)
+		: InputMemoryStreamBufView(buffer), buffer(std::move(buffer)) {
+
 }

--- a/src/filesystem_stream.h
+++ b/src/filesystem_stream.h
@@ -67,18 +67,30 @@ namespace Filesystem_Stream {
 		std::string name;
 	};
 
-	class InputMemoryStreamBuf : public std::streambuf {
+	/** Streambuf interface for an in-memory buffer. Does not take ownership of the buffer. */
+	class InputMemoryStreamBufView : public std::streambuf {
 	public:
-		explicit InputMemoryStreamBuf(Span<uint8_t> buffer);
-		InputMemoryStreamBuf(InputMemoryStreamBuf const& other) = delete;
-		InputMemoryStreamBuf const& operator=(InputMemoryStreamBuf const& other) = delete;
+		explicit InputMemoryStreamBufView(Span<uint8_t> buffer_view);
+		InputMemoryStreamBufView(InputMemoryStreamBufView const& other) = delete;
+		InputMemoryStreamBufView const& operator=(InputMemoryStreamBufView const& other) = delete;
 
 	protected:
 		std::streambuf::pos_type seekoff(std::streambuf::off_type offset, std::ios_base::seekdir dir, std::ios_base::openmode mode) override;
 		std::streambuf::pos_type seekpos(std::streambuf::pos_type pos, std::ios_base::openmode mode) override;
 
 	private:
-		Span<uint8_t> buffer;
+		Span<uint8_t> buffer_view;
+	};
+
+	/** Streambuf interface for an in-memory buffer. Takes ownership of the buffer. */
+	class InputMemoryStreamBuf : public InputMemoryStreamBufView {
+	public:
+		explicit InputMemoryStreamBuf(std::vector<uint8_t> buffer);
+		InputMemoryStreamBuf(InputMemoryStreamBuf const& other) = delete;
+		InputMemoryStreamBuf const& operator=(InputMemoryStreamBuf const& other) = delete;
+
+	private:
+		std::vector<uint8_t> buffer;
 	};
 
 	static constexpr std::ios_base::seekdir CSeekdirToCppSeekdir(int origin);

--- a/src/filesystem_zip.cpp
+++ b/src/filesystem_zip.cpp
@@ -326,11 +326,6 @@ std::streambuf* ZipFilesystem::CreateInputStreambuffer(StringView path, std::ios
 	std::string path_normalized = normalize_path(path);
 	auto entry = Find(path);
 	if (entry && !entry->is_directory) {
-		auto pool_it = input_pool.find(path_normalized);
-		if (pool_it != input_pool.end()) {
-			return new Filesystem_Stream::InputMemoryStreamBuf(pool_it->second);
-		}
-
 		auto zip_file = GetParent().OpenInputStream(GetPath());
 		zip_file.seekg(entry->fileoffset);
 		StorageMethod method;
@@ -341,8 +336,7 @@ std::streambuf* ZipFilesystem::CreateInputStreambuffer(StringView path, std::ios
 			if (method == StorageMethod::Plain) {
 				auto data = std::vector<uint8_t>(entry->filesize);
 				zip_file.read(reinterpret_cast<char*>(data.data()), data.size());
-				input_pool[path_normalized] = std::move(data);
-				return new Filesystem_Stream::InputMemoryStreamBuf(input_pool[path_normalized]);
+				return new Filesystem_Stream::InputMemoryStreamBuf(std::move(data));
 			} else if (method == StorageMethod::Deflate) {
 				std::vector<uint8_t> comp_buf;
 				comp_buf.resize(compressed_size);
@@ -367,8 +361,7 @@ std::streambuf* ZipFilesystem::CreateInputStreambuffer(StringView path, std::ios
 					Output::Warning("ZipFS: zlib failed for {}: {}", path_normalized, zlib_stream.msg);
 					return nullptr;
 				}
-				input_pool[path_normalized] = std::move(dec_buf);
-				return new Filesystem_Stream::InputMemoryStreamBuf(input_pool[path_normalized]);
+				return new Filesystem_Stream::InputMemoryStreamBuf(std::move(dec_buf));
 			} else {
 				Output::Warning("ZipFS: {} has unsupported compression format. Only Deflate is supported", path_normalized);
 				return nullptr;

--- a/src/filesystem_zip.cpp
+++ b/src/filesystem_zip.cpp
@@ -22,6 +22,7 @@
 
 #include <zlib.h>
 #include <lcf/reader_util.h>
+#include <lcf/scope_guard.h>
 #include <iostream>
 #include <sstream>
 #include <cassert>
@@ -353,6 +354,9 @@ std::streambuf* ZipFilesystem::CreateInputStreambuffer(StringView path, std::ios
 				zlib_stream.next_out = reinterpret_cast<Bytef*>(dec_buf.data());
 				zlib_stream.avail_out = static_cast<uInt>(dec_buf.size());
 				inflateInit2(&zlib_stream, -MAX_WBITS);
+				auto inflate_sg = lcf::makeScopeGuard([&]() {
+					inflateEnd(&zlib_stream);
+				});
 
 				int zlib_error = inflate(&zlib_stream, Z_NO_FLUSH);
 				if (zlib_error == Z_OK) {

--- a/src/filesystem_zip.h
+++ b/src/filesystem_zip.h
@@ -66,7 +66,6 @@ private:
 	bool ReadLocalHeader(std::istream& zipfile, uint32_t& offset, StorageMethod& method, uint32_t& compressed_size) const;
 	const ZipEntry* Find(StringView what) const;
 
-	mutable std::unordered_map<std::string, std::vector<uint8_t>> input_pool;
 	std::vector<std::pair<std::string, ZipEntry>> zip_entries;
 	std::vector<std::pair<std::string, ZipEntry>> zip_entries_cp437;
 	std::string encoding;


### PR DESCRIPTION
The Zip FS cached all the decompressed files in memory.

This is very wasteful in terms of RAM making this unusable on many devices.

In general a compressed read + decompress will be still faster than a uncompressed read because IO is much slower than CPU.

Also in most cases the decompress only happens once. We already have caching for assets. BGM is also never decompressed until the track changes.