### PR TITLE
DirectMenuPatch

### DIFF
--- a/resources/unix/easyrpg-player.6.adoc
+++ b/resources/unix/easyrpg-player.6.adoc
@@ -78,16 +78,21 @@ NOTE: For games that only use ASCII (English games) use '1252'.
   Disable support for the Runtime Package (RTP). Will lead to checkerboard
   graphics and silent music/sound effects in games depending on the RTP.
 
-*--patch-anti-lag-switch*:: _SWITCH_
+*--patch-antilag-switch*:: _SWITCH_
   Disables event page refreshing when the switch 'SWITCH' is set to 'ON'.
 
 *--patch-common-this*::
   Enable usage of __This Event__ in common events in any version of the engine.
   By default, this behaviour is only enabled for RPG Maker 2003 v1.12.
 
+*--patch-direct-menu*:: _VAR_
+  Directly access subscreens of the default menu by setting VAR.
+  See also: https://dev.makerpendium.de/docs/patch_db/main-en.htm?page=direct_menu
+
 *--patch-dynrpg*::
   Enable limited support for the DynRPG patch from Cherry. The patches are not
-  loaded from DLL files, but re-implemented by the engine.
+  loaded from DLL files, but re-implemented by the engine. See also:
+  https://rpg-maker.cherrytree.at/dynrpg/getting_started.html
 
 *--patch-easyrpg*::
   Enable EasyRPG extensions such as support for 32 bit images and large charsets.

--- a/src/game_config_game.cpp
+++ b/src/game_config_game.cpp
@@ -242,7 +242,6 @@ void Game_ConfigGame::PrintActivePatches() {
 
 	add_bool(patch_easyrpg);
 	add_bool(patch_dynrpg);
-	add_bool(patch_maniac);
 	add_bool(patch_common_this_event);
 	add_bool(patch_unlock_pics);
 	add_bool(patch_key_patch);
@@ -254,6 +253,7 @@ void Game_ConfigGame::PrintActivePatches() {
 		}
 	};
 
+	add_int(patch_maniac);
 	add_int(patch_anti_lag_switch);
 	add_int(patch_direct_menu);
 
@@ -261,10 +261,14 @@ void Game_ConfigGame::PrintActivePatches() {
 		Output::Debug("Patch configuration: None");
 	} else {
 		std::string out = "Patch configuration: ";
+		bool first = true;
 		for (const auto& s: patches) {
-			out += s + " ";
+			if (!first) {
+				out += ", ";
+			}
+			out += s;
+			first = false;
 		}
-		out.pop_back();
 		Output::DebugStr(out);
 	}
 }

