### PR TITLE
NewCommand  2052 - AnimateVariable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ add_library(${PROJECT_NAME} OBJECT
 	src/async_op.h
 	src/algo.h
 	src/algo.cpp
+	src/animation_helper.cpp
+	src/animation_helper.h
 	src/attribute.h
 	src/attribute.cpp
 	src/audio.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/async_op.h \
 	src/algo.h \
 	src/algo.cpp \
+	src/animation_helper.cpp \
+	src/animation_helper.h \
 	src/attribute.h \
 	src/attribute.cpp \
 	src/audio.cpp \

--- a/src/animation_helper.cpp
+++ b/src/animation_helper.cpp
@@ -1,0 +1,161 @@
+#include "animation_helper.h"
+#include <cmath>
+#include <vector>
+#include <sstream>
+
+
+// references for cubic bezier:
+// https://matthewlein.com/tools/ceaser
+// https://cubic-bezier.com/
+double Animation_Helper::CubicBezier(float t, const double& p0, const double& p1, const double& p2, const double& p3) {
+
+	float u = 1 - t;
+	float tt = t * t;
+	float uu = u * u;
+	float uuu = uu * u;
+	float ttt = tt * t;
+
+	//Point2d p = {0,0};
+	//p.x = uuu * 0 + 3 * uu * t * p0 + 3 * u * tt * p2 + ttt * 1;
+	return uuu * 0 + 3 * uu * t * p1 + 3 * u * tt * p3 + ttt * 1;
+
+	//return p.y;
+}
+
+double Animation_Helper::GetEasedTime(const std::string& easing_type, double t, double b, double c, double d) {
+	if (easing_type == "linear")  return Animation_Helper::CubicBezier(t, 0.250, 0.250, 0.750, 0.750);
+
+	else if (easing_type == "ease")  return Animation_Helper::CubicBezier(t, 0.250, 0.100, 0.250, 1.000);
+	else if (easing_type == "easeIn")  return Animation_Helper::CubicBezier(t, 0.420, 0.000, 1.000, 1.000);
+	else if (easing_type == "easeOut")  return Animation_Helper::CubicBezier(t, 0.000, 0.000, 0.580, 1.000);
+	else if (easing_type == "easeInOut")  return Animation_Helper::CubicBezier(t, 0.420, 0.000, 0.580, 1.000);
+
+	else if (easing_type == "quadIn")  return Animation_Helper::CubicBezier(t, 0.550, 0.085, 0.680, 0.530);
+	else if (easing_type == "quadOut")  return Animation_Helper::CubicBezier(t, 0.250, 0.460, 0.450, 0.940);
+	else if (easing_type == "quadInOut")  return Animation_Helper::CubicBezier(t, 0.455, 0.030, 0.515, 0.955);
+
+	else if (easing_type == "cubicIn")  return Animation_Helper::CubicBezier(t, 0.550, 0.055, 0.675, 0.190);
+	else if (easing_type == "cubicOut")  return Animation_Helper::CubicBezier(t, 0.215, 0.610, 0.355, 1.000);
+	else if (easing_type == "cubicInOut")  return Animation_Helper::CubicBezier(t, 0.645, 0.045, 0.355, 1.000);
+
+	else if (easing_type == "quartIn")  return Animation_Helper::CubicBezier(t, 0.895, 0.030, 0.685, 0.220);
+	else if (easing_type == "quartOut")  return Animation_Helper::CubicBezier(t, 0.165, 0.840, 0.440, 1.000);
+	else if (easing_type == "quartInOut")  return Animation_Helper::CubicBezier(t, 0.770, 0.000, 0.175, 1.000);
+
+	else if (easing_type == "quintIn")  return Animation_Helper::CubicBezier(t, 0.755, 0.050, 0.855, 0.060);
+	else if (easing_type == "quintOut")  return Animation_Helper::CubicBezier(t, 0.230, 1.000, 0.320, 1.000);
+	else if (easing_type == "quintInOut")  return Animation_Helper::CubicBezier(t, 0.860, 0.000, 0.070, 1.000);
+
+	else if (easing_type == "sineIn")  return Animation_Helper::CubicBezier(t, 0.470, 0.000, 0.745, 0.715);
+	else if (easing_type == "sineOut")  return Animation_Helper::CubicBezier(t, 0.390, 0.575, 0.565, 1.000);
+	else if (easing_type == "sineInOut")  return Animation_Helper::CubicBezier(t, 0.445, 0.050, 0.550, 0.950);
+
+	else if (easing_type == "ExpoIn")  return Animation_Helper::CubicBezier(t, 0.950, 0.050, 0.795, 0.035);
+	else if (easing_type == "expoOut")  return Animation_Helper::CubicBezier(t, 0.190, 1.000, 0.220, 1.000);
+	else if (easing_type == "expoInOut")  return Animation_Helper::CubicBezier(t, 1.000, 0.000, 0.000, 1.000);
+
+	else if (easing_type == "circIn")  return Animation_Helper::CubicBezier(t, 0.600, 0.040, 0.980, 0.335);
+	else if (easing_type == "circOut")  return Animation_Helper::CubicBezier(t, 0.075, 0.820, 0.165, 1.000);
+	else if (easing_type == "circInOut")  return Animation_Helper::CubicBezier(t, 0.785, 0.135, 0.150, 0.860);
+
+	else if (easing_type == "backIn")  return Animation_Helper::CubicBezier(t, 0.600, -0.280, 0.735, 0.045);
+	else if (easing_type == "backOut")  return Animation_Helper::CubicBezier(t, 0.175, 0.885, 0.320, 1.275);
+	else if (easing_type == "backInOut")  return Animation_Helper::CubicBezier(t, 0.680, -0.550, 0.265, 1.550);
+
+	else if (easing_type == "elasticIn") {
+		if (t == 0) {
+			return b;
+		}
+		if ((t /= d) == 1) {
+			return b + c;
+		}
+
+		double p = d * 0.3;
+		double a = c;
+		double s = p / 4;
+
+		double post_increment_fix = a * pow(2, 10 * (t -= 1));
+		return -(post_increment_fix * sin((t * d - s) * (2 * M_PI) / p)) + b;
+	}
+	else if (easing_type == "elasticOut") {
+		if (t == 0) {
+			return b;
+		}
+		if ((t /= d) == 1) {
+			return b + c;
+		}
+
+		double p = d * 0.3;
+		double a = c;
+		double s = p / 4;
+
+		return (a * pow(2, -10 * t) * sin((t * d - s) * (2 * M_PI) / p) + c + b);
+	}
+	else if (easing_type == "elasticInOut") {
+		if (t == 0) {
+			return b;
+		}
+		if ((t /= d / 2) == 2) {
+			return b + c;
+		}
+
+		double p = d * (0.3 * 1.5);
+		double a = c;
+		double s = p / 4;
+
+		if (t < 1) {
+			double post_increment_fix = a * pow(2, 10 * (t -= 1));
+			return -0.5 * (post_increment_fix * sin((t * d - s) * (2 * M_PI) / p)) + b;
+		}
+
+		double post_increment_fix = a * pow(2, -10 * (t -= 1));
+		return post_increment_fix * sin((t * d - s) * (2 * M_PI) / p) * 0.5 + c + b;
+	}
+
+	else if (easing_type == "bounceIn") {
+		return c - Animation_Helper::GetEasedTime("bounceOut", d - t, 0, c, d) + b;
+	}
+	else if (easing_type == "bounceOut") {
+		if ((t /= d) < (1 / 2.75)) {
+			return c * (7.5625 * t * t) + b;
+		}
+		else if (t < (2 / 2.75)) {
+			t -= (1.5 / 2.75);
+			return c * (7.5625 * t * t + 0.75) + b;
+		}
+		else if (t < (2.5 / 2.75)) {
+			t -= (2.25 / 2.75);
+			return c * (7.5625 * t * t + 0.9375) + b;
+		}
+		else {
+			t -= (2.625 / 2.75);
+			return c * (7.5625 * t * t + 0.984375) + b;
+		}
+	}
+	else if (easing_type == "bounceInOut") {
+		if (t < d / 2) {
+			return Animation_Helper::GetEasedTime("bounceIn", t * 2, 0, c, d) * 0.5 + b;
+		}
+		else {
+			return Animation_Helper::GetEasedTime("bounceOut", t * 2 - d, 0, c, d) * 0.5 + c * 0.5 + b;
+		}
+	}
+
+	if (easing_type.substr(0, 6) == "bezier") {
+		std::vector<double> bezier_params;
+
+		size_t start_pos = easing_type.find("(") + 1;
+		size_t end_pos = easing_type.find(")");
+		std::string value_string = easing_type.substr(start_pos, end_pos - start_pos);
+
+		std::istringstream iss(value_string);
+		double value;
+
+		while (iss >> value) bezier_params.push_back(value), iss.ignore();
+
+		if (bezier_params.size() == 4)
+			return Animation_Helper::CubicBezier(t, bezier_params[0], bezier_params[1], bezier_params[2], bezier_params[3]);
+	}
+
+	return c * t / d + b; // Default to linear easing if the easing type is not recognized
+}

--- a/src/animation_helper.cpp
+++ b/src/animation_helper.cpp
@@ -1,3 +1,20 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "animation_helper.h"
 #include <cmath>
 #include <vector>

--- a/src/animation_helper.cpp
+++ b/src/animation_helper.cpp
@@ -17,162 +17,237 @@
 
 #include "animation_helper.h"
 #include <cmath>
-#include <vector>
+#include <unordered_map>
+#include <algorithm>
 #include <sstream>
+#include <vector>
 
+namespace {
+    constexpr double PI = 3.14159265358979323846;
 
-// references for cubic bezier:
-// https://matthewlein.com/tools/ceaser
-// https://cubic-bezier.com/
-double Animation_Helper::CubicBezier(float t, const double& p0, const double& p1, const double& p2, const double& p3) {
+    // Forward declarations
+    double HandleElasticEasing(Animation_Helper::EaseType type, double t, double b, double c, double d);
+    double HandleBounceEasing(Animation_Helper::EaseType type, double t, double b, double c, double d);
 
-	float u = 1 - t;
-	float tt = t * t;
-	float uu = u * u;
-	float uuu = uu * u;
-	float ttt = tt * t;
+    struct EasingData {
+        std::string_view name;
+        double x1, y1, x2, y2;
+        Animation_Helper::EaseType type;
+    };
 
-	//Point2d p = {0,0};
-	//p.x = uuu * 0 + 3 * uu * t * p0 + 3 * u * tt * p2 + ttt * 1;
-	return uuu * 0 + 3 * uu * t * p1 + 3 * u * tt * p3 + ttt * 1;
+    const EasingData EASING_DATA[] = {
+        {"linear", 0.250, 0.250, 0.750, 0.750, Animation_Helper::EaseType::Linear},
+        {"ease", 0.250, 0.100, 0.250, 1.000, Animation_Helper::EaseType::Ease},
+        {"easeIn", 0.420, 0.000, 1.000, 1.000, Animation_Helper::EaseType::EaseIn},
+        {"easeOut", 0.000, 0.000, 0.580, 1.000, Animation_Helper::EaseType::EaseOut},
+        {"easeInOut", 0.420, 0.000, 0.580, 1.000, Animation_Helper::EaseType::EaseInOut},
+        {"quadIn", 0.550, 0.085, 0.680, 0.530, Animation_Helper::EaseType::QuadIn},
+        {"quadOut", 0.250, 0.460, 0.450, 0.940, Animation_Helper::EaseType::QuadOut},
+        {"quadInOut", 0.455, 0.030, 0.515, 0.955, Animation_Helper::EaseType::QuadInOut},
+        {"cubicIn", 0.550, 0.055, 0.675, 0.190, Animation_Helper::EaseType::CubicIn},
+        {"cubicOut", 0.215, 0.610, 0.355, 1.000, Animation_Helper::EaseType::CubicOut},
+        {"cubicInOut", 0.645, 0.045, 0.355, 1.000, Animation_Helper::EaseType::CubicInOut},
+        {"quartIn", 0.895, 0.030, 0.685, 0.220, Animation_Helper::EaseType::QuartIn},
+        {"quartOut", 0.165, 0.840, 0.440, 1.000, Animation_Helper::EaseType::QuartOut},
+        {"quartInOut", 0.770, 0.000, 0.175, 1.000, Animation_Helper::EaseType::QuartInOut},
+        {"quintIn", 0.755, 0.050, 0.855, 0.060, Animation_Helper::EaseType::QuintIn},
+        {"quintOut", 0.230, 1.000, 0.320, 1.000, Animation_Helper::EaseType::QuintOut},
+        {"quintInOut", 0.860, 0.000, 0.070, 1.000, Animation_Helper::EaseType::QuintInOut},
+        {"sineIn", 0.470, 0.000, 0.745, 0.715, Animation_Helper::EaseType::SineIn},
+        {"sineOut", 0.390, 0.575, 0.565, 1.000, Animation_Helper::EaseType::SineOut},
+        {"sineInOut", 0.445, 0.050, 0.550, 0.950, Animation_Helper::EaseType::SineInOut},
+        {"expoIn", 0.950, 0.050, 0.795, 0.035, Animation_Helper::EaseType::ExpoIn},
+        {"expoOut", 0.190, 1.000, 0.220, 1.000, Animation_Helper::EaseType::ExpoOut},
+        {"expoInOut", 1.000, 0.000, 0.000, 1.000, Animation_Helper::EaseType::ExpoInOut},
+        {"circIn", 0.600, 0.040, 0.980, 0.335, Animation_Helper::EaseType::CircIn},
+        {"circOut", 0.075, 0.820, 0.165, 1.000, Animation_Helper::EaseType::CircOut},
+        {"circInOut", 0.785, 0.135, 0.150, 0.860, Animation_Helper::EaseType::CircInOut},
+        {"backIn", 0.600, -0.280, 0.735, 0.045, Animation_Helper::EaseType::BackIn},
+        {"backOut", 0.175, 0.885, 0.320, 1.275, Animation_Helper::EaseType::BackOut},
+        {"backInOut", 0.680, -0.550, 0.265, 1.550, Animation_Helper::EaseType::BackInOut},
+        // Special cases (no bezier points needed)
+        {"elasticIn", 0, 0, 0, 0, Animation_Helper::EaseType::ElasticIn},
+        {"elasticOut", 0, 0, 0, 0, Animation_Helper::EaseType::ElasticOut},
+        {"elasticInOut", 0, 0, 0, 0, Animation_Helper::EaseType::ElasticInOut},
+        {"bounceIn", 0, 0, 0, 0, Animation_Helper::EaseType::BounceIn},
+        {"bounceOut", 0, 0, 0, 0, Animation_Helper::EaseType::BounceOut},
+        {"bounceInOut", 0, 0, 0, 0, Animation_Helper::EaseType::BounceInOut}
+    };
 
-	//return p.y;
+    double HandleElasticEasing(Animation_Helper::EaseType type, double t, double b, double c, double d) {
+        constexpr double pi2 = 2.0 * PI;
+        const double p = d * 0.3;
+        const double s = p / 4.0;
+
+        if (t <= 0.0) return b;
+        if (t >= 1.0) return b + c;
+
+        switch (type) {
+            case Animation_Helper::EaseType::ElasticIn: {
+                const double post_fix = c * std::pow(2.0, 10.0 * (t - 1.0));
+                return -(post_fix * std::sin((t * d - s) * pi2 / p)) + b;
+            }
+            case Animation_Helper::EaseType::ElasticOut: {
+                return (c * std::pow(2.0, -10.0 * t) * std::sin((t * d - s) * pi2 / p) + c + b);
+            }
+            case Animation_Helper::EaseType::ElasticInOut: {
+                if (t < 0.5) {
+                    const double post_fix = c * std::pow(2.0, 10.0 * (2.0 * t - 1.0));
+                    return -0.5 * (post_fix * std::sin(((2.0 * t - 1.0) * d - s) * pi2 / p)) + b;
+                }
+                const double post_fix = c * std::pow(2.0, -10.0 * (2.0 * t - 1.0));
+                return post_fix * std::sin(((2.0 * t - 1.0) * d - s) * pi2 / p) * 0.5 + c + b;
+            }
+            default:
+                return b + c * t;
+        }
+    }
+
+    double HandleBounceEasing(Animation_Helper::EaseType type, double t, double b, double c, double d) {
+        switch (type) {
+            case Animation_Helper::EaseType::BounceIn:
+                return c - HandleBounceEasing(Animation_Helper::EaseType::BounceOut, 1.0 - t, 0, c, d) + b;
+            case Animation_Helper::EaseType::BounceOut:
+                if (t < (1.0 / 2.75)) {
+                    return c * (7.5625 * t * t) + b;
+                } else if (t < (2.0 / 2.75)) {
+                    t -= (1.5 / 2.75);
+                    return c * (7.5625 * t * t + 0.75) + b;
+                } else if (t < (2.5 / 2.75)) {
+                    t -= (2.25 / 2.75);
+                    return c * (7.5625 * t * t + 0.9375) + b;
+                }
+                t -= (2.625 / 2.75);
+                return c * (7.5625 * t * t + 0.984375) + b;
+            case Animation_Helper::EaseType::BounceInOut:
+                if (t < 0.5) {
+                    return HandleBounceEasing(Animation_Helper::EaseType::BounceIn, t * 2.0, 0, c, d) * 0.5 + b;
+                }
+                return HandleBounceEasing(Animation_Helper::EaseType::BounceOut, t * 2.0 - 1.0, 0, c, d) * 0.5 + c * 0.5 + b;
+            default:
+                return b + c * t;
+        }
+    }
 }
 
-double Animation_Helper::GetEasedTime(const std::string& easing_type, double t, double b, double c, double d) {
-	if (easing_type == "linear")  return Animation_Helper::CubicBezier(t, 0.250, 0.250, 0.750, 0.750);
+namespace Animation_Helper {
 
-	else if (easing_type == "ease")  return Animation_Helper::CubicBezier(t, 0.250, 0.100, 0.250, 1.000);
-	else if (easing_type == "easeIn")  return Animation_Helper::CubicBezier(t, 0.420, 0.000, 1.000, 1.000);
-	else if (easing_type == "easeOut")  return Animation_Helper::CubicBezier(t, 0.000, 0.000, 0.580, 1.000);
-	else if (easing_type == "easeInOut")  return Animation_Helper::CubicBezier(t, 0.420, 0.000, 0.580, 1.000);
-
-	else if (easing_type == "quadIn")  return Animation_Helper::CubicBezier(t, 0.550, 0.085, 0.680, 0.530);
-	else if (easing_type == "quadOut")  return Animation_Helper::CubicBezier(t, 0.250, 0.460, 0.450, 0.940);
-	else if (easing_type == "quadInOut")  return Animation_Helper::CubicBezier(t, 0.455, 0.030, 0.515, 0.955);
-
-	else if (easing_type == "cubicIn")  return Animation_Helper::CubicBezier(t, 0.550, 0.055, 0.675, 0.190);
-	else if (easing_type == "cubicOut")  return Animation_Helper::CubicBezier(t, 0.215, 0.610, 0.355, 1.000);
-	else if (easing_type == "cubicInOut")  return Animation_Helper::CubicBezier(t, 0.645, 0.045, 0.355, 1.000);
-
-	else if (easing_type == "quartIn")  return Animation_Helper::CubicBezier(t, 0.895, 0.030, 0.685, 0.220);
-	else if (easing_type == "quartOut")  return Animation_Helper::CubicBezier(t, 0.165, 0.840, 0.440, 1.000);
-	else if (easing_type == "quartInOut")  return Animation_Helper::CubicBezier(t, 0.770, 0.000, 0.175, 1.000);
-
-	else if (easing_type == "quintIn")  return Animation_Helper::CubicBezier(t, 0.755, 0.050, 0.855, 0.060);
-	else if (easing_type == "quintOut")  return Animation_Helper::CubicBezier(t, 0.230, 1.000, 0.320, 1.000);
-	else if (easing_type == "quintInOut")  return Animation_Helper::CubicBezier(t, 0.860, 0.000, 0.070, 1.000);
-
-	else if (easing_type == "sineIn")  return Animation_Helper::CubicBezier(t, 0.470, 0.000, 0.745, 0.715);
-	else if (easing_type == "sineOut")  return Animation_Helper::CubicBezier(t, 0.390, 0.575, 0.565, 1.000);
-	else if (easing_type == "sineInOut")  return Animation_Helper::CubicBezier(t, 0.445, 0.050, 0.550, 0.950);
-
-	else if (easing_type == "ExpoIn")  return Animation_Helper::CubicBezier(t, 0.950, 0.050, 0.795, 0.035);
-	else if (easing_type == "expoOut")  return Animation_Helper::CubicBezier(t, 0.190, 1.000, 0.220, 1.000);
-	else if (easing_type == "expoInOut")  return Animation_Helper::CubicBezier(t, 1.000, 0.000, 0.000, 1.000);
-
-	else if (easing_type == "circIn")  return Animation_Helper::CubicBezier(t, 0.600, 0.040, 0.980, 0.335);
-	else if (easing_type == "circOut")  return Animation_Helper::CubicBezier(t, 0.075, 0.820, 0.165, 1.000);
-	else if (easing_type == "circInOut")  return Animation_Helper::CubicBezier(t, 0.785, 0.135, 0.150, 0.860);
-
-	else if (easing_type == "backIn")  return Animation_Helper::CubicBezier(t, 0.600, -0.280, 0.735, 0.045);
-	else if (easing_type == "backOut")  return Animation_Helper::CubicBezier(t, 0.175, 0.885, 0.320, 1.275);
-	else if (easing_type == "backInOut")  return Animation_Helper::CubicBezier(t, 0.680, -0.550, 0.265, 1.550);
-
-	else if (easing_type == "elasticIn") {
-		if (t == 0) {
-			return b;
-		}
-		if ((t /= d) == 1) {
-			return b + c;
-		}
-
-		double p = d * 0.3;
-		double a = c;
-		double s = p / 4;
-
-		double post_increment_fix = a * pow(2, 10 * (t -= 1));
-		return -(post_increment_fix * sin((t * d - s) * (2 * M_PI) / p)) + b;
-	}
-	else if (easing_type == "elasticOut") {
-		if (t == 0) {
-			return b;
-		}
-		if ((t /= d) == 1) {
-			return b + c;
-		}
-
-		double p = d * 0.3;
-		double a = c;
-		double s = p / 4;
-
-		return (a * pow(2, -10 * t) * sin((t * d - s) * (2 * M_PI) / p) + c + b);
-	}
-	else if (easing_type == "elasticInOut") {
-		if (t == 0) {
-			return b;
-		}
-		if ((t /= d / 2) == 2) {
-			return b + c;
-		}
-
-		double p = d * (0.3 * 1.5);
-		double a = c;
-		double s = p / 4;
-
-		if (t < 1) {
-			double post_increment_fix = a * pow(2, 10 * (t -= 1));
-			return -0.5 * (post_increment_fix * sin((t * d - s) * (2 * M_PI) / p)) + b;
-		}
-
-		double post_increment_fix = a * pow(2, -10 * (t -= 1));
-		return post_increment_fix * sin((t * d - s) * (2 * M_PI) / p) * 0.5 + c + b;
-	}
-
-	else if (easing_type == "bounceIn") {
-		return c - Animation_Helper::GetEasedTime("bounceOut", d - t, 0, c, d) + b;
-	}
-	else if (easing_type == "bounceOut") {
-		if ((t /= d) < (1 / 2.75)) {
-			return c * (7.5625 * t * t) + b;
-		}
-		else if (t < (2 / 2.75)) {
-			t -= (1.5 / 2.75);
-			return c * (7.5625 * t * t + 0.75) + b;
-		}
-		else if (t < (2.5 / 2.75)) {
-			t -= (2.25 / 2.75);
-			return c * (7.5625 * t * t + 0.9375) + b;
-		}
-		else {
-			t -= (2.625 / 2.75);
-			return c * (7.5625 * t * t + 0.984375) + b;
-		}
-	}
-	else if (easing_type == "bounceInOut") {
-		if (t < d / 2) {
-			return Animation_Helper::GetEasedTime("bounceIn", t * 2, 0, c, d) * 0.5 + b;
-		}
-		else {
-			return Animation_Helper::GetEasedTime("bounceOut", t * 2 - d, 0, c, d) * 0.5 + c * 0.5 + b;
-		}
-	}
-
-	if (easing_type.substr(0, 6) == "bezier") {
-		std::vector<double> bezier_params;
-
-		size_t start_pos = easing_type.find("(") + 1;
-		size_t end_pos = easing_type.find(")");
-		std::string value_string = easing_type.substr(start_pos, end_pos - start_pos);
-
-		std::istringstream iss(value_string);
-		double value;
-
-		while (iss >> value) bezier_params.push_back(value), iss.ignore();
-
-		if (bezier_params.size() == 4)
-			return Animation_Helper::CubicBezier(t, bezier_params[0], bezier_params[1], bezier_params[2], bezier_params[3]);
-	}
-
-	return c * t / d + b; // Default to linear easing if the easing type is not recognized
+double CubicBezier(double progress, double x1, double y1, double x2, double y2) {
+    // This is a cubic Bezier curve for animation timing:
+    // P₀(0,0) - start point, always fixed
+    // P₁(x1,y1) - first control point
+    // P₂(x2,y2) - second control point
+    // P₃(1,1) - end point, always fixed
+    //
+    // x coordinates (x1,x2) control the timing curve's shape
+    // y coordinates (y1,y2) control the rate of change at those points
+    
+    ////progress = std::clamp(progress, 0.0, 1.0);
+    
+    // Since we need to find y for a given x (progress), 
+    // we need to solve for t where the curve's x equals our progress
+    // This is a rough approximation using a few iterations
+    double t = progress;  // Initial guess
+    
+    // Newton's method to find better t value
+    for (int i = 0; i < 5; i++) {  // Usually converges in 4-5 iterations
+        const double currentT = t;
+        const double oneMinusT = 1.0 - t;
+        
+        // Calculate x(t) - current x position on curve
+        const double x = 3.0 * oneMinusT * oneMinusT * t * x1 +
+                        3.0 * oneMinusT * t * t * x2 +
+                        t * t * t;
+        
+        // If we're close enough to desired x, calculate final y
+        if (std::abs(x - progress) < 0.001) {
+            break;
+        }
+        
+        // Calculate x'(t) - derivative of x with respect to t
+        const double dx = 3.0 * oneMinusT * oneMinusT * x1 +
+                         6.0 * oneMinusT * t * (x2 - x1) +
+                         3.0 * t * t * (1 - x2);
+        
+        // Avoid division by zero
+        if (std::abs(dx) < 0.0001) {
+            break;
+        }
+        
+        // Newton iteration
+        t = t - (x - progress) / dx;
+        //// t = std::clamp(t, 0.0, 1.0);
+        
+        // If t hasn't changed significantly, we're done
+        if (std::abs(t - currentT) < 0.0001) {
+            break;
+        }
+    }
+    
+    // Calculate final y value using found t
+    const double oneMinusT = 1.0 - t;
+    return 3.0 * oneMinusT * oneMinusT * t * y1 +
+           3.0 * oneMinusT * t * t * y2 +
+           t * t * t;
 }
+
+EaseType StringToEaseType(std::string_view type_name) {
+    for (const auto& data : EASING_DATA) {
+        if (data.name == type_name) {
+            return data.type;
+        }
+    }
+    return EaseType::Linear;
+}
+
+double GetEasedTime(EaseType type, double t, double b, double c, double d) {
+    t = std::clamp(t, 0.0, d);
+    const double normalized_t = t / d;
+
+    // Handle special cases first
+    switch (type) {
+        case EaseType::ElasticIn:
+        case EaseType::ElasticOut:
+        case EaseType::ElasticInOut:
+            return HandleElasticEasing(type, normalized_t, b, c, d);
+        case EaseType::BounceIn:
+        case EaseType::BounceOut:
+        case EaseType::BounceInOut:
+            return HandleBounceEasing(type, normalized_t, b, c, d);
+        default:
+            break;
+    }
+
+    // Find bezier points for the type
+    for (const auto& data : EASING_DATA) {
+        if (data.type == type) {
+            return b + c * CubicBezier(normalized_t, data.x1, data.y1, data.x2, data.y2);
+        }
+    }
+
+    return b + c * normalized_t; // Linear fallback
+}
+
+double GetEasedTime(const std::string& easing_type, double t, double b, double c, double d) {
+    if (easing_type.substr(0, 6) == "bezier") {
+        std::vector<double> params;
+        size_t start = easing_type.find('(') + 1;
+        size_t end = easing_type.find(')');
+        if (start != std::string::npos && end != std::string::npos) {
+            std::string values = easing_type.substr(start, end - start);
+            std::istringstream iss(values);
+            double val;
+            while (iss >> val) {
+                params.push_back(val);
+                iss.ignore();
+            }
+            if (params.size() == 4) {
+                return b + c * CubicBezier(t/d, params[0], params[1], params[2], params[3]);
+            }
+        }
+    }
+
+    return GetEasedTime(StringToEaseType(easing_type), t, b, c, d);
+}
+
+} // namespace Animation_Helper

--- a/src/animation_helper.h
+++ b/src/animation_helper.h
@@ -1,3 +1,20 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef ANIMATION_HELPER_H
 #define ANIMATION_HELPER_H
 

--- a/src/animation_helper.h
+++ b/src/animation_helper.h
@@ -1,0 +1,11 @@
+#ifndef ANIMATION_HELPER_H
+#define ANIMATION_HELPER_H
+
+#include <string>
+
+namespace Animation_Helper {
+	double CubicBezier(float t, const double& p0, const double& p1, const double& p2, const double& p3);
+	double GetEasedTime(const std::string& easing_type, double t, double b, double c, double d);
+}
+
+#endif

--- a/src/animation_helper.h
+++ b/src/animation_helper.h
@@ -19,10 +19,107 @@
 #define ANIMATION_HELPER_H
 
 #include <string>
+#include <string_view>
 
 namespace Animation_Helper {
-	double CubicBezier(float t, const double& p0, const double& p1, const double& p2, const double& p3);
-	double GetEasedTime(const std::string& easing_type, double t, double b, double c, double d);
+    /**
+     * Supported easing types for animations.
+     * These match CSS animation timing functions for familiarity.
+     */
+    enum class EaseType {
+        Linear,
+        // Basic
+        Ease,
+        EaseIn,
+        EaseOut,
+        EaseInOut,
+        // Quadratic
+        QuadIn,
+        QuadOut,
+        QuadInOut,
+        // Cubic
+        CubicIn,
+        CubicOut,
+        CubicInOut,
+        // Quartic
+        QuartIn,
+        QuartOut,
+        QuartInOut,
+        // Quintic
+        QuintIn,
+        QuintOut,
+        QuintInOut,
+        // Sinusoidal
+        SineIn,
+        SineOut,
+        SineInOut,
+        // Exponential
+        ExpoIn,
+        ExpoOut,
+        ExpoInOut,
+        // Circular
+        CircIn,
+        CircOut,
+        CircInOut,
+        // Back
+        BackIn,
+        BackOut,
+        BackInOut,
+        // Elastic
+        ElasticIn,
+        ElasticOut,
+        ElasticInOut,
+        // Bounce
+        BounceIn,
+        BounceOut,
+        BounceInOut
+    };
+
+    /**
+     * Converts a string to an EaseType enum value
+     * @param type_name The name of the easing type
+     * @return The corresponding EaseType enum value
+     */
+    EaseType StringToEaseType(std::string_view type_name);
+
+    /**
+     * Calculates a point on a cubic Bezier curve for animation timing
+     * @param progress Current animation progress (0 to 1)
+     * @param x1 X coordinate of first control point, controls when early changes occur
+     * @param y1 Y coordinate of first control point, controls magnitude of early changes
+     * @param x2 X coordinate of second control point, controls when later changes occur
+     * @param y2 Y coordinate of second control point, controls magnitude of later changes
+     * @return The calculated animation progress value
+     * 
+     * Control points affect the animation as follows:
+     * - x values control timing (when changes happen)
+     * - y values control magnitude (how much change occurs)
+     * - Values > current progress create overshoots
+     * - Values < current progress create undershoots
+     */
+    double CubicBezier(double progress, double x1, double y1, double x2, double y2);
+
+    /**
+     * Gets the eased time value based on the specified easing type
+     * @param easing_type Type of easing to apply
+     * @param t Current time (0 to 1)
+     * @param b Start value
+     * @param c Change in value (end - start)
+     * @param d Duration
+     * @return The eased value
+     */
+    double GetEasedTime(const std::string& easing_type, double t, double b, double c, double d);
+
+    /**
+     * Gets the eased time value using enum-based easing type
+     * @param type The easing type enum
+     * @param t Current time (0 to 1)
+     * @param b Start value
+     * @param c Change in value (end - start)
+     * @param d Duration
+     * @return The eased value
+     */
+    double GetEasedTime(EaseType type, double t, double b, double c, double d);
 }
 
 #endif

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -5504,129 +5504,65 @@ int Game_Interpreter::ManiacBitmask(int value, int mask) const {
 
 	return value;
 }
-std::vector<double> parseBezier(const std::string& bezierParams) {
-	std::vector<double> params;
-	std::string temp;
-	size_t startPos = bezierParams.find("(") + 1;
-	size_t endPos = bezierParams.find(")");
-	std::string valuesString = bezierParams.substr(startPos, endPos - startPos);
 
-	size_t commaPos = valuesString.find(",");
-	while (commaPos != std::string::npos) {
-		temp = valuesString.substr(0, commaPos);
-		params.push_back(std::stod(temp));
-		valuesString = valuesString.substr(commaPos + 1);
-		commaPos = valuesString.find(",");
-	}
-	// Push the last value into the vector
-	params.push_back(std::stod(valuesString));
-
-	return params;
-}
-
-//FIXME: cubicBezier is completely Broken
-// references to how it should work:
+// references for cubic bezier:
 // https://matthewlein.com/tools/ceaser
 // https://cubic-bezier.com/
+double cubicBezier(float t, const double& p0,const double& p1, const double& p2, const double& p3) {
 
-double cubicBezier(double t, double p0, double p1, double p2, double p3) {
-	double u = 1 - t;
-	double tt = t * t;
-	double uu = u * u;
-	double uuu = uu * u;
-	double ttt = tt * t;
+	float u = 1 - t;
+	float tt = t * t;
+	float uu = u * u;
+	float uuu = uu * u;
+	float ttt = tt * t;
 
-	double p = uuu * p0; // (1-t)^3
-	double q = 3 * uu * t * p1; // 3t(1-t)^2
-	double r = 3 * u * tt * p2; // 3(1-t)t^2
-	double s = ttt * p3; // t^3
+	//Point2d p = {0,0};
+	//p.x = uuu * 0 + 3 * uu * t * p0 + 3 * u * tt * p2 + ttt * 1;
+	return uuu * 0 + 3 * uu * t * p1 + 3 * u * tt * p3 + ttt * 1;
 
-	return p + q + r + s;
+	//return p.y;
 }
 
-double getEasedT(const std::string& easingType, double t, double b, double c, double d) {
-	if (easingType == "linear") {
-		return c * t / d + b;
-	}
-	else if (easingType == "quadIn") {
-		t /= d;
-		return c * t * t + b;
-	}
-	else if (easingType == "quadOut") {
-		t /= d;
-		return -c * t * (t - 2) + b;
-	}
-	else if (easingType == "quadInOut") {
-		t /= d / 2;
-		if (t < 1) {
-			return c / 2 * t * t + b;
-		}
-		else {
-			t -= 1;
-			return -c / 2 * (t * (t - 2) - 1) + b;
-		}
-	}
-	else if (easingType == "cubicIn") {
-		t /= d;
-		return c * t * t * t + b;
-	}
-	else if (easingType == "cubicOut") {
-		t = (t / d) - 1;
-		return c * (t * t * t + 1) + b;
-	}
-	else if (easingType == "cubicInOut") {
-		t /= d / 2;
-		if (t < 1) {
-			return c / 2 * t * t * t + b;
-		}
-		else {
-			t -= 2;
-			return c / 2 * (t * t * t + 2) + b;
-		}
-	}
-	else if (easingType == "sinIn") {
-		return -c * cos(t / d * (M_PI / 2)) + c + b;
-	}
-	else if (easingType == "sinOut") {
-		return c * sin(t / d * (M_PI / 2)) + b;
-	}
-	else if (easingType == "sinInOut") {
-		return -c / 2 * (cos(M_PI * t / d) - 1) + b;
-	}
-	else if (easingType == "expoIn") {
-		return c * pow(2, 10 * (t / d - 1)) + b;
-	}
-	else if (easingType == "expoOut") {
-		return c * (-pow(2, -10 * t / d) + 1) + b;
-	}
-	else if (easingType == "expoInOut") {
-		t /= d / 2;
-		if (t < 1) {
-			return c / 2 * pow(2, 10 * (t - 1)) + b;
-		}
-		else {
-			t -= 1;
-			return c / 2 * (-pow(2, -10 * t) + 2) + b;
-		}
-	}
-	else if (easingType == "circIn") {
-		t /= d;
-		return -c * (sqrt(1 - t * t) - 1) + b;
-	}
-	else if (easingType == "circOut") {
-		t = (t / d) - 1;
-		return c * sqrt(1 - t * t) + b;
-	}
-	else if (easingType == "circInOut") {
-		t /= d / 2;
-		if (t < 1) {
-			return -c / 2 * (sqrt(1 - t * t) - 1) + b;
-		}
-		else {
-			t -= 2;
-			return c / 2 * (sqrt(1 - t * t) + 1) + b;
-		}
-	}
+double getEasedTime(const std::string& easingType, double t, double b, double c, double d) {
+	if (easingType == "linear")  return cubicBezier(t, 0.250, 0.250, 0.750, 0.750);
+
+	else if (easingType == "ease")  return cubicBezier(t, 0.250, 0.100, 0.250, 1.000);
+	else if (easingType == "easeIn")  return cubicBezier(t, 0.420, 0.000, 1.000, 1.000);
+	else if (easingType == "easeOut")  return cubicBezier(t, 0.000, 0.000, 0.580, 1.000);
+	else if (easingType == "easeInOut")  return cubicBezier(t, 0.420, 0.000, 0.580, 1.000);
+
+	else if (easingType == "quadIn")  return cubicBezier(t, 0.550, 0.085, 0.680, 0.530);
+	else if (easingType == "quadOut")  return cubicBezier(t, 0.250, 0.460, 0.450, 0.940);
+	else if (easingType == "quadInOut")  return cubicBezier(t, 0.455, 0.030, 0.515, 0.955);
+
+	else if (easingType == "cubicIn")  return cubicBezier(t, 0.550, 0.055, 0.675, 0.190);
+	else if (easingType == "cubicOut")  return cubicBezier(t, 0.215, 0.610, 0.355, 1.000);
+	else if (easingType == "cubicInOut")  return cubicBezier(t, 0.645, 0.045, 0.355, 1.000);
+
+	else if (easingType == "quartIn")  return cubicBezier(t, 0.895, 0.030, 0.685, 0.220);
+	else if (easingType == "quartOut")  return cubicBezier(t, 0.165, 0.840, 0.440, 1.000);
+	else if (easingType == "quartInOut")  return cubicBezier(t, 0.770, 0.000, 0.175, 1.000);
+
+	else if (easingType == "quintIn")  return cubicBezier(t, 0.755, 0.050, 0.855, 0.060);
+	else if (easingType == "quintOut")  return cubicBezier(t, 0.230, 1.000, 0.320, 1.000);
+	else if (easingType == "quintInOut")  return cubicBezier(t, 0.860, 0.000, 0.070, 1.000);
+
+	else if (easingType == "sineIn")  return cubicBezier(t, 0.470, 0.000, 0.745, 0.715);
+	else if (easingType == "sineOut")  return cubicBezier(t, 0.390, 0.575, 0.565, 1.000);
+	else if (easingType == "sineInOut")  return cubicBezier(t, 0.445, 0.050, 0.550, 0.950);
+
+	else if (easingType == "ExpoIn")  return cubicBezier(t, 0.950, 0.050, 0.795, 0.035);
+	else if (easingType == "expoOut")  return cubicBezier(t, 0.190, 1.000, 0.220, 1.000);
+	else if (easingType == "expoInOut")  return cubicBezier(t, 1.000, 0.000, 0.000, 1.000);
+
+	else if (easingType == "circIn")  return cubicBezier(t, 0.600, 0.040, 0.980, 0.335);
+	else if (easingType == "circOut")  return cubicBezier(t, 0.075, 0.820, 0.165, 1.000);
+	else if (easingType == "circInOut")  return cubicBezier(t, 0.785, 0.135, 0.150, 0.860);
+
+	else if (easingType == "backIn")  return cubicBezier(t, 0.600, -0.280, 0.735, 0.045);
+	else if (easingType == "backOut")  return cubicBezier(t, 0.175, 0.885, 0.320, 1.275);
+	else if (easingType == "backInOut")  return cubicBezier(t, 0.680, -0.550, 0.265, 1.550);
+
 	else if (easingType == "elasticIn") {
 		if (t == 0) {
 			return b;
@@ -5676,8 +5612,9 @@ double getEasedT(const std::string& easingType, double t, double b, double c, do
 		double postFix = a * pow(2, -10 * (t -= 1)); // this is a fix, again, with post-increment operators
 		return postFix * sin((t * d - s) * (2 * M_PI) / p) * 0.5 + c + b;
 	}
+
 	else if (easingType == "bounceIn") {
-		return c - getEasedT("bounceOut", d - t, 0, c, d) + b;
+		return c - getEasedTime("bounceOut", d - t, 0, c, d) + b;
 	}
 	else if (easingType == "bounceOut") {
 		if ((t /= d) < (1 / 2.75)) {
@@ -5698,65 +5635,30 @@ double getEasedT(const std::string& easingType, double t, double b, double c, do
 	}
 	else if (easingType == "bounceInOut") {
 		if (t < d / 2) {
-			return getEasedT("bounceIn", t * 2, 0, c, d) * 0.5 + b;
+			return getEasedTime("bounceIn", t * 2, 0, c, d) * 0.5 + b;
 		}
 		else {
-			return getEasedT("bounceOut", t * 2 - d, 0, c, d) * 0.5 + c * 0.5 + b;
+			return getEasedTime("bounceOut", t * 2 - d, 0, c, d) * 0.5 + c * 0.5 + b;
 		}
 	}
+
 	if (easingType.substr(0, 6) == "bezier") {
-		std::vector < double > bezierParams = parseBezier(easingType.substr(7));
-		if (bezierParams.size() == 4) {
-			return cubicBezier(t / d, bezierParams[0], bezierParams[1], bezierParams[2], bezierParams[3]);
-		}
+		std::vector<double> bezierParams;
+
+		size_t startPos = easingType.find("(") + 1;
+		size_t endPos = easingType.find(")");
+		std::string valuesString = easingType.substr(startPos, endPos - startPos);
+
+		std::istringstream iss(valuesString);
+		double value;
+
+		while (iss >> value) bezierParams.push_back(value), iss.ignore();
+
+		if (bezierParams.size() == 4)
+			return cubicBezier(t, bezierParams[0], bezierParams[1], bezierParams[2], bezierParams[3]);
 	}
 
 	return c * t / d + b; // Default to linear easing if the easing type is not recognized
-}
-
-std::vector<double> interpolate(double start, double end, double duration, const std::string& easingTypeAtStart, const std::string& easingTypeAtEnd) {
-	std::vector<double> interpolatedValues;
-	interpolatedValues.push_back(start);
-
-	// Calculate the number of steps based on the duration
-	int numSteps = static_cast<int>(duration); // Convert duration to an integer
-	double stepSize = 1.0 / numSteps;
-
-	// Calculate the halfway point
-	double halfway = start + (end - start) * 0.5;
-
-	if (easingTypeAtEnd == "null") {
-		// Use easingTypeAtStart for the entire animation
-		for (int step = 1; step <= numSteps; ++step) {
-			double t = step * stepSize;
-			double easedT = getEasedT(easingTypeAtStart, t, 0, 1, 1);  // Call getEasedT with appropriate parameters
-			double interpolatedValue = start + easedT * (end - start);
-			interpolatedValues.push_back(interpolatedValue);
-		}
-	}
-	else {
-		// Generate the first half of the interpolation
-		for (int step = 1; step <= numSteps / 2; ++step) {
-			double t = step * stepSize;
-			double normalizedT = t / 0.5;  // Normalize the time for the first half
-			double easedT = getEasedT(easingTypeAtStart, normalizedT, 0, 1, 1);  // Call getEasedT with appropriate parameters
-			double interpolatedValue = start + easedT * (halfway - start);
-			interpolatedValues.push_back(interpolatedValue);
-		}
-
-		// Generate the second half of the interpolation
-		for (int step = numSteps / 2 + 1; step <= numSteps; ++step) {
-			double t = step * stepSize;
-			double normalizedT = (t - 0.5) / 0.5;  // Normalize the time for the second half
-			double easedT = getEasedT(easingTypeAtEnd, normalizedT, 0, 1, 1);  // Call getEasedT with appropriate parameters
-			double interpolatedValue = halfway + easedT * (end - halfway);
-			interpolatedValues.push_back(interpolatedValue);
-		}
-	}
-
-	interpolatedValues.push_back(end);
-
-	return interpolatedValues;
 }
 
 bool Game_Interpreter::CommandEasyRpgAnimateVariable(lcf::rpg::EventCommand const& com) {
@@ -5767,6 +5669,17 @@ bool Game_Interpreter::CommandEasyRpgAnimateVariable(lcf::rpg::EventCommand cons
 	int32_t end = ValueOrVariable(com.parameters[4], com.parameters[5]);
 	int32_t duration = ValueOrVariable(com.parameters[6], com.parameters[7]);
 
+	// Extract easing information
+	std::string easingTypeAtStart = ToString(com.string);
+	std::string easingTypeAtEnd = "null";
+
+	std::size_t pos = easingTypeAtStart.find('/');
+
+	if (pos != std::string::npos) {
+		easingTypeAtEnd = easingTypeAtStart.substr(pos + 1);
+		easingTypeAtStart = easingTypeAtStart.substr(0, pos);
+	}
+
 	// Prepare animation-related commands
 	lcf::rpg::EventCommand waitCom;
 	waitCom.code = int(Cmd::Wait);
@@ -5774,35 +5687,49 @@ bool Game_Interpreter::CommandEasyRpgAnimateVariable(lcf::rpg::EventCommand cons
 	lcf::rpg::EventCommand animatedCom;
 	animatedCom.code = int(Cmd::ControlVars);
 	std::vector<int32_t> animatedVarParams = { 0, static_cast<int32_t>(target), 0, 0, 0, static_cast<int32_t>(end) };
-	animatedCom.parameters = lcf::DBArray<int32_t>(animatedVarParams.begin(), animatedVarParams.end());
 
 	std::vector<lcf::rpg::EventCommand> cmdList;
 
-	// Extract easing information
-	std::string easeStart = ToString(com.string);
-	std::string easeEnd = "null";
+	int numSteps = static_cast<int>(duration);
+	double stepSize = 1.0 / numSteps;
 
-	std::size_t pos = easeStart.find('/');
+	for (int step = 1; step <= numSteps; ++step) {
+		double normalizedTime;
+		double currentTime = step * stepSize;
+		double halfway;
 
-	if (pos != std::string::npos) {
-		easeEnd = easeStart.substr(pos + 1);
-		easeStart = easeStart.substr(0, pos);
-	}
+		std::string easingType;
 
-	// Insert animation commands
-	std::vector<double> interpolatedValues = interpolate(start, end, duration, easeStart, easeEnd);
+		if (easingTypeAtEnd == "null") { // use a single interpolation.
+			normalizedTime = currentTime;
+			easingType = easingTypeAtStart;
+			halfway = (step <= numSteps / 2) ? end : start;
+		}
+		else {
+			if (step <= numSteps / 2) { // use 2 interpolations: start and end.
+				normalizedTime = currentTime / 0.5;
+				easingType = easingTypeAtStart;
+			}
+			else {
+				normalizedTime = (currentTime - 0.5) / 0.5;
+				easingType = easingTypeAtEnd;
+			}
+			halfway = start + 0.5 * (end - start);
+		}
 
-	// Insert animatedCom and waitCom commands for each interpolated value
-	for (int value : interpolatedValues) {
-		animatedVarParams.back() = value;
+		double easedTime = getEasedTime(easingType, normalizedTime, 0, 1, 1);
+
+		double startValue = (step <= numSteps / 2) ? start : halfway;
+		double endValue = (step <= numSteps / 2) ? halfway : end;
+		double interpolatedValue = startValue + easedTime * (endValue - startValue);
+
+		animatedVarParams.back() = interpolatedValue;
 		animatedCom.parameters = lcf::DBArray<int32_t>(animatedVarParams.begin(), animatedVarParams.end());
-		animatedCom.indent = com.indent + 1;
 
 		cmdList.push_back(animatedCom);
 		cmdList.push_back(waitCom);
 	}
 
-	// Update current_command index and return true to indicate success
 	Push(cmdList, 0, false);
 	return true;
 }

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -297,6 +297,7 @@ protected:
 	bool CommandManiacSetGameOption(lcf::rpg::EventCommand const& com);
 	bool CommandManiacControlStrings(lcf::rpg::EventCommand const& com);
 	bool CommandManiacCallCommand(lcf::rpg::EventCommand const& com);
+	bool CommandEasyRpgAnimateVariable(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgSetInterpreterFlag(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgProcessJson(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgCloneMapEvent(lcf::rpg::EventCommand const& com);


### PR DESCRIPTION
[Video Demo
![image](https://github.com/EasyRPG/Player/assets/45118493/c822f2de-44b3-46f7-a55d-3b91d8be0605)](https://cdn.discordapp.com/attachments/946771467360673832/1128970913052893264/2023-07-13_05-45-34.mp4?ex=65436218&is=6530ed18&hm=d8f206f5f1c36ac01f1661700ad69f195829f99d393ed3b3c2a0f8f0a1ff9ada&)



The idea is to generate and execute a sequence of variables command changes that goes from 
a `start` value to an `end` value. Following Motion Easing, Time Duration and a pause between frames.

```js
@raw 2052, "linear/bounceOut", 0, 1, 0, 0, 0, 240, 0, 640, 0, 0 
```
 ```js
@raw 2052, "easeTypeStart/easeTypeEnd", targetVariableIsVar, targetVariable, startIsVar, start, endIsVar, end, durationIsVar, duration, pauseIsVar, pause
 ```
 You can also write only `bounceInOut` instead of `bounceIn/bounceOut`
`easeTypeStart` and `easeTypeEnd` can be:

```js

"linear"
"ease", "easeIn", "easeOut", "easeInOut"

"quadIn", "quadOut", "quadInOut" //quadratic easing
"cubicIn", "cubicOut", "cubicInOut"
"quartIn", "quartOut", "quartInOut"
"quintIn", "quintOut", "quintInOut"

"sineIn", "sineOut", "sineInOut" //sinusoidal easing
"ExpoIn", "expoOut", "expoInOut"  //exponential easing
"circIn", "circOut", "circInOut"  //circular easing
"backIn", "backOut", "backInOut"

"elasticIn", "elasticOut", "elasticInOut"
"bounceIn", "bounceOut", "bounceInOut"

bezier(x1, y1, x2, y2) //cubic Bezier(curveHandle1_x, curveHandle1_y, curveHandle2_x, curveHandle2_y,)
```

cubic bezier works!!!!!!!!!!
References for getting bezier values:
https://matthewlein.com/tools/ceaser
https://cubic-bezier.com/

![image](https://github.com/EasyRPG/Player/assets/45118493/9972de69-6545-41ee-a3ea-98b6db3bcc0f)
`bezier(0.9, -0.3, 0.03, 1.3)` - Black dots position representx `x1, y1` and `x2, y2`.
