### PR TITLE
Add ExecuteCommand(com);

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -615,7 +615,7 @@ lcf::rpg::MoveCommand Game_Interpreter::DecodeMove(lcf::DBArray<int32_t>::const_
 bool Game_Interpreter::ExecuteCommand() {
 	auto& frame = GetFrame();
 	const auto& com = frame.commands[frame.current_command];
-	return Game_Interpreter::ExecuteCommand(com);
+	return ExecuteCommand(com);
 }
 
 bool Game_Interpreter::ExecuteCommand(lcf::rpg::EventCommand const& com) {

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -615,7 +615,10 @@ lcf::rpg::MoveCommand Game_Interpreter::DecodeMove(lcf::DBArray<int32_t>::const_
 bool Game_Interpreter::ExecuteCommand() {
 	auto& frame = GetFrame();
 	const auto& com = frame.commands[frame.current_command];
+	return Game_Interpreter::ExecuteCommand(com);
+}
 
+bool Game_Interpreter::ExecuteCommand(lcf::rpg::EventCommand const& com) {
 	switch (static_cast<Cmd>(com.code)) {
 		case Cmd::ShowMessage:
 			return CommandShowMessage(com);

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -75,7 +75,7 @@ public:
 	void InputButton();
 	void SetupChoices(const std::vector<std::string>& choices, int indent, PendingMessage& pm);
 
-	virtual bool ExecuteCommand();
+	bool ExecuteCommand();
 	virtual bool ExecuteCommand(lcf::rpg::EventCommand const& com);
 
 

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -76,6 +76,7 @@ public:
 	void SetupChoices(const std::vector<std::string>& choices, int indent, PendingMessage& pm);
 
 	virtual bool ExecuteCommand();
+	virtual bool ExecuteCommand(lcf::rpg::EventCommand const& com);
 
 
 	/**

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -157,7 +157,10 @@ int Game_Interpreter_Battle::ScheduleNextPage(lcf::rpg::TroopPageCondition::Flag
 bool Game_Interpreter_Battle::ExecuteCommand() {
 	auto& frame = GetFrame();
 	const auto& com = frame.commands[frame.current_command];
+	return Game_Interpreter_Battle::ExecuteCommand(com);
+}
 
+bool Game_Interpreter_Battle::ExecuteCommand(lcf::rpg::EventCommand const& com) {
 	switch (static_cast<Cmd>(com.code)) {
 		case Cmd::CallCommonEvent:
 			return CommandCallCommonEvent(com);
@@ -194,7 +197,7 @@ bool Game_Interpreter_Battle::ExecuteCommand() {
 		case Cmd::Maniac_GetBattleInfo:
 			return CommandManiacGetBattleInfo(com);
 		default:
-			return Game_Interpreter::ExecuteCommand();
+			return Game_Interpreter::ExecuteCommand(com);
 	}
 }
 

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -154,12 +154,6 @@ int Game_Interpreter_Battle::ScheduleNextPage(lcf::rpg::TroopPageCondition::Flag
 }
 
 // Execute Command.
-bool Game_Interpreter_Battle::ExecuteCommand() {
-	auto& frame = GetFrame();
-	const auto& com = frame.commands[frame.current_command];
-	return Game_Interpreter_Battle::ExecuteCommand(com);
-}
-
 bool Game_Interpreter_Battle::ExecuteCommand(lcf::rpg::EventCommand const& com) {
 	switch (static_cast<Cmd>(com.code)) {
 		case Cmd::CallCommonEvent:

--- a/src/game_interpreter_battle.h
+++ b/src/game_interpreter_battle.h
@@ -57,7 +57,6 @@ public:
 
 	bool IsForceFleeEnabled() const;
 
-	bool ExecuteCommand() override;
 	bool ExecuteCommand(lcf::rpg::EventCommand const& com) override;
 
 private:

--- a/src/game_interpreter_battle.h
+++ b/src/game_interpreter_battle.h
@@ -58,6 +58,8 @@ public:
 	bool IsForceFleeEnabled() const;
 
 	bool ExecuteCommand() override;
+	bool ExecuteCommand(lcf::rpg::EventCommand const& com) override;
+
 private:
 	bool CommandCallCommonEvent(lcf::rpg::EventCommand const& com);
 	bool CommandForceFlee(lcf::rpg::EventCommand const& com);

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -89,7 +89,10 @@ void Game_Interpreter_Map::OnMapChange() {
 bool Game_Interpreter_Map::ExecuteCommand() {
 	auto& frame = GetFrame();
 	const auto& com = frame.commands[frame.current_command];
+	return Game_Interpreter_Map::ExecuteCommand(com);
+}
 
+bool Game_Interpreter_Map::ExecuteCommand(lcf::rpg::EventCommand const& com) {
 	switch (static_cast<Cmd>(com.code)) {
 		case Cmd::RecallToLocation:
 			return CommandRecallToLocation(com);
@@ -146,7 +149,7 @@ bool Game_Interpreter_Map::ExecuteCommand() {
 		case Cmd::ToggleAtbMode:
 			return CommandToggleAtbMode(com);
 		default:
-			return Game_Interpreter::ExecuteCommand();
+			return Game_Interpreter::ExecuteCommand(com);
 	}
 }
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -86,12 +86,6 @@ void Game_Interpreter_Map::OnMapChange() {
 /**
  * Execute Command.
  */
-bool Game_Interpreter_Map::ExecuteCommand() {
-	auto& frame = GetFrame();
-	const auto& com = frame.commands[frame.current_command];
-	return Game_Interpreter_Map::ExecuteCommand(com);
-}
-
 bool Game_Interpreter_Map::ExecuteCommand(lcf::rpg::EventCommand const& com) {
 	switch (static_cast<Cmd>(com.code)) {
 		case Cmd::RecallToLocation:

--- a/src/game_interpreter_map.h
+++ b/src/game_interpreter_map.h
@@ -52,6 +52,7 @@ public:
 	void OnMapChange();
 
 	bool ExecuteCommand() override;
+	bool ExecuteCommand(lcf::rpg::EventCommand const& com) override;
 
 private:
 	bool CommandRecallToLocation(lcf::rpg::EventCommand const& com);

--- a/src/game_interpreter_map.h
+++ b/src/game_interpreter_map.h
@@ -51,7 +51,6 @@ public:
 	 */
 	void OnMapChange();
 
-	bool ExecuteCommand() override;
 	bool ExecuteCommand(lcf::rpg::EventCommand const& com) override;
 
 private:


### PR DESCRIPTION
Minor Change.
It's a variation of ExecuteCommand(); that accepts `com` as a parameter.

Ghabry commented that this would make the code faster. But, this also open possibilities to create a scripting language, since we can create `com` parameters from strings.

------------------

This implementation could also be used to attach code from dynRPG patches to new `com` stuff. Having both @comments and `com` commands share the same code.