### PR TITLE
Add freetype font rendering

### DIFF
--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -319,53 +319,57 @@ void Bitmap::HueChangeBlit(int x, int y, Bitmap const& src, Rect const& src_rect
 	Blit(dst_rect.x, dst_rect.y, bmp, bmp.GetRect(), Opacity::Opaque());
 }
 
-void Bitmap::TextDraw(Rect const& rect, int color, StringView text, Text::Alignment align) {
+Point Bitmap::TextDraw(Rect const& rect, int color, StringView text, Text::Alignment align) {
 	FontRef font = Font::Default();
 	Rect text_rect = font->GetSize(text);
 	int dx = text_rect.width - rect.width;
 
 	switch (align) {
 	case Text::AlignLeft:
-		TextDraw(rect.x, rect.y, color, text);
+		return TextDraw(rect.x, rect.y, color, text);
 		break;
 	case Text::AlignCenter:
-		TextDraw(rect.x + dx / 2, rect.y, color, text);
+		return TextDraw(rect.x + dx / 2, rect.y, color, text);
 		break;
 	case Text::AlignRight:
-		TextDraw(rect.x + dx, rect.y, color, text);
+		return TextDraw(rect.x + dx, rect.y, color, text);
 		break;
 	default: assert(false);
 	}
+
+	return Point();
 }
 
-void Bitmap::TextDraw(int x, int y, int color, StringView text, Text::Alignment align) {
+Point Bitmap::TextDraw(int x, int y, int color, StringView text, Text::Alignment align) {
 	auto font = Font::Default();
 	auto system = Cache::SystemOrBlack();
-	Text::Draw(*this, x, y, *font, *system, color, text, align);
+	return Text::Draw(*this, x, y, *font, *system, color, text, align);
 }
 
-void Bitmap::TextDraw(Rect const& rect, Color color, StringView text, Text::Alignment align) {
+Point Bitmap::TextDraw(Rect const& rect, Color color, StringView text, Text::Alignment align) {
 	FontRef font = Font::Default();
 	Rect text_rect = font->GetSize(text);
 	int dx = text_rect.width - rect.width;
 
 	switch (align) {
 	case Text::AlignLeft:
-		TextDraw(rect.x, rect.y, color, text);
+		return TextDraw(rect.x, rect.y, color, text);
 		break;
 	case Text::AlignCenter:
-		TextDraw(rect.x + dx / 2, rect.y, color, text);
+		return TextDraw(rect.x + dx / 2, rect.y, color, text);
 		break;
 	case Text::AlignRight:
-		TextDraw(rect.x + dx, rect.y, color, text);
+		return TextDraw(rect.x + dx, rect.y, color, text);
 		break;
 	default: assert(false);
 	}
+
+	return Point();
 }
 
-void Bitmap::TextDraw(int x, int y, Color color, StringView text) {
+Point Bitmap::TextDraw(int x, int y, Color color, StringView text) {
 	auto font = Font::Default();
-	Text::Draw(*this, x, y, *font, color, text);
+	return Text::Draw(*this, x, y, *font, color, text);
 }
 
 Rect Bitmap::TransformRectangle(const Transform& xform, const Rect& rect) {

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -233,8 +233,9 @@ public:
 	 * @param color system color index.
 	 * @param text text to draw.
 	 * @param align text alignment.
+	 * @return Where to draw the next glyph
 	 */
-	void TextDraw(int x, int y, int color, StringView text, Text::Alignment align = Text::AlignLeft);
+	Point TextDraw(int x, int y, int color, StringView text, Text::Alignment align = Text::AlignLeft);
 
 	/**
 	 * Draws text to bitmap using the Font::Default() font.
@@ -243,8 +244,9 @@ public:
 	 * @param color system color index.
 	 * @param text text to draw.
 	 * @param align text alignment inside bounding rectangle.
+	 * @return Where to draw the next glyph
 	 */
-	void TextDraw(Rect const& rect, int color, StringView text, Text::Alignment align = Text::AlignLeft);
+	Point TextDraw(Rect const& rect, int color, StringView text, Text::Alignment align = Text::AlignLeft);
 
 	/**
 	 * Draws text to bitmap using the Font::Default() font.
@@ -253,8 +255,9 @@ public:
 	 * @param y y coordinate where text rendering starts.
 	 * @param color text color.
 	 * @param text text to draw.
+	 * @return Where to draw the next glyph
 	 */
-	void TextDraw(int x, int y, Color color, StringView text);
+	Point TextDraw(int x, int y, Color color, StringView text);
 
 	/**
 	 * Draws text to bitmap using the Font::Default() font.
@@ -264,7 +267,7 @@ public:
 	 * @param text text to draw.
 	 * @param align text alignment inside bounding rectangle.
 	 */
-	void TextDraw(Rect const& rect, Color color, StringView, Text::Alignment align = Text::AlignLeft);
+	Point TextDraw(Rect const& rect, Color color, StringView, Text::Alignment align = Text::AlignLeft);
 
 	/**
 	 * Blits source bitmap to this one.

--- a/src/directory_tree.cpp
+++ b/src/directory_tree.cpp
@@ -180,11 +180,11 @@ void DirectoryTree::ClearCache(StringView path) const {
 	}), dir_missing_cache.end());
 }
 
-std::string DirectoryTree::FindFile(StringView filename, Span<StringView> exts) const {
+std::string DirectoryTree::FindFile(StringView filename, const Span<const StringView> exts) const {
 	return FindFile({ ToString(filename), exts });
 }
 
-std::string DirectoryTree::FindFile(StringView directory, StringView filename, Span<StringView> exts) const {
+std::string DirectoryTree::FindFile(StringView directory, StringView filename, const Span<const StringView> exts) const {
 	return FindFile({ FileFinder::MakePath(directory, filename), exts });
 }
 

--- a/src/directory_tree.h
+++ b/src/directory_tree.h
@@ -62,7 +62,7 @@ public:
 		/** File relative to the current tree to search */
 		std::string path;
 		/** File extensions to append to the filename when searching */
-		Span<StringView> exts;
+		const Span<const StringView> exts;
 		/**
 		 * How often moving upwards when ".." is encountered in the path is
 		 * allowed (to prevent directory traversal)
@@ -95,7 +95,7 @@ public:
 	 * @param exts List of file extensions to probe
 	 * @return Path to file or empty string when not found
 	 */
-	std::string FindFile(StringView filename, Span<StringView> exts = {}) const;
+	std::string FindFile(StringView filename, const Span<const StringView> exts = {}) const;
 
 	/**
 	 * Does a case insensitive search for the file in a specific
@@ -106,7 +106,7 @@ public:
 	 * @param exts List of file extensions to probe
 	 * @return Path to file or empty string when not found
 	 */
-	std::string FindFile(StringView directory, StringView filename, Span<StringView> exts = {}) const;
+	std::string FindFile(StringView directory, StringView filename, const Span<const StringView> exts = {}) const;
 
 	/**
 	 * Does a case insensitive search for a file.

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -470,6 +470,12 @@ Filesystem_Stream::InputStream FileFinder::OpenSound(StringView name) {
 	return open_generic("Sound", name, args);
 }
 
+Filesystem_Stream::InputStream FileFinder::OpenFont(StringView name) {
+	auto FONT_TYPES = Utils::MakeSvArray(".ttf", ".ttc", ".otf", ".fon");
+	DirectoryTree::Args args = { MakePath("Font", name), FONT_TYPES, 1, false };
+	return open_generic("Font", name, args);
+}
+
 bool FileFinder::IsMajorUpdatedTree() {
 	auto fs = Game();
 	assert(fs);

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -61,6 +61,13 @@ namespace {
 	std::shared_ptr<Filesystem> root_fs;
 	FilesystemView game_fs;
 	FilesystemView save_fs;
+
+	constexpr const auto IMG_TYPES = Utils::MakeSvArray(".bmp",  ".png", ".xyz");
+	constexpr const auto MUSIC_TYPES = Utils::MakeSvArray(
+			".opus", ".oga", ".ogg", ".wav", ".mid", ".midi", ".mp3", ".wma");
+	constexpr const auto SOUND_TYPES = Utils::MakeSvArray(
+			".opus", ".oga", ".ogg", ".wav", ".mp3", ".wma");
+	constexpr const auto FONTS_TYPES = Utils::MakeSvArray(".ttf", ".ttc", ".otf", ".fon", ".fnt", ".bdf");
 }
 
 FilesystemView FileFinder::Game() {
@@ -278,85 +285,6 @@ std::string FileFinder::GetPathInsideGamePath(StringView path_in) {
 	return ToString(path_in);
 }
 
-#if defined(_WIN32) && !defined(_ARM_)
-std::string GetFontsPath() {
-	static std::string fonts_path = "";
-	static bool init = false;
-
-	if (init) {
-		return fonts_path;
-	} else {
-		// Retrieve the Path of the Font Directory
-		TCHAR path[MAX_PATH];
-
-		if (SHGetFolderPath(NULL, CSIDL_FONTS, NULL, SHGFP_TYPE_CURRENT, path) == S_OK)	{
-			char fpath[MAX_PATH];
-#ifdef UNICODE
-			WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS | WC_COMPOSITECHECK, path, MAX_PATH, fpath, MAX_PATH, NULL, NULL);
-#endif
-			fonts_path = FileFinder::MakePath(fpath, "");
-		}
-
-		init = true;
-
-		return fonts_path;
-	}
-}
-
-std::string GetFontFilename(StringView name) {
-	std::string real_name = Registry::ReadStrValue(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts", ToString(name) + " (TrueType)");
-	if (real_name.length() > 0) {
-		if (FileFinder::Root().Exists(real_name))
-			return real_name;
-		if (FileFinder::Root().Exists(GetFontsPath() + real_name))
-			return GetFontsPath() + real_name;
-	}
-
-	real_name = Registry::ReadStrValue(HKEY_LOCAL_MACHINE, "Software\\Microsoft\\Windows\\CurrentVersion\\Fonts", ToString(name) + " (TrueType)");
-	if (real_name.length() > 0) {
-		if (FileFinder::Root().Exists(real_name))
-			return real_name;
-		if (FileFinder::Root().Exists(GetFontsPath() + real_name))
-			return GetFontsPath() + real_name;
-	}
-
-	return ToString(name);
-}
-#endif
-
-std::string FileFinder::FindFont(StringView name) {
-	auto FONTS_TYPES = Utils::MakeSvArray(".ttf", ".ttc", ".otf", ".fon");
-	std::string path = Game().FindFile({ MakePath("Font", name), FONTS_TYPES, 1, true });
-
-#if defined(_WIN32) && !defined(_ARM_)
-	if (!path.empty()) {
-		return path;
-	}
-
-	std::string folder_path = "";
-	std::string filename = ToString(name);
-
-	size_t separator_pos = path.rfind('\\');
-	if (separator_pos != std::string::npos) {
-		folder_path = path.substr(0, separator_pos);
-		filename = path.substr(separator_pos, path.length() - separator_pos);
-	}
-
-	std::string font_filename = GetFontFilename(filename);
-	if (!font_filename.empty()) {
-		if (FileFinder::Root().Exists(folder_path + font_filename))
-			return folder_path + font_filename;
-
-		if (FileFinder::Root().Exists(fonts_path + font_filename))
-			return fonts_path + font_filename;
-	}
-
-	return "";
-#else
-	return path;
-#endif
-}
-
 void FileFinder::Quit() {
 	root_fs.reset();
 }
@@ -411,24 +339,25 @@ std::string find_generic(const DirectoryTree::Args& args) {
 }
 
 std::string FileFinder::FindImage(StringView dir, StringView name) {
-	auto IMG_TYPES = Utils::MakeSvArray(".bmp",  ".png", ".xyz");
 	DirectoryTree::Args args = { MakePath(dir, name), IMG_TYPES, 1, false };
 	return find_generic(args);
 }
 
 std::string FileFinder::FindMusic(StringView name) {
-	auto MUSIC_TYPES = Utils::MakeSvArray(
-			".opus", ".oga", ".ogg", ".wav", ".mid", ".midi", ".mp3", ".wma");
 	DirectoryTree::Args args = { MakePath("Music", name), MUSIC_TYPES, 1, false };
 	return find_generic(args);
 
 }
 
 std::string FileFinder::FindSound(StringView name) {
-	auto SOUND_TYPES = Utils::MakeSvArray(
-			".opus", ".oga", ".ogg", ".wav", ".mp3", ".wma");
 	DirectoryTree::Args args = { MakePath("Sound", name), SOUND_TYPES, 1, false };
 	return find_generic(args);
+}
+
+std::string FileFinder::FindFont(StringView name) {
+	std::string path = Game().FindFile({ MakePath("Font", name), FONTS_TYPES, 1, true });
+
+	return path;
 }
 
 Filesystem_Stream::InputStream open_generic(StringView dir, StringView name, DirectoryTree::Args& args) {
@@ -451,28 +380,22 @@ Filesystem_Stream::InputStream open_generic(StringView dir, StringView name, Dir
 }
 
 Filesystem_Stream::InputStream FileFinder::OpenImage(StringView dir, StringView name) {
-	auto IMG_TYPES = Utils::MakeSvArray(".bmp",  ".png", ".xyz");
 	DirectoryTree::Args args = { MakePath(dir, name), IMG_TYPES, 1, false };
 	return open_generic(dir, name, args);
 }
 
 Filesystem_Stream::InputStream FileFinder::OpenMusic(StringView name) {
-	auto MUSIC_TYPES = Utils::MakeSvArray(
-		".opus", ".oga", ".ogg", ".wav", ".mid", ".midi", ".mp3", ".wma");
 	DirectoryTree::Args args = { MakePath("Music", name), MUSIC_TYPES, 1, false };
 	return open_generic("Music", name, args);
 }
 
 Filesystem_Stream::InputStream FileFinder::OpenSound(StringView name) {
-	auto SOUND_TYPES = Utils::MakeSvArray(
-		".opus", ".oga", ".ogg", ".wav", ".mp3", ".wma");
 	DirectoryTree::Args args = { MakePath("Sound", name), SOUND_TYPES, 1, false };
 	return open_generic("Sound", name, args);
 }
 
 Filesystem_Stream::InputStream FileFinder::OpenFont(StringView name) {
-	auto FONT_TYPES = Utils::MakeSvArray(".ttf", ".ttc", ".otf", ".fon");
-	DirectoryTree::Args args = { MakePath("Font", name), FONT_TYPES, 1, false };
+	DirectoryTree::Args args = { MakePath("Font", name), FONTS_TYPES, 1, false };
 	return open_generic("Font", name, args);
 }
 

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -67,7 +67,7 @@ namespace {
 			".opus", ".oga", ".ogg", ".wav", ".mid", ".midi", ".mp3", ".wma");
 	constexpr const auto SOUND_TYPES = Utils::MakeSvArray(
 			".opus", ".oga", ".ogg", ".wav", ".mp3", ".wma");
-	constexpr const auto FONTS_TYPES = Utils::MakeSvArray(".ttf", ".ttc", ".otf", ".fon", ".fnt", ".bdf");
+	constexpr const auto FONTS_TYPES = Utils::MakeSvArray(".ttf", ".ttc", ".otf", ".fon", ".fnt", ".bdf", ".woff2", ".woff");
 }
 
 FilesystemView FileFinder::Game() {

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -128,6 +128,15 @@ namespace FileFinder {
 	Filesystem_Stream::InputStream OpenSound(StringView name);
 
 	/**
+	 * Finds a font file and opens a file handle to it.
+	 * Searches through the Font folder of the current RPG Maker game.
+	 *
+	 * @param name the font path and name.
+	 * @return read handle on success or invalid handle if not found
+	 */
+	Filesystem_Stream::InputStream OpenFont(StringView name);
+
+	/**
 	 * Finds a font file.
 	 * Searches through the current RPG Maker game and the RTP directories.
 	 *

--- a/src/filefinder_rtp.cpp
+++ b/src/filefinder_rtp.cpp
@@ -229,7 +229,7 @@ void FileFinder_RTP::ReadRegistry(StringView company, StringView product, String
 #endif
 }
 
-Filesystem_Stream::InputStream FileFinder_RTP::LookupInternal(StringView dir, StringView name, Span<StringView> exts, bool& is_rtp_asset) const {
+Filesystem_Stream::InputStream FileFinder_RTP::LookupInternal(StringView dir, StringView name, const Span<const StringView> exts, bool& is_rtp_asset) const {
 	int version = Player::EngineVersion();
 
 	auto normal_search = [&]() {
@@ -302,7 +302,7 @@ Filesystem_Stream::InputStream FileFinder_RTP::LookupInternal(StringView dir, St
 	return normal_search();
 }
 
-Filesystem_Stream::InputStream FileFinder_RTP::Lookup(StringView dir, StringView name, Span<StringView> exts) const {
+Filesystem_Stream::InputStream FileFinder_RTP::Lookup(StringView dir, StringView name, const Span<const StringView> exts) const {
 	if (!disable_rtp) {
 		bool is_rtp_asset;
 		auto is = LookupInternal(lcf::ReaderUtil::Normalize(dir), lcf::ReaderUtil::Normalize(name), exts, is_rtp_asset);

--- a/src/filefinder_rtp.h
+++ b/src/filefinder_rtp.h
@@ -41,12 +41,12 @@ public:
 	 * @param exts Extensions to probe
 	 * @return A handle to the file or an invalid handle if not found
 	 */
-	 Filesystem_Stream::InputStream Lookup(StringView dir, StringView name, Span<StringView> exts) const;
+	 Filesystem_Stream::InputStream Lookup(StringView dir, StringView name, const Span<const StringView> exts) const;
 
 private:
 	void AddPath(StringView p);
 	void ReadRegistry(StringView company, StringView product, StringView key);
-	Filesystem_Stream::InputStream LookupInternal(StringView dir, StringView name, Span<StringView> exts, bool& is_rtp_asset) const;
+	Filesystem_Stream::InputStream LookupInternal(StringView dir, StringView name, const Span<const StringView> exts, bool& is_rtp_asset) const;
 
 	using search_path_list = std::vector<FilesystemView>;
 

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -157,11 +157,11 @@ bool Filesystem::IsValid() const {
 	return Exists("");
 }
 
-std::string Filesystem::FindFile(StringView filename, Span<StringView> exts) const {
+std::string Filesystem::FindFile(StringView filename, const Span<const StringView> exts) const {
 	return tree->FindFile(filename, exts);
 }
 
-std::string Filesystem::FindFile(StringView directory, StringView filename, Span<StringView> exts) const {
+std::string Filesystem::FindFile(StringView directory, StringView filename, const Span<const StringView> exts) const {
 	return tree->FindFile(directory, filename, exts);
 }
 
@@ -169,11 +169,11 @@ std::string Filesystem::FindFile(const DirectoryTree::Args& args) const {
 	return tree->FindFile(args);
 }
 
-Filesystem_Stream::InputStream Filesystem::OpenFile(StringView filename, Span<StringView> exts) const {
+Filesystem_Stream::InputStream Filesystem::OpenFile(StringView filename, const Span<const StringView> exts) const {
 	return OpenInputStream(tree->FindFile(filename, exts));
 }
 
-Filesystem_Stream::InputStream Filesystem::OpenFile(StringView directory, StringView filename, Span<StringView> exts) const {
+Filesystem_Stream::InputStream Filesystem::OpenFile(StringView directory, StringView filename, const Span<const StringView> exts) const {
 	return OpenInputStream(tree->FindFile(directory, filename, exts));
 }
 
@@ -211,7 +211,7 @@ void FilesystemView::ClearCache() const {
 	fs->ClearCache(GetSubPath());
 }
 
-std::string FilesystemView::FindFile(StringView name, Span<StringView> exts) const {
+std::string FilesystemView::FindFile(StringView name, const Span<const StringView> exts) const {
 	assert(fs);
 	std::string found = fs->FindFile(MakePath(name), exts);
 	if (!found.empty() && !sub_path.empty()) {
@@ -222,7 +222,7 @@ std::string FilesystemView::FindFile(StringView name, Span<StringView> exts) con
 	return found;
 }
 
-std::string FilesystemView::FindFile(StringView dir, StringView name, Span<StringView> exts) const {
+std::string FilesystemView::FindFile(StringView dir, StringView name, const Span<const StringView> exts) const {
 	assert(fs);
 	std::string found = fs->FindFile(MakePath(dir), name, exts);
 	if (!found.empty() && !sub_path.empty()) {
@@ -247,12 +247,12 @@ std::string FilesystemView::FindFile(const DirectoryTree::Args& args) const {
 	return found;
 }
 
-Filesystem_Stream::InputStream FilesystemView::OpenFile(StringView name, Span<StringView> exts) const {
+Filesystem_Stream::InputStream FilesystemView::OpenFile(StringView name, const Span<const StringView> exts) const {
 	assert(fs);
 	return fs->OpenFile(MakePath(name), exts);
 }
 
-Filesystem_Stream::InputStream FilesystemView::OpenFile(StringView dir, StringView name, Span<StringView> exts) const {
+Filesystem_Stream::InputStream FilesystemView::OpenFile(StringView dir, StringView name, const Span<const StringView> exts) const {
 	assert(fs);
 	return fs->OpenFile(MakePath(dir), name, exts);
 }

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -142,7 +142,7 @@ public:
 	 * @param exts List of file extensions to probe
 	 * @return Path to file or empty string when not found
 	 */
-	std::string FindFile(StringView filename, Span<StringView> exts = {}) const;
+	std::string FindFile(StringView filename, const Span<const StringView> exts = {}) const;
 
 	/**
 	 * Does a case insensitive search for the file in a specific
@@ -153,7 +153,7 @@ public:
 	 * @param exts List of file extensions to probe
 	 * @return Path to file or empty string when not found
 	 */
-	std::string FindFile(StringView directory, StringView filename, Span<StringView> exts = {}) const;
+	std::string FindFile(StringView directory, StringView filename, const Span<const StringView> exts = {}) const;
 
 	/**
 	 * Does a case insensitive search for a file.
@@ -173,7 +173,7 @@ public:
 	 * @param exts List of file extensions to probe
 	 * @return Handle to the file if found, otherwise an invalid handle
 	 */
-	Filesystem_Stream::InputStream OpenFile(StringView filename, Span<StringView> exts = {}) const;
+	Filesystem_Stream::InputStream OpenFile(StringView filename, const Span<const StringView> exts = {}) const;
 
 	/**
 	 * Does a case insensitive search for the file in a specific directory
@@ -184,7 +184,7 @@ public:
 	 * @param exts List of file extensions to probe
 	 * @return Handle to the file if found, otherwise an invalid handle
 	 */
-	Filesystem_Stream::InputStream OpenFile(StringView directory, StringView filename, Span<StringView> exts = {}) const;
+	Filesystem_Stream::InputStream OpenFile(StringView directory, StringView filename, const Span<const StringView> exts = {}) const;
 
 	/**
 	 * Does a case insensitive search for the file and opens a read handle.
@@ -283,7 +283,7 @@ public:
 	 * @param exts List of file extensions to probe
 	 * @return Path to file or empty string when not found
 	 */
-	std::string FindFile(StringView filename, Span<StringView> exts = {}) const;
+	std::string FindFile(StringView filename, const Span<const StringView> exts = {}) const;
 
 	/**
 	 * Does a case insensitive search for the file in a specific
@@ -294,7 +294,7 @@ public:
 	 * @param exts List of file extensions to probe
 	 * @return Path to file or empty string when not found
 	 */
-	std::string FindFile(StringView directory, StringView filename, Span<StringView> exts = {}) const;
+	std::string FindFile(StringView directory, StringView filename, const Span<const StringView> exts = {}) const;
 
 	/**
 	 * Does a case insensitive search for a file.
@@ -314,7 +314,7 @@ public:
 	 * @param exts List of file extensions to probe
 	 * @return Handle to the file if found, otherwise an invalid handle
 	 */
-	Filesystem_Stream::InputStream OpenFile(StringView filename, Span<StringView> exts = {}) const;
+	Filesystem_Stream::InputStream OpenFile(StringView filename, const Span<const StringView> exts = {}) const;
 
 	/**
 	 * Does a case insensitive search for the file in a specific directory
@@ -325,7 +325,7 @@ public:
 	 * @param exts List of file extensions to probe
 	 * @return Handle to the file if found, otherwise an invalid handle
 	 */
-	Filesystem_Stream::InputStream OpenFile(StringView directory, StringView filename, Span<StringView> exts = {}) const;
+	Filesystem_Stream::InputStream OpenFile(StringView directory, StringView filename, const Span<const StringView> exts = {}) const;
 
 	/**
 	 * Does a case insensitive search for the file and opens a read handle.

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -316,7 +316,7 @@ Rect FTFont::GetSize(char32_t ch) const {
 Font::GlyphRet FTFont::Glyph(char32_t code) {
     auto glyph_index = FT_Get_Char_Index(face, code);
 
-	if (FT_Load_Glyph(face, glyph_index, FT_LOAD_NO_BITMAP | FT_LOAD_TARGET_MONO) != FT_Err_Ok) {
+	if (FT_Load_Glyph(face, glyph_index, FT_LOAD_TARGET_MONO) != FT_Err_Ok) {
 		Output::Error("Couldn't load FreeType character {:#x}", uint32_t(code));
 	}
 

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -363,23 +363,23 @@ FontRef Font::Default() {
 	return Default(mincho);
 }
 
-FontRef Font::Default(bool const m) {
-	if (m && default_mincho) {
+FontRef Font::Default(bool const use_mincho) {
+	if (use_mincho && default_mincho) {
 		return default_mincho;
-	} else if (m && default_gothic) {
+	} else if (!use_mincho && default_gothic) {
 		return default_gothic;
 	}
 
 	if (Player::IsCJK()) {
-		return m ? mincho : gothic;
+		return use_mincho ? mincho : gothic;
 	}
 	else {
-		return m ? rmg2000 : ttyp0;
+		return use_mincho ? rmg2000 : ttyp0;
 	}
 }
 
-void Font::SetDefault(FontRef new_default, bool mincho) {
-	if (mincho) {
+void Font::SetDefault(FontRef new_default, bool use_mincho) {
+	if (use_mincho) {
 		default_mincho = new_default;
 	} else {
 		default_gothic = new_default;

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -429,14 +429,26 @@ Point Font::Render(Bitmap& dest, int const x, int const y, const Bitmap& sys, in
 	rect.x += gret.offset.x;
 	rect.y -= gret.offset.y;
 
-	if(color != ColorShadow) {
+	unsigned src_x;
+	unsigned src_y;
+
+	if (color != ColorShadow) {
 		auto shadow_rect = Rect(rect.x + 1, rect.y + 1, rect.width, rect.height);
 		dest.MaskedBlit(shadow_rect, *gret.bitmap, 0, 0, sys, 16, 32);
-	}
 
-	unsigned const
-		src_x = color == ColorShadow? 16 : color % 10 * 16 + 2,
-		src_y = color == ColorShadow? 32 : color / 10 * 16 + 48 + 16 - gret.bitmap->height();
+		src_x = color % 10 * 16 + 2;
+		src_y = color / 10 * 16 + 48 + 16 - 12 - gret.offset.y;
+
+		// When the glyph is large the system graphic color mask will be outside the rectangle
+		// Move the mask slightly up to avoid this
+		int offset = gret.bitmap->height() - gret.offset.y;
+		if (offset > 12) {
+			src_y -= offset - 12;
+		}
+	} else {
+		src_x = 16;
+		src_y = 32;
+	}
 
 	if (!gret.has_color) {
 		dest.MaskedBlit(rect, *gret.bitmap, 0, 0, sys, src_x, src_y);

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -497,8 +497,10 @@ Point Font::Render(Bitmap& dest, int const x, int const y, const Bitmap& sys, in
 	unsigned src_y;
 
 	if (color != ColorShadow) {
-		auto shadow_rect = Rect(rect.x + 1, rect.y + 1, rect.width, rect.height);
-		dest.MaskedBlit(shadow_rect, *gret.bitmap, 0, 0, sys, 16, 32);
+		if (!gret.has_color) {
+			auto shadow_rect = Rect(rect.x + 1, rect.y + 1, rect.width, rect.height);
+			dest.MaskedBlit(shadow_rect, *gret.bitmap, 0, 0, sys, 16, 32);
+		}
 
 		src_x = color % 10 * 16 + 2;
 		src_y = color / 10 * 16 + 48 + 16 - 12 - gret.offset.y;

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -247,6 +247,11 @@ FTFont::FTFont(Filesystem_Stream::InputStream is, int size, bool bold, bool ital
 
 	FT_New_Memory_Face(library, ft_buffer.data(), ft_buffer.size(), 0, &face);
 
+	if (face->num_charmaps > 0) {
+		// Force first charmap. Is enabled by default for Unicode fonts but not for legacy fonts (FON, BDF, etc.)
+		FT_Set_Charmap(face, face->charmaps[0]);
+	}
+
 	FT_Set_Pixel_Sizes(face, 0, HEIGHT);
 }
 

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -394,8 +394,8 @@ Font::GlyphRet FTFont::Glyph(char32_t code) {
 #endif
 
 FontRef Font::Default() {
-	const bool mincho = (Main_Data::game_system && Main_Data::game_system->GetFontId() == lcf::rpg::System::Font_mincho);
-	return Default(mincho);
+	const bool m = (Main_Data::game_system && Main_Data::game_system->GetFontId() == lcf::rpg::System::Font_mincho);
+	return Default(m);
 }
 
 FontRef Font::Default(bool const use_mincho) {
@@ -406,6 +406,11 @@ FontRef Font::Default(bool const use_mincho) {
 	}
 
 	return DefaultBitmapFont(use_mincho);
+}
+
+FontRef Font::DefaultBitmapFont() {
+	const bool m = (Main_Data::game_system && Main_Data::game_system->GetFontId() == lcf::rpg::System::Font_mincho);
+	return DefaultBitmapFont(m);
 }
 
 FontRef Font::DefaultBitmapFont(bool use_mincho) {

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -288,7 +288,7 @@ Rect FTFont::GetSize(StringView txt) const {
 Rect FTFont::GetSize(char32_t ch) const {
 	auto glyph_index = FT_Get_Char_Index(face, ch);
 
-	if (FT_Load_Glyph(face, glyph_index, FT_LOAD_TARGET_MONO) != FT_Err_Ok) {
+	if (FT_Load_Glyph(face, glyph_index, FT_LOAD_MONOCHROME) != FT_Err_Ok) {
 		Output::Error("Couldn't load FreeType character {:#x}", uint32_t(ch));
 	}
 
@@ -316,7 +316,7 @@ Rect FTFont::GetSize(char32_t ch) const {
 Font::GlyphRet FTFont::Glyph(char32_t code) {
     auto glyph_index = FT_Get_Char_Index(face, code);
 
-	if (FT_Load_Glyph(face, glyph_index, FT_LOAD_TARGET_MONO) != FT_Err_Ok) {
+	if (FT_Load_Glyph(face, glyph_index, FT_LOAD_MONOCHROME) != FT_Err_Ok) {
 		Output::Error("Couldn't load FreeType character {:#x}", uint32_t(code));
 	}
 

--- a/src/font.h
+++ b/src/font.h
@@ -100,9 +100,10 @@ class Font {
 	 */
 	Point Render(Bitmap& dest, int x, int y, Color const& color, char32_t glyph);
 
-	static FontRef Create(StringView name, int size, bool bold, bool italic);
+	static FontRef CreateFtFont(Filesystem_Stream::InputStream is, int size, bool bold, bool italic);
 	static FontRef Default();
 	static FontRef Default(bool mincho);
+	static void SetDefault(FontRef new_default, bool mincho);
 	static void Dispose();
 
 	static FontRef exfont;

--- a/src/font.h
+++ b/src/font.h
@@ -19,6 +19,8 @@
 #define EP_FONT_H
 
 // Headers
+#include "filesystem_stream.h"
+#include "point.h"
 #include "system.h"
 #include "memory_management.h"
 #include "rect.h"
@@ -51,10 +53,15 @@ class Font {
 	virtual Rect GetSize(char32_t ch) const = 0;
 
 	struct GlyphRet {
-		/* bitmap which the glyph pixels are located within */
+		/** bitmap which the glyph pixels are located within */
 		BitmapRef bitmap;
-		/* sub-rect of the bitmap which contains glyph pixels */
-		Rect rect;
+		/**
+		 * How far to advance the x/y offset after drawing for the next glyph.
+		 * y value is only relevant for vertical layouts.
+		 */
+		Point advance;
+		/** x/y position in the buffer where the glyph is rendered at */
+		Point offset;
 	};
 
 	/* Returns a bitmap and rect containing the pixels of the glyph.
@@ -78,7 +85,7 @@ class Font {
 	 *
 	 * @return Rect containing the x offset, y offset, width, and height of the subrect that was blitted onto dest. Not including text shadow!
 	 */
-	Rect Render(Bitmap& dest, int x, int y, const Bitmap& sys, int color, char32_t glyph);
+	Point Render(Bitmap& dest, int x, int y, const Bitmap& sys, int color, char32_t glyph);
 
 	/**
 	 * Renders the glyph onto bitmap at the given position with system graphic and color
@@ -91,9 +98,9 @@ class Font {
 	 *
 	 * @return Rect containing the x offset, y offset, width, and height of the subrect that was blitted onto dest.
 	 */
-	Rect Render(Bitmap& dest, int x, int y, Color const& color, char32_t glyph);
+	Point Render(Bitmap& dest, int x, int y, Color const& color, char32_t glyph);
 
-	static FontRef Create(const std::string& name, int size, bool bold, bool italic);
+	static FontRef Create(StringView name, int size, bool bold, bool italic);
 	static FontRef Default();
 	static FontRef Default(bool mincho);
 	static void Dispose();
@@ -120,7 +127,7 @@ class Font {
 
 	size_t pixel_size() const { return size * 96 / 72; }
  protected:
-	Font(const std::string& name, int size, bool bold, bool italic);
+	Font(StringView name, int size, bool bold, bool italic);
 };
 
 #endif

--- a/src/font.h
+++ b/src/font.h
@@ -113,6 +113,7 @@ class Font {
 	static FontRef CreateFtFont(Filesystem_Stream::InputStream is, int size, bool bold, bool italic);
 	static FontRef Default();
 	static FontRef Default(bool use_mincho);
+	static FontRef DefaultBitmapFont();
 	static FontRef DefaultBitmapFont(bool use_mincho);
 	static void SetDefault(FontRef new_default, bool use_mincho);
 	static void Dispose();

--- a/src/font.h
+++ b/src/font.h
@@ -102,9 +102,18 @@ class Font {
 	 */
 	Point Render(Bitmap& dest, int x, int y, Color const& color, char32_t glyph);
 
+	/**
+	 * Defines a fallback font that shall be used when a glyph is not found in the current font.
+	 * Currently only used by FreeType Fonts.
+	 *
+	 * @param fallback_font Font to fallback to
+	 */
+	void SetFallbackFont(FontRef fallback_font);
+
 	static FontRef CreateFtFont(Filesystem_Stream::InputStream is, int size, bool bold, bool italic);
 	static FontRef Default();
 	static FontRef Default(bool use_mincho);
+	static FontRef DefaultBitmapFont(bool use_mincho);
 	static void SetDefault(FontRef new_default, bool use_mincho);
 	static void Dispose();
 
@@ -127,6 +136,8 @@ class Font {
 	size_t pixel_size() const { return size * 96 / 72; }
  protected:
 	Font(StringView name, int size, bool bold, bool italic);
+
+	FontRef fallback_font;
 };
 
 #endif

--- a/src/font.h
+++ b/src/font.h
@@ -62,6 +62,8 @@ class Font {
 		Point advance;
 		/** x/y position in the buffer where the glyph is rendered at */
 		Point offset;
+		/** When enabled the glyph is colored and not masked with the system graphic */
+		bool has_color = false;
 	};
 
 	/* Returns a bitmap and rect containing the pixels of the glyph.

--- a/src/font.h
+++ b/src/font.h
@@ -102,8 +102,8 @@ class Font {
 
 	static FontRef CreateFtFont(Filesystem_Stream::InputStream is, int size, bool bold, bool italic);
 	static FontRef Default();
-	static FontRef Default(bool mincho);
-	static void SetDefault(FontRef new_default, bool mincho);
+	static FontRef Default(bool use_mincho);
+	static void SetDefault(FontRef new_default, bool use_mincho);
 	static void Dispose();
 
 	static FontRef exfont;

--- a/src/font.h
+++ b/src/font.h
@@ -85,7 +85,7 @@ class Font {
 	 * @param color which color in the system graphic
 	 * @param glyph which utf32 glyph to render
 	 *
-	 * @return Rect containing the x offset, y offset, width, and height of the subrect that was blitted onto dest. Not including text shadow!
+	 * @return Point containing how far to advance in x/y direction.
 	 */
 	Point Render(Bitmap& dest, int x, int y, const Bitmap& sys, int color, char32_t glyph);
 
@@ -98,7 +98,7 @@ class Font {
 	 * @param color which color in the system graphic
 	 * @param glyph which utf32 glyph to render
 	 *
-	 * @return Rect containing the x offset, y offset, width, and height of the subrect that was blitted onto dest.
+	 * @return Point containing how far to advance in x/y direction.
 	 */
 	Point Render(Bitmap& dest, int x, int y, Color const& color, char32_t glyph);
 

--- a/src/font.h
+++ b/src/font.h
@@ -35,7 +35,7 @@ class Rect;
  */
 class Font {
  public:
-	virtual ~Font() {}
+	virtual ~Font() = default;
 
 	/**
 	 * Returns the size of the rendered string, not including shadows.
@@ -107,10 +107,6 @@ class Font {
 	static void Dispose();
 
 	static FontRef exfont;
-
-	static const int default_size = 9;
-	static const bool default_bold = false;
-	static const bool default_italic = false;
 
 	enum SystemColor {
 		ColorShadow = -1,

--- a/src/fps_overlay.cpp
+++ b/src/fps_overlay.cpp
@@ -66,7 +66,7 @@ void FpsOverlay::Draw(Bitmap& dst) {
 	if (draw_fps) {
 		if (fps_dirty) {
 			std::string text = GetFpsString();
-			Rect rect = Font::Default()->GetSize(text);
+			Rect rect = Font::DefaultBitmapFont()->GetSize(text);
 
 			if (!fps_bitmap || fps_bitmap->GetWidth() < rect.width + 1) {
 				// Height never changes
@@ -74,7 +74,7 @@ void FpsOverlay::Draw(Bitmap& dst) {
 			}
 			fps_bitmap->Clear();
 			fps_bitmap->Fill(Color(0, 0, 0, 128));
-			fps_bitmap->TextDraw(1, 0, Color(255, 255, 255, 255), text);
+			Text::Draw(*fps_bitmap, 1, 0, *Font::DefaultBitmapFont(), Color(255, 255, 255, 255), text);
 
 			fps_rect = Rect(0, 0, rect.width + 1, rect.height - 1);
 
@@ -89,7 +89,7 @@ void FpsOverlay::Draw(Bitmap& dst) {
 		if (speedup_dirty) {
 			std::string text = "> x" + std::to_string(last_speed_mod);
 
-			Rect rect = Font::Default()->GetSize(text);
+			Rect rect = Font::DefaultBitmapFont()->GetSize(text);
 
 			if (!speedup_bitmap || speedup_bitmap->GetWidth() < rect.width + 1) {
 				// Height never changes
@@ -97,7 +97,7 @@ void FpsOverlay::Draw(Bitmap& dst) {
 			}
 			speedup_bitmap->Clear();
 			speedup_bitmap->Fill(Color(0, 0, 0, 128));
-			speedup_bitmap->TextDraw(1, 0, Color(255, 255, 255, 255), text);
+			Text::Draw(*speedup_bitmap, 1, 0, *Font::DefaultBitmapFont(), Color(255, 255, 255, 255), text);
 
 			speedup_rect = Rect(0, 0, rect.width + 1, rect.height - 1);
 

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -81,9 +81,12 @@ int Game_Message::GetRealPosition() {
 }
 
 int Game_Message::WordWrap(StringView line, const int limit, const WordWrapCallback& callback) {
+	return WordWrap(line, limit, callback, *Font::Default());
+}
+
+int Game_Message::WordWrap(StringView line, const int limit, const WordWrapCallback& callback, const Font& font) {
 	int start = 0;
 	int line_count = 0;
-	FontRef font = Font::Default();
 
 	do {
 		int next = start;
@@ -94,7 +97,7 @@ int Game_Message::WordWrap(StringView line, const int limit, const WordWrapCallb
 			}
 
 			auto wrapped = line.substr(start, found - start);
-			auto width = font->GetSize(wrapped).width;
+			auto width = font.GetSize(wrapped).width;
 			if (width > limit) {
 				if (next == start) {
 					next = found + 1;

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -24,6 +24,7 @@
 #include <functional>
 #include "string_view.h"
 #include "pending_message.h"
+#include "memory_management.h"
 
 class Window_Message;
 class AsyncOp;
@@ -79,6 +80,7 @@ namespace Game_Message {
 	 * @param callback a function to be called for each word-wrapped line
 	 */
 	int WordWrap(StringView line, int limit, const WordWrapCallback& callback);
+	int WordWrap(StringView line, int limit, const WordWrapCallback& callback, const Font& font);
 
 	/**
 	 * Return if it's legal to show a new message box.

--- a/src/message_overlay.cpp
+++ b/src/message_overlay.cpp
@@ -52,12 +52,7 @@ void MessageOverlay::Draw(Bitmap& dst) {
 				text += " [" + std::to_string(message.repeat_count + 1) + "x]";
 			}
 
-			bitmap->TextDraw(Rect(2,
-						i * text_height,
-						bitmap->GetWidth(),
-						text_height),
-				message.color,
-				text);
+			Text::Draw(*bitmap, 2, i * text_height, *Font::DefaultBitmapFont(), message.color, text);
 			++i;
 		}
 	}
@@ -88,7 +83,7 @@ void MessageOverlay::AddMessage(const std::string& message, Color color) {
 			SCREEN_TARGET_WIDTH - 6, // hardcoded to screen width because the bitmap is not initialized early enough
 			[&](StringView line) {
 				messages.emplace_back(std::string(line), color);
-			}
+			}, *Font::DefaultBitmapFont()
 	);
 
 	while (messages.size() > (unsigned)message_max) {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -218,8 +218,8 @@ static void HandleErrorOutput(const std::string& err) {
 
 	error += "\n\nEasyRPG Player will close now.\nPress [ENTER] key to exit...";
 
-	Text::Draw(*surface, 11, 11, *Font::Default(), Color(0, 0, 0, 255), error);
-	Text::Draw(*surface, 10, 10, *Font::Default(), Color(255, 255, 255, 255), error);
+	Text::Draw(*surface, 11, 11, *Font::DefaultBitmapFont(), Color(0, 0, 0, 255), error);
+	Text::Draw(*surface, 10, 10, *Font::DefaultBitmapFont(), Color(255, 255, 255, 255), error);
 	DisplayUi->UpdateDisplay();
 
 	if (ignore_pause) { return; }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -383,7 +383,7 @@ void Player::Exit() {
 #ifdef EMSCRIPTEN
 	BitmapRef surface = DisplayUi->GetDisplaySurface();
 	std::string message = "It's now safe to turn off\n      your browser.";
-	Text::Draw(*surface, 84, DisplayUi->GetHeight() / 2 - 30, *Font::Default(), Color(221, 123, 64, 255), message);
+	Text::Draw(*surface, 84, DisplayUi->GetHeight() / 2 - 30, *Font::DefaultBitmapFont(), Color(221, 123, 64, 255), message);
 	DisplayUi->UpdateDisplay();
 
 	auto ret = FileFinder::Root().OpenOutputStream("/tmp/message.png", std::ios_base::binary | std::ios_base::out | std::ios_base::trunc);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -784,7 +784,12 @@ void Player::CreateGameObjects() {
 	// ExFont parsing
 	Cache::exfont_custom.clear();
 	// Check for bundled ExFont
-	auto exfont_stream = FileFinder::OpenImage(".", "ExFont");
+	auto exfont_stream = FileFinder::OpenImage("Font", "ExFont");
+	if (!exfont_stream) {
+		// Backwards compatible with older Player versions
+		exfont_stream = FileFinder::OpenImage(".", "ExFont");
+	}
+
 #ifndef EMSCRIPTEN
 	if (!exfont_stream) {
 		// Attempt reading ExFont from RPG_RT.exe (not supported on Emscripten,

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -811,6 +811,8 @@ void Player::CreateGameObjects() {
 
 	ResetGameObjects();
 
+	LoadFonts();
+
 	Main_Data::game_ineluki->ExecuteScriptList(FileFinder::Game().FindFile("autorun.script"));
 }
 
@@ -991,6 +993,24 @@ void Player::LoadDatabase() {
 			FileExtGuesser::GuessAndAddLmuExtension(FileFinder::Game(), *meta, fileext_map);
 		}
 	}
+}
+
+void Player::LoadFonts() {
+	Font::SetDefault(nullptr, true);
+	Font::SetDefault(nullptr, false);
+
+#ifdef HAVE_FREETYPE
+	// Look for bundled fonts
+	auto gothic = FileFinder::OpenFont("Font");
+	if (gothic) {
+		Font::SetDefault(Font::CreateFtFont(std::move(gothic), 12, false, false), false);
+	}
+
+	auto mincho = FileFinder::OpenFont("Font2");
+	if (mincho) {
+		Font::SetDefault(Font::CreateFtFont(std::move(mincho), 12, false, false), true);
+	}
+#endif
 }
 
 static void OnMapSaveFileReady(FileRequestResult*, lcf::rpg::Save save) {

--- a/src/player.h
+++ b/src/player.h
@@ -137,7 +137,7 @@ namespace Player {
 	void ResetGameObjects();
 
 	/**
-	 * Determine if the LDB and LMT files are not present, and if so, guess 
+	 * Determine if the LDB and LMT files are not present, and if so, guess
 	 * if they may have been renamed. Populates fileext_map.
 	 */
 	void GuessNonStandardExtensions();
@@ -146,6 +146,11 @@ namespace Player {
 	 * Loads all databases.
 	 */
 	void LoadDatabase();
+
+	/**
+	 * Loads the default fonts.for text rendering.
+	 */
+	void LoadFonts();
 
 	/**
 	 * Loads savegame data.

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -128,7 +128,7 @@ void Scene_Logo::OnIndexReady(FileRequestResult*) {
 	tree->SetImportantFile(true);
 	FileRequestAsync* ini = AsyncHandler::RequestFile(INI_NAME);
 	ini->SetImportantFile(true);
-	FileRequestAsync* exfont = AsyncHandler::RequestFile("ExFont");
+	FileRequestAsync* exfont = AsyncHandler::RequestFile("Font/ExFont");
 	exfont->SetImportantFile(true);
 	FileRequestAsync* soundfont = AsyncHandler::RequestFile("easyrpg.soundfont");
 	soundfont->SetImportantFile(true);

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -134,6 +134,10 @@ void Scene_Logo::OnIndexReady(FileRequestResult*) {
 	soundfont->SetImportantFile(true);
 	FileRequestAsync* autorun_ineluki = AsyncHandler::RequestFile("autorun.script");
 	autorun_ineluki->SetImportantFile(true);
+	FileRequestAsync* font_gothic = AsyncHandler::RequestFile("Font/Font");
+	font_gothic->SetImportantFile(true);
+	FileRequestAsync* font_mincho = AsyncHandler::RequestFile("Font/Font2");
+	font_mincho->SetImportantFile(true);
 
 	db->Start();
 	tree->Start();
@@ -141,4 +145,6 @@ void Scene_Logo::OnIndexReady(FileRequestResult*) {
 	exfont->Start();
 	soundfont->Start();
 	autorun_ineluki->Start();
+	font_gothic->Start();
+	font_mincho->Start();
 }

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -28,7 +28,7 @@
 #include <cctype>
 #include <iterator>
 
-Rect Text::Draw(Bitmap& dest, int x, int y, Font& font, const Bitmap& system, int color, char32_t ch, bool is_exfont) {
+Point Text::Draw(Bitmap& dest, int x, int y, Font& font, const Bitmap& system, int color, char32_t ch, bool is_exfont) {
 	if (is_exfont) {
 		return Font::exfont->Render(dest, x, y, system, color, ch);
 	} else {
@@ -36,7 +36,7 @@ Rect Text::Draw(Bitmap& dest, int x, int y, Font& font, const Bitmap& system, in
 	}
 }
 
-Rect Text::Draw(Bitmap& dest, int x, int y, Font& font, Color color, char32_t ch, bool is_exfont) {
+Point Text::Draw(Bitmap& dest, int x, int y, Font& font, Color color, char32_t ch, bool is_exfont) {
 	if (is_exfont) {
 		return Font::exfont->Render(dest, x, y, color, ch);
 	} else {
@@ -44,8 +44,8 @@ Rect Text::Draw(Bitmap& dest, int x, int y, Font& font, Color color, char32_t ch
 	}
 }
 
-Rect Text::Draw(Bitmap& dest, const int x, const int y, Font& font, const Bitmap& system, const int color, StringView text, const Text::Alignment align) {
-	if (text.length() == 0) return { x, y, 0, 0 };
+Point Text::Draw(Bitmap& dest, const int x, const int y, Font& font, const Bitmap& system, const int color, StringView text, const Text::Alignment align) {
+	if (text.length() == 0) return { 0, 0 };
 
 	Rect dst_rect = font.GetSize(text);
 
@@ -63,7 +63,7 @@ Rect Text::Draw(Bitmap& dest, const int x, const int y, Font& font, const Bitmap
 
 	dst_rect.y = y;
 	dst_rect.width += 1; dst_rect.height += 1; // Need place for shadow
-	if (dst_rect.IsOutOfBounds(dest.GetWidth(), dest.GetHeight())) return { x, y, 0, 0 };
+	if (dst_rect.IsOutOfBounds(dest.GetWidth(), dest.GetHeight())) return { 0, 0 };
 
 	const int iy = dst_rect.y;
 	const int ix = dst_rect.x;
@@ -82,13 +82,13 @@ Rect Text::Draw(Bitmap& dest, const int x, const int y, Font& font, const Bitmap
 		if (EP_UNLIKELY(!ret)) {
 			continue;
 		}
-		next_glyph_pos += Text::Draw(dest, ix + next_glyph_pos, iy, font, system, color, ret.ch, ret.is_exfont).width;
+		next_glyph_pos += Text::Draw(dest, ix + next_glyph_pos, iy, font, system, color, ret.ch, ret.is_exfont).x;
 	}
-	return { x, y, next_glyph_pos, ih };
+	return { next_glyph_pos, ih };
 }
 
-Rect Text::Draw(Bitmap& dest, const int x, const int y, Font& font, const Color color, StringView text) {
-	if (text.length() == 0) return { x, y, 0, 0 };
+Point Text::Draw(Bitmap& dest, const int x, const int y, Font& font, const Color color, StringView text) {
+	if (text.length() == 0) return { 0, 0 };
 
 	int dx = x;
 	int mx = x;
@@ -118,14 +118,12 @@ Rect Text::Draw(Bitmap& dest, const int x, const int y, Font& font, const Color 
 		}
 
 		auto rect = font.Render(dest, dx, dy, color, ret.ch);
-		dx += rect.width;
-		assert(ny == 0 || ny == rect.height);
-		ny = rect.height;
+		dx += rect.x;
+		assert(ny == 0 || ny == rect.y);
+		ny = rect.y;
 	}
 	dy += ny;
 	mx = std::max(mx, dx);
 
-	return Rect(x, y, mx - x , dy - y);
+	return { mx - x , dy - y };
 }
-
-

--- a/src/text.h
+++ b/src/text.h
@@ -18,6 +18,7 @@
 #ifndef EP_TEXT_H
 #define EP_TEXT_H
 
+#include "point.h"
 #include "system.h"
 #include "memory_management.h"
 #include "rect.h"
@@ -51,9 +52,9 @@ namespace Text {
 	 * @param text the utf8 / exfont text to render.
 	 * @param align the text alignment to use
 	 *
-	 * @return Rect describing the sub-rect of dest that was rendered to. Does *not* include shadow pixels.
+	 * @return Where to draw the next glyph when continuing drawing. See Font::GlyphRet.advance
 	 */
-	Rect Draw(Bitmap& dest, int x, int y, Font& font, const Bitmap& system, int color, StringView text, Text::Alignment align = Text::AlignLeft);
+	Point Draw(Bitmap& dest, int x, int y, Font& font, const Bitmap& system, int color, StringView text, Text::Alignment align = Text::AlignLeft);
 
 	/**
 	 * Draws the text onto dest bitmap with given parameters. Does not draw a shadow.
@@ -65,9 +66,9 @@ namespace Text {
 	 * @param color which color to use.
 	 * @param text the utf8 / exfont text to render.
 	 *
-	 * @return Rect describing the sub-rect of dest that was rendered to. Does *not* include shadow pixels.
+	 * @return Where to draw the next glyph when continuing drawing. See Font::GlyphRet.advance
 	 */
-	Rect Draw(Bitmap& dest, int x, int y, Font& font, Color color, StringView text);
+	Point Draw(Bitmap& dest, int x, int y, Font& font, Color color, StringView text);
 
 	/**
 	 * Draws the character onto dest bitmap with given parameters.
@@ -79,11 +80,11 @@ namespace Text {
 	 * @param system the system graphic to use to render.
 	 * @param color which color from the system graphic to use.
 	 * @param ch the character to render.
-	 * @param is_exfont if true, treat ch as an exfont character. Otherwise, a utf32 character. 
+	 * @param is_exfont if true, treat ch as an exfont character. Otherwise, a utf32 character.
 	 *
-	 * @return Rect describing the sub-rect of dest that was rendered to. Does *not* include shadow pixels.
+	 * @return Where to draw the next glyph when continuing drawing. See Font::GlyphRet.advance
 	 */
-	Rect Draw(Bitmap& dest, int x, int y, Font& font, const Bitmap& system, int color, char32_t ch, bool is_exfont);
+	Point Draw(Bitmap& dest, int x, int y, Font& font, const Bitmap& system, int color, char32_t ch, bool is_exfont);
 
 
 	/**
@@ -95,10 +96,10 @@ namespace Text {
 	 * @param font the font used to render.
 	 * @param color which color to use.
 	 * @param ch the character to render.
-	 * @param is_exfont if true, treat ch as an exfont character. Otherwise, a utf32 character. 
+	 * @param is_exfont if true, treat ch as an exfont character. Otherwise, a utf32 character.
 	 *
-	 * @return Rect describing the sub-rect of dest that was rendered to. Does *not* include shadow pixels.
+	 * @return Where to draw the next glyph when continuing drawing. See Font::GlyphRet.advance
 	 */
-	Rect Draw(Bitmap& dest, int x, int y, Font& font, Color color, char32_t ch, bool is_exfont);
+	Point Draw(Bitmap& dest, int x, int y, Font& font, Color color, char32_t ch, bool is_exfont);
 }
 #endif

--- a/src/translation.cpp
+++ b/src/translation.cpp
@@ -160,8 +160,9 @@ void Translation::SelectLanguage(StringView lang_id)
 
 		FilesystemView language_tree = root.Subtree(lang_id);
 		if (language_tree) {
-			request_counter = 4;
-			for (auto s: {TRFILE_RPG_RT_LDB, TRFILE_RPG_RT_BATTLE, TRFILE_RPG_RT_COMMON, TRFILE_RPG_RT_LMT}) {
+			auto files = Utils::MakeSvArray(TRFILE_RPG_RT_LDB, TRFILE_RPG_RT_BATTLE, TRFILE_RPG_RT_COMMON, TRFILE_RPG_RT_LMT, "Font/Font", "Font/Font2");
+			request_counter = static_cast<int>(files.size());
+			for (auto s: files) {
 				FileRequestAsync* request = AsyncHandler::RequestFile(language_tree.GetFullPath(), s);
 				request->SetImportantFile(true);
 				requests.emplace_back(request->Bind(&Translation::SelectLanguageAsync, this, lang_id));
@@ -177,7 +178,7 @@ void Translation::SelectLanguage(StringView lang_id)
 	}
 }
 
-void Translation::SelectLanguageAsync(FileRequestResult* result, StringView lang_id) {
+void Translation::SelectLanguageAsync(FileRequestResult*, StringView lang_id) {
 	--request_counter;
 	if (request_counter == 0) {
 		requests.clear();
@@ -192,6 +193,9 @@ void Translation::SelectLanguageAsync(FileRequestResult* result, StringView lang
 
 	// We reload the entire database as a precaution.
 	Player::LoadDatabase();
+
+	// Translation could provide custom fonts
+	Player::LoadFonts();
 
 	// Rewrite our database+messages (unless we are on the Default language).
 	// Note that map Message boxes are changed on map load, to avoid slowdown here.

--- a/src/window_help.cpp
+++ b/src/window_help.cpp
@@ -56,14 +56,17 @@ void Window_Help::AddText(std::string text, int color, Text::Alignment align, bo
 	while (nextpos != std::string::npos) {
 		nextpos = text.find(' ', pos);
 		auto segment = ToStringView(text).substr(pos, nextpos - pos);
-		contents->TextDraw(text_x_offset, 2, color, segment, align);
-		text_x_offset += Font::Default()->GetSize(segment).width;
+		auto offset = contents->TextDraw(text_x_offset, 2, color, segment, align);
+		text_x_offset += offset.x;
 
+		// Special handling for proportional fonts: If the "normal" space is already small do not half it again
 		if (nextpos != decltype(text)::npos) {
-			if (halfwidthspace) {
-				text_x_offset += Font::Default()->GetSize(" ").width / 2;
+			int space_width = Font::Default()->GetSize(" ").width;
+
+			if (halfwidthspace && space_width >= 6) {
+				text_x_offset += space_width / 2;
 			} else {
-				text_x_offset += Font::Default()->GetSize(" ").width;
+				text_x_offset += space_width;
 			}
 			pos = nextpos + 1;
 		}

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -644,7 +644,8 @@ bool Window_Message::DrawGlyph(Font& font, const Bitmap& system, char32_t glyph,
 
 	auto rect = Text::Draw(*contents, contents_x, contents_y, font, system, text_color, glyph, is_exfont);
 
-	int glyph_width = rect.width;
+	// FIXME: When using Freetype the detection is incorrect due to dynamic width
+	int glyph_width = rect.x;
 	contents_x += glyph_width;
 	int width = get_width(glyph_width);
 	SetWaitForCharacter(width);

--- a/tests/font.cpp
+++ b/tests/font.cpp
@@ -56,18 +56,18 @@ TEST_CASE("FontSizeCharEx") {
 TEST_CASE("FontGlyphChar") {
 	Bitmap::SetFormat(format_R8G8B8A8_a().format());
 	auto font = Font::Default();
-	auto check = [&](char32_t ch, Rect r) {
+	auto check = [&](char32_t ch, Point p) {
 		auto ret = font->Glyph(ch);
 		REQUIRE(ret.bitmap != nullptr);
-		REQUIRE_EQ(ret.rect, r);
+		REQUIRE_EQ(ret.advance, p);
 	};
 
-	check(0, Rect(0, 0, 0, ch));
-	check(U' ', Rect(0, 0, cwh, ch));
-	check(U'\n', Rect(0, 0, 0, ch));
-	check(U'X', Rect(0, 0, cwh, ch));
-	check(U'ぽ', Rect(0, 0, cwf, ch));
-	check(U'下', Rect(0, 0, cwf, ch));
+	check(0, Point(0, 0));
+	check(U' ', Point(cwh, 0));
+	check(U'\n', Point(0, 0));
+	check(U'X', Point(cwh, 0));
+	check(U'ぽ', Point(cwf, 0));
+	check(U'下', Point(cwf, 0));
 }
 
 TEST_CASE("FontGlyphCharEx") {
@@ -77,7 +77,7 @@ TEST_CASE("FontGlyphCharEx") {
 	for (char32_t i = 0; i < 52; ++i) {
 		auto ret = font->Glyph(i);
 		REQUIRE(ret.bitmap != nullptr);
-		REQUIRE_EQ(ret.rect, Rect(0, 0, cwf, ch));
+		REQUIRE_EQ(ret.advance, Point(cwf, 0));
 	}
 }
 
@@ -87,16 +87,16 @@ TEST_CASE("FontGlyphChar") {
 	auto system = Cache::SysBlack();
 	auto surface = Bitmap::Create(width, height);
 	int color = 0;
-	auto check = [&](char32_t ch, Rect r) {
-		REQUIRE_EQ(font->Render(*surface, 0, 0, *system, color, ch), r);
+	auto check = [&](char32_t ch, Point p) {
+		REQUIRE_EQ(font->Render(*surface, 0, 0, *system, color, ch), p);
 	};
 
-	check(0, Rect(0, 0, 0, ch));
-	check(U' ', Rect(0, 0, cwh, ch));
-	check(U'\n', Rect(0, 0, 0, ch));
-	check(U'X', Rect(0, 0, cwh, ch));
-	check(U'ぽ', Rect(0, 0, cwf, ch));
-	check(U'下', Rect(0, 0, cwf, ch));
+	check(0, Point(0, 0));
+	check(U' ', Point(cwh, 0));
+	check(U'\n', Point(0, 0));
+	check(U'X', Point(cwh, 0));
+	check(U'ぽ', Point(cwf, 0));
+	check(U'下', Point(cwf, 0));
 }
 
 TEST_CASE("FontGlyphCharEx") {
@@ -107,7 +107,7 @@ TEST_CASE("FontGlyphCharEx") {
 	int color = 0;
 
 	for (char32_t i = 0; i < 52; ++i) {
-		REQUIRE_EQ(font->Render(*surface, 0, 0, *system, color, ch), Rect(0, 0, cwf, ch));
+		REQUIRE_EQ(font->Render(*surface, 0, 0, *system, color, ch), Point(cwf, 0));
 	}
 }
 

--- a/tests/text.cpp
+++ b/tests/text.cpp
@@ -25,10 +25,10 @@ TEST_CASE("TextDrawSystemStrReturn") {
 		return Text::Draw(*surface, x, y, *font, *system, 0, text);
 	};
 
-	REQUIRE_EQ(draw(0, 0, ""), Rect(0, 0, 0, 0));
-	REQUIRE_EQ(draw(0, 0, "abc"), Rect(0, 0, cwh * 3, ch));
-	REQUIRE_EQ(draw(3, 17, "$A"), Rect(3, 17, cwf, ch));
-	REQUIRE_EQ(draw(3, 17, "$A $B"), Rect(3, 17, cwf * 2 + cwh, ch));
+	REQUIRE_EQ(draw(0, 0, ""), Point(0, 0));
+	REQUIRE_EQ(draw(0, 0, "abc"), Point(cwh * 3, ch));
+	REQUIRE_EQ(draw(3, 17, "$A"), Point(cwf, ch));
+	REQUIRE_EQ(draw(3, 17, "$A $B"), Point(cwf * 2 + cwh, ch));
 }
 
 TEST_CASE("TextDrawColorStrReturn") {
@@ -41,11 +41,11 @@ TEST_CASE("TextDrawColorStrReturn") {
 		return Text::Draw(*surface, x, y, *font, color, text);
 	};
 
-	REQUIRE_EQ(draw(0, 0, ""), Rect(0, 0, 0, 0));
-	REQUIRE_EQ(draw(0, 0, "abc"), Rect(0, 0, cwh * 3, ch));
-	REQUIRE_EQ(draw(3, 17, "\n"), Rect(3, 17, 0, ch));
-	REQUIRE_EQ(draw(3, 17, "x\nyz"), Rect(3, 17, cwh * 2, ch *2));
-	REQUIRE_EQ(draw(10, 0, "xy\nz"), Rect(10, 0, cwh * 2, ch *2));
+	REQUIRE_EQ(draw(0, 0, ""), Point(0, 0));
+	REQUIRE_EQ(draw(0, 0, "abc"), Point(cwh * 3, 0));
+	REQUIRE_EQ(draw(3, 17, "\n"), Point(0, 12));
+	REQUIRE_EQ(draw(3, 17, "x\nyz"), Point(cwh * 2, 12));
+	REQUIRE_EQ(draw(10, 0, "xy\nz"), Point(cwh * 2, 12));
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
This adds experimental freetype rendering support.

Still marked as draft as I must test some stuff. But the basic rendering works.

When fonts are provided as "Font/Font.ttf" (gothic) or "Font/Font2.ttf" (mincho) these fonts are used instead of the built-in. Should also work for the web player and translations can provide custom fonts.

Also supports complex stuff like Thai (not using Harfbuzz though as Freetype is good enough to render Thai properly).

~~TODO: Testing testing testing. Fallback logic?~~

![screenshot_0](https://user-images.githubusercontent.com/1331889/198832143-5d92e4f0-b2c6-47a7-ac35-8062f8afcc65.png)
![screenshot_1](https://user-images.githubusercontent.com/1331889/198832144-a84cdab0-407e-4a4f-8b9f-1825772ca6a1.png)
![screenshot_2](https://user-images.githubusercontent.com/1331889/198832146-df8ed872-b68d-4f48-bb05-12d0f6a28a15.png)

Fix #2857
