### PR TITLE
CMake: Add WiiU preset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@ include(PlayerBuildType)
 include(PlayerMisc)
 include(GetGitRevisionDescription)
 
+# Dependencies provided by CMake Presets
+list(APPEND CMAKE_PREFIX_PATH "${PLAYER_PREFIX_PATH_APPEND}")
+
 # C++17 is required
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -133,61 +133,61 @@
 			]
 		},
 		{
-			"name": "windows-x86-parent",
+			"name": "windows-parent",
 			"cacheVariables": {
-				"VCPKG_TARGET_TRIPLET": "x86-windows-static"
+				"VCPKG_TARGET_TRIPLET": "$env{VSCMD_ARG_TGT_ARCH}-windows-static"
 			},
 			"inherits": "win-user",
 			"hidden": true
 		},
 		{
-			"name": "windows-x86-debug",
-			"displayName": "Windows (x86) (Debug)",
+			"name": "windows-debug",
+			"displayName": "Windows (Debug)",
 			"inherits": [
-				"windows-x86-parent",
+				"windows-parent",
 				"type-debug"
 			]
 		},
 		{
-			"name": "windows-x86-relwithdebinfo",
-			"displayName": "Windows (x86) (RelWithDebInfo)",
+			"name": "windows-relwithdebinfo",
+			"displayName": "Windows (RelWithDebInfo)",
 			"inherits": [
-				"windows-x86-parent",
+				"windows-parent",
 				"type-relwithdebinfo"
 			]
 		},
 		{
-			"name": "windows-x86-release",
-			"displayName": "Windows (x86) (Release)",
+			"name": "windows-release",
+			"displayName": "Windows (Release)",
 			"inherits": [
-				"windows-x86-parent",
+				"windows-parent",
 				"type-release"
 			]
 		},
 		{
-			"name": "windows-x86-libretro-debug",
-			"displayName": "Windows (x86) (libretro core) (Debug)",
+			"name": "windows-libretro-debug",
+			"displayName": "Windows (libretro core) (Debug)",
 			"inherits": [
 				"build-libretro",
-				"windows-x86-parent",
+				"windows-parent",
 				"type-debug"
 			]
 		},
 		{
-			"name": "windows-x86-libretro-relwithdebinfo",
-			"displayName": "Windows (x86) (libretro core) (RelWithDebInfo)",
+			"name": "windows-libretro-relwithdebinfo",
+			"displayName": "Windows (libretro core) (RelWithDebInfo)",
 			"inherits": [
 				"build-libretro",
-				"windows-x86-parent",
+				"windows-parent",
 				"type-relwithdebinfo"
 			]
 		},
 		{
-			"name": "windows-x86-libretro-release",
-			"displayName": "Windows (x86) (libretro core) (Release)",
+			"name": "windows-libretro-release",
+			"displayName": "Windows (libretro core) (Release)",
 			"inherits": [
 				"build-libretro",
-				"windows-x86-parent",
+				"windows-parent",
 				"type-release"
 			]
 		},
@@ -249,66 +249,6 @@
 			"inherits": [
 				"build-libretro",
 				"windows-x86-vs2022-parent",
-				"type-release"
-			]
-		},
-		{
-			"name": "windows-x64-parent",
-			"architecture": "x64",
-			"cacheVariables": {
-				"VCPKG_TARGET_TRIPLET": "x64-windows-static"
-			},
-			"inherits": "win-user",
-			"hidden": true
-		},
-		{
-			"name": "windows-x64-debug",
-			"displayName": "Windows (x64) (Debug)",
-			"inherits": [
-				"windows-x64-parent",
-				"type-debug"
-			]
-		},
-		{
-			"name": "windows-x64-relwithdebinfo",
-			"displayName": "Windows (x64) (RelWithDebInfo)",
-			"inherits": [
-				"windows-x64-parent",
-				"type-relwithdebinfo"
-			]
-		},
-		{
-			"name": "windows-x64-release",
-			"displayName": "Windows (x64) (Release)",
-			"inherits": [
-				"windows-x64-parent",
-				"type-release"
-			]
-		},
-		{
-			"name": "windows-x64-libretro-debug",
-			"displayName": "Windows (x64) (libretro core) (Debug)",
-			"inherits": [
-				"build-libretro",
-				"windows-x64-parent",
-				"type-debug"
-			]
-		},
-		{
-			"name": "windows-x64-libretro-relwithdebinfo",
-			"displayName": "Windows (x64) (libretro core) (RelWithDebInfo)",
-			"inherits": [
-				"build-libretro",
-				"windows-x64-parent",
-				"type-relwithdebinfo"
-			]
-		},
-		{
-			"name": "windows-x64-libretro-release",
-			"displayName": "Windows (x64) (libretro core) (Release)",
-			"inherits": [
-				"build-libretro",
-				"windows-x64-parent",
 				"type-release"
 			]
 		},
