### PR TITLE
Use 64 bit z-layer

### DIFF
--- a/src/drawable.cpp
+++ b/src/drawable.cpp
@@ -34,24 +34,34 @@ Drawable::Z_t Drawable::GetPriorityForMapLayer(int which) {
 	switch (which) {
 		case lcf::rpg::SavePicture::MapLayer_parallax:
 			layer = Priority_Background;
+			break;
 		case lcf::rpg::SavePicture::MapLayer_tilemap_below:
 			layer = Priority_TilesetBelow;
+			break;
 		case lcf::rpg::SavePicture::MapLayer_events_below:
 			layer = Priority_EventsBelow;
+			break;
 		case lcf::rpg::SavePicture::MapLayer_events_same_as_player:
 			layer = Priority_Player;
+			break;
 		case lcf::rpg::SavePicture::MapLayer_tilemap_above:
 			layer = Priority_TilesetAbove;
+			break;
 		case lcf::rpg::SavePicture::MapLayer_events_above:
 			layer = Priority_EventsFlying;
+			break;
 		case lcf::rpg::SavePicture::MapLayer_weather:
 			layer = Priority_PictureNew;
+			break;
 		case lcf::rpg::SavePicture::MapLayer_animations:
 			layer = Priority_BattleAnimation;
+			break;
 		case lcf::rpg::SavePicture::MapLayer_windows:
 			layer = Priority_Window;
+			break;
 		case lcf::rpg::SavePicture::MapLayer_timers:
 			layer = Priority_Timer;
+			break;
 		default:
 			return layer;
 	}
@@ -65,14 +75,19 @@ Drawable::Z_t Drawable::GetPriorityForBattleLayer(int which) {
 	switch (which) {
 		case lcf::rpg::SavePicture::BattleLayer_background:
 			layer = Priority_Background;
+			break;
 		case lcf::rpg::SavePicture::BattleLayer_battlers_and_animations:
 			layer = Priority_Battler;
+			break;
 		case lcf::rpg::SavePicture::BattleLayer_weather:
 			layer = Priority_PictureNew;
+			break;
 		case lcf::rpg::SavePicture::BattleLayer_windows_and_status:
 			layer = Priority_Window;
+			break;
 		case lcf::rpg::SavePicture::BattleLayer_timers:
 			layer = Priority_Timer;
+			break;
 		default:
 			return layer;
 	}

--- a/src/drawable.cpp
+++ b/src/drawable.cpp
@@ -29,45 +29,53 @@ void Drawable::SetZ(Z_t nz) {
 }
 
 Drawable::Z_t Drawable::GetPriorityForMapLayer(int which) {
+	Z_t layer = 0;
+
 	switch (which) {
 		case lcf::rpg::SavePicture::MapLayer_parallax:
-			return Priority_Background;
+			layer = Priority_Background;
 		case lcf::rpg::SavePicture::MapLayer_tilemap_below:
-			return Priority_TilesetBelow;
+			layer = Priority_TilesetBelow;
 		case lcf::rpg::SavePicture::MapLayer_events_below:
-			return Priority_EventsBelow;
+			layer = Priority_EventsBelow;
 		case lcf::rpg::SavePicture::MapLayer_events_same_as_player:
-			return Priority_Player;
+			layer = Priority_Player;
 		case lcf::rpg::SavePicture::MapLayer_tilemap_above:
-			return Priority_TilesetAbove;
+			layer = Priority_TilesetAbove;
 		case lcf::rpg::SavePicture::MapLayer_events_above:
-			return Priority_EventsFlying;
+			layer = Priority_EventsFlying;
 		case lcf::rpg::SavePicture::MapLayer_weather:
-			return Priority_PictureNew;
+			layer = Priority_PictureNew;
 		case lcf::rpg::SavePicture::MapLayer_animations:
-			return Priority_BattleAnimation;
+			layer = Priority_BattleAnimation;
 		case lcf::rpg::SavePicture::MapLayer_windows:
-			return Priority_Window;
+			layer = Priority_Window;
 		case lcf::rpg::SavePicture::MapLayer_timers:
-			return Priority_Timer;
+			layer = Priority_Timer;
 		default:
-			return 0;
+			return layer;
 	}
+
+	return layer + (1ULL << z_offset);
 }
 
 Drawable::Z_t Drawable::GetPriorityForBattleLayer(int which) {
+	Z_t layer = 0;
+
 	switch (which) {
 		case lcf::rpg::SavePicture::BattleLayer_background:
-			return Priority_Background;
+			layer = Priority_Background;
 		case lcf::rpg::SavePicture::BattleLayer_battlers_and_animations:
-			return Priority_Battler;
+			layer = Priority_Battler;
 		case lcf::rpg::SavePicture::BattleLayer_weather:
-			return Priority_PictureNew;
+			layer = Priority_PictureNew;
 		case lcf::rpg::SavePicture::BattleLayer_windows_and_status:
-			return Priority_Window;
+			layer = Priority_Window;
 		case lcf::rpg::SavePicture::BattleLayer_timers:
-			return Priority_Timer;
+			layer = Priority_Timer;
 		default:
-			return 0;
+			return layer;
 	}
+
+	return layer + (1ULL << z_offset);
 }

--- a/src/drawable.cpp
+++ b/src/drawable.cpp
@@ -23,12 +23,12 @@ Drawable::~Drawable() {
 	DrawableMgr::Remove(this);
 }
 
-void Drawable::SetZ(int nz) {
+void Drawable::SetZ(Z_t nz) {
 	if (_z != nz) DrawableMgr::OnUpdateZ(this);
 	_z = nz;
 }
 
-int Drawable::GetPriorityForMapLayer(int which) {
+Drawable::Z_t Drawable::GetPriorityForMapLayer(int which) {
 	switch (which) {
 		case lcf::rpg::SavePicture::MapLayer_parallax:
 			return Priority_Background;
@@ -55,7 +55,7 @@ int Drawable::GetPriorityForMapLayer(int which) {
 	}
 }
 
-int Drawable::GetPriorityForBattleLayer(int which) {
+Drawable::Z_t Drawable::GetPriorityForBattleLayer(int which) {
 	switch (which) {
 		case lcf::rpg::SavePicture::BattleLayer_background:
 			return Priority_Background;

--- a/src/drawable.h
+++ b/src/drawable.h
@@ -137,6 +137,7 @@ inline void Drawable::SetVisible(bool value) {
 	_flags = value ? _flags & ~Flags::Invisible : _flags | Flags::Invisible;
 }
 
+// Upper 8 bit are reserved for the layer 
 static constexpr uint64_t z_offset = 64 - 8;
 
 // Lower 56 Bit are free to use

--- a/src/drawable.h
+++ b/src/drawable.h
@@ -27,33 +27,13 @@ class Drawable;
 template <typename T>
 static constexpr bool IsDrawable = std::is_base_of<Drawable,T>::value;
 
-enum Priority {
-	Priority_Background = 5 << 24,
-	Priority_TilesetBelow = 10 << 24,
-	Priority_EventsBelow = 15 << 24,
-	Priority_Player = 20 << 24, // In Map, shared with "same as hero" events
-	Priority_Battler = 20 << 24, // In Battle (includes animations)
-	Priority_TilesetAbove = 25 << 24,
-	Priority_EventsAbove = 30 << 24,
-	Priority_EventsFlying = 35 << 24,
-	Priority_Weather = 36 << 24,
-	Priority_Screen = 40 << 24,
-	Priority_PictureNew = 45 << 24, // Pictures in RPG2k Value! and RPG2k3 >=1.05, shared
-	Priority_BattleAnimation = 50 << 24,
-	Priority_PictureOld = 55 << 24, // Picture in RPG2k <1.5 and RPG2k3 <1.05, shared
-	Priority_Window = 60 << 24,
-	Priority_Timer = 65 << 24,
-	Priority_Frame = 70 << 24,
-	Priority_Transition = 75 << 24,
-	Priority_Overlay = 80 << 24,
-	Priority_Maximum = 100 << 24
-};
-
 /**
  * Drawable virtual
  */
 class Drawable {
 public:
+	using Z_t = uint64_t;
+
 	/** Flags with dictate certain attributes of drawables */
 	enum class Flags : uint32_t {
 		/** No flags */
@@ -68,7 +48,7 @@ public:
 		Default = None
 	};
 
-	Drawable(int z, Flags flags = Flags::Default);
+	Drawable(Z_t z, Flags flags = Flags::Default);
 
 	Drawable(const Drawable&) = delete;
 	Drawable& operator=(const Drawable&) = delete;
@@ -77,9 +57,9 @@ public:
 
 	virtual void Draw(Bitmap& dst) = 0;
 
-	int GetZ() const;
+	Z_t GetZ() const;
 
-	void SetZ(int z);
+	void SetZ(Z_t z);
 
 	/* @return true if this drawable should appear in all scenes */
 	bool IsGlobal() const;
@@ -102,16 +82,16 @@ public:
 	 *
 	 * @return Priority or 0 when not found
 	 */
-	static int GetPriorityForMapLayer(int which);
+	static Z_t GetPriorityForMapLayer(int which);
 
 	/**
 	 * Converts a RPG Maker battle layer value into a EasyRPG priority value.
 	 *
 	 * @return Priority or 0 when not found
 	 */
-	static int GetPriorityForBattleLayer(int which);
+	static Z_t GetPriorityForBattleLayer(int which);
 private:
-	int32_t _z = 0;
+	Z_t _z = 0;
 	Flags _flags = Flags::Default;
 };
 
@@ -131,13 +111,13 @@ inline Drawable::Flags operator~(Drawable::Flags f) {
 	return static_cast<Drawable::Flags>(~static_cast<unsigned>(f));
 }
 
-inline Drawable::Drawable(int z, Flags flags)
+inline Drawable::Drawable(Z_t z, Flags flags)
 	: _z(z),
 	_flags(flags)
 {
 }
 
-inline int Drawable::GetZ() const {
+inline Drawable::Z_t Drawable::GetZ() const {
 	return _z;
 }
 
@@ -156,5 +136,27 @@ inline bool Drawable::IsVisible() const {
 inline void Drawable::SetVisible(bool value) {
 	_flags = value ? _flags & ~Flags::Invisible : _flags | Flags::Invisible;
 }
+
+enum Priority : Drawable::Z_t {
+	Priority_Background = 5 << 24,
+	Priority_TilesetBelow = 10 << 24,
+	Priority_EventsBelow = 15 << 24,
+	Priority_Player = 20 << 24, // In Map, shared with "same as hero" events
+	Priority_Battler = 20 << 24, // In Battle (includes animations)
+	Priority_TilesetAbove = 25 << 24,
+	Priority_EventsAbove = 30 << 24,
+	Priority_EventsFlying = 35 << 24,
+	Priority_Weather = 36 << 24,
+	Priority_Screen = 40 << 24,
+	Priority_PictureNew = 45 << 24, // Pictures in RPG2k Value! and RPG2k3 >=1.05, shared
+	Priority_BattleAnimation = 50 << 24,
+	Priority_PictureOld = 55 << 24, // Picture in RPG2k <1.5 and RPG2k3 <1.05, shared
+	Priority_Window = 60 << 24,
+	Priority_Timer = 65 << 24,
+	Priority_Frame = 70 << 24,
+	Priority_Transition = 75 << 24,
+	Priority_Overlay = 80 << 24,
+	Priority_Maximum = 100 << 24
+};
 
 #endif

--- a/src/drawable.h
+++ b/src/drawable.h
@@ -137,26 +137,30 @@ inline void Drawable::SetVisible(bool value) {
 	_flags = value ? _flags & ~Flags::Invisible : _flags | Flags::Invisible;
 }
 
+static constexpr uint64_t z_offset = 64 - 8;
+
+// Lower 56 Bit are free to use
+// Keep a gap of 1 between layers everywhere because Pictures on the same layer have a z_offset of + 1
 enum Priority : Drawable::Z_t {
-	Priority_Background = 5 << 24,
-	Priority_TilesetBelow = 10 << 24,
-	Priority_EventsBelow = 15 << 24,
-	Priority_Player = 20 << 24, // In Map, shared with "same as hero" events
-	Priority_Battler = 20 << 24, // In Battle (includes animations)
-	Priority_TilesetAbove = 25 << 24,
-	Priority_EventsAbove = 30 << 24,
-	Priority_EventsFlying = 35 << 24,
-	Priority_Weather = 36 << 24,
-	Priority_Screen = 40 << 24,
-	Priority_PictureNew = 45 << 24, // Pictures in RPG2k Value! and RPG2k3 >=1.05, shared
-	Priority_BattleAnimation = 50 << 24,
-	Priority_PictureOld = 55 << 24, // Picture in RPG2k <1.5 and RPG2k3 <1.05, shared
-	Priority_Window = 60 << 24,
-	Priority_Timer = 65 << 24,
-	Priority_Frame = 70 << 24,
-	Priority_Transition = 75 << 24,
-	Priority_Overlay = 80 << 24,
-	Priority_Maximum = 100 << 24
+	Priority_Background = 10ULL << z_offset,
+	Priority_TilesetBelow = 20ULL << z_offset,
+	Priority_EventsBelow = 30ULL << z_offset,
+	Priority_Player = 40ULL << z_offset, // In Map, shared with "same as hero" events
+	Priority_Battler = 40ULL << z_offset, // In Battle (includes animations)
+	Priority_TilesetAbove = 50ULL << z_offset,
+	Priority_EventsAbove = 60ULL << z_offset,
+	Priority_EventsFlying = 70ULL << z_offset,
+	Priority_Weather = 80ULL << z_offset,
+	Priority_Screen = 90ULL << z_offset,
+	Priority_PictureNew = 100ULL << z_offset, // Pictures in RPG2k Value! and RPG2k3 >=1.05, shared
+	Priority_BattleAnimation = 110ULL << z_offset,
+	Priority_PictureOld = 120ULL << z_offset, // Picture in RPG2k <1.5 and RPG2k3 <1.05, shared
+	Priority_Window = 130ULL << z_offset,
+	Priority_Timer = 140ULL << z_offset,
+	Priority_Frame = 150ULL << z_offset,
+	Priority_Transition = 160ULL << z_offset,
+	Priority_Overlay = 170ULL << z_offset,
+	Priority_Maximum = 255ULL << z_offset // Higher values will overflow
 };
 
 #endif

--- a/src/drawable_list.cpp
+++ b/src/drawable_list.cpp
@@ -90,7 +90,7 @@ void DrawableList::TakeFrom(DrawableList& other) noexcept {
 	other.SetClean();
 }
 
-void DrawableList::Draw(Bitmap& dst, int min_z, int max_z) {
+void DrawableList::Draw(Bitmap& dst, Drawable::Z_t min_z, Drawable::Z_t max_z) {
 	if (IsDirty()) {
 		Sort();
 	} else {

--- a/src/drawable_list.h
+++ b/src/drawable_list.h
@@ -43,9 +43,9 @@ class DrawableList {
 		/** Return true if drawables are sorted */
 		bool IsSorted() const;
 
-		/** 
+		/**
 		 * Add a drawable to the list.
-		 * 
+		 *
 		 * @param drawable the Drawable to add
 		 */
 		void Append(Drawable* drawable);
@@ -100,7 +100,7 @@ class DrawableList {
 
 		/**
 		 * Return drawable at i'th index
-		 * 
+		 *
 		 * @param i index of drawable
 		 * @pre if i < 0 and i >= size(), the result is undefined.
 		 * @return the drawable at i
@@ -129,7 +129,7 @@ class DrawableList {
 		 * @param min_z Skip any drawables with z < min_z
 		 * @param max_z Skip any drawables with z > max_z
 		 */
-		void Draw(Bitmap& dst, int min_z, int max_z);
+		void Draw(Bitmap& dst, Drawable::Z_t min_z, Drawable::Z_t max_z);
 
 	private:
 		std::vector<Drawable*> _list;
@@ -188,7 +188,7 @@ inline void DrawableList::SetClean() {
 }
 
 inline void DrawableList::Draw(Bitmap& dst) {
-	Draw(dst, std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+	Draw(dst, std::numeric_limits<Drawable::Z_t>::min(), std::numeric_limits<Drawable::Z_t>::max());
 }
 
 #endif

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -120,6 +120,14 @@ Drawable::Z_t Game_Character::GetScreenZ(bool apply_shift) const {
 
 	Drawable::Z_t x = static_cast<Drawable::Z_t>(GetScreenX(apply_shift));
 
+	// The rendering order of characters is: Highest Y-coordinate, Highest X-coordinate, Highest ID
+	// To encode this behaviour all of them get 16 Bit in the Z value
+	// L- YY XX II (1 letter = 8 bit)
+	// L: Layer (specified by the event page)
+	// -: Unused
+	// Y: Y-coordinate
+	// X: X-coordinate
+	// I: ID (This is only applied by subclasses, characters itself put nothing (0) here
 	z += (y << 32) + (x << 16);
 
 	return z;

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -103,8 +103,8 @@ int Game_Character::GetScreenY(bool apply_shift, bool apply_jump) const {
 	return y;
 }
 
-int Game_Character::GetScreenZ(bool apply_shift) const {
-	int z = 0;
+Drawable::Z_t Game_Character::GetScreenZ(bool apply_shift) const {
+	Drawable::Z_t z = 0;
 
 	if (IsFlying()) {
 		z = Priority_EventsFlying;

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -116,7 +116,11 @@ Drawable::Z_t Game_Character::GetScreenZ(bool apply_shift) const {
 		z = Priority_EventsAbove;
 	}
 
-	z += GetScreenY(apply_shift, false);
+	Drawable::Z_t y = static_cast<Drawable::Z_t>(GetScreenY(apply_shift, false));
+
+	Drawable::Z_t x = static_cast<Drawable::Z_t>(GetScreenX(apply_shift));
+
+	z += (y << 32) + (x << 16);
 
 	return z;
 }

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -25,6 +25,7 @@
 #include <lcf/rpg/moveroute.h>
 #include <lcf/rpg/eventpage.h>
 #include <lcf/rpg/savemapeventbase.h>
+#include "drawable.h"
 #include "utils.h"
 
 /**
@@ -690,7 +691,7 @@ public:
 	 * @param apply_shift Forwarded to GetScreenY
 	 * @return screen z coordinate in pixels.
 	 */
-	virtual int GetScreenZ(bool apply_shift = false) const;
+	virtual Drawable::Z_t GetScreenZ(bool apply_shift = false) const;
 
 	/**
 	 * Gets tile graphic ID.

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -116,6 +116,8 @@ lcf::rpg::SaveMapEvent Game_Event::GetSaveData() const {
 }
 
 Drawable::Z_t Game_Event::GetScreenZ(bool apply_shift) const {
+	// Lowest 16 bit are reserved for the ID
+	// See base function for full explanation
 	return Game_Character::GetScreenZ(apply_shift) + GetId();
 }
 

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -115,6 +115,10 @@ lcf::rpg::SaveMapEvent Game_Event::GetSaveData() const {
 	return save;
 }
 
+Drawable::Z_t Game_Event::GetScreenZ(bool apply_shift) const {
+	return Game_Character::GetScreenZ(apply_shift) + GetId();
+}
+
 int Game_Event::GetOriginalMoveRouteIndex() const {
 	return data()->original_move_route_index;
 }

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -49,6 +49,7 @@ public:
 	 * Implementation of abstract methods
 	 */
 	/** @{ */
+	Drawable::Z_t GetScreenZ(bool apply_shift = false) const override;
 	bool Move(int dir) override;
 	void UpdateNextMovementAction() override;
 	bool IsVisible() const override;
@@ -116,7 +117,7 @@ public:
 	 */
 	bool ScheduleForegroundExecution(bool triggered_by_decision_key, bool face_player);
 
-	/** 
+	/**
 	 * Update this for the current frame
 	 *
 	 * @param resume_async If we're resuming from an async operation.

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -67,7 +67,8 @@ lcf::rpg::SavePartyLocation Game_Player::GetSaveData() const {
 Drawable::Z_t Game_Player::GetScreenZ(bool apply_shift) const {
 	// Player is always slightly above events
 	// (and always on "same layer as hero" obviously)
-	return Game_Character::GetScreenZ(apply_shift) + 1;
+	// Set all "ID bits" (first 16) to ensure this
+	return Game_Character::GetScreenZ(apply_shift) + 65535;
 }
 
 void Game_Player::ReserveTeleport(int map_id, int x, int y, int direction, TeleportTarget::Type tt) {

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -64,7 +64,7 @@ lcf::rpg::SavePartyLocation Game_Player::GetSaveData() const {
 	return *data();
 }
 
-int Game_Player::GetScreenZ(bool apply_shift) const {
+Drawable::Z_t Game_Player::GetScreenZ(bool apply_shift) const {
 	// Player is always slightly above events
 	// (and always on "same layer as hero" obviously)
 	return Game_Character::GetScreenZ(apply_shift) + 1;

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -67,7 +67,8 @@ lcf::rpg::SavePartyLocation Game_Player::GetSaveData() const {
 Drawable::Z_t Game_Player::GetScreenZ(bool apply_shift) const {
 	// Player is always slightly above events
 	// (and always on "same layer as hero" obviously)
-	// Set all "ID bits" (first 16) to ensure this
+	// To ensure this fake an ID of 65535 (all bit set)
+	// See base function for full explanation
 	return Game_Character::GetScreenZ(apply_shift) + 65535;
 }
 

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -47,7 +47,7 @@ public:
 	 * Implementation of abstract methods
 	 */
 	/** @{ */
-	int GetScreenZ(bool apply_shift = false) const override;
+	Drawable::Z_t GetScreenZ(bool apply_shift = false) const override;
 	bool IsVisible() const override;
 	bool MakeWay(int from_x, int from_y, int to_x, int to_y) override;
 	void UpdateNextMovementAction() override;

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -108,8 +108,8 @@ void Graphics::UpdateTitle() {
 void Graphics::Draw(Bitmap& dst) {
 	auto& transition = Transition::instance();
 
-	int min_z = std::numeric_limits<int>::min();
-	int max_z = std::numeric_limits<int>::max();
+	auto min_z = std::numeric_limits<Drawable::Z_t>::min();
+	auto max_z = std::numeric_limits<Drawable::Z_t>::max();
 	if (transition.IsActive()) {
 		min_z = transition.GetZ();
 	} else if (transition.IsErasedNotActive()) {
@@ -119,10 +119,10 @@ void Graphics::Draw(Bitmap& dst) {
 	LocalDraw(dst, min_z, max_z);
 }
 
-void Graphics::LocalDraw(Bitmap& dst, int min_z, int max_z) {
+void Graphics::LocalDraw(Bitmap& dst, Drawable::Z_t min_z, Drawable::Z_t max_z) {
 	auto& drawable_list = DrawableMgr::GetLocalList();
 
-	if (!drawable_list.empty() && min_z == std::numeric_limits<int>::min()) {
+	if (!drawable_list.empty() && min_z == std::numeric_limits<Drawable::Z_t>::min()) {
 		current_scene->DrawBackground(dst);
 	}
 

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -50,7 +50,7 @@ namespace Graphics {
 
 	void Draw(Bitmap& dst);
 
-	void LocalDraw(Bitmap& dst, int min_z, int max_z);
+	void LocalDraw(Bitmap& dst, Drawable::Z_t min_z, Drawable::Z_t max_z);
 
 	std::shared_ptr<Scene> UpdateSceneCallback();
 

--- a/src/sprite_battler.cpp
+++ b/src/sprite_battler.cpp
@@ -45,7 +45,7 @@ void Sprite_Battler::ResetZ() {
 		y += 24;
 	}
 
-	int z = battler->GetType();
+	Drawable::Z_t z = battler->GetType();
 	z += y;
 	z *= id_limit;
 	z += id_limit - battle_index;

--- a/src/sprite_picture.cpp
+++ b/src/sprite_picture.cpp
@@ -25,10 +25,6 @@
 #include "player.h"
 #include "bitmap.h"
 
-
-// Applied to ensure that all pictures are above "normal" objects on this layer
-constexpr int z_mask = (1 << 16);
-
 Sprite_Picture::Sprite_Picture(int pic_id, Drawable::Flags flags)
 	: Sprite(flags),
 	pic_id(pic_id),
@@ -57,7 +53,7 @@ void Sprite_Picture::OnPictureShow() {
 			priority = Drawable::GetPriorityForMapLayer(pic.data.map_layer);
 		}
 		if (priority > 0) {
-			SetZ(priority + z_mask + pic_id);
+			SetZ(priority + pic_id);
 		}
 	}
 }

--- a/src/sprite_picture.cpp
+++ b/src/sprite_picture.cpp
@@ -46,7 +46,7 @@ void Sprite_Picture::OnPictureShow() {
 
 	if (feature_priority_layers) {
 		// Battle Animations are above pictures
-		int priority = 0;
+		Drawable::Z_t priority;
 		if (is_battle) {
 			priority = Drawable::GetPriorityForBattleLayer(pic.data.battle_layer);
 		} else {

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -145,10 +145,10 @@ TilemapLayer::TilemapLayer(int ilayer) :
 	layer(ilayer),
 	// SubLayer for the tiles without Wall or Above passability
 	// Its z-value should be under z of the events in the lower layer
-	lower_layer(this, Priority_TilesetBelow + layer),
+	lower_layer(this, Priority_TilesetBelow + TileBelow + layer),
 	// SubLayer for the tiles with Wall or Above passability
 	// Its z-value should be between the z of the events in the upper layer and the hero
-	upper_layer(this, Priority_TilesetAbove + layer)
+	upper_layer(this, Priority_TilesetAbove + TileAbove + layer)
 {
 }
 
@@ -205,7 +205,7 @@ static uint32_t MakeAbTileHash(int id, int anim_step) {
 	return static_cast<uint32_t>((id + (anim_step << 12)) | (4 << 24));
 }
 
-void TilemapLayer::Draw(Bitmap& dst, Drawable::Z_t z_order) {
+void TilemapLayer::Draw(Bitmap& dst, uint8_t z_order) {
 	// Get the number of tiles that can be displayed on window
 	int tiles_x = (int)ceil(DisplayUi->GetWidth() / (float)TILE_SIZE);
 	int tiles_y = (int)ceil(DisplayUi->GetHeight() / (float)TILE_SIZE);
@@ -277,7 +277,7 @@ void TilemapLayer::Draw(Bitmap& dst, Drawable::Z_t z_order) {
 			if (z_order == tile.z) {
 				if (layer == 0) {
 					// If lower layer
-					bool allow_fast_blit = (tile.z == Priority_TilesetBelow);
+					bool allow_fast_blit = (tile.z == TileBelow);
 
 					if (tile.ID >= BLOCK_E && tile.ID < BLOCK_E + BLOCK_E_TILES) {
 						int id = substitutions[tile.ID - BLOCK_E];
@@ -381,15 +381,15 @@ void TilemapLayer::CreateTileCache(const std::vector<short>& nmap_data) {
 			// Get the tile ID
 			tile.ID = nmap_data[x + y * width];
 
-			tile.z = Priority_TilesetBelow;
+			tile.z = TileBelow;
 
 			// Calculate the tile Z
 			if (!passable.empty()) {
 				if (tile.ID >= BLOCK_F) { // Upper layer
 					if ((passable[substitutions[tile.ID - BLOCK_F]] & Passable::Above) != 0)
-						tile.z = Priority_TilesetAbove + 1; // Upper sublayer
+						tile.z = TileAbove + 1; // Upper sublayer
 					else
-						tile.z = Priority_TilesetBelow + 1; // Lower sublayer
+						tile.z = TileBelow + 1; // Lower sublayer
 
 				} else { // Lower layer
 					int chip_index =
@@ -398,9 +398,9 @@ void TilemapLayer::CreateTileCache(const std::vector<short>& nmap_data) {
 						tile.ID >= BLOCK_C ? (tile.ID - BLOCK_C) / 50 + 3 :
 						tile.ID / 1000;
 					if ((passable[chip_index] & (Passable::Wall | Passable::Above)) != 0)
-						tile.z = Priority_TilesetAbove; // Upper sublayer
+						tile.z = TileAbove; // Upper sublayer
 					else
-						tile.z = Priority_TilesetBelow; // Lower sublayer
+						tile.z = TileBelow; // Lower sublayer
 
 				}
 			}
@@ -671,7 +671,8 @@ void TilemapLayer::OnSubstitute() {
 
 TilemapSubLayer::TilemapSubLayer(TilemapLayer* tilemap, Drawable::Z_t z) :
 	Drawable(z),
-	tilemap(tilemap)
+	tilemap(tilemap),
+	internal_z(static_cast<uint8_t>(z))
 {
 	DrawableMgr::Register(this);
 }

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -205,7 +205,7 @@ static uint32_t MakeAbTileHash(int id, int anim_step) {
 	return static_cast<uint32_t>((id + (anim_step << 12)) | (4 << 24));
 }
 
-void TilemapLayer::Draw(Bitmap& dst, int z_order) {
+void TilemapLayer::Draw(Bitmap& dst, Drawable::Z_t z_order) {
 	// Get the number of tiles that can be displayed on window
 	int tiles_x = (int)ceil(DisplayUi->GetWidth() / (float)TILE_SIZE);
 	int tiles_y = (int)ceil(DisplayUi->GetHeight() / (float)TILE_SIZE);
@@ -669,7 +669,7 @@ void TilemapLayer::OnSubstitute() {
 	CreateTileCache(map_data);
 }
 
-TilemapSubLayer::TilemapSubLayer(TilemapLayer* tilemap, int z) :
+TilemapSubLayer::TilemapSubLayer(TilemapLayer* tilemap, Drawable::Z_t z) :
 	Drawable(z),
 	tilemap(tilemap)
 {

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -42,6 +42,9 @@ public:
 
 private:
 	TilemapLayer* tilemap = nullptr;
+
+	// z value truncated to lower 8 bits for tile cache
+	uint8_t internal_z = 0;
 };
 
 /**
@@ -49,9 +52,14 @@ private:
  */
 class TilemapLayer {
 public:
+	// For performance reasons the tile cache only uses 8-bit z-layer because it only contains 4 values
+	// Do not change anything here to Drawable::Z_t
+	static constexpr uint8_t TileBelow = 0;
+	static constexpr uint8_t TileAbove = 100;
+
 	TilemapLayer(int ilayer);
 
-	void Draw(Bitmap& dst, Drawable::Z_t z_order);
+	void Draw(Bitmap& dst, uint8_t z_order);
 
 	BitmapRef const& GetChipset() const;
 	void SetChipset(BitmapRef const& nchipset);
@@ -137,7 +145,7 @@ private:
 
 	struct TileData {
 		short ID;
-		Drawable::Z_t z;
+		uint8_t z;
 	};
 
 	TileData& GetDataCache(int x, int y);

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -36,7 +36,7 @@ class TilemapLayer;
  */
 class TilemapSubLayer : public Drawable {
 public:
-	TilemapSubLayer(TilemapLayer* tilemap, int z);
+	TilemapSubLayer(TilemapLayer* tilemap, Drawable::Z_t z);
 
 	void Draw(Bitmap& dst) override;
 
@@ -51,7 +51,7 @@ class TilemapLayer {
 public:
 	TilemapLayer(int ilayer);
 
-	void Draw(Bitmap& dst, int z_order);
+	void Draw(Bitmap& dst, Drawable::Z_t z_order);
 
 	BitmapRef const& GetChipset() const;
 	void SetChipset(BitmapRef const& nchipset);
@@ -137,7 +137,7 @@ private:
 
 	struct TileData {
 		short ID;
-		int z;
+		Drawable::Z_t z;
 	};
 
 	TileData& GetDataCache(int x, int y);

--- a/src/transition.cpp
+++ b/src/transition.cpp
@@ -406,13 +406,13 @@ void Transition::Update() {
 			// any -> erase - screen1 was drawn in init.
 			assert(ToErase() && !FromErase());
 			screen1 =  Bitmap::Create(DisplayUi->GetWidth(), DisplayUi->GetHeight(), false);
-			Graphics::LocalDraw(*screen1, std::numeric_limits<int>::min(), GetZ() - 1);
+			Graphics::LocalDraw(*screen1, std::numeric_limits<Drawable::Z_t>::min(), GetZ() - 1);
 		}
 		if (ToErase()) {
 			screen2 = Bitmap::Create(DisplayUi->GetWidth(), DisplayUi->GetHeight(), Color(0, 0, 0, 255));
 		} else {
 			screen2 =  Bitmap::Create(DisplayUi->GetWidth(), DisplayUi->GetHeight(), false);
-			Graphics::LocalDraw(*screen2, std::numeric_limits<int>::min(), GetZ() - 1);
+			Graphics::LocalDraw(*screen2, std::numeric_limits<Drawable::Z_t>::min(), GetZ() - 1);
 		}
 	}
 

--- a/tests/drawable_list.cpp
+++ b/tests/drawable_list.cpp
@@ -12,13 +12,13 @@ namespace {
 
 class TestSprite : public Drawable {
 	public:
-		TestSprite(int z = 0) : Drawable(z, Drawable::Flags::Global) {}
+		TestSprite(Drawable::Z_t z = 0) : Drawable(z, Drawable::Flags::Global) {}
 		void Draw(Bitmap&) override {}
 };
 
 class TestFrame : public Drawable {
 	public:
-		TestFrame(int z = 0) : Drawable(z, Drawable::Flags::Global | Drawable::Flags::Shared) {}
+		TestFrame(Drawable::Z_t z = 0) : Drawable(z, Drawable::Flags::Global | Drawable::Flags::Shared) {}
 		void Draw(Bitmap&) override {}
 };
 

--- a/tests/game_character.cpp
+++ b/tests/game_character.cpp
@@ -85,7 +85,7 @@ static_assert(!Game_Character::IsDirectionFixedAnimationType(lcf::rpg::EventPage
 	/** @return the direction we would need to face away from hero. */
 	int GetDirectionAwayHero();
 
-	virtual int GetScreenZ(bool apply_shift = false) const;
+	virtual Drawable::Z_t GetScreenZ(bool apply_shift = false) const;
 
 	int DistanceXfromPlayer() const;
 	int DistanceYfromPlayer() const;
@@ -137,7 +137,7 @@ static void testInit(Game_Character& ch, int max_stop_count = 0) {
 	REQUIRE_EQ(ch.GetOpacity(), 255);
 	REQUIRE_EQ(ch.GetTransparency(), 0);
 	// FIXME: MAP
-	//REQUIRE(ch.IsVisible()); 
+	//REQUIRE(ch.IsVisible());
 	REQUIRE(!ch.IsSpriteHidden());
 	REQUIRE(ch.IsAnimated());
 	REQUIRE(!ch.IsContinuous());
@@ -346,7 +346,7 @@ static void testBasicSet(Game_Character& ch) {
 	REQUIRE_EQ(ch.GetAnimCount(), 78);
 
 	// FIXME: Test anim count basic increment logic
-	// FIXME: Test anim count real 
+	// FIXME: Test anim count real
 
 	// FIXME: Test movement sequence
 	ch.SetRemainingStep(889);


### PR DESCRIPTION
Found in Il Mito. Reported by mokodeoz. Thanks!

------

This changes the Z-layer value from int32_t to uint64_t.

For correct render order of events it is necessary to put in Y, X and the ID in the Z value and this simply does not fit in ~28 Bit properly.

Now Z-Value is:

- Upper 8 bit = Layer
- Next 8 Bit = Unused yet :)
- Next 48 Bit: Layer specific, Event uses 16 Bit Y, 16 Bit X and 16 Bit ID.

It is possible that I missed a Z variable somewhere which will then overflow. So please test some games if you find rendering order bugs.

------

Performace impact: Likely a non-relevant amount of nanoseconds slower on 32 bit hardware

Also optimized the Tile cache structure, is now 4 byte instead of 8.

