### PR TITLE
Fix issue 3135 (Fluidsynth: Turn off all sound when the music changes)

### DIFF
--- a/src/audio_decoder_midi.cpp
+++ b/src/audio_decoder_midi.cpp
@@ -398,6 +398,8 @@ void AudioDecoderMidi::reset() {
 		midi_msg = midimsg_make(midi_event_control_change, channel, midi_set_reg_param_lower, 0);
 		mididec->SendMidiMessage(midi_msg);
 	}
+
+	mididec->Reset();
 }
 
 void AudioDecoderMidi::reset_tempos_after_loop() {

--- a/src/audio_midi.cpp
+++ b/src/audio_midi.cpp
@@ -126,7 +126,7 @@ std::unique_ptr<AudioDecoderBase> MidiDecoder::CreateFmMidi(bool resample) {
 	return mididec;
 }
 
-void MidiDecoder::Reset() {
+void MidiDecoder::ResetGlobalState() {
 	works.fluidsynth = true;
 	works.wildmidi = true;
 

--- a/src/audio_midi.h
+++ b/src/audio_midi.h
@@ -60,7 +60,7 @@ public:
 	 *
 	 * The library must implement the following commands:
 	 * - SendMidiMessage
-	 * - SendSysExMessage (nice to have)
+	 * - SendSysExMessage
 	 *
 	 * When Midi messages are not supported (library uses own sequencer)
 	 * - Open
@@ -167,6 +167,12 @@ public:
 	};
 
 	/**
+	 * Called when the device is reset due to a Midi file change.
+	 * Can be used when the normal reset sequence (GM reset etc.) is not sufficient.
+	 */
+	virtual void Reset() {};
+
+	/**
 	 * Returns the unique name of the Midi decoder.
 	 *
 	 * @return decoder name
@@ -197,7 +203,7 @@ public:
 	/**
 	 * Resets the global state of the midi libraries.
 	 */
-	static void Reset();
+	static void ResetGlobalState();
 
 protected:
 	int frequency = EP_MIDI_FREQ;

--- a/src/decoder_fluidsynth.cpp
+++ b/src/decoder_fluidsynth.cpp
@@ -339,6 +339,15 @@ void FluidSynthDecoder::SendSysExMessage(const uint8_t* data, std::size_t size) 
 		nullptr, nullptr, nullptr, 0);
 }
 
+void FluidSynthDecoder::Reset() {
+	// Prevent that old notes resume playing when BGM is stopped and resumed later
+	auto* instance_synth = GetSynthInstance();
+
+	for (int channel = 0; channel < 16; channel++) {
+		fluid_synth_all_sounds_off(GetSynthInstance(), channel);
+	}
+}
+
 fluid_synth_t *FluidSynthDecoder::GetSynthInstance() {
 	if (use_global_synth) {
 		return global_synth.get();

--- a/src/decoder_fluidsynth.h
+++ b/src/decoder_fluidsynth.h
@@ -61,6 +61,8 @@ public:
 
 	void SendSysExMessage(const uint8_t* data, size_t size) override;
 
+	void Reset() override;
+
 	std::string GetName() override {
 #if defined(HAVE_FLUIDSYNTH)
 		return "FluidSynth";

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -51,7 +51,7 @@ void Scene_GameBrowser::Continue(SceneType /* prev_scene */) {
 
 	Cache::ClearAll();
 	AudioSeCache::Clear();
-	MidiDecoder::Reset();
+	MidiDecoder::ResetGlobalState();
 	lcf::Data::Clear();
 	Main_Data::Cleanup();
 


### PR DESCRIPTION
Solves an issue that old notes finish fading out when using BGM Stop followed by a BGM Play later.

Fix #3135