@@ -828,28 +768,28 @@
 			"configurePreset": "linux-libretro-release"
 		},
 		{
-			"name": "windows-x86-debug",
-			"configurePreset": "windows-x86-debug"
+			"name": "windows-debug",
+			"configurePreset": "windows-debug"
 		},
 		{
-			"name": "windows-x86-relwithdebinfo",
-			"configurePreset": "windows-x86-relwithdebinfo"
+			"name": "windows-relwithdebinfo",
+			"configurePreset": "windows-relwithdebinfo"
 		},
 		{
-			"name": "windows-x86-release",
-			"configurePreset": "windows-x86-release"
+			"name": "windows-release",
+			"configurePreset": "windows-release"
 		},
 		{
-			"name": "windows-x86-libretro-debug",
-			"configurePreset": "windows-x86-libretro-debug"
+			"name": "windows-libretro-debug",
+			"configurePreset": "windows-libretro-debug"
 		},
 		{
-			"name": "windows-x86-libretro-relwithdebinfo",
-			"configurePreset": "windows-x86-libretro-relwithdebinfo"
+			"name": "windows-libretro-relwithdebinfo",
+			"configurePreset": "windows-libretro-relwithdebinfo"
 		},
 		{
-			"name": "windows-x86-libretro-release",
-			"configurePreset": "windows-x86-libretro-release"
+			"name": "windows-libretro-release",
+			"configurePreset": "windows-libretro-release"
 		},
 		{
 			"name": "windows-x86-vs2022-debug",
@@ -874,30 +814,6 @@
 		{
 			"name": "windows-x86-vs2022-libretro-release",
 			"configurePreset": "windows-x86-vs2022-libretro-release"
-		},
-		{
-			"name": "windows-x64-debug",
-			"configurePreset": "windows-x64-debug"
-		},
-		{
-			"name": "windows-x64-relwithdebinfo",
-			"configurePreset": "windows-x64-relwithdebinfo"
-		},
-		{
-			"name": "windows-x64-release",
-			"configurePreset": "windows-x64-release"
-		},
-		{
-			"name": "windows-x64-libretro-debug",
-			"configurePreset": "windows-x64-libretro-debug"
-		},
-		{
-			"name": "windows-x64-libretro-relwithdebinfo",
-			"configurePreset": "windows-x64-libretro-relwithdebinfo"
-		},
-		{
-			"name": "windows-x64-libretro-release",
-			"configurePreset": "windows-x64-libretro-release"
 		},
 		{
 			"name": "windows-x64-vs2022-debug",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -76,7 +76,7 @@
 			"name": "linux-parent",
 			"toolchainFile": "${sourceDir}/builds/cmake/LinuxToolchain.cmake",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/linux-static"
+				"PLAYER_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/linux-static"
 			},
 			"hidden": true,
 			"inherits": "base-user"
@@ -316,7 +316,7 @@
 		{
 			"name": "macos-parent",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/osx",
+				"PLAYER_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/osx",
 				"CMAKE_OSX_DEPLOYMENT_TARGET": "10.9"
 			},
 			"condition": {
@@ -382,7 +382,7 @@
 			"name": "emscripten-parent",
 			"toolchainFile": "$env{EASYRPG_BUILDSCRIPTS}/emscripten/emsdk-portable/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/emscripten",
+				"PLAYER_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/emscripten",
 				"CMAKE_FIND_ROOT_PATH": "$env{EASYRPG_BUILDSCRIPTS}/emscripten",
 				"PLAYER_JS_BUILD_SHELL": "ON"
 			},
@@ -418,7 +418,7 @@
 			"toolchainFile": "$env{DEVKITPRO}/cmake/3DS.cmake",
 			"cacheVariables": {
 				"PLAYER_TARGET_PLATFORM": "3ds",
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/3ds"
+				"PLAYER_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/3ds"
 			},
 			"inherits": "dkp-user",
 			"hidden": true
@@ -479,7 +479,7 @@
 			"toolchainFile": "$env{DEVKITPRO}/cmake/Switch.cmake",
 			"cacheVariables": {
 				"PLAYER_TARGET_PLATFORM": "switch",
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/switch"
+				"PLAYER_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/switch"
 			},
 			"inherits": "dkp-user",
 			"hidden": true
@@ -540,7 +540,7 @@
 			"toolchainFile": "$env{DEVKITPRO}/cmake/Wii.cmake",
 			"cacheVariables": {
 				"PLAYER_TARGET_PLATFORM": "wii",
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/wii"
+				"PLAYER_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/wii"
 			},
 			"inherits": "dkp-user",
 			"hidden": true
@@ -600,7 +600,7 @@
 			"name": "wiiu-parent",
 			"toolchainFile": "$env{DEVKITPRO}/cmake/WiiU.cmake",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/wiiu"
+				"PLAYER_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/wiiu"
 			},
 			"inherits": "dkp-user",
 			"hidden": true

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -657,6 +657,66 @@
 			]
 		},
 		{
+			"name": "wiiu-parent",
+			"toolchainFile": "$env{DEVKITPRO}/cmake/WiiU.cmake",
+			"cacheVariables": {
+				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/wiiu"
+			},
+			"inherits": "dkp-user",
+			"hidden": true
+		},
+		{
+			"name": "wiiu-debug",
+			"displayName": "Nintendo WiiU (Debug)",
+			"inherits": [
+				"wiiu-parent",
+				"type-debug"
+			]
+		},
+		{
+			"name": "wiiu-relwithdebinfo",
+			"displayName": "Nintendo WiiU (RelWithDebInfo)",
+			"inherits": [
+				"wiiu-parent",
+				"type-relwithdebinfo"
+			]
+		},
+		{
+			"name": "wiiu-release",
+			"displayName": "Nintendo WiiU (Release)",
+			"inherits": [
+				"wiiu-parent",
+				"type-release"
+			]
+		},
+		{
+			"name": "wiiu-libretro-debug",
+			"displayName": "Nintendo WiiU (libretro core) (Debug)",
+			"inherits": [
+				"build-libretro",
+				"wiiu-parent",
+				"type-debug"
+			]
+		},
+		{
+			"name": "wiiu-libretro-relwithdebinfo",
+			"displayName": "Nintendo WiiU (libretro core) (RelWithDebInfo)",
+			"inherits": [
+				"build-libretro",
+				"wiiu-parent",
+				"type-relwithdebinfo"
+			]
+		},
+		{
+			"name": "wiiu-libretro-release",
+			"displayName": "Nintendo WiiU (libretro core) (Release)",
+			"inherits": [
+				"build-libretro",
+				"wiiu-parent",
+				"type-release"
+			]
+		},
+		{
 			"name": "psvita-parent",
 			"toolchainFile": "$env{EASYRPG_BUILDSCRIPTS}/vita/vitasdk/share/vita.toolchain.cmake",
 			"cacheVariables": {
@@ -970,6 +1030,30 @@
 		{
 			"name": "wii-libretro-release",
 			"configurePreset": "wii-libretro-release"
+		},
+		{
+			"name": "wiiu-debug",
+			"configurePreset": "wiiu-debug"
+		},
+		{
+			"name": "wiiu-relwithdebinfo",
+			"configurePreset": "wiiu-relwithdebinfo"
+		},
+		{
+			"name": "wiiu-release",
+			"configurePreset": "wiiu-release"
+		},
+		{
+			"name": "wiiu-libretro-debug",
+			"configurePreset": "wiiu-libretro-debug"
+		},
+		{
+			"name": "wiiu-libretro-relwithdebinfo",
+			"configurePreset": "wiiu-libretro-relwithdebinfo"
+		},
+		{
+			"name": "wiiu-libretro-release",
+			"configurePreset": "wiiu-libretro-release"
 		},
 		{
 			"name": "psvita-debug",

--- a/builds/cmake/CMakePresets.json.template
+++ b/builds/cmake/CMakePresets.json.template
@@ -22,10 +22,10 @@
 			}
 		},
 		{
-			"name": "windows-x86",
-			"displayName": "Windows (x86)",
+			"name": "windows",
+			"displayName": "Windows",
 			"cacheVariables": {
-				"VCPKG_TARGET_TRIPLET": "x86-windows-static"
+				"VCPKG_TARGET_TRIPLET": "$env{VSCMD_ARG_TGT_ARCH}-windows-static"
 			},
 			"inherits": "win-user"
 		},
@@ -36,15 +36,6 @@
 			"architecture": "Win32",
 			"cacheVariables": {
 				"VCPKG_TARGET_TRIPLET": "x86-windows-static"
-			},
-			"inherits": "win-user"
-		},
-		{
-			"name": "windows-x64",
-			"displayName": "Windows (x64)",
-			"architecture": "x64",
-			"cacheVariables": {
-				"VCPKG_TARGET_TRIPLET": "x64-windows-static"
 			},
 			"inherits": "win-user"
 		},

