### PR TITLE
Bugfix: When loading a save do not recreate detached StringPictures

### DIFF
--- a/src/game_pictures.cpp
+++ b/src/game_pictures.cpp
@@ -324,7 +324,7 @@ void Game_Pictures::Picture::Erase() {
 	if (sprite) {
 		sprite->SetBitmap(nullptr);
 	}
-	if (data.easyrpg_type == lcf::rpg::SavePicture::EasyRpgType_window) {
+	if (IsWindowAttached()) {
 		data.easyrpg_type = lcf::rpg::SavePicture::EasyRpgType_default;
 		Main_Data::game_windows->Erase(data.ID);
 	}
@@ -497,6 +497,10 @@ void Game_Pictures::Picture::AttachWindow(const Window_Base& window) {
 	sprite->SetVisible(true);
 
 	ApplyOrigin(false);
+}
+
+bool Game_Pictures::Picture::IsWindowAttached() const {
+	return data.easyrpg_type == lcf::rpg::SavePicture::EasyRpgType_window;
 }
 
 void Game_Pictures::Picture::Update(bool is_battle) {

--- a/src/game_pictures.h
+++ b/src/game_pictures.h
@@ -126,6 +126,7 @@ public:
 		void OnMapScrolled(int dx, int dy);
 
 		void AttachWindow(const Window_Base& window);
+		bool IsWindowAttached() const;
 	};
 
 	Picture& GetPicture(int id);

--- a/src/game_windows.cpp
+++ b/src/game_windows.cpp
@@ -42,9 +42,12 @@ void Game_Windows::SetSaveData(std::vector<lcf::rpg::SaveEasyRpgWindow> save) {
 		auto& win = windows.back();
 		int id = win.data.ID;
 		if (id > 0) {
-			// no special async handling needed, loading will already yield
-			bool async_wait;
-			win.Refresh(async_wait);
+			auto pic = Main_Data::game_pictures->GetPicturePtr(id);
+			if (pic && pic->IsWindowAttached()) {
+				// no special async handling needed, loading will already yield
+				bool async_wait;
+				win.Refresh(async_wait);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Reported yesterday by @mimigris and @florianessl

Thanks!