### PR TITLE
Fix regression of MakeWay() from MakeWay()/CheckWay() split

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -476,10 +476,10 @@ bool Game_Character::CheckWay(int from_x, int from_y, int to_x, int to_y) {
 }
 
 
-bool Game_Character::CheckWayEx(
+bool Game_Character::CheckWay(
 		int from_x, int from_y, int to_x, int to_y, bool ignore_all_events,
 		std::unordered_set<int> *ignore_some_events_by_id) {
-	return Game_Map::CheckWayEx(*this, from_x, from_y, to_x, to_y,
+	return Game_Map::CheckWay(*this, from_x, from_y, to_x, to_y,
 		ignore_all_events, ignore_some_events_by_id);
 }
 

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -587,22 +587,6 @@ public:
 	virtual bool MakeWay(int from_x, int from_y, int to_x, int to_y);
 
 	/**
-	 * Check if this can move to the given tile, but without
-	 * affecting the map. This is usually what you want to use
-	 * for planning, e.g. path finding, where the move isn't
-	 * meant to be actually executed just yet.
-	 *
-	 * @param from_x Moving from x position
-	 * @param from_y Moving from y position
-	 * @param to_x Moving from x position
-	 * @param to_y Moving from y position
-	 *
-	 * @return true if the hypothetical movement of
-	 *	 this event from (to_x, to_y) from (from_x, from_y) is possible
-	 */
-	virtual bool CheckWay(int from_x, int from_y, int to_x, int to_y);
-
-	/**
 	 * Like CheckWay, but allows ignoring all events in the check,
 	 * or only some events specified by event id.
 	 *
@@ -610,14 +594,17 @@ public:
 	 * @param from_y See CheckWay.
 	 * @param to_x See CheckWay.
 	 * @param to_y See Checkway.
-	 * @param ignore_all_events If true, only consider map collision
+	 * @param ignore_all_events (Optional) If true, only consider map collision
 	 *   and completely ignore any events in the way.
-	 * @param ignore_some_events_by_id If specified, all events with
+	 * @param ignore_some_events_by_id (Optional) If specified, all events with
 	 *   ids found in this list will be ignored in the collision check.
 	 * @return true See CheckWay.
 	 */
-	virtual bool CheckWayEx(int from_x, int from_y, int to_x, int to_y,
+	virtual bool CheckWay(int from_x, int from_y, int to_x, int to_y,
 		bool ignore_all_events, std::unordered_set<int> *ignore_some_events_by_id);
+
+	/** Short version of CheckWay. **/
+	virtual bool CheckWay(int from_x, int from_y, int to_x, int to_y);
 
 	/**
 	 * Turns the character 90 Degree to the left.

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -210,49 +210,48 @@ namespace Game_Map {
 	 * @param from_y from tile y.
 	 * @param to_x to new tile x.
 	 * @param to_y to new tile y.
+	 * @param check_events_and_events (Optional) Whether to check
+	 * events, or only consider map collision.
+	 * @param ignore_some_events_by_id (Optional) A set of
+	 * specific event IDs to ignore.
 	 * @return whether move is possible.
 	 */
+	bool CheckWay(const Game_Character& self,
+			int from_x, int from_y,
+			int to_x, int to_y,
+			bool check_events_and_vehicles,
+			std::unordered_set<int> *ignore_some_events_by_id);
+
+	/** Shorter version of CheckWay. */
 	bool CheckWay(const Game_Character& self,
 			int from_x, int from_y,
 			int to_x, int to_y);
 
 	/**
-	 * Extended function of CheckWay that spits out some
-	 * additional computed values for use in MakeWay.
+	 * Extended function behind MakeWay and CheckWay
+	 * that allows controlling exactly which events are
+	 * ignored in the collision, and whether events should
+	 * be prompted to make way with side effects (for MakeWay)
+	 * or not (for CheckWay).
 	 *
-	 * @param self See CheckWay.
-	 * @param from_x See CheckWay.
-	 * @param from_y See CheckWay.
-	 * @param to_x See CheckWay.
-	 * @param to_y See CheckWay.
-	 * @param ignore_events_and_vehicles Whether to ignore
-	 *   all events and vehicles and only check map geometry.
-	 * @param ignore_some_events_by_id Ignore some specific
-	 *   events by ID.
-	 * @param out_bit_from Outputs bitmap mask for passability.
-	 * @param out_bit_to Outputs bitmap mask for passability.
-	 * @param out_to_x Target pos adjusted for map repeat.
-	 * @param out_to_y Target pos adjusted for map repeat.
-	 * @param out_self_conflict Outputs whether the moving self
-	 *	 has a tile graphic that conflicts with the movement
-	 *	 direction.
-	 * @return See CheckWay.
+	 * @param self See CheckWay or MakeWay.
+	 * @param from_x See CheckWay or MakeWay.
+	 * @param from_y See CheckWay or MakeWay.
+	 * @param to_x See CheckWay or MakeWay.
+	 * @param to_y See CheckWay or MakeWay.
+	 * @param check_events_and_vehicles whether to check
+	 * events, or only consider map collision.
+	 * @param make_way Whether to cause side effects.
+	 * @param ignore_some_events_by_id A set of
+	 * specific event IDs to ignore.
+	 * @return See CheckWay or MakeWay.
 	 */
-	 bool CheckWayEx(const Game_Character& self,
+	 bool CheckOrMakeWayEx(const Game_Character& self,
 			int from_x, int from_y,
 			int to_x, int to_y,
-			bool ignore_events_and_vehicles,
+			bool check_events_and_vehicles,
 			std::unordered_set<int> *ignore_some_events_by_id,
-			int *out_bit_from,
-			int *out_bit_to,
-			int *out_to_x,
-			int *out_to_y,
-			bool *out_self_conflict);
-	bool CheckWayEx(const Game_Character& self,
-			int from_x, int from_y,
-			int to_x, int to_y,
-			bool ignore_all_events,
-			std::unordered_set<int> *ignore_some_events_by_id);
+			bool make_way);
 
 	/**
 	 * Gets if possible to land the airship at (x,y)


### PR DESCRIPTION
This should fix the regression I introduced in #3120 into `MakeWay`, where some corner cases no longer call `MakeWayCollide` like before which breaks some movement routes that disable collision dynamically. This fix also removes the unnecessary `CheckWayEx` functions of GameMap and GameCharacter again, and just adds multiple signatures for `CheckWay`. It also removes all the `out_...` pointers since I managed to merge the core functionality of `MakeWay` and `CheckWay` once more, making this whole pointer passing around unnecessary.

Sorry again for the regression. I hope this one will fare better, I compared it directly against the original `MakeWay` before all my changes and hopefully this time, no unintended change slipped by.

Fixes #3129 (at least in my tests)