### PR TITLE
Improve DirectoryTree & FileFinder_RTP performance

### DIFF
--- a/bench/bitmap.cpp
+++ b/bench/bitmap.cpp
@@ -272,7 +272,7 @@ static void BM_ToneBlit(benchmark::State& state) {
 	auto rect = src->GetRect();
 	auto tone = Tone(255,255,255,128);
 	for (auto _: state) {
-		dest->ToneBlit(0, 0, *src, rect, tone, opacity, false);
+		dest->ToneBlit(0, 0, *src, rect, tone, opacity);
 	}
 }
 

--- a/bench/rtp.cpp
+++ b/bench/rtp.cpp
@@ -1,14 +1,38 @@
 #include <benchmark/benchmark.h>
 #include "filefinder_rtp.h"
+#include "output.h"
+#include "player.h"
 
-static void BM_InitRtp(benchmark::State& state) {
+static void BM_InitRtp2k(benchmark::State& state) {
+	Output::SetLogLevel(LogLevel::Error);
+	Player::engine = Player::EngineRpg2k;
+
 	bool no_rtp_flag = false;
 	bool no_rtp_warning_flag = false;
 	for (auto _: state) {
 		FileFinder_RTP(no_rtp_flag, no_rtp_warning_flag, "");
 	}
+
+	Player::engine = Player::EngineNone;
+	Output::SetLogLevel(LogLevel::Debug);
 }
 
-BENCHMARK(BM_InitRtp);
+BENCHMARK(BM_InitRtp2k);
+
+static void BM_InitRtp2k3(benchmark::State& state) {
+	Output::SetLogLevel(LogLevel::Error);
+	Player::engine = Player::EngineRpg2k3;
+
+	bool no_rtp_flag = false;
+	bool no_rtp_warning_flag = false;
+	for (auto _: state) {
+		FileFinder_RTP(no_rtp_flag, no_rtp_warning_flag, "");
+	}
+
+	Player::engine = Player::EngineNone;
+	Output::SetLogLevel(LogLevel::Debug);
+}
+
+BENCHMARK(BM_InitRtp2k3);
 
 BENCHMARK_MAIN();

--- a/src/directory_tree.cpp
+++ b/src/directory_tree.cpp
@@ -75,7 +75,7 @@ DirectoryTree::DirectoryListType* DirectoryTree::ListDirectory(StringView path) 
 		return nullptr;
 	}
 