--- a/builds/cmake/CMakePresets.json.template
+++ b/builds/cmake/CMakePresets.json.template
@@ -112,6 +112,15 @@
 			"inherits": "dkp-user"
 		},
 		{
+			"name": "wiiu",
+			"displayName": "Nintendo WiiU",
+			"toolchainFile": "$env{DEVKITPRO}/cmake/WiiU.cmake",
+			"cacheVariables": {
+				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/wiiu"
+			},
+			"inherits": "dkp-user"
+		},
+		{
 			"name": "psvita",
 			"displayName": "PlayStation Vita",
 			"toolchainFile": "$env{EASYRPG_BUILDSCRIPTS}/vita/vitasdk/share/vita.toolchain.cmake",

--- a/builds/cmake/CMakePresets.json.template
+++ b/builds/cmake/CMakePresets.json.template
@@ -18,7 +18,7 @@
 			"displayName": "Linux",
 			"toolchainFile": "${sourceDir}/builds/cmake/LinuxToolchain.cmake",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/linux-static"
+				"PLAYER_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/linux-static"
 			}
 		},
 		{
@@ -53,7 +53,7 @@
 			"name": "macos",
 			"displayName": "macOS",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/osx",
+				"PLAYER_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/osx",
 				"CMAKE_OSX_DEPLOYMENT_TARGET": "10.9"
 			},
 			"condition": {
@@ -67,7 +67,7 @@
 			"displayName": "Emscripten (Web)",
 			"toolchainFile": "$env{EASYRPG_BUILDSCRIPTS}/emscripten/emsdk-portable/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/emscripten",
+				"PLAYER_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/emscripten",
 				"CMAKE_FIND_ROOT_PATH": "$env{EASYRPG_BUILDSCRIPTS}/emscripten",
 				"PLAYER_JS_BUILD_SHELL": "ON"
 			}
