### PR TITLE
First attempt at a fix for multi-game functionality

### DIFF
--- a/src/meta.cpp
+++ b/src/meta.cpp
@@ -142,30 +142,27 @@ std::vector<Meta::FileItem> Meta::SearchImportPaths(const FilesystemView& parent
 
 
 std::vector<Meta::FileItem> Meta::BuildImportCandidateList(const FilesystemView& parent_fs, StringView child_path, StringView parent_game_name, int pivot_map_id) const {
-	(void)parent_fs;
-	(void)child_path;
-	(void)parent_game_name;
-	(void)pivot_map_id;
-
 	// Scan each folder, looking for an ini file
 	// For now, this only works with "standard" folder layouts, since we need Game files + Save files
 	std::vector<Meta::FileItem> res;
-#if 0
-	FIXME
+
 	// Try to read the game name. Note that we assume the games all have the same encoding (and use Player::encoding)
-	auto child_full_path = child_path;
-	auto child_tree = FileFinder::CreateDirectoryTree(child_full_path);
 	bool is_match = false;
-	if (child_tree != nullptr) {
-		// Try to match the parent game name
-		std::string lmtPath = child_tree->FindFile(TREEMAP_NAME);
+
+	// NOTE: FindFile doesn't work outside the root of the FileSystemView, so we use Exists() and pass a relative path.
+	//       This will likely only work on Native filesystems; the Exists(".") attempts to sanity check this.
+	auto child_tree = parent_fs.Subtree(child_path);
+	if (child_tree.Exists(".")) {
+		// Try to match the parent game name.
+		std::string lmtPath = child_tree.GetSubPath() + "/" + TREEMAP_NAME;
 		std::string crcLMT = crc32file(lmtPath);
 		std::string crcLDB = "*";
+
 		if (parent_game_name.find(crcLMT)==0) {
 			if (parent_game_name == crcLMT + "/" + crcLDB) {
 				is_match = true;
 			} else {
-				std::string ldbPath = child_tree->FindFile(DATABASE_NAME);
+				std::string ldbPath = child_tree.GetSubPath() + "/" + DATABASE_NAME;
 				crcLDB = crc32file(ldbPath);
 				if (parent_game_name == crcLMT + "/" + crcLDB) {
 					is_match = true;
@@ -182,13 +179,13 @@ std::vector<Meta::FileItem> Meta::BuildImportCandidateList(const FilesystemView&
 
 			// Check for an existing, non-corrupt file with the right mapID
 			// Note that corruptness is checked later (in window_savefile.cpp)
-			std::string file = child_tree->FindFile(ss.str());
-			if (!file.empty()) {
-				std::unique_ptr<lcf::rpg::Save> savegame = lcf::LSD_Reader::Load(file, Player::encoding);
+			if (child_tree.Exists(ss.str())) {
+				auto filePath= child_tree.GetSubPath() + "/" + ss.str();
+				std::unique_ptr<lcf::rpg::Save> savegame = lcf::LSD_Reader::Load(filePath, Player::encoding);
 				if (savegame != nullptr) {
 					if (savegame->party_location.map_id == pivot_map_id || pivot_map_id==0) {
 						FileItem item;
-						item.full_path = file;
+						item.full_path = filePath;
 						item.short_path = FileFinder::MakeCanonical(child_path, 1);
 						item.file_id = saveId + 1;
 						res.push_back(item);
@@ -197,7 +194,6 @@ std::vector<Meta::FileItem> Meta::BuildImportCandidateList(const FilesystemView&
 			}
 		}
 	}
-#endif
 	return res;
 }
 

--- a/src/scene_import.cpp
+++ b/src/scene_import.cpp
@@ -75,6 +75,8 @@ void Scene_Import::Start() {
 	index = latest_slot;
 	top_index = std::max(0, index - 2);
 
+	Scene_File::Start();
+
 	Refresh();
 	Update();
 }
@@ -85,7 +87,7 @@ void Scene_Import::vUpdate() {
 		return;
 	}
 
-	Scene_File::Update();
+	Scene_File::vUpdate();
 }
 
 void Scene_Import::UpdateScanAndProgress() {
@@ -104,8 +106,8 @@ void Scene_Import::UpdateScanAndProgress() {
 
 	// Gather the list of children, if it does not exist.
 	if (children.empty()) {
-		/*FIXME if (Main_Data::GetSavePath() == Main_Data::GetProjectPath()) {
-			auto parentPath = FileFinder::MakePath(Main_Data::GetSavePath(), "..");
+		std::string parentPath = FileFinder::Save().MakePath("../");
+		if (FileFinder::Save().Exists("../")) {
 			parent_fs = FileFinder::Root().Create(parentPath);
 			if (parent_fs) {
 				children = Player::meta->GetImportChildPaths(parent_fs);
@@ -113,7 +115,7 @@ void Scene_Import::UpdateScanAndProgress() {
 		}
 		if (children.empty()) {
 			FinishScan();
-		}*/
+		}
 	} else if (curr_child_id < children.size()) {
 		auto candidates = Player::meta->SearchImportPaths(parent_fs, children[curr_child_id]);
 		files.insert(files.end(), candidates.begin(), candidates.end());


### PR DESCRIPTION
Hi all,

I implemented the "multi game" functionality a while ago, and it seems that a recent-ish commit broke it. I've done a cursory fix of the functionality, and confirmed that it now works on "The Way: Episode 2". The fix uses "FileSystemView::Exists()" (rather than "FindFile") since it needs to access files outside of the save directory (e.g., from "Episode1" we need to read "../Episode2/<save_files>". 

This also fixes a few smaller issues: infinite looping in Update(), and failing to call Start() in the parent class. Tested on Windows.

Definitely open to suggestions and comments, but I'd like to get this feature back to (at least) what it was doing before.

Thanks!