### PR TITLE
Detect the engine version for "Ahriman's Prophecy" correctly

### DIFF
--- a/src/exe_reader.cpp
+++ b/src/exe_reader.cpp
@@ -327,7 +327,14 @@ int EXEReader::FileInfo::GetEngineType(bool& is_maniac_patch) const {
 			// VALUE! or Rpg2k3 < 1.0.2.1
 			// Check CODE segment size to be sure
 			if (code_size > 0xB0000) {
-				return Player::EngineRpg2k3;
+				if (code_size >= 0xC7400) {
+					// Code segment size for >= 1.0.5.0
+					// In theory this check is unnecessary because this version has a VERSIONINFO.
+					// However the modified exe shipped with Ahriman's Prophecy is a 1.0.8.0 without a VERSIONINFO.
+					return Player::EngineRpg2k3 | Player::EngineMajorUpdated;
+				} else {
+					return Player::EngineRpg2k3;
+				}
 			}
 
 			return Player::EngineRpg2k | Player::EngineMajorUpdated;


### PR DESCRIPTION
It is RPG Maker 2003 1.0.8.0 but their exe file lacks a VERSIONINFO.

The code segment size is checked instead to detect the version correctly.

----------

Segment size taken from this Makerpendium page: https://www.makerpendium.de/index.php/RPG_RT.exe

Finally a simple commit to review ;)

----------

Reported by samuel in the forum https://community.easyrpg.org/t/ahrimans-prophecy-battle-menu-problem-android/1332 Thanks!