### PR TITLE
Add some Panorama legacy mode support

### DIFF
--- a/src/game_config_game.cpp
+++ b/src/game_config_game.cpp
@@ -26,7 +26,7 @@
 Game_ConfigGame Game_ConfigGame::Create(CmdlineParser& cp) {
 	Game_ConfigGame cfg;
 
-	auto cli_config = FileFinder::Game().OpenOrCreateInputStream(EASYRPG_INI_NAME);
+	auto cli_config = FileFinder::Game().OpenFile(EASYRPG_INI_NAME);
 	if (cli_config) {
 		cfg.LoadFromStream(cli_config);
 	}

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -696,6 +696,12 @@ namespace Game_Map {
 		 * the map properties.
 		 */
 		void ClearChangedBG();
+
+		/** @return Whether ox adjustment is required for fake resolution mode */
+		bool FakeXPosition();
+
+		/** @return Whether oy adjustment is required for fake resolution mode */
+		bool FakeYPosition();
 	}
 }
 

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -88,8 +88,18 @@ void Spriteset_Map::Update() {
 		character_sprites[i]->SetTone(new_tone);
 	}
 
-	panorama->SetOx(Game_Map::Parallax::GetX());
-	panorama->SetOy(Game_Map::Parallax::GetY());
+	int pan_x_off = 0;
+	int pan_y_off = 0;
+	if (Player::game_config.fake_resolution.Get()) {
+		if (Game_Map::Parallax::FakeXPosition()) {
+			pan_x_off = (static_cast<float>(Player::screen_width) - SCREEN_TARGET_WIDTH) / 2;
+		}
+		if (Game_Map::Parallax::FakeYPosition()) {
+			pan_y_off = (static_cast<float>(Player::screen_height) - SCREEN_TARGET_HEIGHT) / 2;
+		}
+	}
+	panorama->SetOx(Game_Map::Parallax::GetX() + pan_x_off);
+	panorama->SetOy(Game_Map::Parallax::GetY() + pan_y_off);
 	panorama->SetTone(new_tone);
 
 	Game_Vehicle* vehicle;


### PR DESCRIPTION
easyrpg.ini was created due to a copy paste error. Is fixed.

Added some fake resolution handling to panoramas. Makes them a bit more usable in legacy mode but complex stuff that relies on parallax mapping and where the screen scroll matters (e.g. this maid room in Yume2kki) are still broken and will likely stay broken.

