### PR TITLE
Improve Android SAF UX a bit

### DIFF
--- a/builds/android/app/src/main/java/org/easyrpg/player/Helper.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/Helper.java
@@ -9,6 +9,7 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Paint.Style;
 import android.net.Uri;
+import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsContract;
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -19,6 +20,7 @@ import android.widget.RelativeLayout.LayoutParams;
 
 import androidx.documentfile.provider.DocumentFile;
 
+import org.easyrpg.player.game_browser.GameBrowserHelper;
 import org.easyrpg.player.settings.SettingsManager;
 
 import java.io.BufferedReader;
@@ -147,34 +149,51 @@ public class Helper {
         return gameSaveFolder;
     }
 
-    public static boolean testContentProvider(Context context, Uri baseURI) {
+    public static GameBrowserHelper.SafError testContentProvider(Context context, Uri baseURI) {
         DocumentFile folder = Helper.getFileFromURI(context, baseURI);
         if (folder != null) {
             String testName = ".easyrpg_access_test";
             DocumentFile testFile = Helper.findFile(context, folder.getUri(), testName);
             if (testFile != null && testFile.exists()) {
                 if (!testFile.delete()) {
-                    return false;
+                    return GameBrowserHelper.SafError.BAD_CONTENT_PROVIDER_DELETE;
                 }
             }
 
             testFile = folder.createFile("", testName);
             if (testFile == null) {
-                return false;
+                return GameBrowserHelper.SafError.BAD_CONTENT_PROVIDER_CREATE;
             }
 
             if (!testFile.getUri().toString().endsWith(testName)) {
                 testFile.delete();
-                return false;
+                return GameBrowserHelper.SafError.BAD_CONTENT_PROVIDER_FILENAME_IGNORED;
             }
 
             DocumentFile testFileFound = Helper.findFile(context, folder.getUri(), testName);
-            testFile.delete();
 
-            return testFileFound != null;
+            try (ParcelFileDescriptor fd = context.getContentResolver().openFileDescriptor(testFile.getUri(), "r")) {
+            } catch (IOException | IllegalArgumentException e) {
+                return GameBrowserHelper.SafError.BAD_CONTENT_PROVIDER_READ;
+            }
+
+            try (ParcelFileDescriptor fd = context.getContentResolver().openFileDescriptor(testFile.getUri(), "r")) {
+            } catch (IOException | IllegalArgumentException e) {
+                return GameBrowserHelper.SafError.BAD_CONTENT_PROVIDER_WRITE;
+            }
+
+            if (!testFile.delete()) {
+                return GameBrowserHelper.SafError.BAD_CONTENT_PROVIDER_DELETE;
+            }
+
+            if (testFileFound == null) {
+                return GameBrowserHelper.SafError.BAD_CONTENT_PROVIDER_FILE_ACCESS;
+            }
+
+            return GameBrowserHelper.SafError.OK;
         }
 
-        return false;
+        return GameBrowserHelper.SafError.BAD_CONTENT_PROVIDER_BASE_FOLDER_NOT_FOUND;
     }
 
     /** List files (with DOCUMENT_ID) in the folder pointed by "folderURI" */

--- a/builds/android/app/src/main/java/org/easyrpg/player/Helper.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/Helper.java
@@ -96,7 +96,7 @@ public class Helper {
 		} catch (IOException e) {
 			Log.e("JSO reading", "Error reading the file " + fileName + "\n" + e.getMessage());
 		}
-		return file.toString();
+        return file.toString();
 	}
 
 	/** Create EasyRPG's folders and .nomedia file */
@@ -145,6 +145,36 @@ public class Helper {
             Log.e("EasyRPG", "Problem creating savegame folder " + folderName);
         }
         return gameSaveFolder;
