### PR TITLE
Midi: Properly reset Midi by sending SysEx GM On

### DIFF
--- a/src/audio_decoder_midi.cpp
+++ b/src/audio_decoder_midi.cpp
@@ -368,7 +368,10 @@ void AudioDecoderMidi::reset() {
 	// MIDI reset event
 	SendMessageToAllChannels(midimsg_all_sound_off(0));
 	SendMessageToAllChannels(midimsg_reset_all_controller(0));
-	mididec->SendMidiReset();
+
+	// GM system on (resets most parameters)
+	const unsigned char gm_reset[] = {0xF0, 0x7E, 0x7F, 0x09, 0x01, 0xF7};
+	mididec->SendSysExMessage(gm_reset, sizeof(gm_reset));
 }
 
 void AudioDecoderMidi::reset_tempos_after_loop() {

--- a/src/audio_midi.h
+++ b/src/audio_midi.h
@@ -61,7 +61,6 @@ public:
 	 * The library must implement the following commands:
 	 * - SendMidiMessage
 	 * - SendSysExMessage (nice to have)
-	 * - SendMidiReset
 	 *
 	 * When Midi messages are not supported (library uses own sequencer)
 	 * - Open
@@ -153,11 +152,6 @@ public:
 		(void)data;
 		(void)size;
 	}
-
-	/**
-	 * Requests a reset of the Midi Sequencer
-	 */
-	virtual void SendMidiReset() {}
 
 	/**
 	 * Called when the synthesizer shall write data in a buffer.

--- a/src/decoder_fmmidi.cpp
+++ b/src/decoder_fmmidi.cpp
@@ -49,10 +49,6 @@ void FmMidiDecoder::SendSysExMessage(const uint8_t* data, std::size_t size) {
 	synth->sysex_message(data, size);
 }
 
-void FmMidiDecoder::SendMidiReset() {
-	synth->reset();
-}
-
 void FmMidiDecoder::load_programs() {
 	// beautiful
 	#include "midiprogram.h"

--- a/src/decoder_fmmidi.h
+++ b/src/decoder_fmmidi.h
@@ -36,7 +36,6 @@ public:
 
 	void SendMidiMessage(uint32_t message) override;
 	void SendSysExMessage(const uint8_t* data, size_t size) override;
-	void SendMidiReset() override;
 
 	std::unique_ptr<midisynth::synthesizer> synth;
 	std::unique_ptr<midisynth::fm_note_factory> note_factory;

--- a/src/platform/libretro/midiout_device.cpp
+++ b/src/platform/libretro/midiout_device.cpp
@@ -66,11 +66,6 @@ void LibretroMidiOutDevice::SendSysExMessage(const uint8_t* data, size_t size) {
 	midi_out.flush();
 }
 
-void LibretroMidiOutDevice::SendMidiReset() {
-	unsigned char gm_reset[] = {0xF0, 0x7E, 0x7F, 0x09, 0x01, 0xF7};
-	SendSysExMessage(gm_reset, sizeof(gm_reset));
-}
-
 std::string LibretroMidiOutDevice::GetName() {
 	return "libretro MIDI";
 }

--- a/src/platform/libretro/midiout_device.h
+++ b/src/platform/libretro/midiout_device.h
@@ -31,7 +31,6 @@ public:
 
 	void SendMidiMessage(uint32_t message) override;
 	void SendSysExMessage(const uint8_t* data, size_t size) override;
-	void SendMidiReset() override;
 	std::string GetName() override;
 	bool IsInitialized() const;
 

--- a/src/platform/linux/midiout_device_alsa.cpp
+++ b/src/platform/linux/midiout_device_alsa.cpp
@@ -178,11 +178,6 @@ void AlsaMidiOutDevice::SendSysExMessage(const uint8_t* data, size_t size) {
 	}
 }
 
-void AlsaMidiOutDevice::SendMidiReset() {
-	const uint8_t gm_reset[] = {0xF0, 0x7E, 0x7F, 0x09, 0x01, 0xF7};
-	SendSysExMessage(gm_reset, sizeof(gm_reset));
-}
-
 std::string AlsaMidiOutDevice::GetName() {
 	return "ALSA MIDI";
 }

--- a/src/platform/linux/midiout_device_alsa.h
+++ b/src/platform/linux/midiout_device_alsa.h
@@ -32,7 +32,6 @@ public:
 
 	void SendMidiMessage(uint32_t message) override;
 	void SendSysExMessage(const uint8_t* data, size_t size) override;
-	void SendMidiReset() override;
 	std::string GetName() override;
 	bool IsInitialized() const;
 

--- a/src/platform/macos/midiout_device_coreaudio.cpp
+++ b/src/platform/macos/midiout_device_coreaudio.cpp
@@ -94,10 +94,6 @@ void CoreAudioMidiOutDevice::SendSysExMessage(const uint8_t* data, size_t size) 
 	MusicDeviceSysEx(midi_out, (const UInt8*) data, (UInt32) size);
 }
 
-void CoreAudioMidiOutDevice::SendMidiReset() {
-	// TODO: how do you MIDI reset a MusicDevice?
-}
-
 std::string CoreAudioMidiOutDevice::GetName() {
 	return "CoreAudio MIDI";
 }

--- a/src/platform/macos/midiout_device_coreaudio.h
+++ b/src/platform/macos/midiout_device_coreaudio.h
@@ -31,7 +31,6 @@ public:
 
 	void SendMidiMessage(uint32_t message) override;
 	void SendSysExMessage(const uint8_t* data, size_t size) override;
-	void SendMidiReset() override;
 	std::string GetName() override;
 	bool IsInitialized() const;
 

--- a/src/platform/windows/midiout_device_win32.cpp
+++ b/src/platform/windows/midiout_device_win32.cpp
@@ -42,8 +42,9 @@ Win32MidiOutDevice::Win32MidiOutDevice() {
 
 Win32MidiOutDevice::~Win32MidiOutDevice() {
 	if (midi_out) {
+		midiOutReset(midi_out);
 		midiOutClose(midi_out);
-		midi_out = NULL;
+		midi_out = nullptr;
 	}
 }
 
@@ -71,10 +72,6 @@ void Win32MidiOutDevice::SendSysExMessage(const uint8_t* data, size_t size) {
 	if (res != MMSYSERR_NOERROR) {
 		Output::Debug("Win32 midiOutUnprepareHeader failed: ({}) {}", res, get_error_str(res));
 	}
-}
-
-void Win32MidiOutDevice::SendMidiReset() {
-	midiOutReset(midi_out);
 }
 
 std::string Win32MidiOutDevice::GetName() {

--- a/src/platform/windows/midiout_device_win32.h
+++ b/src/platform/windows/midiout_device_win32.h
@@ -36,7 +36,6 @@ public:
 
 	void SendMidiMessage(uint32_t message) override;
 	void SendSysExMessage(const uint8_t* data, size_t size) override;
-	void SendMidiReset() override;
 	std::string GetName() override;
 	bool IsInitialized() const;
 


### PR DESCRIPTION
This is the same RPG_RT does and was already used by some of the Midi implementations.

Was already working everywhere except on Windows because this is the documented way to reset a Midi device.

Fix #2732

---------

About midiOutReset moved to destructor: This function is only called by RPG_RT when shutting down, not when switching files.

About FmMidi change: reset() and GM sysex on invoke the same function.


