### PR TITLE
Refactor String Vars

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -3614,8 +3614,8 @@ bool Game_Interpreter::CommandConditionalBranch(lcf::rpg::EventCommand const& co
 			int ignoreCase = com.parameters[4] >> 8 & 1;
 
 			std::string str_param = ToString(com.string);
-			StringView str_l = Main_Data::game_strings->GetWithMode(str_param, com.parameters[2], modes[0]+1, *Main_Data::game_variables);
-			StringView str_r = Main_Data::game_strings->GetWithMode(str_param, com.parameters[3], modes[1], *Main_Data::game_variables);
+			StringView str_l = Main_Data::game_strings->GetWithMode(str_param, modes[0]+1, com.parameters[2], *Main_Data::game_variables);
+			StringView str_r = Main_Data::game_strings->GetWithMode(str_param, modes[1], com.parameters[3], *Main_Data::game_variables);
 			result = ManiacPatch::CheckString(str_l, str_r, op, ignoreCase);
 		}
 		break;
@@ -4317,8 +4317,8 @@ bool Game_Interpreter::CommandManiacShowStringPicture(lcf::rpg::EventCommand con
 	if (com.parameters.size() >= 23) {
 		text.text = ToString(Main_Data::game_strings->GetWithMode(
 			components[1],
-			com.parameters[22],
 			delims[0] - 1,
+			com.parameters[22],
 			*Main_Data::game_variables
 		));
 	} else {
@@ -4759,7 +4759,7 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 		switch (fn)
 		{
 		case 0: //String <fn(string text, int min_size)>
-			result = ToString(Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables));
+			result = ToString(Main_Data::game_strings->GetWithMode(str_param, modes[0], args[0], *Main_Data::game_variables));
 			args[1] = ValueOrVariable(modes[1], args[1]);
 
 			// min_size
@@ -4798,7 +4798,7 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 			int pos = 0;
 			std::string op_string;
 			for (int i = 0; i < 3; i++) {
-				op_string += ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[i], modes[i], &pos, *Main_Data::game_variables));
+				op_string += ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, modes[i], args[i], &pos, *Main_Data::game_variables));
 			}
 			result = std::move(op_string);
 			break;
@@ -4809,8 +4809,8 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 			std::string base, insert;
 
 			args[1] = ValueOrVariable(modes[1], args[1]);
-			base = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[0], modes[0], &pos, *Main_Data::game_variables));
-			insert = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[2], modes[2], &pos, *Main_Data::game_variables));
+			base = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, modes[0], args[0], &pos, *Main_Data::game_variables));
+			insert = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, modes[2], args[2], &pos, *Main_Data::game_variables));
 
 			result = base.insert(args[1], insert);
 			break;
@@ -4820,9 +4820,9 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 			int pos = 0;
 			std::string base, search, replacement;
 
-			base = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[0], modes[0], &pos, *Main_Data::game_variables));
-			search = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[1], modes[1], &pos, *Main_Data::game_variables));
-			replacement = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[2], modes[2], &pos, *Main_Data::game_variables));
+			base = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, modes[0], args[0], &pos, *Main_Data::game_variables));
+			search = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, modes[1], args[1], &pos, *Main_Data::game_variables));
+			replacement = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, modes[2], args[2], &pos, *Main_Data::game_variables));
 
 			std::size_t index = base.find(search);
 			while (index != std::string::npos) {
@@ -4836,12 +4836,12 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 		case 9: //Substring (subs) <fn(string base, int index, int size)>
 			args[1] = ValueOrVariable(modes[1], args[1]);
 			args[2] = ValueOrVariable(modes[2], args[2]);
-			result = ToString(Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables).substr(args[1], args[2]));
+			result = ToString(Main_Data::game_strings->GetWithMode(str_param, modes[0], args[0], *Main_Data::game_variables).substr(args[1], args[2]));
 			break;
 		case 10: //Join (join) <fn(string delimiter, int id, int size)>
 		{
 			std::string op_string;
-			std::string delimiter = ToString(Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables));
+			std::string delimiter = ToString(Main_Data::game_strings->GetWithMode(str_param, modes[0], args[0], *Main_Data::game_variables));
 
 			// args[1] & mode[1] relates to starting ID for strings to join
 			// mode 0 = id literal, 1 = direct var, 2 = var literal, 3 = direct var
@@ -4864,7 +4864,7 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 		case 12: //File (file) <fn(string filename, int encode)>
 		{
 			// maniacs does not like a file extension
-			StringView filename = Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables);
+			StringView filename = Main_Data::game_strings->GetWithMode(str_param, modes[0], args[0], *Main_Data::game_variables);
 			// args[1] is the encoding... 0 for ansi, 1 for utf8
 			bool do_yield;
 			result = Game_Strings::FromFile(filename, args[1], do_yield);
