### PR TITLE
Add Harfbuzz support

### DIFF
--- a/bench/font.cpp
+++ b/bench/font.cpp
@@ -13,7 +13,7 @@ constexpr int height = 80;
 static void BM_FontSizeStr(benchmark::State& state) {
 	auto font = Font::Default();
 	for (auto _: state) {
-		auto rect = font->GetSize(text);
+		auto rect = Text::GetSize(*font, text);
 		(void)rect;
 	}
 }
@@ -30,15 +30,15 @@ static void BM_FontSizeChar(benchmark::State& state) {
 
 BENCHMARK(BM_FontSizeChar);
 
-static void BM_Glyph(benchmark::State& state) {
+static void BM_vRender(benchmark::State& state) {
 	auto font = Font::Default();
 	for (auto _: state) {
-		auto bm = font->Glyph(symbol);
+		auto bm = font->vRender(symbol);
 		(void)bm;
 	}
 }
 
-BENCHMARK(BM_Glyph);
+BENCHMARK(BM_vRender);
 
 static void BM_Render(benchmark::State& state) {
 	Bitmap::SetFormat(format_R8G8B8A8_a().format());

--- a/builds/cmake/Modules/FindHarfbuzz.cmake
+++ b/builds/cmake/Modules/FindHarfbuzz.cmake
@@ -64,6 +64,30 @@ if(HARFBUZZ_FOUND)
 			INTERFACE_INCLUDE_DIRECTORIES "${HARFBUZZ_INCLUDE_DIRS}"
 			INTERFACE_LINK_LIBRARIES Freetype::Freetype
 			IMPORTED_LOCATION "${HARFBUZZ_LIBRARY}")
+
+		if(APPLE)
+			# Framework list taken from Harfbuzz CMakeLists
+			if(IOS)
+				find_library(COREFOUNDATION CoreFoundation REQUIRED)
+				find_library(CORETEXT CoreText REQUIRED)
+				find_library(COREGRAPHICS CoreGraphics REQUIRED)
+
+				set_property(TARGET Harfbuzz::Harfbuzz APPEND PROPERTY
+					INTERFACE_LINK_LIBRARIES ${COREFOUNDATION} ${CORETEXT}
+						${COREGRAPHICS})
+
+				mark_as_advanced(COREFOUNDATION)
+				mark_as_advanced(CORETEXT)
+				mark_as_advanced(COREGRAPHICS)
+			else()
+				find_library(APPLICATION_SERVICES ApplicationServices REQUIRED)
+
+				set_property(TARGET Harfbuzz::Harfbuzz APPEND PROPERTY
+					INTERFACE_LINK_LIBRARIES ${APPLICATION_SERVICES})
+
+				mark_as_advanced(APPLICATION_SERVICES)
+			endif()
+		endif()
 	endif()
 endif()
 

--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -273,7 +273,6 @@ void FileRequestAsync::Start() {
 	}
 
 	if (graphic && Tr::HasActiveTranslation()) {
-		// FIXME: Asset replacement will only work once for translations
 		std::string modified_path_trans = FileFinder::MakePath(lcf::ReaderUtil::Normalize(Tr::GetCurrentTranslationFilesystem().GetFullPath()), modified_path);
 		auto it = file_mapping.find(modified_path_trans);
 		if (it != file_mapping.end()) {

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -321,19 +321,23 @@ void Bitmap::HueChangeBlit(int x, int y, Bitmap const& src, Rect const& src_rect
 
 Point Bitmap::TextDraw(Rect const& rect, int color, StringView text, Text::Alignment align) {
 	FontRef font = Font::Default();
-	Rect text_rect = font->GetSize(text);
-	int dx = rect.width - text_rect.width;
 
 	switch (align) {
 	case Text::AlignLeft:
 		return TextDraw(rect.x, rect.y, color, text);
 		break;
-	case Text::AlignCenter:
-		return TextDraw(rect.x + dx / 2, rect.y, color, text);
+	case Text::AlignCenter: {
+		Rect text_rect = Text::GetSize(*font, text);
+		int dx = rect.x + (rect.width - text_rect.width) / 2;
+		return TextDraw(dx, rect.y, color, text);
 		break;
-	case Text::AlignRight:
-		return TextDraw(rect.x + dx, rect.y, color, text);
+	}
+	case Text::AlignRight: {
+		Rect text_rect = Text::GetSize(*font, text);
+		int dx = rect.x + rect.width - text_rect.width;
+		return TextDraw(dx, rect.y, color, text);
 		break;
+	}
 	default: assert(false);
 	}
 
@@ -348,19 +352,23 @@ Point Bitmap::TextDraw(int x, int y, int color, StringView text, Text::Alignment
 
 Point Bitmap::TextDraw(Rect const& rect, Color color, StringView text, Text::Alignment align) {
 	FontRef font = Font::Default();
-	Rect text_rect = font->GetSize(text);
-	int dx = rect.width - text_rect.width;
 
 	switch (align) {
 	case Text::AlignLeft:
 		return TextDraw(rect.x, rect.y, color, text);
 		break;
-	case Text::AlignCenter:
-		return TextDraw(rect.x + dx / 2, rect.y, color, text);
+	case Text::AlignCenter: {
+		Rect text_rect = Text::GetSize(*font, text);
+		int dx = rect.x + (rect.width - text_rect.width) / 2;
+		return TextDraw(dx, rect.y, color, text);
 		break;
-	case Text::AlignRight:
-		return TextDraw(rect.x + dx, rect.y, color, text);
+	}
+	case Text::AlignRight: {
+		Rect text_rect = Text::GetSize(*font, text);
+		int dx = rect.x + rect.width - text_rect.width;
+		return TextDraw(dx, rect.y, color, text);
 		break;
+	}
 	default: assert(false);
 	}
 

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -520,6 +520,11 @@ Font::Font(StringView name, int size, bool bold, bool italic)
 
 Rect Font::GetSize(char32_t glyph) const {
 	if (EP_UNLIKELY(Utils::IsControlCharacter(glyph))) {
+		if (glyph == '\n') {
+			// FIXME: Does not work for larger fonts
+			return {0, 0, 0, 12};
+		}
+
 		return {};
 	}
 

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -139,7 +139,9 @@ namespace {
 		GlyphRet vRender(char32_t glyph) const override;
 		GlyphRet vRenderShaped(char32_t glyph) const override;
 		bool vCanShape() const override;
+#ifdef HAVE_HARFBUZZ
 		std::vector<ShapeRet> vShape(U32StringView txt) const override;
+#endif
 
 	private:
 		FT_Face face = nullptr;

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -493,6 +493,10 @@ void Font::SetDefault(FontRef new_default, bool use_mincho) {
 
 FontRef Font::CreateFtFont(Filesystem_Stream::InputStream is, int size, bool bold, bool italic) {
 #ifdef HAVE_FREETYPE
+	if (!is) {
+		return nullptr;
+	}
+
 	return std::make_shared<FTFont>(std::move(is), size, bold, italic);
 #else
 	return nullptr;
@@ -527,8 +531,7 @@ Font::Font(StringView name, int size, bool bold, bool italic)
 Rect Font::GetSize(char32_t glyph) const {
 	if (EP_UNLIKELY(Utils::IsControlCharacter(glyph))) {
 		if (glyph == '\n') {
-			// FIXME: Does not work for larger fonts
-			return {0, 0, 0, 12};
+			return {0, 0, 0, static_cast<int>(size)};
 		}
 
 		return {};

--- a/src/font.h
+++ b/src/font.h
@@ -91,6 +91,21 @@ class Font {
 	Point Render(Bitmap& dest, int x, int y, const Bitmap& sys, int color, char32_t glyph) const;
 
 	/**
+	 * Renders the glyph onto bitmap at the given position with system graphic and color.
+	 * For glyph positioning pre-calculated shaping data can be specified.
+	 *
+	 * @param dest the bitmap to render to
+	 * @param x X offset to render glyph
+	 * @param y Y offset to render glyph
+	 * @param sys system graphic to use
+	 * @param color which color in the system graphic
+	 * @param shape shaping information for the glyph
+	 *
+	 * @return Rect containing the x offset, y offset, width, and height of the subrect that was blitted onto dest. Not including text shadow!
+	 */
+	Point Render(Bitmap& dest, int x, int y, const Bitmap& sys, int color, const ShapeRet& shape) const;
+
+	/**
 	 * Renders the glyph onto bitmap at the given position with system graphic and color
 	 *
 	 * @param dest the bitmap to render to
@@ -153,8 +168,9 @@ class Font {
 
 	virtual Rect vGetSize(char32_t glyph) const = 0;
 	virtual GlyphRet vRender(char32_t glyph) const = 0;
+	virtual GlyphRet vRenderShaped(char32_t glyph) const { return vRender(glyph); };
 	virtual bool vCanShape() const { return false; }
-	virtual std::vector<ShapeRet> vShape(U32StringView) const { assert(false); return {}; }
+	virtual std::vector<ShapeRet> vShape(U32StringView) const { return {}; }
 
  protected:
 	Font(StringView name, int size, bool bold, bool italic);

--- a/src/font.h
+++ b/src/font.h
@@ -149,6 +149,15 @@ class Font {
 	 */
 	void SetFallbackFont(FontRef fallback_font);
 
+	/**
+	 * Uses the FreeType library to load a font from the provided stream.
+	 *
+	 * @param is Stream to read from
+	 * @param size Font size (height) in px
+	 * @param bold Configure for bold rendering. This option is ignored.
+	 * @param italic Configure for italic rendering. This option is ignored.
+	 * @return font handle or nullptr on failure or if FreeType is unavailable
+	 */
 	static FontRef CreateFtFont(Filesystem_Stream::InputStream is, int size, bool bold, bool italic);
 	static FontRef Default();
 	static FontRef Default(bool use_mincho);

--- a/src/font.h
+++ b/src/font.h
@@ -35,10 +35,14 @@ class Rect;
  * Font class.
  *
  * All methods in this class are private API.
+ * Only use it when low level access is required.
  * Use the API in Text instead.
+ *
+ * @see Text
  */
 class Font {
  public:
+	/** Contains bitmap and metrics of a glyph */
 	struct GlyphRet {
 		/** bitmap which the glyph pixels are located within */
 		BitmapRef bitmap;
@@ -53,6 +57,7 @@ class Font {
 		bool has_color = false;
 	};
 
+	/** Contains metrics of a glyph shaped by Harfbuzz */
 	struct ShapeRet {
 		/** Codepoint of this glyph after shaping */
 		char32_t code;
@@ -70,10 +75,15 @@ class Font {
 		bool not_found;
 	};
 
+	/** Contains style informations */
 	struct Style {
+		/** Size in pixel to render at. -1 will use the size specified during initialisation */
 		int size = -1;
+		/** Whether to render text in bold (currently unsupported) */
 		bool bold = false;
+		/** Whether to render text in italic (currently unsupported) */
 		bool italic = false;
+		/** Whether to render a drop shadow */
 		bool draw_shadow = false;
 	};
 

--- a/src/font.h
+++ b/src/font.h
@@ -62,6 +62,11 @@ class Font {
 		Point advance;
 		/** x/y position in the buffer where the glyph is rendered at */
 		Point offset;
+		/**
+		 * When true the glyph was not found.
+		 * In that case code contains the original codepoint usable for a fallback.
+		 */
+		bool not_found;
 	};
 
 	virtual ~Font() = default;

--- a/src/fps_overlay.cpp
+++ b/src/fps_overlay.cpp
@@ -66,7 +66,7 @@ void FpsOverlay::Draw(Bitmap& dst) {
 	if (draw_fps) {
 		if (fps_dirty) {
 			std::string text = GetFpsString();
-			Rect rect = Font::DefaultBitmapFont()->GetSize(text);
+			Rect rect = Text::GetSize(*Font::DefaultBitmapFont(), text);
 
 			if (!fps_bitmap || fps_bitmap->GetWidth() < rect.width + 1) {
 				// Height never changes
@@ -89,7 +89,7 @@ void FpsOverlay::Draw(Bitmap& dst) {
 		if (speedup_dirty) {
 			std::string text = "> x" + std::to_string(last_speed_mod);
 
-			Rect rect = Font::DefaultBitmapFont()->GetSize(text);
+			Rect rect = Text::GetSize(*Font::DefaultBitmapFont(), text);
 
 			if (!speedup_bitmap || speedup_bitmap->GetWidth() < rect.width + 1) {
 				// Height never changes

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -97,7 +97,7 @@ int Game_Message::WordWrap(StringView line, const int limit, const WordWrapCallb
 			}
 
 			auto wrapped = line.substr(start, found - start);
-			auto width = font.GetSize(wrapped).width;
+			auto width = Text::GetSize(font, wrapped).width;
 			if (width > limit) {
 				if (next == start) {
 					next = found + 1;

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -497,7 +497,7 @@ void Scene_Battle_Rpg2k3::UpdateAnimations() {
 }
 
 void Scene_Battle_Rpg2k3::DrawFloatText(int x, int y, int color, StringView text) {
-	Rect rect = Font::Default()->GetSize(text);
+	Rect rect = Text::GetSize(*Font::Default(), text);
 
 	BitmapRef graphic = Bitmap::Create(rect.width, rect.height);
 	graphic->Clear();

--- a/src/scene_end.cpp
+++ b/src/scene_end.cpp
@@ -70,7 +70,7 @@ void Scene_End::CreateCommandWindow() {
 }
 
 void Scene_End::CreateHelpWindow() {
-	int text_size = Font::Default()->GetSize(lcf::Data::terms.exit_game_message).width;
+	int text_size = Text::GetSize(*Font::Default(), lcf::Data::terms.exit_game_message).width;
 
 	int window_width = text_size + 16;
 

--- a/src/string_view.h
+++ b/src/string_view.h
@@ -28,6 +28,7 @@
 #endif
 
 using StringView = lcf::StringView;
+using U32StringView = lcf::U32StringView;
 
 using lcf::ToString;
 using lcf::ToStringView;

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -173,6 +173,7 @@ Point Text::Draw(Bitmap& dest, const int x, const int y, const Font& font, const
 
 Rect Text::GetSize(const Font& font, StringView text) {
 	Rect rect;
+	Rect rect_tmp;
 
 	auto iter = text.data();
 	const auto end = iter + text.size();
@@ -188,7 +189,9 @@ Rect Text::GetSize(const Font& font, StringView text) {
 			}
 
 			if (EP_UNLIKELY(Utils::IsControlCharacter(ret.ch))) {
-				rect.width += GetSize(font, ret.ch, ret.is_exfont).width;
+				rect_tmp = GetSize(font, ret.ch, ret.is_exfont);
+				rect.width += rect_tmp.width;
+				rect.height = std::max(rect.height, rect_tmp.height);
 				continue;
 			}
 
@@ -202,7 +205,9 @@ Rect Text::GetSize(const Font& font, StringView text) {
 					}
 				}
 
-				rect.width += GetSize(font, ret.ch, ret.is_exfont).width;
+				rect_tmp = GetSize(font, ret.ch, ret.is_exfont);
+				rect.width += rect_tmp.width;
+				rect.height = std::max(rect.height, rect_tmp.height);
 				continue;
 			}
 
@@ -213,7 +218,8 @@ Rect Text::GetSize(const Font& font, StringView text) {
 			auto shape_ret = font.Shape(text32);
 
 			for (const auto& ch: shape_ret) {
-				rect.width += ch.advance.x;
+				rect.width += ch.offset.x + ch.advance.x;
+				rect.height = std::max(rect.height, ch.offset.y);
 			}
 		}
 	} else {
@@ -224,7 +230,10 @@ Rect Text::GetSize(const Font& font, StringView text) {
 			if (EP_UNLIKELY(!ret)) {
 				continue;
 			}
-			rect.width += GetSize(font, ret.ch, ret.is_exfont).width;
+
+			rect_tmp = GetSize(font, ret.ch, ret.is_exfont);
+			rect.width += rect_tmp.width;
+			rect.height = std::max(rect.height, rect_tmp.height);
 		}
 	}
 

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -28,26 +28,26 @@
 #include <cctype>
 #include <iterator>
 
-Point Text::Draw(Bitmap& dest, int x, int y, Font& font, const Bitmap& system, int color, char32_t ch, bool is_exfont) {
+Point Text::Draw(Bitmap& dest, int x, int y, const Font& font, const Bitmap& system, int color, char32_t glyph, bool is_exfont) {
 	if (is_exfont) {
-		return Font::exfont->Render(dest, x, y, system, color, ch);
+		return Font::exfont->Render(dest, x, y, system, color, glyph);
 	} else {
-		return font.Render(dest, x, y, system, color, ch);
+		return font.Render(dest, x, y, system, color, glyph);
 	}
 }
 
-Point Text::Draw(Bitmap& dest, int x, int y, Font& font, Color color, char32_t ch, bool is_exfont) {
+Point Text::Draw(Bitmap& dest, int x, int y, const Font& font, Color color, char32_t glyph, bool is_exfont) {
 	if (is_exfont) {
-		return Font::exfont->Render(dest, x, y, color, ch);
+		return Font::exfont->Render(dest, x, y, color, glyph);
 	} else {
-		return font.Render(dest, x, y, color, ch);
+		return font.Render(dest, x, y, color, glyph);
 	}
 }
 
-Point Text::Draw(Bitmap& dest, const int x, const int y, Font& font, const Bitmap& system, const int color, StringView text, const Text::Alignment align) {
+Point Text::Draw(Bitmap& dest, const int x, const int y, const Font& font, const Bitmap& system, const int color, StringView text, const Text::Alignment align) {
 	if (text.length() == 0) return { 0, 0 };
 
-	Rect dst_rect = font.GetSize(text);
+	Rect dst_rect = Text::GetSize(font, text);
 
 	const int ih = dst_rect.height;
 
@@ -87,7 +87,7 @@ Point Text::Draw(Bitmap& dest, const int x, const int y, Font& font, const Bitma
 	return { next_glyph_pos, ih };
 }
 
-Point Text::Draw(Bitmap& dest, const int x, const int y, Font& font, const Color color, StringView text) {
+Point Text::Draw(Bitmap& dest, const int x, const int y, const Font& font, const Color color, StringView text) {
 	if (text.length() == 0) return { 0, 0 };
 
 	int dx = x;
@@ -126,4 +126,34 @@ Point Text::Draw(Bitmap& dest, const int x, const int y, Font& font, const Color
 	mx = std::max(mx, dx);
 
 	return { mx - x , dy - y };
+}
+
+Rect Text::GetSize(const Font& font, StringView text) {
+	Rect rect;
+
+	//if (font.CanShape()) {
+		//auto text_shaped = font.Shape()
+	//} else {
+		auto iter = text.data();
+		const auto end = iter + text.size();
+		while (iter != end) {
+			auto ret = Utils::TextNext(iter, end, 0);
+
+			iter = ret.next;
+			if (EP_UNLIKELY(!ret)) {
+				continue;
+			}
+			rect.width += GetSize(font, ret.ch, ret.is_exfont).width;
+		}
+	//}
+	int a = 0;
+	return rect;
+}
+
+Rect Text::GetSize(const Font& font, char32_t glyph, bool is_exfont) {
+	if (is_exfont) {
+		return Font::exfont->GetSize(glyph);
+	} else {
+		return font.GetSize(glyph);
+	}
 }

--- a/src/text.h
+++ b/src/text.h
@@ -120,7 +120,7 @@ namespace Text {
 	 * For continuous rendering use the "width" property.
 	 *
 	 * @param font the font used to render.
-	 * @param ch the character to mesaure.
+	 * @param glyph the character to mesaure.
 	 * @param is_exfont if true, treat ch as an exfont character. Otherwise, a utf32 character.
 	 *
 	 * @return Rect describing the rendered string boundary

--- a/src/text.h
+++ b/src/text.h
@@ -54,7 +54,7 @@ namespace Text {
 	 *
 	 * @return Where to draw the next glyph when continuing drawing. See Font::GlyphRet.advance
 	 */
-	Point Draw(Bitmap& dest, int x, int y, Font& font, const Bitmap& system, int color, StringView text, Text::Alignment align = Text::AlignLeft);
+	Point Draw(Bitmap& dest, int x, int y, const Font& font, const Bitmap& system, int color, StringView text, Text::Alignment align = Text::AlignLeft);
 
 	/**
 	 * Draws the text onto dest bitmap with given parameters. Does not draw a shadow.
@@ -68,7 +68,7 @@ namespace Text {
 	 *
 	 * @return Where to draw the next glyph when continuing drawing. See Font::GlyphRet.advance
 	 */
-	Point Draw(Bitmap& dest, int x, int y, Font& font, Color color, StringView text);
+	Point Draw(Bitmap& dest, int x, int y, const Font& font, Color color, StringView text);
 
 	/**
 	 * Draws the character onto dest bitmap with given parameters.
@@ -84,7 +84,7 @@ namespace Text {
 	 *
 	 * @return Where to draw the next glyph when continuing drawing. See Font::GlyphRet.advance
 	 */
-	Point Draw(Bitmap& dest, int x, int y, Font& font, const Bitmap& system, int color, char32_t ch, bool is_exfont);
+	Point Draw(Bitmap& dest, int x, int y, const Font& font, const Bitmap& system, int color, char32_t glyph, bool is_exfont);
 
 
 	/**
@@ -100,6 +100,31 @@ namespace Text {
 	 *
 	 * @return Where to draw the next glyph when continuing drawing. See Font::GlyphRet.advance
 	 */
-	Point Draw(Bitmap& dest, int x, int y, Font& font, Color color, char32_t ch, bool is_exfont);
+	Point Draw(Bitmap& dest, int x, int y, const Font& font, Color color, char32_t glyph, bool is_exfont);
+
+	/**
+	 * Determines the size of a bitmap required to render a string.
+	 * The dimensions of the Rect describe a bounding box to fit the text.
+	 * For continuous rendering use the "width" property.
+	 *
+	 * @param font the font used to render.
+	 * @param text the string to measure.
+	 *
+	 * @return Rect describing the rendered string boundary
+	 */
+	Rect GetSize(const Font& font, StringView text);
+
+	/**
+	 * Determines the size of a bitmap required to render a single character.
+	 * The dimensions of the Rect describe a bounding box to fit the character.
+	 * For continuous rendering use the "width" property.
+	 *
+	 * @param font the font used to render.
+	 * @param ch the character to mesaure.
+	 * @param is_exfont if true, treat ch as an exfont character. Otherwise, a utf32 character.
+	 *
+	 * @return Rect describing the rendered string boundary
+	 */
+	Rect GetSize(const Font& font, char32_t glyph, bool is_exfont);
 }
 #endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -387,6 +387,8 @@ Utils::ExFontRet Utils::ExFontNext(const char* iter, const char* end) {
 		if (is_lower || is_upper) {
 			ret.next = iter + 2;
 			ret.value = is_lower ? (next_ch - 'a' + 26) : (next_ch - 'A');
+			// Ensure that ExFont is never detected as a control character
+			ret.value += 32;
 			ret.is_valid = true;
 		}
 	}

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -292,7 +292,7 @@ void Window_Base::DrawCurrencyValue(int money, int cx, int cy) const {
 	std::stringstream gold;
 	gold << money;
 
-	Rect gold_text_size = Font::Default()->GetSize(lcf::Data::terms.gold);
+	Rect gold_text_size = Text::GetSize(*Font::Default(), lcf::Data::terms.gold);
 	contents->TextDraw(cx, cy, 1, lcf::Data::terms.gold, Text::AlignRight);
 
 	contents->TextDraw(cx - gold_text_size.width, cy, Font::ColorDefault, gold.str(), Text::AlignRight);

--- a/src/window_command.cpp
+++ b/src/window_command.cpp
@@ -25,7 +25,7 @@ static int CalculateWidth(const std::vector<std::string>& commands, int width) {
 	if (width < 0) {
 		int max = 0;
 		for (size_t i = 0; i < commands.size(); ++i) {
-			max = std::max(max, Font::Default()->GetSize(commands[i]).width);
+			max = std::max(max, Text::GetSize(*Font::Default(), commands[i]).width);
 		}
 		return max + 16;
 	} else {

--- a/src/window_command_horizontal.cpp
+++ b/src/window_command_horizontal.cpp
@@ -25,7 +25,7 @@ static int CalculateWidth(const std::vector<std::string>& commands, int width) {
 	if (width < 0) {
 		width = 0;
 		for (size_t i = 0; i < commands.size(); ++i) {
-			width += std::max(width, Font::Default()->GetSize(commands[i]).width) + 16;
+			width += std::max(width, Text::GetSize(*Font::Default(), commands[i]).width) + 16;
 		}
 	}
 	return width;

--- a/src/window_equipstatus.cpp
+++ b/src/window_equipstatus.cpp
@@ -136,7 +136,7 @@ void Window_EquipStatus::DrawParameter(int cx, int cy, int type) {
 			}
 		} else {
 			// Draw arrow
-			int offset = (12 - Font::Default()->GetSize(lcf::Data::terms.easyrpg_equipment_arrow).width) / 2;
+			int offset = (12 - Text::GetSize(*Font::Default(), lcf::Data::terms.easyrpg_equipment_arrow).width) / 2;
 			contents->TextDraw(cx + offset, cy, 1, lcf::Data::terms.easyrpg_equipment_arrow);
 		}
 

--- a/src/window_help.cpp
+++ b/src/window_help.cpp
@@ -61,7 +61,7 @@ void Window_Help::AddText(std::string text, int color, Text::Alignment align, bo
 
 		// Special handling for proportional fonts: If the "normal" space is already small do not half it again
 		if (nextpos != decltype(text)::npos) {
-			int space_width = Font::Default()->GetSize(" ").width;
+			int space_width = Text::GetSize(*Font::Default(), " ").width;
 
 			if (halfwidthspace && space_width >= 6) {
 				text_x_offset += space_width / 2;

--- a/src/window_keyboard.cpp
+++ b/src/window_keyboard.cpp
@@ -243,7 +243,7 @@ std::string const& Window_Keyboard::GetSelected() const {
 Rect Window_Keyboard::GetItemRect(int row, int col) const {
 	return Rect(col * col_spacing + border_x,
 				row * row_spacing + border_y,
-				Font::Default()->GetSize(GetKey(row, col)).width + 8,
+				Text::GetSize(*Font::Default(), GetKey(row, col)).width + 8,
 				row_spacing);
 }
 

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -681,6 +681,7 @@ bool Window_Message::DrawGlyph(Font& font, const Bitmap& system, char32_t glyph,
 
 	// RPG_RT compatible for half-width (6) and full-width (12)
 	// generalizes the algo for even bigger glyphs
+	// FIXME: When using Freetype this can cause slow rendering speeds due to dynamic width
 	auto get_width = [](int w) {
 		return (w > 0) ? (w - 1) / 6 + 1 : 0;
 	};
@@ -700,7 +701,6 @@ bool Window_Message::DrawGlyph(Font& font, const Bitmap& system, char32_t glyph,
 
 	auto rect = Text::Draw(*contents, contents_x, contents_y, font, system, text_color, glyph, is_exfont);
 
-	// FIXME: When using Freetype the detection is incorrect due to dynamic width
 	int glyph_width = rect.x;
 	contents_x += glyph_width;
 	int width = get_width(glyph_width);
@@ -714,6 +714,7 @@ bool Window_Message::DrawGlyph(Font& font, const Bitmap& system, const Font::Sha
 
 	// RPG_RT compatible for half-width (6) and full-width (12)
 	// generalizes the algo for even bigger glyphs
+	// FIXME: This can cause slow rendering speeds for complex shapes
 	auto get_width = [](int w) {
 		return (w > 0) ? (w - 1) / 6 + 1 : 0;
 	};
@@ -731,7 +732,6 @@ bool Window_Message::DrawGlyph(Font& font, const Bitmap& system, const Font::Sha
 
 	auto rect = font.Render(*contents, contents_x, contents_y, system, text_color, shape);
 
-	// FIXME: When using Freetype the detection is incorrect due to dynamic width
 	int glyph_width = rect.x;
 	contents_x += glyph_width;
 	int width = get_width(glyph_width);

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -563,7 +563,7 @@ void Window_Message::UpdateMessage() {
 				break;
 			case '_':
 				// Insert half size space
-				contents_x += Font::Default()->GetSize(" ").width / 2;
+				contents_x += Text::GetSize(*Font::Default(), " ").width / 2;
 				DebugLogText("{}: MSG HalfWait \\_");
 				SetWaitForCharacter(1);
 				break;

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -131,7 +131,7 @@ public:
 	/** @return the number of lines per page */
 	int GetMaxLinesPerPage() const;
 
-	/** 
+	/**
 	 * Set the number of lines per page
 	 *
 	 * @param lines the number of lines
@@ -186,7 +186,10 @@ protected:
 
 	PendingMessage pending_message;
 
+	std::vector<Font::ShapeRet> shape_ret;
+
 	bool DrawGlyph(Font& font, const Bitmap& system, char32_t glyph, bool is_exfont);
+	bool DrawGlyph(Font& font, const Bitmap& system, const Font::ShapeRet& shape);
 	void IncrementLineCharCounter(int width);
 
 	void SetWaitForCharacter(int width);

--- a/src/window_name.cpp
+++ b/src/window_name.cpp
@@ -46,7 +46,7 @@ void Window_Name::Set(std::string text) {
 void Window_Name::Append(StringView text) {
 	// Avoid string copies by reusing the buffer in name
 	name.append(text.begin(), text.end());
-	if(Font::Default()->GetSize(name).width <= (12 * 6)) {
+	if (Text::GetSize(*Font::Default(), name).width <= (12 * 6)) {
 		Refresh();
 	} else {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
@@ -55,7 +55,7 @@ void Window_Name::Append(StringView text) {
 }
 
 void Window_Name::Update() {
-	Rect const name_size = Font::Default()->GetSize(name);
+	Rect const name_size = Text::GetSize(*Font::Default(), name);
 	SetCursorRect(Rect(name_size.width + 2, 0, 16, 16));
 }
 

--- a/src/window_savefile.cpp
+++ b/src/window_savefile.cpp
@@ -41,9 +41,9 @@ void Window_SaveFile::UpdateCursorRect() {
 
 	if (GetActive()) {
 		if (override_index > 0) {
-			rect = Rect(0, 0, Font::Default()->GetSize(GetSaveFileName()).width + 6, 16);
+			rect = Rect(0, 0, Text::GetSize(*Font::Default(), GetSaveFileName()).width + 6, 16);
 		} else {
-			rect = Rect(0, 0, Font::Default()->GetSize(GetSaveFileName()).width + Font::Default()->GetSize(" ").width * 5 / 2 + 8, 16);
+			rect = Rect(0, 0, Text::GetSize(*Font::Default(), GetSaveFileName()).width + Text::GetSize(*Font::Default(), " ").width * 5 / 2 + 8, 16);
 		}
 	}
 
@@ -96,11 +96,11 @@ void Window_SaveFile::Refresh() {
 	Font::SystemColor fc = has_save ? Font::ColorDefault : Font::ColorDisabled;
 
 	contents->TextDraw(4, 2, fc, GetSaveFileName());
-	contents->TextDraw(4 + Font::Default()->GetSize(GetSaveFileName()).width, 2, fc, " ");
+	contents->TextDraw(4 + Text::GetSize(*Font::Default(), GetSaveFileName()).width, 2, fc, " ");
 
 	std::stringstream out;
 	out << std::setw(2) << std::setfill(' ') << index + 1;
-	contents->TextDraw(4 + Font::Default()->GetSize(GetSaveFileName()).width + Font::Default()->GetSize(" ").width / 2, 2, fc, out.str());
+	contents->TextDraw(4 + Text::GetSize(*Font::Default(), GetSaveFileName()).width + Text::GetSize(*Font::Default(), " ").width / 2, 2, fc, out.str());
 
 	if (corrupted) {
 		contents->TextDraw(4, 16 + 2, Font::ColorKnockout, "Savegame corrupted");
@@ -126,7 +126,7 @@ void Window_SaveFile::Refresh() {
 
 	contents->TextDraw(4, 32 + 2, 1, lvl_short);
 
-	int lx = Font::Default()->GetSize(lvl_short).width;
+	int lx = Text::GetSize(*Font::Default(), lvl_short).width;
 	out.str("");
 	out << std::setw(2) << std::setfill(' ') << data.hero_level;
 	contents->TextDraw(4 + lx, 32 + 2, fc, out.str());
@@ -138,7 +138,7 @@ void Window_SaveFile::Refresh() {
 
 	contents->TextDraw(46, 32 + 2, 1, hp_short);
 
-	int hx = Font::Default()->GetSize(hp_short).width;
+	int hx = Text::GetSize(*Font::Default(), hp_short).width;
 	out.str("");
 	out << std::setw(Player::IsRPG2k3() ? 4 : 3) << std::setfill(' ') << data.hero_hp;
 	contents->TextDraw(46 + hx, 32 + 2, fc, out.str());

--- a/src/window_settings.cpp
+++ b/src/window_settings.cpp
@@ -429,7 +429,7 @@ void Window_Settings::RefreshButtonList() {
 
 		// Append as many buttons as fit on the screen, then add ...
 		int contents_w = GetContents()->width();
-		int name_size = Font::Default()->GetSize(name).width;
+		int name_size = Text::GetSize(*Font::Default(), name).width;
 		int value_size = 0;
 
 		for (auto ki = mappings.LowerBound(button); ki != mappings.end() && ki->first == button; ++ki) {
@@ -444,7 +444,7 @@ void Window_Settings::RefreshButtonList() {
 				cur_value = Input::Keys::kNames.tag(ki->second);
 			}
 
-			int cur_value_size = Font::Default()->GetSize(cur_value + ",").width;
+			int cur_value_size = Text::GetSize(*Font::Default(), cur_value + ",").width;
 
 			if (value.empty()) {
 				value = cur_value;

--- a/tests/font.cpp
+++ b/tests/font.cpp
@@ -15,21 +15,10 @@ constexpr int ch = 12;
 constexpr int cwh = 6;
 constexpr int cwf = 12;
 
-TEST_CASE("FontSizeStr") {
-	auto font = Font::Default();
-
-	REQUIRE_EQ(font->GetSize(""), Rect(0, 0, 0, ch));
-	REQUIRE_EQ(font->GetSize(" "), Rect(0, 0, cwh, ch));
-	REQUIRE_EQ(font->GetSize("\n"), Rect(0, 0, 0, ch));
-	REQUIRE_EQ(font->GetSize("$A"), Rect(0, 0, cwh * 2, ch));
-	REQUIRE_EQ(font->GetSize("X\nX"), Rect(0, 0, cwh * 2, ch));
-	REQUIRE_EQ(font->GetSize("下"), Rect(0, 0, cwf, ch));
-}
-
 TEST_CASE("FontSizeChar") {
 	auto font = Font::Default();
 
-	REQUIRE_EQ(font->GetSize(0), Rect(0, 0, 0, ch));
+	REQUIRE_EQ(font->GetSize(0), Rect(0, 0, 0, 0));
 	REQUIRE_EQ(font->GetSize(U' '), Rect(0, 0, cwh, ch));
 	REQUIRE_EQ(font->GetSize(U'\n'), Rect(0, 0, 0, ch));
 	REQUIRE_EQ(font->GetSize(U'X'), Rect(0, 0, cwh, ch));
@@ -37,18 +26,10 @@ TEST_CASE("FontSizeChar") {
 	REQUIRE_EQ(font->GetSize(U'下'), Rect(0, 0, cwf, ch));
 }
 
-TEST_CASE("FontSizeStrEx") {
-	auto font = Font::exfont;
-
-	for (char i = 0; i < 52; ++i) {
-		REQUIRE_EQ(font->GetSize(std::string(1,i)), Rect(0, 0, cwf, cwf));
-	}
-}
-
 TEST_CASE("FontSizeCharEx") {
 	auto font = Font::exfont;
 
-	for (char32_t i = 0; i < 52; ++i) {
+	for (char32_t i = 32; i < 32 + 52; ++i) {
 		REQUIRE_EQ(font->GetSize(i), Rect(0, 0, cwf, cwf));
 	}
 }
@@ -57,14 +38,13 @@ TEST_CASE("FontGlyphChar") {
 	Bitmap::SetFormat(format_R8G8B8A8_a().format());
 	auto font = Font::Default();
 	auto check = [&](char32_t ch, Point p) {
-		auto ret = font->Glyph(ch);
+		auto ret = font->vRender(ch);
 		REQUIRE(ret.bitmap != nullptr);
 		REQUIRE_EQ(ret.advance, p);
 	};
 
-	check(0, Point(0, 0));
 	check(U' ', Point(cwh, 0));
-	check(U'\n', Point(0, 0));
+	check(U'\n', Point(cwh, 0));
 	check(U'X', Point(cwh, 0));
 	check(U'ぽ', Point(cwf, 0));
 	check(U'下', Point(cwf, 0));
@@ -75,7 +55,7 @@ TEST_CASE("FontGlyphCharEx") {
 	auto font = Font::exfont;
 
 	for (char32_t i = 0; i < 52; ++i) {
-		auto ret = font->Glyph(i);
+		auto ret = font->vRender(i);
 		REQUIRE(ret.bitmap != nullptr);
 		REQUIRE_EQ(ret.advance, Point(cwf, 0));
 	}
@@ -106,8 +86,8 @@ TEST_CASE("FontGlyphCharEx") {
 	auto surface = Bitmap::Create(width, height);
 	int color = 0;
 
-	for (char32_t i = 0; i < 52; ++i) {
-		REQUIRE_EQ(font->Render(*surface, 0, 0, *system, color, ch), Point(cwf, 0));
+	for (char32_t i = 32; i < 32 + 52; ++i) {
+		REQUIRE_EQ(font->Render(*surface, 0, 0, *system, color, i), Point(cwf, 0));
 	}
 }
 

--- a/tests/utf.cpp
+++ b/tests/utf.cpp
@@ -107,14 +107,14 @@ TEST_CASE("TextNext") {
 	iter = ret.next;
 
 	ret = Utils::TextNext(iter, end, escape);
-	REQUIRE_EQ(ret.ch, 0);
+	REQUIRE_EQ(ret.ch, 0 + 32);
 	REQUIRE_NE(ret.next, end);
 	REQUIRE(ret.is_exfont);
 	REQUIRE_FALSE(ret.is_escape);
 	iter = ret.next;
 
 	ret = Utils::TextNext(iter, end, escape);
-	REQUIRE_EQ(ret.ch, 1);
+	REQUIRE_EQ(ret.ch, 1 + 32);
 	REQUIRE_NE(ret.next, end);
 	REQUIRE(ret.is_exfont);
 	REQUIRE_FALSE(ret.is_escape);


### PR DESCRIPTION
~~WIP PR to test harfbuzz shaping support :)~~

First I refactored the ``Font`` and ``Text`` Api: ``Font`` is now only responsible for rendering single glyphs (``char32_t``). For any high level usage the ``Text`` Api must be used.

The exception to "single glyph" is the shaping Api which takes a ``u32string`` because this conditionally converts codepoints depending on the shaping rules. When Harfbuzz is enabled the ``Text`` Api will automatically handle this.

A special case is ``Window_Message``. It renders glyph-by-glyph instead of all-in-one-go. This requires usage of the low level ``Font`` Api directly because the shaping information must be known.
