### PR TITLE
CMake: Fix Big endian detection when crosscompiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -767,11 +767,15 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
 endif()
 
 # Endianess check
-if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.20)
+	if (CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+		target_compile_definitions(${PROJECT_NAME} PRIVATE WORDS_BIGENDIAN=1)
+	endif()
+else()
 	include(TestBigEndian)
 	test_big_endian(WORDS_BIGENDIAN)
 	if(WORDS_BIGENDIAN)
-		target_compile_definitions(${PROJECT_NAME} PUBLIC WORDS_BIGENDIAN=1)
+		target_compile_definitions(${PROJECT_NAME} PRIVATE WORDS_BIGENDIAN=1)
 	endif()
 endif()
 

--- a/src/pixel_format.h
+++ b/src/pixel_format.h
@@ -532,7 +532,11 @@ public:
 	PixelFormatT(const DynamicFormat& format) : dynamic_traits(format) {}
 
 	static inline int endian(int byte) {
-		return Utils::IsBigEndian()? (bytes - 1 - byte) : byte;
+#if defined(WORDS_BIGENDIAN)
+		return bytes - 1 - byte;
+#else
+		return byte;
+#endif
 	}
 
 	inline void uint32_to_rgba(uint32_t pix, uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& a) const {

--- a/src/platform/sdl/sdl_ui.cpp
+++ b/src/platform/sdl/sdl_ui.cpp
@@ -79,25 +79,23 @@ SdlUi::SdlUi(long width, long height, const Game_Config& cfg) : BaseUi(cfg)
 	EndDisplayModeChange();
 
 	// Create the surface we draw on
-	DynamicFormat format;
-
-	if (Utils::IsBigEndian()) {
-		format = DynamicFormat(
-			32,
-			0x0000FF00,
-			0x00FF0000,
-			0xFF000000,
-			0x000000FF,
-			PF::NoAlpha);
-	} else {
-		format = DynamicFormat(
-			32,
-			0x00FF0000,
-			0x0000FF00,
-			0x000000FF,
-			0xFF000000,
-			PF::NoAlpha);
-	}
+#if defined(WORDS_BIGENDIAN)
+	DynamicFormat format = DynamicFormat(
+		32,
+		0x0000FF00,
+		0x00FF0000,
+		0xFF000000,
+		0x000000FF,
+		PF::NoAlpha);
+#else
+	DynamicFormat format = DynamicFormat(
+		32,
+		0x00FF0000,
+		0x0000FF00,
+		0x000000FF,
+		0xFF000000,
+		PF::NoAlpha);
+#endif
 
 	Bitmap::SetFormat(Bitmap::ChooseFormat(format));
 	main_surface = Bitmap::Create(

--- a/src/system.h
+++ b/src/system.h
@@ -65,7 +65,6 @@
 #  define SUPPORT_JOYSTICK_AXIS
 #elif defined(GEKKO)
 #  include <cstdint>
-#  define WORDS_BIGENDIAN
 #  define SUPPORT_JOYSTICK
 #  define SUPPORT_JOYSTICK_AXIS
 #elif defined(_WIN32)
@@ -80,7 +79,6 @@
 #elif defined(PLAYER_AMIGA) && !defined(__AROS__)
 #  define SUPPORT_ZOOM
 #  define SUPPORT_MOUSE
-#  define WORDS_BIGENDIAN
 #  define SUPPORT_JOYSTICK
 #  define SUPPORT_JOYSTICK_AXIS
 #else // Everything not catched above, e.g. Linux/*BSD/macOS

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -470,46 +470,31 @@ int Utils::PositiveModulo(int i, int m) {
 	return (i % m + m) % m;
 }
 
-bool Utils::IsBigEndian() {
-	union {
-		uint32_t i;
-		char c[4];
-	} d = {0x01020304};
-
-	return d.c[0] == 1;
-}
-
 void Utils::SwapByteOrder(uint16_t& us) {
-	if (!IsBigEndian()) {
-		return;
-	}
-
+#ifdef WORDS_BIGENDIAN
 	us =	(us >> 8) |
 			(us << 8);
+#endif
 }
 
 void Utils::SwapByteOrder(uint32_t& ui) {
-	if (!IsBigEndian()) {
-		return;
-	}
-
+#ifdef WORDS_BIGENDIAN
 	ui =	(ui >> 24) |
 			((ui<<8) & 0x00FF0000) |
 			((ui>>8) & 0x0000FF00) |
 			(ui << 24);
+#endif
 }
 
 void Utils::SwapByteOrder(double& d) {
-	if (!IsBigEndian()) {
-		return;
-	}
-
+#ifdef WORDS_BIGENDIAN
 	uint32_t *p = reinterpret_cast<uint32_t *>(&d);
 	SwapByteOrder(p[0]);
 	SwapByteOrder(p[1]);
 	uint32_t tmp = p[0];
 	p[0] = p[1];
 	p[1] = tmp;
+#endif
 }
 
 // based on https://stackoverflow.com/questions/6089231/

--- a/src/utils.h
+++ b/src/utils.h
@@ -208,13 +208,6 @@ namespace Utils {
 	int PositiveModulo(int i, int m);
 
 	/**
-	 * Checks if the platform is big endian
-	 *
-	 * @return true if big, false if little endian
-	 */
-	bool IsBigEndian();
-
-	/**
 	 * Swaps the byte order of the passed number when on big endian systems.
 	 * Does nothing otherwise.
 	 *


### PR DESCRIPTION
Needs at least CMake 3.20 to work properly

Removed runtime check as everything uses a build system now.

(untested)