--- a/src/game_config_game.h
+++ b/src/game_config_game.h
@@ -46,6 +46,7 @@ struct Game_ConfigGame {
 	BoolConfigParam patch_key_patch{ "Ineluki Key Patch", "Support \"Ineluki Key Patch\"", "Patch", "KeyPatch", false };
 	BoolConfigParam patch_rpg2k3_commands{ "RPG2k3 Event Commands", "Enable support for RPG2k3 event commands", "Patch", "RPG2k3Commands", false };
 	ConfigParam<int> patch_anti_lag_switch{ "Anti-Lag Switch", "Disable event page refreshes when switch is set", "Patch", "AntiLagSwitch", 0 };
+	ConfigParam<int> patch_direct_menu{ "Direct Menu", " Allows direct access to subscreens of the default menu", "Patch", "DirectMenu", 0 };
 
 	// Command line only
 	BoolConfigParam patch_support{ "Support patches", "When OFF all patch support is disabled", "", "", true };
@@ -75,6 +76,9 @@ struct Game_ConfigGame {
 	 * @post values of this are updated with values found in command line args.
 	 */
 	void LoadFromArgs(CmdlineParser& cp);
+
+	/** Outputs a list of active patches */
+	void PrintActivePatches();
 };
 
 #endif

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -23,6 +23,7 @@
 #include <sstream>
 #include <cassert>
 #include "audio.h"
+#include "feature.h"
 #include "game_map.h"
 #include "game_battle.h"
 #include "game_event.h"
@@ -38,8 +39,13 @@
 #include "sprite_character.h"
 #include "scene_map.h"
 #include "scene_battle.h"
+#include "scene_equip.h"
+#include "scene_item.h"
 #include "scene_menu.h"
+#include "scene_order.h"
 #include "scene_save.h"
+#include "scene_status.h"
+#include "scene_skill.h"
 #include "scene_load.h"
 #include "scene_name.h"
 #include "scene_shop.h"
@@ -81,6 +87,82 @@ void Game_Interpreter_Map::OnMapChange() {
 	for (auto& frame: _state.stack) {
 		frame.event_id = 0;
 	}
+}
+
+bool Game_Interpreter_Map::RequestMainMenuScene(int subscreen_id, int actor_index, bool is_db_actor) {
+
+	if (Player::game_config.patch_direct_menu.Get() && subscreen_id == -1) {
+		subscreen_id = Main_Data::game_variables->Get(Player::game_config.patch_direct_menu.Get());
+		actor_index = Main_Data::game_variables->Get(Player::game_config.patch_direct_menu.Get() + 1);
+		is_db_actor = (actor_index < 0);
+		actor_index = std::abs(actor_index);
+	}
+
+	switch (subscreen_id)
+	{
+	case 1: // Inventory
+		Scene::instance->SetRequestedScene(std::make_shared<Scene_Item>());
+		return true;
+	case 2: // Skills
+	case 3: // Equipment
+	case 4: // Status
+		if (!is_db_actor) {
+			if (actor_index == 0 || actor_index > 4) {
+				actor_index = 1;
+			}
+			actor_index--;
+		}
+
+		if (is_db_actor && !Main_Data::game_actors->GetActor(actor_index)) {
+			Output::Warning("Invalid actor ID {}", actor_index);
+			return false;
+		}
+
+		if (subscreen_id == 2) {
+			Scene::instance->SetRequestedScene(std::make_shared<Scene_Skill>(actor_index, 0, is_db_actor));
+		}
+		else if (subscreen_id == 3) {
+			Game_Actor* actor;
+			if (!is_db_actor) {
+				actor = Main_Data::game_party->GetActors()[actor_index];
+			}
+			else {
+				actor = Main_Data::game_actors->GetActor(actor_index);
+			}
+			Scene::instance->SetRequestedScene(std::make_shared<Scene_Equip>(*actor));
+		}
+		else if (subscreen_id == 4) {
+			Scene::instance->SetRequestedScene(std::make_shared<Scene_Status>(actor_index, is_db_actor));
+		}
+		return true;
+	case 5: // Order
+		if (!Feature::HasRow()) {
+			break;
+		}
+
+		if (Main_Data::game_party->GetActors().size() <= 1) {
+			Output::Warning("Party size must exceed '1' for 'Order' subscreen to be opened");
+			return false;
+		}
+		else {
+			Scene::instance->SetRequestedScene(std::make_shared<Scene_Order>());
+			return true;
+		}
+	/*
+	case 6: // Settings
+		Scene::instance->SetRequestedScene(std::make_shared<Scene_Settings>());
+		return true;
+	case 7: // Language
+		Scene::instance->SetRequestedScene(std::make_shared<Scene_Language>());
+		return true;
+	case 8: // Debug
+		Scene::instance->SetRequestedScene(std::make_shared<Scene_Debug>());
+		return true;
+		*/
+	}
+
+	Scene::instance->SetRequestedScene(std::make_shared<Scene_Menu>());
+	return true;
 }
 
 /**
@@ -638,7 +720,7 @@ bool Game_Interpreter_Map::CommandOpenSaveMenu(lcf::rpg::EventCommand const& /* 
 	return false;
 }
 
-bool Game_Interpreter_Map::CommandOpenMainMenu(lcf::rpg::EventCommand const& /* com */) { // code 11950
+bool Game_Interpreter_Map::CommandOpenMainMenu(lcf::rpg::EventCommand const& com) { // code 11950
 	auto& frame = GetFrame();
 	auto& index = frame.current_command;
 
@@ -646,9 +728,14 @@ bool Game_Interpreter_Map::CommandOpenMainMenu(lcf::rpg::EventCommand const& /* 
 		return false;
 	}
 
-	Scene::instance->SetRequestedScene(std::make_shared<Scene_Menu>());
-	++index;
-	return false;
+	int subscreen_id = -1, actor_index = 0;
+	bool is_db_actor = false;
+
+	if (RequestMainMenuScene(subscreen_id, actor_index, is_db_actor)) {
+		++index;
+		return false;
+	}
+	return true;
 }
 
 bool Game_Interpreter_Map::CommandOpenLoadMenu(lcf::rpg::EventCommand const& /* com */) {

--- a/src/game_interpreter_map.h
+++ b/src/game_interpreter_map.h
@@ -51,6 +51,8 @@ public:
 	 */
 	void OnMapChange();
 
+	bool RequestMainMenuScene(int subscreen_id = -1, int actor_index = 0, bool is_db_actor = false);
+
 	bool ExecuteCommand(lcf::rpg::EventCommand const& com) override;
 
 private:

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -295,7 +295,7 @@ void Game_Player::UpdateNextMovementAction() {
 
 		ResetAnimation();
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
-		Scene::instance->SetRequestedScene(std::make_shared<Scene_Menu>());
+		Game_Map::GetInterpreter().RequestMainMenuScene();
 		return;
 	}
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -825,9 +825,7 @@ void Player::CreateGameObjects() {
 		}
 	}
 
-	Output::Debug("Patch configuration: easyrpg={} dynrpg={} maniac={} key-patch={} common-this={} pic-unlock={} 2k3-commands={} anti-lag-switch={}",
-		Player::HasEasyRpgExtensions(), Player::IsPatchDynRpg(), Player::IsPatchManiac(), Player::IsPatchKeyPatch(), game_config.patch_common_this_event.Get(),
-		game_config.patch_unlock_pics.Get(), game_config.patch_rpg2k3_commands.Get(), game_config.patch_anti_lag_switch.Get());
+	game_config.PrintActivePatches();
 
 	ResetGameObjects();
 
@@ -1394,11 +1392,14 @@ Engine options:
  --new-game           Skip the title scene and start a new game directly.
  --no-log-color       Disable colors in terminal log.
  --no-rtp             Disable support for the Runtime Package (RTP).
- --patch-anti-lag-switch SWITCH
+ --patch-antilag-switch SWITCH
                       Disables event page refreshing when the switch SWITCH is
                       enabled.
  --patch-common-this  Enable usage of "This Event" in common events in any
                       version of the engine.
+ --patch-direct-menu VAR
+                      Directly access subscreens of the default menu by setting
+                      VAR.
  --patch-dynrpg       Enable support of DynRPG patch by Cherry (very limited).
  --patch-easyrpg      Enable EasyRPG extensions.
  --patch-key-patch    Enable Key Patch by Ineluki.

--- a/src/scene_equip.cpp
+++ b/src/scene_equip.cpp
@@ -27,10 +27,11 @@
 #include "scene_menu.h"
 #include <lcf/rpg/item.h>
 
-Scene_Equip::Scene_Equip(Game_Actor& actor, int equip_index) :
-	actor(actor),
-	equip_index(equip_index) {
+Scene_Equip::Scene_Equip(std::vector<Game_Actor*> actors, int actor_index, int equip_index) :
+	actors(actors), actor_index(actor_index), equip_index(equip_index) {
 	type = Scene::Equip;
+
+	assert(!actors.empty());
 }
 
 void Scene_Equip::Start() {
@@ -40,9 +41,11 @@ void Scene_Equip::Start() {
 	int menu_equip_status_height = 96;
 	int menu_equip_height = 96;
 
+	const auto& actor = *actors[actor_index];
+
 	help_window.reset(new Window_Help(Player::menu_offset_x, Player::menu_offset_y, MENU_WIDTH, menu_help_height));
-	equipstatus_window.reset(new Window_EquipStatus(Player::menu_offset_x, Player::menu_offset_y + menu_help_height, menu_equip_status_width, menu_equip_status_height, actor.GetId()));
-	equip_window.reset(new Window_Equip(Player::menu_offset_x + menu_equip_status_width, Player::menu_offset_y + menu_help_height, (MENU_WIDTH - menu_equip_status_width), menu_equip_height, actor.GetId()));
+	equipstatus_window.reset(new Window_EquipStatus(Player::menu_offset_x, Player::menu_offset_y + menu_help_height, menu_equip_status_width, menu_equip_status_height, actor));
+	equip_window.reset(new Window_Equip(Player::menu_offset_x + menu_equip_status_width, Player::menu_offset_y + menu_help_height, (MENU_WIDTH - menu_equip_status_width), menu_equip_height, actor));
 
 	equip_window->SetIndex(equip_index);
 
@@ -94,6 +97,7 @@ void Scene_Equip::UpdateStatusWindow() {
 		const lcf::rpg::Item* current_item = item_window->GetItem();
 
 		const auto eidx = equip_window->GetIndex();
+		const auto& actor = *actors[actor_index];
 
 		auto atk = actor.GetBaseAtk(Game_Battler::WeaponAll, true, false);
 		auto def = actor.GetBaseDef(Game_Battler::WeaponAll, true, false);
@@ -167,6 +171,7 @@ void Scene_Equip::UpdateEquipSelection() {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
 		Scene::Pop();
 	} else if (Input::IsTriggered(Input::DECISION)) {
+		const auto& actor = *actors[actor_index];
 		if (!CanRemoveEquipment(actor, equip_window->GetIndex())) {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 			return;
@@ -176,20 +181,18 @@ void Scene_Equip::UpdateEquipSelection() {
 		equip_window->SetActive(false);
 		item_window->SetActive(true);
 		item_window->SetIndex(0);
-	} else if (Main_Data::game_party->GetActors().size() > 1 && Input::IsTriggered(Input::RIGHT)) {
+	} else if (actors.size() > 1 && Input::IsTriggered(Input::RIGHT)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
-		int actor_index = Main_Data::game_party->GetActorPositionInParty(actor.GetId());
-		if (actor_index != -1) {
-			actor_index = (actor_index + 1) % Main_Data::game_party->GetActors().size();
-			Scene::Push(std::make_shared<Scene_Equip>((*Main_Data::game_party)[actor_index], equip_window->GetIndex()), true);
-		}
-	} else if (Main_Data::game_party->GetActors().size() > 1 && Input::IsTriggered(Input::LEFT)) {
+		const auto& actor = actors[actor_index];
+		actor_index = (actor_index + 1) % actors.size();
+		Scene::Push(std::make_shared<Scene_Equip>(actors, actor_index, equip_window->GetIndex()), true);
+	} else if (actors.size() > 1 && Input::IsTriggered(Input::LEFT)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
-		int actor_index = Main_Data::game_party->GetActorPositionInParty(actor.GetId());
-		if (actor_index != -1) {
-			actor_index = (actor_index + Main_Data::game_party->GetActors().size() - 1) % Main_Data::game_party->GetActors().size();
-			Scene::Push(std::make_shared<Scene_Equip>((*Main_Data::game_party)[actor_index], equip_window->GetIndex()), true);
+		actor_index = actor_index - 1;
+		if (actor_index < 0) {
+			actor_index = actors.size() - 1;
 		}
+		Scene::Push(std::make_shared<Scene_Equip>(actors, actor_index, equip_window->GetIndex()), true);
 	}
 }
 
@@ -204,6 +207,7 @@ void Scene_Equip::UpdateItemSelection() {
 
 		const lcf::rpg::Item* current_item = item_window->GetItem();
 		int current_item_id = current_item ? current_item->ID : 0;
+		auto& actor = *actors[actor_index];
 
 		actor.ChangeEquipment(
 			equip_window->GetIndex() + 1, current_item_id);

--- a/src/scene_equip.cpp
+++ b/src/scene_equip.cpp
@@ -179,13 +179,17 @@ void Scene_Equip::UpdateEquipSelection() {
 	} else if (Main_Data::game_party->GetActors().size() > 1 && Input::IsTriggered(Input::RIGHT)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 		int actor_index = Main_Data::game_party->GetActorPositionInParty(actor.GetId());
-		actor_index = (actor_index + 1) % Main_Data::game_party->GetActors().size();
-		Scene::Push(std::make_shared<Scene_Equip>((*Main_Data::game_party)[actor_index], equip_window->GetIndex()), true);
+		if (actor_index != -1) {
+			actor_index = (actor_index + 1) % Main_Data::game_party->GetActors().size();
+			Scene::Push(std::make_shared<Scene_Equip>((*Main_Data::game_party)[actor_index], equip_window->GetIndex()), true);
+		}
 	} else if (Main_Data::game_party->GetActors().size() > 1 && Input::IsTriggered(Input::LEFT)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 		int actor_index = Main_Data::game_party->GetActorPositionInParty(actor.GetId());
-		actor_index = (actor_index + Main_Data::game_party->GetActors().size() - 1) % Main_Data::game_party->GetActors().size();
-		Scene::Push(std::make_shared<Scene_Equip>((*Main_Data::game_party)[actor_index], equip_window->GetIndex()), true);
+		if (actor_index != -1) {
+			actor_index = (actor_index + Main_Data::game_party->GetActors().size() - 1) % Main_Data::game_party->GetActors().size();
+			Scene::Push(std::make_shared<Scene_Equip>((*Main_Data::game_party)[actor_index], equip_window->GetIndex()), true);
+		}
 	}
 }
 

--- a/src/scene_equip.h
+++ b/src/scene_equip.h
@@ -36,10 +36,11 @@ public:
 	/**
 	 * Constructor.
 	 *
-	 * @param actor actor in the party.
+	 * @param actors Vector containing all the actors
+	 * @param actor_index actor whose equipment is shown.
 	 * @param equip_index selected equipment.
 	 */
-	Scene_Equip(Game_Actor& actor, int equip_index = 0);
+	Scene_Equip(std::vector<Game_Actor*> actors, int actor_index, int equip_index = 0);
 
 	void Start() override;
 	void vUpdate() override;
@@ -70,8 +71,9 @@ public:
 	void UpdateItemSelection();
 
 private:
-	/** Actor in the party whose equipment is displayed. */
-	Game_Actor& actor;
+	std::vector<Game_Actor*> actors;
+	/** Index of the actor in the party whose equipment is displayed. */
+	int actor_index;
 	/** Selected equipment on startup. */
 	int equip_index;
 

--- a/src/scene_menu.cpp
+++ b/src/scene_menu.cpp
@@ -271,15 +271,15 @@ void Scene_Menu::UpdateActorSelection() {
 				return;
 			}
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
-			Scene::Push(std::make_shared<Scene_Skill>(menustatus_window->GetIndex()));
+			Scene::Push(std::make_shared<Scene_Skill>(Main_Data::game_party->GetActors(), menustatus_window->GetIndex()));
 			break;
 		case Equipment:
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
-			Scene::Push(std::make_shared<Scene_Equip>(*menustatus_window->GetActor()));
+			Scene::Push(std::make_shared<Scene_Equip>(Main_Data::game_party->GetActors(), menustatus_window->GetIndex()));
 			break;
 		case Status:
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
-			Scene::Push(std::make_shared<Scene_Status>(menustatus_window->GetIndex()));
+			Scene::Push(std::make_shared<Scene_Status>(Main_Data::game_party->GetActors(), menustatus_window->GetIndex()));
 			break;
 		case Row:
 		{

--- a/src/scene_skill.h
+++ b/src/scene_skill.h
@@ -19,6 +19,7 @@
 #define EP_SCENE_SKILL_H
 
 // Headers
+#include <vector>
 #include "scene.h"
 #include "window_help.h"
 #include "window_skill.h"
@@ -33,7 +34,8 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Scene_Skill(int actor_index, int skill_index = 0, bool is_db_actor = false);
+
+	Scene_Skill(std::vector<Game_Actor*> actors, int actor_index, int skill_index = 0);
 
 	void Start() override;
 	void Continue(SceneType prev_scene) override;
@@ -41,12 +43,11 @@ public:
 	void TransitionOut(SceneType next_scene) override;
 
 private:
-	/** Actor in the party whose skills are displayed. */
+	std::vector<Game_Actor*> actors;
+	/** Actor in the span whose skills are displayed. */
 	int actor_index;
 	/** Skill to select at startup. */
 	int skill_index;
-	/** Given actor index refers to a database actor instead of a party member index. */
-	bool is_db_actor;
 	/** Displays available skills. */
 	std::unique_ptr<Window_Skill> skill_window;
 	/** Displays information about the actor. */

--- a/src/scene_skill.h
+++ b/src/scene_skill.h
@@ -33,7 +33,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Scene_Skill(int actor_index, int skill_index = 0);
+	Scene_Skill(int actor_index, int skill_index = 0, bool is_db_actor = false);
 
 	void Start() override;
 	void Continue(SceneType prev_scene) override;
@@ -45,6 +45,8 @@ private:
 	int actor_index;
 	/** Skill to select at startup. */
 	int skill_index;
+	/** Given actor index refers to a database actor instead of a party member index. */
+	bool is_db_actor;
 	/** Displays available skills. */
 	std::unique_ptr<Window_Skill> skill_window;
 	/** Displays information about the actor. */

--- a/src/scene_status.cpp
+++ b/src/scene_status.cpp
@@ -23,11 +23,13 @@
 #include "game_party.h"
 #include "game_system.h"
 #include "input.h"
-#include <player.h>
+#include "player.h"
 
-Scene_Status::Scene_Status(int actor_index, bool is_db_actor) :
-	actor_index(actor_index), is_db_actor(is_db_actor) {
+Scene_Status::Scene_Status(std::vector<Game_Actor*> actors, int actor_index) :
+	actors(actors), actor_index(actor_index) {
 	type = Scene::Status;
+
+	assert(!actors.empty());
 }
 
 void Scene_Status::Start() {
@@ -42,14 +44,7 @@ void Scene_Status::Start() {
 	int window_equip_width = 196;
 	int window_equip_height = 96;
 
-	int actor;
-
-	if (!is_db_actor) {
-		actor = Main_Data::game_party->GetActors()[actor_index]->GetId();
-	}
-	else {
-		actor = Main_Data::game_actors->GetActor(actor_index)->GetId();
-	}
+	const auto& actor = *actors[actor_index];
 	actorinfo_window.reset(new Window_ActorInfo(Player::menu_offset_x, Player::menu_offset_y, window_actor_info_width, window_actor_info_height, actor));
 	gold_window.reset(new Window_Gold(Player::menu_offset_x, Player::menu_offset_y + window_actor_info_height, window_gold_width, window_gold_height));
 	actorstatus_window.reset(new Window_ActorStatus(Player::menu_offset_x + window_actor_info_width, Player::menu_offset_y, window_actor_status_width, window_actor_status_height, actor));
@@ -70,13 +65,17 @@ void Scene_Status::vUpdate() {
 	if (Input::IsTriggered(Input::CANCEL)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
 		Scene::Pop();
-	} else if (!is_db_actor && Main_Data::game_party->GetActors().size() > 1 && Input::IsTriggered(Input::RIGHT)) {
+	} else if (actors.size() > 1 && Input::IsTriggered(Input::RIGHT)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
-		actor_index = (actor_index + 1) % Main_Data::game_party->GetActors().size();
-		Scene::Push(std::make_shared<Scene_Status>(actor_index), true);
-	} else if (!is_db_actor && Main_Data::game_party->GetActors().size() > 1 && Input::IsTriggered(Input::LEFT)) {
+		const auto& actor = actors[actor_index];
+		actor_index = (actor_index + 1) % actors.size();
+		Scene::Push(std::make_shared<Scene_Status>(actors, actor_index), true);
+	} else if (actors.size() > 1 && Input::IsTriggered(Input::LEFT)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
-		actor_index = (actor_index + Main_Data::game_party->GetActors().size() - 1) % Main_Data::game_party->GetActors().size();
-		Scene::Push(std::make_shared<Scene_Status>(actor_index), true);
+		actor_index = actor_index - 1;
+		if (actor_index < 0) {
+			actor_index = actors.size() - 1;
+		}
+		Scene::Push(std::make_shared<Scene_Status>(actors, actor_index), true);
 	}
 }

--- a/src/scene_status.cpp
+++ b/src/scene_status.cpp
@@ -19,13 +19,14 @@
 #include <string>
 #include <vector>
 #include "scene_status.h"
+#include "game_actors.h"
 #include "game_party.h"
 #include "game_system.h"
 #include "input.h"
 #include <player.h>
 
-Scene_Status::Scene_Status(int actor_index) :
-	actor_index(actor_index) {
+Scene_Status::Scene_Status(int actor_index, bool is_db_actor) :
+	actor_index(actor_index), is_db_actor(is_db_actor) {
 	type = Scene::Status;
 }
 
@@ -41,8 +42,14 @@ void Scene_Status::Start() {
 	int window_equip_width = 196;
 	int window_equip_height = 96;
 
-	int actor = Main_Data::game_party->GetActors()[actor_index]->GetId();
+	int actor;
 
+	if (!is_db_actor) {
+		actor = Main_Data::game_party->GetActors()[actor_index]->GetId();
+	}
+	else {
+		actor = Main_Data::game_actors->GetActor(actor_index)->GetId();
+	}
 	actorinfo_window.reset(new Window_ActorInfo(Player::menu_offset_x, Player::menu_offset_y, window_actor_info_width, window_actor_info_height, actor));
 	gold_window.reset(new Window_Gold(Player::menu_offset_x, Player::menu_offset_y + window_actor_info_height, window_gold_width, window_gold_height));
 	actorstatus_window.reset(new Window_ActorStatus(Player::menu_offset_x + window_actor_info_width, Player::menu_offset_y, window_actor_status_width, window_actor_status_height, actor));
@@ -63,11 +70,11 @@ void Scene_Status::vUpdate() {
 	if (Input::IsTriggered(Input::CANCEL)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
 		Scene::Pop();
-	} else if (Main_Data::game_party->GetActors().size() > 1 && Input::IsTriggered(Input::RIGHT)) {
+	} else if (!is_db_actor && Main_Data::game_party->GetActors().size() > 1 && Input::IsTriggered(Input::RIGHT)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 		actor_index = (actor_index + 1) % Main_Data::game_party->GetActors().size();
 		Scene::Push(std::make_shared<Scene_Status>(actor_index), true);
-	} else if (Main_Data::game_party->GetActors().size() > 1 && Input::IsTriggered(Input::LEFT)) {
+	} else if (!is_db_actor && Main_Data::game_party->GetActors().size() > 1 && Input::IsTriggered(Input::LEFT)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 		actor_index = (actor_index + Main_Data::game_party->GetActors().size() - 1) % Main_Data::game_party->GetActors().size();
 		Scene::Push(std::make_shared<Scene_Status>(actor_index), true);

--- a/src/scene_status.h
+++ b/src/scene_status.h
@@ -19,6 +19,7 @@
 #define EP_SCENE_STATUS_H
 
 // Headers
+#include <vector>
 #include "scene.h"
 #include "window_actorinfo.h"
 #include "window_actorstatus.h"
@@ -35,17 +36,17 @@ public:
 	/**
 	 * Constructor.
 	 *
-	 * @param actor_index party index of the actor.
+	 * @param actors list of actors
+	 * @param index index in the span to show
 	 */
-	Scene_Status(int actor_index, bool is_db_actor = false);
+	Scene_Status(std::vector<Game_Actor*> actors, int actor_index);
 
 	void Start() override;
 	void vUpdate() override;
 
 private:
+	std::vector<Game_Actor*> actors;
 	int actor_index;
-	/** Given actor index refers to a database actor instead of a party member index. */
-	bool is_db_actor;
 
 	std::unique_ptr<Window_ActorInfo> actorinfo_window;
 	std::unique_ptr<Window_ActorStatus> actorstatus_window;

--- a/src/scene_status.h
+++ b/src/scene_status.h
@@ -37,13 +37,15 @@ public:
 	 *
 	 * @param actor_index party index of the actor.
 	 */
-	Scene_Status(int actor_index);
+	Scene_Status(int actor_index, bool is_db_actor = false);
 
 	void Start() override;
 	void vUpdate() override;
 
 private:
 	int actor_index;
+	/** Given actor index refers to a database actor instead of a party member index. */
+	bool is_db_actor;
 
 	std::unique_ptr<Window_ActorInfo> actorinfo_window;
 	std::unique_ptr<Window_ActorStatus> actorstatus_window;

--- a/src/window_actorinfo.cpp
+++ b/src/window_actorinfo.cpp
@@ -25,9 +25,9 @@
 #include "font.h"
 #include "feature.h"
 
-Window_ActorInfo::Window_ActorInfo(int ix, int iy, int iwidth, int iheight, int actor_id) :
+Window_ActorInfo::Window_ActorInfo(int ix, int iy, int iwidth, int iheight, const Game_Actor& actor) :
 	Window_Base(ix, iy, iwidth, iheight),
-	actor_id(actor_id) {
+	actor(actor) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 
@@ -43,11 +43,9 @@ void Window_ActorInfo::Refresh() {
 void Window_ActorInfo::DrawInfo() {
 	if (Feature::HasRow()) {
 		// Draw Row formation.
-		std::string battle_row = Main_Data::game_actors->GetActor(actor_id)->GetBattleRow() == Game_Actor::RowType::RowType_back ? lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_back, "Back") : lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_front, "Front");
+		std::string battle_row = actor.GetBattleRow() == Game_Actor::RowType::RowType_back ? lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_back, "Back") : lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_status_scene_front, "Front");
 		contents->TextDraw(contents->GetWidth(), 2, Font::ColorDefault, battle_row, Text::AlignRight);
 	}
-
-	const Game_Actor& actor = *Main_Data::game_actors->GetActor(actor_id);
 
 	// Draw Face
 	DrawActorFace(actor, 0, 0);

--- a/src/window_actorinfo.h
+++ b/src/window_actorinfo.h
@@ -31,7 +31,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_ActorInfo(int ix, int iy, int iwidth, int iheight, int actor_id);
+	Window_ActorInfo(int ix, int iy, int iwidth, int iheight, const Game_Actor& actor);
 
 	/**
 	 * Renders the stats on the window.
@@ -43,7 +43,7 @@ public:
 	 */
 	void DrawInfo();
 private:
-	int actor_id;
+	const Game_Actor& actor;
 };
 
 #endif

--- a/src/window_actorstatus.cpp
+++ b/src/window_actorstatus.cpp
@@ -24,9 +24,9 @@
 #include "bitmap.h"
 #include "font.h"
 
-Window_ActorStatus::Window_ActorStatus(int ix, int iy, int iwidth, int iheight, int actor_id) :
+Window_ActorStatus::Window_ActorStatus(int ix, int iy, int iwidth, int iheight, const Game_Actor& actor) :
 	Window_Base(ix, iy, iwidth, iheight),
-	actor_id(actor_id) {
+	actor(actor) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 
@@ -40,9 +40,6 @@ void Window_ActorStatus::Refresh() {
 }
 
 void Window_ActorStatus::DrawStatus() {
-
-	Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
-
 	int have, max;
 	auto fontcolor = [&have, &max](bool can_knockout) {
 		if (can_knockout && have == 0) return Font::ColorKnockout;
@@ -52,14 +49,14 @@ void Window_ActorStatus::DrawStatus() {
 
 	// Draw Hp
 	contents->TextDraw(1, 2, 1, lcf::Data::terms.health_points);
-	have = actor->GetHp();
-	max = actor->GetMaxHp();
+	have = actor.GetHp();
+	max = actor.GetMaxHp();
 	DrawMinMax(90, 2, have, max, fontcolor(true));
 
 	// Draw Sp
 	contents->TextDraw(1, 18, 1, lcf::Data::terms.spirit_points);
-	have = actor->GetSp();
-	max = actor->GetMaxSp();
+	have = actor.GetSp();
+	max = actor.GetMaxSp();
 	DrawMinMax(90, 18, have, max, fontcolor(false));
 
 	// Draw Exp
@@ -69,16 +66,18 @@ void Window_ActorStatus::DrawStatus() {
 
 void Window_ActorStatus::DrawMinMax(int cx, int cy, int min, int max, int color) {
 	std::stringstream ss;
-	if (max >= 0)
+	if (max >= 0) {
 		ss << min;
-	else
-		ss << Main_Data::game_actors->GetActor(actor_id)->GetExpString(true);
+	} else {
+		ss << actor.GetExpString(true);
+	}
 	contents->TextDraw(cx, cy, color, ss.str(), Text::AlignRight);
 	contents->TextDraw(cx, cy, Font::ColorDefault, "/");
 	ss.str("");
-	if (max >= 0)
+	if (max >= 0) {
 		ss << max;
-	else
-		ss << Main_Data::game_actors->GetActor(actor_id)->GetNextExpString(true);
+	} else {
+		ss << actor.GetNextExpString(true);
+	}
 	contents->TextDraw(cx + 48, cy, Font::ColorDefault, ss.str(), Text::AlignRight);
 }

--- a/src/window_actorstatus.h
+++ b/src/window_actorstatus.h
@@ -32,7 +32,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_ActorStatus(int ix, int iy, int iwidth, int iheight, int actor_id);
+	Window_ActorStatus(int ix, int iy, int iwidth, int iheight, const Game_Actor& actor);
 
 	/**
 	 * Renders the stats on the window.
@@ -50,7 +50,7 @@ public:
 	void DrawMinMax(int cx, int cy, int min, int max, int color = Font::ColorDefault);
 
 private:
-	int actor_id;
+	const Game_Actor& actor;
 };
 
 #endif

--- a/src/window_battlecommand.cpp
+++ b/src/window_battlecommand.cpp
@@ -30,8 +30,6 @@
 Window_BattleCommand::Window_BattleCommand(int x, int y, int width, int height) :
 	Window_Base(x, y, width, height) {
 
-	SetActor(0);
-
 	disabled.resize(commands.size());
 	index = -1;
 	top_row = 0;
@@ -133,18 +131,17 @@ void Window_BattleCommand::SetIndex(int _index) {
 	index = _index;
 }
 
-void Window_BattleCommand::SetActor(int _actor_id) {
-	actor_id = Feature::HasRpg2kBattleSystem() ? 0 : _actor_id;
+void Window_BattleCommand::SetActor(const Game_Actor* actor) {
+	this->actor = Feature::HasRpg2kBattleSystem() ? nullptr : actor;
 	commands.clear();
 
-	if (actor_id == 0) {
+	if (actor == nullptr) {
 		commands.push_back(!lcf::Data::terms.command_attack.empty() ? ToString(lcf::Data::terms.command_attack) : "Attack");
 		commands.push_back(!lcf::Data::terms.command_defend.empty() ? ToString(lcf::Data::terms.command_defend) : "Defend");
 		commands.push_back(!lcf::Data::terms.command_item.empty() ? ToString(lcf::Data::terms.command_item) : "Item");
 		commands.push_back(!lcf::Data::terms.command_skill.empty() ? ToString(lcf::Data::terms.command_skill) : "Skill");
 	}
 	else {
-		Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
 		const std::vector<const lcf::rpg::BattleCommand*> bcmds = actor->GetBattleCommands();
 		for (const lcf::rpg::BattleCommand* command : bcmds) {
 			commands.push_back(ToString(command->name));
@@ -156,10 +153,10 @@ void Window_BattleCommand::SetActor(int _actor_id) {
 }
 
 int Window_BattleCommand::GetSkillSubset() {
-	if (actor_id == 0)
+	if (actor == nullptr) {
 		return lcf::rpg::Skill::Type_normal;
+	}
 
-	Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
 	const std::vector<const lcf::rpg::BattleCommand*> bcmds = actor->GetBattleCommands();
 	int bcmd = bcmds[index]->ID;
 

--- a/src/window_battlecommand.h
+++ b/src/window_battlecommand.h
@@ -53,7 +53,7 @@ public:
 	 */
 	void SetEnabled(int index, bool enabled);
 
-	void SetActor(int actor_id);
+	void SetActor(const Game_Actor* actor);
 
 	int GetIndex();
 	void SetIndex(int index);
@@ -62,7 +62,7 @@ public:
 	int GetSkillSubset();
 
 protected:
-	int actor_id;
+	const Game_Actor* actor = nullptr;
 	std::vector<std::string> commands;
 	int index;
 	int num_rows;

--- a/src/window_equip.cpp
+++ b/src/window_equip.cpp
@@ -22,9 +22,9 @@
 #include <lcf/reader_util.h>
 #include "output.h"
 
-Window_Equip::Window_Equip(int ix, int iy, int iwidth, int iheight, int actor_id) :
+Window_Equip::Window_Equip(int ix, int iy, int iwidth, int iheight, const Game_Actor& actor) :
 	Window_Selectable(ix, iy, iwidth, iheight),
-	actor_id(actor_id) {
+	actor(actor) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 
@@ -42,16 +42,15 @@ void Window_Equip::Refresh() {
 
 	// Add the equipment of the actor to data
 	data.clear();
-	Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
 	for (int i = 1; i <= 5; ++i) {
-		const lcf::rpg::Item* item = actor->GetEquipment(i);
+		const lcf::rpg::Item* item = actor.GetEquipment(i);
 		data.push_back(item ? item->ID : 0);
 	}
 	item_max = data.size();
 
 	// Draw equipment text
 	for (int i = 0; i < 5; ++i) {
-		DrawEquipmentType(*actor, 0, (12 + 4) * i + 2, i);
+		DrawEquipmentType(actor, 0, (12 + 4) * i + 2, i);
 		if (data[i] > 0) {
 			// Equipment and items are guaranteed to be valid
 			DrawItemName(*lcf::ReaderUtil::GetElement(lcf::Data::items, data[i]), 60, (12 + 4) * i + 2);

--- a/src/window_equip.h
+++ b/src/window_equip.h
@@ -34,9 +34,9 @@ public:
 	 * @param iy window y position.
 	 * @param iwidth window width.
 	 * @param iheight window height.
-	 * @param actor_id actor whose inventory is displayed.
+	 * @param actor actor whose inventory is displayed.
 	 */
-	Window_Equip(int ix, int iy, int iwidth, int iheight, int actor_id);
+	Window_Equip(int ix, int iy, int iwidth, int iheight, const Game_Actor& actor);
 
 	/**
 	 * Refreshes.
@@ -56,8 +56,7 @@ public:
 	void UpdateHelp() override;
 
 private:
-	int actor_id;
-
+	const Game_Actor& actor;
 	std::vector<int> data;
 
 };

--- a/src/window_equipitem.cpp
+++ b/src/window_equipitem.cpp
@@ -22,16 +22,16 @@
 #include <lcf/reader_util.h>
 #include "output.h"
 
-Window_EquipItem::Window_EquipItem(int ix, int iy, int iwidth, int iheight, int actor_id, int equip_type) :
+Window_EquipItem::Window_EquipItem(int ix, int iy, int iwidth, int iheight,  const Game_Actor& actor, int equip_type) :
 	Window_Item(ix, iy, iwidth, iheight),
-	actor_id(actor_id) {
+	actor(actor) {
 	this->equip_type = equip_type;
 	if (equip_type > 4 || equip_type < 0) {
 		this->equip_type = Window_EquipItem::other;
 	}
 
 	if (this->equip_type == Window_EquipItem::shield &&
-		Main_Data::game_actors->GetActor(actor_id)->HasTwoWeapons()) {
+		actor.HasTwoWeapons()) {
 
 		this->equip_type = Window_EquipItem::weapon;
 	}
@@ -39,7 +39,7 @@ Window_EquipItem::Window_EquipItem(int ix, int iy, int iwidth, int iheight, int 
 
 bool Window_EquipItem::CheckInclude(int item_id) {
 	// Do not show equippable items if the actor has its equipment fixed
-	if (Main_Data::game_actors->GetActor(actor_id)->IsEquipmentFixed(false)) {
+	if (actor.IsEquipmentFixed(false)) {
 		return false;
 	}
 
@@ -78,7 +78,7 @@ bool Window_EquipItem::CheckInclude(int item_id) {
 		if (Main_Data::game_party->GetItemCount(item_id) == 0) {
 			return false;
 		} else {
-			return Main_Data::game_actors->GetActor(actor_id)->IsEquippable(item_id);
+			return actor.IsEquippable(item_id);
 		}
 	} else {
 		return false;

--- a/src/window_equipitem.h
+++ b/src/window_equipitem.h
@@ -40,10 +40,10 @@ public:
 	/**
 	 * Constructor.
 	 *
-	 * @param actor_id actor whos equipment is displayed.
+	 * @param actor actor whos equipment is displayed.
 	 * @param equip_type type of equipment to show.
 	 */
-	Window_EquipItem(int ix, int iy, int iwidth, int iheight, int actor_id, int equip_type);
+	Window_EquipItem(int ix, int iy, int iwidth, int iheight,  const Game_Actor& actor, int equip_type);
 
 	/**
 	 * Checks if the item should be in the list based on
@@ -61,8 +61,8 @@ public:
 	bool CheckEnable(int item_id) override;
 
 private:
-	int actor_id;
-	int equip_type;
+	const Game_Actor& actor;
+ 	int equip_type;
 };
 
 #endif

--- a/src/window_equipstatus.cpp
+++ b/src/window_equipstatus.cpp
@@ -24,9 +24,9 @@
 #include "font.h"
 #include "player.h"
 
-Window_EquipStatus::Window_EquipStatus(int ix, int iy, int iwidth, int iheight, int actor_id) :
+Window_EquipStatus::Window_EquipStatus(int ix, int iy, int iwidth, int iheight, const Game_Actor& actor) :
 	Window_Base(ix, iy, iwidth, iheight),
-	actor_id(actor_id),
+	actor(actor),
 	draw_params(false),
 	dirty(true) {
 
@@ -43,7 +43,7 @@ void Window_EquipStatus::Refresh() {
 
 		y_offset = 18;
 		// Actor data is guaranteed to be valid
-		DrawActorName(*Main_Data::game_actors->GetActor(actor_id), 0, 2);
+		DrawActorName(actor, 0, 2);
 
 		for (int i = 0; i < 4; ++i) {
 			DrawParameter(0, y_offset + ((12 + 4) * i), i);
@@ -87,27 +87,26 @@ void Window_EquipStatus::DrawParameter(int cx, int cy, int type) {
 	StringView name;
 	int value;
 	int new_value;
-	Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
 
 	switch (type) {
 	case 0:
 		name = lcf::Data::terms.attack;
-		value = actor->GetAtk();
+		value = actor.GetAtk();
 		new_value = atk;
 		break;
 	case 1:
 		name = lcf::Data::terms.defense;
-		value = actor->GetDef();
+		value = actor.GetDef();
 		new_value = def;
 		break;
 	case 2:
 		name = lcf::Data::terms.spirit;
-		value = actor->GetSpi();
+		value = actor.GetSpi();
 		new_value = spi;
 		break;
 	case 3:
 		name = lcf::Data::terms.agility;
-		value = actor->GetAgi();
+		value = actor.GetAgi();
 		new_value = agi;
 		break;
 	default:
@@ -115,7 +114,7 @@ void Window_EquipStatus::DrawParameter(int cx, int cy, int type) {
 	}
 
 	// Check if 4 digits are needed instead of 3
-	int limit = actor->MaxStatBaseValue();
+	int limit = actor.MaxStatBaseValue();
 	bool more_space_needed = (Player::IsRPG2k3() && limit >= 500) || limit >= 1000;
 
 	// Draw Term

--- a/src/window_equipstatus.h
+++ b/src/window_equipstatus.h
@@ -22,7 +22,7 @@
 #include "window_base.h"
 
 /**
- * Window_EquipLeft class.
+ * Window_EquipStatus class.
  * Displays stats of the hero/item.
  */
 class Window_EquipStatus : public Window_Base {
@@ -35,9 +35,9 @@ public:
 	 * @param iy window y position.
 	 * @param iwidth window width.
 	 * @param iheight window height.
-	 * @param actor_id actor whose stats are displayed.
+	 * @param actor actor whose stats are displayed.
 	 */
-	Window_EquipStatus(int ix, int iy, int iwidth, int iheight, int actor_id);
+	Window_EquipStatus(int ix, int iy, int iwidth, int iheight, const Game_Actor& actor);
 
 	/**
 	 * Refreshes screen.
@@ -78,7 +78,8 @@ public:
 	void DrawParameter(int cx, int cy, int type);
 
 private:
-	int actor_id;
+ 	const Game_Actor& actor;
+
 	/** Draws the params if true. */
 	bool draw_params;
 

--- a/src/window_face.cpp
+++ b/src/window_face.cpp
@@ -21,7 +21,7 @@
 #include "window_face.h"
 
 Window_Face::Window_Face(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight), actor_id(1) {
+	Window_Base(ix, iy, iwidth, iheight) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 }
@@ -29,10 +29,10 @@ Window_Face::Window_Face(int ix, int iy, int iwidth, int iheight) :
 void Window_Face::Refresh() {
 	contents->Clear();
 	// Actor data is guaranteed to be valid
-	DrawActorFace(*Main_Data::game_actors->GetActor(actor_id), 0, 0);
+	DrawActorFace(*actor, 0, 0);
 }
 
-void Window_Face::Set(int id) {
-	actor_id = id;
+void Window_Face::Set(const Game_Actor& actor) {
+	this->actor = &actor;
 	Refresh();
 }

--- a/src/window_face.h
+++ b/src/window_face.h
@@ -37,10 +37,10 @@ public:
 	 */
 	void Refresh();
 
-	void Set(int actor_id);
+	void Set(const Game_Actor& actor);
 
 protected:
-	int actor_id;
+	const Game_Actor* actor = nullptr;
 };
 
 #endif

--- a/src/window_paramstatus.cpp
+++ b/src/window_paramstatus.cpp
@@ -23,9 +23,9 @@
 #include "bitmap.h"
 #include "font.h"
 
-Window_ParamStatus::Window_ParamStatus(int ix, int iy, int iwidth, int iheight, int actor_id) :
+Window_ParamStatus::Window_ParamStatus(int ix, int iy, int iwidth, int iheight, const Game_Actor& actor) :
 	Window_Base(ix, iy, iwidth, iheight),
-	actor_id(actor_id)
+	actor(actor)
 {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
@@ -35,8 +35,6 @@ Window_ParamStatus::Window_ParamStatus(int ix, int iy, int iwidth, int iheight, 
 
 void Window_ParamStatus::Refresh() {
 	contents->Clear();
-
-	auto* actor = Main_Data::game_actors->GetActor(actor_id);
 
 	auto draw = [this](int y, StringView name, int value) {
 		// Draw Term
@@ -48,9 +46,9 @@ void Window_ParamStatus::Refresh() {
 	};
 
 	int y = 2;
-	y = draw(y, lcf::Data::terms.attack, actor->GetAtk());
-	y = draw(y, lcf::Data::terms.defense, actor->GetDef());
-	y = draw(y, lcf::Data::terms.spirit, actor->GetSpi());
-	y = draw(y, lcf::Data::terms.agility, actor->GetAgi());
+	y = draw(y, lcf::Data::terms.attack, actor.GetAtk());
+	y = draw(y, lcf::Data::terms.defense, actor.GetDef());
+	y = draw(y, lcf::Data::terms.spirit, actor.GetSpi());
+	y = draw(y, lcf::Data::terms.agility, actor.GetAgi());
 }
 

--- a/src/window_paramstatus.h
+++ b/src/window_paramstatus.h
@@ -35,9 +35,9 @@ public:
 	 * @param iy window y position.
 	 * @param iwidth window width.
 	 * @param iheight window height.
-	 * @param actor_id actor whose stats are displayed.
+	 * @param actor actor whose stats are displayed.
 	 */
-	Window_ParamStatus(int ix, int iy, int iwidth, int iheight, int actor_id);
+	Window_ParamStatus(int ix, int iy, int iwidth, int iheight,  const Game_Actor& actor);
 
 	/**
 	 * Refreshes screen.
@@ -45,7 +45,7 @@ public:
 	void Refresh();
 
 private:
-	int actor_id = 0;
+	 const Game_Actor& actor;
 };
 
 #endif

--- a/src/window_skill.cpp
+++ b/src/window_skill.cpp
@@ -30,12 +30,12 @@
 #include "game_battle.h"
 
 Window_Skill::Window_Skill(int ix, int iy, int iwidth, int iheight) :
-	Window_Selectable(ix, iy, iwidth, iheight), actor_id(-1), subset(0) {
+	Window_Selectable(ix, iy, iwidth, iheight), subset(0) {
 	column_max = 2;
 }
 
-void Window_Skill::SetActor(int actor_id) {
-	this->actor_id = actor_id;
+void Window_Skill::SetActor(const Game_Actor& actor) {
+	this->actor = &actor;
 	Refresh();
 }
 
@@ -50,7 +50,7 @@ const lcf::rpg::Skill* Window_Skill::GetSkill() const {
 void Window_Skill::Refresh() {
 	data.clear();
 
-	const std::vector<int16_t>& skills = Main_Data::game_actors->GetActor(actor_id)->GetSkills();
+	const std::vector<int16_t>& skills = actor->GetSkills();
 	for (size_t i = 0; i < skills.size(); ++i) {
 		if (CheckInclude(skills[i]))
 			data.push_back(skills[i]);
@@ -78,7 +78,6 @@ void Window_Skill::DrawItem(int index) {
 	int skill_id = data[index];
 
 	if (skill_id > 0) {
-		const Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
 		int costs = actor->CalculateSkillCost(skill_id);
 
 		bool enabled = CheckEnable(skill_id);
@@ -119,8 +118,6 @@ bool Window_Skill::CheckInclude(int skill_id) {
 }
 
 bool Window_Skill::CheckEnable(int skill_id) {
-	const Game_Actor* actor = Main_Data::game_actors->GetActor(actor_id);
-
 	return actor->IsSkillLearned(skill_id) && actor->IsSkillUsable(skill_id);
 }
 

--- a/src/window_skill.h
+++ b/src/window_skill.h
@@ -36,9 +36,9 @@ public:
 	/**
 	 * Sets the actor whose skills are displayed.
 	 *
-	 * @param actor_id ID of the actor.
+	 * @param actor actor.
 	 */
-	void SetActor(int actor_id);
+	void SetActor(const Game_Actor& actor);
 
 	/**
 	 * Gets skill.
@@ -88,7 +88,7 @@ public:
 protected:
 	std::vector<int> data;
 
-	int actor_id;
+	const Game_Actor* actor;
 
 	int subset;
 };

--- a/src/window_skillstatus.cpp
+++ b/src/window_skillstatus.cpp
@@ -24,13 +24,13 @@
 #include "player.h"
 
 Window_SkillStatus::Window_SkillStatus(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight), actor_id(-1) {
+	Window_Base(ix, iy, iwidth, iheight) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 }
 
-void Window_SkillStatus::SetActor(int actor_id) {
-	this->actor_id = actor_id;
+void Window_SkillStatus::SetActor(const Game_Actor& actor) {
+	this->actor = &actor;
 	Refresh();
 }
 
@@ -38,19 +38,17 @@ void Window_SkillStatus::Refresh() {
 	contents->ClearRect(Rect(0, 0, contents->GetWidth(), 16));
 
 	// Actors are guaranteed to be valid
-	const Game_Actor& actor = *Main_Data::game_actors->GetActor(actor_id);
-
 	int x = 0;
 	int y = 2;
-	DrawActorName(actor, x, y);
+	DrawActorName(*actor, x, y);
 	x += 80;
-	DrawActorLevel(actor, x, y);
+	DrawActorLevel(*actor, x, y);
 	x += 44;
-	DrawActorState(actor, x, y);
-	int hpdigits = (actor.MaxHpValue() >= 1000) ? 4 : 3;
-	int spdigits = (actor.MaxSpValue() >= 1000) ? 4 : 3;
+	DrawActorState(*actor, x, y);
+	int hpdigits = (actor->MaxHpValue() >= 1000) ? 4 : 3;
+	int spdigits = (actor->MaxSpValue() >= 1000) ? 4 : 3;
 	x += (96 - hpdigits * 6 - spdigits * 6);
-	DrawActorHp(actor, x, y, hpdigits);
+	DrawActorHp(*actor, x, y, hpdigits);
 	x += (66 + hpdigits * 6 - spdigits * 6);
-	DrawActorSp(actor, x, y, spdigits);
+	DrawActorSp(*actor, x, y, spdigits);
 }

--- a/src/window_skillstatus.h
+++ b/src/window_skillstatus.h
@@ -34,9 +34,9 @@ public:
 
 	/**
 	 * Sets the actor whose stats are displayed.
-	 * @param actor_id ID of the actor.
+	 * @param actor actor.
 	 */
-	void SetActor(int actor_id);
+	void SetActor(const Game_Actor& actor);
 
 	/**
 	 * Renders the stats of the actor.
@@ -44,7 +44,7 @@ public:
 	void Refresh();
 
 private:
-	int actor_id;
+	const Game_Actor* actor = nullptr;
 };
 
 #endif


### PR DESCRIPTION
Implementation for the _DirectMenuPatch_ for RM2k(3) as described in Makerpendiums patch database:
https://dev.makerpendium.de/docs/patch_db/main-en.htm?page=direct_menu

This patch is enabled by adding the following line to the **[Patch]** section in _EasyRPG.ini_
`DirectMenu=[VariableId]`

Additionally the "OpenMainMenu" command is extended to mirror the same functionality. (If both variants are used, scenes set via command parameter take priority)
_1st param_: scene id
_2nd param_: party member id or actor id
_3rd param_: **0**: party member id is used, **1**: db actor id is used

Default var ids for this patch are V3326 & V3327

EDIT: It should be noted that in this implementation scene id 4 (Status) also works for RM2K and not just 2k3 engine type games.