### PR TITLE
Android: Update app store text

### DIFF
--- a/builds/android/metadata/de-DE/full_description.txt
+++ b/builds/android/metadata/de-DE/full_description.txt
@@ -1,7 +1,7 @@
-Der EasyRPG Player ermöglicht die Ausführung von RPG Maker 2000 und RPG Maker 2003-Spielen (neuere Engines, u.a. XP, VX, VX Ace und MV, werden NICHT unterstützt)
+Mit EasyRPG Player kannst du Spiele genießen, die mit RPG Maker 2000 oder RPG Maker 2003 erstellt wurden. Neuere Engines wie XP, VX, MV und MZ werden nicht unterstützt.
+
+EasyRPG Player ist kein Editor. Du kannst damit keine eigenen Spiele erstellen.
 
 Homepage: https://easyrpg.org/
-Änderungen: https://blog.easyrpg.org/
-Bugs melden: https://github.com/EasyRPG/Player/issues/
 
 Diese App steht in keinerlei Verbindung zu Kadokawa Corporation.

--- a/builds/android/metadata/de-DE/short_description.txt
+++ b/builds/android/metadata/de-DE/short_description.txt
@@ -1,1 +1,1 @@
-Genieße deine RPG Maker 2000/2003-Spiele überall - Mit EasyRPG Player.
+Genieße deine RPG Maker 2000/2003-Spiele überall.

--- a/builds/android/metadata/en-US/full_description.txt
+++ b/builds/android/metadata/en-US/full_description.txt
@@ -1,7 +1,7 @@
-EasyRPG Player is a program that allows to play games created with RPG Maker 2000 and RPG Maker 2003 (the newer RPG engines like XP, VX, VX Ace and MV are not supported).
+With EasyRPG Player you can play games created with RPG Maker 2000 and RPG Maker 2003. Newer engines such as XP, VX, MV and MZ are not supported.
+
+EasyRPG Player is not an editor. You cannot create your own games with it.
 
 Homepage: https://easyrpg.org/
-Changelog: https://blog.easyrpg.org/
-Bug reports: https://github.com/EasyRPG/Player/issues/
 
 This app is not affiliated with Kadokawa Corporation.

--- a/builds/android/metadata/en-US/short_description.txt
+++ b/builds/android/metadata/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Play your RPG Maker 2000 and 2003 games everywhere with EasyRPG Player.
+Play your RPG Maker 2000 and 2003 games everywhere.

--- a/builds/android/metadata/en-US/title.txt
+++ b/builds/android/metadata/en-US/title.txt
@@ -1,1 +1,1 @@
-EasyRPG for RPG Maker 2000
+EasyRPG Player

--- a/builds/android/metadata/ja-JP/title.txt
+++ b/builds/android/metadata/ja-JP/title.txt
@@ -1,1 +1,0 @@
-EasyRPG for RPG Maker 2000

--- a/builds/android/metadata/zh-CN/title.txt
+++ b/builds/android/metadata/zh-CN/title.txt
@@ -1,1 +1,0 @@
-EasyRPG for RPG Maker 2000

--- a/builds/android/metadata/zh-TW/title.txt
+++ b/builds/android/metadata/zh-TW/title.txt
@@ -1,1 +1,0 @@
-EasyRPG for RPG Maker 2000


### PR DESCRIPTION
The app is now called "EasyRPG Player" to reduce confusion.

Short description:

> Play your RPG Maker 2000 and 2003 games everywhere.

Removed the "with EasyRPG Player." part. Is not really needed.

Long description (Old):

> EasyRPG Player is a program that allows to play games created with RPG Maker 2000 and RPG Maker 2003 (the newer RPG engines like XP, VX, VX Ace and MV are not supported).
>
> Homepage: https://easyrpg.org/
> Changelog: https://blog.easyrpg.org/
> Bug reports: https://github.com/EasyRPG/Player/issues/
> 
> This app is not affiliated with Kadokawa Corporation.

Long description (New):

> With EasyRPG Player you can play games created with RPG Maker 2000 and RPG Maker 2003. Newer engines such as XP, VX, MV and MZ are not supported.
>
> EasyRPG Player is not an editor. You cannot create your own games with it.
>
> Homepage: https://easyrpg.org/
>
> This app is not affiliated with Kadokawa Corporation.

Added a remark that we are not an editor and updated the engine list ;).

Removed most of the links as they aren't clickable anyway. Maybe add more links to the app instead?