-	assert(fs_cache.find(dir_key) == fs_cache.end());
+	assert(Find(fs_cache, dir_key) == fs_cache.end());
 
 	if (!fs->Exists(fs_path)) {
 		std::string parent_dir, child_dir;

--- a/src/directory_tree.h
+++ b/src/directory_tree.h
@@ -131,13 +131,19 @@ public:
 private:
 	Filesystem* fs = nullptr;
 
-	/** lowered dir (full path from root) -> <map of> lowered file -> Entry */
+	// Cache vectors are sorted for a binary search
+	// Except dir_missing_cache as this vector will be (almost) empty usually
+
+	/** lowered dir (full path from root) -> <list of> lowered file -> Entry */
 	using fs_cache_pair = std::pair<std::string, DirectoryListType>;
 	mutable std::vector<fs_cache_pair> fs_cache;
 
 	/** lowered dir -> real dir (both full path from root) */
 	using dir_cache_pair = std::pair<std::string, std::string>;
 	mutable std::vector<dir_cache_pair> dir_cache;
+
+	/** lowered dir (full path from root) of missing directories */
+	mutable std::vector<std::string> dir_missing_cache;
 
 	template<class T>
 	const auto Find(T& cache, StringView what) const {

--- a/src/directory_tree.h
+++ b/src/directory_tree.h
@@ -146,7 +146,7 @@ private:
 	mutable std::vector<std::string> dir_missing_cache;
 
 	template<class T>
-	const auto Find(T& cache, StringView what) const {
+	auto Find(T& cache, StringView what) const {
 		auto it = std::lower_bound(cache.begin(), cache.end(), what, [](const auto& e, const auto& w) {
 			return e.first < w;
 		});
@@ -162,7 +162,7 @@ private:
 		auto it = std::lower_bound(cache.begin(), cache.end(), key, [](const auto& e, const auto& k) {
 			return e.first < k;
 		});
-		assert(it->first != key);
+		assert(it == cache.end() || it->first != key);
 		cache.insert(it, std::make_pair(key, value));
 	}
 };

--- a/src/filefinder_rtp.cpp
+++ b/src/filefinder_rtp.cpp
@@ -178,6 +178,12 @@ void FileFinder_RTP::AddPath(StringView p) {
 	using namespace FileFinder;
 	auto fs = FileFinder::Root().Create(FileFinder::MakeCanonical(p));
 	if (fs) {
+		auto files = fs.ListDirectory();
+		if (files->size() == 0) {
+			Output::Debug("RTP path {} is empty, not adding", p);
+			return;
+		}
+
 		Output::Debug("Adding {} to RTP path", p);
 
 		auto hit_info = RTP::Detect(fs, Player::EngineVersion());

--- a/src/rtp.cpp
+++ b/src/rtp.cpp
@@ -52,7 +52,7 @@ static std::pair<int, int> get_table_idx(const char* const lookup_table[16], con
 
 template <typename T>
 static void detect_helper(const FilesystemView& fs, std::vector<struct RTP::RtpHitInfo>& hit_list,
-		T rtp_table, int num_rtps, int offset, const std::pair<int, int>& range, Span<StringView> ext_list) {
+		T rtp_table, int num_rtps, int offset, const std::pair<int, int>& range, Span<StringView> ext_list, int miss_limit) {
 	std::string ret;
 	for (int j = 1; j <= num_rtps; ++j) {
 		int cur_miss = 0;
@@ -67,7 +67,7 @@ static void detect_helper(const FilesystemView& fs, std::vector<struct RTP::RtpH
 					hit_list[offset + j - 1].hits++;
 				} else {
 					++cur_miss;
-					if (cur_miss > 10) {
+					if (cur_miss > miss_limit) {
 						break;
 					}
 				}
@@ -76,7 +76,7 @@ static void detect_helper(const FilesystemView& fs, std::vector<struct RTP::RtpH
 	}
 }
 
-std::vector<RTP::RtpHitInfo> RTP::Detect(const FilesystemView& fs, int version) {
+std::vector<RTP::RtpHitInfo> RTP::Detect(const FilesystemView& fs, int version, int miss_limit) {
 	std::vector<struct RTP::RtpHitInfo> hit_list = {{
 		{RTP::Type::RPG2000_OfficialJapanese, Names[0], 2000, 0, 465, fs},
 		{RTP::Type::RPG2000_OfficialEnglish, Names[1], 2000, 0, 465, fs},
@@ -113,7 +113,7 @@ std::vector<RTP::RtpHitInfo> RTP::Detect(const FilesystemView& fs, int version) 
 			const char* category = rtp_table_2k_categories[i];
 			std::pair<int, int> range = {rtp_table_2k_categories_idx[i], rtp_table_2k_categories_idx[i+1]};
 			auto ext_list = ext_for_cat(category);
-			detect_helper(fs, hit_list, rtp_table_2k, num_2k_rtps, 0, range, ext_list);
+			detect_helper(fs, hit_list, rtp_table_2k, num_2k_rtps, 0, range, ext_list, miss_limit);
 		}
 	}
 	if (version == 2003 || version == 0) {
@@ -121,7 +121,7 @@ std::vector<RTP::RtpHitInfo> RTP::Detect(const FilesystemView& fs, int version) 
 			const char* category = rtp_table_2k3_categories[i];
 			std::pair<int, int> range = {rtp_table_2k3_categories_idx[i], rtp_table_2k3_categories_idx[i+1]};
 			auto ext_list = ext_for_cat(category);
-			detect_helper(fs, hit_list, rtp_table_2k3, num_2k3_rtps, num_2k_rtps, range, ext_list);
+			detect_helper(fs, hit_list, rtp_table_2k3, num_2k3_rtps, num_2k_rtps, range, ext_list, miss_limit);
 		}
 	}
 

--- a/src/rtp.h
+++ b/src/rtp.h
@@ -69,9 +69,10 @@ namespace RTP {
 	 *
 	 * @param fs Filesystem tree
 	 * @param version RTP version in the folder (2000 or 2003), use 0 to detect all
+	 * @param miss_limit How many RTP files required to be missing to stop scanning early.
 	 * @return List of detected RTP types
 	 */
-	std::vector<RtpHitInfo> Detect(const FilesystemView& fs, int version);
+	std::vector<RtpHitInfo> Detect(const FilesystemView& fs, int version, int miss_limit = 10);
 
 	/**
 	 * Takes an asset name and returns all RTP that match

--- a/tests/filesystem.cpp
+++ b/tests/filesystem.cpp
@@ -28,11 +28,11 @@ TEST_CASE("ListDirectory") {
 
 	auto charset = fs.ListDirectory("Charset");
 	CHECK(charset->size() == 1);
-	CHECK(charset->find("chara1.png") != charset->end());
+	CHECK((*charset)[0].first == "chara1.png");
 
 	charset = fs.ListDirectory("cHaRsEt");
 	CHECK(charset->size() == 1);
-	CHECK(charset->find("chara1.png") != charset->end());
+	CHECK((*charset)[0].first == "chara1.png");
 
 	CHECK(!fs.ListDirectory("!!!invaliddir!!!"));
 }
@@ -60,7 +60,7 @@ TEST_CASE("ListDirectorySubtree") {
 	Player::escape_symbol = "\\";
 	auto charset = subtree.Subtree("charset").ListDirectory();
 	CHECK(charset->size() == 1);
-	CHECK(charset->find("chara1.png") != charset->end());
+	CHECK((*charset)[0].first == "chara1.png");
 	Player::escape_symbol = "";
 }
 

--- a/tests/rtp.cpp
+++ b/tests/rtp.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include <ostream>
 #include "filefinder.h"
 #include "player.h"
@@ -36,7 +37,7 @@ TEST_CASE("RTP 2000: Detection") {
 	Player::escape_symbol = "\\";
 
 	auto tree = make_tree();
-	std::vector<RTP::RtpHitInfo> hits = RTP::Detect(tree, 2000);
+	std::vector<RTP::RtpHitInfo> hits = RTP::Detect(tree, 2000, std::numeric_limits<int>::max());
 
 	REQUIRE(hits.size() == 2);
 
@@ -52,7 +53,7 @@ TEST_CASE("RTP 2000: Detection") {
 TEST_CASE("RTP 2003: Detection") {
 	Player::escape_symbol = "\\";
 
-	std::vector<RTP::RtpHitInfo> hits = RTP::Detect(make_tree(), 2003);
+	std::vector<RTP::RtpHitInfo> hits = RTP::Detect(make_tree(), 2003, std::numeric_limits<int>::max());
 
 	REQUIRE(hits.size() == 2);
 


### PR DESCRIPTION
As observed by @BlisterB and @carstene1ns the RTP detection is incredible slow on Android but even on other systems we are wasting time in the detector.

Added three layers of _speed_ to make the RTP detection on startup faster:

1. When the RTP folder is empty the folder is considered invalid and not scanned (Android will hit this one)
2. When not empty the RTP-type-scan will abort when for a certain RTP type there are 10 missing files (this makes RTP2k detect ``30%`` faster, RTP2k3 detect ``59%`` faster).
3. When a folder is missing this is cached making the lookup much faster  because the filesystem is not hit again (this makes the ``RTP::Detect`` Unit Test where almost all folders are missing and "abort after 10 misses" is disabled ``20%`` faster). On slow systems with shitty IPC (hello Android and 3DS) the speedup in this rare error case should be gigantic.

---------

Redesigned the data structure of the DirectoryTree from std::unordered_map to sorted std::vector as suggested by fmatthew in #2306

This gives a ``5%`` speedup for ``FindFile`` lookups in my benchmarks and reduces memory usage of the tree by ``15%``. Could be more on systems with a smaller cpu cache.

---------

Faster startup when a RTP exists (or the folder is empty) should be noticable on slower systems. Faster ``FindFile`` likely not (microbenchmarks...).

---------

Android loading times (old):

- RTP Off: 2s 
- RTP On & installed: 5s
- RTP On & empty: 16s

Android loading times this branch: _Note that the PR build has debug on so you will not hit these times_

- RTP Off: 2s
- RTP On & installed: 5s (could be a few ms faster but can't properly measure this on Android)
- RTP On & empty: **2s**

