### PR TITLE
Fix Samsung Multitouch bug

### DIFF
--- a/builds/android/app/src/main/java/org/easyrpg/player/Helper.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/Helper.java
@@ -8,6 +8,7 @@ import android.database.Cursor;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Paint.Style;
+import android.graphics.Point;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsContract;
@@ -318,5 +319,16 @@ public class Helper {
             return mimeType.equals(DocumentsContract.Document.MIME_TYPE_DIR);
         }
         return false;
+    }
+
+    public static double getTouchScale(Context context) {
+        // via https://github.com/F0RIS/SamsungMultitouchBugSample/blob/Fix1/app/src/main/java/com/jelly/blob/TouchView.java
+        DisplayMetrics displayMetrics = new DisplayMetrics();
+        Point outSmallestSize = new Point();
+        Point outLargestSize = new Point();
+        ((Activity)context).getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+        ((Activity)context).getWindowManager().getDefaultDisplay().getCurrentSizeRange(outSmallestSize, outLargestSize);
+
+        return Math.max(displayMetrics.widthPixels, displayMetrics.heightPixels) / (float) outLargestSize.x;
     }
 }

--- a/builds/android/app/src/main/java/org/easyrpg/player/button_mapping/VirtualCross.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/button_mapping/VirtualCross.java
@@ -4,10 +4,12 @@ import android.app.Activity;
 import android.graphics.Canvas;
 import android.graphics.Path;
 import android.graphics.Rect;
+import android.util.Log;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 
 import org.easyrpg.player.Helper;
+import org.easyrpg.player.player.EasyRpgPlayerActivity;
 import org.easyrpg.player.settings.SettingsManager;
 import org.libsdl.app.SDLActivity;
 
@@ -60,13 +62,23 @@ public class VirtualCross extends VirtualButton {
             int action = event.getActionMasked();
             int keyCode = -1;
 
-            if (boundLeft.contains(this.getLeft() + (int) event.getX(), this.getTop() + (int) event.getY())) {
+            float x = event.getX() + this.getLeft();
+            float y = event.getY() + this.getTop();
+
+            // bug is hard to detect here, instead rely on the detection by the other buttons (see #2915)
+            if (EasyRpgPlayerActivity.pointerCount > 1 && EasyRpgPlayerActivity.samsungMultitouchWorkaround) {
+                double scale = Helper.getTouchScale(getContext());
+                x /= scale;
+                y /= scale;
+            }
+
+            if (boundLeft.contains((int)x, (int)y)) {
                 keyCode = KeyEvent.KEYCODE_DPAD_LEFT;
-            } else if (boundRight.contains(this.getLeft() + (int) event.getX(), this.getTop() + (int) event.getY())) {
+            } else if (boundRight.contains((int)x, (int)y)) {
                 keyCode = KeyEvent.KEYCODE_DPAD_RIGHT;
-            } else if (boundUp.contains(this.getLeft() + (int) event.getX(), this.getTop() + (int) event.getY())) {
+            } else if (boundUp.contains((int)x, (int)y)) {
                 keyCode = KeyEvent.KEYCODE_DPAD_UP;
-            } else if (boundDown.contains(this.getLeft() + (int) event.getX(), this.getTop() + (int) event.getY())) {
+            } else if (boundDown.contains((int)x, (int)y)) {
                 keyCode = KeyEvent.KEYCODE_DPAD_DOWN;
             }
 

--- a/builds/android/app/src/main/java/org/easyrpg/player/player/EasyRpgPlayerActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/player/EasyRpgPlayerActivity.java
@@ -38,6 +38,7 @@ import android.text.method.LinkMovementMethod;
 import android.text.util.Linkify;
 import android.util.Log;
 import android.view.MenuItem;
+import android.view.MotionEvent;
 import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup;
@@ -74,6 +75,9 @@ public class EasyRpgPlayerActivity extends SDLActivity implements NavigationView
     public static final String TAG_COMMAND_LINE = "command_line";
     public static final String TAG_STANDALONE = "standalone_mode";
     public static final int LAYOUT_EDIT = 12345;
+
+    public static boolean samsungMultitouchWorkaround = false;
+    public static int pointerCount = 0;
 
     DrawerLayout drawer;
     InputLayout inputLayout;
@@ -145,6 +149,12 @@ public class EasyRpgPlayerActivity extends SDLActivity implements NavigationView
         setFastForwardMultiplier(SettingsManager.getFastForwardMultiplier());
 
         showInputLayout();
+    }
+
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent ev) {
+        pointerCount = ev.getPointerCount();
+        return super.dispatchTouchEvent(ev);
     }
 
     /**


### PR DESCRIPTION
I'm pretty annoyed right now but I think this is working >.>

Please also test on other devices to ensure my heuristic does not cause fall-positives.

-------

This happens when a game is running (GlSurface exists) and a touch happens across different views.
Our touch ui uses one view per button and is affected.

The culprit is a game optimisation that reduces the size of the surface.

Fix is based on https://github.com/F0RIS/SamsungMultitouchBugSample/tree/Fix1

See also: https://github.com/Swordfish90/Lemuroid/issues/178

Fix #2830
Fix https://github.com/EasyRPG/Player/issues/2915