### PR TITLE
Font fixes

### DIFF
--- a/src/font.cpp
+++ b/src/font.cpp
@@ -451,11 +451,7 @@ Font::GlyphRet FTFont::vRenderShaped(char32_t glyph) const {
 
 bool FTFont::vCanShape() const {
 #ifdef HAVE_HARFBUZZ
-	if (EP_UNLIKELY(rm2000_workaround)) {
-		return false;
-	}
-
-	return true;
+	return FT_IS_SFNT(face);
 #else
 	return false;
 #endif

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -482,14 +482,16 @@ std::vector<Font::ShapeRet> FTFont::vShape(U32StringView txt) const {
 		auto& info = glyph_info[i];
 		auto& pos = glyph_pos[i];
 
-		advance.x = pos.x_advance / 64;
-		advance.y = pos.y_advance / 64;
-		offset.x = pos.x_offset / 64;
-		offset.y = pos.y_offset / 64;
-
 		if (info.codepoint == 0) {
+			auto s = vGetSize(txt[info.cluster]);
+			advance.x = s.width;
+			advance.y = s.height;
 			ret.push_back({txt[info.cluster], advance, offset, true});
 		} else {
+			advance.x = pos.x_advance / 64;
+			advance.y = pos.y_advance / 64;
+			offset.x = pos.x_offset / 64;
+			offset.y = pos.y_offset / 64;
 			ret.push_back({static_cast<char32_t>(info.codepoint), advance, offset, false});
 		}
 	}


### PR DESCRIPTION
The fonts appear to have some kind of shaping information but Harfbuzz always inserts a width of 0 and "glyph not found".

In that case the size of from FreeType is now inserted to fix the size calculation.

-----------------

This fixes the underlying bug however it is likely safer to not run FON fonts through Harfbuzz as they are usually a half-broken mess.

So instead I also disabled shaping for anything that is not a TrueType/OpenType font.

The first commit will be still useful in case there are any semi-broken TrueType fonts. Bet there are some...
