### PR TITLE
Improve Engine detection

### DIFF
--- a/src/exe_reader.h
+++ b/src/exe_reader.h
@@ -47,10 +47,12 @@ public:
 		int logos = 0;
 		std::string version_str;
 		uint32_t code_size = 0;
+		uint32_t cherry_size = 0;
+		uint32_t geep_size = 0;
 		bool is_i386 = true;
 		bool is_easyrpg_player = false;
 
-		int GetEngineType() const;
+		int GetEngineType(bool& is_maniac_patch) const;
 		void Print() const;
 	};
 

--- a/src/exe_reader.h
+++ b/src/exe_reader.h
@@ -46,6 +46,7 @@ public:
 		uint64_t version = 0;
 		int logos = 0;
 		std::string version_str;
+		uint32_t code_size = 0;
 		bool is_i386 = true;
 		bool is_easyrpg_player = false;
 

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -281,8 +281,7 @@ std::string FileFinder::GetPathInsidePath(StringView path_to, StringView path_in
 }
 
 std::string FileFinder::GetPathInsideGamePath(StringView path_in) {
-	// FIXME return FileFinder::GetPathInsidePath(ToString(Root().GetRootPath()), path_in);
-	return ToString(path_in);
+	return FileFinder::GetPathInsidePath(Game().GetFullPath(), path_in);
 }
 
 void FileFinder::Quit() {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -763,7 +763,6 @@ void Player::CreateGameObjects() {
 	auto exeis = FileFinder::Game().OpenFile(EXE_NAME);
 
 	if (exeis) {
-		Output::Debug("Analyzing RPG_RT {}", exeis.GetName());
 		exe_reader.reset(new EXEReader(std::move(exeis)));
 		Cache::exfont_custom = exe_reader->GetExFont();
 		if (!Cache::exfont_custom.empty()) {
@@ -773,7 +772,11 @@ void Player::CreateGameObjects() {
 		if (engine == EngineNone) {
 			auto version_info = exe_reader->GetFileInfo();
 			version_info.Print();
-			engine = version_info.GetEngineType();
+			bool is_patch_maniac;
+			engine = version_info.GetEngineType(is_patch_maniac);
+			if (!game_config.patch_override) {
+				game_config.patch_maniac.Set(is_patch_maniac);
+			}
 		}
 
 		if (engine == EngineNone) {
@@ -785,7 +788,7 @@ void Player::CreateGameObjects() {
 #endif
 
 	if (exfont_stream) {
-		Output::Debug("Using custom ExFont: {}", exfont_stream.GetName());
+		Output::Debug("Using custom ExFont: {}", FileFinder::GetPathInsideGamePath(exfont_stream.GetName()));
 		Cache::exfont_custom = Utils::ReadStream(exfont_stream);
 	}
 


### PR DESCRIPTION
While looking for the resources I obtain now the sizes of the segments ``CODE``, ``CHERRY`` and ``GEEP``. The sizes of these segments are enough for fingerprinting.

Should detect old RPG Maker 2003 properly and all versions of Maniac I found on the harddrive.

(got a regression tag as old 2003 was properly detected before the new heuristic)