### PR TITLE
Support "going up" from the working directory in the game browser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,8 @@ add_library(${PROJECT_NAME} OBJECT
 	src/fileext_guesser.h
 	src/filesystem.cpp
 	src/filesystem.h
+	src/filesystem_drive.cpp
+	src/filesystem_drive.h	
 	src/filesystem_lzh.cpp
 	src/filesystem_lzh.h
 	src/filesystem_native.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -103,6 +103,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/fileext_guesser.h \
 	src/filesystem.cpp \
 	src/filesystem.h \
+	src/filesystem_drive.cpp \
+	src/filesystem_drive.h \
 	src/filesystem_lzh.cpp \
 	src/filesystem_lzh.h \
 	src/filesystem_native.cpp \

--- a/src/directory_tree.h
+++ b/src/directory_tree.h
@@ -43,6 +43,8 @@ public:
 		Regular,
 		/** Directory */
 		Directory,
+		/** A virtual directory that will access a different virtual filesystem */
+		Filesystem,
 		/** Anything of no interest such as block devices */
 		Other
 	};
@@ -53,8 +55,15 @@ public:
 		std::string name;
 		/** File type */
 		FileType type;
+		/** Human readable name shown in the Game Browser (if different to the filename) */
+		std::string human_name;
 
 		Entry(std::string name, FileType type) : name(std::move(name)), type(type) {}
+		Entry(std::string name, FileType type, std::string human_name) : name(std::move(name)), type(type), human_name(std::move(human_name)) {}
+
+		StringView GetReadableName() const {
+			return human_name.empty() ? name : human_name;
+		}
 	};
 
 	/** Argument struct for more complex find operations */

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -143,7 +143,7 @@ FilesystemView FileFinder::Root() {
 		root_fs = std::make_unique<RootFilesystem>();
 	}
 