@@ -4880,7 +4880,7 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 		case 13: //Remove (rem) <fn(string base, int index, int size)>
 			args[1] = ValueOrVariable(modes[1], args[1]);
 			args[2] = ValueOrVariable(modes[2], args[2]);
-			result = ToString(Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables));
+			result = ToString(Main_Data::game_strings->GetWithMode(str_param, modes[0], args[0], *Main_Data::game_variables));
 			result = result.erase(args[1], args[2]);
 			break;
 		case 14: //Replace Ex (exRep) <fn(string base, string search, string replacement, bool first)>, edge case: the arg "first" is at ((flags >> 19) & 1). Wtf BingShan
@@ -4888,9 +4888,9 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 			int pos = 0;
 			std::string base, search, replacement;
 
-			base = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[0], modes[0], &pos, *Main_Data::game_variables));
-			search = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[1], modes[1], &pos, *Main_Data::game_variables));
-			replacement = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[2], modes[2], &pos, *Main_Data::game_variables));
+			base = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, modes[0], args[0], &pos, *Main_Data::game_variables));
+			search = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, modes[1], args[1], &pos, *Main_Data::game_variables));
+			replacement = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, modes[2], args[2], &pos, *Main_Data::game_variables));
 
 			std::regex rexp(search);
 
@@ -4921,7 +4921,7 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 		break;
 	case 4: //inStr <fn(string text, int var_id, int begin)> FIXME: takes hex?
 	{
-		StringView search = Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables);
+		StringView search = Main_Data::game_strings->GetWithMode(str_param, modes[0], args[0], *Main_Data::game_variables);
 		args[1] = ValueOrVariable(modes[1], args[1]); // not sure this is necessary but better safe
 		args[2] = ValueOrVariable(modes[2], args[2]);
 		
@@ -4931,7 +4931,7 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 	}
 	case 5: //split <fn(string text, int str_id, int var_id)> takes hex
 	{
-		StringView delimiter = Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables);
+		StringView delimiter = Main_Data::game_strings->GetWithMode(str_param, modes[0], args[0], *Main_Data::game_variables);
 		args[1] = ValueOrVariable(modes[1], args[1]);
 		args[2] = ValueOrVariable(modes[2], args[2]);
 		
@@ -4941,7 +4941,7 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 	}
 	case 7: //toFile <fn(string filename, int encode)>  takes hex
 	{
-		StringView filename = Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables);
+		StringView filename = Main_Data::game_strings->GetWithMode(str_param, modes[0], args[0], *Main_Data::game_variables);
 		args[1] = ValueOrVariable(modes[1], args[1]);
 
 		Main_Data::game_strings->ToFile(str_params, ToString(filename), args[1]);
@@ -4961,7 +4961,7 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 	case 10: //exMatch <fn(string text, int var_id, int begin, int str_id)>, edge case: the only command that generates 8 parameters instead of 7
 	{
 		// takes hex
-		std::string expr = ToString(Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables));
+		std::string expr = ToString(Main_Data::game_strings->GetWithMode(str_param, modes[0], args[0], *Main_Data::game_variables));
 		args[1] = ValueOrVariable(modes[1], args[1]); // output var
 		args[2] = ValueOrVariable(modes[2], args[2]); // beginning pos
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -3614,8 +3614,8 @@ bool Game_Interpreter::CommandConditionalBranch(lcf::rpg::EventCommand const& co
 			int ignoreCase = com.parameters[4] >> 8 & 1;
 
 			std::string str_param = ToString(com.string);
-			StringView str_l = Main_Data::game_strings->GetWithMode(str_param, com.parameters[2], modes[0]+1);
-			StringView str_r = Main_Data::game_strings->GetWithMode(str_param, com.parameters[3], modes[1]);
+			StringView str_l = Main_Data::game_strings->GetWithMode(str_param, com.parameters[2], modes[0]+1, *Main_Data::game_variables);
+			StringView str_r = Main_Data::game_strings->GetWithMode(str_param, com.parameters[3], modes[1], *Main_Data::game_variables);
 			result = ManiacPatch::CheckString(str_l, str_r, op, ignoreCase);
 		}
 		break;
@@ -4318,7 +4318,8 @@ bool Game_Interpreter::CommandManiacShowStringPicture(lcf::rpg::EventCommand con
 		text.text = ToString(Main_Data::game_strings->GetWithMode(
 			components[1],
 			com.parameters[22],
-			delims[0] - 1
+			delims[0] - 1,
+			*Main_Data::game_variables
 		));
 	} else {
 		text.text = components[1];
@@ -4758,7 +4759,7 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 		switch (fn)
 		{
 		case 0: //String <fn(string text, int min_size)>
-			result = ToString(Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0]));
+			result = ToString(Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables));
 			args[1] = ValueOrVariable(modes[1], args[1]);
 
 			// min_size