+    }
+
+    public static boolean testContentProvider(Context context, Uri baseURI) {
+        DocumentFile folder = Helper.getFileFromURI(context, baseURI);
+        if (folder != null) {
+            String testName = ".easyrpg_access_test";
+            DocumentFile testFile = Helper.findFile(context, folder.getUri(), testName);
+            if (testFile != null && testFile.exists()) {
+                if (!testFile.delete()) {
+                    return false;
+                }
+            }
+
+            testFile = folder.createFile("", testName);
+            if (testFile == null) {
+                return false;
+            }
+
+            if (!testFile.getUri().toString().endsWith(testName)) {
+                testFile.delete();
+                return false;
+            }
+
+            DocumentFile testFileFound = Helper.findFile(context, folder.getUri(), testName);
+            testFile.delete();
+
+            return testFileFound != null;
+        }
+
+        return false;
     }
 
     /** List files (with DOCUMENT_ID) in the folder pointed by "folderURI" */

--- a/builds/android/app/src/main/java/org/easyrpg/player/InitActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/InitActivity.java
@@ -1,6 +1,7 @@
 package org.easyrpg.player;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Intent;
 import android.content.res.AssetManager;
 import android.net.Uri;
@@ -26,11 +27,14 @@ import java.io.File;
  */
 public class InitActivity extends AppCompatActivity {
     private boolean standaloneMode = false;
+    private GameBrowserHelper.SafError safError = GameBrowserHelper.SafError.OK;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_init);
+
+        safError = GameBrowserHelper.SafError.OK;
 
         // Retrieve User's preferences
         SettingsManager.init(getApplicationContext());
