### PR TITLE
Battle: Fix broken animation when the sprite is flipped

### DIFF
--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -107,10 +107,9 @@ void BattleAnimation::DrawAt(Bitmap& dst, int x, int y) {
 			continue;
 		}
 
-		SetX(invert ? x - cell.x : cell.x + x);
+		SetX(cell.x + x);
 		SetY(cell.y + y);
 		int sx = cell.cell_id % 5;
-		if (invert) sx = 4 - sx;
 		int sy = cell.cell_id / 5;
 		int size = animation.large ? 128 : 96;
 		SetSrcRect(Rect(sx * size, sy * size, size, size));

--- a/src/sprite_actor.cpp
+++ b/src/sprite_actor.cpp
@@ -126,8 +126,7 @@ void Sprite_Actor::Update() {
 		animation->SetVisible(IsVisible());
 	}
 
-	const bool flip = battler->IsDirectionFlipped();
-	SetFlipX(flip);
+	SetFlipX(battler->IsDirectionFlipped());
 }
 
 void Sprite_Actor::SetAnimationState(int state, LoopState loop, int animation_id) {
@@ -268,7 +267,7 @@ void Sprite_Actor::DoIdleAnimation() {
 
 void Sprite_Actor::OnBattlercharsetReady(FileRequestResult* result, int32_t battler_index) {
 	SetBitmap(Cache::Battlecharset(result->file));
-	SetSrcRect(Rect((battler->IsDirectionFlipped() ? 96 : 0), battler_index * 48, 48, 48));
+	SetSrcRect(Rect(0, battler_index * 48, 48, 48));
 }
 
 void Sprite_Actor::Draw(Bitmap& dst) {

--- a/src/sprite_weapon.cpp
+++ b/src/sprite_weapon.cpp
@@ -64,8 +64,7 @@ void Sprite_Weapon::Update() {
 
 	SetSrcRect(Rect(frame * 64, battler_animation_weapon->weapon_index * 64, 64, 64));
 
-	const bool flip = battler->IsDirectionFlipped();
-	SetFlipX(flip);
+	SetFlipX(battler->IsDirectionFlipped());
 }
 
 void Sprite_Weapon::SetWeaponAnimation(int nweapon_animation_id) {
@@ -125,9 +124,8 @@ void Sprite_Weapon::CreateSprite() {
 
 void Sprite_Weapon::OnBattleWeaponReady(FileRequestResult* result, int32_t weapon_index) {
 	SetBitmap(Cache::Battleweapon(result->file));
-	const bool flip = battler->IsDirectionFlipped();
-	SetFlipX(flip);
-	SetSrcRect(Rect((flip ? 128 : 0), weapon_index * 64, 64, 64));
+	SetFlipX(battler->IsDirectionFlipped());
+	SetSrcRect(Rect(0, weapon_index * 64, 64, 64));
 }
 
 void Sprite_Weapon::Draw(Bitmap& dst) {


### PR DESCRIPTION
While fixing flipped spritesheets I forgot to consider that battle sprites can be also flipped.

The battle sprites contained adjustment for the src_rect when they were flipped. As I added a fix to the sprite class this means it was double-inverted and broke.

Solved this by removing all the adjustment code from the battle sprites.

(seeing these workarounds this means that this was a long-standing bug in the flip-code)

------

**Please test various 2k3 games and check if the battles look correct!**

I tested:

- Lufia V For the Savior