### PR TITLE
10220 - Control Variables New Entry: GetTime

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -821,8 +821,6 @@ bool Game_Interpreter::ExecuteCommand(lcf::rpg::EventCommand const& com) {
 			return CommandManiacSetGameOption(com);
 		case Cmd::Maniac_CallCommand:
 			return CommandManiacCallCommand(com);
-		case static_cast<Game_Interpreter::Cmd>(2054): //Cmd::EasyRpg_GetTime
-			return CommandGetTime(com);
 		default:
 			return true;
 	}
@@ -1074,6 +1072,33 @@ bool Game_Interpreter::CommandControlSwitches(lcf::rpg::EventCommand const& com)
 }
 
 bool Game_Interpreter::CommandControlVariables(lcf::rpg::EventCommand const& com) { // code 10220
+
+	if (!com.string.empty()){
+	std::string periodName = Utils::LowerCase(ToString(com.string));
+	int32_t outputVariable = ValueOrVariable(com.parameters[0], com.parameters[1]);
+
+	std::time_t t = std::time(nullptr);
+	std::tm* tm = std::localtime(&t);
+
+	int32_t dateOutput{};
+
+	if (periodName == "getyear") dateOutput = tm->tm_year + 1900;
+	if (periodName == "getmonth") dateOutput = tm->tm_mon + 1;
+	if (periodName == "getday") dateOutput = tm->tm_mday;
+	if (periodName == "gethour") dateOutput = tm->tm_hour;
+	if (periodName == "getminute") dateOutput = tm->tm_min;
+	if (periodName == "getsecond") dateOutput = tm->tm_sec;
+	if (periodName == "getweekday") dateOutput = tm->tm_wday + 1;
+	if (periodName == "getyearday") dateOutput = tm->tm_yday + 1;
+	if (periodName == "getdaylightsavings") dateOutput = tm->tm_isdst + 1;
+	if (periodName == "gettimestamp") dateOutput = t;
+
+	Main_Data::game_variables->Set(outputVariable, dateOutput);
+	Game_Map::SetNeedRefresh(true);
+
+	return true;
+	}
+
 	int value = 0;
 	int operand = com.parameters[4];
 
@@ -4642,32 +4667,6 @@ bool Game_Interpreter::CommandManiacCallCommand(lcf::rpg::EventCommand const&) {
 	}
 
 	Output::Warning("Maniac Patch: Command CallCommand not supported");
-	return true;
-}
-
-bool Game_Interpreter::CommandGetTime(lcf::rpg::EventCommand const& com) {
-
-	std::string periodName = Utils::LowerCase(ToString(com.string));
-	int32_t outputVariable = ValueOrVariable(com.parameters[0], com.parameters[1]);
-
-	std::time_t t = std::time(nullptr);
-	std::tm* tm = std::localtime(&t);
-
-	int32_t dateOutput{};
-
-	if (periodName == "getyear") dateOutput = tm->tm_year + 1900;
-	if (periodName == "getmonth") dateOutput = tm->tm_mon + 1;
-	if (periodName == "getday") dateOutput = tm->tm_mday;
-	if (periodName == "gethour") dateOutput = tm->tm_hour;
-	if (periodName == "getminute") dateOutput = tm->tm_min;
-	if (periodName == "getsecond") dateOutput = tm->tm_sec;
-	if (periodName == "getweekday") dateOutput = tm->tm_wday +1;
-	if (periodName == "getyearday") dateOutput = tm->tm_yday +1;
-	if (periodName == "gettimestamp") dateOutput = t;
-
-	Main_Data::game_variables->Set(outputVariable, dateOutput);
-	Game_Map::SetNeedRefresh(true);
-
 	return true;
 }
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -821,6 +821,8 @@ bool Game_Interpreter::ExecuteCommand(lcf::rpg::EventCommand const& com) {
 			return CommandManiacSetGameOption(com);
 		case Cmd::Maniac_CallCommand:
 			return CommandManiacCallCommand(com);
+		case static_cast<Game_Interpreter::Cmd>(2054): //Cmd::EasyRpg_GetTime
+			return CommandGetTime(com);
 		default:
 			return true;
 	}
@@ -4640,6 +4642,32 @@ bool Game_Interpreter::CommandManiacCallCommand(lcf::rpg::EventCommand const&) {
 	}
 
 	Output::Warning("Maniac Patch: Command CallCommand not supported");
+	return true;
+}
+
+bool Game_Interpreter::CommandGetTime(lcf::rpg::EventCommand const& com) {
+
+	std::string periodName = Utils::LowerCase(ToString(com.string));
+	int32_t outputVariable = ValueOrVariable(com.parameters[0], com.parameters[1]);
+
+	std::time_t t = std::time(nullptr);
+	std::tm* tm = std::localtime(&t);
+
+	int32_t dateOutput{};
+
+	if (periodName == "getyear") dateOutput = tm->tm_year + 1900;
+	if (periodName == "getmonth") dateOutput = tm->tm_mon + 1;
+	if (periodName == "getday") dateOutput = tm->tm_mday;
+	if (periodName == "gethour") dateOutput = tm->tm_hour;
+	if (periodName == "getminute") dateOutput = tm->tm_min;
+	if (periodName == "getsecond") dateOutput = tm->tm_sec;
+	if (periodName == "getweekday") dateOutput = tm->tm_wday +1;
+	if (periodName == "getyearday") dateOutput = tm->tm_yday +1;
+	if (periodName == "gettimestamp") dateOutput = t;
+
+	Main_Data::game_variables->Set(outputVariable, dateOutput);
+	Game_Map::SetNeedRefresh(true);
+
 	return true;
 }
 

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -284,6 +284,7 @@ protected:
 	bool CommandManiacChangePictureId(lcf::rpg::EventCommand const& com);
 	bool CommandManiacSetGameOption(lcf::rpg::EventCommand const& com);
 	bool CommandManiacCallCommand(lcf::rpg::EventCommand const& com);
+	bool CommandGetTime(lcf::rpg::EventCommand const& com);
 
 	int DecodeInt(lcf::DBArray<int32_t>::const_iterator& it);
 	const std::string DecodeString(lcf::DBArray<int32_t>::const_iterator& it);


### PR DESCRIPTION
This one was requested a lot by the Creative Unconscious devs,
They want to include special events related to christmas date or other holydays:

### 10220 - Control Variables New Entry: GetTime
Gets current date information and attach it to a variable.
![image](https://github.com/EasyRPG/Player/assets/45118493/e0b47a59-c96f-4e72-8364-3ea26ef07850)

Usage:
```js
@raw 10220, "Type_of_Date", targetVar_IsVar, targerVar

```
```js
// "set year to variable 1:"
@raw 10220, "getYear", 0, 1
// "set month to variable 2:"
@raw 10220, "getMonth", 0, 2
// "set day to variable 3:"
@raw 10220, "getDay", 0, 3
// "set hour to variable 4:"
@raw 10220, "getHour", 0, 4
// "set minute to variable 5:"
@raw 10220, "getMinute", 0, 5
// "set second to variable 6:"
@raw 10220, "getSecond", 0, 6
// "set day of week to variable 7:"
@raw 10220, "getWeekDay", 0, 7
// "set days in year to variable 8:"
@raw 10220, "getYearDay", 0, 8
// "set daylight savings flag to variable 9:"
@raw 10220, "getdaylightsavings", 0, 9
// "set the entire timestamp to variable 10:"
@raw 10220, "gettimestamp", 0, 10
```