@@ -49,6 +53,12 @@ public class InitActivity extends AppCompatActivity {
         super.onResume();
 
         if (!standaloneMode) {
+            if (safError != GameBrowserHelper.SafError.OK && safError != GameBrowserHelper.SafError.ABORTED) {
+                GameBrowserHelper.showErrorMessage(this, safError);
+                safError = GameBrowserHelper.SafError.OK;
+                return;
+            }
+
             // If we have a readable EasyRPG folder, start the GameBrowser
             Uri easyRPGFolderURI = SettingsManager.getEasyRPGFolderURI(this);
             DocumentFile easyRPGFolder = Helper.getFileFromURI(this, easyRPGFolderURI);
@@ -67,7 +77,7 @@ public class InitActivity extends AppCompatActivity {
     public void onActivityResult(int requestCode, int resultCode, Intent resultData) {
         super.onActivityResult(requestCode, resultCode, resultData);
 
-        GameBrowserHelper.dealAfterFolderSelected(this, requestCode, resultCode, resultData);
+        safError = GameBrowserHelper.dealAfterFolderSelected(this, requestCode, resultCode, resultData);
     }
 
     /**

--- a/builds/android/app/src/main/java/org/easyrpg/player/InitActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/InitActivity.java
@@ -7,6 +7,7 @@ import android.content.res.AssetManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
+import android.widget.Button;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.documentfile.provider.DocumentFile;
@@ -42,7 +43,11 @@ public class InitActivity extends AppCompatActivity {
         Activity thisActivity = this;
         (findViewById(R.id.set_games_folder)).setOnClickListener(v -> GameBrowserHelper.pickAGamesFolder(thisActivity));
 
-        // prepareData();
+        // Video button
+        findViewById(R.id.watch_video).setOnClickListener(v -> {
+            Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(GameBrowserHelper.VIDEO_URL));
+            startActivity(browserIntent);
+        });
 
         // If the app is called in a game folder : start the game
         startGameStandalone();

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
@@ -201,6 +201,12 @@ public class GameBrowserActivity extends AppCompatActivity
                         }
                         TextView errorLayout = findViewById(R.id.error_text);
                         errorLayout.setText(errorString.toString());
+
+                        // Video button
+                        findViewById(R.id.watch_video).setOnClickListener(v -> {
+                            Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(GameBrowserHelper.VIDEO_URL));
+                            startActivity(browserIntent);
+                        });
                     }
 
                     isScanProcessing = false;

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
@@ -201,24 +201,6 @@ public class GameBrowserActivity extends AppCompatActivity
                         }
                         TextView errorLayout = findViewById(R.id.error_text);
                         errorLayout.setText(errorString.toString());
-
-                        // The "Open the games folder" button
-                        Button button = findViewById(R.id.open_game_folder);
-                        // We can open the file picker in a specific folder only with API >= 26
-                        if (android.os.Build.VERSION.SDK_INT >= 26) {
-                            button.setOnClickListener(v -> {
-                                // Open the file explorer in the "soundfont" folder
-                                Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-                                intent.setType("*/*");
-                                intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, SettingsManager.getGamesFolderURI(this));
-                                startActivity(intent);
-                            });
-                        } else {
-                            ViewGroup layout = (ViewGroup) button.getParent();
-                            if(layout != null) {
-                                layout.removeView(button);
-                            }
-                        }
                     }
 
                     isScanProcessing = false;

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserHelper.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserHelper.java
@@ -149,6 +149,8 @@ public class GameBrowserHelper {
     public static void pickAGamesFolder(Activity activity){
         // Choose a directory using the system's file picker.
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+        // show storage root on some systems by default
+        intent.putExtra("android.content.extra.SHOW_ADVANCED", true);
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION
             | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
             | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserHelper.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserHelper.java
@@ -41,6 +41,8 @@ public class GameBrowserHelper {
     private final static String TAG_FIRST_LAUNCH = "FIRST_LAUNCH";
     public static int FOLDER_HAS_BEEN_CHOSEN = 1;
 
+    public static String VIDEO_URL = "https://youtu.be/r9qU-6P3HOs";
+
     public static void launchGame(Context context, Game game) {
         launchGame(context, game, false);
     }

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserHelper.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserHelper.java
@@ -26,7 +26,15 @@ public class GameBrowserHelper {
         OK,
         ABORTED,
         DOWNLOAD_SELECTED,
-        BAD_CONTENT_PROVIDER,
+        BAD_CONTENT_PROVIDER_CREATE,
+
+        BAD_CONTENT_PROVIDER_READ,
+        BAD_CONTENT_PROVIDER_WRITE,
+        BAD_CONTENT_PROVIDER_DELETE,
+
+        BAD_CONTENT_PROVIDER_FILENAME_IGNORED,
+        BAD_CONTENT_PROVIDER_BASE_FOLDER_NOT_FOUND,
+        BAD_CONTENT_PROVIDER_FILE_ACCESS,
         FOLDER_NOT_ALMOST_EMPTY
     }
 
@@ -178,14 +186,15 @@ public class GameBrowserHelper {
             activity.getContentResolver().takePersistableUriPermission(uri, takeFlags);
 
             // Check if write operations inside the folder work as expected
-            if (!Helper.testContentProvider(activity, uri)) {
-                return SafError.BAD_CONTENT_PROVIDER;
+            SafError error = Helper.testContentProvider(activity, uri);
+            if (error != SafError.OK) {
+                return error;
             }
 
             // Check if the folder contains too many normal files already
             DocumentFile folder = Helper.getFileFromURI(activity, uri);
             if (folder == null) {
-                return SafError.BAD_CONTENT_PROVIDER;
+                return SafError.BAD_CONTENT_PROVIDER_BASE_FOLDER_NOT_FOUND;
             }
 
             List<String[]> items = Helper.listChildrenDocumentIDAndType(activity, folder.getUri());
@@ -220,20 +229,50 @@ public class GameBrowserHelper {
         builder.setTitle(R.string.error_saf_title)
             .setNeutralButton(R.string.ok, null);
 
+        String errorMsg = "";
+
         switch (error) {
             case OK:
             case ABORTED:
                 break;
             case DOWNLOAD_SELECTED:
-                builder.setMessage(R.string.error_saf_download_selected);
+                errorMsg = context.getString(R.string.error_saf_download_selected);
                 break;
-            case BAD_CONTENT_PROVIDER:
-                builder.setMessage(R.string.error_saf_bad_content_provider);
+            case BAD_CONTENT_PROVIDER_CREATE:
+                errorMsg = context.getString(R.string.error_saf_bad_content_provider);
+                errorMsg += context.getString(R.string.error_saf_bad_content_provider_create);
+                break;
+            case BAD_CONTENT_PROVIDER_READ:
+                errorMsg = context.getString(R.string.error_saf_bad_content_provider);
+                errorMsg += context.getString(R.string.error_saf_bad_content_provider_read);
+                break;
+            case BAD_CONTENT_PROVIDER_WRITE:
+                errorMsg = context.getString(R.string.error_saf_bad_content_provider);
+                errorMsg += context.getString(R.string.error_saf_bad_content_provider_write);
+                break;
+            case BAD_CONTENT_PROVIDER_DELETE:
+                errorMsg = context.getString(R.string.error_saf_bad_content_provider);
+                errorMsg += context.getString(R.string.error_saf_bad_content_provider_delete);
+                break;
+            case BAD_CONTENT_PROVIDER_FILENAME_IGNORED:
+                errorMsg = context.getString(R.string.error_saf_bad_content_provider);
+                errorMsg += context.getString(R.string.error_saf_bad_content_provider_filename_ignored);
+                break;
+            case BAD_CONTENT_PROVIDER_BASE_FOLDER_NOT_FOUND:
+                errorMsg = context.getString(R.string.error_saf_bad_content_provider);
+                errorMsg += context.getString(R.string.error_saf_bad_content_provider_base_folder_not_found);
+                break;
+            case BAD_CONTENT_PROVIDER_FILE_ACCESS:
+                errorMsg = context.getString(R.string.error_saf_bad_content_provider);
+                errorMsg += context.getString(R.string.error_saf_bad_content_provider_file_access);
                 break;
             case FOLDER_NOT_ALMOST_EMPTY:
-                builder.setMessage(R.string.error_saf_folder_not_empty);
+                errorMsg = context.getString(R.string.error_saf_folder_not_empty);
                 break;
         }
+
+        errorMsg += "\n\n" + context.getString(R.string.error_saf_select_easyrpg);
+        builder.setMessage(errorMsg);
 
         builder.create();
         builder.show();

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsGamesFolderActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsGamesFolderActivity.java
@@ -15,11 +15,14 @@ import org.easyrpg.player.game_browser.GameBrowserActivity;
 import org.easyrpg.player.game_browser.GameBrowserHelper;
 
 public class SettingsGamesFolderActivity extends AppCompatActivity {
+    private GameBrowserHelper.SafError safError = GameBrowserHelper.SafError.OK;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         this.setContentView(R.layout.activity_settings_easyrpg_folders);
+
+        safError = GameBrowserHelper.SafError.OK;
 
         SettingsManager.init(getApplicationContext());
 
@@ -70,12 +73,25 @@ public class SettingsGamesFolderActivity extends AppCompatActivity {
         }
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        if (safError != GameBrowserHelper.SafError.OK && safError != GameBrowserHelper.SafError.ABORTED) {
+            GameBrowserHelper.showErrorMessage(this, safError);
+            safError = GameBrowserHelper.SafError.OK;
+        }
+    }
+
     /** Called when the user has chosen a game folder */
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent resultData) {
         super.onActivityResult(requestCode, resultCode, resultData);
 
-        GameBrowserHelper.dealAfterFolderSelected(this, requestCode, resultCode, resultData);
+        safError = GameBrowserHelper.dealAfterFolderSelected(this, requestCode, resultCode, resultData);
+        if (safError != GameBrowserHelper.SafError.OK && safError != GameBrowserHelper.SafError.ABORTED) {
+            return;
+        }
 
         // <!> Important <!>
         // We directly start a new GameBrowser activity because the folder permission seems the be

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsGamesFolderActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsGamesFolderActivity.java
@@ -2,6 +2,7 @@ package org.easyrpg.player.settings;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.provider.DocumentsContract;
 import android.view.ViewGroup;
@@ -71,6 +72,12 @@ public class SettingsGamesFolderActivity extends AppCompatActivity {
                 layout.removeView(openRTPFolderButton);
             }
         }
+
+        // Video button
+        findViewById(R.id.watch_video).setOnClickListener(v -> {
+            Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(GameBrowserHelper.VIDEO_URL));
+            startActivity(browserIntent);
+        });
     }
 
     @Override

--- a/builds/android/app/src/main/res/layout/activity_init.xml
+++ b/builds/android/app/src/main/res/layout/activity_init.xml
@@ -22,5 +22,9 @@
         android:textSize="25sp"
         android:gravity="center"
         />
-
+    <Button
+        android:id="@+id/watch_video"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/watch_explanation_video" />
 </LinearLayout>

--- a/builds/android/app/src/main/res/layout/activity_settings_easyrpg_folders.xml
+++ b/builds/android/app/src/main/res/layout/activity_settings_easyrpg_folders.xml
@@ -23,6 +23,12 @@
             android:text="@string/id_select_games_folder_explanation"
             android:textSize="18sp" />
 
+        <Button
+            android:id="@+id/watch_video"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/watch_explanation_video" />
+
         <include layout="@layout/separator"/>
 
         <Button

--- a/builds/android/app/src/main/res/layout/browser_error_panel.xml
+++ b/builds/android/app/src/main/res/layout/browser_error_panel.xml
@@ -11,9 +11,4 @@
         android:layout_height="wrap_content"
         android:textSize="20sp"
         android:text=""/>
-    <Button
-        android:id="@+id/open_game_folder"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/open_games_folder" />
 </LinearLayout>

--- a/builds/android/app/src/main/res/layout/browser_error_panel.xml
+++ b/builds/android/app/src/main/res/layout/browser_error_panel.xml
@@ -11,4 +11,9 @@
         android:layout_height="wrap_content"
         android:textSize="20sp"
         android:text=""/>
+    <Button
+        android:id="@+id/watch_video"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/watch_explanation_video" />
 </LinearLayout>

--- a/builds/android/app/src/main/res/values/strings.xml
+++ b/builds/android/app/src/main/res/values/strings.xml
@@ -24,8 +24,8 @@
     <string name="no">No</string>
     <string name="creating_dir_failed">Creating $PATH directory failed</string>
     <string name="path_not_readable">$PATH not readable</string>
-    <string name="no_games_found_and_explanation_android_30">No RPG Maker 2000/2003 games found. Put them in subdirectories of the "games" folder.\nGames can be in directories or in ZIP archives. The EasyRPG folder can be changed in the settings.</string>
-    <string name="open_games_folder">Open the games folder</string>
+    <string name="no_games_found_and_explanation_android_30">No RPG Maker 2000/2003 games found.\nThe EasyRPG folder you selected contains a \"games\" folder. Use a file manager app to put your games in this folder.\nGames can be in folders or in ZIP archives.\nThe EasyRPG folder can be changed in the settings.</string>
+    <string name="open_games_folder">Open the \"games\" folder</string>
     <string name="no_external_storage">No external storage (e.g. SD card) found</string>
     <string name="not_valid_game">$PATH is not a valid game</string>
     <string name="select_game_region">Select game region</string>
@@ -37,10 +37,14 @@
     <string name="refresh">Refresh</string>
     <string name="change_default_mapping">Change the default button mapping</string>
     <string name="how_to_use_easy_rpg">How to use EasyRPG Player</string>
-    <string name="how_to_use_easy_rpg_explanation_android_30">Put your RPG Maker 2000/2003 games in subdirectories of the "games" folder.\nGames have to be uncompressed or in a ZIP archive.\nRAR, LZH and EXE files are NOT supported.\n\nOptional features (Please refer to the settings):\n- The RTP (shared assets used by some games) can be provided\n- A custom soundfont to alter how MIDI music sounds can be provided</string>
+    <string name="how_to_use_easy_rpg_explanation_android_30">Put your RPG Maker 2000/2003 games in subdirectories of the \"games\" folder.\nGames have to be uncompressed or in a ZIP archive.\nRAR, LZH and EXE files are NOT supported.\n\nOptional features (Please refer to the settings):\n- The RTP (shared assets used by some games) can be provided\n- A custom soundfont to alter how MIDI music sounds can be provided</string>
     <string name="visit_website">Visit our website</string>
-    <string name="error_no_games_folder">The "games" folder does not exist or is not a folder.</string>
-    <string name="error_games_no_rw">The "games" folder is not readable or writable. Please select a different location for the EasyRPG folder. The EasyRPG folder can be changed in the settings.</string>
+    <string name="error_no_games_folder">The \"games\" folder does not exist or is not a folder. Please create it manually or select a different location for the EasyRPG folder. The EasyRPG folder can be changed in the settings.</string>
+    <string name="error_games_no_rw">The \"games\" folder is not readable or writable. Please select a different location for the EasyRPG folder. The EasyRPG folder can be changed in the settings.</string>
+    <string name="error_saf_title">Bad folder selected</string>
+    <string name="error_saf_download_selected">The Download folder cannot be used as the EasyRPG folder.\nPlease create an empty EasyRPG folder and select it.</string>
+    <string name="error_saf_bad_content_provider">The selected folder cannot be used as the EasyRPG folder. This usually happens when you selected the root of your storage.\nPlease create an empty EasyRPG folder and select it.</string>
+    <string name="error_saf_folder_not_empty">The selected folder contains other files and cannot be used as the EasyRPG folder.\nPlease remove all files inside this folder or create an empty EasyRPG folder and select it.</string>
 
     <!--Ingame menu-->
     <string name="toggle_ui">Toggle virtual buttons</string>
@@ -91,7 +95,7 @@ Please tell us in detail what went wrong.\n\n
     </string-array>
     <string name="fast_forward_factor">Speed multiplier:</string>
     <string name="select_the_games_folder">Select EasyRPG folder</string>
-    <string name="id_select_games_folder_explanation">For using EasyRPG Player you must select a folder.\nThis folder is exclusive to EasyRPG Player.\n\nDo not select a folder that contains other things, such as the download folder.\nRPG Maker 2000/2003 games must be put in the "games" subdirectory of this folder.</string>
+    <string name="id_select_games_folder_explanation">EasyRPG Player requires a dedicated folder. After touching the button you are asked to select a folder.\nIf you use this app for the first time there is no EasyRPG folder. Create a new EasyRPG folder and then select it.\nIf you used this app before, select the existing EasyRPG folder.</string>
     <string name="Loading">Loading…</string>
     <string name="enable_rtp_support">Enable RTP support</string>
     <string name="rtp_explanation">The RTP provides shared assets used by some games.\nPut the RPG Maker 2000 RTP in \"rtp/2000\" and the RPG Maker 2003 RTP in \"rtp/2003\".\nPlease note that enabling RTP support will significantly increase the initial loading time of a game.</string>

--- a/builds/android/app/src/main/res/values/strings.xml
+++ b/builds/android/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="how_to_use_easy_rpg">How to use EasyRPG Player</string>
     <string name="how_to_use_easy_rpg_explanation_android_30">Put your RPG Maker 2000/2003 games in subdirectories of the \"games\" folder.\nGames have to be uncompressed or in a ZIP archive.\nRAR, LZH and EXE files are NOT supported.\n\nOptional features (Please refer to the settings):\n- The RTP (shared assets used by some games) can be provided\n- A custom soundfont to alter how MIDI music sounds can be provided</string>
     <string name="visit_website">Visit our website</string>
+    <string name="watch_explanation_video">Getting started and adding games (Video Guide)</string>
     <string name="error_no_games_folder">The \"games\" folder does not exist or is not a folder. Please create it manually or select a different location for the EasyRPG folder. The EasyRPG folder can be changed in the settings.</string>
     <string name="error_games_no_rw">The \"games\" folder is not readable or writable. Please select a different location for the EasyRPG folder. The EasyRPG folder can be changed in the settings.</string>
     <string name="error_saf_title">Bad folder selected</string>
@@ -98,9 +99,11 @@ Please tell us in detail what went wrong.\n\n
     <string name="quick_access">Quick access</string>
     <string name="fast_forward">Fast-forward button mode:</string>
     <string-array name="fast_forward_mode">
-        <item>hold</item>
-        <item>tap</item>
+        <item>@string/fast_forward_mode_hold</item>
+        <item>@string/fast_forward_mode_tap</item>
     </string-array>
+    <string name="fast_forward_mode_hold">hold</string>
+    <string name="fast_forward_mode_tap">tap</string>
     <string name="fast_forward_factor">Speed multiplier:</string>
     <string name="select_the_games_folder">Select EasyRPG folder</string>
     <string name="id_select_games_folder_explanation">EasyRPG Player requires a dedicated folder. After touching the button you are asked to select a folder.\n\nIf you use this app for the first time there is no EasyRPG folder. Create a new EasyRPG folder and then select it.\n\nIf you used this app before, select the existing EasyRPG folder.</string>

--- a/builds/android/app/src/main/res/values/strings.xml
+++ b/builds/android/app/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="no">No</string>
     <string name="creating_dir_failed">Creating $PATH directory failed</string>
     <string name="path_not_readable">$PATH not readable</string>
-    <string name="no_games_found_and_explanation_android_30">No RPG Maker 2000/2003 games found.\nThe EasyRPG folder you selected contains a \"games\" folder. Use a file manager app to put your games in this folder.\nGames can be in folders or in ZIP archives.\nThe EasyRPG folder can be changed in the settings.</string>
+    <string name="no_games_found_and_explanation_android_30">No RPG Maker 2000/2003 games found.\n\nThe EasyRPG folder you selected contains a \"games\" folder. Use a file manager app to put your games in this folder.\nGames can be put in subfolders or in ZIP archives.\n\nThe EasyRPG folder can be changed in the settings.</string>
     <string name="open_games_folder">Open the \"games\" folder</string>
     <string name="no_external_storage">No external storage (e.g. SD card) found</string>
     <string name="not_valid_game">$PATH is not a valid game</string>
@@ -42,9 +42,17 @@
     <string name="error_no_games_folder">The \"games\" folder does not exist or is not a folder. Please create it manually or select a different location for the EasyRPG folder. The EasyRPG folder can be changed in the settings.</string>
     <string name="error_games_no_rw">The \"games\" folder is not readable or writable. Please select a different location for the EasyRPG folder. The EasyRPG folder can be changed in the settings.</string>
     <string name="error_saf_title">Bad folder selected</string>
-    <string name="error_saf_download_selected">The Download folder cannot be used as the EasyRPG folder.\nPlease create an empty EasyRPG folder and select it.</string>
-    <string name="error_saf_bad_content_provider">The selected folder cannot be used as the EasyRPG folder. This usually happens when you selected the root of your storage.\nPlease create an empty EasyRPG folder and select it.</string>
-    <string name="error_saf_folder_not_empty">The selected folder contains other files and cannot be used as the EasyRPG folder.\nPlease remove all files inside this folder or create an empty EasyRPG folder and select it.</string>
+    <string name="error_saf_select_easyrpg">Please create an empty EasyRPG folder and select it.</string>
+    <string name="error_saf_download_selected">The Download folder cannot be used as the EasyRPG folder.</string>
+    <string name="error_saf_folder_not_empty">The selected folder contains other files and cannot be used as the EasyRPG folder. When you remove all files inside the folder you can use it as the EasyRPG folder.</string>
+    <string name="error_saf_bad_content_provider">The selected folder cannot be used as the EasyRPG folder. This problem can occur for various reasons, for example if you have selected the root directory or a storage location in the cloud.\n\n</string>
+    <string name="error_saf_bad_content_provider_create">File creation failed.</string>
+    <string name="error_saf_bad_content_provider_read">Read operation failed.</string>
+    <string name="error_saf_bad_content_provider_write">Write operation failed.</string>
+    <string name="error_saf_bad_content_provider_delete">File deletion failed.</string>
+    <string name="error_saf_bad_content_provider_filename_ignored">Provided filename ignored.</string>
+    <string name="error_saf_bad_content_provider_base_folder_not_found">Selected folder not found.</string>
+    <string name="error_saf_bad_content_provider_file_access">A file was successfully created but cannot be accessed.</string>
 
     <!--Ingame menu-->
     <string name="toggle_ui">Toggle virtual buttons</string>
@@ -95,7 +103,7 @@ Please tell us in detail what went wrong.\n\n
     </string-array>
     <string name="fast_forward_factor">Speed multiplier:</string>
     <string name="select_the_games_folder">Select EasyRPG folder</string>
-    <string name="id_select_games_folder_explanation">EasyRPG Player requires a dedicated folder. After touching the button you are asked to select a folder.\nIf you use this app for the first time there is no EasyRPG folder. Create a new EasyRPG folder and then select it.\nIf you used this app before, select the existing EasyRPG folder.</string>
+    <string name="id_select_games_folder_explanation">EasyRPG Player requires a dedicated folder. After touching the button you are asked to select a folder.\n\nIf you use this app for the first time there is no EasyRPG folder. Create a new EasyRPG folder and then select it.\n\nIf you used this app before, select the existing EasyRPG folder.</string>
     <string name="Loading">Loading…</string>
     <string name="enable_rtp_support">Enable RTP support</string>
     <string name="rtp_explanation">The RTP provides shared assets used by some games.\nPut the RPG Maker 2000 RTP in \"rtp/2000\" and the RPG Maker 2003 RTP in \"rtp/2003\".\nPlease note that enabling RTP support will significantly increase the initial loading time of a game.</string>

--- a/src/platform/android/filesystem_saf.cpp
+++ b/src/platform/android/filesystem_saf.cpp
@@ -275,10 +275,12 @@ bool SafFilesystem::GetDirectoryContent(StringView path, std::vector<DirectoryTr
 		const char* str = env->GetStringUTFChars(elem, nullptr);
 		entries.emplace_back(str, types[i] == 0 ? DirectoryTree::FileType::Regular : DirectoryTree::FileType::Directory);
 		env->ReleaseStringUTFChars(elem, str);
+		env->DeleteLocalRef(elem);
 	}
 
 	env->DeleteLocalRef(cls_directory_tree);
 	env->DeleteLocalRef(names_arr);
+	env->DeleteLocalRef(types_arr);
 
 	return true;
 }


### PR DESCRIPTION
Most common problems are now detected and the user is notified.

Related #2943 which has more suggestions for better UX but I have no time right now to embed images etc.

**I invite all of you to test it.**

First start:

![image](https://user-images.githubusercontent.com/1331889/229544461-6deed5c1-7777-4094-8f5e-afe736793dc1.png)

Errors detected:

Generic error when a quick sanity check (create a file and read it) fails:

![image](https://user-images.githubusercontent.com/1331889/229545687-9193059f-53e3-47d1-9db5-b7031e9116fd.png)

The Download folder already hits the sanity check but here a better message for it:

![image](https://user-images.githubusercontent.com/1331889/229544616-db9bc7a9-f624-4bd9-b37f-48824ee59d13.png)

This can cause false-positives on some systems (user is a messy :P) but is imo a good idea. It will trigger when the folder contains more than 3 regular files except ".nomedia" (folders do not count).

![image](https://user-images.githubusercontent.com/1331889/229545621-a2ef0542-33c2-4cc0-8010-c2c308c59dd8.png)

When no games found afterwards:

![image](https://user-images.githubusercontent.com/1331889/229543994-e9db4815-a50c-49be-b072-65d2996d1278.png)