-	return root_fs->Subtree("");
+	return *root_fs;
 }
 
 std::string FileFinder::MakePath(StringView dir, StringView name) {

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -382,6 +382,20 @@ FilesystemView FilesystemView::Subtree(StringView sub_path) const {
 	return FilesystemView(fs, MakePath(sub_path));
 }
 
+bool FilesystemView::CanGoUp() const {
+	return static_cast<bool>(GoUp());
+}
+
+FilesystemView FilesystemView::GoUp() const {
+	if (GetSubPath().empty() || GetSubPath() == "/") {
+		return fs->GetParent();
+	}
+
+	auto [path, file] = FileFinder::GetPathAndFilename(GetSubPath());
+
+	return FilesystemView(fs, path);
+}
+
 std::string FilesystemView::Describe() const {
 	assert(fs);
 	if (GetSubPath().empty()) {

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -87,9 +87,13 @@ void Filesystem::ClearCache(StringView path) const {
 FilesystemView Filesystem::Create(StringView path) const {
 	// Determine the proper file system to use
 
-	// When the path doesn't exist check if the path contains a file that can
-	// be handled by another filesystem
-	if (!IsDirectory(path, true)) {
+	if (IsFilesystemNode(path)) {
+		// The support for "mounted" virtual filesystems is very limited and the only
+		// use right now is to delegate from DriveFilesystem to NativeFilesystem.
+		return CreateFromNode(path);
+	} else if (!IsDirectory(path, true)) {
+		// When the path doesn't exist check if the path contains a file that can
+		// be handled by another filesystem
 		std::string dir_of_file;
 		std::string path_prefix;
 		std::vector<std::string> components = FileFinder::SplitPath(path);
@@ -175,8 +179,16 @@ FilesystemView Filesystem::Subtree(std::string sub_path) const {
 	return FilesystemView(shared_from_this(), sub_path);
 }
 
+bool Filesystem::IsFilesystemNode(StringView) const {
+	return false;
+}
+
 bool Filesystem::MakeDirectory(StringView, bool) const {
 	return false;
+}
+
+FilesystemView Filesystem::CreateFromNode(StringView) const {
+	return FilesystemView();
 }
 
 bool Filesystem::IsValid() const {
@@ -307,6 +319,11 @@ bool FilesystemView::IsDirectory(StringView path, bool follow_symlinks) const {
 	return fs->IsDirectory(MakePath(path), follow_symlinks);
 }
 
+bool FilesystemView::IsFilesystemNode(StringView path) const {
+	assert(fs);
+	return fs->IsFilesystemNode(MakePath(path));
+}
+
 bool FilesystemView::Exists(StringView path) const {
 	assert(fs);
 	return fs->Exists(MakePath(path));
@@ -372,6 +389,11 @@ bool FilesystemView::MakeDirectory(StringView dir, bool follow_symlinks) const {
 	return fs->MakeDirectory(MakePath(dir), follow_symlinks);
 }
 
+FilesystemView FilesystemView::CreateFromNode(StringView path) const {
+	assert(fs);
+	return fs->CreateFromNode(MakePath(path));
+}
+
 bool FilesystemView::IsFeatureSupported(Filesystem::Feature f) const {
 	assert(fs);
 	return fs->IsFeatureSupported(f);
@@ -392,6 +414,10 @@ FilesystemView FilesystemView::GoUp() const {
 	}
 
 	auto [path, file] = FileFinder::GetPathAndFilename(GetSubPath());
+
+	if (path == GetSubPath()) {
+		return fs->GetParent();
+	}
 
 	return FilesystemView(fs, path);
 }

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -475,6 +475,19 @@ public:
 	 */
 	FilesystemView Subtree(StringView sub_path) const;
 
+	/**
+	 * @return Whether it is possible to go up from the current view
+	 */
+	bool CanGoUp() const;
+
+	/**
+	 * From the current view goes up by one.
+	 * Returns an invalid view when going up is not possible (no parent).
+	 *
+	 * @return View that is rooted at the parent.
+	 */
+	FilesystemView GoUp() const;
+
 	/** @return human readable representation of this filesystem for debug purposes */
 	std::string Describe() const;
 

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -217,9 +217,11 @@ public:
 	/** @{ */
 	virtual bool IsFile(StringView path) const = 0;
 	virtual bool IsDirectory(StringView path, bool follow_symlinks) const = 0;
+	virtual bool IsFilesystemNode(StringView path) const;
 	virtual bool Exists(StringView path) const = 0;
 	virtual int64_t GetFilesize(StringView path) const = 0;
 	virtual bool MakeDirectory(StringView dir, bool follow_symlinks) const;
+	virtual FilesystemView CreateFromNode(StringView path) const;
 	virtual bool IsFeatureSupported(Feature f) const;
 	virtual std::string Describe() const = 0;
 	/** @} */
@@ -371,6 +373,12 @@ public:
 
 	/**
 	 * @param path Path to check
+	 * @return True when path is pointing to a virtual filesystem
+	 */
+	bool IsFilesystemNode(StringView path) const;
+
+	/**
+	 * @param path Path to check
 	 * @return True when a file exists at the path
 	 */
 	bool Exists(StringView path) const;
@@ -460,6 +468,14 @@ public:
 	 * @return true when the path was created
 	 */
 	bool MakeDirectory(StringView dir, bool follow_symlinks) const;
+
+	/**
+	 * Create a filesystem view from the passed in path.
+	 * The path must point to a virtual filesystem entry (type Filesystem).
+	 * @param path Path to create filesystem from
+	 * @return view pointing at the new fs
+	 */
+	FilesystemView CreateFromNode(StringView path) const;
 
 	/**
 	 * @param f Filesystem feature to check

--- a/src/filesystem_drive.cpp
+++ b/src/filesystem_drive.cpp
@@ -1,0 +1,110 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "filesystem_drive.h"
+#include "filefinder.h"
+#include "output.h"
+
+#include <algorithm>
+
+#ifdef _WIN32
+#  include <windows.h>
+#  include <fileapi.h>
+#endif
+
+DriveFilesystem::DriveFilesystem() : Filesystem("", FilesystemView()) {
+#ifdef _WIN32
+	std::wstring volume = L"A:\\";
+
+	DWORD logical_drives = GetLogicalDrives();
+	for (int i = 0; i < 26; i++) {
+		if ((logical_drives & (1 << i)) > 0) {
+			DirectoryTree::Entry entry = { Utils::FromWideString(volume), DirectoryTree::FileType::Filesystem };
+
+			wchar_t volume_name[MAX_PATH];
+			if (GetVolumeInformation(volume.c_str(), volume_name, MAX_PATH, nullptr, nullptr, nullptr, nullptr, 0) != 0) {
+				entry.human_name = fmt::format("{} ({})", Utils::FromWideString(volume), Utils::FromWideString(volume_name));
+			}
+
+			drives.push_back(entry);
+		}
+		volume[0]++; // Increment drive letter
+	}
+#endif
+}
+
+bool DriveFilesystem::HasDrives() const {
+	return !drives.empty();
+}
+
+bool DriveFilesystem::IsFile(StringView path) const {
+	(void)path;
+	return false;
+}
+
+bool DriveFilesystem::IsDirectory(StringView path, bool) const {
+	return path.empty();
+}
+
+bool DriveFilesystem::IsFilesystemNode(StringView path) const {
+	for (const auto& drive: drives) {
+		if (drive.name == path) {
+			return true;
+		}
+#ifdef _WIN32
+		if (drive.name == Utils::ReplaceAll(ToString(path), "/", "\\")) {
+			return true;
+		}
+#endif
+	}
+
+	return false;
+}
+
+bool DriveFilesystem::Exists(StringView path) const {
+	return IsDirectory(path, false) || IsFilesystemNode(path);
+}
+
+int64_t DriveFilesystem::GetFilesize(StringView path) const {
+	(void)path;
+	return 0;
+}
+
+FilesystemView DriveFilesystem::CreateFromNode(StringView path) const {
+	if (!IsFilesystemNode(path)) {
+		return {};
+	}
+
+	return FileFinder::Root().Create(path);
+}
+
+std::streambuf* DriveFilesystem::CreateInputStreambuffer(StringView path, std::ios_base::openmode mode) const {
+	return nullptr;
+}
+
+bool DriveFilesystem::GetDirectoryContent(StringView path, std::vector<DirectoryTree::Entry>& tree) const {
+	if (!path.empty()) {
+		return false;
+	}
+
+	tree = drives;
+	return true;
+}
+
+std::string DriveFilesystem::Describe() const {
+	return "[Drive]";
+}

--- a/src/filesystem_drive.h
+++ b/src/filesystem_drive.h
@@ -1,0 +1,56 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_FILESYSTEM_DRIVE_H
+#define EP_FILESYSTEM_DRIVE_H
+
+#include "filesystem.h"
+
+/**
+ * A virtual filesystem that lists e.g. drive letters on Windows
+ */
+class DriveFilesystem : public Filesystem {
+public:
+	/**
+	 * Initializes a OS Filesystem on the given os path
+	 */
+	explicit DriveFilesystem();
+
+	/** @return Whether the current target platform has drive letters to list */
+	bool HasDrives() const;
+
+protected:
+	/**
+ 	 * Implementation of abstract methods
+ 	 */
+	/** @{ */
+	bool IsFile(StringView path) const override;
+	bool IsDirectory(StringView path, bool follow_symlinks) const override;
+	bool IsFilesystemNode(StringView path) const override;
+	bool Exists(StringView path) const override;
+	int64_t GetFilesize(StringView path) const override;
+	FilesystemView CreateFromNode(StringView path) const override;
+	std::streambuf* CreateInputStreambuffer(StringView path, std::ios_base::openmode mode) const override;
+	bool GetDirectoryContent(StringView path, std::vector<DirectoryTree::Entry>& entries) const override;
+	std::string Describe() const override;
+	/** @} */
+
+private:
+	std::vector<DirectoryTree::Entry> drives;
+};
+
+#endif

--- a/src/main_data.cpp
+++ b/src/main_data.cpp
@@ -41,9 +41,12 @@
 #include "system.h"
 #include "output.h"
 
-#ifndef _WIN32
+#ifdef _WIN32
+#  include <windows.h>
+#else
 #  include <unistd.h>
 #endif
+
 #if defined(USE_SDL) && defined(__ANDROID__)
 #  include <jni.h>
 #  include <SDL_system.h>
@@ -89,22 +92,27 @@ void Main_Data::Init() {
 			// Set to current directory
 			project_path = "";
 
-#if defined(PLAYER_AMIGA)
-			// Working directory not correctly handled
-			char working_dir[256];
-			getcwd(working_dir, 255);
-			project_path = std::string(working_dir);
-#elif defined(__APPLE__) && TARGET_OS_OSX
+#ifdef _WIN32
+			wchar_t working_dir[MAX_PATH];
+			if (GetCurrentDirectory(MAX_PATH, working_dir) != 0) {
+				project_path = Utils::FromWideString(working_dir);
+			}
+#else
+			char working_dir[PATH_MAX];
+			if (getcwd(working_dir, sizeof(working_dir))) {
+				project_path = std::string(working_dir);
+			}
+
+#  if defined(__APPLE__) && TARGET_OS_OSX
 			// Apple Finder does not set the working directory
 			// It points to HOME instead. When it is HOME change it to
 			// the application directory instead
 
 			char* home = getenv("HOME");
-			char current_dir[PATH_MAX] = { 0 };
-			getcwd(current_dir, sizeof(current_dir));
-			if (strcmp(current_dir, "/") == 0 || strcmp(current_dir, home) == 0) {
+			if (strcmp(working_dir, "/") == 0 || strcmp(working_dir, home) == 0) {
 				project_path = MacOSUtils::GetBundleDir();
 			}
+#  endif
 #endif
 		}
 	}

--- a/src/main_data.cpp
+++ b/src/main_data.cpp
@@ -98,6 +98,10 @@ void Main_Data::Init() {
 				project_path = Utils::FromWideString(working_dir);
 			}
 #else
+
+#  ifndef PATH_MAX
+#    define PATH_MAX 256
+#  endif
 			char working_dir[PATH_MAX];
 			if (getcwd(working_dir, sizeof(working_dir))) {
 				project_path = std::string(working_dir);

--- a/src/platform.h
+++ b/src/platform.h
@@ -157,6 +157,8 @@ namespace Platform {
 	inline Directory::operator bool() const noexcept {
 #ifdef __vita__
 		return dir_handle >= 0;
+#elif defined(_WIN32)
+		return dir_handle != INVALID_HANDLE_VALUE;
 #else
 		return dir_handle != nullptr;
 #endif

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -105,6 +105,10 @@ void Scene_GameBrowser::CreateWindows() {
 		command_window->DisableItem(0);
 	}
 
+#ifdef EMSCRIPTEN
+	command_window->DisableItem(0);
+#endif
+
 	help_window = std::make_unique<Window_Help>(0, 0, Player::screen_width, 32);
 	help_window->SetText("EasyRPG Player - RPG Maker 2000/2003 interpreter");
 

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -194,9 +194,7 @@ void Scene_GameBrowser::BootGame() {
 		return;
 	}
 
-	FilesystemView fs;
-	std::string entry;
-	std::tie(fs, entry) = gamelist_window->GetGameFilesystem();
+	FilesystemView fs = gamelist_window->GetGameFilesystem();
 
 	if (!fs) {
 		Output::Warning("The selected file or directory cannot be opened");

--- a/src/window_gamelist.cpp
+++ b/src/window_gamelist.cpp
@@ -111,6 +111,12 @@ void Window_GameList::DrawItem(int index) {
 	contents->TextDraw(rect.x, rect.y, Font::ColorDefault, game_directories[index]);
 }
 
+#ifdef HAVE_LHASA
+#define LZH_STR "/LZH"
+#else
+#define LZH_STR ""
+#endif
+
 void Window_GameList::DrawErrorText(bool show_dotdot) {
 	std::vector<std::string> error_msg = {
 #ifdef EMSCRIPTEN
@@ -128,7 +134,7 @@ void Window_GameList::DrawErrorText(bool show_dotdot) {
 		"with RPG Maker 2000 and RPG Maker 2003.",
 		"",
 		"These games have an RPG_RT.ldb and they can be",
-		"extracted or in ZIP archives.",
+		"extracted or in ZIP" LZH_STR " archives.",
 		"",
 		"Newer engines such as RPG Maker XP, VX, MV and MZ",
 		"are not supported."

--- a/src/window_gamelist.cpp
+++ b/src/window_gamelist.cpp
@@ -84,6 +84,10 @@ bool Window_GameList::Refresh(FilesystemView filesystem_base, bool show_dotdot) 
 		}
 	}
 	else {
+#ifdef EMSCRIPTEN
+	show_dotdot = false;
+#endif
+
 		item_max = 1;
 
 		SetContents(Bitmap::Create(width - 16, height - 16));
@@ -102,12 +106,7 @@ void Window_GameList::DrawItem(int index) {
 	Rect rect = GetItemRect(index);
 	contents->ClearRect(rect);
 
-	StringView text;
-
-	if (HasValidEntry()) {
-		text = game_directories[index].GetReadableName();
-	}
-
+	StringView text = game_directories[index].GetReadableName();
 	contents->TextDraw(rect.x, rect.y, Font::ColorDefault, text);
 }
 

--- a/src/window_gamelist.h
+++ b/src/window_gamelist.h
@@ -55,13 +55,13 @@ public:
 	bool HasValidEntry();
 
 	/**
-	 * @return filesystem and entry name of the selected game
+	 * @return filesystem of the selected game
 	 */
-	std::pair<FilesystemView, std::string> GetGameFilesystem() const;
+	FilesystemView GetGameFilesystem() const;
 
 private:
 	FilesystemView base_fs;
-	std::vector<std::string> game_directories;
+	std::vector<DirectoryTree::Entry> game_directories;
 
 	bool show_dotdot = false;
 };

--- a/tests/filefinder.cpp
+++ b/tests/filefinder.cpp
@@ -8,8 +8,6 @@
 TEST_SUITE_BEGIN("FileFinder");
 
 TEST_CASE("IsRPG2kProject") {
-	Main_Data::Init();
-
 	Player::escape_symbol = "\\";
 
 	auto fs = FileFinder::Root().Subtree(EP_TEST_PATH "/game");
@@ -19,8 +17,6 @@ TEST_CASE("IsRPG2kProject") {
 }
 
 TEST_CASE("IsNotRPG2kProject") {
-	Main_Data::Init();
-
 	auto fs = FileFinder::Root().Subtree(EP_TEST_PATH "/notagame");
 	CHECK(!FileFinder::IsRPG2kProject(fs));
 }

--- a/tests/output.cpp
+++ b/tests/output.cpp
@@ -7,7 +7,6 @@ TEST_SUITE_BEGIN("Output");
 
 TEST_CASE("Message Output") {
 	Graphics::Init();
-	Main_Data::Init();
 	Output::Debug("Test {}", "debg");
 	Output::Warning("Test {}", "test");
 	Output::Info("Test {}", "info");


### PR DESCRIPTION
Currently when starting the Player and the game browser launches you cannot go up from the working directory.

This is now working for the following cases (first commit):

1. Project path is empty (working directory is used)
2. Project Path is an absolute path.
3. When Project path is not absolute the _going up_ will end when the relative path ends. (fixing this edge-case is annoying, so I just gave up for now 🤷 )

No there is no special code for these 3 cases, the implementation just only works correctly for 1 and 2.

----

A bit more involved (second commit): When you can go fully up you will reach the drive letters on Windows.

I implemented this using a new virtual filesystem class ``DriveFilesystem`` and a new filetype ``FilesystemNode`` (which can returns an arbitrary VFS when selected). This filesystem is the parent of ``NativeFilesystem`` so you _reach_ it when selecting ``..`` at the highest location (``c:/``).

It is not attached as a parent when no drives are specified (= disabled under !Windows)

In theory this could be also hardcoded in ``NativeFilesystem`` (when going up from ``C:\`` or ``/`` return a drive list) but we make some assumptions about how the _root_ has to look (e.g. on the 3DS ``romfs:`` is not a valid directory but ``romfs:/`` is. Therefore I decided to add an additional layer here just to not break any of our existing code.

This ``DriveFilesystem`` is flexible enough to also support more _drives_ on other platforms later, implemented is only for Windows as here it is the most useful.

![screenshot_2](https://github.com/EasyRPG/Player/assets/1331889/0a518f62-641a-485a-8697-df0a680f4089)
![screenshot_1](https://github.com/EasyRPG/Player/assets/1331889/624dc488-6833-41c1-8780-17f7cc832b51)


