### PR TITLE
Widescreen improvements

### DIFF
--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -31,6 +31,8 @@
 #include "player.h"
 #include "options.h"
 #include "drawable_mgr.h"
+#include "scene_map.h"
+#include "spriteset_map.h"
 
 BattleAnimation::BattleAnimation(const lcf::rpg::Animation& anim, bool only_sound, int cutoff) :
 	animation(anim), only_sound(only_sound)
@@ -261,9 +263,16 @@ void BattleAnimationMap::DrawSingle(Bitmap& dst) {
 		return;
 	}
 	const int character_height = 24;
-	int vertical_center = target.GetScreenY(false, false) - character_height / 2;
+	int x_off = target.GetScreenX();
+	int y_off = target.GetScreenY(false, false);
+	if (Scene::instance->type == Scene::Map) {
+		x_off += static_cast<Scene_Map*>(Scene::instance.get())->spriteset->GetRenderOx();
+		y_off += static_cast<Scene_Map*>(Scene::instance.get())->spriteset->GetRenderOy();
+	}
+	int vertical_center = y_off - character_height / 2;
 	int offset = CalculateOffset(animation.position, character_height);
-	DrawAt(dst, target.GetScreenX(), vertical_center + offset);
+
+	DrawAt(dst, x_off, vertical_center + offset);
 }
 
 void BattleAnimationMap::FlashTargets(int r, int g, int b, int p) {

--- a/src/drawable.h
+++ b/src/drawable.h
@@ -61,21 +61,44 @@ public:
 
 	void SetZ(Z_t z);
 
-	/* @return true if this drawable should appear in all scenes */
+	/** @return true if this drawable should appear in all scenes */
 	bool IsGlobal() const;
 
-	/* @return true if this drawable should appear in all scenes that use shared drawables */
+	/** @return true if this drawable should appear in all scenes that use shared drawables */
 	bool IsShared() const;
 
-	/* @return true if the drawable is currently visible */
+	/** @return true if the drawable is currently visible */
 	bool IsVisible() const;
 
 	/**
-	 * Set if the drawable should be visisble
+	 * Set if the drawable should be visible
 	 *
 	 * @param value whether is visible or not.
 	 */
 	void SetVisible(bool value);
+
+	/** @return x offset for the rendering */
+	int GetRenderOx() const;
+
+	/**
+	 * Sets the rendering offset in x direction. Used for custom resolutions.
+	 * This is not enforced by the Drawable. Drawables must honor this value.
+	 *
+	 * @param offset_x x offset
+	 */
+	// FIXME: Currently only used by panorama, sprites and tiles on the map
+	void SetRenderOx(int offset_x);
+
+	/** @return y offset for the rendering */
+	int GetRenderOy() const;
+
+	/**
+	 * Sets the rendering offset in y direction. Used for custom resolutions.
+	 * This is not enforced by the Drawable. Drawables must honor this value.
+	 *
+	 * @param offset_y y offset
+	 */
+	void SetRenderOy(int offset_y);
 
 	/**
 	 * Converts a RPG Maker map layer value into a EasyRPG priority value.
@@ -93,6 +116,8 @@ public:
 private:
 	Z_t _z = 0;
 	Flags _flags = Flags::Default;
+	int render_ox = 0;
+	int render_oy = 0;
 };
 
 inline Drawable::Flags operator|(Drawable::Flags l, Drawable::Flags r) {
@@ -135,6 +160,22 @@ inline bool Drawable::IsVisible() const {
 
 inline void Drawable::SetVisible(bool value) {
 	_flags = value ? _flags & ~Flags::Invisible : _flags | Flags::Invisible;
+}
+
+inline int Drawable::GetRenderOx() const {
+	return render_ox;
+}
+
+inline void Drawable::SetRenderOx(int offset_x) {
+	render_ox = offset_x;
+}
+
+inline int Drawable::GetRenderOy() const {
+	return render_oy;
+}
+
+inline void Drawable::SetRenderOy(int offset_y) {
+	render_oy = offset_y;
 }
 
 // Upper 8 bit are reserved for the layer 

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -74,12 +74,12 @@ int Game_Character::GetScreenX(bool apply_shift) const {
 	int x = GetSpriteX() / TILE_SIZE - Game_Map::GetDisplayX() / TILE_SIZE + TILE_SIZE;
 
 	if (Game_Map::LoopHorizontal()) {
-		x = Utils::PositiveModulo(x, Game_Map::GetWidth() * TILE_SIZE);
+		x = Utils::PositiveModulo(x, Game_Map::GetTilesX() * TILE_SIZE);
 	}
 	x -= TILE_SIZE / 2;
 
 	if (apply_shift) {
-		x += Game_Map::GetWidth() * TILE_SIZE;
+		x += Game_Map::GetTilesX() * TILE_SIZE;
 	}
 
 	return x;
@@ -93,11 +93,11 @@ int Game_Character::GetScreenY(bool apply_shift, bool apply_jump) const {
 	}
 
 	if (Game_Map::LoopVertical()) {
-		y = Utils::PositiveModulo(y, Game_Map::GetHeight() * TILE_SIZE);
+		y = Utils::PositiveModulo(y, Game_Map::GetTilesY() * TILE_SIZE);
 	}
 
 	if (apply_shift) {
-		y += Game_Map::GetHeight() * TILE_SIZE;
+		y += Game_Map::GetTilesY() * TILE_SIZE;
 	}
 
 	return y;
@@ -699,7 +699,7 @@ bool Game_Character::Jump(int x, int y) {
 	// Adjust positions for looping maps. jump begin positions
 	// get set off the edge of the map to preserve direction.
 	if (Game_Map::LoopHorizontal()
-			&& (x < 0 || x >= Game_Map::GetWidth()))
+			&& (x < 0 || x >= Game_Map::GetTilesX()))
 	{
 		const auto old_x = x;
 		x = Game_Map::RoundX(x);
@@ -707,7 +707,7 @@ bool Game_Character::Jump(int x, int y) {
 	}
 
 	if (Game_Map::LoopVertical()
-			&& (y < 0 || y >= Game_Map::GetHeight()))
+			&& (y < 0 || y >= Game_Map::GetTilesY()))
 	{
 		auto old_y = y;
 		y = Game_Map::RoundY(y);
@@ -727,11 +727,11 @@ bool Game_Character::Jump(int x, int y) {
 int Game_Character::DistanceXfromPlayer() const {
 	int sx = GetX() - Main_Data::game_player->GetX();
 	if (Game_Map::LoopHorizontal()) {
-		if (std::abs(sx) > Game_Map::GetWidth() / 2) {
+		if (std::abs(sx) > Game_Map::GetTilesX() / 2) {
 			if (sx > 0)
-				sx -= Game_Map::GetWidth();
+				sx -= Game_Map::GetTilesX();
 			else
-				sx += Game_Map::GetWidth();
+				sx += Game_Map::GetTilesX();
 		}
 	}
 	return sx;
@@ -740,11 +740,11 @@ int Game_Character::DistanceXfromPlayer() const {
 int Game_Character::DistanceYfromPlayer() const {
 	int sy = GetY() - Main_Data::game_player->GetY();
 	if (Game_Map::LoopVertical()) {
-		if (std::abs(sy) > Game_Map::GetHeight() / 2) {
+		if (std::abs(sy) > Game_Map::GetTilesY() / 2) {
 			if (sy > 0)
-				sy -= Game_Map::GetHeight();
+				sy -= Game_Map::GetTilesY();
 			else
-				sy += Game_Map::GetHeight();
+				sy += Game_Map::GetTilesY();
 		}
 	}
 	return sy;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -459,7 +459,7 @@ static void ClampingAdd(int low, int high, int& acc, int& inc) {
 }
 
 void Game_Map::AddScreenX(int& screen_x, int& inc) {
-	int map_width = GetWidth() * SCREEN_TILE_SIZE;
+	int map_width = GetTilesX() * SCREEN_TILE_SIZE;
 	if (LoopHorizontal()) {
 		screen_x = (screen_x + inc) % map_width;
 	} else {
@@ -468,7 +468,7 @@ void Game_Map::AddScreenX(int& screen_x, int& inc) {
 }
 
 void Game_Map::AddScreenY(int& screen_y, int& inc) {
-	int map_height = GetHeight() * SCREEN_TILE_SIZE;
+	int map_height = GetTilesY() * SCREEN_TILE_SIZE;
 	if (LoopVertical()) {
 		screen_y = (screen_y + inc) % map_height;
 	} else {
@@ -477,7 +477,7 @@ void Game_Map::AddScreenY(int& screen_y, int& inc) {
 }
 
 bool Game_Map::IsValid(int x, int y) {
-	return (x >= 0 && x < GetWidth() && y >= 0 && y < GetHeight());
+	return (x >= 0 && x < GetTilesX() && y >= 0 && y < GetTilesY());
 }
 
 static int GetPassableMask(int old_x, int old_y, int new_x, int new_y) {
@@ -673,7 +673,7 @@ bool Game_Map::CanLandAirship(int x, int y) {
 
 	const int bit = Passable::Down | Passable::Right | Passable::Left | Passable::Up;
 
-	int tile_index = x + y * GetWidth();
+	int tile_index = x + y * GetTilesX();
 
 	if (!IsPassableLowerTile(bit, tile_index)) {
 		return false;
@@ -792,7 +792,7 @@ bool Game_Map::IsPassableTile(const Game_Character* self, int bit, int x, int y)
 		};
 	}
 
-	int tile_index = x + y * GetWidth();
+	int tile_index = x + y * GetTilesX();
 	int tile_id = map->upper_layer[tile_index] - BLOCK_F;
 	tile_id = map_info.upper_tiles[tile_id];
 
@@ -825,7 +825,7 @@ int Game_Map::GetBushDepth(int x, int y) {
 bool Game_Map::IsCounter(int x, int y) {
 	if (!Game_Map::IsValid(x, y)) return false;
 
-	int const tile_id = map->upper_layer[x + y * GetWidth()];
+	int const tile_id = map->upper_layer[x + y * GetTilesX()];
 	if (tile_id < BLOCK_F) return false;
 	int const index = map_info.upper_tiles[tile_id - BLOCK_F];
 	return !!(passages_up[index] & Passable::Counter);
@@ -857,7 +857,7 @@ int Game_Map::GetTerrainTag(int x, int y) {
 	unsigned chip_index = 0;
 
 	if (Game_Map::IsValid(x, y)) {
-		const auto chip_id = map->lower_layer[x + y * GetWidth()];
+		const auto chip_id = map->lower_layer[x + y * GetTilesX()];
 		chip_index = ChipIdToIndex(chip_id);
 
 		// Apply tile substitution
@@ -900,7 +900,7 @@ bool Game_Map::LoopVertical() {
 
 int Game_Map::RoundX(int x, int units) {
 	if (LoopHorizontal()) {
-		return Utils::PositiveModulo(x, GetWidth() * units);
+		return Utils::PositiveModulo(x, GetTilesX() * units);
 	} else {
 		return x;
 	}
@@ -908,7 +908,7 @@ int Game_Map::RoundX(int x, int units) {
 
 int Game_Map::RoundY(int y, int units) {
 	if (LoopVertical()) {
-		return Utils::PositiveModulo(y, GetHeight() * units);
+		return Utils::PositiveModulo(y, GetTilesY() * units);
 	} else {
 		return y;
 	}
@@ -916,7 +916,7 @@ int Game_Map::RoundY(int y, int units) {
 
 int Game_Map::RoundDx(int dx, int units) {
 	if (LoopHorizontal()) {
-		return Utils::PositiveModulo(std::abs(dx), GetWidth() * units) * Utils::Sign(dx);
+		return Utils::PositiveModulo(std::abs(dx), GetTilesX() * units) * Utils::Sign(dx);
 	} else {
 		return dx;
 	}
@@ -924,7 +924,7 @@ int Game_Map::RoundDx(int dx, int units) {
 
 int Game_Map::RoundDy(int dy, int units) {
 	if (LoopVertical()) {
-		return Utils::PositiveModulo(std::abs(dy), GetHeight() * units) * Utils::Sign(dy);
+		return Utils::PositiveModulo(std::abs(dy), GetTilesY() * units) * Utils::Sign(dy);
 	} else {
 		return dy;
 	}
@@ -1210,11 +1210,11 @@ void Game_Map::PrintPathToMap() {
 	Output::Debug("Tree: {}", ss.str());
 }
 
-int Game_Map::GetWidth() {
+int Game_Map::GetTilesX() {
 	return map->width;
 }
 
-int Game_Map::GetHeight() {
+int Game_Map::GetTilesY() {
 	return map->height;
 }
 
@@ -1391,7 +1391,7 @@ int Game_Map::GetDisplayX() {
 }
 
 void Game_Map::SetPositionX(int x, bool reset_panorama) {
-	const int map_width = GetWidth() * SCREEN_TILE_SIZE;
+	const int map_width = GetTilesX() * SCREEN_TILE_SIZE;
 	if (LoopHorizontal()) {
 		x = Utils::PositiveModulo(x, map_width);
 	} else {
@@ -1413,7 +1413,7 @@ int Game_Map::GetDisplayY() {
 }
 
 void Game_Map::SetPositionY(int y, bool reset_panorama) {
-	const int map_height = GetHeight() * SCREEN_TILE_SIZE;
+	const int map_height = GetTilesY() * SCREEN_TILE_SIZE;
 	if (LoopVertical()) {
 		y = Utils::PositiveModulo(y, map_height);
 	} else {
@@ -1738,8 +1738,8 @@ void Game_Map::Parallax::ResetPositionX() {
 			++tiles_per_screen;
 		}
 
-		if (GetWidth() > tiles_per_screen && parallax_width > screen_width) {
-			const int w = (GetWidth() - tiles_per_screen) * TILE_SIZE;
+		if (GetTilesX() > tiles_per_screen && parallax_width > screen_width) {
+			const int w = (GetTilesX() - tiles_per_screen) * TILE_SIZE;
 			const int ph = 2 * std::min(w, parallax_width - screen_width) * map_info.position_x / w;
 			if (Player::IsRPG2k()) {
 				SetPositionX(ph);
@@ -1776,8 +1776,8 @@ void Game_Map::Parallax::ResetPositionY() {
 			++tiles_per_screen;
 		}
 
-		if (GetHeight() > tiles_per_screen && parallax_height > screen_height) {
-			const int h = (GetHeight() - tiles_per_screen) * TILE_SIZE;
+		if (GetTilesY() > tiles_per_screen && parallax_height > screen_height) {
+			const int h = (GetTilesY() - tiles_per_screen) * TILE_SIZE;
 			const int pv = 2 * std::min(h, parallax_height - screen_height) * map_info.position_y / h;
 			SetPositionY(pv);
 		} else {

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -331,19 +331,11 @@ namespace Game_Map {
 	 */
 	void PrintPathToMap();
 
-	/**
-	 * Gets current map width.
-	 *
-	 * @return current map width.
-	 */
-	int GetWidth();
+	/** @return amount of tiles in x direction */
+	int GetTilesX();
 
-	/**
-	 * Gets current map height.
-	 *
-	 * @return current map height.
-	 */
-	int GetHeight();
+	/** @return amount of tiles in y direction */
+	int GetTilesY();
 
 	/** @return original map battle encounter rate steps. */
 	int GetOriginalEncounterSteps();

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -193,8 +193,8 @@ void Game_Player::UpdateScroll(int amount, bool was_jumping) {
 	auto dx = (GetX() * SCREEN_TILE_SIZE) - Game_Map::GetPositionX() - GetPanX();
 	auto dy = (GetY() * SCREEN_TILE_SIZE) - Game_Map::GetPositionY() - GetPanY();
 
-	const auto w = Game_Map::GetWidth() * SCREEN_TILE_SIZE;
-	const auto h = Game_Map::GetHeight() * SCREEN_TILE_SIZE;
+	const auto w = Game_Map::GetTilesX() * SCREEN_TILE_SIZE;
+	const auto h = Game_Map::GetTilesY() * SCREEN_TILE_SIZE;
 
 	dx = Utils::PositiveModulo(dx + w / 2, w) - w / 2;
 	dy = Utils::PositiveModulo(dy + h / 2, h) - h / 2;

--- a/src/plane.cpp
+++ b/src/plane.cpp
@@ -60,7 +60,7 @@ void Plane::Draw(Bitmap& dst) {
 		// Using coordinates where the top-left of the screen is the origin...
 		// Minimal width is a 20 tile wide map by default, smaller maps are hacked
 		int bg_x = -Game_Map::GetDisplayX() / TILE_SIZE + shake_x;
-		int bg_width = std::max(Game_Map::GetWidth() * TILE_SIZE, Player::screen_width);
+		int bg_width = std::max(Game_Map::GetTilesX() * TILE_SIZE, Player::screen_width);
 
 		// Clip the panorama to the screen
 		if (bg_x < 0) {

--- a/src/plane.cpp
+++ b/src/plane.cpp
@@ -47,8 +47,8 @@ void Plane::Draw(Bitmap& dst) {
 	BitmapRef source = tone_effect == Tone() ? bitmap : tone_bitmap;
 
 	Rect dst_rect = dst.GetRect();
-	int src_x = -ox;
-	int src_y = -oy;
+	int src_x = -ox - GetRenderOx();
+	int src_y = -oy - GetRenderOy();
 
 	// Apply screen shaking
 	const int shake_x = Main_Data::game_screen->GetShakeOffsetX();

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -64,6 +64,8 @@ struct BattleArgs {
 
 constexpr int option_command_mov = 76;
 constexpr int option_command_time = 8;
+// size of options_window, command window and status window
+constexpr int battle_menu_offset_x = MENU_WIDTH + option_command_mov;
 
 /**
  * Scene_Battle class.

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -73,7 +73,7 @@ void Scene_Battle_Rpg2k::CreateUi() {
 		}
 	}
 
-	SetCommandWindows(Player::menu_offset_x);
+	SetCommandWindowsX();
 
 	ResetWindows(true);
 	battle_message_window->SetVisible(true);
@@ -136,9 +136,8 @@ void Scene_Battle_Rpg2k::CreateBattleCommandWindow() {
 		ToString(lcf::Data::terms.command_item)
 	};
 
-	command_window.reset(new Window_Command(std::move(commands), 76));
+	command_window.reset(new Window_Command(std::move(commands), option_command_mov));
 	command_window->SetHeight(80);
-	command_window->SetX(Player::screen_width - Player::menu_offset_x - option_command_mov);
 	command_window->SetY(Player::screen_height - Player::menu_offset_y - 80);
 }
 
@@ -395,7 +394,12 @@ void Scene_Battle_Rpg2k::ResetWindows(bool make_invisible) {
 	help_window->SetVisible(false);
 }
 
-void Scene_Battle_Rpg2k::SetCommandWindows(int x) {
+void Scene_Battle_Rpg2k::SetCommandWindowsX() {
+	int x = Player::menu_offset_x;
+	if (Player::screen_width >= battle_menu_offset_x) {
+		x = std::max<int>((Player::screen_width - battle_menu_offset_x) / 2, 0);
+	}
+
 	options_window->SetX(x);
 	x += options_window->GetWidth();
 	status_window->SetX(x);
@@ -404,6 +408,11 @@ void Scene_Battle_Rpg2k::SetCommandWindows(int x) {
 }
 
 void Scene_Battle_Rpg2k::MoveCommandWindows(int x, int frames) {
+	if (Player::screen_width >= battle_menu_offset_x) {
+		// Do not animate as they fit on the screen in widescreen mode
+		return;
+	}
+
 	options_window->InitMovement(options_window->GetX(), options_window->GetY(),
 			x, options_window->GetY(), frames);
 
@@ -457,7 +466,7 @@ Scene_Battle_Rpg2k::SceneActionReturn Scene_Battle_Rpg2k::ProcessSceneActionFigh
 		if (previous_state == State_SelectCommand) {
 			MoveCommandWindows(Player::menu_offset_x, 8);
 		} else {
-			SetCommandWindows(Player::menu_offset_x);
+			SetCommandWindowsX();
 		}
 		SetSceneActionSubState(eWaitForInput);
 		// Prevent that DECISION from a closed message triggers a battle option in eWaitForInput

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -151,10 +151,9 @@ protected:
 	void RefreshTargetWindow();
 
 	bool CheckBattleEndConditions();
-	bool RefreshEventsAndCheckBattleEnd();
 
 	void ResetWindows(bool make_invisible);
-	void SetCommandWindows(int x);
+	void SetCommandWindowsX();
 	void MoveCommandWindows(int x, int frames);
 	void RefreshCommandWindow();
 

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -130,7 +130,11 @@ void Scene_Title::TransitionIn(SceneType prev_scene) {
 	Transition::instance().InitShow(Transition::TransitionFadeIn, this);
 }
 
-void Scene_Title::Suspend(Scene::SceneType) {
+void Scene_Title::Suspend(Scene::SceneType scene_type) {
+	if (scene_type == Scene::Settings) {
+		restart_title_cache = true;
+	}
+
 	// Unload title graphic to save memory
 	title.reset();
 }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -33,10 +33,29 @@ void Screen::Draw(Bitmap& dst) {
 	auto flash_color = Main_Data::game_screen->GetFlashColor();
 	if (flash_color.alpha > 0) {
 		if (!flash) {
-			flash = Bitmap::Create(Player::screen_width, Player::screen_height, flash_color);
+			flash = Bitmap::Create(dst.GetWidth(), dst.GetHeight(), flash_color);
 		} else {
 			flash->Fill(flash_color);
 		}
 		dst.Blit(0, 0, *flash, flash->GetRect(), 255);
+	}
+
+	if (viewport != Rect()) {
+		// Clear all parts of the screen that are out-of-bounds
+		Rect dst_rect = dst.GetRect();
+		int dx = viewport.x - dst_rect.x;
+		int dy = viewport.y - dst_rect.y;
+
+		if (dx > 0) {
+			// Left and Right
+			dst.ClearRect({0, 0, dx, dst.GetHeight()});
+			dst.ClearRect({dst.GetWidth() - dx, 0, dx, dst.GetHeight()});
+		}
+
+		if (dy > 0) {
+			// Top and Bottom
+			dst.ClearRect({0, 0, dst.GetWidth(), dy});
+			dst.ClearRect({0, dst.GetHeight() - dy, dst.GetWidth(), dy});
+		}
 	}
 }

--- a/src/screen.h
+++ b/src/screen.h
@@ -38,8 +38,21 @@ public:
 
 	void Draw(Bitmap& dst) override;
 
+	Rect GetViewport() const;
+	void SetViewport(const Rect& rect);
+
 private:
 	BitmapRef flash;
+
+	Rect viewport;
 };
+
+inline Rect Screen::GetViewport() const {
+	return viewport;
+}
+
+inline void Screen::SetViewport(const Rect &rect) {
+	viewport = rect;
+}
 
 #endif

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -72,7 +72,7 @@ void Sprite::BlitScreenIntern(Bitmap& dst, Bitmap const& draw_bitmap, Rect const
 	double zoom_x = zoom_x_effect;
 	double zoom_y = zoom_y_effect;
 
-	dst.EffectsBlit(x, y, ox, oy, draw_bitmap, src_rect,
+	dst.EffectsBlit(x, y, ox - GetRenderOx(), oy - GetRenderOy(), draw_bitmap, src_rect,
 		Opacity(opacity_top_effect, opacity_bottom_effect, bush_effect),
 		zoom_x, zoom_y, angle_effect,
 		waver_effect_depth, waver_effect_phase, static_cast<Bitmap::BlendMode>(blend_type_effect));

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -282,6 +282,7 @@ void Spriteset_Map::CalculateMapRenderOffset() {
 
 	panorama->SetRenderOx(0);
 	panorama->SetRenderOy(0);
+	screen->SetViewport(Rect());
 
 	if (Player::game_config.fake_resolution.Get()) {
 		// Resolution hack for tiles and sprites
@@ -297,6 +298,8 @@ void Spriteset_Map::CalculateMapRenderOffset() {
 		}
 
 		CalculatePanoramaRenderOffset();
+
+		screen->SetViewport({map_render_ox, map_render_oy, map_tiles_x, map_tiles_y});
 	}
 }
 

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -54,8 +54,8 @@ Spriteset_Map::Spriteset_Map() {
 
 void Spriteset_Map::Refresh() {
 	tilemap.reset(new Tilemap());
-	tilemap->SetWidth(Game_Map::GetWidth());
-	tilemap->SetHeight(Game_Map::GetHeight());
+	tilemap->SetWidth(Game_Map::GetTilesX());
+	tilemap->SetHeight(Game_Map::GetTilesY());
 
 	airship_shadows.clear();
 	character_sprites.clear();

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -31,18 +31,17 @@
 #include "player.h"
 #include "drawable_list.h"
 
-// Constructor
 Spriteset_Map::Spriteset_Map() {
-	panorama.reset(new Plane());
+	panorama = std::make_unique<Plane>();
 	panorama->SetZ(Priority_Background);
 
-	timer1.reset(new Sprite_Timer(0));
-	timer2.reset(new Sprite_Timer(1));
+	timer1 = std::make_unique<Sprite_Timer>(0);
+	timer2 = std::make_unique<Sprite_Timer>(1);
 
-	screen.reset(new Screen());
+	screen = std::make_unique<Screen>();
 
 	if (Player::IsRPG2k3()) {
-		frame.reset(new Frame());
+		frame = std::make_unique<Frame>();
 	}
 
 	ParallaxUpdated();
@@ -86,9 +85,9 @@ void Spriteset_Map::Update() {
 	tilemap->SetOy(Game_Map::GetDisplayY() / (SCREEN_TILE_SIZE / TILE_SIZE));
 	tilemap->SetTone(new_tone);
 
-	for (size_t i = 0; i < character_sprites.size(); i++) {
-		character_sprites[i]->Update();
-		character_sprites[i]->SetTone(new_tone);
+	for (const auto& character_sprite : character_sprites) {
+		character_sprite->Update();
+		character_sprite->SetTone(new_tone);
 	}
 
 	int pan_x_off = 0;
@@ -122,18 +121,6 @@ void Spriteset_Map::Update() {
 	}
 
 	DynRpg::Update();
-}
-
-// Finds the sprite for a specific character
-Sprite_Character* Spriteset_Map::FindCharacter(Game_Character* character) const
-{
-	std::vector<std::shared_ptr<Sprite_Character> >::const_iterator it;
-	for (it = character_sprites.begin(); it != character_sprites.end(); ++it) {
-		Sprite_Character* sprite = it->get();
-		if (sprite->GetCharacter() == character)
-			return sprite;
-	}
-	return NULL;
 }
 
 void Spriteset_Map::ChipsetUpdated() {
@@ -229,15 +216,15 @@ bool Spriteset_Map::RequireClear(DrawableList& drawable_list) {
 void Spriteset_Map::CreateSprite(Game_Character* character, bool create_x_clone, bool create_y_clone) {
 	using CloneType = Sprite_Character::CloneType;
 
-	character_sprites.push_back(std::make_shared<Sprite_Character>(character));
+	character_sprites.push_back(std::make_unique<Sprite_Character>(character));
 	if (create_x_clone) {
-		character_sprites.push_back(std::make_shared<Sprite_Character>(character, CloneType::XClone));
+		character_sprites.push_back(std::make_unique<Sprite_Character>(character, CloneType::XClone));
 	}
 	if (create_y_clone) {
-		character_sprites.push_back(std::make_shared<Sprite_Character>(character, CloneType::YClone));
+		character_sprites.push_back(std::make_unique<Sprite_Character>(character, CloneType::YClone));
 	}
 	if (create_x_clone && create_y_clone) {
-		character_sprites.push_back(std::make_shared<Sprite_Character>(character,
+		character_sprites.push_back(std::make_unique<Sprite_Character>(character,
 			(CloneType)(CloneType::XClone | CloneType::YClone)));
 	}
 }
@@ -245,15 +232,15 @@ void Spriteset_Map::CreateSprite(Game_Character* character, bool create_x_clone,
 void Spriteset_Map::CreateAirshipShadowSprite(bool create_x_clone, bool create_y_clone) {
 	using CloneType = Sprite_AirshipShadow::CloneType;
 
-	airship_shadows.push_back(std::make_shared<Sprite_AirshipShadow>());
+	airship_shadows.push_back(std::make_unique<Sprite_AirshipShadow>());
 	if (create_x_clone) {
-		airship_shadows.push_back(std::make_shared<Sprite_AirshipShadow>(CloneType::XClone));
+		airship_shadows.push_back(std::make_unique<Sprite_AirshipShadow>(CloneType::XClone));
 	}
 	if (create_y_clone) {
-		airship_shadows.push_back(std::make_shared<Sprite_AirshipShadow>(CloneType::YClone));
+		airship_shadows.push_back(std::make_unique<Sprite_AirshipShadow>(CloneType::YClone));
 	}
 	if (create_x_clone && create_y_clone) {
-		airship_shadows.push_back(std::make_shared<Sprite_AirshipShadow>(
+		airship_shadows.push_back(std::make_unique<Sprite_AirshipShadow>(
 			(CloneType)(CloneType::XClone | CloneType::YClone)));
 	}
 }

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -52,7 +52,7 @@ Spriteset_Map::Spriteset_Map() {
 }
 
 void Spriteset_Map::Refresh() {
-	CalculateRenderOffset();
+	CalculateMapRenderOffset();
 
 	tilemap = std::make_unique<Tilemap>();
 	tilemap->SetWidth(Game_Map::GetTilesX());
@@ -271,11 +271,14 @@ void Spriteset_Map::OnPanoramaSpriteReady(FileRequestResult* result) {
 	BitmapRef panorama_bmp = Cache::Panorama(result->file);
 	panorama->SetBitmap(panorama_bmp);
 	Game_Map::Parallax::Initialize(panorama_bmp->GetWidth(), panorama_bmp->GetHeight());
+	CalculatePanoramaRenderOffset();
 }
 
-void Spriteset_Map::CalculateRenderOffset() {
+void Spriteset_Map::CalculateMapRenderOffset() {
 	map_render_ox = 0;
 	map_render_oy = 0;
+	map_tiles_x = 0;
+	map_tiles_y = 0;
 
 	panorama->SetRenderOx(0);
 	panorama->SetRenderOy(0);
@@ -283,17 +286,23 @@ void Spriteset_Map::CalculateRenderOffset() {
 	if (Player::game_config.fake_resolution.Get()) {
 		// Resolution hack for tiles and sprites
 		// Smallest possible map. Smaller maps are hacked
-		int tiles_x = std::max<int>(Game_Map::GetTilesX(), 20) * TILE_SIZE;
-		int tiles_y = std::max<int>(Game_Map::GetTilesY(), 15) * TILE_SIZE;
+		map_tiles_x = std::max<int>(Game_Map::GetTilesX(), 20) * TILE_SIZE;
+		map_tiles_y = std::max<int>(Game_Map::GetTilesY(), 15) * TILE_SIZE;
 
-		if (tiles_x < Player::screen_width) {
-			map_render_ox = (Player::screen_width - tiles_x) / 2;
+		if (map_tiles_x < Player::screen_width) {
+			map_render_ox = (Player::screen_width - map_tiles_x) / 2;
 		}
-		if (tiles_y < Player::screen_height) {
-			map_render_oy = (Player::screen_height - tiles_y) / 2;
+		if (map_tiles_y < Player::screen_height) {
+			map_render_oy = (Player::screen_height - map_tiles_y) / 2;
 		}
 
-		// Resolution hack for Panorama
+		CalculatePanoramaRenderOffset();
+	}
+}
+
+void Spriteset_Map::CalculatePanoramaRenderOffset() {
+	// Resolution hack for Panorama
+	if (Player::game_config.fake_resolution.Get()) {
 		if (Game_Map::Parallax::FakeXPosition()) {
 			panorama->SetRenderOx((Player::screen_width - SCREEN_TARGET_WIDTH) / 2);
 		}

--- a/src/spriteset_map.h
+++ b/src/spriteset_map.h
@@ -78,9 +78,13 @@ public:
 
 	/**
 	 * Determines the map render offset when Fake Resolution is used.
-	 * Applies offset for panorama.
 	 */
-	void CalculateRenderOffset();
+	void CalculateMapRenderOffset();
+
+	/**
+	 * Determines the panorama offset when Fake Resolution is used.
+	 */
+	void CalculatePanoramaRenderOffset();
 
 protected:
 	std::unique_ptr<Tilemap> tilemap;
@@ -107,6 +111,8 @@ protected:
 
 	int map_render_ox = 0;
 	int map_render_oy = 0;
+	int map_tiles_x = 0;
+	int map_tiles_y = 0;
 
 	bool vehicle_loaded[3] = {};
 

--- a/src/spriteset_map.h
+++ b/src/spriteset_map.h
@@ -25,11 +25,11 @@
 #include "plane.h"
 #include "screen.h"
 #include "sprite_airshipshadow.h"
+#include "sprite_character.h"
 #include "sprite_timer.h"
 #include "system.h"
 #include "tilemap.h"
 
-class Sprite_Character;
 class Game_Character;
 class FileRequestAsync;
 class DrawableList;
@@ -45,11 +45,6 @@ public:
 	void Refresh();
 
 	void Update();
-
-	/**
-	 * Finds the sprite for a specific character.
-	 */
-	Sprite_Character* FindCharacter(Game_Character* character) const;
 
 	/**
 	 * Notifies that the map's chipset has changed.
@@ -85,8 +80,8 @@ protected:
 	std::unique_ptr<Tilemap> tilemap;
 	std::unique_ptr<Plane> panorama;
 	std::string panorama_name;
-	std::vector<std::shared_ptr<Sprite_Character>> character_sprites;
-	std::vector<std::shared_ptr<Sprite_AirshipShadow>> airship_shadows;
+	std::vector<std::unique_ptr<Sprite_Character>> character_sprites;
+	std::vector<std::unique_ptr<Sprite_AirshipShadow>> airship_shadows;
 	std::unique_ptr<Sprite_Timer> timer1;
 	std::unique_ptr<Sprite_Timer> timer2;
 	std::unique_ptr<Screen> screen;

--- a/src/spriteset_map.h
+++ b/src/spriteset_map.h
@@ -76,6 +76,12 @@ public:
 	 */
 	bool RequireClear(DrawableList& drawable_list);
 
+	/**
+	 * Determines the map render offset when Fake Resolution is used.
+	 * Applies offset for panorama.
+	 */
+	void CalculateRenderOffset();
+
 protected:
 	std::unique_ptr<Tilemap> tilemap;
 	std::unique_ptr<Plane> panorama;
@@ -98,6 +104,9 @@ protected:
 
 	bool need_x_clone = false;
 	bool need_y_clone = false;
+
+	int map_render_ox = 0;
+	int map_render_oy = 0;
 
 	bool vehicle_loaded[3] = {};
 

--- a/src/spriteset_map.h
+++ b/src/spriteset_map.h
@@ -86,6 +86,12 @@ public:
 	 */
 	void CalculatePanoramaRenderOffset();
 
+	/** @return x offset for the rendering of the tilemap and events */
+	int GetRenderOx() const;
+
+	/** @return y offset for the rendering of the tilemap and events */
+	int GetRenderOy() const;
+
 protected:
 	std::unique_ptr<Tilemap> tilemap;
 	std::unique_ptr<Plane> panorama;
@@ -118,4 +124,12 @@ protected:
 
 	Tone last_tone;
 };
+
+inline int Spriteset_Map::GetRenderOx() const {
+	return map_render_ox;
+}
+
+inline int Spriteset_Map::GetRenderOy() const {
+	return map_render_oy;
+}
 #endif

--- a/src/spriteset_map.h
+++ b/src/spriteset_map.h
@@ -77,7 +77,7 @@ public:
 	bool RequireClear(DrawableList& drawable_list);
 
 	/**
-	 * Determines the map render offset when Fake Resolution is used.
+	 * Determines the map render offset when Fake Resolution is used and sets the viewport of the screen for cropping.
 	 */
 	void CalculateMapRenderOffset();
 

--- a/src/tilemap.cpp
+++ b/src/tilemap.cpp
@@ -54,6 +54,20 @@ void Tilemap::SetOy(int noy) {
 	layer_down.SetOy(noy);
 	layer_up.SetOy(noy);
 }
+int Tilemap::GetRenderOx() const {
+	return layer_down.GetRenderOx();
+}
+void Tilemap::SetRenderOx(int render_x) {
+	layer_down.SetRenderOx(render_x);
+	layer_up.SetRenderOx(render_x);
+}
+int Tilemap::GetRenderOy() const {
+	return layer_down.GetRenderOy();
+}
+void Tilemap::SetRenderOy(int render_y) {
+	layer_down.SetRenderOy(render_y);
+	layer_up.SetRenderOy(render_y);
+}
 int Tilemap::GetWidth() const {
 	return layer_down.GetWidth();
 }

--- a/src/tilemap.h
+++ b/src/tilemap.h
@@ -52,6 +52,10 @@ public:
 	void SetOx(int nox);
 	int GetOy() const;
 	void SetOy(int noy);
+	int GetRenderOx() const;
+	void SetRenderOx(int offset_x);
+	int GetRenderOy() const;
+	void SetRenderOy(int offset_y);
 	int GetWidth() const;
 	void SetWidth(int nwidth);
 	int GetHeight() const;

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -205,17 +205,17 @@ static uint32_t MakeAbTileHash(int id, int anim_step) {
 	return static_cast<uint32_t>((id + (anim_step << 12)) | (4 << 24));
 }
 
-void TilemapLayer::Draw(Bitmap& dst, uint8_t z_order) {
+void TilemapLayer::Draw(Bitmap& dst, uint8_t z_order, int render_ox, int render_oy) {
 	// Get the number of tiles that can be displayed on window
 	int tiles_x = (int)ceil(Player::screen_width / (float)TILE_SIZE);
 	int tiles_y = (int)ceil(Player::screen_height / (float)TILE_SIZE);
 
 	// If ox or oy are not equal to the tile size draw the next tile too
 	// to prevent black (empty) tiles at the borders
-	if (ox % TILE_SIZE != 0) {
+	if ((ox - render_ox) % TILE_SIZE != 0) {
 		++tiles_x;
 	}
-	if (oy % TILE_SIZE != 0) {
+	if ((oy - render_oy) % TILE_SIZE != 0) {
 		++tiles_y;
 	}
 
@@ -244,11 +244,11 @@ void TilemapLayer::Draw(Bitmap& dst, uint8_t z_order) {
 		}
 	}
 
-	const int div_ox = div_rounding_down(ox, TILE_SIZE);
-	const int div_oy = div_rounding_down(oy, TILE_SIZE);
+	const int div_ox = div_rounding_down(ox - render_ox, TILE_SIZE);
+	const int div_oy = div_rounding_down(oy - render_oy, TILE_SIZE);
 
-	const int mod_ox = mod(ox, TILE_SIZE);
-	const int mod_oy = mod(oy, TILE_SIZE);
+	const int mod_ox = mod(ox - render_ox, TILE_SIZE);
+	const int mod_oy = mod(oy - render_oy, TILE_SIZE);
 
 	for (int y = 0; y < tiles_y; y++) {
 		for (int x = 0; x < tiles_x; x++) {
@@ -688,7 +688,7 @@ void TilemapSubLayer::Draw(Bitmap& dst) {
 		return;
 	}
 
-	tilemap->Draw(dst, internal_z);
+	tilemap->Draw(dst, internal_z, GetRenderOx(), GetRenderOy());
 }
 
 void TilemapLayer::SetTone(Tone tone) {

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -60,7 +60,7 @@ public:
 
 	TilemapLayer(int ilayer);
 
-	void Draw(Bitmap& dst, uint8_t z_order);
+	void Draw(Bitmap& dst, uint8_t z_order, int render_ox, int render_oy);
 
 	BitmapRef const& GetChipset() const;
 	void SetChipset(BitmapRef const& nchipset);
@@ -74,6 +74,10 @@ public:
 	void SetOx(int nox);
 	int GetOy() const;
 	void SetOy(int noy);
+	int GetRenderOx() const;
+	void SetRenderOx(int offset_x);
+	int GetRenderOy() const;
+	void SetRenderOy(int offset_y);
 	int GetWidth() const;
 	void SetWidth(int nwidth);
 	int GetHeight() const;
@@ -195,6 +199,24 @@ inline int TilemapLayer::GetOy() const {
 
 inline void TilemapLayer::SetOy(int noy) {
 	oy = noy;
+}
+
+inline int TilemapLayer::GetRenderOx() const {
+	return lower_layer.GetRenderOx();
+}
+
+inline void TilemapLayer::SetRenderOx(int offset_x) {
+	lower_layer.SetRenderOx(offset_x);
+	upper_layer.SetRenderOx(offset_x);
+}
+
+inline int TilemapLayer::GetRenderOy() const {
+	return lower_layer.GetRenderOy();
+}
+
+inline void TilemapLayer::SetRenderOy(int offset_y) {
+	lower_layer.SetRenderOy(offset_y);
+	upper_layer.SetRenderOy(offset_y);
 }
 
 inline int TilemapLayer::GetWidth() const {

--- a/src/transition.cpp
+++ b/src/transition.cpp
@@ -29,6 +29,8 @@
 #include "graphics.h"
 #include "main_data.h"
 #include "scene.h"
+#include "scene_map.h"
+#include "spriteset_map.h"
 #include "baseui.h"
 #include "drawable.h"
 #include "drawable_mgr.h"
@@ -156,8 +158,10 @@ void Transition::SetAttributesTransitions() {
 	case TransitionZoomIn:
 	case TransitionZoomOut:
 		if (scene != nullptr && scene->type == Scene::Map) {
-			zoom_position[0] = std::max(0, std::min(Main_Data::game_player->GetScreenX(), (int)Player::screen_width));
-			zoom_position[1] = std::max(0, std::min(Main_Data::game_player->GetScreenY() - 8, (int)Player::screen_height));
+			auto map = static_cast<Scene_Map*>(Scene::instance.get());
+
+			zoom_position[0] = std::max(0, std::min(Main_Data::game_player->GetScreenX() + map->spriteset->GetRenderOx(), (int)Player::screen_width));
+			zoom_position[1] = std::max(0, std::min(Main_Data::game_player->GetScreenY() - 8 + map->spriteset->GetRenderOy(), (int)Player::screen_height));
 		}
 		else {
 			zoom_position[0] = Player::screen_width / 2;
@@ -347,6 +351,7 @@ void Transition::Draw(Bitmap& dst) {
 	case TransitionMosaicIn:
 	case TransitionMosaicOut:
 		// If TransitionMosaicIn, invert percentage and screen:
+		// FIXME: When the map is smaller than the viewport this will look weird because it mixes the black corners with the mosaic
 		if (transition_type == TransitionMosaicIn) { percentage = 100 - percentage; }
 		screen_pointer1 = transition_type == TransitionMosaicIn ? screen2 : screen1;
 


### PR DESCRIPTION
Like everything else the map is now centered when fake resolution is active. Should improve the UX because it gets rid of some glitches :).

First two commits are not changing any behaviour.

3rd commit allows to change the resolution while in the title scene. Until now this didn't work without: Start game, press F12.

4th and 5th commit: 4th results in the screenshot in the middle and 5th results in the screenshot at the bottom. (top is before) Cropping the panorama makes sense here because technically it is drawn outside of the size of the map, nothing should be drawn their.

![out2](https://github.com/EasyRPG/Player/assets/1331889/6d60d880-439e-4a7b-94ff-ea951db4c43e)

Another example using Fake Res for a custom resolution. That map is again 20x15. Cropping works.

![out](https://github.com/EasyRPG/Player/assets/1331889/33b5f853-ba95-4517-89a2-f3a9f65fc324)
