### PR TITLE
New Command: 99999 - Barebones Scripting Language

### DIFF
--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -284,6 +284,7 @@ protected:
 	bool CommandManiacChangePictureId(lcf::rpg::EventCommand const& com);
 	bool CommandManiacSetGameOption(lcf::rpg::EventCommand const& com);
 	bool CommandManiacCallCommand(lcf::rpg::EventCommand const& com);
+	bool InjectCommand(lcf::rpg::EventCommand const& com);
 
 	int DecodeInt(lcf::DBArray<int32_t>::const_iterator& it);
 	const std::string DecodeString(lcf::DBArray<int32_t>::const_iterator& it);


### PR DESCRIPTION
TPC commands for testing purposes:
```js
@raw 99999, "@10110(""test"",[1 ,2, 3,4 ,5,6],0) //show dialog" 
@raw 99999, "@10310 ("""",[0 ,0, 100],0) //add 100 money" 
@raw 99999, "@10110(""@10110(\""test\"",[1 ,2, 3,4 ,5,6],0)"",[1 ,2, 3,4 ,5,6],0) //a collection of problematic syntax just to test how it deals with it"
```
Work in progress. I need a lot of help with this one.

It injects commands from 99999's com.string.

I can't parse proper syntax, since it isn't mapped anywhere. 
But it can be useful alongside stringvars to load commands from txt files.