### PR TITLE
Fix building with fmtlib 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,6 +345,7 @@ add_library(${PROJECT_NAME} OBJECT
 	src/state.cpp
 	src/state.h
 	src/std_clock.h
+	src/string_view.cpp
 	src/string_view.h
 	src/system.h
 	src/teleport_target.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -327,6 +327,7 @@ libeasyrpg_player_a_SOURCES = \
 	src/state.cpp \
 	src/state.h \
 	src/std_clock.h \
+	src/string_view.cpp \
 	src/string_view.h \
 	src/system.h \
 	src/teleport_target.h \

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2187,7 +2187,7 @@ bool Game_Interpreter::CommandChangeVehicleGraphic(lcf::rpg::EventCommand const&
 	Game_Vehicle* vehicle = Game_Map::GetVehicle(vehicle_id);
 
 	if (!vehicle) {
-		Output::Warning("ChangeVehicleGraphic: Invalid vehicle ID {}", vehicle_id);
+		Output::Warning("ChangeVehicleGraphic: Invalid vehicle ID {}", static_cast<int>(vehicle_id));
 		return true;
 	}
 
@@ -2261,7 +2261,7 @@ bool Game_Interpreter::CommandSetVehicleLocation(lcf::rpg::EventCommand const& c
 			// 0 because we adjust all vehicle IDs by +1 to match the lcf values
 			Output::Debug("SetVehicleLocation: Party referenced");
 		} else {
-			Output::Warning("SetVehicleLocation: Invalid vehicle ID {}", vehicle_id);
+			Output::Warning("SetVehicleLocation: Invalid vehicle ID {}", static_cast<int>(vehicle_id));
 			return true;
 		}
 	}
@@ -3494,7 +3494,7 @@ bool Game_Interpreter::CommandConditionalBranch(lcf::rpg::EventCommand const& co
 		Game_Vehicle* vehicle = Game_Map::GetVehicle(vehicle_id);
 
 		if (!vehicle) {
-			Output::Warning("ConditionalBranch: Invalid vehicle ID {}", vehicle_id);
+			Output::Warning("ConditionalBranch: Invalid vehicle ID {}", static_cast<int>(vehicle_id));
 			return true;
 		}
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -345,7 +345,7 @@ bool Game_Interpreter_Map::CommandEndShop(lcf::rpg::EventCommand const& /* com *
 
 bool Game_Interpreter_Map::CommandShowInn(lcf::rpg::EventCommand const& com) { // code 10730
 	int inn_type = com.parameters[0];
-	auto inn_price = com.parameters[1];
+	int inn_price = com.parameters[1];
 	// Not used, but left here for documentation purposes
 	// bool has_inn_handlers = com.parameters[2] != 0;
 

--- a/src/output.h
+++ b/src/output.h
@@ -22,16 +22,7 @@
 #include <string>
 #include <iosfwd>
 #include <fmt/core.h>
-#include <lcf/dbstring.h>
-
 #include "filesystem_stream.h"
-
-namespace lcf {
-// FIXME: liblcf doesn't depend on fmt, so we need to add this here to enable fmtlib support for lcf::DBString
-inline fmt::basic_string_view<char> to_string_view(const lcf::DBString& s) {
-	return to_string_view(StringView(s));
-}
-}
 
 enum class LogLevel {
 	Error,

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1240,7 +1240,7 @@ void Player::SetupBattleTest() {
 		}
 
 		Output::Debug("BattleTest Mode 2k3 troop=({}) background=({}) formation=({}) condition=({}) terrain=({})",
-				args.troop_id, args.background.c_str(), args.formation, args.condition, args.terrain_id);
+				args.troop_id, args.background, static_cast<int>(args.formation), static_cast<int>(args.condition), args.terrain_id);
 	} else {
 		Output::Debug("BattleTest Mode 2k troop=({}) background=({})", args.troop_id, args.background);
 	}

--- a/src/string_view.cpp
+++ b/src/string_view.cpp
@@ -1,0 +1,34 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "string_view.h"
+
+#if FMT_VERSION >= EP_FMT_MODERN_VERSION
+
+#include <fmt/format.h>
+
+auto fmt::formatter<lcf::DBString>::format(const lcf::DBString& s, format_context& ctx) const -> decltype(ctx.out()) {
+	string_view sv(s.data(), s.size());
+	return formatter<string_view>::format(sv, ctx);
+}
+
+auto fmt::formatter<lcf::StringView>::format(const lcf::StringView& s, format_context& ctx) const -> decltype(ctx.out()) {
+	string_view sv(s.data(), s.size());
+	return formatter<string_view>::format(sv, ctx);
+}
+
+#endif

--- a/src/string_view.h
+++ b/src/string_view.h
@@ -22,9 +22,9 @@
 #include <lcf/dbstring.h>
 #include <fmt/core.h>
 
-// FIXME: needed to allow building with fmt 5, older versions are untested.
+// Needed to allow building with fmt 5, older versions are untested.
 #if FMT_VERSION < 60000
-#include <fmt/ostream.h>
+#  include <fmt/ostream.h>
 #endif
 
 using StringView = lcf::StringView;
@@ -33,12 +33,33 @@ using U32StringView = lcf::U32StringView;
 using lcf::ToString;
 using lcf::ToStringView;
 
+// Version required to use the new formatting API
+#define EP_FMT_MODERN_VERSION 80000
+
 // FIXME: liblcf doesn't depend on fmt, so we need to add this here to enable fmtlib support for our StringView.
+#if FMT_VERSION >= EP_FMT_MODERN_VERSION
+template<>
+struct fmt::formatter<lcf::StringView> : fmt::formatter<fmt::string_view> {
+	auto format(const lcf::StringView& s, format_context& ctx) const -> decltype(ctx.out());
+};
+
+template<>
+struct fmt::formatter<lcf::DBString> : formatter<string_view> {
+	auto format(const lcf::DBString& s, format_context& ctx) const -> decltype(ctx.out());
+};
+#else
 namespace nonstd { namespace sv_lite {
 template <typename C, typename T>
 inline fmt::basic_string_view<C> to_string_view(basic_string_view<C,T> s) {
-    return fmt::basic_string_view<C>(s.data(), s.size());
+	return fmt::basic_string_view<C>(s.data(), s.size());
 }
 } }
+
+namespace lcf {
+inline fmt::basic_string_view<char> to_string_view(const lcf::DBString& s) {
+	return to_string_view(StringView(s));
+}
+}
+#endif
 
 #endif


### PR DESCRIPTION
to_string_view is a private API since fmt10.

The new API only works properly since fmt8.

Added casts to enum formating as they are not converted automatically anymore.

Fix #3002


Tested this down until fmt 5.2: Still compiles (fmt 7 doesn't compile at all but 6 and 8 work, so must be an upstream issue)