### PR TITLE
Emscripten: Add Api and remove Asynchify

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1124,7 +1124,7 @@ if(${PLAYER_BUILD_EXECUTABLE} AND ${PLAYER_TARGET_PLATFORM} MATCHES "^SDL(1|2)$"
 		set(PLAYER_JS_POSTJS "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-post.js")
 		set(PLAYER_JS_SHELL "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-shell.html")
 
-		set_property(TARGET ${EXE_NAME} PROPERTY LINK_FLAGS "-s ALLOW_MEMORY_GROWTH -s EXIT_RUNTIME -s ASYNCIFY -s ASYNCIFY_IGNORE_INDIRECT -s MINIFY_HTML=0 --pre-js ${PLAYER_JS_PREJS} --post-js ${PLAYER_JS_POSTJS} -sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=['$autoResumeAudioContext','$dynCall']")
+		set_property(TARGET ${EXE_NAME} PROPERTY LINK_FLAGS "-s ALLOW_MEMORY_GROWTH -s EXIT_RUNTIME -s ASYNCIFY -s ASYNCIFY_IGNORE_INDIRECT -s MINIFY_HTML=0 -s MODULARIZE -s EXPORT_NAME='createEasyRpgPlayer' --bind --pre-js ${PLAYER_JS_PREJS} --post-js ${PLAYER_JS_POSTJS} -sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=['$autoResumeAudioContext','$dynCall']")
 		set_source_files_properties("src/platform/sdl/main.cpp" PROPERTIES
 			OBJECT_DEPENDS "${PLAYER_JS_PREJS};${PLAYER_JS_POSTJS};${PLAYER_JS_SHELL}")
 
@@ -1132,6 +1132,12 @@ if(${PLAYER_BUILD_EXECUTABLE} AND ${PLAYER_TARGET_PLATFORM} MATCHES "^SDL(1|2)$"
 			set_target_properties(${EXE_NAME} PROPERTIES SUFFIX ".html")
 			set_property(TARGET ${EXE_NAME} APPEND_STRING PROPERTY LINK_FLAGS " --shell-file ${PLAYER_JS_SHELL}")
 		endif()
+
+		target_compile_options(${PROJECT_NAME} PUBLIC -fno-exceptions)
+
+		target_sources(${PROJECT_NAME} PRIVATE
+				src/platform/emscripten/interface.cpp
+				src/platform/emscripten/interface.h)
 
 		target_link_libraries(${EXE_NAME} "idbfs.js")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1124,7 +1124,11 @@ if(${PLAYER_BUILD_EXECUTABLE} AND ${PLAYER_TARGET_PLATFORM} MATCHES "^SDL(1|2)$"
 		set(PLAYER_JS_POSTJS "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-post.js")
 		set(PLAYER_JS_SHELL "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-shell.html")
 
-		set_property(TARGET ${EXE_NAME} PROPERTY LINK_FLAGS "-s ALLOW_MEMORY_GROWTH -s MINIFY_HTML=0 -s MODULARIZE -s EXIT_RUNTIME -s EXPORT_NAME='createEasyRpgPlayer' --bind --pre-js ${PLAYER_JS_PREJS} --post-js ${PLAYER_JS_POSTJS} -sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=['$autoResumeAudioContext','$dynCall']")
+		set_property(TARGET ${EXE_NAME} PROPERTY LINK_FLAGS
+			"-sALLOW_MEMORY_GROWTH -sMINIFY_HTML=0 -sMODULARIZE -sEXPORT_NAME=createEasyRpgPlayer \
+			 -sEXIT_RUNTIME --bind --pre-js ${PLAYER_JS_PREJS} --post-js ${PLAYER_JS_POSTJS} \
+			 -sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=['$autoResumeAudioContext','$dynCall'] \
+			 -sEXPORTED_FUNCTIONS=_main,_malloc,_free")
 		set_source_files_properties("src/platform/sdl/main.cpp" PROPERTIES
 			OBJECT_DEPENDS "${PLAYER_JS_PREJS};${PLAYER_JS_POSTJS};${PLAYER_JS_SHELL}")
 
@@ -1420,7 +1424,10 @@ if(PLAYER_ENABLE_TESTS)
 	if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
 		target_compile_definitions(test_runner_player PUBLIC EP_NATIVE_TEST_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/tests/assets\")
 		target_compile_definitions(test_runner_player PUBLIC EP_TEST_PATH=\"/assets\")
+		target_compile_definitions(test_runner_player PUBLIC DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS=1)
+
 		target_link_libraries(test_runner_player "nodefs.js")
+		set_property(TARGET test_runner_player PROPERTY LINK_FLAGS "-sALLOW_MEMORY_GROWTH --bind")
 	else()
 		target_compile_definitions(test_runner_player PUBLIC EP_TEST_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/tests/assets\")
 	endif()
@@ -1434,10 +1441,6 @@ if(PLAYER_ENABLE_TESTS)
 	endif()
 	add_dependencies(check_player test_runner_player)
 	add_dependencies(check check_player)
-
-	if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-		set_property(TARGET test_runner_player APPEND_STRING PROPERTY LINK_FLAGS "-s ALLOW_MEMORY_GROWTH")
-	endif()
 endif()
 
 # Instrumentation framework

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1124,7 +1124,7 @@ if(${PLAYER_BUILD_EXECUTABLE} AND ${PLAYER_TARGET_PLATFORM} MATCHES "^SDL(1|2)$"
 		set(PLAYER_JS_POSTJS "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-post.js")
 		set(PLAYER_JS_SHELL "${CMAKE_CURRENT_SOURCE_DIR}/resources/emscripten/emscripten-shell.html")
 
-		set_property(TARGET ${EXE_NAME} PROPERTY LINK_FLAGS "-s ALLOW_MEMORY_GROWTH -s EXIT_RUNTIME -s ASYNCIFY -s ASYNCIFY_IGNORE_INDIRECT -s MINIFY_HTML=0 -s MODULARIZE -s EXPORT_NAME='createEasyRpgPlayer' --bind --pre-js ${PLAYER_JS_PREJS} --post-js ${PLAYER_JS_POSTJS} -sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=['$autoResumeAudioContext','$dynCall']")
+		set_property(TARGET ${EXE_NAME} PROPERTY LINK_FLAGS "-s ALLOW_MEMORY_GROWTH -s MINIFY_HTML=0 -s MODULARIZE -s EXIT_RUNTIME -s EXPORT_NAME='createEasyRpgPlayer' --bind --pre-js ${PLAYER_JS_PREJS} --post-js ${PLAYER_JS_POSTJS} -sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=['$autoResumeAudioContext','$dynCall']")
 		set_source_files_properties("src/platform/sdl/main.cpp" PROPERTIES
 			OBJECT_DEPENDS "${PLAYER_JS_PREJS};${PLAYER_JS_POSTJS};${PLAYER_JS_SHELL}")
 
@@ -1136,6 +1136,7 @@ if(${PLAYER_BUILD_EXECUTABLE} AND ${PLAYER_TARGET_PLATFORM} MATCHES "^SDL(1|2)$"
 		target_compile_options(${PROJECT_NAME} PUBLIC -fno-exceptions)
 
 		target_sources(${PROJECT_NAME} PRIVATE
+				src/platform/emscripten/clock.h
 				src/platform/emscripten/interface.cpp
 				src/platform/emscripten/interface.h)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -531,6 +531,9 @@ EXTRA_DIST += \
 	src/platform/android/filesystem_saf.h \
 	src/platform/android/org_easyrpg_player_player_EasyRpgPlayerActivity.cpp \
 	src/platform/android/org_easyrpg_player_player_EasyRpgPlayerActivity.h \
+	src/platform/emscripten/clock.h \
+	src/platform/emscripten/interface.cpp \
+	src/platform/emscripten/interface.h \
 	src/platform/emscripten/main.cpp \
 	src/platform/libretro/audio.cpp \
 	src/platform/libretro/audio.h \

--- a/resources/emscripten/emscripten-post.js
+++ b/resources/emscripten/emscripten-post.js
@@ -2,15 +2,15 @@
 FS.mkdir("easyrpg");
 FS.chdir("easyrpg");
 
-if (Module.EASYRPG_GAME.length > 0) {
-  FS.mkdir(Module.EASYRPG_GAME);
-  FS.chdir(Module.EASYRPG_GAME);
+if (Module.game.length > 0) {
+  FS.mkdir(Module.game);
+  FS.chdir(Module.game);
 }
 
 // Use IDBFS for save file storage when the filesystem was not
 // overwritten by a custom emscripten shell file
 if (typeof Module.EASYRPG_FS === "undefined") {
-  Module.EASYRPG_FS = IDBFS;
+  Module.saveFs = IDBFS;
 }
 
 // Display the nice end message forever

--- a/resources/emscripten/emscripten-post.js
+++ b/resources/emscripten/emscripten-post.js
@@ -14,14 +14,11 @@ if (Module.saveFs === undefined) {
 }
 
 Module.initApi = function() {
-  Module.api_private.downloadSavegame_js = function(buffer, size, index) {
+  Module.api_private.download_js = function(buffer, size, filename) {
     const blob = new Blob([Module.HEAPU8.slice(buffer, buffer + size)]);
     const link = document.createElement('a');
     link.href = window.URL.createObjectURL(blob);
-    if (index < 10) {
-      index = "0" + index;
-    }
-    link.download = "Save" + index + ".lsd";
+    link.download = UTF8ToString(filename);
     link.click();
     link.remove();
   }

--- a/resources/emscripten/emscripten-post.js
+++ b/resources/emscripten/emscripten-post.js
@@ -40,10 +40,9 @@ Module.initApi = function() {
           const result = new Uint8Array(file.currentTarget.result);
           var buf = Module._malloc(result.length);
           Module.HEAPU8.set(result, buf);
-          Module.api_private.uploadSavegameStep2(slot, buf, result.length).then(function() {
-            Module._free(buf);
-            Module.api.refreshScene();
-          });
+          Module.api_private.uploadSavegameStep2(slot, buf, result.length);
+          Module._free(buf);
+          Module.api.refreshScene();
         };
         reader.readAsArrayBuffer(save);
       });

--- a/resources/emscripten/emscripten-post.js
+++ b/resources/emscripten/emscripten-post.js
@@ -9,8 +9,47 @@ if (Module.game.length > 0) {
 
 // Use IDBFS for save file storage when the filesystem was not
 // overwritten by a custom emscripten shell file
-if (typeof Module.EASYRPG_FS === "undefined") {
+if (Module.saveFs === undefined) {
   Module.saveFs = IDBFS;
+}
+
+Module.initApi = function() {
+  Module.api_private.downloadSavegame_js = function(buffer, size, index) {
+    const blob = new Blob([Module.HEAPU8.slice(buffer, buffer + size)]);
+    const link = document.createElement('a');
+    link.href = window.URL.createObjectURL(blob);
+    if (index < 10) {
+      index = "0" + index;
+    }
+    link.download = "Save" + index + ".lsd";
+    link.click();
+    link.remove();
+  }
+
+  Module.api_private.uploadSavegame_js = function(slot) {
+    let saveFile = document.getElementById('easyrpg_saveFile');
+    if (saveFile == null) {
+      saveFile = document.createElement('input');
+      saveFile.type = 'file';
+      saveFile.id = 'easyrpg_saveFile';
+      saveFile.style.display = 'none';
+      saveFile.addEventListener('change', function(evt) {
+        const save = evt.target.files[0];
+        const reader = new FileReader();
+        reader.onload = function (file) {
+          const result = new Uint8Array(file.currentTarget.result);
+          var buf = Module._malloc(result.length);
+          Module.HEAPU8.set(result, buf);
+          Module.api_private.uploadSavegameStep2(slot, buf, result.length).then(function() {
+            Module._free(buf);
+            Module.api.refreshScene();
+          });
+        };
+        reader.readAsArrayBuffer(save);
+      });
+    }
+    saveFile.click();
+  }
 }
 
 // Display the nice end message forever

--- a/resources/emscripten/emscripten-pre.js
+++ b/resources/emscripten/emscripten-pre.js
@@ -1,8 +1,6 @@
 // Note: The `Module` context is already initialized as an
 // empty object by emscripten even before the pre script
-Module = {
-  EASYRPG_GAME: "",
-
+Module = { ...Module,
   preRun: [onPreRun],
   postRun: [],
 
@@ -67,7 +65,8 @@ function parseArgs () {
 
     // Filesystem is not ready when processing arguments, store path to game
     if (tmp[0] === "game" && tmp.length > 1) {
-      Module.EASYRPG_GAME = tmp[1].toLowerCase();
+      Module.game = tmp[1].toLowerCase();
+      continue;
     }
 
     result.push("--" + tmp[0]);
@@ -91,7 +90,7 @@ function parseArgs () {
 function onPreRun () {
   // Retrieve save directory from persistent storage before using it
   FS.mkdir("Save");
-  FS.mount(Module.EASYRPG_FS, {}, 'Save');
+  FS.mount(Module.saveFs, {}, 'Save');
 
   // For preserving the configuration. Shared across website
   FS.mkdir("/home/web_user/.config");
@@ -102,6 +101,12 @@ function onPreRun () {
 
 Module.setStatus('Downloading...');
 Module.arguments = ["easyrpg-player", ...parseArgs()];
+
+if (Module.game === undefined) {
+  Module.game = "";
+} else {
+  Module.arguments.push("--game", Module.game);
+}
 
 // Catch all errors occuring inside the window
 window.addEventListener('error', (event) => {

--- a/resources/emscripten/emscripten-pre.js
+++ b/resources/emscripten/emscripten-pre.js
@@ -42,7 +42,7 @@ Module = { ...Module,
     Module.totalDependencies = Math.max(Module.totalDependencies, left);
     Module.setStatus(left ? `Preparing... (${Module.totalDependencies - left}/${Module.totalDependencies})` : 'Downloading game data...');
   }
-});
+};
 
 /**
  * Parses the current location query to setup a specific game

--- a/resources/emscripten/emscripten-pre.js
+++ b/resources/emscripten/emscripten-pre.js
@@ -42,7 +42,7 @@ Module = { ...Module,
     Module.totalDependencies = Math.max(Module.totalDependencies, left);
     Module.setStatus(left ? `Preparing... (${Module.totalDependencies - left}/${Module.totalDependencies})` : 'Downloading game data...');
   }
-};
+});
 
 /**
  * Parses the current location query to setup a specific game

--- a/resources/emscripten/emscripten-shell.html
+++ b/resources/emscripten/emscripten-shell.html
@@ -156,7 +156,22 @@ const preventNativeKeys = ['ArrowUp', 'ArrowDown', 'ArrowRight', 'ArrowLeft', ' 
 const keys = new Map();
 const keysDown = new Map();
 const canvas = document.getElementById('canvas');
+let player;
 let lastTouchedId;
+
+// Launch the Player and configure it
+window.addEventListener('load', (event) => {
+    createEasyRpgPlayer({
+      game: undefined,
+      saveFs: undefined
+    }).then(function(Module) {
+      // Module is ready
+      player = Module;
+      player.initApi();
+
+      // Custom code here
+    });
+});
 
 // Make EasyRPG player embeddable
 canvas.addEventListener('mouseenter', () => window.focus());

--- a/resources/emscripten/emscripten-shell.html
+++ b/resources/emscripten/emscripten-shell.html
@@ -156,7 +156,7 @@ const preventNativeKeys = ['ArrowUp', 'ArrowDown', 'ArrowRight', 'ArrowLeft', ' 
 const keys = new Map();
 const keysDown = new Map();
 const canvas = document.getElementById('canvas');
-let player;
+let easyrpgPlayer;
 let lastTouchedId;
 
 // Launch the Player and configure it
@@ -166,8 +166,8 @@ window.addEventListener('load', (event) => {
       saveFs: undefined
     }).then(function(Module) {
       // Module is ready
-      player = Module;
-      player.initApi();
+      easyrpgPlayer = Module;
+      easyrpgPlayer.initApi();
 
       // Custom code here
     });

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -173,7 +173,7 @@ Bitmap::Bitmap(Bitmap const& source, Rect const& src_rect, bool transparent) {
 	Blit(0, 0, source, src_rect, Opacity::Opaque());
 }
 
-bool Bitmap::WritePNG(Filesystem_Stream::OutputStream& os) const {
+bool Bitmap::WritePNG(std::ostream& os) const {
 	size_t const width = GetWidth(), height = GetHeight();
 	size_t const stride = width * 4;
 

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -198,7 +198,7 @@ public:
 	 * @param os output stream that PNG will be output.
 	 * @return true if success, otherwise false.
 	 */
-	bool WritePNG(Filesystem_Stream::OutputStream&) const;
+	bool WritePNG(std::ostream& os) const;
 
 	/**
 	 * Gets the background color

--- a/src/image_png.cpp
+++ b/src/image_png.cpp
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <csetjmp>
 #include <vector>
+#include <fstream>
 
 #include "output.h"
 #include "image_png.h"
@@ -250,7 +251,7 @@ static void flush_stream(png_structp out_ptr) {
 	reinterpret_cast<Filesystem_Stream::OutputStream*>(png_get_io_ptr(out_ptr))->flush();
 }
 
-bool ImagePNG::WritePNG(Filesystem_Stream::OutputStream& os, uint32_t width, uint32_t height, uint32_t* data) {
+bool ImagePNG::WritePNG(std::ostream& os, uint32_t width, uint32_t height, uint32_t* data) {
 	png_structp write = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
 	if (!write) {
 		Output::Warning("Bitmap::WritePNG: error in png_create_write");

--- a/src/image_png.h
+++ b/src/image_png.h
@@ -24,7 +24,7 @@
 namespace ImagePNG {
 	bool ReadPNG(const void* buffer, bool transparent, int& width, int& height, void*& pixels);
 	bool ReadPNG(Filesystem_Stream::InputStream& is, bool transparent, int& width, int& height, void*& pixels);
-	bool WritePNG(Filesystem_Stream::OutputStream& os, uint32_t width, uint32_t height, uint32_t* data);
+	bool WritePNG(std::ostream& os, uint32_t width, uint32_t height, uint32_t* data);
 }
 
 #endif

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -28,6 +28,7 @@
 #  include <android/log.h>
 #elif defined(EMSCRIPTEN)
 #  include <emscripten.h>
+#  include "platform/emscripten/interface.h"
 #elif defined(__vita__)
 #  include <psp2/kernel/processmgr.h>
 #endif
@@ -275,12 +276,17 @@ void Output::Quit() {
 }
 
 bool Output::TakeScreenshot() {
+#ifdef EMSCRIPTEN
+	Emscripten_Interface::TakeScreenshot();
+	return true;
+#else
 	int index = 0;
 	std::string p;
 	do {
 		p = "screenshot_" + std::to_string(index++) + ".png";
 	} while(FileFinder::Save().Exists(p));
 	return TakeScreenshot(p);
+#endif
 }
 
 bool Output::TakeScreenshot(StringView file) {
@@ -293,7 +299,7 @@ bool Output::TakeScreenshot(StringView file) {
 	return false;
 }
 
-bool Output::TakeScreenshot(Filesystem_Stream::OutputStream& os) {
+bool Output::TakeScreenshot(std::ostream& os) {
 	return DisplayUi->GetDisplaySurface()->WritePNG(os);
 }
 

--- a/src/output.h
+++ b/src/output.h
@@ -78,7 +78,7 @@ namespace Output {
 	 * @param os output stream that PNG will be stored.
 	 * @return true if success, otherwise false.
 	 */
-	bool TakeScreenshot(Filesystem_Stream::OutputStream& os);
+	bool TakeScreenshot(std::ostream& os);
 
 	/**
 	 * Shows/Hides the output log overlay.

--- a/src/platform/clock.h
+++ b/src/platform/clock.h
@@ -34,6 +34,9 @@ using Platform_Clock = NxClock;
 #elif defined(__vita__)
 #include "platform/psvita/clock.h"
 using Platform_Clock = Psp2Clock;
+#elif defined(EMSCRIPTEN)
+#include "platform/emscripten/clock.h"
+using Platform_Clock = EmscriptenClock;
 #elif defined(USE_LIBRETRO)
 // Only use libretro clock on platforms with no custom clock
 #include "platform/libretro/clock.h"

--- a/src/platform/emscripten/clock.h
+++ b/src/platform/emscripten/clock.h
@@ -1,0 +1,56 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_EMSCRIPTEN_CLOCK_H
+#define EP_EMSCRIPTEN_CLOCK_H
+
+#include <chrono>
+
+struct EmscriptenClock {
+	using clock = std::chrono::steady_clock;
+
+	using rep = clock::rep;
+	using period = clock::period;
+	using duration = clock::duration;
+	using time_point = clock::time_point;
+
+	static constexpr bool is_steady = clock::is_steady;
+
+	/** Get current time */
+	static time_point now();
+
+	/** Sleep for the specified duration */
+	template <typename R, typename P>
+	static void SleepFor(std::chrono::duration<R,P> dt);
+
+	static constexpr const char* Name();
+};
+
+inline EmscriptenClock::time_point EmscriptenClock::now() {
+	return clock::now();
+}
+
+template <typename R, typename P>
+inline void EmscriptenClock::SleepFor(std::chrono::duration<R,P> dt) {
+	// Browser handles sleep
+}
+
+constexpr const char* EmscriptenClock::Name() {
+	return "Emscripten";
+}
+
+#endif

--- a/src/platform/emscripten/interface.cpp
+++ b/src/platform/emscripten/interface.cpp
@@ -1,0 +1,95 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "interface.h"
+
+#include <emscripten.h>
+#include <emscripten/bind.h>
+#include <lcf/lsd/reader.h>
+
+#include "filefinder.h"
+#include "player.h"
+#include "scene_save.h"
+#include "output.h"
+
+void Emscripten_Interface::Reset() {
+	Player::reset_flag = true;
+}
+
+bool Emscripten_Interface::DownloadSavegame(int slot) {
+	auto fs = FileFinder::Save();
+	std::string name = Scene_Save::GetSaveFilename(fs, slot);
+	auto is = fs.OpenInputStream(name);
+	if (!is) {
+		return false;
+	}
+	auto save_buffer = Utils::ReadStream(is);
+	EM_ASM_ARGS({
+		Module.api_private.downloadSavegame_js($0, $1, $2);
+	}, save_buffer.data(), save_buffer.size(), slot);
+	return true;
+}
+
+void Emscripten_Interface::UploadSavegame(int slot) {
+	EM_ASM_INT({
+		Module.api_private.uploadSavegame_js($0);
+	}, slot);
+}
+
+void Emscripten_Interface::RefreshScene() {
+	Scene::instance->Refresh();
+}
+
+bool Emscripten_Interface_Private::UploadSavegameStep2(int slot, int buffer_addr, int size) {
+	auto fs = FileFinder::Save();
+	std::string name = Scene_Save::GetSaveFilename(fs, slot);
+
+	std::istream is(new Filesystem_Stream::InputMemoryStreamBuf(lcf::Span<uint8_t>(reinterpret_cast<uint8_t*>(buffer_addr), size)));
+
+	if (!lcf::LSD_Reader::Load(is)) {
+		Output::Warning("Selected file is not a valid savegame");
+		return false;
+	}
+
+	{
+		auto os = fs.OpenOutputStream(name);
+		if (!os)
+			return false;
+		os.write(reinterpret_cast<char*>(buffer_addr), size);
+	}
+
+	// Save changed file system
+	EM_ASM({
+		FS.syncfs(function(err) {});
+	});
+
+	return true;
+}
+
+// Binding code
+EMSCRIPTEN_BINDINGS(player_interface) {
+	emscripten::class_<Emscripten_Interface>("api")
+		.class_function("requestReset", &Emscripten_Interface::Reset)
+		.class_function("downloadSavegame", &Emscripten_Interface::DownloadSavegame)
+		.class_function("uploadSavegame", &Emscripten_Interface::UploadSavegame)
+		.class_function("refreshScene", &Emscripten_Interface::RefreshScene)
+	;
+
+	emscripten::class_<Emscripten_Interface_Private>("api_private")
+		.class_function("uploadSavegameStep2", &Emscripten_Interface_Private::UploadSavegameStep2)
+	;
+}

--- a/src/platform/emscripten/interface.cpp
+++ b/src/platform/emscripten/interface.cpp
@@ -58,7 +58,7 @@ bool Emscripten_Interface_Private::UploadSavegameStep2(int slot, int buffer_addr
 	auto fs = FileFinder::Save();
 	std::string name = Scene_Save::GetSaveFilename(fs, slot);
 
-	std::istream is(new Filesystem_Stream::InputMemoryStreamBuf(lcf::Span<uint8_t>(reinterpret_cast<uint8_t*>(buffer_addr), size)));
+	std::istream is(new Filesystem_Stream::InputMemoryStreamBufView(lcf::Span<uint8_t>(reinterpret_cast<uint8_t*>(buffer_addr), size)));
 
 	if (!lcf::LSD_Reader::Load(is)) {
 		Output::Warning("Selected file is not a valid savegame");

--- a/src/platform/emscripten/interface.h
+++ b/src/platform/emscripten/interface.h
@@ -23,6 +23,7 @@ public:
 	static bool DownloadSavegame(int slot);
 	static void UploadSavegame(int slot);
 	static void RefreshScene();
+	static void TakeScreenshot();
 	static void Reset();
 };
 

--- a/src/platform/emscripten/interface.h
+++ b/src/platform/emscripten/interface.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_EMSCRIPTEN_INTERFACE_H
+#define EP_EMSCRIPTEN_INTERFACE_H
+
+class Emscripten_Interface {
+public:
+	static bool DownloadSavegame(int slot);
+	static void UploadSavegame(int slot);
+	static void RefreshScene();
+	static void Reset();
+};
+
+class Emscripten_Interface_Private {
+public:
+	static bool UploadSavegameStep2(int slot, int buffer_addr, int size);
+};
+
+#endif

--- a/src/platform/emscripten/main.cpp
+++ b/src/platform/emscripten/main.cpp
@@ -19,28 +19,46 @@
 #include <string>
 #include <vector>
 #include <emscripten.h>
+#include "baseui.h"
 #include "output.h"
 #include "player.h"
+
+namespace {
+	std::vector<std::string> args;
+	int counter = 0;
+}
+
+void main_loop() {
+	if (counter < 5) {
+		++counter;
+	}
+
+	if (counter == 5) {
+		// Yield on start to ensure async operations (e.g. "mounting" of filesystems) can finish
+		Player::Init(std::move(args));
+		Player::Run();
+		++counter;
+	} else if (counter == 6) {
+		Player::MainLoop();
+		if (!DisplayUi.get()) {
+			// Yield on shutdown to ensure async operations (e.g. IDBFS saving) can finish
+			counter = -5;
+		}
+	} else if (counter == -1) {
+		emscripten_cancel_main_loop();
+	}
+}
 
 /**
  * If the main function ever needs to change, be sure to update the `main()`
  * functions of the other platforms as well.
  */
 extern "C" int main(int argc, char* argv[]) {
-	// Yield on start to ensure async operations (e.g. "mounting" of filesystems) can finish
-	// 10ms appears to work already but to be on the safe side better use 100ms
-	emscripten_sleep(100);
-
-	std::vector<std::string> args;
 	args.assign(argv, argv + argc);
 
 	Output::IgnorePause(true);
 
-	Player::Init(std::move(args));
-	Player::Run();
-
-	// Yield on shutdown to ensure async operations (e.g. IDBFS saving) can finish
-	emscripten_sleep(100);
+	emscripten_set_main_loop(main_loop, 0, 0);
 
 	return EXIT_SUCCESS;
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -214,9 +214,8 @@ void Player::Run() {
 	Game_Clock::ResetFrame(Game_Clock::now());
 
 	// Main loop
-#ifdef EMSCRIPTEN
-	emscripten_set_main_loop(Player::MainLoop, 0, 0);
-#elif defined(USE_LIBRETRO)
+#if defined(USE_LIBRETRO) || defined(EMSCRIPTEN)
+	// emscripten implemented in main.cpp
 	// libretro invokes the MainLoop through a retro_run-callback
 #else
 	while (Transition::instance().IsActive() || (Scene::instance && Scene::instance->type != Scene::Null)) {
@@ -394,8 +393,6 @@ void Player::Exit() {
 
 	Graphics::UpdateSceneCallback();
 #ifdef EMSCRIPTEN
-	emscripten_cancel_main_loop();
-
 	BitmapRef surface = DisplayUi->GetDisplaySurface();
 	std::string message = "It's now safe to turn off\n      your browser.";
 	DisplayUi->CleanDisplay();

--- a/src/scene.h
+++ b/src/scene.h
@@ -137,6 +137,11 @@ public:
 	static bool IsAsyncPending();
 
 	/**
+	 * Called when data was modified from the outside and must be reloaded.
+	 */
+	virtual void Refresh() {}
+
+	/**
 	 * Called every frame.
 	 */
 	void Update();

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -204,7 +204,7 @@ void Scene_File::vUpdate() {
 #ifdef EMSCRIPTEN
 		extra_commands_window->SetX(SCREEN_TARGET_WIDTH - extra_commands_window->GetWidth() - 8);
 		extra_commands_window->SetY(file_windows[index]->GetY() + 8);
-		extra_commands_window->SetItemEnabled(0, file_windows[index]->IsValid());
+		extra_commands_window->SetItemEnabled(0, file_windows[index]->IsValid() && file_windows[index]->HasParty());
 		extra_commands_window->SetVisible(true);
 		return;
 #endif

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -32,6 +32,11 @@
 #include <lcf/reader_util.h>
 #include "output.h"
 
+#ifdef EMSCRIPTEN
+#  include <emscripten.h>
+#  include "platform/emscripten/interface.h"
+#endif
+
 constexpr int arrow_animation_frames = 20;
 
 Scene_File::Scene_File(std::string message) :
@@ -137,18 +142,35 @@ void Scene_File::Start() {
 	index = latest_slot;
 	top_index = std::max(0, index - 2);
 
-	Refresh();
+	RefreshWindows();
 
 	for (auto& fw: file_windows) {
 		fw->Update();
 	}
+
+	std::vector<std::string> commands;
+#ifdef EMSCRIPTEN
+	commands.emplace_back("Download Savegame");
+	commands.emplace_back("Upload Savegame");
+#endif
+	extra_commands_window = std::make_unique<Window_Command>(commands);
+	extra_commands_window->SetZ(Priority_Window + 100);
+	extra_commands_window->SetVisible(false);
 }
 
-void Scene_File::Refresh() {
+void Scene_File::RefreshWindows() {
 	for (int i = 0; i < (int)file_windows.size(); i++) {
 		Window_SaveFile *w = file_windows[i].get();
 		w->SetY(40 + (i - top_index) * 64);
 		w->SetActive(i == index);
+		w->Refresh();
+	}
+}
+
+void Scene_File::Refresh() {
+	for (int i = 0; i < Utils::Clamp<int32_t>(lcf::Data::system.easyrpg_max_savefiles, 3, 99); i++) {
+		Window_SaveFile *w = file_windows[i].get();
+		PopulateSaveWindow(*w, i);
 		w->Refresh();
 	}
 }
@@ -163,6 +185,10 @@ void Scene_File::vUpdate() {
 		return;
 	}
 
+	if (HandleExtraCommandsWindow()) {
+		return;
+	}
+
 	if (Input::IsTriggered(Input::CANCEL)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
 		Scene::Pop();
@@ -174,6 +200,14 @@ void Scene_File::vUpdate() {
 		else {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 		}
+	} else if (Input::IsTriggered(Input::SHIFT)) {
+#ifdef EMSCRIPTEN
+		extra_commands_window->SetX(SCREEN_TARGET_WIDTH - extra_commands_window->GetWidth() - 8);
+		extra_commands_window->SetY(file_windows[index]->GetY() + 8);
+		extra_commands_window->SetItemEnabled(0, file_windows[index]->IsValid());
+		extra_commands_window->SetVisible(true);
+		return;
+#endif
 	}
 
 	int old_top_index = top_index;
@@ -220,7 +254,7 @@ void Scene_File::vUpdate() {
 	//top_index = std::min(top_index, std::max(top_index, index - 3 + 1));
 
 	if (top_index != old_top_index || index != old_index)
-		Refresh();
+		RefreshWindows();
 
 	for (auto& fw: file_windows) {
 		fw->Update();
@@ -255,4 +289,37 @@ void Scene_File::UpdateArrows() {
 	bool arrow_visible = (arrow_frame < arrow_animation_frames);
 	up_arrow->SetVisible(show_up_arrow && arrow_visible);
 	down_arrow->SetVisible(show_down_arrow && arrow_visible);
+}
+
+bool Scene_File::HandleExtraCommandsWindow() {
+	if (!extra_commands_window->IsVisible()) {
+		return false;
+	}
+
+	extra_commands_window->Update();
+
+#ifdef EMSCRIPTEN
+	if (Input::IsTriggered(Input::DECISION)) {
+		if (extra_commands_window->GetIndex() == 0) {
+			// Download
+			if (!extra_commands_window->IsItemEnabled(0)) {
+				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
+				return true;
+			}
+
+			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
+			Emscripten_Interface::DownloadSavegame(index + 1);
+			extra_commands_window->SetVisible(false);
+		} else {
+			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
+			Emscripten_Interface::UploadSavegame(index + 1);
+			extra_commands_window->SetVisible(false);
+		}
+	} else if (Input::IsTriggered(Input::CANCEL)) {
+		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
+		extra_commands_window->SetVisible(false);
+	}
+#endif
+
+	return true;
 }

--- a/src/scene_file.h
+++ b/src/scene_file.h
@@ -25,6 +25,7 @@
 #include "scene.h"
 #include "window_help.h"
 #include "window_savefile.h"
+#include "window_command.h"
 #include "sprite.h"
 
 
@@ -43,6 +44,7 @@ public:
 
 	void Start() override;
 	void vUpdate() override;
+	void Refresh() override;
 
 	virtual void Action(int index) = 0;
 
@@ -58,9 +60,10 @@ protected:
 	static std::unique_ptr<Sprite> MakeBorderSprite(int y);
 	static std::unique_ptr<Sprite> MakeArrowSprite(bool down);
 
-	void Refresh();
+	void RefreshWindows();
 	void MoveFileWindows(int dy, int dt);
 	void UpdateArrows();
+	bool HandleExtraCommandsWindow();
 
 	int index = 0;
 	int top_index = 0;
@@ -70,6 +73,7 @@ protected:
 	std::unique_ptr<Sprite> border_bottom;
 	std::unique_ptr<Sprite> up_arrow;
 	std::unique_ptr<Sprite> down_arrow;
+	std::unique_ptr<Window_Command> extra_commands_window;
 	std::string message;
 
 	FilesystemView fs;
@@ -78,6 +82,7 @@ protected:
 	int latest_slot = 0;
 
 	int arrow_frame = 0;
+
 };
 
 #endif

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -188,6 +188,15 @@ void Scene_Title::vUpdate() {
 	}
 }
 
+void Scene_Title::Refresh() {
+	// Enable load game if available
+	continue_enabled = FileFinder::HasSavegame();
+	if (continue_enabled) {
+		command_window->SetIndex(1);
+	}
+	command_window->SetItemEnabled(1, continue_enabled);
+}
+
 void Scene_Title::OnTranslationChanged() {
 	Start();
 
@@ -257,12 +266,7 @@ void Scene_Title::CreateCommandWindow() {
 	command_window.reset(new Window_Command(options));
 	RepositionWindow(*command_window, Player::hide_title_flag);
 
-	// Enable load game if available
-	continue_enabled = FileFinder::HasSavegame();
-	if (continue_enabled) {
-		command_window->SetIndex(1);
-	}
-	command_window->SetItemEnabled(1, continue_enabled);
+	Refresh();
 
 	// Set the number of frames for the opening animation to last
 	if (!Player::hide_title_flag) {

--- a/src/scene_title.h
+++ b/src/scene_title.h
@@ -40,6 +40,7 @@ public:
 	void TransitionIn(SceneType prev_scene) override;
 	void Suspend(SceneType next_scene) override;
 	void vUpdate() override;
+	void Refresh() override;
 
 	void OnTranslationChanged() override;
 

--- a/src/window_savefile.cpp
+++ b/src/window_savefile.cpp
@@ -82,8 +82,12 @@ void Window_SaveFile::SetCorrupted(bool corrupted) {
 	this->corrupted = corrupted;
 }
 
-bool Window_SaveFile::IsValid() {
+bool Window_SaveFile::IsValid() const {
 	return has_save && !corrupted;
+}
+
+bool Window_SaveFile::HasParty() const {
+	return has_party;
 }
 
 void Window_SaveFile::SetHasSave(bool valid) {

--- a/src/window_savefile.h
+++ b/src/window_savefile.h
@@ -67,7 +67,12 @@ public:
 	 *
 	 * @return Whether save is valid
 	 */
-	bool IsValid();
+	bool IsValid() const;
+
+	/**
+	 * @return Whether the save slot contains party information from a save file.
+	 */
+	bool HasParty() const;
 
 	/**
 	 * Sets if there is a savegame in the slot.


### PR DESCRIPTION
Already wrote this in February but never gave it the final touch... **Better for post 0.7.1, removing asynchify can cause problems**.

Had to remove Asynchify because it breaks the Api (you cannot call back into the Player while the endless async loop is running). Previously we had bad experiences when the browser does the mainloop timing. I hope this works better by now...

New feature: Save upload and download (fix: #1025).

![Screenshot_20221121_231818](https://user-images.githubusercontent.com/1331889/203170607-01587cda-e393-4cf1-a214-22602e633de8.png)

New feature: Api under "easyrpgPlayer.api". Currently can do: Reset, Refresh (called after upload to refresh the scene), Upload, Download. Can be used as an extension point if you have a website that wants to access certain functionality of the Player.