### PR TITLE
Revamp MakeWay() and split it into CheckWay()/MakeWay()

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -33,6 +33,7 @@
 #include "rand.h"
 #include <cmath>
 #include <cassert>
+#include <unordered_set>
 
 Game_Character::Game_Character(Type type, lcf::rpg::SaveMapEventBase* d) :
 	_type(type), _data(d)
@@ -468,6 +469,20 @@ void Game_Character::UpdateMoveRoute(int32_t& current_index, const lcf::rpg::Mov
 bool Game_Character::MakeWay(int from_x, int from_y, int to_x, int to_y) {
 	return Game_Map::MakeWay(*this, from_x, from_y, to_x, to_y);
 }
+
+
+bool Game_Character::CheckWay(int from_x, int from_y, int to_x, int to_y) {
+	return Game_Map::CheckWay(*this, from_x, from_y, to_x, to_y);
+}
+
+
+bool Game_Character::CheckWayEx(
+		int from_x, int from_y, int to_x, int to_y, bool ignore_all_events,
+		std::unordered_set<int> *ignore_some_events_by_id) {
+	return Game_Map::CheckWayEx(*this, from_x, from_y, to_x, to_y,
+		ignore_all_events, ignore_some_events_by_id);
+}
+
 
 bool Game_Character::Move(int dir) {
 	if (!IsStopping()) {

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -21,6 +21,7 @@
 // Headers
 #include <cstdint>
 #include <string>
+#include <unordered_set>
 #include "color.h"
 #include "flash.h"
 #include <lcf/rpg/moveroute.h>
@@ -584,6 +585,39 @@ public:
 	 * @return true if this can occupy (to_x, to_y) from (from_x, from_y)
 	 */
 	virtual bool MakeWay(int from_x, int from_y, int to_x, int to_y);
+
+	/**
+	 * Check if this can move to the given tile, but without
+	 * affecting the map. This is usually what you want to use
+	 * for planning, e.g. path finding, where the move isn't
+	 * meant to be actually executed just yet.
+	 *
+	 * @param from_x Moving from x position
+	 * @param from_y Moving from y position
+	 * @param to_x Moving from x position
+	 * @param to_y Moving from y position
+	 *
+	 * @return true if the hypothetical movement of
+	 *	 this event from (to_x, to_y) from (from_x, from_y) is possible
+	 */
+	virtual bool CheckWay(int from_x, int from_y, int to_x, int to_y);
+
+	/**
+	 * Like CheckWay, but allows ignoring all events in the check,
+	 * or only some events specified by event id.
+	 *
+	 * @param from_x See CheckWay.
+	 * @param from_y See CheckWay.
+	 * @param to_x See CheckWay.
+	 * @param to_y See Checkway.
+	 * @param ignore_all_events If true, only consider map collision
+	 *   and completely ignore any events in the way.
+	 * @param ignore_some_events_by_id If specified, all events with
+	 *   ids found in this list will be ignored in the collision check.
+	 * @return true See CheckWay.
+	 */
+	virtual bool CheckWayEx(int from_x, int from_y, int to_x, int to_y,
+		bool ignore_all_events, std::unordered_set<int> *ignore_some_events_by_id);
 
 	/**
 	 * Turns the character 90 Degree to the left.

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <vector>
 #include <string>
+#include <unordered_set>
 #include "system.h"
 #include "game_commonevent.h"
 #include "game_event.h"
@@ -91,7 +92,7 @@ namespace Game_Map {
 	 */
 	void Quit();
 
-	/** Disposes Game_Map.  */
+	/** Disposes Game_Map. */
 	void Dispose();
 
 	/**
@@ -197,6 +198,61 @@ namespace Game_Map {
 	bool MakeWay(const Game_Character& self,
 			int from_x, int from_y,
 			int to_x, int to_y);
+
+	/**
+	 * Check if a move of self is possible to (to_x,to_y).
+	 * Any events that are blocked will also be checked for collision.
+	 *
+	 * Returns true if move is possible.
+	 *
+	 * @param self Character to move.
+	 * @param from_x from tile x.
+	 * @param from_y from tile y.
+	 * @param to_x to new tile x.
+	 * @param to_y to new tile y.
+	 * @return whether move is possible.
+	 */
+	bool CheckWay(const Game_Character& self,
+			int from_x, int from_y,
+			int to_x, int to_y);
+
+	/**
+	 * Extended function of CheckWay that spits out some
+	 * additional computed values for use in MakeWay.
+	 *
+	 * @param self See CheckWay.
+	 * @param from_x See CheckWay.
+	 * @param from_y See CheckWay.
+	 * @param to_x See CheckWay.
+	 * @param to_y See CheckWay.
+	 * @param ignore_events_and_vehicles Whether to ignore
+	 *   all events and vehicles and only check map geometry.
+	 * @param ignore_some_events_by_id Ignore some specific
+	 *   events by ID.
+	 * @param out_bit_from Outputs bitmap mask for passability.
+	 * @param out_bit_to Outputs bitmap mask for passability.
+	 * @param out_to_x Target pos adjusted for map repeat.
+	 * @param out_to_y Target pos adjusted for map repeat.
+	 * @param out_self_conflict Outputs whether the moving self
+	 *	 has a tile graphic that conflicts with the movement
+	 *	 direction.
+	 * @return See CheckWay.
+	 */
+	 bool CheckWayEx(const Game_Character& self,
+			int from_x, int from_y,
+			int to_x, int to_y,
+			bool ignore_events_and_vehicles,
+			std::unordered_set<int> *ignore_some_events_by_id,
+			int *out_bit_from,
+			int *out_bit_to,
+			int *out_to_x,
+			int *out_to_y,
+			bool *out_self_conflict);
+	bool CheckWayEx(const Game_Character& self,
+			int from_x, int from_y,
+			int to_x, int to_y,
+			bool ignore_all_events,
+			std::unordered_set<int> *ignore_some_events_by_id);
 
 	/**
 	 * Gets if possible to land the airship at (x,y)
@@ -569,8 +625,14 @@ namespace Game_Map {
 	 * @param bit which direction bits to check
 	 * @param x target tile x.
 	 * @param y target tile y.
+	 * @param check_events_and_vehicles Whether to consider events and vehicles.
+	 * @param check_map_geometry Whether to take map collision into account.
 	 * @return whether is passable.
 	 */
+	bool IsPassableTile(
+		const Game_Character* self, int bit, int x, int y,
+		bool check_events_and_vehicles, bool check_map_geometry
+		);
 	bool IsPassableTile(const Game_Character* self, int bit, int x, int y);
 
 	/**


### PR DESCRIPTION
This change revamps `MakeWay()` with the following changes that are meant for allowing pathfinding and more:

1. There is now a separate `CheckWay` which allows to just check collision but without causing possible map or state changes. `MakeWay` will cause event updates sometimes, trying to move an event out of the way that blocks movement. This is undesirable for e.g. path finding wwhere just some hypothetical plan is being made and no movement or map changes intended yet.

2. There is now a separate `CheckWayEx`, which has the additional more complex options to either ignore all events and vehicles (and just check underlying map geometry for collision) and the option to specify a list of event IDs to specifically ignore for collision. This can be required for pathfinding.
 
   *Elaborate reason: e.g. if you have two followers they need to ignore each other in pathing or in thin narrow corridors they'll block each others way, which will then cause them to search really elaborate and far routes around through e.g. entirely different corridors unless they ignore each other for the path planning (**not** the actual collision, just the planning).*

5. There were two small behavior changes for `MakeWay` and `MakeWayCollide`: sometimes either would cause updates on an event that was deemed in the way when attempting a move, even though the map geometry would actually block that movement anyway. This seems like both unintended, and also not like someone would actually exploit that quirk for something useful, and also would have been harder to keep in that way than to just fix it.

I anticipate there might be some discussion if I did this split in a nice way. So therefore I decided that it might be better to pull request this in advance, before later actually trying to to pull request the path finding that makes use of all of this.