@@ -4797,7 +4798,7 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 			int pos = 0;
 			std::string op_string;
 			for (int i = 0; i < 3; i++) {
-				op_string += ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[i], modes[i], &pos));
+				op_string += ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[i], modes[i], &pos, *Main_Data::game_variables));
 			}
 			result = std::move(op_string);
 			break;
@@ -4808,8 +4809,8 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 			std::string base, insert;
 
 			args[1] = ValueOrVariable(modes[1], args[1]);
-			base = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[0], modes[0], &pos));
-			insert = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[2], modes[2], &pos));
+			base = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[0], modes[0], &pos, *Main_Data::game_variables));
+			insert = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[2], modes[2], &pos, *Main_Data::game_variables));
 
 			result = base.insert(args[1], insert);
 			break;
@@ -4819,9 +4820,9 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 			int pos = 0;
 			std::string base, search, replacement;
 
-			base = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[0], modes[0], &pos));
-			search = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[1], modes[1], &pos));
-			replacement = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[2], modes[2], &pos));
+			base = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[0], modes[0], &pos, *Main_Data::game_variables));
+			search = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[1], modes[1], &pos, *Main_Data::game_variables));
+			replacement = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[2], modes[2], &pos, *Main_Data::game_variables));
 
 			std::size_t index = base.find(search);
 			while (index != std::string::npos) {
@@ -4835,12 +4836,12 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 		case 9: //Substring (subs) <fn(string base, int index, int size)>
 			args[1] = ValueOrVariable(modes[1], args[1]);
 			args[2] = ValueOrVariable(modes[2], args[2]);
-			result = ToString(Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0]).substr(args[1], args[2]));
+			result = ToString(Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables).substr(args[1], args[2]));
 			break;
 		case 10: //Join (join) <fn(string delimiter, int id, int size)>
 		{
 			std::string op_string;
-			std::string delimiter = ToString(Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0]));
+			std::string delimiter = ToString(Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables));
 
 			// args[1] & mode[1] relates to starting ID for strings to join
 			// mode 0 = id literal, 1 = direct var, 2 = var literal, 3 = direct var
@@ -4863,7 +4864,7 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 		case 12: //File (file) <fn(string filename, int encode)>
 		{
 			// maniacs does not like a file extension
-			StringView filename = Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0]);
+			StringView filename = Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables);
 			// args[1] is the encoding... 0 for ansi, 1 for utf8
 			bool do_yield;
 			result = Game_Strings::FromFile(filename, args[1], do_yield);
@@ -4879,7 +4880,7 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 		case 13: //Remove (rem) <fn(string base, int index, int size)>
 			args[1] = ValueOrVariable(modes[1], args[1]);
 			args[2] = ValueOrVariable(modes[2], args[2]);
-			result = ToString(Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0]));
+			result = ToString(Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables));
 			result = result.erase(args[1], args[2]);
 			break;
 		case 14: //Replace Ex (exRep) <fn(string base, string search, string replacement, bool first)>, edge case: the arg "first" is at ((flags >> 19) & 1). Wtf BingShan
@@ -4887,9 +4888,9 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 			int pos = 0;
 			std::string base, search, replacement;
 
-			base = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[0], modes[0], &pos));
-			search = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[1], modes[1], &pos));
-			replacement = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[2], modes[2], &pos));
+			base = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[0], modes[0], &pos, *Main_Data::game_variables));
+			search = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[1], modes[1], &pos, *Main_Data::game_variables));
+			replacement = ToString(Main_Data::game_strings->GetWithModeAndPos(str_param, args[2], modes[2], &pos, *Main_Data::game_variables));
 
 			std::regex rexp(search);
 
@@ -4901,7 +4902,7 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 			Output::Warning("Unknown or unimplemented string sub-operation {}", op);
 			break;
 		}
-		if (is_range) Main_Data::game_strings->RangeOp(str_params, string_id_1, result, op);
+		if (is_range) Main_Data::game_strings->RangeOp(str_params, string_id_1, result, op, nullptr, *Main_Data::game_variables);
 		else {
 			if (op == 0) Main_Data::game_strings->Asg(str_params, result);
 			if (op == 1) Main_Data::game_strings->Cat(str_params, result);
@@ -4909,35 +4910,38 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 		break;
 	case 2: //toNum <fn(int var_id)> takes hex
 	case 3: //getLen <fn(int var_id)>
-		if (is_range) Main_Data::game_strings->RangeOp(str_params, string_id_1, result, op, args);
+		if (is_range) Main_Data::game_strings->RangeOp(str_params, string_id_1, result, op, args, *Main_Data::game_variables);
 		else {
-			if (op == 2) Main_Data::game_strings->ToNum(str_params, args[0]);
-			if (op == 3) Main_Data::game_strings->GetLen(str_params, args[0]);
+			if (op == 2) {
+				int num = Main_Data::game_strings->ToNum(str_params, args[0], *Main_Data::game_variables);
+				Main_Data::game_variables->Set(args[0], num);
+			}
+			if (op == 3) Main_Data::game_strings->GetLen(str_params, args[0], *Main_Data::game_variables);
 		}
 		break;
 	case 4: //inStr <fn(string text, int var_id, int begin)> FIXME: takes hex?
 	{
-		StringView search = Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0]);
+		StringView search = Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables);
 		args[1] = ValueOrVariable(modes[1], args[1]); // not sure this is necessary but better safe
 		args[2] = ValueOrVariable(modes[2], args[2]);
 		
