### PR TITLE
Game_Browser - Autorun a specific game

### DIFF
--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -320,6 +320,40 @@ bool FileFinder::IsRPG2kProjectWithRenames(const FilesystemView& fs) {
 	return !FileExtGuesser::GetRPG2kProjectWithRenames(fs).Empty();
 }
 
+bool FileFinder::OpenViewToEasyRpgFile(FilesystemView& fs) {
+	auto files = fs.ListDirectory();
+	if (!files) {
+		return false;
+	}
+
+	int items = 0;
+	std::string filename;
+
+	for (auto& file : *files) {
+		if (StringView(file.second.name).ends_with(".easyrpg")) {
+			++items;
+			if (items == 2) {
+				// Contains more than one game
+				return false;
+			}
+			filename = file.second.name;
+		}
+	}
+
+	if (filename.empty()) {
+		return false;
+	}
+
+	// One candidate to check
+	auto ep_fs = fs.Create(filename);
+	if (FileFinder::IsValidProject(ep_fs)) {
+		fs = ep_fs;
+		return true;
+	} else {
+		return false;
+	}
+}
+
 bool FileFinder::HasSavegame() {
 	return GetSavegames() > 0;
 }

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -253,19 +253,19 @@ namespace FileFinder {
 	bool IsSupportedArchiveExtension(std::string path);
 
 	/**
-	 * @param p tree Tree to check
+	 * @param p fs Tree to check
 	 * @return Whether the tree contains a valid RPG2k(3) or EasyRPG project
 	 */
 	bool IsValidProject(const FilesystemView& fs);
 
 	/**
-	 * @param p tree Tree to check
+	 * @param p fs Tree to check
 	 * @return Whether the tree contains a valid RPG2k(3) project
 	 */
 	bool IsRPG2kProject(const FilesystemView& fs);
 
 	/**
-	 * @param p tree Tree to check
+	 * @param p fs Tree to check
 	 * @return Whether the tree contains a valid EasyRPG project
 	 */
 	bool IsEasyRpgProject(const FilesystemView& fs);
@@ -274,10 +274,19 @@ namespace FileFinder {
 	 * Determines if the directory in question represents an RPG2k project with non-standard
 	 *   database, map tree, or map file names.
 	 *
-	 * @param tree The directory tree in question
+	 * @param fs The directory tree in question
 	 * @return true if this is likely an RPG2k project; false otherwise
 	 */
 	bool IsRPG2kProjectWithRenames(const FilesystemView& fs);
+
+	/**
+	 * Determines if the directory contains a single file/directory ending in ".easyrpg" for use in the
+	 * autostart feature.
+	 *
+	 * @param fs The directory tree to check. Is replaced with a view to the game for autorun.
+	 * @return true when autorun is possible, fs contains the new view; when false fs is not modified
+	 */
+	bool OpenViewToEasyRpgFile(FilesystemView& fs);
 
 	/**
 	 * Checks whether the save directory contains any savegame with name

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -199,7 +199,7 @@ void Scene_GameBrowser::BootGame() {
 		return;
 	}
 
-	if (!FileFinder::IsValidProject(fs)) {
+	if (!FileFinder::IsValidProject(fs) && !FileFinder::OpenViewToEasyRpgFile(fs)) {
 		// Not a game: Open as directory
 		load_window->SetVisible(false);
 		game_loading = false;

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -147,7 +147,8 @@ bool Scene_Logo::DetectGame() {
 	}
 #endif
 
-	if (FileFinder::IsValidProject(fs)) {
+	if (FileFinder::IsValidProject(fs) || FileFinder::OpenViewToEasyRpgFile(fs)) {
+		FileFinder::SetGameFilesystem(fs);
 		Player::CreateGameObjects();
 		detected_game = true;
 	}


### PR DESCRIPTION
If a game filename contains `gamedata.easyrpg` and there's only one game in player's folder, the player will autorun it.
![image](https://github.com/EasyRPG/Player/assets/45118493/1d7e6d1b-a2da-438f-8529-9d213c9cf6af) ![image](https://github.com/EasyRPG/Player/assets/45118493/2550225d-a5b7-4c97-8023-adeb449876c9) ![image](https://github.com/EasyRPG/Player/assets/45118493/b42734bd-9d5c-49aa-88cc-aba84f801568) ![image](https://github.com/EasyRPG/Player/assets/45118493/e192f743-9cad-4b63-9aa2-116cb7ad8638)
![image](https://github.com/EasyRPG/Player/assets/45118493/d428c9b2-107d-48d4-8e58-4f8ab27d05f2)



It would be better if I could skip the game_browser scene or hide the screen with default system. But this is working fine.