### PR TITLE
Midi: Properly shutdown and reinitialize

### DIFF
--- a/src/audio_generic.cpp
+++ b/src/audio_generic.cpp
@@ -22,31 +22,20 @@
 #include <memory>
 #include "audio_decoder_midi.h"
 #include "audio_generic.h"
-#include "audio_generic_midiout.h"
-#include "filefinder.h"
 #include "output.h"
-
-GenericAudio::BgmChannel GenericAudio::BGM_Channels[nr_of_bgm_channels];
-GenericAudio::SeChannel GenericAudio::SE_Channels[nr_of_se_channels];
-bool GenericAudio::BGM_PlayedOnceIndicator;
-
-std::vector<int16_t> GenericAudio::sample_buffer = {};
-std::vector<uint8_t> GenericAudio::scrap_buffer = {};
-unsigned GenericAudio::scrap_buffer_size = 0;
-std::vector<float> GenericAudio::mixer_buffer = {};
-
-std::unique_ptr<GenericAudioMidiOut> GenericAudio::midi_thread;
 
 GenericAudio::GenericAudio(const Game_ConfigAudio& cfg) : AudioInterface(cfg) {
 	int i = 0;
 	for (auto& BGM_Channel : BGM_Channels) {
 		BGM_Channel.id = i++;
 		BGM_Channel.decoder.reset();
+		BGM_Channel.instance = this;
 	}
 	i = 0;
 	for (auto& SE_Channel : SE_Channels) {
 		SE_Channel.id = i++;
 		SE_Channel.decoder.reset();
+		SE_Channel.instance = this;
 	}
 	BGM_PlayedOnceIndicator = false;
 	midi_thread.reset();
@@ -492,8 +481,8 @@ void GenericAudio::BgmChannel::Stop() {
 	stopped = true;
 	if (midi_out_used) {
 		midi_out_used = false;
-		midi_thread->GetMidiOut().Reset();
-		midi_thread->GetMidiOut().Pause();
+		instance->midi_thread->GetMidiOut().Reset();
+		instance->midi_thread->GetMidiOut().Pause();
 	} else if (decoder) {
 		decoder.reset();
 	}
@@ -503,16 +492,16 @@ void GenericAudio::BgmChannel::SetPaused(bool newPaused) {
 	paused = newPaused;
 	if (midi_out_used) {
 		if (newPaused) {
-			midi_thread->GetMidiOut().Pause();
+			instance->midi_thread->GetMidiOut().Pause();
 		} else {
-			midi_thread->GetMidiOut().Resume();
+			instance->midi_thread->GetMidiOut().Resume();
 		}
 	}
 }
 
 int GenericAudio::BgmChannel::GetTicks() const {
 	if (midi_out_used) {
-		return midi_thread->GetMidiOut().GetTicks();
+		return instance->midi_thread->GetMidiOut().GetTicks();
 	} else if (decoder) {
 		return decoder->GetTicks();
 	}
@@ -521,7 +510,7 @@ int GenericAudio::BgmChannel::GetTicks() const {
 
 void GenericAudio::BgmChannel::SetFade(int fade) {
 	if (midi_out_used) {
-		midi_thread->GetMidiOut().SetFade(0, std::chrono::milliseconds(fade));
+		instance->midi_thread->GetMidiOut().SetFade(0, std::chrono::milliseconds(fade));
 	} else if (decoder) {
 		decoder->SetFade(0, std::chrono::milliseconds(fade));
 	}
@@ -529,7 +518,7 @@ void GenericAudio::BgmChannel::SetFade(int fade) {
 
 void GenericAudio::BgmChannel::SetVolume(int volume) {
 	if (midi_out_used) {
-		midi_thread->GetMidiOut().SetVolume(volume);
+		instance->midi_thread->GetMidiOut().SetVolume(volume);
 	} else if (decoder) {
 		decoder->SetVolume(volume);
 	}
@@ -537,7 +526,7 @@ void GenericAudio::BgmChannel::SetVolume(int volume) {
 
 void GenericAudio::BgmChannel::SetPitch(int pitch) {
 	if (midi_out_used) {
-		midi_thread->GetMidiOut().SetPitch(pitch);
+		instance->midi_thread->GetMidiOut().SetPitch(pitch);
 	} else if (decoder) {
 		decoder->SetPitch(pitch);
 	}

--- a/src/audio_generic.cpp
+++ b/src/audio_generic.cpp
@@ -20,7 +20,6 @@
 #include <cstring>
 #include <cassert>
 #include <memory>
-#include "audio_decoder_midi.h"
 #include "audio_generic.h"
 #include "output.h"
 

--- a/src/audio_generic.h
+++ b/src/audio_generic.h
@@ -21,9 +21,8 @@
 #include "audio.h"
 #include "audio_secache.h"
 #include "audio_decoder_base.h"
+#include "audio_generic_midiout.h"
 #include <memory>
-
-class GenericAudioMidiOut;
 
 /**
  * A software implementation for handling EasyRPG Audio utilizing the
@@ -73,6 +72,7 @@ private:
 	struct BgmChannel {
 		int id;
 		std::unique_ptr<AudioDecoderBase> decoder;
+		GenericAudio* instance = nullptr;
 		bool paused;
 		bool stopped;
 		bool midi_out_used = false;
@@ -87,6 +87,7 @@ private:
 	struct SeChannel {
 		int id;
 		std::unique_ptr<AudioDecoderBase> decoder;
+		GenericAudio* instance = nullptr;
 		bool paused;
 		bool stopped;
 	};
@@ -103,17 +104,17 @@ private:
 	static constexpr unsigned nr_of_se_channels = 31;
 	static constexpr unsigned nr_of_bgm_channels = 2;
 
-	static BgmChannel BGM_Channels[nr_of_bgm_channels];
-	static SeChannel SE_Channels[nr_of_se_channels];
-	static bool BGM_PlayedOnceIndicator;
-	static bool Muted;
+	BgmChannel BGM_Channels[nr_of_bgm_channels];
+	SeChannel SE_Channels[nr_of_se_channels];
+	mutable bool BGM_PlayedOnceIndicator;
+	bool Muted;
 
-	static std::vector<int16_t> sample_buffer;
-	static std::vector<uint8_t> scrap_buffer;
-	static unsigned scrap_buffer_size;
-	static std::vector<float> mixer_buffer;
+	std::vector<int16_t> sample_buffer = {};
+	std::vector<uint8_t> scrap_buffer = {};
+	unsigned scrap_buffer_size = 0;
+	std::vector<float> mixer_buffer = {};
 
-	static std::unique_ptr<GenericAudioMidiOut> midi_thread;
+	std::unique_ptr<GenericAudioMidiOut> midi_thread;
 };
 
 #endif

--- a/src/audio_generic_midiout.h
+++ b/src/audio_generic_midiout.h
@@ -20,8 +20,8 @@
 
 #include <memory>
 #include "system.h"
+#include "audio_decoder_midi.h"
 
-class AudioDecoderMidi;
 namespace Filesystem_Stream {
 	class InputStream;
 }

--- a/src/audio_midi.cpp
+++ b/src/audio_midi.cpp
@@ -125,3 +125,16 @@ std::unique_ptr<AudioDecoderBase> MidiDecoder::CreateFmMidi(bool resample) {
 
 	return mididec;
 }
+
+void MidiDecoder::Reset() {
+	works.fluidsynth = true;
+	works.wildmidi = true;
+
+#ifdef HAVE_LIBWILDMIDI
+	WildMidiDecoder::ResetState();
+#endif
+
+#if defined(HAVE_FLUIDSYNTH) || defined(HAVE_FLUIDLITE)
+	FluidSynthDecoder::ResetState();
+#endif
+}

--- a/src/audio_midi.h
+++ b/src/audio_midi.h
@@ -194,6 +194,11 @@ public:
 
 	static std::unique_ptr<AudioDecoderBase> CreateFmMidi(bool resample);
 
+	/**
+	 * Resets the global state of the midi libraries.
+	 */
+	static void Reset();
+
 protected:
 	int frequency = EP_MIDI_FREQ;
 };

--- a/src/decoder_fluidsynth.h
+++ b/src/decoder_fluidsynth.h
@@ -45,6 +45,7 @@ public:
 	~FluidSynthDecoder() override;
 
 	static bool Initialize(std::string& error_message);
+	static void ResetState();
 
 	/**
 	 * Sets the name of the preferred soundfont.

--- a/src/decoder_wildmidi.h
+++ b/src/decoder_wildmidi.h
@@ -34,6 +34,7 @@ public:
 	~WildMidiDecoder();
 
 	static bool Initialize(std::string& error_message);
+	static void ResetState();
 
 	// Audio Decoder interface
 	bool Open(std::vector<uint8_t>& data) override;

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include "options.h"
 #include "scene_settings.h"
+#include "audio_midi.h"
 #include "audio_secache.h"
 #include "cache.h"
 #include "game_system.h"
@@ -49,6 +50,7 @@ void Scene_GameBrowser::Continue(SceneType /* prev_scene */) {
 
 	Cache::ClearAll();
 	AudioSeCache::Clear();
+	MidiDecoder::Reset();
 	lcf::Data::Clear();
 	Main_Data::Cleanup();
 


### PR DESCRIPTION
First commit fixes an oversight in the shutdown logic of the Player: Most audio stuff was not deleted because they were static variables... 

This fixes the fluidsynth crashes on shutdown.

_Should also fix the libretro crash when playing a second game but I havn't tested this (yet)_.

-------------

Second commit is less serious: Fluidsynth and WildMidi are now reinitialized when loading a second game. This saves RAM (unloaded when not used by the game) and allows per-game soundfonts. Before only the first was loaded.