-		if (is_range) Main_Data::game_strings->RangeOp(str_params, string_id_1, ToString(search), op, args);
-		else          Main_Data::game_strings->InStr(str_params, ToString(search), args[1], args[2]);
+		if (is_range) Main_Data::game_strings->RangeOp(str_params, string_id_1, ToString(search), op, args, *Main_Data::game_variables);
+		else          Main_Data::game_strings->InStr(str_params, ToString(search), args[1], args[2], *Main_Data::game_variables);
 		break;
 	}
 	case 5: //split <fn(string text, int str_id, int var_id)> takes hex
 	{
-		StringView delimiter = Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0]);
+		StringView delimiter = Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables);
 		args[1] = ValueOrVariable(modes[1], args[1]);
 		args[2] = ValueOrVariable(modes[2], args[2]);
 		
-		if (is_range) Main_Data::game_strings->RangeOp(str_params, string_id_1, ToString(delimiter), op, args);
-		else          Main_Data::game_strings->Split(str_params, ToString(delimiter), args[1], args[2]);
+		if (is_range) Main_Data::game_strings->RangeOp(str_params, string_id_1, ToString(delimiter), op, args, *Main_Data::game_variables);
+		else          Main_Data::game_strings->Split(str_params, ToString(delimiter), args[1], args[2], *Main_Data::game_variables);
 		break;
 	}
 	case 7: //toFile <fn(string filename, int encode)>  takes hex
 	{
-		StringView filename = Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0]);
+		StringView filename = Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables);
 		args[1] = ValueOrVariable(modes[1], args[1]);
 
 		Main_Data::game_strings->ToFile(str_params, ToString(filename), args[1]);
