### PR TITLE
Make UI/Map compatible with Custom Resolutions 

### DIFF
--- a/src/game_map.h
+++ b/src/game_map.h
@@ -42,8 +42,8 @@ struct BattleArgs;
 
 // These are in sixteenths of a pixel.
 constexpr int SCREEN_TILE_SIZE = 256;
-constexpr int SCREEN_WIDTH = 20 * SCREEN_TILE_SIZE;
-constexpr int SCREEN_HEIGHT = 15 * SCREEN_TILE_SIZE;
+constexpr int SCREEN_WIDTH = (SCREEN_TARGET_WIDTH / 16) * SCREEN_TILE_SIZE;
+constexpr int SCREEN_HEIGHT = (SCREEN_TARGET_HEIGHT / 16) * SCREEN_TILE_SIZE;
 
 class MapUpdateAsyncContext {
 	public:

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -27,6 +27,7 @@
 #include "game_pictures.h"
 #include "input.h"
 #include "main_data.h"
+#include "options.h"
 #include "player.h"
 #include "util_macro.h"
 #include "game_switches.h"
@@ -41,6 +42,16 @@
 #include <algorithm>
 #include <cmath>
 #include "scene_gameover.h"
+
+namespace {
+	int default_pan_x() {
+		return (Utils::RoundTo<int>(static_cast<float>(SCREEN_TARGET_WIDTH) / TILE_SIZE / 2) - 1) * SCREEN_TILE_SIZE;
+	}
+
+	int default_pan_y() {
+		return (Utils::RoundTo<int>(static_cast<float>(SCREEN_TARGET_HEIGHT) / TILE_SIZE / 2) - 1) * SCREEN_TILE_SIZE;
+	}
+}
 
 Game_Player::Game_Player(): Game_PlayerBase(Player)
 {
@@ -144,10 +155,10 @@ void Game_Player::MoveTo(int map_id, int x, int y) {
 
 		// pan_state does not reset when you change maps.
 		data()->pan_speed = lcf::rpg::SavePartyLocation::kPanSpeedDefault;
-		data()->pan_finish_x = lcf::rpg::SavePartyLocation::kPanXDefault;
-		data()->pan_finish_y = lcf::rpg::SavePartyLocation::kPanYDefault;
-		data()->pan_current_x = lcf::rpg::SavePartyLocation::kPanXDefault;
-		data()->pan_current_y = lcf::rpg::SavePartyLocation::kPanYDefault;
+		data()->pan_finish_x = default_pan_x();
+		data()->pan_finish_y = default_pan_y();
+		data()->pan_current_x = default_pan_x();
+		data()->pan_current_y = default_pan_y();
 
 		ResetAnimation();
 
@@ -782,8 +793,8 @@ void Game_Player::StartPan(int direction, int distance, int speed) {
 }
 
 void Game_Player::ResetPan(int speed) {
-	data()->pan_finish_x = lcf::rpg::SavePartyLocation::kPanXDefault;
-	data()->pan_finish_y = lcf::rpg::SavePartyLocation::kPanYDefault;
+	data()->pan_finish_x = default_pan_x();
+	data()->pan_finish_y = default_pan_y();
 	data()->pan_speed = 2 << speed;
 }
 

--- a/src/options.h
+++ b/src/options.h
@@ -29,7 +29,9 @@
 
 /** Menus width and offset */
 #define MENU_WIDTH 320
+#define MENU_HEIGHT 240
 const int MENU_OFFSET_X = (SCREEN_TARGET_WIDTH - MENU_WIDTH) / 2;
+const int MENU_OFFSET_Y = (SCREEN_TARGET_HEIGHT - MENU_HEIGHT) / 2;
 
 /** MessageBox dimension and offset */
 #define MESSAGE_BOX_WIDTH 320

--- a/src/options.h
+++ b/src/options.h
@@ -31,6 +31,11 @@
 #define MENU_WIDTH 320
 const int MENU_OFFSET_X = (SCREEN_TARGET_WIDTH - MENU_WIDTH) / 2;
 
+/** MessageBox dimension and offset */
+#define MESSAGE_BOX_WIDTH 320
+#define MESSAGE_BOX_HEIGHT 80
+const int MESSAGE_BOX_OFFSET_X = (SCREEN_TARGET_WIDTH - MENU_WIDTH) / 2;
+
 /** Working with hi resolutions. default 16 */
 #define TILE_SIZE 16
 

--- a/src/options.h
+++ b/src/options.h
@@ -27,6 +27,10 @@
 /** Targeted screen default height. */
 #define SCREEN_TARGET_HEIGHT 240
 
+/** Menus width and offset */
+#define MENU_WIDTH 320
+const int MENU_OFFSET_X = (SCREEN_TARGET_WIDTH - MENU_WIDTH) / 2;
+
 /** Working with hi resolutions. default 16 */
 #define TILE_SIZE 16
 

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -472,8 +472,10 @@ void Scene_Debug::CreateRangeWindow() {
 		ranges.push_back("");
 	range_window.reset(new Window_Command(ranges, 96));
 
-	range_window->SetHeight(176);
-	range_window->SetY(32);
+	int height = 176;
+	range_window->SetHeight(height);
+	range_window->SetX(MENU_OFFSET_X);
+	range_window->SetY(MENU_OFFSET_Y + ((MENU_HEIGHT - height) / 2));
 }
 
 void Scene_Debug::UpdateRangeListWindow() {
@@ -597,7 +599,7 @@ void Scene_Debug::CreateVarListWindow() {
 	for (int i = 0; i < 10; i++)
 		vars.push_back("");
 	var_window.reset(new Window_VarList(vars));
-	var_window->SetX(range_window->GetWidth());
+	var_window->SetX(MENU_OFFSET_X + range_window->GetWidth());
 	var_window->SetY(range_window->GetY());
 	var_window->SetVisible(false);
 	var_window->SetIndex(-1);
@@ -606,7 +608,7 @@ void Scene_Debug::CreateVarListWindow() {
 }
 
 void Scene_Debug::CreateNumberInputWindow() {
-	numberinput_window.reset(new Window_NumberInput(160 - (Main_Data::game_variables->GetMaxDigits() + 1) * 6 - 8, 104,
+	numberinput_window.reset(new Window_NumberInput(MENU_OFFSET_X + 160 - (Main_Data::game_variables->GetMaxDigits() + 1) * 6 - 8, MENU_OFFSET_Y + 104,
 		(Main_Data::game_variables->GetMaxDigits() + 1) * 12 + 16, 32));
 	numberinput_window->SetVisible(false);
 	numberinput_window->SetOpacity(255);

--- a/src/scene_end.cpp
+++ b/src/scene_end.cpp
@@ -72,8 +72,10 @@ void Scene_End::CreateCommandWindow() {
 void Scene_End::CreateHelpWindow() {
 	int text_size = Font::Default()->GetSize(lcf::Data::terms.exit_game_message).width;
 
-	help_window.reset(new Window_Help((SCREEN_TARGET_WIDTH/2) - (text_size + 16)/ 2,
-									  72, text_size + 16, 32));
+	int window_width = text_size + 16;
+
+	help_window.reset(new Window_Help(MENU_OFFSET_X + (MENU_WIDTH / 2) - (window_width / 2),
+									  MENU_OFFSET_Y + 72, window_width, 32));
 	help_window->SetText(ToString(lcf::Data::terms.exit_game_message), Font::ColorDefault, Text::AlignLeft, false);
 
 	command_window->SetHelpWindow(help_window.get());

--- a/src/scene_equip.cpp
+++ b/src/scene_equip.cpp
@@ -35,14 +35,19 @@ Scene_Equip::Scene_Equip(Game_Actor& actor, int equip_index) :
 
 void Scene_Equip::Start() {
 	// Create the windows
-	help_window.reset(new Window_Help(0, 0, SCREEN_TARGET_WIDTH, 32));
-	equipstatus_window.reset(new Window_EquipStatus(0, 32, 124, 96, actor.GetId()));
-	equip_window.reset(new Window_Equip(124, 32, (SCREEN_TARGET_WIDTH-124),96, actor.GetId()));
+	int menu_help_height = 32;
+	int menu_equip_status_width = 124;
+	int menu_equip_status_height = 96;
+	int menu_equip_height = 96;
+
+	help_window.reset(new Window_Help(MENU_OFFSET_X, MENU_OFFSET_Y, MENU_WIDTH, menu_help_height));
+	equipstatus_window.reset(new Window_EquipStatus(MENU_OFFSET_X, MENU_OFFSET_Y + menu_help_height, menu_equip_status_width, menu_equip_status_height, actor.GetId()));
+	equip_window.reset(new Window_Equip(MENU_OFFSET_X + menu_equip_status_width, MENU_OFFSET_Y + menu_help_height, (MENU_WIDTH - menu_equip_status_width), menu_equip_height, actor.GetId()));
 
 	equip_window->SetIndex(equip_index);
 
 	for (int i = 0; i < 5; ++i) {
-		item_windows.push_back(std::make_shared<Window_EquipItem>(actor.GetId(), i));
+		item_windows.push_back(std::make_shared<Window_EquipItem>(MENU_OFFSET_X, MENU_OFFSET_Y + menu_help_height + menu_equip_status_height, MENU_WIDTH, MENU_HEIGHT - menu_help_height - menu_equip_status_height,actor.GetId(), i));
 	}
 
 	// Assign the help windows

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -39,30 +39,34 @@ Scene_File::Scene_File(std::string message) :
 }
 
 std::unique_ptr<Sprite> Scene_File::MakeBorderSprite(int y) {
-	auto bitmap = Bitmap::Create(SCREEN_TARGET_WIDTH, 8, Cache::System()->GetBackgroundColor());
+	int border_height = 8;
+	auto bitmap = Bitmap::Create(MENU_WIDTH, border_height, Cache::System()->GetBackgroundColor());
 	auto sprite = std::unique_ptr<Sprite>(new Sprite());
 	sprite->SetVisible(true);
 	sprite->SetZ(Priority_Window + 1);
 	sprite->SetBitmap(bitmap);
-	sprite->SetX(0);
+	sprite->SetX(MENU_OFFSET_X);
 	sprite->SetY(y);
 	return sprite;
 }
 
 std::unique_ptr<Sprite> Scene_File::MakeArrowSprite(bool down) {
-	Rect rect = Rect(40, (down ? 16 : 8), 16, 8);
+	int sprite_width = 8;
+	int sprite_height = 8;
+
+	Rect rect = Rect(40, (down ? 16 : sprite_height), 16, sprite_height);
 	auto bitmap = Bitmap::Create(*(Cache::System()), rect);
 	auto sprite = std::unique_ptr<Sprite>(new Sprite());
 	sprite->SetVisible(false);
 	sprite->SetZ(Priority_Window + 2);
 	sprite->SetBitmap(bitmap);
-	sprite->SetX(SCREEN_TARGET_WIDTH / 2 - 8);
-	sprite->SetY(down ? SCREEN_TARGET_HEIGHT - 8 : 32);
+	sprite->SetX((MENU_WIDTH / 2) - sprite_width + MENU_OFFSET_X);
+	sprite->SetY(down ? SCREEN_TARGET_HEIGHT - sprite_height : 32);
 	return sprite;
 }
 
 void Scene_File::CreateHelpWindow() {
-	help_window.reset(new Window_Help(0, 0, SCREEN_TARGET_WIDTH, 32));
+	help_window.reset(new Window_Help(MENU_OFFSET_X, 0, MENU_WIDTH, 32));
 	help_window->SetText(message);
 	help_window->SetZ(Priority_Window + 1);
 }
@@ -116,7 +120,7 @@ void Scene_File::Start() {
 
 	for (int i = 0; i < Utils::Clamp<int32_t>(lcf::Data::system.easyrpg_max_savefiles, 3, 99); i++) {
 		std::shared_ptr<Window_SaveFile>
-			w(new Window_SaveFile(0, 40 + i * 64, SCREEN_TARGET_WIDTH, 64));
+			w(new Window_SaveFile(MENU_OFFSET_X, 40 + i * 64, MENU_WIDTH, 64));
 		w->SetIndex(i);
 		w->SetZ(Priority_Window);
 		PopulateSaveWindow(*w, i);

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -57,7 +57,7 @@ std::unique_ptr<Sprite> Scene_File::MakeArrowSprite(bool down) {
 	sprite->SetZ(Priority_Window + 2);
 	sprite->SetBitmap(bitmap);
 	sprite->SetX(SCREEN_TARGET_WIDTH / 2 - 8);
-	sprite->SetY(down ? 232 : 32);
+	sprite->SetY(down ? SCREEN_TARGET_HEIGHT - 8 : 32);
 	return sprite;
 }
 
@@ -125,7 +125,7 @@ void Scene_File::Start() {
 		file_windows.push_back(w);
 	}
 
-	border_bottom = Scene_File::MakeBorderSprite(232);
+	border_bottom = Scene_File::MakeBorderSprite(SCREEN_TARGET_HEIGHT - 8);
 
 	up_arrow = Scene_File::MakeArrowSprite(false);
 	down_arrow = Scene_File::MakeArrowSprite(true);

--- a/src/scene_item.cpp
+++ b/src/scene_item.cpp
@@ -38,8 +38,9 @@ Scene_Item::Scene_Item(int item_index) :
 
 void Scene_Item::Start() {
 	// Create the windows
-	help_window.reset(new Window_Help(0, 0, SCREEN_TARGET_WIDTH, 32));
-	item_window.reset(new Window_Item(0, 32, SCREEN_TARGET_WIDTH, SCREEN_TARGET_HEIGHT - 32));
+	int menu_help_height = 32;
+	help_window.reset(new Window_Help(MENU_OFFSET_X, MENU_OFFSET_Y, MENU_WIDTH, menu_help_height));
+	item_window.reset(new Window_Item(MENU_OFFSET_X, MENU_OFFSET_Y + menu_help_height, MENU_WIDTH, MENU_HEIGHT - menu_help_height));
 	item_window->SetHelpWindow(help_window.get());
 	item_window->Refresh();
 	item_window->SetIndex(item_index);

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -38,6 +38,8 @@ void Scene_Logo::Start() {
 		logo_img = Bitmap::Create(easyrpg_logo, sizeof(easyrpg_logo), false);
 		logo.reset(new Sprite());
 		logo->SetBitmap(logo_img);
+		logo->SetX((SCREEN_TARGET_WIDTH - logo->GetWidth()) / 2);
+		logo->SetY((SCREEN_TARGET_HEIGHT - logo->GetHeight()) / 2);
 	}
 }
 

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -73,7 +73,7 @@ Scene_Map::~Scene_Map() {
 void Scene_Map::Start() {
 	Scene_Debug::ResetPrevIndices();
 	spriteset.reset(new Spriteset_Map());
-	message_window.reset(new Window_Message(0, SCREEN_TARGET_HEIGHT - 80, SCREEN_TARGET_WIDTH, 80));
+	message_window.reset(new Window_Message((SCREEN_TARGET_WIDTH - 320) / 2, SCREEN_TARGET_HEIGHT - 80, 320, 80));
 
 	Game_Message::SetWindow(message_window.get());
 

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -73,7 +73,7 @@ Scene_Map::~Scene_Map() {
 void Scene_Map::Start() {
 	Scene_Debug::ResetPrevIndices();
 	spriteset.reset(new Spriteset_Map());
-	message_window.reset(new Window_Message((SCREEN_TARGET_WIDTH - 320) / 2, SCREEN_TARGET_HEIGHT - 80, 320, 80));
+	message_window.reset(new Window_Message(MESSAGE_BOX_OFFSET_X, SCREEN_TARGET_HEIGHT - MESSAGE_BOX_HEIGHT, MESSAGE_BOX_WIDTH, MESSAGE_BOX_HEIGHT));
 
 	Game_Message::SetWindow(message_window.get());
 

--- a/src/scene_menu.cpp
+++ b/src/scene_menu.cpp
@@ -35,6 +35,13 @@
 #include "bitmap.h"
 #include "feature.h"
 
+constexpr int menu_command_width = 88;
+
+constexpr int menu_status_offset_x = MENU_OFFSET_X + 88;
+
+constexpr int gold_window_width = 88;
+constexpr int gold_window_height = 32;
+
 Scene_Menu::Scene_Menu(int menu_index) :
 	menu_index(menu_index) {
 	type = Scene::Menu;
@@ -44,10 +51,10 @@ void Scene_Menu::Start() {
 	CreateCommandWindow();
 
 	// Gold Window
-	gold_window.reset(new Window_Gold(0, (SCREEN_TARGET_HEIGHT-32), 88, 32));
+	gold_window.reset(new Window_Gold(MENU_OFFSET_X, (SCREEN_TARGET_HEIGHT - gold_window_height - MENU_OFFSET_Y), gold_window_width, gold_window_height));
 
 	// Status Window
-	menustatus_window.reset(new Window_MenuStatus(88, 0, (SCREEN_TARGET_WIDTH-88), SCREEN_TARGET_HEIGHT));
+	menustatus_window.reset(new Window_MenuStatus(menu_status_offset_x, MENU_OFFSET_Y, (MENU_WIDTH - menu_command_width), MENU_HEIGHT));
 	menustatus_window->SetActive(false);
 }
 
@@ -144,7 +151,9 @@ void Scene_Menu::CreateCommandWindow() {
 		}
 	}
 
-	command_window.reset(new Window_Command(options, 88));
+	command_window.reset(new Window_Command(options, menu_command_width));
+	command_window->SetX(MENU_OFFSET_X);
+	command_window->SetY(MENU_OFFSET_Y);
 	command_window->SetIndex(menu_index);
 
 	// Disable items

--- a/src/scene_name.cpp
+++ b/src/scene_name.cpp
@@ -41,13 +41,22 @@ void Scene_Name::Start() {
 	auto *actor = Main_Data::game_actors->GetActor(actor_id);
 	assert(actor);
 
-	name_window.reset(new Window_Name(96, 40, 192, 32));
-	name_window->Set(use_default_name ? ToString(actor->GetName()) : "");
-	name_window->Refresh();
+	int margin_x = 32;
+	int margin_y = 8;
+	int window_face_width = 64;
+	int window_face_height = 64;
+	int window_name_width = 192;
+	int window_name_height = 32;
+	int window_keyboard_width = 256;
+	int window_keyboard_height = 160;
 
-	face_window.reset(new Window_Face(32, 8, 64, 64));
+	face_window.reset(new Window_Face(MENU_OFFSET_X + margin_x, MENU_OFFSET_Y + margin_y, window_face_width, window_face_height));
 	face_window->Set(actor_id);
 	face_window->Refresh();
+
+	name_window.reset(new Window_Name(MENU_OFFSET_X + window_face_width + margin_x, MENU_OFFSET_Y + margin_y + 32, window_name_width, window_name_height));
+	name_window->Set(use_default_name ? ToString(actor->GetName()) : "");
+	name_window->Refresh();
 
 	const char* done = Window_Keyboard::DONE;
 	// Japanese pages
@@ -79,7 +88,7 @@ void Scene_Name::Start() {
 	// Letter and symbol pages are used everywhere
 	layouts.push_back(Window_Keyboard::Letter);
 	layouts.push_back(Window_Keyboard::Symbol);
-	kbd_window.reset(new Window_Keyboard(32, 72, 256, SCREEN_TARGET_WIDTH / 2, done));
+	kbd_window.reset(new Window_Keyboard(MENU_OFFSET_X + margin_x, MENU_OFFSET_Y + window_face_height + margin_y, window_keyboard_width, window_keyboard_height, done));
 
 	auto next_index = layout_index + 1;
 	if (next_index >= static_cast<int>(layouts.size())) {

--- a/src/scene_order.cpp
+++ b/src/scene_order.cpp
@@ -113,18 +113,18 @@ void Scene_Order::CreateCommandWindow() {
 	options_confirm.push_back(lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_order_scene_redo, "Redo"));
 
 	window_left.reset(new Window_Command(options_left, 88, 4));
-	window_left->SetX(68);
-	window_left->SetY(48);
+	window_left->SetX(MENU_OFFSET_X + 68);
+	window_left->SetY(MENU_OFFSET_Y + 48);
 
 	window_right.reset(new Window_Command(options_right, 88, 4));
-	window_right->SetX(164);
-	window_right->SetY(48);
+	window_right->SetX(MENU_OFFSET_X + 164);
+	window_right->SetY(MENU_OFFSET_Y + 48);
 	window_right->SetActive(false);
 	window_right->SetIndex(-1);
 
 	window_confirm.reset(new Window_Command(options_confirm, 80));
-	window_confirm->SetX(120);
-	window_confirm->SetY(144);
+	window_confirm->SetX(MENU_OFFSET_X + 120);
+	window_confirm->SetY(MENU_OFFSET_Y + 144);
 	window_confirm->SetActive(false);
 	window_confirm->SetVisible(false);
 }

--- a/src/scene_shop.cpp
+++ b/src/scene_shop.cpp
@@ -50,16 +50,27 @@ void Scene_Shop::Start() {
 		}
 	}
 
-	shop_window.reset(new Window_Shop(shop_type, 0, (SCREEN_TARGET_WIDTH/2), SCREEN_TARGET_WIDTH, 80));
-	help_window.reset(new Window_Help(0, 0, SCREEN_TARGET_WIDTH, 32));
-	gold_window.reset(new Window_Gold(184, 128, 136, 32));
-	empty_window.reset(new Window_Base(0, 32, SCREEN_TARGET_WIDTH, 128));
-	empty_window2.reset(new Window_Base(0, 32, 184, 128));
-	buy_window.reset(new Window_ShopBuy(goods, 0, 32, 184, 128));
-	party_window.reset(new Window_ShopParty(184, 32, 136, 48));
-	sell_window.reset(new Window_ShopSell(0, 32, SCREEN_TARGET_WIDTH, 128));
-	status_window.reset(new Window_ShopStatus(184, 80, 136, 48));
-	number_window.reset(new Window_ShopNumber(0, 32, 184, 128));
+	int window_help_height = 32;
+	int window_buy_width = 184;
+	int window_buy_height = 128;
+	int window_party_width = 136;
+	int window_party_height = 48;
+	int window_status_width = 136;
+	int window_status_height = 48;
+	int window_gold_width = 136;
+	int window_gold_height = 32;
+	int window_shop_height = 80;
+
+	help_window.reset(new Window_Help(MENU_OFFSET_X, MENU_OFFSET_Y, MENU_WIDTH, window_help_height));
+	buy_window.reset(new Window_ShopBuy(goods, MENU_OFFSET_X, MENU_OFFSET_Y + window_help_height, window_buy_width, window_buy_height));
+	number_window.reset(new Window_ShopNumber(MENU_OFFSET_X, MENU_OFFSET_Y + window_help_height, window_buy_width, window_buy_height));
+	party_window.reset(new Window_ShopParty(MENU_OFFSET_X + window_buy_width, MENU_OFFSET_Y + window_help_height, window_party_width, window_party_height));
+	status_window.reset(new Window_ShopStatus(MENU_OFFSET_X + window_buy_width, MENU_OFFSET_Y + window_help_height + window_party_height, window_status_width, window_status_height));
+	gold_window.reset(new Window_Gold(MENU_OFFSET_X + window_buy_width, MENU_OFFSET_Y + window_help_height + window_party_height + window_status_height, window_gold_width, window_gold_height));
+	shop_window.reset(new Window_Shop(shop_type, MENU_OFFSET_X, MENU_OFFSET_Y + window_help_height + window_party_height + window_status_height + window_gold_height, MENU_WIDTH, window_shop_height));
+	sell_window.reset(new Window_ShopSell(MENU_OFFSET_X, MENU_OFFSET_Y + window_help_height, MENU_WIDTH, window_buy_height));
+	empty_window.reset(new Window_Base(MENU_OFFSET_X, MENU_OFFSET_Y + window_help_height, MENU_WIDTH, window_buy_height));
+	empty_window2.reset(new Window_Base(MENU_OFFSET_X, MENU_OFFSET_Y + window_help_height, window_buy_width, window_buy_height));
 
 	buy_window->SetActive(false);
 	buy_window->SetVisible(false);

--- a/src/scene_skill.cpp
+++ b/src/scene_skill.cpp
@@ -35,9 +35,11 @@ Scene_Skill::Scene_Skill(int actor_index, int skill_index) :
 
 void Scene_Skill::Start() {
 	// Create the windows
-	help_window.reset(new Window_Help(0, 0, SCREEN_TARGET_WIDTH, 32));
-	skillstatus_window.reset(new Window_SkillStatus(0, 32, SCREEN_TARGET_WIDTH, 32));
-	skill_window.reset(new Window_Skill(0, 64, SCREEN_TARGET_WIDTH, SCREEN_TARGET_HEIGHT - 64));
+	int window_help_height = 32;
+	int window_skillstatus_height = 32;
+	help_window.reset(new Window_Help(MENU_OFFSET_X, MENU_OFFSET_Y, MENU_WIDTH, window_help_height));
+	skillstatus_window.reset(new Window_SkillStatus(MENU_OFFSET_X, MENU_OFFSET_Y + window_help_height, MENU_WIDTH, window_skillstatus_height));
+	skill_window.reset(new Window_Skill(MENU_OFFSET_X, MENU_OFFSET_Y + window_help_height + window_skillstatus_height, MENU_WIDTH, MENU_HEIGHT - (window_help_height + window_skillstatus_height)));
 
 	// Assign actors and help to windows
 	skill_window->SetActor(Main_Data::game_party->GetActors()[actor_index]->GetId());

--- a/src/scene_status.cpp
+++ b/src/scene_status.cpp
@@ -29,13 +29,24 @@ Scene_Status::Scene_Status(int actor_index) :
 }
 
 void Scene_Status::Start() {
+	int window_actor_info_width = 124;
+	int window_actor_info_height = 208;
+	int window_gold_width = 124;
+	int window_gold_height = 32;
+	int window_actor_status_width = 196;
+	int window_actor_status_height = 64;
+	int window_param_status_width = 196;
+	int window_param_status_height = 80;
+	int window_equip_width = 196;
+	int window_equip_height = 96;
+
 	int actor = Main_Data::game_party->GetActors()[actor_index]->GetId();
 
-	actorinfo_window.reset(new Window_ActorInfo(0, 0, 124, 208, actor));
-	actorstatus_window.reset(new Window_ActorStatus(124, 0, 196, 64, actor));
-	gold_window.reset(new Window_Gold(0, 208, 124, 32));
-	paramstatus_window.reset(new Window_ParamStatus(124, 64, 196, 80, actor));
-	equip_window.reset(new Window_Equip(124, 144, 196, 96, actor));
+	actorinfo_window.reset(new Window_ActorInfo(MENU_OFFSET_X, MENU_OFFSET_Y, window_actor_info_width, window_actor_info_height, actor));
+	gold_window.reset(new Window_Gold(MENU_OFFSET_X, MENU_OFFSET_Y + window_actor_info_height, window_gold_width, window_gold_height));
+	actorstatus_window.reset(new Window_ActorStatus(MENU_OFFSET_X + window_actor_info_width, MENU_OFFSET_Y, window_actor_status_width, window_actor_status_height, actor));
+	paramstatus_window.reset(new Window_ParamStatus(MENU_OFFSET_X + window_actor_info_width, MENU_OFFSET_Y + window_actor_status_height, window_param_status_width, window_param_status_height, actor));
+	equip_window.reset(new Window_Equip(MENU_OFFSET_X + window_actor_info_width, MENU_OFFSET_Y + window_actor_status_height + window_param_status_height, window_equip_width, window_equip_height, actor));
 
 	equip_window->SetActive(false);
 	paramstatus_window->SetActive(false);

--- a/src/window_equipitem.cpp
+++ b/src/window_equipitem.cpp
@@ -22,8 +22,8 @@
 #include <lcf/reader_util.h>
 #include "output.h"
 
-Window_EquipItem::Window_EquipItem(int actor_id, int equip_type) :
-	Window_Item(0, 128, SCREEN_TARGET_WIDTH, (SCREEN_TARGET_HEIGHT-128)),
+Window_EquipItem::Window_EquipItem(int ix, int iy, int iwidth, int iheight, int actor_id, int equip_type) :
+	Window_Item(ix, iy, iwidth, iheight),
 	actor_id(actor_id) {
 	this->equip_type = equip_type;
 	if (equip_type > 4 || equip_type < 0) {

--- a/src/window_equipitem.h
+++ b/src/window_equipitem.h
@@ -43,7 +43,7 @@ public:
 	 * @param actor_id actor whos equipment is displayed.
 	 * @param equip_type type of equipment to show.
 	 */
-	Window_EquipItem(int actor_id, int equip_type);
+	Window_EquipItem(int ix, int iy, int iwidth, int iheight, int actor_id, int equip_type);
 
 	/**
 	 * Checks if the item should be in the list based on

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -260,8 +260,21 @@ void Window_Message::InsertNewPage() {
 	prev_char_printable = false;
 	prev_char_waited = true;
 
+	// Position the message box vertically
+	// Game_Message::GetRealPosition() specify top/middle/bottom
 	float factor = Game_Message::GetRealPosition() / (float)2;
-	y = (SCREEN_TARGET_HEIGHT * factor) - (MESSAGE_BOX_HEIGHT * factor);
+	// In case of hight vertical resolution, we add a margin for top/bottom
+	int off_set_y = 0;
+	if (SCREEN_TARGET_HEIGHT > 240) {
+		int margin_y = SCREEN_TARGET_HEIGHT * 0.03;
+		if (Game_Message::GetRealPosition() == 0) {
+			off_set_y = margin_y;
+		}
+		else if (Game_Message::GetRealPosition() == 2) {
+			off_set_y = (-1) * margin_y;
+		}
+	}
+	y = (SCREEN_TARGET_HEIGHT * factor) - (MESSAGE_BOX_HEIGHT * factor) + off_set_y;
 
 	if (Main_Data::game_system->IsMessageTransparent()) {
 		SetOpacity(0);

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -213,7 +213,7 @@ void Window_Message::StartChoiceProcessing() {
 void Window_Message::StartNumberInputProcessing() {
 	number_input_window->SetMaxDigits(pending_message.GetNumberInputDigits());
 	if (IsFaceEnabled() && !Main_Data::game_system->IsMessageFaceRightPosition()) {
-		number_input_window->SetX(LeftMargin + FaceSize + RightFaceMargin);
+		number_input_window->SetX(MESSAGE_BOX_OFFSET_X + LeftMargin + FaceSize + RightFaceMargin);
 	} else {
 		number_input_window->SetX(x);
 	}

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -258,7 +258,8 @@ void Window_Message::InsertNewPage() {
 	prev_char_printable = false;
 	prev_char_waited = true;
 
-	y = Game_Message::GetRealPosition() * 80;
+	float factor = Game_Message::GetRealPosition() / (float)2;
+	y = (SCREEN_TARGET_HEIGHT * factor) - (MESSAGE_BOX_HEIGHT * factor);
 
 	if (Main_Data::game_system->IsMessageTransparent()) {
 		SetOpacity(0);

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -40,6 +40,8 @@
 
 // FIXME: Off by 1 bug in window base class
 constexpr int message_animation_frames = 7;
+constexpr int gold_window_width = 88;
+constexpr int gold_window_height = 32;
 
 namespace {
 #if defined(EP_DEBUG_MESSAGE) || defined(EP_DEBUG_MESSAGE_TEXT)
@@ -85,7 +87,7 @@ void DebugLogText(const char*, Args&&...) { }
 Window_Message::Window_Message(int ix, int iy, int iwidth, int iheight) :
 	Window_Selectable(ix, iy, iwidth, iheight),
 	number_input_window(new Window_NumberInput(0, 0)),
-	gold_window(new Window_Gold(232, 0, 88, 32))
+	gold_window(new Window_Gold(SCREEN_TARGET_WIDTH - gold_window_width, 0, gold_window_width, gold_window_height))
 {
 	SetContents(Bitmap::Create(width - 16, height - 16));
 


### PR DESCRIPTION
This PR make some element "responsive" by not being dependant of a fixed resolution : 
- Startup scene : The EasyRPG logo is now centered
- Loading/Saving scene : the bottom border dans the cursor are placed at the bottom of the screen, no matter the resolution

------------------

Just to track the status, not the tasklist of this PR :)

- [x] Game Browser (should be fine with full stretch?)
- [x] Startup
- [x] Main Menu
- [x] Items
- [x] Skills
- [x] Equipment
- [x] Status
- [x] This dumb reorder scene nobody uses
- [x] Save/Load
- [x] Name input (Change Hero Name)
- [x] Debug
- [x] End Game
- [x] Shop
- [ ] Battle
- [x] Map (Message Box & Gold)
- [x] Map (Screen Pan)
- [x] Map (Weather Effects)
- [x] Map (Correct Panorama rendering)
- [x] Map (Correct Picture offsetting)