### PR TITLE
Use more Exe information for the version detection

### DIFF
--- a/src/exe_reader.h
+++ b/src/exe_reader.h
@@ -23,6 +23,7 @@
 #include <istream>
 #include <vector>
 #include "bitmap.h"
+#include "player.h"
 
 /**
  * Extracts resources from an EXE.
@@ -35,11 +36,25 @@ public:
 	// 1. everywhere else uses "unsigned", which is equally as odd...
 	// 2. max offset value is this size
 
-	EXEReader(Filesystem_Stream::InputStream& core);
+	EXEReader(Filesystem_Stream::InputStream core);
 
 	// Extracts an EXFONT resource with BMP header if present
 	// and returns exfont buffer on success.
 	std::vector<uint8_t> GetExFont();
+
+	struct FileInfo {
+		uint64_t version = 0;
+		int logos = 0;
+		std::string version_str;
+		bool is_i386 = true;
+		bool is_easyrpg_player = false;
+
+		int GetEngineType() const;
+		void Print() const;
+	};
+
+	const FileInfo& GetFileInfo();
+
 private:
 	// Bounds-checked unaligned reader primitives.
 	// In case of out-of-bounds, returns 0 - this will usually result in a harmless error at some other level,
@@ -48,13 +63,16 @@ private:
 	uint16_t GetU16(uint32_t point);
 	uint32_t GetU32(uint32_t point);
 
+	uint32_t ResOffsetByType(uint32_t type);
+	uint32_t GetLogoCount();
 	bool ResNameCheck(uint32_t namepoint, const char* name);
 
 	// 0 if resource section was unfindable.
-	uint32_t resource_ofs;
-	uint32_t resource_rva;
+	uint32_t resource_ofs = 0;
+	uint32_t resource_rva = 0;
 
-	Filesystem_Stream::InputStream& corefile;
+	FileInfo file_info;
+	Filesystem_Stream::InputStream corefile;
 };
 
 #endif

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -369,7 +369,7 @@ Filesystem_Stream::InputStream open_generic(StringView dir, StringView name, Dir
 	}
 
 	auto is = FileFinder::Game().OpenFile(args);
-	if (!is) {
+	if (!is && Main_Data::filefinder_rtp) {
 		is = Main_Data::filefinder_rtp->Lookup(dir, name, args.exts);
 		if (!is) {
 			Output::Debug("Cannot find: {}/{}", dir, name);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -786,42 +786,57 @@ void Player::CreateGameObjects() {
 		Output::Debug("Game does not need RTP (FullPackageFlag=1)");
 	}
 
+	// ExFont parsing
+	Cache::exfont_custom.clear();
+	// Check for bundled ExFont
+	auto exfont_stream = FileFinder::OpenImage("Font", "ExFont");
+	if (!exfont_stream) {
+		// Backwards compatible with older Player versions
+		exfont_stream = FileFinder::OpenImage(".", "ExFont");
+	}
+
+#ifndef EMSCRIPTEN
+	// Attempt reading ExFont and version information from RPG_RT.exe (not supported on Emscripten)
+	std::unique_ptr<EXEReader> exe_reader;
+	auto exeis = FileFinder::Game().OpenFile(EXE_NAME);
+
+	if (exeis) {
+		Output::Debug("Analyzing RPG_RT {}", exeis.GetName());
+		exe_reader.reset(new EXEReader(std::move(exeis)));
+		Cache::exfont_custom = exe_reader->GetExFont();
+		if (!Cache::exfont_custom.empty()) {
+			Output::Debug("ExFont loaded from RPG_RT");
+		}
+
+		if (Player::engine == EngineNone) {
+		auto version_info = exe_reader->GetFileInfo();
+			version_info.Print();
+			engine = version_info.GetEngineType();
+		}
+	}
+#endif
+
+	if (exfont_stream) {
+		Output::Debug("Using custom ExFont: {}", exfont_stream.GetName());
+		Cache::exfont_custom = Utils::ReadStream(exfont_stream);
+	}
+
 	if (engine == EngineNone) {
+		Output::Debug("Could not detect version from EXE. Using old detection strategy");
 		if (lcf::Data::system.ldb_id == 2003) {
 			engine = EngineRpg2k3;
-
-			if (FileFinder::Game().FindFile("ultimate_rt_eb.dll").empty()) {
-				// Heuristic: Detect if game was converted from 2000 to 2003 and
-				// no typical 2003 feature was used at all (breaks .flow e.g.)
-				if (lcf::Data::classes.size() == 1 &&
-					lcf::Data::classes[0].name.empty() &&
-					lcf::Data::system.menu_commands.empty() &&
-					lcf::Data::system.system2_name.empty() &&
-					lcf::Data::battleranimations.size() == 1 &&
-					lcf::Data::battleranimations[0].name.empty()) {
-					engine = EngineRpg2k;
-					Output::Debug("Using RPG2k Interpreter (heuristic)");
-				} else {
-					Output::Debug("Using RPG2k3 Interpreter");
-				}
-			} else {
+			if (!FileFinder::Game().FindFile("ultimate_rt_eb.dll").empty()) {
 				engine |= EngineEnglish | EngineMajorUpdated;
-				Output::Debug("Using RPG2k3 (English release, v1.11) Interpreter");
 			}
 		} else {
 			engine = EngineRpg2k;
-			Output::Debug("Using RPG2k Interpreter");
 			if (lcf::Data::data.version >= 1) {
 				engine |= EngineEnglish | EngineMajorUpdated;
-				Output::Debug("RM2k >= v.1.61 (English release) detected");
 			}
 		}
 		if (!(engine & EngineMajorUpdated)) {
 			if (FileFinder::IsMajorUpdatedTree()) {
 				engine |= EngineMajorUpdated;
-				Output::Debug("RPG2k >= v1.50 / RPG2k3 >= v1.05 detected");
-			} else {
-				Output::Debug("RPG2k < v1.50 / RPG2k3 < v1.05 detected");
 			}
 		}
 	}
@@ -843,39 +858,6 @@ void Player::CreateGameObjects() {
 	}
 
 	Output::Debug("Patch configuration: dynrpg={} maniac={}", Player::IsPatchDynRpg(), Player::IsPatchManiac());
-
-	// ExFont parsing
-	Cache::exfont_custom.clear();
-	// Check for bundled ExFont
-	auto exfont_stream = FileFinder::OpenImage("Font", "ExFont");
-	if (!exfont_stream) {
-		// Backwards compatible with older Player versions
-		exfont_stream = FileFinder::OpenImage(".", "ExFont");
-	}
-
-#ifndef EMSCRIPTEN
-	if (!exfont_stream) {
-		// Attempt reading ExFont from RPG_RT.exe (not supported on Emscripten,
-		// a ExFont can be manually bundled there)
-		std::string exep = FileFinder::Game().FindFile(EXE_NAME);
-		if (!exep.empty()) {
-			auto exesp = FileFinder::Game().OpenInputStream(exep);
-			if (exesp) {
-				Output::Debug("Loading ExFont from {}", exep);
-				EXEReader exe_reader = EXEReader(exesp);
-				Cache::exfont_custom = exe_reader.GetExFont();
-			} else {
-				Output::Debug("ExFont loading failed: {} not readable", exep);
-			}
-		} else {
-			Output::Debug("ExFont loading failed: {} not found", EXE_NAME);
-		}
-	}
-#endif
-	if (exfont_stream) {
-		Output::Debug("Using custom ExFont: {}", exfont_stream.GetName());
-		Cache::exfont_custom = Utils::ReadStream(exfont_stream);
-	}
 
 	ResetGameObjects();
 


### PR DESCRIPTION
wrote 90% of this code a year ago and just remembered that it exists.

Finished it. Please give it a test.

Useless for emscripten obviously.

The check is quite defensive so when there is anything that looks off the engine is reported as "None" and it uses the old check.

see ``FileInfo::GetEngineType()`` for the logic. Not explaining this again.

Also disabled the "heuristic" to detect 2k3 in the old codepath because this caused alot of problems because it only fixed .flow but broke many other games.

Detection results for some exes:

```
Debug: !! rpg2000/RPG_RT.2000.1.0.5.0.dons.eng.exe
Debug: version= logos=3 i386=true easyrpg=false
 
Debug: !! rpg2000/RPG_RT.2000.1.0.7.0.dons.eng.exe
Debug: version= logos=3 i386=true easyrpg=false
 
Debug: !! rpg2000/RPG_RT.2000.1.0.9.0.dons.eng.exe
Debug: version= logos=3 i386=true easyrpg=false
 
Debug: !! rpg2000/RPG_RT.2000.1.5.1.0.fdelapena.spa.cleartype.exe
Debug: version= logos=1 i386=true easyrpg=false
 
Debug: !! rpg2000/RPG_RT.2000.1.5.1.0.jp.exe
Debug: version= logos=1 i386=true easyrpg=false
 
Debug: !! rpg2000/RPG_RT.2000.1.5.1.0.rpghacker.eng.exe
Debug: version= logos=1 i386=true easyrpg=false
 
Debug: !! rpg2000/RPG_RT.2000.1.6.1.0.eng.exe
Debug: version=1.6.1.0 logos=1 i386=true easyrpg=false
 
Debug: !! rpg2003/RPG_RT.2003.1.0.3.0.jp.exe
Debug: version=1.0.3.0 logos=1 i386=true easyrpg=false
 
Debug: !! rpg2003/RPG_RT.2003.1.0.3.0.advocate.eng.exe
Debug: version=1.0.3.0 logos=1 i386=true easyrpg=false
 
Debug: !! rpg2003/RPG_RT.2003.1.0.8.0.vampires.dawn.II.unknown.eng.exe
Debug: version=1.0.8.0 logos=1 i386=true easyrpg=false
 
Debug: !! rpg2003/RPG_RT.2003.1.0.9.1.fdelapena.spa.cleartype.exe
Debug: version=1.0.9.1 logos=1 i386=true easyrpg=false
 
Debug: !! rpg2003/RPG_RT.2003.1.0.9.1.unknown.eng.exe
Debug: version=1.0.9.1 logos=1 i386=true easyrpg=false
 
Debug: !! rpg2003/RPG_RT.2003.1.1.2.0.eng.exe
Debug: version=1.1.2.0 logos=1 i386=true easyrpg=false
 
Debug: !! rpg2003/RPG_RT.2003.1.1.2.1.eng.exe
Debug: version=1.1.2.1 logos=1 i386=true easyrpg=false
```