### PR TITLE
Enable animated RPG2k3e spritesheets when using RM2k engine with 'RPG2k3Commands=1'

### DIFF
--- a/src/game_pictures.cpp
+++ b/src/game_pictures.cpp
@@ -508,7 +508,7 @@ void Game_Pictures::Picture::Update(bool is_battle) {
 		return;
 	}
 
-	if (Player::IsRPG2k3E()) {
+	if (Player::IsRPG2k3ECommands()) {
 		++data.frames;
 	}
 
@@ -574,7 +574,7 @@ void Game_Pictures::Picture::Update(bool is_battle) {
 	}
 
 	// RPG Maker 2k3 1.12: Animated spritesheets
-	if (Player::IsRPG2k3E()
+	if (Player::IsRPG2k3ECommands()
 			&& data.spritesheet_speed > 0
 			&& data.frames > data.spritesheet_speed)
 	{


### PR DESCRIPTION
Self explanatory.
Normal RPG2k3e spritesheets have been working for a while now in RM2k games by using the .ini option.
Animation updates however, were still skipped.