### PR TITLE
Fix broken native midiout playback after playing a song that alters pitch bend

### DIFF
--- a/src/audio_decoder_midi.cpp
+++ b/src/audio_decoder_midi.cpp
@@ -224,7 +224,7 @@ void AudioDecoderMidi::Update(std::chrono::microseconds delta) {
 	if (paused) {
 		return;
 	}
-	if (fade_steps >= 0 && mtime - last_fade_mtime > 0.1s) {
+	if (fade_steps > 0 && mtime - last_fade_mtime > 0.1s) {
 		volume = Utils::Clamp<float>(volume + delta_volume_step, 0.0f, 1.0f);
 		if (!mididec->SupportsMidiMessages()) {
 			log_volume = AdjustVolume(volume * 100.0f);

--- a/src/audio_decoder_midi.cpp
+++ b/src/audio_decoder_midi.cpp
@@ -117,6 +117,7 @@ bool AudioDecoderMidi::Open(Filesystem_Stream::InputStream stream) {
 		return false;
 	}
 	seq->rewind();
+	tempo.clear();
 	tempo.emplace_back(this, midi_default_tempo);
 	mtime = seq->get_start_skipping_silence();
 	seq->play(mtime, this);


### PR DESCRIPTION
1. Clearing the tempo data should fix that the next song is faster than usual at the beginning (prior speed became normal after the first tempo event).
2. The fade code change solves the "sometimes Toilet in Wonderland music is mute" bug for me
3. I hooked the Windows Midi API to compare the events. Harmony never generated "all sound off", I removed this event. But what Harmony does is resetting the pitch bend. When you look at the code it looks awful. The reason is that Pbend is > 127, so it uses some weird "calling convention" of preregistering a number so a larger value like 256 can be set. Midi...

The pitch bend reset fixes the broken music after playing some Toilet in Wonderland tracks because these songs indeed alter the pitch bend.

There are some further inaccuracies: The timing when we send volume changes for fade (and pan is completely missing) but system command wise we should be doing exactly the same now.

Frida hook for reference:

```js
var midiOutLongMsg = Module.getExportByName(null, "midiOutLongMsg");
var midiOutShortMsg = Module.getExportByName(null, "midiOutShortMsg");

Interceptor.attach(midiOutLongMsg, {
    onEnter: function(args)
    {
		let size = args[1].add(4).readInt();
        console.log("LongMsg:" + hexdump(args[1].readPointer().readByteArray(size)));
	}
	
});

Interceptor.attach(midiOutShortMsg, {
    onEnter: function(args)
    {
        console.log("ShrtMsg:" + args[1]);
	}
	
});
```

---

@Mimigris please check if this fixes the tracks for you.