### PR TITLE
Do not support 2k3 features in 2k

### DIFF
--- a/resources/unix/easyrpg-player.6.adoc
+++ b/resources/unix/easyrpg-player.6.adoc
@@ -71,8 +71,10 @@ for some additional binary patches.
   patches.
    - 'common-this' - Support for __This Event__ in common events
    - 'dynrpg'      - DynRPG patch by Cherry
+   - 'key-patch'   - Key Patch by Ineluki
    - 'maniac'      - Maniac Patch by BingShan
-   - 'unlock-pics' - Pictures are not blocked by messages
+   - 'pic-unlock'  - Pictures are not blocked by messages
+   - 'rpg2k3-cmds' - Support RPG Maker 2003 event commands in all engines
 
 *--no-patch*::
   Disable all engine patches.

--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -139,7 +139,7 @@ void AsyncHandler::CreateRequestMapping(const std::string& file) {
 		}
 
 		// Create some empty DLL files. Engine & patch detection depend on them.
-		for (const auto& s : {"ultimate_rt_eb.dll", "dynloader.dll", "accord.dll"}) {
+		for (const auto& s : {"harmony.dll", "ultimate_rt_eb.dll", "dynloader.dll", "accord.dll"}) {
 			auto it = file_mapping.find(s);
 			if (it != file_mapping.end()) {
 				FileFinder::Game().OpenOutputStream(s);

--- a/src/audio.h
+++ b/src/audio.h
@@ -109,6 +109,11 @@ struct AudioInterface {
 	virtual void BGM_Pitch(int pitch) = 0;
 
 	/**
+	 * @return Type of music being played.
+	 */
+	virtual std::string BGM_GetType() const = 0;
+
+	/**
 	 * Plays a sound effect.
 	 *
 	 * @param se se to play.
@@ -145,6 +150,7 @@ public:
 	void BGM_Fade(int) override {}
 	void BGM_Volume(int) override {}
 	void BGM_Pitch(int) override {};
+	std::string BGM_GetType() const override { return {}; };
 	void SE_Play(std::unique_ptr<AudioSeCache>, int, int) override {}
 	void SE_Stop() override {}
 	void Update() override {}

--- a/src/audio_decoder_midi.cpp
+++ b/src/audio_decoder_midi.cpp
@@ -87,6 +87,7 @@ AudioDecoderMidi::AudioDecoderMidi(std::unique_ptr<MidiDecoder> mididec)
 	: mididec(std::move(mididec)) {
 	seq = std::make_unique<midisequencer::sequencer>();
 	channel_volumes.fill(127);
+	music_type = "midi";
 }
 
 AudioDecoderMidi::~AudioDecoderMidi() {

--- a/src/audio_generic.cpp
+++ b/src/audio_generic.cpp
@@ -347,7 +347,7 @@ void GenericAudio::Decode(uint8_t* output_buffer, int buffer_length) {
 
 					read_bytes = currently_mixed_channel.decoder->Decode(scrap_buffer.data(), bytes_to_read);
 
-					if (read_bytes < 0) {
+					if (read_bytes <= 0) {
 						// An error occured when reading - the channel is faulty - discard
 						currently_mixed_channel.decoder.reset();
 						continue; // skip this loop run - there is nothing to mix

--- a/src/audio_generic.cpp
+++ b/src/audio_generic.cpp
@@ -96,6 +96,7 @@ void GenericAudio::BGM_Stop() {
 	for (auto& BGM_Channel : BGM_Channels) {
 		BGM_Channel.Stop();
 	}
+	BGM_PlayedOnceIndicator = false;
 	UnlockMutex();
 }
 
@@ -160,6 +161,26 @@ void GenericAudio::BGM_Pitch(int pitch) {
 		BGM_Channel.SetPitch(pitch);
 	}
 	UnlockMutex();
+}
+
+std::string GenericAudio::BGM_GetType() const {
+	std::string type;
+
+	LockMutex();
+	for (auto& BGM_Channel : BGM_Channels) {
+		if (BGM_Channel.IsUsed()) {
+			if (BGM_Channel.midi_out_used) {
+				type = "midi";
+				break;
+			} else {
+				type = BGM_Channel.decoder->GetType();
+				break;
+			}
+		}
+	}
+	UnlockMutex();
+
+	return type;
 }
 
 void GenericAudio::SE_Play(std::unique_ptr<AudioSeCache> se, int volume, int pitch) {
@@ -359,7 +380,7 @@ void GenericAudio::Decode(uint8_t* output_buffer, int buffer_length) {
 
 					read_bytes = currently_mixed_channel.decoder->Decode(scrap_buffer.data(), bytes_to_read);
 
-					if (read_bytes < 0) {
+					if (read_bytes <= 0) {
 						// An error occured when reading - the channel is faulty - discard
 						currently_mixed_channel.decoder.reset();
 						continue; // skip this loop run - there is nothing to mix

--- a/src/audio_generic.h
+++ b/src/audio_generic.h
@@ -54,6 +54,8 @@ public:
 	void BGM_Fade(int fade) override;
 	void BGM_Volume(int volume) override;
 	void BGM_Pitch(int pitch) override;
+	std::string BGM_GetType() const override;
+
 	void SE_Play(std::unique_ptr<AudioSeCache> se, int volume, int pitch) override;
 	void SE_Stop() override;
 	virtual void Update() override;

--- a/src/game_config_game.cpp
+++ b/src/game_config_game.cpp
@@ -86,9 +86,11 @@ void Game_ConfigGame::LoadFromArgs(CmdlineParser& cp) {
 			patch_maniac.Lock(false);
 			patch_unlock_pics.Lock(false);
 			patch_common_this_event.Lock(false);
+			patch_key_patch.Lock(false);
+			patch_rpg2k3_commands.Lock(false);
 			patch_override = true;
 		}
-		if (cp.ParseNext(arg, 4, "--patch")) {
+		if (cp.ParseNext(arg, 6, "--patch")) {
 			for (int i = 0; i < arg.NumValues(); ++i) {
 				const auto& v = arg.Value(i);
 				if (v == "dynrpg") {
@@ -99,6 +101,10 @@ void Game_ConfigGame::LoadFromArgs(CmdlineParser& cp) {
 					patch_common_this_event.Set(true);
 				} else if (v == "pic-unlock") {
 					patch_unlock_pics.Set(true);
+				} else if (v == "key-patch") {
+					patch_key_patch.Set(true);
+				} else if (v == "rpg2k3-cmds" || v == "rpg2k3-commands") {
+					patch_rpg2k3_commands.Set(true);
 				}
 			}
 			patch_override = true;
@@ -135,6 +141,14 @@ void Game_ConfigGame::LoadFromStream(Filesystem_Stream::InputStream& is) {
 	}
 
 	if (patch_unlock_pics.FromIni(ini)) {
+		patch_override = true;
+	}
+
+	if (patch_key_patch.FromIni(ini)) {
+		patch_override = true;
+	}
+
+	if (patch_rpg2k3_commands.FromIni(ini)) {
 		patch_override = true;
 	}
 }

--- a/src/game_config_game.h
+++ b/src/game_config_game.h
@@ -42,6 +42,8 @@ struct Game_ConfigGame {
 	BoolConfigParam patch_maniac{ "Maniac Patch", "", "Patch", "Maniac", false };
 	BoolConfigParam patch_common_this_event{ "Common This Event", "Support \"This Event\" in Common Events", "Patch", "CommonThisEvent", false };
 	BoolConfigParam patch_unlock_pics{ "Unlock Pictures", "Allow picture commands while a message is shown", "Patch", "PicUnlock", false };
+	BoolConfigParam patch_key_patch{ "Ineluki Key Patch", "Support \"Ineluki Key Patch\"", "Patch", "KeyPatch", false };
+	BoolConfigParam patch_rpg2k3_commands{ "RPG2k3 Event Commands", "Enable support for RPG2k3 event commands", "Patch", "RPG2k3Commands", false };
 
 	// Command line only
 	BoolConfigParam patch_support{ "Support patches", "When OFF all patch support is disabled", "", "", true };

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -307,7 +307,7 @@ bool Game_Event::AreConditionsMet(const lcf::rpg::EventPage& page) {
 	}
 
 	// Timer2
-	if (page.condition.flags.timer2) {
+	if (page.condition.flags.timer2 && Player::IsRPG2k3Commands()) {
 		int secs = Main_Data::game_party->GetTimerSeconds(Main_Data::game_party->Timer2);
 		if (secs > page.condition.timer2_sec)
 			return false;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -3489,7 +3489,7 @@ bool Game_Interpreter::CommandConditionalBranch(lcf::rpg::EventCommand const& co
 		break;
 	case 9:
 		// BGM looped at least once
-		result = Audio().BGM_PlayedOnce();
+		result = Main_Data::game_system->BgmPlayedOnce();
 		break;
 	case 10:
 		value1 = Main_Data::game_party->GetTimerSeconds(Main_Data::game_party->Timer2);

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -3805,8 +3805,19 @@ bool Game_Interpreter::CommandCallEvent(lcf::rpg::EventCommand const& com) { // 
 	int event_page;
 
 	switch (com.parameters[0]) {
-	case 0: { // Common Event
-		evt_id = com.parameters[1];
+	case 0:
+	case 3:
+	case 4: { // Common Event
+		if (com.parameters[0] == 0) {
+			evt_id = com.parameters[1];
+		} else if (com.parameters[0] == 3 && Player::IsPatchManiac()) {
+			evt_id = Main_Data::game_variables->Get(com.parameters[1]);
+		} else if (com.parameters[0] == 4 && Player::IsPatchManiac()) {
+			evt_id = Main_Data::game_variables->GetIndirect(com.parameters[1]);
+		} else {
+			return true;
+		}
+
 		Game_CommonEvent* common_event = lcf::ReaderUtil::GetElement(Game_Map::GetCommonEvents(), evt_id);
 		if (!common_event) {
 			Output::Warning("CallEvent: Can't call invalid common event {}", evt_id);
@@ -3826,19 +3837,19 @@ bool Game_Interpreter::CommandCallEvent(lcf::rpg::EventCommand const& com) { // 
 		event_page = Main_Data::game_variables->Get(com.parameters[2]);
 		break;
 	default:
-		return false;
+		return true;
 	}
 
 	Game_Event* event = static_cast<Game_Event*>(GetCharacter(evt_id));
 	if (!event) {
-		Output::Warning("CallEvent: Can't call non-existant event {}", evt_id);
-		return false;
+		Output::Warning("CallEvent: Can't call non-existent event {}", evt_id);
+		return true;
 	}
 
 	const lcf::rpg::EventPage* page = event->GetPage(event_page);
 	if (!page) {
-		Output::Warning("CallEvent: Can't call non-existant page {} of event {}", event_page, evt_id);
-		return false;
+		Output::Warning("CallEvent: Can't call non-existent page {} of event {}", event_page, evt_id);
+		return true;
 	}
 
 	Push(page->event_commands, event->GetId(), false);

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1991,7 +1991,7 @@ bool Game_Interpreter::CommandWait(lcf::rpg::EventCommand const& com) { // code 
 		return true;
 	}
 
-	if (maniac && com.parameters.size() > 1) {
+	if (maniac && com.parameters.size() > 1 && com.parameters[1] != 1) {
 		int wait_type = com.parameters[1];
 		int mode = 0;
 

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -201,6 +201,10 @@ bool Game_Interpreter_Battle::ExecuteCommand() {
 // Commands
 
 bool Game_Interpreter_Battle::CommandCallCommonEvent(lcf::rpg::EventCommand const& com) {
+	if (!Player::IsRPG2k3Commands()) {
+		return true;
+	}
+
 	int evt_id = com.parameters[0];
 
 	Game_CommonEvent* common_event = lcf::ReaderUtil::GetElement(Game_Map::GetCommonEvents(), evt_id);
@@ -215,6 +219,10 @@ bool Game_Interpreter_Battle::CommandCallCommonEvent(lcf::rpg::EventCommand cons
 }
 
 bool Game_Interpreter_Battle::CommandForceFlee(lcf::rpg::EventCommand const& com) {
+	if (!Player::IsRPG2k3Commands()) {
+		return true;
+	}
+
 	bool check = com.parameters[2] == 0;
 
 	switch (com.parameters[0]) {
@@ -254,6 +262,10 @@ bool Game_Interpreter_Battle::CommandForceFlee(lcf::rpg::EventCommand const& com
 }
 
 bool Game_Interpreter_Battle::CommandEnableCombo(lcf::rpg::EventCommand const& com) {
+	if (!Player::IsRPG2k3Commands()) {
+		return true;
+	}
+
 	int actor_id = com.parameters[0];
 
 	if (!Main_Data::game_party->IsActorInParty(actor_id)) {

--- a/src/game_interpreter_control_variables.cpp
+++ b/src/game_interpreter_control_variables.cpp
@@ -28,6 +28,7 @@
 #include "player.h"
 #include "rand.h"
 #include "utils.h"
+#include "audio.h"
 #include <cmath>
 #include <cstdint>
 #include <lcf/rpg/savepartylocation.h>
@@ -250,7 +251,11 @@ int ControlVariables::Other(int op) {
 			break;
 		case 8:
 			// MIDI play position
-			return Main_Data::game_ineluki->GetMidiTicks();
+			if (Player::IsPatchKeyPatch()) {
+				return Main_Data::game_ineluki->GetMidiTicks();
+			} else {
+				return Audio().BGM_GetTicks();
+			}
 			break;
 		case 9:
 			// Timer 2 remaining time

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -488,7 +488,10 @@ bool Game_Interpreter_Map::CommandTeleport(lcf::rpg::EventCommand const& com) { 
 	int y = com.parameters[2];
 
 	// RPG2k3 feature
-	int direction = com.parameters.size() > 3 ? com.parameters[3] - 1 : -1;
+	int direction = -1;
+	if (com.parameters.size() > 3 && Player::IsRPG2k3Commands()) {
+		direction = com.parameters[3] - 1;
+	}
 
 	auto tt = main_flag ? TeleportTarget::eForegroundTeleport : TeleportTarget::eParallelTeleport;
 
@@ -650,6 +653,10 @@ bool Game_Interpreter_Map::CommandOpenMainMenu(lcf::rpg::EventCommand const& /* 
 }
 
 bool Game_Interpreter_Map::CommandOpenLoadMenu(lcf::rpg::EventCommand const& /* com */) {
+	if (!Player::IsRPG2k3ECommands()) {
+		return true;
+	}
+
 	auto& frame = GetFrame();
 	auto& index = frame.current_command;
 
@@ -663,7 +670,10 @@ bool Game_Interpreter_Map::CommandOpenLoadMenu(lcf::rpg::EventCommand const& /* 
 }
 
 bool Game_Interpreter_Map::CommandToggleAtbMode(lcf::rpg::EventCommand const& /* com */) {
+	if (!Player::IsRPG2k3ECommands()) {
+		return true;
+	}
+
 	Main_Data::game_system->ToggleAtbMode();
 	return true;
 }
-

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -652,7 +652,7 @@ bool Game_Player::Move(int dir) {
 				}
 			}
 		}
-		if (!terrain->on_damage_se || red_flash) {
+		if ((!terrain->on_damage_se || red_flash) && Player::IsRPG2k3()) {
 			Main_Data::game_system->SePlay(terrain->footstep);
 		}
 	} else {

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -561,7 +561,7 @@ void Game_System::OnSeReady(FileRequestResult* result, lcf::rpg::Sound se, bool 
 		se_request_ids.erase(item);
 	}
 
-	if (StringView(result->file).ends_with(".script")) {
+	if (Player::IsPatchKeyPatch() && StringView(result->file).ends_with(".script")) {
 		// Is a Ineluki Script File
 		Main_Data::game_ineluki->Execute(se);
 		return;

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -134,6 +134,18 @@ void Game_System::BgmFade(int duration, bool clear_current_music) {
 	data.music_stopping = true;
 }
 
+bool Game_System::BgmPlayedOnce() {
+	if (Audio().BGM_PlayedOnce()) {
+		if (Audio().BGM_GetType() == "wav") {
+			// RPG_RT does not report looping for WAV
+			return false;
+		}
+		return true;
+	}
+
+	return false;
+}
+
 void Game_System::SePlay(const lcf::rpg::Sound& se, bool stop_sounds) {
 	if (se.name.empty()) {
 		return;

--- a/src/game_system.h
+++ b/src/game_system.h
@@ -80,26 +80,6 @@ public:
 
 	using AtbMode = lcf::rpg::SaveSystem::AtbMode;
 
-	class Target {
-	public:
-		int map_id;
-		int x;
-		int y;
-		int switch_id;
-		Target()
-			: map_id(0),
-			  x(0),
-			  y(0),
-			  switch_id(0)
-		{}
-		Target(int map_id, int x, int y, int switch_id)
-			: map_id(map_id),
-			  x(x),
-			  y(y),
-			  switch_id(switch_id)
-		{}
-	};
-
 	/**
 	 * Initializes Game System.
 	 */
@@ -234,48 +214,6 @@ public:
 	 * @param transition the transition.
 	 */
 	void SetTransition(int which, int transition);
-
-	/**
-	 * Sets a teleport target.
-	 *
-	 * @param map_id the destination map.
-	 * @param x the destination X coordinate.
-	 * @param y the destination Y coordinate.
-	 * @param switch_id the switch ID.
-	 */
-	void AddTeleportTarget(int map_id, int x, int y, int switch_id);
-
-	/**
-	 * Removes a teleport target.
-	 *
-	 * @param map_id the map for which the target was used.
-	 */
-	void RemoveTeleportTarget(int map_id);
-
-	/**
-	 * Finds a teleport target.
-	 *
-	 * @param map_id the map for which to obtain the target.
-	 * @return: pointer to a Target structure, or NULL.
-	 */
-	Target* GetTeleportTarget(int map_id);
-
-	/**
-	 * Sets an escape  target.
-	 *
-	 * @param map_id the destination map.
-	 * @param x the destination X coordinate.
-	 * @param y the destination Y coordinate.
-	 * @param switch_id the switch ID.
-	 */
-	void SetEscapeTarget(int map_id, int x, int y, int switch_id);
-
-	/**
-	 * Finds an escape target.
-	 *
-	 * @return pointer to a Target structure, or NULL.
-	 */
-	Target* GetEscapeTarget();
 
 	bool GetAllowTeleport();
 	void SetAllowTeleport(bool allow);

--- a/src/game_system.h
+++ b/src/game_system.h
@@ -132,6 +132,15 @@ public:
 	void BgmFade(int duration, bool clear_current_music = false);
 
 	/**
+	 * Returns whether a Bgm track played once.
+	 * For RPG_RT compatibility always returns false for WAV files.
+	 * Use Audio().BGM_PlayedOnce() if this is not desired.
+	 *
+	 * @return Whether Bgm played once
+	 */
+	bool BgmPlayedOnce();
+
+	/**
 	 * Plays a Sound.
 	 *
 	 * @param se sound data.

--- a/src/platform/3ds/audio.cpp
+++ b/src/platform/3ds/audio.cpp
@@ -165,7 +165,7 @@ void CtrAudio::BGM_Stop() {
 
 bool CtrAudio::BGM_PlayedOnce() const {
 	if (!bgm.decoder)
-		return true;
+		return false;
 
 	return bgm.decoder->GetLoopCount() > 0;
 }
@@ -203,6 +203,13 @@ void CtrAudio::BGM_Pitch(int pitch) {
 	if (is_new_3ds && bgm.decoder) {
 		bgm.decoder->SetPitch(pitch);
 	}
+}
+
+std::string CtrAudio::BGM_GetType() const {
+	if (bgm.decoder) {
+		return bgm.decoder->GetType();
+	}
+	return "";
 }
 
 void CtrAudio::SE_Play(std::unique_ptr<AudioSeCache> se_cache, int volume, int pitch) {

--- a/src/platform/3ds/audio.h
+++ b/src/platform/3ds/audio.h
@@ -43,6 +43,7 @@ public:
 	void BGM_Fade(int fade) override;
 	void BGM_Volume(int volume) override;
 	void BGM_Pitch(int pitch) override;
+	std::string BGM_GetType() const override;
 	void SE_Play(std::unique_ptr<AudioSeCache> se, int volume, int pitch) override;
 	void SE_Stop() override;
 	void Update() override;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -808,6 +808,10 @@ void Player::CreateGameObjects() {
 	Main_Data::filefinder_rtp = std::make_unique<FileFinder_RTP>(no_rtp_flag, no_rtp_warning_flag, rtp_path);
 
 	if (!game_config.patch_override) {
+		if (!FileFinder::Game().FindFile("harmony.dll").empty()) {
+			game_config.patch_key_patch.Set(true);
+		}
+
 		if (!FileFinder::Game().FindFile("dynloader.dll").empty()) {
 			game_config.patch_dynrpg.Set(true);
 			Output::Warning("This game uses DynRPG and will not run properly.");
@@ -818,14 +822,16 @@ void Player::CreateGameObjects() {
 		}
 	}
 
-	Output::Debug("Patch configuration: dynrpg={} maniac={} common-this={} pic-unlock={}",
-		Player::IsPatchDynRpg(), Player::IsPatchManiac(), game_config.patch_common_this_event.Get(), game_config.patch_unlock_pics.Get());
+	Output::Debug("Patch configuration: dynrpg={} maniac={} key-patch={} common-this={} pic-unlock={} 2k3-commands={}",
+		Player::IsPatchDynRpg(), Player::IsPatchManiac(), Player::IsPatchKeyPatch(), game_config.patch_common_this_event.Get(), game_config.patch_unlock_pics.Get(), game_config.patch_rpg2k3_commands.Get());
 
 	ResetGameObjects();
 
 	LoadFonts();
 
-	Main_Data::game_ineluki->ExecuteScriptList(FileFinder::Game().FindFile("autorun.script"));
+	if (Player::IsPatchKeyPatch()) {
+		Main_Data::game_ineluki->ExecuteScriptList(FileFinder::Game().FindFile("autorun.script"));
+	}
 }
 
 bool Player::ChangeResolution(int width, int height) {
@@ -1380,8 +1386,11 @@ Engine options:
                       Options:
                        common-this - "This Event" in common events
                        dynrpg      - DynRPG patch by Cherry
+                       key-patch   - Key Patch by Ineluki
                        maniac      - Maniac Patch by BingShan
                        pic-unlock  - Pictures are not blocked by messages
+                       rpg2k3-cmds - Support all RPG Maker 2003 event commands
+                                     in any version of the engine
  --no-patch           Disable all engine patches.
  --project-path PATH  Instead of using the working directory, the game in PATH
                       is used.

--- a/src/player.h
+++ b/src/player.h
@@ -282,6 +282,11 @@ namespace Player {
 	bool IsPatchManiac();
 
 	/**
+	 * @return True when Ineluki Key Patch is active
+	 */
+	bool IsPatchKeyPatch();
+
+	/**
 	 * @return Running engine version. 2000 for RPG2k and 2003 for RPG2k3
 	 */
 	int EngineVersion();
@@ -454,6 +459,10 @@ inline bool Player::IsPatchDynRpg() {
 
 inline bool Player::IsPatchManiac() {
 	return game_config.patch_maniac.Get();
+}
+
+inline bool Player::IsPatchKeyPatch() {
+	return game_config.patch_key_patch.Get();
 }
 
 #endif

--- a/src/player.h
+++ b/src/player.h
@@ -271,6 +271,12 @@ namespace Player {
 	 */
 	bool IsCP1251();
 
+	/** @return true when engine is 2k3 or the 2k3-commands patch is enabled */
+	bool IsRPG2k3Commands();
+
+	/** @return true when engine is 2k3e or the 2k3-commands patch is enabled */
+	bool IsRPG2k3ECommands();
+
 	/**
 	 * @return True when the DynRPG patch is active
 	 */
@@ -451,6 +457,14 @@ inline bool Player::IsRPG2kE() {
 
 inline bool Player::IsRPG2k3E() {
 	return (IsRPG2k3() && IsEnglish());
+}
+
+inline bool Player::IsRPG2k3Commands() {
+	return (IsRPG2k3() || game_config.patch_rpg2k3_commands.Get());
+}
+
+inline bool Player::IsRPG2k3ECommands() {
+	return (IsRPG2k3E() || game_config.patch_rpg2k3_commands.Get());
 }
 
 inline bool Player::IsPatchDynRpg() {

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -529,6 +529,7 @@ void Scene_Map::UpdateInn() {
 		return;
 	}
 
+	// Do not use Game_System::BgmPlayedOnce here as it does not report looping for WAV correctly
 	if (Audio().BGM_IsPlaying() && !Audio().BGM_PlayedOnce() && (Game_Clock::GetFrameTime() - inn_timer < 10s)) {
 		return;
 	}

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -120,7 +120,7 @@ void Scene_Title::Continue(SceneType prev_scene) {
 }
 
 void Scene_Title::TransitionIn(SceneType prev_scene) {
-	if (Game_Battle::battle_test.enabled || !lcf::Data::system.show_title || Player::game_config.new_game.Get())
+	if (Game_Battle::battle_test.enabled || !Check2k3ShowTitle() || Player::game_config.new_game.Get())
 		return;
 
 	if (prev_scene == Scene::Load || Player::hide_title_flag) {
@@ -141,7 +141,7 @@ void Scene_Title::vUpdate() {
 		return;
 	}
 
-	if (!lcf::Data::system.show_title || Player::game_config.new_game.Get()) {
+	if (!Check2k3ShowTitle() || Player::game_config.new_game.Get()) {
 		Player::SetupNewGame();
 		if (Player::debug_flag && Player::hide_title_flag) {
 			Scene::Push(std::make_shared<Scene_Load>());
@@ -320,10 +320,14 @@ void Scene_Title::PlayTitleMusic() {
 }
 
 bool Scene_Title::CheckEnableTitleGraphicAndMusic() {
-	return lcf::Data::system.show_title &&
+	return Check2k3ShowTitle() &&
 		!Player::game_config.new_game.Get() &&
 		!Game_Battle::battle_test.enabled &&
 		!Player::hide_title_flag;
+}
+
+bool Scene_Title::Check2k3ShowTitle() {
+	return !Player::IsRPG2k3E() || (Player::IsRPG2k3E() && lcf::Data::system.show_title);
 }
 
 bool Scene_Title::CheckValidPlayerLocation() {

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -103,7 +103,9 @@ void Scene_Title::Continue(SceneType prev_scene) {
 		AudioSeCache::Clear();
 
 		Player::ResetGameObjects();
-		Main_Data::game_ineluki->ExecuteScriptList(FileFinder::Game().FindFile("autorun.script"));
+		if (Player::IsPatchKeyPatch()) {
+			Main_Data::game_ineluki->ExecuteScriptList(FileFinder::Game().FindFile("autorun.script"));
+		}
 
 		Start();
 

--- a/src/scene_title.h
+++ b/src/scene_title.h
@@ -77,6 +77,11 @@ public:
 	bool CheckEnableTitleGraphicAndMusic();
 
 	/**
+	 * @return Whether the 2k3E chunk for showing the title is set
+	 */
+	bool Check2k3ShowTitle();
+
+	/**
 	 * Checks if there is a player start location.
 	 *
 	 * @return true if there is one, false otherwise.

--- a/src/sprite_picture.cpp
+++ b/src/sprite_picture.cpp
@@ -28,7 +28,7 @@
 Sprite_Picture::Sprite_Picture(int pic_id, Drawable::Flags flags)
 	: Sprite(flags),
 	pic_id(pic_id),
-	feature_spritesheet(Player::IsRPG2k3E()),
+	feature_spritesheet(Player::IsRPG2k3ECommands()),
 	feature_priority_layers(Player::IsMajorUpdatedVersion()),
 	feature_bottom_trans(Player::IsRPG2k3() && !Player::IsRPG2k3E())
 {

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -40,7 +40,10 @@ Spriteset_Map::Spriteset_Map() {
 	timer2.reset(new Sprite_Timer(1));
 
 	screen.reset(new Screen());
-	frame.reset(new Frame());
+
+	if (Player::IsRPG2k3()) {
+		frame.reset(new Frame());
+	}
 
 	ParallaxUpdated();
 


### PR DESCRIPTION
First commit is unrelated to 2k/2k3 but it stops reporting the loop state for WAV. You know for what ;)

Ineluki Key Patch is now locked behind a "harmony.dll" file or ``KeyPatch=1`` in EasyRPG.ini.

When emulating RPG Maker 2000 then RPG Maker 2003 commands are not supported anymore. This makes sense in general. Could solve some bugs in games that were initially developed in 2k3 and moved to 2k. Opt-in is available: ``RPG2k3Commands=1`` in EasyRPG.ini.