@@ -78,7 +78,7 @@
 			"toolchainFile": "$env{DEVKITPRO}/cmake/3DS.cmake",
 			"cacheVariables": {
 				"PLAYER_TARGET_PLATFORM": "3ds",
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/3ds"
+				"PLAYER_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/3ds"
 			},
 			"inherits": "dkp-user"
 		},
@@ -88,7 +88,7 @@
 			"toolchainFile": "$env{DEVKITPRO}/cmake/Switch.cmake",
 			"cacheVariables": {
 				"PLAYER_TARGET_PLATFORM": "switch",
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/switch"
+				"PLAYER_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/switch"
 			},
 			"inherits": "dkp-user"
 		},
@@ -98,7 +98,7 @@
 			"toolchainFile": "$env{DEVKITPRO}/cmake/Wii.cmake",
 			"cacheVariables": {
 				"PLAYER_TARGET_PLATFORM": "wii",
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/wii"
+				"PLAYER_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/wii"
 			},
 			"inherits": "dkp-user"
 		},
@@ -107,7 +107,7 @@
 			"displayName": "Nintendo WiiU",
 			"toolchainFile": "$env{DEVKITPRO}/cmake/WiiU.cmake",
 			"cacheVariables": {
-				"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/wiiu"
+				"PLAYER_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/wiiu"
 			},
 			"inherits": "dkp-user"
 		},


### PR DESCRIPTION
btw the presets do not really work currently for our CI:

usually we do ``-DCMAKE_PREFIX_PATH="$TOOLCHAIN_DIR;$LIBLCF_DIR"`` but the preset only specifies ``"CMAKE_PREFIX_PATH": "$env{EASYRPG_BUILDSCRIPTS}/wiiu"``. So no way to provide liblcf.

How to solve this? Just add another env-var?
