### PR TITLE
PS Vita: Update to latest libvita2d

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1088,7 +1088,8 @@ elseif(${PLAYER_TARGET_PLATFORM} MATCHES "^(psvita|3ds|switch|wii)$")
 			ScePgf_stub
 			ScePower_stub
 			SceCommonDialog_stub
-			SceAudio_stub)
+			SceAudio_stub
+			SceAppMgr_stub)
 		vita_create_self(eboot.bin easyrpg-player.elf $<$<NOT:CONFIG:Debug>:STRIPPED>)
 		set(VITA_MKSFOEX_FLAGS "-d ATTRIBUTE2=12")
 		configure_file(resources/psvita/template.xml.in resources/psvita/template.xml @ONLY)


### PR DESCRIPTION
This removes the shader support because this depends on 7 year old,
unmantained code.

If you want to readd it consider using libvita2d_ext or wait until the Player
receives a OpenGL renderer in 10 years ;)