@@ -4957,16 +4961,16 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 	case 10: //exMatch <fn(string text, int var_id, int begin, int str_id)>, edge case: the only command that generates 8 parameters instead of 7
 	{
 		// takes hex
-		std::string expr = ToString(Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0]));
+		std::string expr = ToString(Main_Data::game_strings->GetWithMode(str_param, args[0], modes[0], *Main_Data::game_variables));
 		args[1] = ValueOrVariable(modes[1], args[1]); // output var
 		args[2] = ValueOrVariable(modes[2], args[2]); // beginning pos
 
 		if (is_range) {
-			Main_Data::game_strings->RangeOp(str_params, string_id_1, expr, op, args);
+			Main_Data::game_strings->RangeOp(str_params, string_id_1, expr, op, args, *Main_Data::game_variables);
 		}
 		else {
-			if (op == 9) Main_Data::game_strings->ExMatch(str_params, expr, args[1], args[2]);
-			else         Main_Data::game_strings->ExMatch(str_params, expr, args[1], args[2], args[3]);
+			if (op == 9) Main_Data::game_strings->ExMatch(str_params, expr, args[1], args[2], -1, *Main_Data::game_variables);
+			else         Main_Data::game_strings->ExMatch(str_params, expr, args[1], args[2], args[3], *Main_Data::game_variables);
 		}
 		break;
 	}

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -161,7 +161,7 @@ static std::optional<std::string> CommandCodeInserterNoRecurse(char ch, const ch
 		*iter = parse_ret.next;
 		int value = parse_ret.value;
 
-		std::string str = Main_Data::game_strings->Get(value);
+		std::string str = ToString(Main_Data::game_strings->Get(value));
 
 		// \t[] is evaluated but command codes inside it are not evaluated again
 		return PendingMessage::ApplyTextInsertingCommands(str, escape_char, PendingMessage::DefaultCommandInserter);
@@ -176,7 +176,7 @@ std::optional<std::string> Game_Message::CommandCodeInserter(char ch, const char
 		*iter = parse_ret.next;
 		int value = parse_ret.value;
 
-		std::string str = Main_Data::game_strings->Get(value);
+		std::string str = ToString(Main_Data::game_strings->Get(value));
 
 		// Command codes in \t[] are evaluated once.
 		return PendingMessage::ApplyTextInsertingCommands(str, escape_char, CommandCodeInserterNoRecurse);

--- a/src/game_strings.cpp
+++ b/src/game_strings.cpp
@@ -35,7 +35,9 @@ Game_Strings::Str_t Game_Strings::Asg(Str_Params params, Str_t string) {
 }
 
 Game_Strings::Str_t Game_Strings::Cat(Str_Params params, Str_t string) {
-	if (!ResizeWithId(params.string_id)) return "";
+	if (params.string_id <= 0) {
+		return {};
+	}
 
 	Str_t s = Get(params.string_id);
 	std::string op_string = s;
@@ -45,7 +47,10 @@ Game_Strings::Str_t Game_Strings::Cat(Str_Params params, Str_t string) {
 }
 
 int Game_Strings::ToNum(Str_Params params, int var_id) {
-	if (!ResizeWithId(params.string_id)) return -1;
+	if (params.string_id <= 0) {
+		return -1;
+	}
+
 	std::string str = Get(params.string_id);
 
 	int num;
@@ -61,7 +66,9 @@ int Game_Strings::ToNum(Str_Params params, int var_id) {
 int Game_Strings::GetLen(Str_Params params, int var_id) {
 	// Note: The length differs between Maniac and EasyRPG due to different internal encoding (utf-8 vs. ansi)
 
-	if (!ResizeWithId(params.string_id)) return -1;
+	if (params.string_id <= 0) {
+		return -1;
+	}
 
 	int len = Get(params.string_id).length();
 	Main_Data::game_variables->Set(var_id, len);
@@ -69,7 +76,9 @@ int Game_Strings::GetLen(Str_Params params, int var_id) {
 }
 
 int Game_Strings::InStr(Str_Params params, std::string search, int var_id, int begin) {
-	if (!ResizeWithId(params.string_id)) return -1;
+	if (params.string_id <= 0) {
+		return -1;
+	}
 
 	if (params.extract) {
 		search = Extract(search, params.hex);
@@ -83,7 +92,9 @@ int Game_Strings::InStr(Str_Params params, std::string search, int var_id, int b
 }
 
 int Game_Strings::Split(Str_Params params, std::string delimiter, int string_out_id, int var_id) {
-	if (!ResizeWithId(params.string_id)) return -1;
+	if (params.string_id <= 0) {
+		return -1;
+	}
 
 	size_t index;
 	std::string token;
@@ -173,7 +184,9 @@ Game_Strings::Str_t Game_Strings::ToFile(Str_Params params, std::string filename
 
 Game_Strings::Str_t Game_Strings::PopLine(Str_Params params, int offset, int string_out_id) {
 	// FIXME: consideration needed around encoding -- what mode are files read in?
-	if (!ResizeWithId(params.string_id)) return "";
+	if (params.string_id <= 0) {
+		return {};
+	}
 
 	int index;
 	std::string result;
@@ -231,10 +244,6 @@ const Game_Strings::Strings_t& Game_Strings::RangeOp(Str_Params params, int stri
 	// swap so that id_0 is < id_1
 	if (params.string_id > string_id_1) {
 		std::swap(params.string_id, string_id_1);
-	}
-
-	if (EP_UNLIKELY(string_id_1 > static_cast<int>(_strings.size()))) {
-		_strings.resize(string_id_1, "");
 	}
 
 	for (int start = params.string_id; params.string_id <= string_id_1; params.string_id++) {

--- a/src/game_strings.cpp
+++ b/src/game_strings.cpp
@@ -30,20 +30,23 @@ void Game_Strings::WarnGet(int id) const {
 	--_warnings;
 }
 
-Game_Strings::Str_t Game_Strings::Asg(Str_Params params, Str_t string) {
-	return Set(params, string);
+StringView Game_Strings::Asg(Str_Params params, StringView string) {
+	Set(params, string);
+	return Get(params.string_id);
 }
 
-Game_Strings::Str_t Game_Strings::Cat(Str_Params params, Str_t string) {
+StringView Game_Strings::Cat(Str_Params params, StringView string) {
 	if (params.string_id <= 0) {
 		return {};
 	}
 
-	Str_t s = Get(params.string_id);
-	std::string op_string = s;
-	op_string.append(string);
-	Set(params, op_string);
-	return s;
+	auto it = _strings.find(params.string_id);
+	if (it == _strings.end()) {
+		Set(params, string);
+		return Get(params.string_id);
+	}
+	it->second += ToString(string);
+	return it->second;
 }
 
 int Game_Strings::ToNum(Str_Params params, int var_id) {
@@ -51,19 +54,22 @@ int Game_Strings::ToNum(Str_Params params, int var_id) {
 		return -1;
 	}
 
-	std::string str = Get(params.string_id);
+	auto it = _strings.find(params.string_id);
+	if (it == _strings.end()) {
+		return 0;
+	}
 
 	int num;
 	if (params.hex)
-		num = static_cast<int>(std::strtol(str.c_str(), nullptr, 16));
+		num = static_cast<int>(std::strtol(it->second.c_str(), nullptr, 16));
 	else
-		num = static_cast<int>(std::strtol(str.c_str(), nullptr, 0));
+		num = static_cast<int>(std::strtol(it->second.c_str(), nullptr, 0));
 
 	Main_Data::game_variables->Set(var_id, num);
 	return num;
 }
 
-int Game_Strings::GetLen(Str_Params params, int var_id) {
+int Game_Strings::GetLen(Str_Params params, int var_id) const {
 	// Note: The length differs between Maniac and EasyRPG due to different internal encoding (utf-8 vs. ansi)
 
 	if (params.string_id <= 0) {
@@ -75,7 +81,7 @@ int Game_Strings::GetLen(Str_Params params, int var_id) {
 	return len;
 }
 
-int Game_Strings::InStr(Str_Params params, std::string search, int var_id, int begin) {
+int Game_Strings::InStr(Str_Params params, std::string search, int var_id, int begin) const {
 	if (params.string_id <= 0) {
 		return -1;
 	}
@@ -84,14 +90,12 @@ int Game_Strings::InStr(Str_Params params, std::string search, int var_id, int b
 		search = Extract(search, params.hex);
 	}
 
-	std::string str = Get(params.string_id);
-
 	int index = Get(params.string_id).find(search, begin);
 	Main_Data::game_variables->Set(var_id, index);
 	return index;
 }
 
-int Game_Strings::Split(Str_Params params, std::string delimiter, int string_out_id, int var_id) {
+int Game_Strings::Split(Str_Params params, const std::string& delimiter, int string_out_id, int var_id) {
 	if (params.string_id <= 0) {
 		return -1;
 	}
@@ -101,7 +105,7 @@ int Game_Strings::Split(Str_Params params, std::string delimiter, int string_out
 
 	// always returns at least 1
 	int splits = 1;
-	std::string str = Get(params.string_id);
+	std::string str = ToString(Get(params.string_id));
 
 	params.string_id = string_out_id;
 
@@ -119,7 +123,7 @@ int Game_Strings::Split(Str_Params params, std::string delimiter, int string_out
 	return splits;
 }
 
-Game_Strings::Str_t Game_Strings::FromFile(StringView filename, int encoding, bool& do_yield) {
+std::string Game_Strings::FromFile(StringView filename, int encoding, bool& do_yield) {
 	do_yield = false;
 
 	Filesystem_Stream::InputStream is = FileFinder::OpenText(filename);
@@ -134,7 +138,7 @@ Game_Strings::Str_t Game_Strings::FromFile(StringView filename, int encoding, bo
 	}
 
 	auto vec = Utils::ReadStream(is);
-	Str_t file_content(vec.begin(), vec.end());
+	std::string file_content(vec.begin(), vec.end());
 
 	if (encoding == 0) {
 		lcf::Encoder enc(Player::encoding);
@@ -144,8 +148,8 @@ Game_Strings::Str_t Game_Strings::FromFile(StringView filename, int encoding, bo
 	return file_content;
 }
 
-Game_Strings::Str_t Game_Strings::ToFile(Str_Params params, std::string filename, int encoding) {
-	std::string str = Get(params.string_id);
+StringView Game_Strings::ToFile(Str_Params params, std::string filename, int encoding) {
+	std::string str = ToString(Get(params.string_id));
 
 	if (params.extract) {
 		filename = Extract(filename, params.hex);
@@ -182,7 +186,7 @@ Game_Strings::Str_t Game_Strings::ToFile(Str_Params params, std::string filename
 	return str;
 }
 
-Game_Strings::Str_t Game_Strings::PopLine(Str_Params params, int offset, int string_out_id) {
+StringView Game_Strings::PopLine(Str_Params params, int offset, int string_out_id) {
 	// FIXME: consideration needed around encoding -- what mode are files read in?
 	if (params.string_id <= 0) {
 		return {};
@@ -190,29 +194,31 @@ Game_Strings::Str_t Game_Strings::PopLine(Str_Params params, int offset, int str
 
 	int index;
 	std::string result;
-	std::string str = Get(params.string_id);
+	StringView str = Get(params.string_id);
 
-	std::stringstream ss(str);
+	std::stringstream ss(ToString(str));
 
 	while (offset >= 0 && Utils::ReadLine(ss, result)) { offset--; }
 
 	offset = ss.rdbuf()->in_avail();
 
 	Set(params, ss.str().substr(str.length() - offset));
+
 	params.string_id = string_out_id;
-	return Set(params, result);
+	Set(params, result);
+	return Get(params.string_id);
 }
 
-Game_Strings::Str_t Game_Strings::ExMatch(Str_Params params, std::string expr, int var_id, int begin, int string_out_id) {
+StringView Game_Strings::ExMatch(Str_Params params, std::string expr, int var_id, int begin, int string_out_id) {
 	int var_result;
-	Str_t str_result;
+	std::string str_result;
 	std::smatch match;
 
 	if (params.extract) {
 		expr = Extract(expr, params.hex);
 	}
 
-	std::string base = Get(params.string_id).erase(0, begin);
+	std::string base = ToString(Get(params.string_id)).erase(0, begin);
 	std::regex r(expr);
 
 	std::regex_search(base, match, r);
@@ -228,7 +234,7 @@ Game_Strings::Str_t Game_Strings::ExMatch(Str_Params params, std::string expr, i
 	return str_result;
 }
 
-const Game_Strings::Strings_t& Game_Strings::RangeOp(Str_Params params, int string_id_1, Str_t string, int op, int args[]) {
+const Game_Strings::Strings_t& Game_Strings::RangeOp(Str_Params params, int string_id_1, std::string string, int op, int args[]) {
 	if (EP_UNLIKELY(ShouldWarn(params.string_id))) {
 		WarnGet(params.string_id);
 	}
@@ -262,16 +268,15 @@ const Game_Strings::Strings_t& Game_Strings::RangeOp(Str_Params params, int stri
 	return GetData();
 }
 
-Game_Strings::Str_t Game_Strings::PrependMin(Str_t string, int min_size, char c) {
+std::string Game_Strings::PrependMin(StringView string, int min_size, char c) {
 	if (string.size() < min_size) {
 		int s = min_size - string.size();
-		std::string res = std::string(s, c) + (std::string)string;
-		return res;
+		return std::string(s, c) + ToString(string);
 	}
-	return string;
+	return ToString(string);
 }
 
-Game_Strings::Str_t Game_Strings::Extract(Str_t string, bool as_hex) {
+std::string Game_Strings::Extract(StringView string, bool as_hex) {
 	PendingMessage::CommandInserter cmd_fn;
 
 	if (as_hex) {
@@ -280,7 +285,7 @@ Game_Strings::Str_t Game_Strings::Extract(Str_t string, bool as_hex) {
 		cmd_fn = ManiacsCommandInserter;
 	}
 
-	return static_cast<Str_t>(PendingMessage::ApplyTextInsertingCommands(string, Player::escape_char, cmd_fn));
+	return PendingMessage::ApplyTextInsertingCommands(ToString(string), Player::escape_char, cmd_fn);
 }
 
 std::optional<std::string> Game_Strings::ManiacsCommandInserter(char ch, const char** iter, const char* end, uint32_t escape_char) {
@@ -298,7 +303,7 @@ std::optional<std::string> Game_Strings::ManiacsCommandInserter(char ch, const c
 		int value = parse_ret.value;
 
 		// Contrary to Messages, the content of \t[]-strings is not evaluated
-		return Main_Data::game_strings->Get(value);
+		return ToString(Main_Data::game_strings->Get(value));
 	}
 
 	return Game_Message::CommandCodeInserter(ch, iter, end, escape_char);

--- a/src/game_strings.h
+++ b/src/game_strings.h
@@ -50,8 +50,8 @@ public:
 
 	StringView Get(int id) const;
 	StringView GetIndirect(int id, const Game_Variables& variables) const;
-	StringView GetWithMode(StringView str_data, int arg, int mode, const Game_Variables& variables) const;
-	StringView GetWithModeAndPos(StringView str_data, int arg, int mode, int* pos, const Game_Variables& variables);
+	StringView GetWithMode(StringView str_data, int mode, int arg, const Game_Variables& variables) const;
+	StringView GetWithModeAndPos(StringView str_data, int mode, int arg, int* pos, const Game_Variables& variables);
 
 	StringView Asg(Str_Params params, StringView string);
 	StringView Cat(Str_Params params, StringView string);
@@ -156,7 +156,7 @@ inline StringView Game_Strings::GetIndirect(int id, const Game_Variables& variab
 	return Get(static_cast<int>(val_indirect));
 }
 
-inline StringView Game_Strings::GetWithMode(StringView str_data, int arg, int mode, const Game_Variables& variables) const {
+inline StringView Game_Strings::GetWithMode(StringView str_data, int mode, int arg, const Game_Variables& variables) const {
 	switch (mode) {
 	case 1: // direct string reference
 		return Get(arg);
@@ -167,7 +167,7 @@ inline StringView Game_Strings::GetWithMode(StringView str_data, int arg, int mo
 	}
 }
 
-inline StringView Game_Strings::GetWithModeAndPos(StringView str_data, int arg, int mode, int* pos, const Game_Variables& variables) {
+inline StringView Game_Strings::GetWithModeAndPos(StringView str_data, int mode, int arg, int* pos, const Game_Variables& variables) {
 	StringView ret;
 	switch (mode) {
 	case 0:

--- a/src/game_strings.h
+++ b/src/game_strings.h
@@ -49,22 +49,22 @@ public:
 	std::vector<lcf::DBString> GetLcfData() const;
 
 	StringView Get(int id) const;
-	StringView GetIndirect(int id) const;
-	StringView GetWithMode(StringView str_data, int arg, int mode) const;
-	StringView GetWithModeAndPos(StringView str_data, int arg, int mode, int* pos);
+	StringView GetIndirect(int id, const Game_Variables& variables) const;
+	StringView GetWithMode(StringView str_data, int arg, int mode, const Game_Variables& variables) const;
+	StringView GetWithModeAndPos(StringView str_data, int arg, int mode, int* pos, const Game_Variables& variables);
 
 	StringView Asg(Str_Params params, StringView string);
 	StringView Cat(Str_Params params, StringView string);
-	int ToNum(Str_Params params, int var_id);
-	int GetLen(Str_Params params, int var_id) const;
-	int InStr(Str_Params params, std::string search, int var_id, int begin = 0) const;
-	int Split(Str_Params params, const std::string& delimiter, int string_out_id, int var_id);
+	int ToNum(Str_Params params, int var_id, Game_Variables& variables);
+	int GetLen(Str_Params params, int var_id, Game_Variables& variables) const;
+	int InStr(Str_Params params, std::string search, int var_id, int begin, Game_Variables& variables) const;
+	int Split(Str_Params params, const std::string& delimiter, int string_out_id, int var_id, Game_Variables& variables);
 	static std::string FromFile(StringView filename, int encoding, bool& do_yield);
 	StringView ToFile(Str_Params params, std::string filename, int encoding);
 	StringView PopLine(Str_Params params, int offset, int string_out_id);
-	StringView ExMatch(Str_Params params, std::string expr, int var_id, int begin, int string_out_id = -1);
+	StringView ExMatch(Str_Params params, std::string expr, int var_id, int begin, int string_out_id, Game_Variables& variables);
 
-	const Strings_t& RangeOp(Str_Params params, int string_id_1, std::string string, int op, int args[] = nullptr);
+	const Strings_t& RangeOp(Str_Params params, int string_id_1, std::string string, int op, int args[], Game_Variables& variables);
 
 	static std::string PrependMin(StringView string, int min_size, char c);
 	static std::string Extract(StringView string, bool as_hex);
@@ -151,23 +151,23 @@ inline StringView Game_Strings::Get(int id) const {
 	return it->second;
 }
 
-inline StringView Game_Strings::GetIndirect(int id) const {
-	auto val_indirect = Main_Data::game_variables->Get(id);
+inline StringView Game_Strings::GetIndirect(int id, const Game_Variables& variables) const {
+	auto val_indirect = variables.Get(id);
 	return Get(static_cast<int>(val_indirect));
 }
 
-inline StringView Game_Strings::GetWithMode(StringView str_data, int arg, int mode) const {
+inline StringView Game_Strings::GetWithMode(StringView str_data, int arg, int mode, const Game_Variables& variables) const {
 	switch (mode) {
 	case 1: // direct string reference
 		return Get(arg);
 	case 2: // indirect string reference
-		return GetIndirect(arg);
+		return GetIndirect(arg, variables);
 	default:
 		return str_data;
 	}
 }
 
-inline StringView Game_Strings::GetWithModeAndPos(StringView str_data, int arg, int mode, int* pos) {
+inline StringView Game_Strings::GetWithModeAndPos(StringView str_data, int arg, int mode, int* pos, const Game_Variables& variables) {
 	StringView ret;
 	switch (mode) {
 	case 0:
@@ -178,7 +178,7 @@ inline StringView Game_Strings::GetWithModeAndPos(StringView str_data, int arg, 
 	case 1: // direct string reference
 		return Get(arg);
 	case 2: // indirect string reference
-		return GetIndirect(arg);
+		return GetIndirect(arg, variables);
 	default:
 		return ret;
 	}

--- a/src/game_windows.cpp
+++ b/src/game_windows.cpp
@@ -34,7 +34,7 @@ static std::optional<std::string> CommandCodeInserter(char ch, const char **iter
 		int value = parse_ret.value;
 
 		// Contrary to Messages, the content of \t[]-strings is not evaluated
-		return Main_Data::game_strings->Get(value);
+		return ToString(Main_Data::game_strings->Get(value));
 	}
 
 	return PendingMessage::DefaultCommandInserter(ch, iter, end, escape_char);

--- a/src/maniac_patch.h
+++ b/src/maniac_patch.h
@@ -34,10 +34,10 @@ namespace ManiacPatch {
 
 	bool GetKeyState(uint32_t key_id);
 
-	bool CheckString(std::string str_l, std::string str_r, int op, bool ignore_case);
+	bool CheckString(StringView str_l, StringView str_r, int op, bool ignore_case);
 
-	Game_Strings::Str_t GetLcfName(int data_type, int id, bool is_dynamic);
-	Game_Strings::Str_t GetLcfDescription(int data_type, int id, bool is_dynamic);
+	StringView GetLcfName(int data_type, int id, bool is_dynamic);
+	StringView GetLcfDescription(int data_type, int id, bool is_dynamic);
 }
 
 #endif


### PR DESCRIPTION
Noteworthy changes:

- unordered_map instead of vector to reduce huge waste of memory for sparse string usage (e.g. starting at 1000)
- StringView used where possible to reduce copying
- Bugfix: Setting variables didn't refresh the interpreter