### PR TITLE
Use Unicode saves when translations are loaded

### DIFF
--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -41,6 +41,7 @@
 #include "output.h"
 #include "player.h"
 #include "scene_save.h"
+#include "translation.h"
 #include "version.h"
 
 Scene_Save::Scene_Save() :
@@ -125,7 +126,10 @@ bool Scene_Save::Save(std::ostream& os, int slot_id, bool prepare_save) {
 	Game_Map::PrepareSave(save);
 
 	if (prepare_save) {
-		lcf::LSD_Reader::PrepareSave(save, PLAYER_SAVEGAME_VERSION);
+		// When a translation is loaded always store in Unicode to prevent data loss
+		int codepage = Tr::HasActiveTranslation() ? 65001 : 0;
+
+		lcf::LSD_Reader::PrepareSave(save, PLAYER_SAVEGAME_VERSION, codepage);
 		Main_Data::game_system->IncSaveCount();
 	}
 


### PR DESCRIPTION
When a translation is loaded always store in Unicode to prevent data loss

Something for @Mimigris

Fix #2887

----------

It is still possible to lose data but this cannot be really avoided without becoming incompatible to RPG_RT:

1. Activate a translation
2. Save the game while some event with messages etc. is loaded (or custom hero name etc.)
3. Change back to native language setting
4. Load the previous savegame and save it again
5. The custom hero name will be lost because "native language" always writes in the game encoding, not in utf-8

The typical use case will be that they stay on the same translation so this will be usually safe
