### PR TITLE
Add new path finding command 2003

### DIFF
--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -1053,7 +1053,7 @@ bool Game_Character::CalculateMoveRoute(const CalculateMoveRouteArgs& args) {
 		std::string debug_output_path("");
 		if (list_move.size() > 0) {
 			lcf::rpg::MoveRoute route;
-			// route.skippable = true;
+			route.skippable = args.skip_when_failed;
 			route.repeat = false;
 
 			for (SearchNode node2 : list_move) {
@@ -1075,7 +1075,7 @@ bool Game_Character::CalculateMoveRoute(const CalculateMoveRouteArgs& args) {
 			cmd.command_id = 23;
 			route.move_commands.push_back(cmd);
 
-			ForceMoveRoute(route, 8);
+			ForceMoveRoute(route, args.frequency);
 		}
 		if (args.debug_print) {
 			Output::Debug(

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -854,7 +854,7 @@ bool Game_Character::CalculateMoveRoute(const CalculateMoveRouteArgs& args) {
 	bool loops_vertical = Game_Map::LoopVertical();
 	std::vector<SearchNode> neighbour;
 	neighbour.reserve(8);
-	while (!queue.empty() && steps_taken < steps_max) {
+	while (!queue.empty() && steps_taken < args.search_max) {
 		SearchNode n = queue[0];
 		queue.erase(queue.begin());
 		steps_taken++;
@@ -1026,7 +1026,6 @@ bool Game_Character::CalculateMoveRoute(const CalculateMoveRouteArgs& args) {
 		}
 		std::vector<SearchNode> list_move;
 
-		//Output::Debug("Chemin :");
 		SearchNode node = closest_node;
 		while (list_move.size() < steps_max) {
 			list_move.push_back(node);

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -1027,9 +1027,8 @@ bool Game_Character::CalculateMoveRoute(const CalculateMoveRouteArgs& args) {
 		std::vector<SearchNode> list_move;
 
 		SearchNode node = closest_node;
-		while (list_move.size() < steps_max) {
+		while (static_cast<int>(list_move.size()) < steps_max) {
 			list_move.push_back(node);
-			bool found_parent = false;
 			if (graph_by_coord.find({node.parent_x,
 					node.parent_y}) == graph_by_coord.end())
 				break;

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -713,7 +713,9 @@ public:
 		int32_t search_max = std::numeric_limits<int32_t>::max();
 		bool allow_diagonal = false;
 		bool debug_print = false;
+		bool skip_when_failed = false;
 		Span<int> event_id_ignore_list;
+		int frequency = 3;
 	};
 
 	bool CalculateMoveRoute(const CalculateMoveRouteArgs& args);

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -613,7 +613,7 @@ public:
 	 * @return true See CheckWay.
 	 */
 	virtual bool CheckWay(int from_x, int from_y, int to_x, int to_y,
-		bool ignore_all_events, std::unordered_set<int> *ignore_some_events_by_id);
+		bool ignore_all_events, Span<int> ignore_some_events_by_id);
 
 	/** Short version of CheckWay. **/
 	virtual bool CheckWay(int from_x, int from_y, int to_x, int to_y);
@@ -704,6 +704,19 @@ public:
 	 * Cancels a previous forced move route.
 	 */
 	void CancelMoveRoute();
+
+	/** Argument struct for more complex find operations */
+	struct CalculateMoveRouteArgs {
+		int32_t dest_x = 0;
+		int32_t dest_y = 0;
+		int32_t steps_max = std::numeric_limits<int32_t>::max();
+		int32_t search_max = std::numeric_limits<int32_t>::max();
+		bool allow_diagonal = false;
+		bool debug_print = false;
+		Span<int> event_id_ignore_list;
+	};
+
+	bool CalculateMoveRoute(const CalculateMoveRouteArgs& args);
 
 	/** @return height of active jump in pixels */
 	int GetJumpHeight() const;

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -246,7 +246,7 @@ bool Game_Interpreter_Map::ExecuteCommand(lcf::rpg::EventCommand const& com) {
 			return CmdSetup<&Game_Interpreter_Map::CommandEasyRpgTriggerEventAt, 4>(com);
 		case Cmd::EasyRpg_WaitForSingleMovement:
 			return CmdSetup<&Game_Interpreter_Map::CommandEasyRpgWaitForSingleMovement, 6>(com);
-		case static_cast<Cmd>(2003):
+		case Cmd::EasyRpg_Pathfinder:
 			return CmdSetup<&Game_Interpreter_Map::CommandEasyRpgPathfinder, 13>(com);
 		default:
 			return Game_Interpreter::ExecuteCommand(com);

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -64,9 +64,6 @@
 #include "util_macro.h"
 #include "game_interpreter_map.h"
 #include <lcf/reader_lcf.h>
-#ifdef _MSC_VER
-#define strcasecmp _stricmp
-#endif
 
 enum EnemyEncounterSubcommand {
 	eOptionEnemyEncounterVictory = 0,
@@ -917,6 +914,9 @@ bool Game_Interpreter_Map::CommandEasyRpgPathfinder(lcf::rpg::EventCommand const
 	Parameter 13 - 13+N: Number of Event IDs specified by 12
 	Parameter 13+N+1, 13+N+2: Move frequency (default 3)
  	*/
+	if (!Player::HasEasyRpgExtensions()) {
+		return true;
+	}
 
 	Game_Character::CalculateMoveRouteArgs args;
 
@@ -950,7 +950,7 @@ bool Game_Interpreter_Map::CommandEasyRpgPathfinder(lcf::rpg::EventCommand const
 	}
 	args.event_id_ignore_list = event_id_ignore_list;
 
-	if (com.parameters.size() > ni + 1) {
+	if (static_cast<int>(com.parameters.size()) > ni + 1) {
 		args.frequency = ValueOrVariable(com.parameters[ni], com.parameters[ni + 1]);
 	}
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -911,33 +911,47 @@ bool Game_Interpreter_Map::CommandEasyRpgPathfinder(lcf::rpg::EventCommand const
 	Parameter 4, 5: Target Y coordinate
 	Parameter 6, 7: Iteration limit when searching
 	Parameter 8, 9: Length of the route in tiles
-	Parameter 10: Flags (1 = Wait when moving, 2 = Allow diagonal, 4 = Debug log, 8 = Do nothing when moving)
+	Parameter 10: Flags (1 = Wait when moving, 2 = Allow diagonal,
+		4 = Debug log, 8 = Skip command when moving, 16 = "skippable" flag of the route)
 	Parameter 11, 12: Ignore Event IDs
-	Parameter 13+: Number of Event IDs specified by 12
+	Parameter 13 - 13+N: Number of Event IDs specified by 12
+	Parameter 13+N+1, 13+N+2: Move frequency (default 3)
  	*/
 
+	Game_Character::CalculateMoveRouteArgs args;
+
 	int event_id = ValueOrVariable(com.parameters[0], com.parameters[1]);
-	int dest_x = ValueOrVariable(com.parameters[2], com.parameters[3]);
-	int dest_y = ValueOrVariable(com.parameters[4], com.parameters[5]);
-	int search_max = ValueOrVariable(com.parameters[6], com.parameters[7]);
-	int steps_max = ValueOrVariable(com.parameters[8], com.parameters[9]);
+	args.dest_x = ValueOrVariable(com.parameters[2], com.parameters[3]);
+	args.dest_y = ValueOrVariable(com.parameters[4], com.parameters[5]);
+	args.search_max = ValueOrVariable(com.parameters[6], com.parameters[7]);
+	args.steps_max = ValueOrVariable(com.parameters[8], com.parameters[9]);
 
 	int flags = com.parameters[10];
 	bool wait_when_moving = (flags & 1) > 0;
-	bool allow_diagonal = (flags & 2) > 0;
-	bool debug_log = (flags & 4) > 0;
+	args.allow_diagonal = (flags & 2) > 0;
+	args.debug_print = (flags & 4) > 0;
 	bool skip_when_moving = (flags & 8) > 0;
+	args.skip_when_failed = (flags & 16) > 0;
 
 	std::vector<int> event_id_ignore_list;
+	int ni; // ni = next_index;
 	if (com.parameters[11] == 0) {
 		// Part of the command
 		int num_events_ids = com.parameters[12];
 		event_id_ignore_list = {com.parameters.begin() + 13, com.parameters.begin() + 13 + num_events_ids};
+		ni = 13 + num_events_ids;
 	} else {
 		// Read from variables
 		int var = ValueOrVariable(com.parameters[11], com.parameters[12]);
 		int num_events_ids = Main_Data::game_variables->Get(var);
-		event_id_ignore_list = Main_Data::game_variables->GetRange(var + 1, num_events_ids);
+		auto lst = Main_Data::game_variables->GetRange(var + 1, num_events_ids);
+		std::copy(lst.begin(), lst.end(), event_id_ignore_list.begin());
+		ni = 13;
+	}
+	args.event_id_ignore_list = event_id_ignore_list;
+
+	if (com.parameters.size() > ni + 1) {
+		args.frequency = ValueOrVariable(com.parameters[ni], com.parameters[ni + 1]);
 	}
 
 	Game_Character* chara = GetCharacter(event_id, "EasyRpgPathFinder");
@@ -952,11 +966,6 @@ bool Game_Interpreter_Map::CommandEasyRpgPathfinder(lcf::rpg::EventCommand const
 			return true;
 		}
 	}
-
-	Game_Character::CalculateMoveRouteArgs args {
-		dest_x, dest_y, steps_max, search_max, allow_diagonal,
-		debug_log, event_id_ignore_list
-	};
 
 	chara->CalculateMoveRoute(args);
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -25,6 +25,7 @@
 #include <unordered_set>
 #include "audio.h"
 #include "feature.h"
+#include "game_character.h"
 #include "game_map.h"
 #include "game_battle.h"
 #include "game_event.h"
@@ -248,10 +249,8 @@ bool Game_Interpreter_Map::ExecuteCommand(lcf::rpg::EventCommand const& com) {
 			return CmdSetup<&Game_Interpreter_Map::CommandEasyRpgTriggerEventAt, 4>(com);
 		case Cmd::EasyRpg_WaitForSingleMovement:
 			return CmdSetup<&Game_Interpreter_Map::CommandEasyRpgWaitForSingleMovement, 6>(com);
-		case Cmd::EasyRpg_SmartMoveRoute:
-			return CommandSmartMoveRoute(com);
-		case Cmd::EasyRpg_SmartStepToward:
-			return CommandSmartStepToward(com);
+		case static_cast<Cmd>(2003):
+			return CmdSetup<&Game_Interpreter_Map::CommandEasyRpgPathfinder, 13>(com);
 		default:
 			return Game_Interpreter::ExecuteCommand(com);
 	}
@@ -284,489 +283,6 @@ bool Game_Interpreter_Map::CommandRecallToLocation(lcf::rpg::EventCommand const&
 		return true;
 
 	index++;
-	return false;
-}
-
-struct SearchNode {  // Used by Game_Interpreter_Map::CommandSearchPath.
-	SearchNode(int a, int b, int c, int d) {
-		x = a;
-		y = b;
-		cost = c;
-		direction = d;
-	}
-	SearchNode() { }
-	int x = 0;
-	int y = 0;
-	int cost = 0;
-	int id = 0;
-
-	int parentID = -1;
-	int parentX = -1;
-	int parentY = -1;
-	int direction = 0;
-
-	friend bool operator==(const SearchNode& n1, const SearchNode& n2)
-	{
-		return n1.x == n2.x && n1.y == n2.y;
-	}
-
-	bool operator()(SearchNode const& a, SearchNode const& b)
-	{
-		return a.id > b.id;
-	}
-};
-
-struct SearchNodeHash {
-	size_t operator()(const SearchNode &p) const {
-		return (p.x ^ (p.y + (p.y >> 12)));
-	}
-};
-
-
-/* This is the "Smart Move Route" command:
- * Like "Set Move Route", this command sets a longer route
- * of all the steps necessary to a possibly farther off target.
- * The route is computed to smartly go around any obstacles.
- * This command is best used in "Autorun" blocking events, e.g.
- * in situations where an event or character should be sent on
- * their way with a single command. Don't use it every frame in a
- * "parallel" event because it uses a higher search depth and will
- * cause extreme lag if used so often, use "Smart Step Toward" for
- * parallel events instead.
- *
- * Event command parameters are as follows:
- *
- * Parameter 0, 1: Passed to ValueOrVariable() to get the moving event's ID.
- *
- * Parameter 2, 3: Passed to ValueOrVariable() to get the target X coord.
- *
- * Parameter 4, 5: Passed to ValueOrVariable() to get the target Y coord.
- *
- * Parameter string: Allows free form options, see generic
- * CommandSmartMoveRoute() function prototype for full list.
- *
- * (Advanced info: this command defaults to options maxRouteSteps=-1
- * for an infinite route length, and abortIfAlreadyMoving=0 to always
- * replace any previous move route even if the event is already moving,
- * and maxSearchSteps=500 for a deep search depth.)
- */
-bool Game_Interpreter_Map::CommandSmartMoveRoute(
-		lcf::rpg::EventCommand const& com
-		) {
-	return CommandSmartMoveRoute(
-		com, -1, 500, 0
-	);
-}
-
-/* This is the "Smart Step Toward" command:
- * Unlike "Set Move Route" that always applies even if the event or
- * character is currently between two tiles and moving, "Smart Step Toward"
- * tries to be economical and doesn't change anything if the event is
- * currently moving, to avoid expensive comptuations.
- * Otherwise, it sets a new one-step move route, computed to smartly move
- * one tile toward a given target. Because of it's economical behavior,
- * this command is useful for "Parallel" event use in every frame to
- * track a moving target continuously.
- *
- * Event command parameters are as follows:
- *
- * Parameter 0, 1: Passed to ValueOrVariable() to get the moving event's ID.
- *
- * Parameter 2, 3: Passed to ValueOrVariable() to get the target X coord.
- *
- * Parameter 4, 5: Passed to ValueOrVariable() to get the target Y coord.
- *
- * Parameter string: Allows free form options, see generic
- * CommandSmartMoveRoute() function prototype for full list.
- *
- * (Advanced info: this command defaults to options maxRouteSteps=1
- * for a one step route, and abortIfAlreadyMoving=1 to never set a
- * route on any moving event or character, and maxSearchSteps=150
- * for a shallower, faster search depth with less accurate results.)
- */
-bool Game_Interpreter_Map::CommandSmartStepToward(
-		lcf::rpg::EventCommand const& com
-		) {
-	return CommandSmartMoveRoute(
-		com, 1, 150, 1
-	);
-}
-
-/* (You might want to check the CommandSmartMoveRoute() alternate
- * variant with less parameters, or CommandStepToward(), for the
- * actual description of the end-user facing commadns.)
- *
- * This is the generic version of the path finding command.
- *
- * Parameter string advanced options:
- *	 Use the string to specify advanced options, like "maxRouteSteps=5" to
- *	 limit the resulting movement route to a maximum of steps (if the
- *	 target is further away, it simply won't be fully reached), or
- *	 like "maxSearchSteps=100" where a larger number gives better results
- *	 for further away targets but causes more lag, or like
- *	 "ignoreEventID=93" where some event can be specified by ID to be
- *	 treated as passable by the path search, so it won't try to find
- *	 a path around it. The "ignoreEventID" option can be used multiple
- *	 times to ignore multiple events. With "allowDiagonalMovement=0" you
- *	 can disable diagonal movement if desired.
- *	 Example string: "maxSearchSteps=50 ignoreEventID=5 ignoreEventId=6"
- */
-bool Game_Interpreter_Map::CommandSmartMoveRoute(
-		lcf::rpg::EventCommand const& com,
-		int maxRouteStepsDefault, int maxSearchStepsDefault,
-		int abortIfAlreadyMovingDefault
-		) {
-	int eventID = ValueOrVariable(com.parameters[0], com.parameters[1]);
-	int destX = ValueOrVariable(com.parameters[2], com.parameters[3]);
-	int destY = ValueOrVariable(com.parameters[4], com.parameters[5]);
-	std::unordered_set<int> ignoreEventIDs;
-	bool outputDebugInfo = 0;
-	int maxRouteSteps = maxRouteStepsDefault;
-	int maxSearchSteps = maxSearchStepsDefault;
-	bool allowDiagonalMovement = true;
-	int abortIfAlreadyMoving = abortIfAlreadyMovingDefault;
-
-	// Parse extra command values:
-	{
-		std::string paramString = std::string(com.string);
-		int i = 0;
-		while (i < paramString.length()) {
-			while (i < paramString.length() && (
-					paramString[i] == '=' ||
-					paramString[i] == ' ' ||
-					paramString[i] == '\t'))
-				i++;
-			int paramStart = i;
-			while (i < paramString.length() &&
-					paramString[i] != '=' && paramString[i] != ' ' &&
-					paramString[i] != '\t')
-				i++;
-			if (i == paramStart) {
-				i++;
-				continue;
-			}
-			std::string paramName = paramString.substr(paramStart, i - paramStart);
-			std::string paramValue = "";
-			int paramValueInt = -1;
-			if (i < paramString.length() && paramString[i] == '=') {
-				i++;
-				int valueStart = i;
-				while (i < paramString.length() &&
-						paramString[i] != '=' && paramString[i] != ' ' &&
-						paramString[i] != '\t')
-					i++;
-				if (i > valueStart) {
-					paramValue = paramString.substr(valueStart, i - valueStart);
-					if (strspn(paramValue.c_str(), "0123456789") ==
-							paramValue.length() && paramValue.length() > 0) {
-						paramValueInt = atoi(paramValue.c_str());
-					}
-				}
-				i++;
-			}
-			if (strcasecmp(paramName.c_str(), "maxRouteSteps") == 0 &&
-					paramValueInt >= 0) {
-				maxRouteSteps = paramValueInt;
-			} else if (strcasecmp(paramName.c_str(), "allowDiagonalMovement") == 0) {
-				if (paramValue == "1")
-					allowDiagonalMovement = true;
-				else if (paramValue == "0")
-					allowDiagonalMovement = false;
-			} else if (strcasecmp(paramName.c_str(), "abortIfAlreadyMoving") == 0) {
-				if (paramValue == "1")
-					abortIfAlreadyMoving = 1;
-				else if (paramValue == "0")
-					abortIfAlreadyMoving = 0;
-			} else if (strcasecmp(paramName.c_str(), "maxSearchSteps") == 0 &&
-					paramValueInt >= 0) {
-				maxSearchSteps = paramValueInt;
-			} else if (strcasecmp(paramName.c_str(), "outputDebugInfo") == 0) {
-				if (paramValue == "1")
-					outputDebugInfo = 1;
-				else if (paramValue == "2")
-					outputDebugInfo = 2;
-			} else if (strcasecmp(paramName.c_str(), "ignoreEventID") == 0 &&
-					paramValueInt >= 0) {
-				ignoreEventIDs.insert(paramValueInt);
-			}
-		}
-	}
-
-	// Extract search source:
-	Game_Character* event;
-	if (eventID == 0)
-		event = Main_Data::game_player.get();
-	else
-		event = GetCharacter(eventID);
-	if (abortIfAlreadyMoving && event->IsMoving())
-		return false;
-	event->CancelMoveRoute();
-
-	// Set up helper variables:
-	SearchNode start = SearchNode(event->GetX(), event->GetY(), 0, -1);
-	if ((start.x == destX && start.y == destY) ||
-			maxRouteSteps == 0)
-		return true;
-	std::vector<SearchNode> list;
-	std::unordered_map<int, SearchNode> closedList;
-	std::map<std::pair<int, int>, SearchNode> closedListByCoord;
-	list.push_back(start);
-	int id = 0;
-	int idd = 0;
-	int stepsTaken = 0; // Initialize steps taken to 0.
-	SearchNode closestNode = SearchNode(destX, destY, INT_MAX, -1); // Initialize with a very high cost.
-	int closestDistance = INT_MAX; // Initialize with a very high distance.
-	std::unordered_set<SearchNode, SearchNodeHash> seen;
-
-	if (outputDebugInfo >= 2) {
-		Output::Debug("Game_Interpreter::CommandSearchPath: "
-			"start search, character x{} y{}, to x{}, y{}, "
-			"ignored event ids count: {}",
-			start.x, start.y, destX, destY, ignoreEventIDs.size());
-	}
-
-	bool GameMapLoopsHorizontal = Game_Map::LoopHorizontal();
-	bool GameMapLoopsVertical = Game_Map::LoopVertical();
-	std::vector<SearchNode> neighbour;
-	neighbour.reserve(8);
-	while (!list.empty() && stepsTaken < maxSearchSteps) {
-		SearchNode n = list[0];
-		list.erase(list.begin());
-		stepsTaken++;
-		closedList[n.id] = n;
-		closedListByCoord.insert({{n.x, n.y}, n});
-
-		if (n.x == destX && n.y == destY) {
-			// Reached the destination.
-			closestNode = n;
-			closestDistance = 0;
-			break;	// Exit the loop to build final route.
-		}
-		else {
-			neighbour.clear();
-			SearchNode nn = SearchNode(n.x + 1, n.y, n.cost + 1, 1); // Right
-			neighbour.push_back(nn);
-			nn = SearchNode(n.x, n.y - 1, n.cost + 1, 0); // Up
-			neighbour.push_back(nn);
-			nn = SearchNode(n.x - 1, n.y, n.cost + 1, 3); // Left
-			neighbour.push_back(nn);
-			nn = SearchNode(n.x, n.y + 1, n.cost + 1, 2); // Down
-			neighbour.push_back(nn);
-
-			if (allowDiagonalMovement) {
-				nn = SearchNode(n.x - 1, n.y + 1, n.cost + 1, 6); // Down Left
-				neighbour.push_back(nn);
-				nn = SearchNode(n.x + 1, n.y - 1, n.cost + 1, 4); // Up Right
-				neighbour.push_back(nn);
-				nn = SearchNode(n.x - 1, n.y - 1, n.cost + 1, 7); // Up Left
-				neighbour.push_back(nn);
-				nn = SearchNode(n.x + 1, n.y + 1, n.cost + 1, 5); // Down Right
-				neighbour.push_back(nn);
-			}
-
-			for (SearchNode a : neighbour) {
-				idd++;
-				a.parentX = n.x;
-				a.parentY = n.y;
-				a.id = idd;
-				a.parentID = n.id;
-
-				// Adjust neighbor coordinates for map looping
-				if (GameMapLoopsHorizontal) {
-					if (a.x >= Game_Map::GetTilesX())
-						a.x -= Game_Map::GetTilesX();
-					else if (a.x < 0)
-						a.x += Game_Map::GetTilesX();
-				}
-
-				if (GameMapLoopsVertical) {
-					if (a.y >= Game_Map::GetTilesY())
-						a.y -= Game_Map::GetTilesY();
-					else if (a.y < 0)
-						a.y += Game_Map::GetTilesY();
-				}
-
-				std::unordered_set<SearchNode, SearchNodeHash>::const_iterator
-					check = seen.find(a);
-				if (check != seen.end()) {
-					SearchNode oldEntry = closedList[(*check).id];
-					if (a.cost < oldEntry.cost) {
-						// Found a shorter path to previous node, update & reinsert:
-						if (outputDebugInfo >= 2) {
-							Output::Debug("Game_Interpreter::CommandSearchPath: "
-								"found shorter path to x:{} y:{}"
-								"from x:{} y:{} direction: {}",
-								a.x, a.y, n.x, n.y, a.direction);
-						}
-						closedList.erase(oldEntry.id);
-						oldEntry.cost = a.cost;
-						oldEntry.parentID = n.id;
-						oldEntry.parentX = n.x;
-						oldEntry.parentY = n.y;
-						oldEntry.direction = a.direction;
-						closedList[oldEntry.id] = oldEntry;
-					}
-					continue;
-				} else if (a.x == start.x && a.y == start.y) {
-					continue;
-				}
-				bool added = false;
-				if (event->CheckWay(n.x, n.y, a.x, a.y, true, &ignoreEventIDs) ||
-						(a.x == destX && a.y == destY &&
-						event->CheckWay(n.x, n.y, a.x, a.y, false, NULL))) {
-					if (a.direction == 4) {
-						if (event->CheckWay(n.x, n.y, n.x + 1, n.y,
-									true, &ignoreEventIDs) ||
-								event->CheckWay(n.x, n.y, n.x, n.y - 1,
-									true, &ignoreEventIDs)) {
-							added = true;
-							list.push_back(a);
-							seen.insert(a);
-						}
-					}
-					else if (a.direction == 5) {
-						if (event->CheckWay(n.x, n.y, n.x + 1, n.y,
-									true, &ignoreEventIDs) ||
-								event->CheckWay(n.x, n.y, n.x, n.y + 1,
-									true, &ignoreEventIDs)) {
-							added = true;
-							list.push_back(a);
-							seen.insert(a);
-						}
-					}
-					else if (a.direction == 6) {
-						if (event->CheckWay(n.x, n.y, n.x - 1, n.y,
-									true, &ignoreEventIDs) ||
-								event->CheckWay(n.x, n.y, n.x, n.y + 1,
-									true, &ignoreEventIDs)) {
-							added = true;
-							list.push_back(a);
-							seen.insert(a);
-						}
-					}
-					else if (a.direction == 7) {
-						if (event->CheckWay(n.x, n.y, n.x - 1, n.y,
-									true, &ignoreEventIDs) ||
-								event->CheckWay(n.x, n.y, n.x, n.y - 1,
-									true, &ignoreEventIDs)) {
-							added = true;
-							list.push_back(a);
-							seen.insert(a);
-						}
-					}
-					else {
-						added = true;
-						list.push_back(a);
-						seen.insert(a);
-					}
-				}
-				if (added && outputDebugInfo >= 2) {
-					Output::Debug("Game_Interpreter::CommandSearchPath: "
-						"discovered id:{} x:{} y:{} parentX:{} parentY:{}"
-						"parentID:{} direction: {}",
-					list[list.size() - 1].id,
-					list[list.size() - 1].x, list[list.size() - 1].y,
-					list[list.size() - 1].parentX,
-					list[list.size() - 1].parentY,
-					list[list.size() - 1].parentID,
-					list[list.size() - 1].direction);
-				}
-			}
-		}
-		id++;
-		// Calculate the Manhattan distance between the current node and the destination
-		int manhattanDist = abs(destX - n.x) + abs(destY - n.y);
-
-		// Check if this node is closer to the destination
-		if (manhattanDist < closestDistance) {
-			closestNode = n;
-			closestDistance = manhattanDist;
-			if (outputDebugInfo >= 2) {
-				Output::Debug("Game_Interpreter::CommandSearchPath: "
-						"new closest node at x:{} y:{} id:{}",
-					closestNode.x, closestNode.y,
-					closestNode.id);
-			}
-		}
-	}
-
-	// Check if a path to the closest node was found.
-	if (closestDistance != INT_MAX) {
-		// Build a route to the closest reachable node.
-		if (outputDebugInfo >= 2) {
-			Output::Debug("Game_Interpreter::CommandSearchPath: "
-					"trying to return route from x:{} y:{} to "
-					"x:{} y:{} (id:{})",
-				start.x, start.y, closestNode.x, closestNode.y,
-				closestNode.id);
-		}
-		std::vector<SearchNode> listMove;
-
-		//Output::Debug("Chemin :");
-		SearchNode node = closestNode;
-		while (maxRouteSteps < 0 ||
-				listMove.size() < maxRouteSteps) {
-			listMove.push_back(node);
-			bool foundParent = false;
-			if (closedListByCoord.find({node.parentX,
-					node.parentY}) == closedListByCoord.end())
-				break;
-			SearchNode node2 = closedListByCoord[
-				{node.parentX, node.parentY}
-			];
-			if (outputDebugInfo >= 2) {
-				Output::Debug(
-					"Game_Interpreter::CommandSearchPath: "
-					"found parent leading to x:{} y:{}, "
-					"it's at x:{} y:{} dir:{}",
-					node.x, node.y,
-					node2.x, node2.y, node2.direction);
-			}
-			node = node2;
-		}
-
-		std::reverse(listMove.rbegin(), listMove.rend());
-
-		std::string debug_output_path("");
-		if (listMove.size() > 0) {
-			lcf::rpg::MoveRoute route;
-			// route.skippable = true;
-			route.repeat = false;
-
-			for (SearchNode node2 : listMove) {
-				if (node2.direction >= 0) {
-					lcf::rpg::MoveCommand cmd;
-					cmd.command_id = node2.direction;
-					route.move_commands.push_back(cmd);
-					if (outputDebugInfo >= 1) {
-						if (debug_output_path.length() > 0)
-							debug_output_path += ",";
-						std::ostringstream dirnum;
-						dirnum << node2.direction;
-						debug_output_path += std::string(dirnum.str());
-					}
-				}
-			}
-
-			lcf::rpg::MoveCommand cmd;
-			cmd.command_id = 23;
-			route.move_commands.push_back(cmd);
-
-			event->ForceMoveRoute(route, 8);
-		}
-		if (outputDebugInfo >= 1) {
-			Output::Debug(
-				"Game_Interpreter::CommandSearchPath: "
-				"setting route {} for character x{} y{}",
-				" (ignored event ids count: {})",
-				debug_output_path, start.x, start.y,
-				ignoreEventIDs.size()
-			);
-		}
-		return true;
-	}
-
-	// No path to the destination, return failure.
 	return false;
 }
 
@@ -1377,6 +893,72 @@ bool Game_Interpreter_Map::CommandEasyRpgTriggerEventAt(lcf::rpg::EventCommand c
 	}
 
 	Main_Data::game_player->TriggerEventAt(x, y, GetFrame().triggered_by_decision_key, face_player);
+
+	return true;
+}
+
+bool Game_Interpreter_Map::CommandEasyRpgPathfinder(lcf::rpg::EventCommand const& com) {
+	/*
+	This commands calculates a path between an event and the target.
+	Then it applies a move route to the event.
+	This command sets a longer route of all the steps necessary to a possibly farther off target.
+ 	The route is computed to smartly go around any obstacles.
+
+	Event command parameters are as follows:
+
+	Parameter 0, 1: Source Event ID
+	Parameter 2, 3: Target X coordinate
+	Parameter 4, 5: Target Y coordinate
+	Parameter 6, 7: Iteration limit when searching
+	Parameter 8, 9: Length of the route in tiles
+	Parameter 10: Flags (1 = Wait when moving, 2 = Allow diagonal, 4 = Debug log, 8 = Do nothing when moving)
+	Parameter 11, 12: Ignore Event IDs
+	Parameter 13+: Number of Event IDs specified by 12
+ 	*/
+
+	int event_id = ValueOrVariable(com.parameters[0], com.parameters[1]);
+	int dest_x = ValueOrVariable(com.parameters[2], com.parameters[3]);
+	int dest_y = ValueOrVariable(com.parameters[4], com.parameters[5]);
+	int search_max = ValueOrVariable(com.parameters[6], com.parameters[7]);
+	int steps_max = ValueOrVariable(com.parameters[8], com.parameters[9]);
+
+	int flags = com.parameters[10];
+	bool wait_when_moving = (flags & 1) > 0;
+	bool allow_diagonal = (flags & 2) > 0;
+	bool debug_log = (flags & 4) > 0;
+	bool skip_when_moving = (flags & 8) > 0;
+
+	std::vector<int> event_id_ignore_list;
+	if (com.parameters[11] == 0) {
+		// Part of the command
+		int num_events_ids = com.parameters[12];
+		event_id_ignore_list = {com.parameters.begin() + 13, com.parameters.begin() + 13 + num_events_ids};
+	} else {
+		// Read from variables
+		int var = ValueOrVariable(com.parameters[11], com.parameters[12]);
+		int num_events_ids = Main_Data::game_variables->Get(var);
+		event_id_ignore_list = Main_Data::game_variables->GetRange(var + 1, num_events_ids);
+	}
+
+	Game_Character* chara = GetCharacter(event_id, "EasyRpgPathFinder");
+	if (chara == nullptr) {
+		return true;
+	}
+
+	if (chara->IsMoving()) {
+		if (wait_when_moving) {
+			return false;
+		} else if (skip_when_moving) {
+			return true;
+		}
+	}
+
+	Game_Character::CalculateMoveRouteArgs args {
+		dest_x, dest_y, steps_max, search_max, allow_diagonal,
+		debug_log, event_id_ignore_list
+	};
+
+	chara->CalculateMoveRoute(args);
 
 	return true;
 }

--- a/src/game_interpreter_map.h
+++ b/src/game_interpreter_map.h
@@ -84,9 +84,8 @@ private:
 	bool CommandOpenLoadMenu(lcf::rpg::EventCommand const& com);
 	bool CommandToggleAtbMode(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgTriggerEventAt(lcf::rpg::EventCommand const& com);
+	bool CommandEasyRpgPathfinder(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgWaitForSingleMovement(lcf::rpg::EventCommand const& com);
-	bool CommandSmartMoveRoute(lcf::rpg::EventCommand const& com);
-	bool CommandSmartStepToward(lcf::rpg::EventCommand const& com);
 	AsyncOp ContinuationShowInnStart(int indent, int choice_result, int price);
 
 	bool CommandSmartMoveRoute(

--- a/src/game_interpreter_map.h
+++ b/src/game_interpreter_map.h
@@ -83,11 +83,17 @@ private:
 	bool CommandOpenMainMenu(lcf::rpg::EventCommand const& com);
 	bool CommandOpenLoadMenu(lcf::rpg::EventCommand const& com);
 	bool CommandToggleAtbMode(lcf::rpg::EventCommand const& com);
-
 	bool CommandEasyRpgTriggerEventAt(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgWaitForSingleMovement(lcf::rpg::EventCommand const& com);
-
+	bool CommandSmartMoveRoute(lcf::rpg::EventCommand const& com);
+	bool CommandSmartStepToward(lcf::rpg::EventCommand const& com);
 	AsyncOp ContinuationShowInnStart(int indent, int choice_result, int price);
+
+	bool CommandSmartMoveRoute(
+		lcf::rpg::EventCommand const& com,
+		int maxRouteStepsDefault, int maxSearchStepsDefault,
+		int abortIfAlreadyMovingDefault
+	);  // Internal generic path finder function.
 
 	static std::vector<Game_Character*> pending;
 };

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -251,7 +251,7 @@ namespace Game_Map {
 			int from_x, int from_y,
 			int to_x, int to_y,
 			bool check_events_and_vehicles,
-			std::unordered_set<int> *ignore_some_events_by_id);
+			Span<int> ignore_some_events_by_id);
 
 	/** Shorter version of CheckWay. */
 	bool CheckWay(const Game_Character& self,
@@ -281,7 +281,7 @@ namespace Game_Map {
 			int from_x, int from_y,
 			int to_x, int to_y,
 			bool check_events_and_vehicles,
-			std::unordered_set<int> *ignore_some_events_by_id,
+			Span<int> ignore_some_events_by_id,
 			bool make_way);
 
 	/**

--- a/src/game_variables.cpp
+++ b/src/game_variables.cpp
@@ -209,6 +209,14 @@ void Game_Variables::WriteArray(const int first_id_a, const int last_id_a, const
 	}
 }
 
+std::vector<Var_t> Game_Variables::GetRange(int variable_id, int length) {
+	std::vector<Var_t> vars;
+	for (int i = 0; i < length; ++i) {
+		vars.push_back(Get(variable_id + i));
+	}
+	return vars;
+}
+
 Game_Variables::Var_t Game_Variables::Set(int variable_id, Var_t value) {
 	return SetOp(variable_id, value, VarSet, "Invalid write var[{}] = {}!");
 }

--- a/src/game_variables.h
+++ b/src/game_variables.h
@@ -49,6 +49,7 @@ public:
 	Var_t Get(int variable_id) const;
 	Var_t GetIndirect(int variable_id) const;
 	Var_t GetWithMode(int id, int mode) const;
+	std::vector<Var_t> GetRange(int variable_id, int length);
 
 	Var_t Set(int variable_id, Var_t value);
 	Var_t Add(int variable_id, Var_t value);


### PR DESCRIPTION
This adds a new path finding command with initial code by @MackValentine that I fixed up, and @jetrotal  helping out coordinating the whole thing. It's based on the new CheckWay command added in #3120 and #3130 and can be used via event command 2001. It has a few special options which are documented in the doc comment that allow ignoring other events in the pathing (they won't be ignored in the actual collision!). The command is intended to both work for a use case where it's used *once* and then sets a movement route that is just left to execute, as you would in an autorun event, and for a use case where it's used *repeatedly* in a parallel event to continuously update the route to a moving target.

**Behavior quirks:** The current algorithm is a breadth first search, so it's not full A* yet. I might update it to an A* later if I get around to that, for now it seemed more relevant to get it to work properly with all the options people may want to use. It uses a search cutoff to avoid huge lag even when used constantly in parallel events by multiple moving things. Whenever a target is too far away to be safely located within that cutoff the command will set a guessed, approximate route. This means if the target is too far away the search might get lost and route into wrong sections of the map, this isn't a bug.

Another edit/additional note: I should be available also in the longer term if something with this code breaks to look into it.