### PR TITLE
New Command: 2049 - SetGameSpeed

### DIFF
--- a/src/fps_overlay.cpp
+++ b/src/fps_overlay.cpp
@@ -85,7 +85,7 @@ void FpsOverlay::Draw(Bitmap& dst) {
 	}
 
 	// Always drawn when speedup is on independent of FPS
-	if (last_speed_mod > 1) {
+	if (!Game_Clock::GetSpeedOverlayMode() && last_speed_mod > 1) {
 		if (speedup_dirty) {
 			std::string text = "> x" + std::to_string(last_speed_mod);
 

--- a/src/game_clock.cpp
+++ b/src/game_clock.cpp
@@ -25,6 +25,8 @@
 constexpr bool Game_Clock::is_steady;
 Game_Clock::Data Game_Clock::data;
 
+int hideDisplay = 0;
+
 // Damping factor fps computation.
 static constexpr auto _fps_smooth = 2.0f / 121.0f;
 

--- a/src/game_clock.h
+++ b/src/game_clock.h
@@ -36,6 +36,8 @@ public:
 	using duration = clock::duration;
 	using time_point = clock::time_point;
 
+	int hideDisplay;
+
 	static constexpr bool is_steady = clock::is_steady;
 
 	/** Get current time */
@@ -75,6 +77,12 @@ public:
 
 	/** @return the speed up or slowdown factor we'll use to run the game. */
 	static float GetGameSpeedFactor();
+
+	/** Set either if Speed Multiplier Overlay is hidden or Visible. */
+	static void setSpeedOverlayMode(bool mode);
+
+	/** Check if Speed Multiplier Overlay is hidden or Visible. */
+	static int GetSpeedOverlayMode();
 
 	/** Get the time of the current frame */
 	static time_point GetFrameTime();
@@ -117,6 +125,7 @@ private:
 		float speed = 1.0;
 		float fps = 0.0;
 		int frame = 0;
+		bool hideSpeedOverlay = 0;
 	};
 	static Data data;
 };
@@ -178,6 +187,14 @@ inline void Game_Clock::SetGameSpeedFactor(float s) {
 
 inline float Game_Clock::GetGameSpeedFactor() {
 	return data.speed;
+}
+
+inline int Game_Clock::GetSpeedOverlayMode() {
+	return data.hideSpeedOverlay;
+}
+
+inline void Game_Clock::setSpeedOverlayMode(bool s) {
+	data.hideSpeedOverlay = s;
 }
 
 #endif

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -4988,8 +4988,20 @@ bool Game_Interpreter::CommandManiacCallCommand(lcf::rpg::EventCommand const&) {
 }
 
 bool Game_Interpreter::CommandSetGameSpeed(lcf::rpg::EventCommand const& com) {
+	// #SetGameSpeed, "",[speedIsVar, speed, speedLimitIsVar,speedLimit, hideSpeedMultiplierIsVar, hideSpeedMultiplier ];
+
 	int32_t speed = ValueOrVariable(com.parameters[0], com.parameters[1]) * Game_Clock::GetGameSpeedFactor();
-	if (speed > 100) speed = 100;
+	int32_t speedLimit = ValueOrVariable(com.parameters[2], com.parameters[3]);
+	bool hideSpeedMultiplier = ValueOrVariable(com.parameters[4], com.parameters[5]);
+
+	if (speedLimit == 0) speedLimit = 100;
+	if (speed > speedLimit) speed = speedLimit;
+
+	if (Input::IsSystemPressed(Input::FAST_FORWARD_A) || Input::IsSystemPressed(Input::FAST_FORWARD_B))
+		Game_Clock::setSpeedOverlayMode(0);
+	else
+		Game_Clock::setSpeedOverlayMode(hideSpeedMultiplier);
+
 	Game_Clock::SetGameSpeedFactor(speed);
 	return true;
 }

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -4988,7 +4988,8 @@ bool Game_Interpreter::CommandManiacCallCommand(lcf::rpg::EventCommand const&) {
 }
 
 bool Game_Interpreter::CommandSetGameSpeed(lcf::rpg::EventCommand const& com) {
-	int32_t speed = ValueOrVariable(com.parameters[0], com.parameters[1]);
+	int32_t speed = ValueOrVariable(com.parameters[0], com.parameters[1]) * Game_Clock::GetGameSpeedFactor();
+	if (speed > 100) speed = 100;
 	Game_Clock::SetGameSpeedFactor(speed);
 	return true;
 }

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -825,6 +825,8 @@ bool Game_Interpreter::ExecuteCommand(lcf::rpg::EventCommand const& com) {
 			return CommandManiacControlStrings(com);
 		case Cmd::Maniac_CallCommand:
 			return CommandManiacCallCommand(com);
+		case static_cast<Game_Interpreter::Cmd>(2049) : //Cmd::Easy_SetGameSpeed
+			return CommandSetGameSpeed(com);
 		default:
 			return true;
 	}
@@ -4982,6 +4984,12 @@ bool Game_Interpreter::CommandManiacCallCommand(lcf::rpg::EventCommand const&) {
 	}
 
 	Output::Warning("Maniac Patch: Command CallCommand not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandSetGameSpeed(lcf::rpg::EventCommand const& com) {
+	int32_t speed = ValueOrVariable(com.parameters[0], com.parameters[1]);
+	Game_Clock::SetGameSpeedFactor(speed);
 	return true;
 }
 

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -285,6 +285,7 @@ protected:
 	bool CommandManiacSetGameOption(lcf::rpg::EventCommand const& com);
 	bool CommandManiacControlStrings(lcf::rpg::EventCommand const& com);
 	bool CommandManiacCallCommand(lcf::rpg::EventCommand const& com);
+	bool CommandSetGameSpeed(lcf::rpg::EventCommand const& com);
 
 	int DecodeInt(lcf::DBArray<int32_t>::const_iterator& it);
 	const std::string DecodeString(lcf::DBArray<int32_t>::const_iterator& it);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -310,6 +310,7 @@ void Player::UpdateInput() {
 	if (Input::IsSystemPressed(Input::FAST_FORWARD_B)) {
 		speed = speed_modifier_b;
 	}
+	Game_Clock::setSpeedOverlayMode(0);
 	Game_Clock::SetGameSpeedFactor(speed);
 
 	if (Main_Data::game_quit) {


### PR DESCRIPTION
Minor experiment, our first new Event Command.

---------------------------

To use it, write in Maniacs TPC:
`@raw 2049, "", speedIsVar, speed, speedLimitIsVar,speedLimit, hideSpeedMultiplierIsVar, hideSpeedMultiplier `

e.g.:
`@raw 2049, "", 0, 10, 0, 50, 0, 1`

The command must be inserted inside a parallel process, because `Game_Clock::SetGameSpeedFactor(speed);` only changes the speed at current frame.

![image](https://github.com/EasyRPG/Player/assets/45118493/29dc0c62-cff9-4c03-bf04-24d5b5d2da3d) ![image](https://github.com/EasyRPG/Player/assets/45118493/7ffafb74-df65-457f-84c3-ce1cf88e2879)


Any refactor (to improve how it's called or to hide the speed counter) is welcome.