### PR TITLE
Custom Logos at Startup

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -106,6 +106,8 @@ namespace Player {
 	int message_box_offset_x = (screen_width - MENU_WIDTH) / 2;
 	bool has_custom_resolution = false;
 
+	int current_logo;
+
 	bool exit_flag;
 	bool reset_flag;
 	bool debug_flag;
@@ -202,6 +204,8 @@ void Player::Init(std::vector<std::string> args) {
 
 void Player::Run() {
 	Instrumentation::Init("EasyRPG-Player");
+
+	current_logo = 0;
 	Scene::Push(std::make_shared<Scene_Logo>());
 	Graphics::UpdateSceneCallback();
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -106,6 +106,7 @@ namespace Player {
 	int message_box_offset_x = (screen_width - MENU_WIDTH) / 2;
 	bool has_custom_resolution = false;
 
+	std::vector<BitmapRef> logos_container;
 	int current_logo;
 
 	bool exit_flag;
@@ -206,6 +207,8 @@ void Player::Run() {
 	Instrumentation::Init("EasyRPG-Player");
 
 	current_logo = 0;
+	logos_container.clear();
+
 	Scene::Push(std::make_shared<Scene_Logo>());
 	Graphics::UpdateSceneCallback();
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -106,9 +106,6 @@ namespace Player {
 	int message_box_offset_x = (screen_width - MENU_WIDTH) / 2;
 	bool has_custom_resolution = false;
 
-	std::vector<BitmapRef> logos_container;
-	int current_logo;
-
 	bool exit_flag;
 	bool reset_flag;
 	bool debug_flag;
@@ -205,9 +202,6 @@ void Player::Init(std::vector<std::string> args) {
 
 void Player::Run() {
 	Instrumentation::Init("EasyRPG-Player");
-
-	current_logo = 0;
-	logos_container.clear();
 
 	Scene::Push(std::make_shared<Scene_Logo>());
 	Graphics::UpdateSceneCallback();

--- a/src/player.h
+++ b/src/player.h
@@ -307,12 +307,6 @@ namespace Player {
 	/** Set the desired rendering frames per second */
 	void SetTargetFps(int fps);
 
-	/** Logos Container - A collection of logo files */
-	extern std::vector<BitmapRef> logos_container;
-
-	/** Current Logo - for startup */
-	extern int current_logo;
-
 	/** Exit flag, if true will exit application on next Player::Update. */
 	extern bool exit_flag;
 

--- a/src/player.h
+++ b/src/player.h
@@ -307,6 +307,9 @@ namespace Player {
 	/** Set the desired rendering frames per second */
 	void SetTargetFps(int fps);
 
+	/** Current Logo - for startup */
+	extern int current_logo;
+
 	/** Exit flag, if true will exit application on next Player::Update. */
 	extern bool exit_flag;
 

--- a/src/player.h
+++ b/src/player.h
@@ -307,6 +307,9 @@ namespace Player {
 	/** Set the desired rendering frames per second */
 	void SetTargetFps(int fps);
 
+	/** Logos Container - A collection of logo files */
+	extern std::vector<BitmapRef> logos_container;
+
 	/** Current Logo - for startup */
 	extern int current_logo;
 

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -219,7 +219,7 @@ void Scene_GameBrowser::BootGame() {
 
 	if (!FileFinder::FindImage("Logo", "LOGO1").empty()) {
 		// Delegate to Scene_Logo when a startup graphic was found
-		Scene::Push(std::make_shared<Scene_Logo>(1), true);
+		Scene::Push(std::make_shared<Scene_Logo>(1));
 		return;
 	}
 

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -26,6 +26,7 @@
 #include "game_system.h"
 #include "input.h"
 #include "player.h"
+#include "scene_logo.h"
 #include "scene_title.h"
 #include "bitmap.h"
 #include "audio.h"
@@ -213,11 +214,17 @@ void Scene_GameBrowser::BootGame() {
 	FileFinder::SetGameFilesystem(fs);
 	Player::CreateGameObjects();
 
+	game_loading = false;
+	load_window->SetVisible(false);
+
+	if (!FileFinder::FindImage("Logo", "LOGO1").empty()) {
+		// Delegate to Scene_Logo when a startup graphic was found
+		Scene::Push(std::make_shared<Scene_Logo>(1), true);
+		return;
+	}
+
 	if (!Player::startup_language.empty()) {
 		Player::translation.SelectLanguage(Player::startup_language);
 	}
 	Scene::Push(std::make_shared<Scene_Title>());
-
-	game_loading = false;
-	load_window->SetVisible(false);
 }

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -160,7 +160,7 @@ std::vector<BitmapRef> Scene_Logo::preloadLogos() {
 
 	for (int logoIndex = 0; ; logoIndex++) {
 		Filesystem_Stream::InputStream logoStream;
-		if (logoIndex != 0) logoStream = FileFinder::OpenImage("Font", "LOGO" + std::to_string(logoIndex));
+		if (logoIndex != 0) logoStream = FileFinder::OpenImage("Logo", "LOGO" + std::to_string(logoIndex));
 		//TODO: Maybe get LOGO1,LOGO2,LOGO3 from rpg_rt too?
 
 		if (!logoStream) {

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -61,11 +61,7 @@ void Scene_Logo::Start() {
 		}
 
 		DrawText(false);
-
-		logo = std::make_unique<Sprite>();
-		logo->SetBitmap(logo_img);
-		logo->SetX((Player::screen_width - logo->GetWidth()) / 2);
-		logo->SetY((Player::screen_height - logo->GetHeight()) / 2);
+		DrawLogo(logo_img);
 	}
 }
 
@@ -171,6 +167,7 @@ std::vector<BitmapRef> Scene_Logo::preloadLogos() {
 				else {
 					logos.push_back(Bitmap::Create(easyrpg_logo, sizeof(easyrpg_logo), false));
 				}
+				DrawLogo(logos[logoIndex]);
 				Scene_Logo::DetectGame();
 			}
 			else break;  // Stop when no more logos can be found
@@ -189,6 +186,13 @@ std::vector<BitmapRef> Scene_Logo::preloadLogos() {
 	}
 
 	return logos;
+}
+
+void Scene_Logo::DrawLogo(BitmapRef logo_img) {
+	logo = std::make_unique<Sprite>();
+	logo->SetBitmap(logo_img);
+	logo->SetX((Player::screen_width - logo->GetWidth()) / 2);
+	logo->SetY((Player::screen_height - logo->GetHeight()) / 2);
 }
 
 void Scene_Logo::DrawBackground(Bitmap& dst) {

--- a/src/scene_logo.h
+++ b/src/scene_logo.h
@@ -36,20 +36,22 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Scene_Logo();
+	Scene_Logo(unsigned current_logo_index = 0);
 
 	void Start() override;
 	void vUpdate() override;
-	void DetectGame();
-	std::vector<BitmapRef> preloadLogos();
+	bool DetectGame();
+	BitmapRef LoadLogo();
 	void DrawLogo(BitmapRef logo_img);
 	void DrawBackground(Bitmap& dst) override;
-	void DrawText(bool verbose);
+	void DrawTextOnLogo(bool verbose);
 
 private:
 	std::unique_ptr<Sprite> logo;
 	BitmapRef logo_img;
 	int frame_counter;
+	unsigned current_logo_index;
+	bool detected_game = false;
 
 	void OnIndexReady(FileRequestResult* result);
 	FileRequestBinding request_id;

--- a/src/scene_logo.h
+++ b/src/scene_logo.h
@@ -42,6 +42,7 @@ public:
 	void vUpdate() override;
 	void DetectGame();
 	std::vector<BitmapRef> preloadLogos();
+	void DrawLogo(BitmapRef logo_img);
 	void DrawBackground(Bitmap& dst) override;
 	void DrawText(bool verbose);
 

--- a/src/scene_logo.h
+++ b/src/scene_logo.h
@@ -51,6 +51,7 @@ private:
 	BitmapRef logo_img;
 	int frame_counter;
 	unsigned current_logo_index;
+	bool skip_logos = false;
 	bool detected_game = false;
 
 	void OnIndexReady(FileRequestResult* result);

--- a/src/scene_logo.h
+++ b/src/scene_logo.h
@@ -40,6 +40,8 @@ public:
 
 	void Start() override;
 	void vUpdate() override;
+	void DetectGame();
+	std::vector<BitmapRef> preloadLogos();
 	void DrawBackground(Bitmap& dst) override;
 	void DrawText(bool verbose);
 


### PR DESCRIPTION
To add custom logos, you need to add image files named LOGO1, LOGO2, LOGO3, LOGO`n` to the Font folder. 
It will always load the next logo file, while sequential files exist in the Font folder.

~~You can skip having LOGO0, it loads default easyRPG logo when LOGO0 doesn't exists.~~
EasyRPG logo is always displayed at bootup, to avoid a blank screen while loading a heavy game.

Some reference files for testing:

![LOGO1](https://github.com/EasyRPG/Player/assets/45118493/495a930d-a386-44e8-ae35-b751a610832d)
![LOGO2](https://github.com/EasyRPG/Player/assets/45118493/337e1113-d9e8-4860-94f8-d462cb7aa819)
![LOGO3](https://github.com/EasyRPG/Player/assets/45118493/2b1aae97-99f0-4806-8f4d-659a4e402dd2)
