### PR TITLE
Ineluki MP3 patch improvements

### DIFF
--- a/src/filesystem_stream.cpp
+++ b/src/filesystem_stream.cpp
@@ -45,6 +45,16 @@ StringView Filesystem_Stream::InputStream::GetName() const {
 	return name;
 }
 
+std::streampos Filesystem_Stream::InputStream::GetSize() const {
+	if (!size_cached) {
+		size_cached = true;
+		auto cur_pos = rdbuf()->pubseekoff(0, std::ios_base::cur, std::ios_base::in);
+		size = rdbuf()->pubseekoff(0, std::ios_base::end, std::ios_base::in);
+		rdbuf()->pubseekoff(cur_pos, std::ios_base::beg, std::ios_base::in);
+	}
+	return size;
+}
+
 void Filesystem_Stream::InputStream::Close() {
 	delete rdbuf();
 	set_rdbuf(nullptr);

--- a/src/filesystem_stream.h
+++ b/src/filesystem_stream.h
@@ -37,6 +37,7 @@ namespace Filesystem_Stream {
 		InputStream& operator=(InputStream&& is) noexcept;
 
 		StringView GetName() const;
+		std::streampos GetSize() const;
 		void Close();
 
 		template <typename T>
@@ -47,6 +48,8 @@ namespace Filesystem_Stream {
 		bool Read0(T& obj);
 
 		std::string name;
+		mutable bool size_cached = false;
+		mutable std::streampos size = 0;
 	};
 
 	class OutputStream final : public std::ostream {

--- a/src/game_system.h
+++ b/src/game_system.h
@@ -437,9 +437,12 @@ public:
 	bool IsLoadedThisFrame() const;
 
 private:
+	std::string InelukiReadLink(Filesystem_Stream::InputStream& stream);
+
 	void OnBgmReady(FileRequestResult* result);
 	void OnBgmInelukiReady(FileRequestResult* result);
 	void OnSeReady(FileRequestResult* result, lcf::rpg::Sound se, bool stop_sounds);
+	void OnSeInelukiReady(FileRequestResult* result, lcf::rpg::Sound se);
 	void OnChangeSystemGraphicReady(FileRequestResult* result);
 private:
 	lcf::rpg::SaveSystem data;


### PR DESCRIPTION
Only consider files as links when they are small (< 500 Byte). "Les aventures d'un avatar 6" uses files with such names for real audio files.

Support of links for sound effects with the same logic as BGM. Note that the "loop" statement is not supported.

Fix #2598
Fix #2609