### PR TITLE
Menu UI - Support Touch Screen and Mouse Input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,6 +450,8 @@ add_library(${PROJECT_NAME} OBJECT
 	src/window_skill.h
 	src/window_skillstatus.cpp
 	src/window_skillstatus.h
+	src/window_target.cpp
+	src/window_target.h
 	src/window_targetstatus.cpp
 	src/window_targetstatus.h
 	src/window_teleport.cpp

--- a/src/baseui.cpp
+++ b/src/baseui.cpp
@@ -119,3 +119,13 @@ bool BaseUi::ChangeDisplaySurfaceResolution(int new_width, int new_height) {
 
 	return vChangeDisplaySurfaceResolution(new_width, new_height);
 }
+
+void BaseUi::SetTimeMouseCursor(int i) {
+	if (i < 0)
+		i = 0;
+	TimeMouseCursor = i;
+}
+
+int BaseUi::GetTimeMouseCursor() {
+	return TimeMouseCursor;
+}

--- a/src/baseui.h
+++ b/src/baseui.h
@@ -234,6 +234,10 @@ public:
 	 */
 	Game_ConfigVideo GetConfig() const;
 
+
+	virtual void ChangeCursor(int curs_type);
+	virtual void Load_Cursor(std::string s, int curs_type);
+
 protected:
 	/**
 	 * Protected Constructor. Use CreateUi instead.
@@ -385,6 +389,13 @@ inline void BaseUi::SetFrameLimit(int fps_limit) {
 	vcfg.fps_limit.Set(fps_limit);
 
 	frame_limit = (fps_limit == 0 ? Game_Clock::duration(0) : Game_Clock::TimeStepFromFps(fps_limit));
+}
+
+inline void BaseUi::ChangeCursor(int curs_type) {
+
+}
+inline void BaseUi::Load_Cursor(std::string s, int curs_type) {
+
 }
 
 #endif

--- a/src/baseui.h
+++ b/src/baseui.h
@@ -238,8 +238,8 @@ public:
 	virtual void ChangeCursor(int curs_type);
 	virtual void Load_Cursor(std::string s, int curs_type);
 
-	void BaseUi::SetTimeMouseCursor(int i);
-	int BaseUi::GetTimeMouseCursor();
+	virtual void SetTimeMouseCursor(int i);
+	virtual int GetTimeMouseCursor();
 
 protected:
 	/**

--- a/src/baseui.h
+++ b/src/baseui.h
@@ -238,6 +238,9 @@ public:
 	virtual void ChangeCursor(int curs_type);
 	virtual void Load_Cursor(std::string s, int curs_type);
 
+	void BaseUi::SetTimeMouseCursor(int i);
+	int BaseUi::GetTimeMouseCursor();
+
 protected:
 	/**
 	 * Protected Constructor. Use CreateUi instead.
@@ -298,6 +301,9 @@ protected:
 
 	/** Ui manages frame rate externally */
 	bool external_frame_rate = false;
+
+
+	int TimeMouseCursor = 0;
 };
 
 /** Global DisplayUi variable. */

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -72,6 +72,7 @@ void Game_ConfigInput::Hide() {
 	gamepad_swap_ab_and_xy.SetOptionVisible(false);
 	gamepad_swap_analog.SetOptionVisible(false);
 	gamepad_swap_dpad_with_buttons.SetOptionVisible(false);
+	mouse_control.SetOptionVisible(false);
 }
 
 Game_Config Game_Config::Create(CmdlineParser& cp) {
@@ -421,6 +422,7 @@ void Game_Config::LoadFromStream(Filesystem_Stream::InputStream& is) {
 	input.gamepad_swap_ab_and_xy.FromIni(ini);
 	input.speed_modifier_a.FromIni(ini);
 	input.speed_modifier_b.FromIni(ini);
+	input.mouse_control.FromIni(ini);
 
 	/** PLAYER SECTION */
 	player.settings_autosave.FromIni(ini);
@@ -491,6 +493,7 @@ void Game_Config::WriteToStream(Filesystem_Stream::OutputStream& os) const {
 	input.gamepad_swap_ab_and_xy.ToIni(os);
 	input.speed_modifier_a.ToIni(os);
 	input.speed_modifier_b.ToIni(os);
+	input.mouse_control.ToIni(os);
 
 	os << "\n";
 

--- a/src/game_config.h
+++ b/src/game_config.h
@@ -113,6 +113,7 @@ struct Game_ConfigInput {
 	BoolConfigParam gamepad_swap_analog{ "Gamepad: Swap Analog Sticks", "Swap left and right stick", "Input", "GamepadSwapAnalog", false };
 	BoolConfigParam gamepad_swap_dpad_with_buttons{ "Gamepad: Swap D-Pad with buttons", "Swap D-Pad with ABXY-Buttons", "Input", "GamepadSwapDpad", false };
 	BoolConfigParam gamepad_swap_ab_and_xy{ "Gamepad: Swap AB and XY", "Swap A and B with X and Y", "Input", "GamepadSwapAbxy", false };
+	BoolConfigParam mouse_control{ "Mouse control", "Use mouse control", "Input", "MouseControl", false };
 	Input::ButtonMappingArray buttons;
 
 	void Hide();

--- a/src/game_quit.cpp
+++ b/src/game_quit.cpp
@@ -28,7 +28,7 @@ constexpr int window_width = SCREEN_TARGET_WIDTH / 2;
 constexpr int window_height = 32;
 
 Game_Quit::Game_Quit()
-	: window(0, 0, window_width, window_height, Drawable::Flags::Global)
+	: window(nullptr, 0, 0, window_width, window_height, Drawable::Flags::Global)
 {
 	window.SetBackOpacity(128);
 	window.SetZ(Priority_Overlay - 20);

--- a/src/game_windows.cpp
+++ b/src/game_windows.cpp
@@ -164,7 +164,7 @@ void Game_Windows::Window_User::Refresh(bool& async_wait) {
 	if (async_wait) {
 		// Create fake window to prevent crashes
 		if (!window) {
-			window = std::make_unique<Window_Selectable>(0, 0, 0, 0);
+			window = std::make_unique<Window_Selectable>(nullptr, 0, 0, 0, 0);
 		}
 		return;
 	}
@@ -345,7 +345,7 @@ void Game_Windows::Window_User::Refresh(bool& async_wait) {
 		}
 	}
 
-	window = std::make_unique<Window_Selectable>(0, 0, data.width, data.height);
+	window = std::make_unique<Window_Selectable>(nullptr, 0, 0, data.width, data.height);
 	if (!data.flags.border_margin) {
 		window->SetBorderX(0);
 		// FIXME: Figure out why 0 does not work here (bug in Window class)

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -251,9 +251,29 @@ bool Input::IsPressed(InputButton button) {
 	return press_time[button] > 0;
 }
 
+bool useMouseButton = false;
+void Input::SetUseMouse(bool b) {
+	useMouseButton = b;
+}
+bool Input::GetUseMouseButton() {
+	return useMouseButton;
+}
+
+
 bool Input::IsTriggered(InputButton button) {
 	assert(!IsSystemButton(button));
 	WaitInput(true);
+		if (useMouseButton) {
+		if (button == Input::DECISION) {
+			if (IsRawKeyReleased(Input::Keys::MOUSE_LEFT)) {
+				return true;
+			}
+		}
+		if (button == Input::CANCEL) {
+			if (IsRawKeyTriggered(Input::Keys::MOUSE_RIGHT))
+				return true;
+		}
+	}
 	return triggered[button];
 }
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -246,6 +246,18 @@ bool Input::GetUseMouseButton() {
 	return useMouseButton;
 }
 
+int oldMouseX;
+int oldMouseY;
+bool Input::mouseHover() {
+	Point mouseP = Input::GetMousePosition();
+	if (mouseP.x != oldMouseX || mouseP.y != oldMouseY ||Input::IsPressed(Input::DECISION)) {
+		oldMouseX = mouseP.x;
+		oldMouseY = mouseP.y;
+		return true;
+	}
+	return false;
+}
+
 
 bool Input::IsTriggered(InputButton button) {
 	assert(!IsSystemButton(button));

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -43,6 +43,10 @@ namespace Input {
 	bool wait_input = false;
 }
 
+int mouseOldX = 0;
+int mouseOldY = 0;
+bool mouseMove = false;
+
 bool Input::IsWaitingInput() { return wait_input; }
 void Input::WaitInput(bool v) { wait_input = v; }
 
@@ -159,6 +163,18 @@ void Input::Update() {
 		raw_released[i] = !raw_pressed_now[i] && raw_pressed[i];
 	}
 	raw_pressed = raw_pressed_now;
+
+	Point mouseP = Input::GetMousePosition();
+	// Output::Debug("{} {} {} {}", mouseP.x , mouseOldX , mouseP.y , mouseOldY);
+	if (mouseP.x != mouseOldX || mouseP.y != mouseOldY || Input::IsTriggered(Input::MOUSE_LEFT))
+	{
+		mouseOldX = mouseP.x;
+		mouseOldY = mouseP.y;
+		mouseMove = true;
+	}
+	else {
+		mouseMove = false;
+	}
 }
 
 void Input::UpdateSystem() {
@@ -246,17 +262,33 @@ bool Input::GetUseMouseButton() {
 	return useMouseButton;
 }
 
-int oldMouseX;
-int oldMouseY;
-bool Input::mouseHover() {
-	Point mouseP = Input::GetMousePosition();
-	if (mouseP.x != oldMouseX || mouseP.y != oldMouseY ||Input::IsPressed(Input::DECISION)) {
-		oldMouseX = mouseP.x;
-		oldMouseY = mouseP.y;
-		return true;
-	}
-	return false;
+
+bool Input::MouseMoved() {
+	return mouseMove;
+	//Point mouseP = Input::GetMousePosition();
+
+	//// Output::Debug("{} {} {} {}", mouseP.x , mouseOldX , mouseP.y , mouseOldY);
+
+	//if (mouseP.x != mouseOldX || mouseP.y != mouseOldY)
+	//{
+	//	mouseOldX = mouseP.x;
+	//	mouseOldY = mouseP.y;
+	//	return true;
+	//}
+	//return false;
 }
+
+//int oldMouseX;
+//int oldMouseY;
+//bool Input::mouseHover() {
+//	Point mouseP = Input::GetMousePosition();
+//	if (mouseP.x != oldMouseX || mouseP.y != oldMouseY || Input::IsPressed(Input::DECISION)) {
+//		oldMouseX = mouseP.x;
+//		oldMouseY = mouseP.y;
+//		return true;
+//	}
+//	return false;
+//}
 
 
 bool Input::IsTriggered(InputButton button) {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -32,19 +32,6 @@
 #include <cassert>
 
 namespace Input {
-	/**
-	 * Start repeat time (in frames) a key has
-	 * to be maintained pressed before being
-	 * repeated for fist time.
-	 */
-	constexpr int start_repeat_time = 23;
-
-	/**
-	 * Repeat time (in frames) a key has to be
-	 * maintained pressed after the start repeat time
-	 * has passed for being repeated again.
-	 */
-	constexpr int repeat_time = 4;
 
 	std::array<int, BUTTON_COUNT> press_time;
 	std::bitset<BUTTON_COUNT> triggered, repeated, released;
@@ -265,12 +252,12 @@ bool Input::IsTriggered(InputButton button) {
 	WaitInput(true);
 		if (useMouseButton) {
 		if (button == Input::DECISION) {
-			if (IsRawKeyReleased(Input::Keys::MOUSE_LEFT)) {
+			if (IsReleased(Input::MOUSE_LEFT)) {
 				return true;
 			}
 		}
 		if (button == Input::CANCEL) {
-			if (IsRawKeyTriggered(Input::Keys::MOUSE_RIGHT))
+			if (IsTriggered(Input::MOUSE_RIGHT))
 				return true;
 		}
 	}

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -46,6 +46,8 @@ namespace Input {
 int mouseOldX = 0;
 int mouseOldY = 0;
 bool mouseMove = false;
+bool useMouseButton = false;
+int useForceMouseButton = 0;
 
 bool Input::IsWaitingInput() { return wait_input; }
 void Input::WaitInput(bool v) { wait_input = v; }
@@ -72,6 +74,8 @@ void Input::Init(
 
 	cfg.Hide();
 	Input::GetSupportedConfig(cfg);
+
+	useMouseButton = cfg.mouse_control.Get();
 
 	source = Source::Create(cfg, std::move(directions), replay_from_path);
 	source->InitRecording(record_to_path);
@@ -254,12 +258,14 @@ bool Input::IsPressed(InputButton button) {
 	return press_time[button] > 0;
 }
 
-bool useMouseButton = false;
 void Input::SetUseMouse(bool b) {
 	useMouseButton = b;
 }
+void Input::SetForceUseMouse(int i) {
+	useForceMouseButton = i;
+}
 bool Input::GetUseMouseButton() {
-	return useMouseButton;
+	return (useMouseButton && useForceMouseButton == 0) || useForceMouseButton == 1;
 }
 
 
@@ -294,7 +300,7 @@ bool Input::MouseMoved() {
 bool Input::IsTriggered(InputButton button) {
 	assert(!IsSystemButton(button));
 	WaitInput(true);
-		if (useMouseButton) {
+	if (GetUseMouseButton()) {
 		if (button == Input::DECISION) {
 			if (IsReleased(Input::MOUSE_LEFT)) {
 				return true;

--- a/src/input.h
+++ b/src/input.h
@@ -37,6 +37,21 @@
  * assigned keys can vary by the system.
  */
 namespace Input {
+
+	/**
+	 * Start repeat time (in frames) a key has
+	 * to be maintained pressed before being
+	 * repeated for fist time.
+	 */
+	constexpr int start_repeat_time = 23;
+
+	/**
+	 * Repeat time (in frames) a key has to be
+	 * maintained pressed after the start repeat time
+	 * has passed for being repeated again.
+	 */
+	constexpr int repeat_time = 4;
+
 	/**
 	 * Initializes Input.
 	 *

--- a/src/input.h
+++ b/src/input.h
@@ -350,8 +350,8 @@ namespace Input {
 
 	void SetUseMouse(bool b);
 	bool GetUseMouseButton();
+	bool MouseMoved();
 
-	bool mouseHover();
 }
 
 #endif

--- a/src/input.h
+++ b/src/input.h
@@ -332,6 +332,9 @@ namespace Input {
 
 	bool IsWaitingInput();
 	void WaitInput(bool val);
+
+	void SetUseMouse(bool b);
+	bool GetUseMouseButton();
 }
 
 #endif

--- a/src/input.h
+++ b/src/input.h
@@ -350,6 +350,8 @@ namespace Input {
 
 	void SetUseMouse(bool b);
 	bool GetUseMouseButton();
+
+	bool mouseHover();
 }
 
 #endif

--- a/src/input.h
+++ b/src/input.h
@@ -349,6 +349,7 @@ namespace Input {
 	void WaitInput(bool val);
 
 	void SetUseMouse(bool b);
+	void SetForceUseMouse(int i);
 	bool GetUseMouseButton();
 	bool MouseMoved();
 

--- a/src/input_buttons_desktop.cpp
+++ b/src/input_buttons_desktop.cpp
@@ -178,6 +178,7 @@ void Input::GetSupportedConfig(Game_ConfigInput& cfg) {
 	cfg.gamepad_swap_ab_and_xy.SetOptionVisible(true);
 	cfg.gamepad_swap_analog.SetOptionVisible(true);
 	cfg.gamepad_swap_dpad_with_buttons.SetOptionVisible(true);
+	cfg.mouse_control.SetOptionVisible(true);
 #endif
 }
 

--- a/src/platform/sdl/sdl2_ui.cpp
+++ b/src/platform/sdl/sdl2_ui.cpp
@@ -1291,4 +1291,6 @@ void Sdl2Ui::ChangeCursor(int curs_type) {
 		SDL_SetCursor(cursorArrow);
 	else
 		SDL_SetCursor(cursorHand);
+	
+	SetTimeMouseCursor(5);
 }

--- a/src/platform/sdl/sdl2_ui.cpp
+++ b/src/platform/sdl/sdl2_ui.cpp
@@ -1262,27 +1262,33 @@ void Sdl2Ui::Load_Cursor(std::string s, int curs_type) {
 	uint32_t Amask = 0x000000FF;
 #endif
 
-
-	if (curs_type == 0)
+	if (curs_type == -1)
+	{
 		cursorArrow = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);
-	else
 		cursorHand = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND);
+	}
+	else { 
+		if (curs_type == 0)
+			cursorArrow = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);
+		else
+			cursorHand = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND);
 
-	auto mouse_stream = FileFinder::OpenImage("Picture", s);
-	if (mouse_stream) {
-		auto c = Utils::ReadStream(mouse_stream);
-		BitmapRef mouse_img;
-		if (!c.empty()) {
-			mouse_img = Bitmap::Create(c.data(), c.size(), true);
-			if (mouse_img) {
-				SDL_Surface* icon = SDL_CreateRGBSurfaceFrom(mouse_img->pixels(), mouse_img->GetWidth(), mouse_img->GetHeight(), 32, mouse_img->GetWidth() * 4, Bmask, Gmask, Rmask, Amask);
-				if (icon)
-					if (curs_type == 0)
-						cursorArrow = SDL_CreateColorCursor(icon, 0, 0);
-					else
-						cursorHand = SDL_CreateColorCursor(icon, 0, 0);
+		auto mouse_stream = FileFinder::OpenImage("Picture", s);
+		if (mouse_stream) {
+			auto c = Utils::ReadStream(mouse_stream);
+			BitmapRef mouse_img;
+			if (!c.empty()) {
+				mouse_img = Bitmap::Create(c.data(), c.size(), true);
+				if (mouse_img) {
+					SDL_Surface* icon = SDL_CreateRGBSurfaceFrom(mouse_img->pixels(), mouse_img->GetWidth(), mouse_img->GetHeight(), 32, mouse_img->GetWidth() * 4, Bmask, Gmask, Rmask, Amask);
+					if (icon)
+						if (curs_type == 0)
+							cursorArrow = SDL_CreateColorCursor(icon, 0, 0);
+						else
+							cursorHand = SDL_CreateColorCursor(icon, 0, 0);
+				}
 			}
-		}
+		} 
 	}
 }
 

--- a/src/platform/sdl/sdl2_ui.cpp
+++ b/src/platform/sdl/sdl2_ui.cpp
@@ -1248,3 +1248,47 @@ Rect Sdl2Ui::GetWindowMetrics() const {
 		return window_mode_metrics;
 	}
 }
+
+void Sdl2Ui::Load_Cursor(std::string s, int curs_type) {
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+	uint32_t Rmask = 0x000000FF;
+	uint32_t Gmask = 0x0000FF00;
+	uint32_t Bmask = 0x00FF0000;
+	uint32_t Amask = 0xFF000000;
+#else
+	uint32_t Rmask = 0xFF000000;
+	uint32_t Gmask = 0x00FF0000;
+	uint32_t Bmask = 0x0000FF00;
+	uint32_t Amask = 0x000000FF;
+#endif
+
+
+	if (curs_type == 0)
+		cursorArrow = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);
+	else
+		cursorHand = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND);
+
+	auto mouse_stream = FileFinder::OpenImage("Picture", s);
+	if (mouse_stream) {
+		auto c = Utils::ReadStream(mouse_stream);
+		BitmapRef mouse_img;
+		if (!c.empty()) {
+			mouse_img = Bitmap::Create(c.data(), c.size(), true);
+			if (mouse_img) {
+				SDL_Surface* icon = SDL_CreateRGBSurfaceFrom(mouse_img->pixels(), mouse_img->GetWidth(), mouse_img->GetHeight(), 32, mouse_img->GetWidth() * 4, Bmask, Gmask, Rmask, Amask);
+				if (icon)
+					if (curs_type == 0)
+						cursorArrow = SDL_CreateColorCursor(icon, 0, 0);
+					else
+						cursorHand = SDL_CreateColorCursor(icon, 0, 0);
+			}
+		}
+	}
+}
+
+void Sdl2Ui::ChangeCursor(int curs_type) {
+	if (curs_type == 0)	
+		SDL_SetCursor(cursorArrow);
+	else
+		SDL_SetCursor(cursorHand);
+}

--- a/src/platform/sdl/sdl2_ui.h
+++ b/src/platform/sdl/sdl2_ui.h
@@ -72,6 +72,9 @@ public:
 	void vGetConfig(Game_ConfigVideo& cfg) const override;
 	Rect GetWindowMetrics() const override;
 
+	void ChangeCursor(int curs_type) override;
+	void Load_Cursor(std::string s, int curs_type) override;
+
 #ifdef SUPPORT_AUDIO
 	AudioInterface& GetAudio() override;
 #endif
@@ -131,6 +134,9 @@ private:
 	SDL_Window* sdl_window = nullptr;
 	SDL_Renderer* sdl_renderer = nullptr;
 	SDL_Joystick *sdl_joystick = nullptr;
+
+	SDL_Cursor* cursorHand;
+	SDL_Cursor* cursorArrow;
 
 	Rect window_mode_metrics;
 	SDL_Rect viewport = {};

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -725,9 +725,13 @@ void Player::CreateGameObjects() {
 					Player::screen_height = ini.GetInteger("RPG_RT", "WinH", SCREEN_TARGET_HEIGHT);
 					Player::has_custom_resolution = true;
 				}
-				std::string s = ini.Get("RPG_RT", "MouseButton", "false");
-				bool b = s == "true";
-				Input::SetUseMouse(b);
+				if (ini.HasValue("RPG_RT", "MouseButton") || ini.HasValue("RPG_RT", "MouseButton")) {
+					bool b = ini.GetBoolean("RPG_RT", "MouseButton", "false");
+					if (b)
+						Input::SetForceUseMouse(1);
+					else
+						Input::SetForceUseMouse(-1);
+				}
 			}
 		}
 	}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -928,6 +928,9 @@ void Player::ResetGameObjects() {
 	Main_Data::game_system->ReloadSystemGraphic();
 
 	Input::ResetMask();
+
+	DisplayUi->Load_Cursor("mouseCursor", 0);
+	DisplayUi->Load_Cursor("mouseCursorHand", 1);
 }
 
 static bool DefaultLmuStartFileExists(const FilesystemView& fs) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -725,6 +725,9 @@ void Player::CreateGameObjects() {
 					Player::screen_height = ini.GetInteger("RPG_RT", "WinH", SCREEN_TARGET_HEIGHT);
 					Player::has_custom_resolution = true;
 				}
+				std::string s = ini.Get("RPG_RT", "MouseButton", "false");
+				bool b = s == "true";
+				Input::SetUseMouse(b);
 			}
 		}
 	}

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -263,14 +263,15 @@ void Scene::Update() {
 	}
 
 	Point mouse_pos = Input::GetMousePosition();
-	for (auto* window: GetWindowSelectables()) {
-		if (!window || !window->GetActive()) {
+	for (auto* window: windows) {
+		if (window->GetType() != Window::WindowType::Selectable || !window->GetActive()) {
 			continue;
 		}
-		int index = window->CursorHitTest({mouse_pos.x - window->GetX(), mouse_pos.y - window->GetY()});
-		if (index >= 0 && index != window->GetIndex()) {
-			// Index changed callback?
-			window->SetIndex(index);
+		auto* sel_window = static_cast<Window_Selectable*>(window);
+		int index = sel_window->CursorHitTest({mouse_pos.x - window->GetX(), mouse_pos.y - window->GetY()});
+		if (index >= 0 && index != sel_window->GetIndex()) {
+			// FIXME: Index changed callback?
+			sel_window->SetIndex(index);
 		}
 	}
 
@@ -426,4 +427,14 @@ void Scene::OnTranslationChanged() {
 		Main_Data::game_actors->ReloadActors();
 	}
 	Game_Map::OnTranslationChanged();
+}
+
+void Scene::RegisterWindow(Window* window) {
+	windows.push_back(window);
+}
+
+void Scene::RemoveWindow(Window* window) {
+	auto it = std::find(windows.begin(), windows.end(), window);
+	assert(it != windows.end());
+	windows.erase(it);
 }

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -271,7 +271,7 @@ void Scene::Update() {
 	if (Input::GetUseMouseButton()) {
 		Point mouse_pos = Input::GetMousePosition();
 		for (auto* window : windows) {
-			if (window->GetType() != Window::WindowType::Selectable || !window->GetActive() || !window->IsVisible() || window->ExcludeForMouse()) {
+			if (window->GetType() != Window::WindowType::Selectable || (!window->GetActive() && !window->GetHalfActive()) || !window->IsVisible() || window->ExcludeForMouse()) {
 				continue;
 			}
 			auto* sel_window = static_cast<Window_Selectable*>(window);
@@ -282,6 +282,15 @@ void Scene::Update() {
 				// FIXME: Index changed callback?
 				sel_window->SetIndex(index);
 				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+				if (window->GetHalfActive()) {
+					for (auto* w : windows) {
+						if (window->GetType() != Window::WindowType::Selectable || (!window->GetActive() && !window->GetHalfActive()) || !window->IsVisible() || window->ExcludeForMouse()) {
+							continue;
+						}
+						w->SetActive(false);
+					}
+					window->SetActive(true);
+				}
 			}
 			if (index == -1 && Input::MouseMoved() && sel_window->GetIndex() != -999) {
 				sel_window->SetMouseOldIndex(sel_window->GetIndex());

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -262,6 +262,18 @@ void Scene::Update() {
 			Scene::Push(std::make_shared<Scene_Settings>());
 	}
 
+	Point mouse_pos = Input::GetMousePosition();
+	for (auto* window: GetWindowSelectables()) {
+		if (!window || !window->GetActive()) {
+			continue;
+		}
+		int index = window->CursorHitTest({mouse_pos.x - window->GetX(), mouse_pos.y - window->GetY()});
+		if (index >= 0 && index != window->GetIndex()) {
+			// Index changed callback?
+			window->SetIndex(index);
+		}
+	}
+
 	vUpdate();
 }
 

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -31,6 +31,7 @@
 #include "main_data.h"
 #include "scene_settings.h"
 #include "game_map.h"
+#include <baseui.h>
 
 #ifndef NDEBUG
 #define DEBUG_VALIDATE(x) Scene::DebugValidate(x)
@@ -220,6 +221,11 @@ void Scene::TransitionIn(SceneType) {
 
 void Scene::TransitionOut(SceneType) {
 	Transition::instance().InitErase(Transition::TransitionFadeOut, this, 6);
+	if (Input::GetUseMouseButton()) {
+
+		// Reset cursor (Arrow)
+		DisplayUi->ChangeCursor(0);
+	}
 }
 
 void Scene::Suspend(SceneType /* next_scene */) {
@@ -242,6 +248,11 @@ bool Scene::IsAsyncPending() {
 }
 
 void Scene::Update() {
+	if (Input::GetUseMouseButton()) {
+		// Reset cursor (Arrow)
+		DisplayUi->ChangeCursor(0);
+	}
+
 	// Allow calling of settings scene everywhere except from Logo (Player is currently starting up)
 	// and from Map (has own handling to prevent breakage)
 	if (instance->type != Scene::Logo &&

--- a/src/scene.h
+++ b/src/scene.h
@@ -22,12 +22,15 @@
 #include "system.h"
 #include "async_op.h"
 #include "drawable_list.h"
+#include "span.h"
+#include "window_selectable.h"
 #include <vector>
 #include <functional>
 #include <lcf/rpg/savesystem.h>
 
 class Game_Battler;
 class Game_Actor;
+class Window_Selectable;
 
 /**
  * Scene virtual class.
@@ -287,6 +290,9 @@ protected:
 	 * @param value whether to use shared drawables.
 	 */
 	void SetUseSharedDrawables(bool value);
+
+	/** @return A list of window selectables suitable for mouse cursor selection */
+	virtual Span<Window_Selectable*> GetWindowSelectables() { return {}; };
 
 	/**
 	 * If no async operation is pending, call f() now. Otherwise

--- a/src/scene.h
+++ b/src/scene.h
@@ -22,7 +22,6 @@
 #include "system.h"
 #include "async_op.h"
 #include "drawable_list.h"
-#include "span.h"
 #include "window_selectable.h"
 #include <vector>
 #include <functional>
@@ -268,6 +267,9 @@ public:
 	/** @return true if this scene uses shared drawables */
 	bool UsesSharedDrawables() const;
 
+	void RegisterWindow(Window* window);
+	void RemoveWindow(Window* window);
+
 	virtual void OnPartyChanged(Game_Actor* actor, bool add);
 	virtual void OnEventHpChanged(Game_Battler* battler, int hp);
 	virtual void OnTranslationChanged();
@@ -290,9 +292,6 @@ protected:
 	 * @param value whether to use shared drawables.
 	 */
 	void SetUseSharedDrawables(bool value);
-
-	/** @return A list of window selectables suitable for mouse cursor selection */
-	virtual Span<Window_Selectable*> GetWindowSelectables() { return {}; };
 
 	/**
 	 * If no async operation is pending, call f() now. Otherwise
@@ -321,6 +320,8 @@ private:
 
 	std::shared_ptr<Scene> request_scene;
 	int delay_frames = 0;
+
+	std::vector<Window*> windows;
 };
 
 inline bool Scene::IsInitialized() const {

--- a/src/scene_actortarget.cpp
+++ b/src/scene_actortarget.cpp
@@ -41,9 +41,9 @@ Scene_ActorTarget::Scene_ActorTarget(
 
 void Scene_ActorTarget::Start() {
 	// Create the windows
-	help_window.reset(new Window_Help(0, 0, 136, 32));
-	target_window.reset(new Window_ActorTarget(136, 0, 184, Player::screen_height));
-	status_window.reset(new Window_TargetStatus(0, 32, 136, 32));
+	help_window = std::make_unique<Window_Help>(this, 0, 0, 136, 32);
+	target_window = std::make_unique<Window_ActorTarget>(this, 136, 0, 184, Player::screen_height);
+	status_window = std::make_unique<Window_TargetStatus>(this, 0, 32, 136, 32);
 
 	target_window->SetActive(true);
 	target_window->SetIndex(0);

--- a/src/scene_actortarget.cpp
+++ b/src/scene_actortarget.cpp
@@ -151,7 +151,7 @@ void Scene_ActorTarget::UpdateItem() {
 }
 
 void Scene_ActorTarget::UpdateSkill() {
-	if (Input::IsTriggered(Input::DECISION)) {
+	if (Input::IsTriggered(Input::DECISION) && target_window->GetIndex() >= 0) {
 		Game_Actor* actor = &(*Main_Data::game_party)[actor_index];
 
 		if (actor->GetSp() < actor->CalculateSkillCost(id) || actor->GetHp() <= actor->CalculateSkillHpCost(id)) {

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -211,23 +211,23 @@ void Scene_Battle::CreateUi() {
 		}
 	}
 
-	options_window.reset(new Window_Command(commands, option_command_mov));
+	options_window = std::make_unique<Window_Command>(this, commands, option_command_mov);
 	options_window->SetHeight(80);
 	options_window->SetX(Player::menu_offset_x);
 	options_window->SetY(Player::menu_offset_y + MENU_HEIGHT - 80);
 
-	help_window.reset(new Window_Help(Player::menu_offset_x, Player::menu_offset_y, MENU_WIDTH, 32));
+	help_window = std::make_unique<Window_Help>(this, Player::menu_offset_x, Player::menu_offset_y, MENU_WIDTH, 32);
 	help_window->SetVisible(false);
 
-	item_window.reset(new Window_Item(Player::menu_offset_x, (Player::menu_offset_y + MENU_HEIGHT - 80), MENU_WIDTH, 80));
+	item_window = std::make_unique<Window_Item>(this, Player::menu_offset_x, (Player::menu_offset_y + MENU_HEIGHT - 80), MENU_WIDTH, 80);
 	item_window->SetHelpWindow(help_window.get());
 	item_window->Refresh();
 	item_window->SetIndex(0);
 
-	skill_window.reset(new Window_BattleSkill(Player::menu_offset_x, (Player::menu_offset_y + MENU_HEIGHT - 80), MENU_WIDTH, 80));
+	skill_window = std::make_unique<Window_BattleSkill>(this, Player::menu_offset_x, (Player::menu_offset_y + MENU_HEIGHT - 80), MENU_WIDTH, 80);
 	skill_window->SetHelpWindow(help_window.get());
 
-	message_window.reset(new Window_Message(Player::menu_offset_x, (Player::menu_offset_y + MENU_HEIGHT - 80), MENU_WIDTH, 80));
+	message_window = std::make_unique<Window_Message>(this, Player::menu_offset_x, (Player::menu_offset_y + MENU_HEIGHT - 80), MENU_WIDTH, 80);
 	Game_Message::SetWindow(message_window.get());
 }
 

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -410,7 +410,8 @@ void Scene_Battle::ItemSelected() {
 	const lcf::rpg::Item* item = item_window->GetItem();
 
 	if (!item || !item_window->CheckEnable(item->ID)) {
-		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
+		if (item_window->GetIndex() >= 0)
+			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 		return;
 	}
 
@@ -456,7 +457,8 @@ void Scene_Battle::SkillSelected() {
 	const lcf::rpg::Skill* skill = skill_window->GetSkill();
 
 	if (!skill || !skill_window->CheckEnable(skill->ID)) {
-		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
+		if (skill_window->GetIndex() >= 0)
+			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 		return;
 	}
 

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -355,6 +355,10 @@ Game_Enemy* Scene_Battle::EnemySelected() {
 }
 
 Game_Actor* Scene_Battle::AllySelected() {
+	
+	//if (status_window->GetIndex() >= (*Main_Data::game_party).GetActors().size()) {
+	//	return Main_Data::game_party->GetActor(0);
+	//}
 	Game_Actor& target = (*Main_Data::game_party)[status_window->GetIndex()];
 
 	if (previous_state == State_SelectSkill) {

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -39,6 +39,8 @@
 #include "window_message.h"
 #include "game_battle.h"
 
+#include "window_target.h"
+
 namespace AutoBattle {
 class AlgorithmBase;
 }
@@ -182,7 +184,7 @@ protected:
 	/** Displays Fight, Autobattle, Flee */
 	std::unique_ptr<Window_Command> options_window;
 	/** Displays list of enemies */
-	std::unique_ptr<Window_Command> target_window;
+	std::unique_ptr<Window_Target> target_window;
 	/** Displays Attack, Defense, Magic, Item */
 	std::unique_ptr<Window_Command> command_window;
 	std::unique_ptr<Window_Item> item_window;

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -59,12 +59,12 @@ void Scene_Battle_Rpg2k::Start() {
 void Scene_Battle_Rpg2k::CreateUi() {
 	Scene_Battle::CreateUi();
 
-	status_window.reset(new Window_BattleStatus(Player::menu_offset_x, (Player::screen_height - Player::menu_offset_y - 80), MENU_WIDTH - option_command_mov, 80));
+	status_window = std::make_unique<Window_BattleStatus>(this, Player::menu_offset_x, (Player::screen_height - Player::menu_offset_y - 80), MENU_WIDTH - option_command_mov, 80);
 
 	CreateBattleTargetWindow();
 	CreateBattleCommandWindow();
 
-	battle_message_window.reset(new Window_BattleMessage(Player::menu_offset_x, (Player::screen_height - Player::menu_offset_y - 80), MENU_WIDTH, 80));
+	battle_message_window = std::make_unique<Window_BattleMessage>(this, Player::menu_offset_x, (Player::screen_height - Player::menu_offset_y - 80), MENU_WIDTH, 80);
 
 	if (!IsEscapeAllowed()) {
 		auto it = std::find(battle_options.begin(), battle_options.end(), Escape);
@@ -102,7 +102,7 @@ static std::vector<std::string> GetEnemyTargetNames() {
 
 void Scene_Battle_Rpg2k::CreateBattleTargetWindow() {
 	auto commands = GetEnemyTargetNames();
-	target_window.reset(new Window_Command(std::move(commands), 136, 4));
+	target_window = std::make_unique<Window_Command>(this, std::move(commands), 136, 4);
 	target_window->SetHeight(80);
 	target_window->SetX(Player::menu_offset_x);
 	target_window->SetY(Player::screen_height - Player::menu_offset_y - 80);
@@ -136,7 +136,7 @@ void Scene_Battle_Rpg2k::CreateBattleCommandWindow() {
 		ToString(lcf::Data::terms.command_item)
 	};
 
-	command_window.reset(new Window_Command(std::move(commands), option_command_mov));
+	command_window = std::make_unique<Window_Command>(this, std::move(commands), option_command_mov);
 	command_window->SetHeight(80);
 	command_window->SetY(Player::screen_height - Player::menu_offset_y - 80);
 }

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -708,7 +708,7 @@ Scene_Battle_Rpg2k::SceneActionReturn Scene_Battle_Rpg2k::ProcessSceneActionEnem
 	}
 
 	if (scene_action_substate == eWaitForInput) {
-		if (Input::IsTriggered(Input::DECISION)) {
+		if (Input::IsTriggered(Input::DECISION) && target_window->GetIndex() >= 0) {
 			EnemySelected();
 			return SceneActionReturn::eWaitTillNextFrame;
 		}

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -102,7 +102,7 @@ static std::vector<std::string> GetEnemyTargetNames() {
 
 void Scene_Battle_Rpg2k::CreateBattleTargetWindow() {
 	auto commands = GetEnemyTargetNames();
-	target_window = std::make_unique<Window_Command>(this, std::move(commands), 136, 4);
+	target_window = std::make_unique<Window_Target>(this, std::move(commands), 136, 4);
 	target_window->SetHeight(80);
 	target_window->SetX(Player::menu_offset_x);
 	target_window->SetY(Player::screen_height - Player::menu_offset_y - 80);

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1194,7 +1194,7 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionFi
 	}
 
 	if (scene_action_substate == eWaitInput) {
-		if (Input::IsTriggered(Input::DECISION)) {
+		if (Input::IsTriggered(Input::DECISION) && options_window->GetIndex() < battle_options.size()) {
 			if (message_window->IsVisible()) {
 				return SceneActionReturn::eWaitTillNextFrame;
 			}

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1303,7 +1303,7 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionAc
 			return SceneActionReturn::eWaitTillNextFrame;
 		}
 
-		if (status_window->GetActive() && status_window->GetIndex() >= 0) {
+		if (status_window->GetActive() && status_window->GetIndex() >= 0 && !status_window->mouseOutside) {
 			if (Input::IsTriggered(Input::DECISION)) {
 				command_window->SetIndex(0);
 				SetState(State_SelectCommand);
@@ -1586,7 +1586,7 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionEn
 	}
 
 	if (scene_action_substate == eWaitInput) {
-		if (Input::IsTriggered(Input::DECISION)) {
+		if (Input::IsTriggered(Input::DECISION) && target_window->GetIndex() >= 0) {
 			auto* actor = active_actor;
 			// active_actor gets reset after the next call, so save it.
 			auto* enemy = EnemySelected();
@@ -1637,7 +1637,7 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionAl
 	}
 
 	if (scene_action_substate == eWaitInput) {
-		if (Input::IsTriggered(Input::DECISION)) {
+		if (Input::IsTriggered(Input::DECISION) && !status_window->mouseOutside) {
 			AllySelected();
 			return SceneActionReturn::eWaitTillNextFrame;
 		}

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1321,7 +1321,8 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionAc
 							// Change cursor (Hand)
 							DisplayUi->ChangeCursor(1);
 
-							if (Input::IsPressed(Input::MOUSE_LEFT) || Input::IsReleased(Input::MOUSE_LEFT)) {
+							//if (Input::IsPressed(Input::MOUSE_LEFT) || Input::IsReleased(Input::MOUSE_LEFT)) {
+							if (Input::mouseHover() || Input::IsReleased(Input::MOUSE_LEFT)) {
 								if (status_window->GetIndex() != i)
 									Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 								status_window->SetIndex(i);
@@ -1652,7 +1653,8 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionEn
 						// Change cursor (Hand)
 						DisplayUi->ChangeCursor(1);
 
-						if (Input::IsPressed(Input::MOUSE_LEFT)) {
+						//if (Input::IsPressed(Input::MOUSE_LEFT)) {
+						if (Input::mouseHover()) {
 							if (status_window->GetIndex() != i)
 								Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 							target_window->SetIndex(i);
@@ -1740,7 +1742,8 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionAl
 						// Change cursor (Hand)
 						DisplayUi->ChangeCursor(1);
 
-						if (Input::IsPressed(Input::MOUSE_LEFT)) {
+						//if (Input::IsPressed(Input::MOUSE_LEFT)) {
+						if (Input::mouseHover()) {
 							if (status_window->GetIndex() != i)
 								Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 							status_window->SetIndex(i);

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -544,7 +544,7 @@ void Scene_Battle_Rpg2k3::CreateBattleTargetWindow() {
 	int width = (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional) ? 104 : 136;
 	int height = 80;
 
-	target_window.reset(new Window_Command(std::move(commands), width, 4));
+	target_window = std::make_unique<Window_Command>(this, std::move(commands), width, 4);
 	target_window->SetHeight(height);
 	target_window->SetX(Player::menu_offset_x);
 	target_window->SetY(Player::screen_height - Player::menu_offset_y - height);
@@ -590,7 +590,7 @@ void Scene_Battle_Rpg2k3::CreateBattleStatusWindow() {
 			break;
 	}
 
-	status_window.reset(new Window_BattleStatus(x, y, w, h));
+	status_window = std::make_unique<Window_BattleStatus>(this, x, y, w, h);
 	status_window->SetZ(Priority_Window + 1);
 }
 
@@ -626,7 +626,7 @@ void Scene_Battle_Rpg2k3::CreateBattleCommandWindow() {
 	auto* actor = Main_Data::game_party->GetActor(0);
 	auto commands = GetBattleCommandNames(actor);
 
-	command_window.reset(new Window_Command(std::move(commands), option_command_mov));
+	command_window = std::make_unique<Window_Command>(this, std::move(commands), option_command_mov);
 
 	SetBattleCommandsDisable(*command_window, actor);
 
@@ -3028,7 +3028,7 @@ void Scene_Battle_Rpg2k3::RecreateSpWindow(Game_Battler* battler) {
 	if (battler && battler->MaxSpValue() >= 1000) {
 		spwindow_size = 72;
 	}
-	sp_window = std::make_unique<Window_ActorSp>(Player::screen_width - Player::menu_offset_x - spwindow_size, (small_window ? Player::menu_offset_y + 154 : Player::menu_offset_y + 136), spwindow_size, spwindow_height);
+	sp_window = std::make_unique<Window_ActorSp>(this, Player::screen_width - Player::menu_offset_x - spwindow_size, (small_window ? Player::menu_offset_y + 154 : Player::menu_offset_y + 136), spwindow_size, spwindow_height);
 	sp_window->SetVisible(false);
 	sp_window->SetBorderY(small_window ? 2 : 8);
 	sp_window->SetContents(Bitmap::Create(sp_window->GetWidth() - sp_window->GetBorderX() / 2, sp_window->GetHeight() - sp_window->GetBorderY() * 2));

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -478,7 +478,7 @@ void Scene_Debug::CreateRangeWindow() {
 	std::vector<std::string> ranges;
 	for (int i = 0; i < 10; i++)
 		ranges.push_back("");
-	range_window.reset(new Window_Command(ranges, 96));
+	range_window = std::make_unique<Window_Command>(this, ranges, 96);
 
 	int height = 176;
 	range_window->SetHeight(height);
@@ -610,7 +610,7 @@ void Scene_Debug::CreateVarListWindow() {
 	std::vector<std::string> vars;
 	for (int i = 0; i < 10; i++)
 		vars.push_back("");
-	var_window.reset(new Window_VarList(vars));
+	var_window = std::make_unique<Window_VarList>(this, vars);
 	var_window->SetX(Player::menu_offset_x + range_window->GetWidth());
 	var_window->SetY(range_window->GetY());
 	var_window->SetVisible(false);
@@ -620,8 +620,8 @@ void Scene_Debug::CreateVarListWindow() {
 }
 
 void Scene_Debug::CreateNumberInputWindow() {
-	numberinput_window.reset(new Window_NumberInput(Player::menu_offset_x + 160 - (Main_Data::game_variables->GetMaxDigits() + 1) * 6 - 8, Player::menu_offset_y + 104,
-		(Main_Data::game_variables->GetMaxDigits() + 1) * 12 + 16, 32));
+	numberinput_window = std::make_unique<Window_NumberInput>(this, Player::menu_offset_x + 160 - (Main_Data::game_variables->GetMaxDigits() + 1) * 6 - 8, Player::menu_offset_y + 104,
+		(Main_Data::game_variables->GetMaxDigits() + 1) * 12 + 16, 32);
 	numberinput_window->SetVisible(false);
 	numberinput_window->SetOpacity(255);
 	numberinput_window->SetShowOperator(true);

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -207,7 +207,6 @@ void Scene_Debug::PushUiNumberInput(int init_value, int digits, bool show_operat
 	numberinput_window->SetActive(true);
 	numberinput_window->SetMaxDigits(digits);
 	numberinput_window->Refresh();
-
 	var_window->Refresh();
 	UpdateRangeListWindow();
 }
@@ -274,21 +273,85 @@ void Scene_Debug::vUpdate() {
 	}
 	var_window->Update();
 
-	if (numberinput_window->GetActive())
+
+	bool validate = false;
+	if (numberinput_window->GetActive()) {
+
+		if (Input::GetUseMouseButton()) {
+			Point mouseP = Input::GetMousePosition();
+
+			int min = 0;
+			int max = numberinput_window->GetMaxDigits();
+			int ddx = 4;
+			if (numberinput_window->GetShowOperator()) {
+				ddx = 11;
+				min = 1;
+				max++;
+			}
+			int new_index = (mouseP.x - numberinput_window->GetX() - numberinput_window->GetBorderX() - numberinput_window->GetItemRect(0).x + ddx) / (12) - 1;
+
+			if (new_index >= min && new_index < max) {
+				// Change cursor (Hand)
+				DisplayUi->ChangeCursor(1);
+				if (Input::IsPressed(Input::MOUSE_LEFT)) {
+					
+					// Output::Debug("{} {} {}", new_index, number_input_window->GetIndex(), number_input_window->GetMouseOldIndex());
+
+					if (new_index != numberinput_window->GetMouseOldIndex())
+						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+
+					if (numberinput_window->GetIndex() != -999 && numberinput_window->GetIndex() != -1)
+						numberinput_window->SetMouseOldIndex(numberinput_window->GetIndex());
+
+					numberinput_window->SetIndex(new_index);
+				}
+			}
+
+			numberinput_window->UpdateCursorRect();
+
+			ddx = 32;
+			if (numberinput_window->GetShowOperator())
+				ddx = 22;
+
+			int dx = numberinput_window->GetMaxDigits() * 12 + ddx + 12;
+			if ((mouseP.x >= numberinput_window->GetX() + numberinput_window->GetBorderX() + dx && mouseP.x <= numberinput_window->GetX() + numberinput_window->GetBorderX() + dx + 14 &&
+				mouseP.y >= numberinput_window->GetY() + numberinput_window->GetBorderY() && mouseP.y < numberinput_window->GetY() + numberinput_window->GetBorderY() + numberinput_window->GetItemRect(0).height)) {
+
+				// Change cursor (Hand)
+				DisplayUi->ChangeCursor(1);
+
+				if (Input::IsReleased(Input::MOUSE_LEFT)) {
+
+					validate = true;
+					//options_window->Refresh();
+					//numberinput_window.reset();
+					//options_window->SetActive(true);
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Game_System::SFX_Decision));
+				}
+			}
+		}
+
 		numberinput_window->Update();
+	}
 
 	if (Input::IsTriggered(Input::CANCEL)) {
 		UpdateFrameValueFromUi();
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
 		Pop();
-	} else if (Input::IsTriggered(Input::DECISION)) {
+	} else if (Input::IsTriggered(Input::DECISION) || validate) {
+		if (numberinput_window->GetActive() && Input::IsReleased(Input::MOUSE_LEFT) && !validate || range_index == -999)
+		{
+			return;
+		}
+		
 		UpdateFrameValueFromUi();
 		if (mode == eMain) {
 			auto next_mode = static_cast<Mode>(range_window->GetIndex() + range_page * 10 + 1);
 			if (next_mode > eMain && next_mode < eLastMainMenuOption) {
 				if (!range_window->IsItemEnabled(range_window->GetIndex())) {
 					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
-				} else {
+				}
+				else {
 					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 					mode = next_mode;
 				}
@@ -621,7 +684,7 @@ void Scene_Debug::CreateVarListWindow() {
 
 void Scene_Debug::CreateNumberInputWindow() {
 	numberinput_window = std::make_unique<Window_NumberInput>(this, Player::menu_offset_x + 160 - (Main_Data::game_variables->GetMaxDigits() + 1) * 6 - 8, Player::menu_offset_y + 104,
-		(Main_Data::game_variables->GetMaxDigits() + 1) * 12 + 16, 32);
+		(Main_Data::game_variables->GetMaxDigits() + 1) * 12 + 16 + 32+8, 32);
 	numberinput_window->SetVisible(false);
 	numberinput_window->SetOpacity(255);
 	numberinput_window->SetShowOperator(true);

--- a/src/scene_end.cpp
+++ b/src/scene_end.cpp
@@ -81,7 +81,7 @@ void Scene_End::CreateCommandWindow() {
 	options.push_back(term_yes);
 	options.push_back(term_no);
 
-	command_window.reset(new Window_Command(options));
+	command_window = std::make_unique<Window_Command>(this, options);
 	command_window->SetX((Player::screen_width / 2) - (command_window->GetWidth() / 2));
 	command_window->SetY(Player::menu_offset_y + 72 + 48);
 	command_window->SetIndex(1);
@@ -97,8 +97,8 @@ void Scene_End::CreateHelpWindow() {
 
 	int window_width = text_size + 16;
 
-	help_window.reset(new Window_Help(Player::menu_offset_x + (MENU_WIDTH / 2) - (window_width / 2),
-									  Player::menu_offset_y + 72, window_width, 32));
+	help_window = std::make_unique<Window_Help>(this, Player::menu_offset_x + (MENU_WIDTH / 2) - (window_width / 2),
+									  Player::menu_offset_y + 72, window_width, 32);
 	help_window->SetText(term_exit_message, Font::ColorDefault, Text::AlignLeft, false);
 
 	command_window->SetHelpWindow(help_window.get());

--- a/src/scene_end.cpp
+++ b/src/scene_end.cpp
@@ -46,7 +46,7 @@ void Scene_End::vUpdate() {
 	if (Input::IsTriggered(Input::CANCEL)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
 		Scene::Pop(); // Select End Game
-	} else if (Input::IsTriggered(Input::DECISION)) {
+	} else if (Input::IsTriggered(Input::DECISION) && command_window->GetIndex() >= 0) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 		switch (command_window->GetIndex()) {
 		case 0: // Yes

--- a/src/scene_equip.cpp
+++ b/src/scene_equip.cpp
@@ -40,14 +40,14 @@ void Scene_Equip::Start() {
 	int menu_equip_status_height = 96;
 	int menu_equip_height = 96;
 
-	help_window.reset(new Window_Help(Player::menu_offset_x, Player::menu_offset_y, MENU_WIDTH, menu_help_height));
-	equipstatus_window.reset(new Window_EquipStatus(Player::menu_offset_x, Player::menu_offset_y + menu_help_height, menu_equip_status_width, menu_equip_status_height, actor.GetId()));
-	equip_window.reset(new Window_Equip(Player::menu_offset_x + menu_equip_status_width, Player::menu_offset_y + menu_help_height, (MENU_WIDTH - menu_equip_status_width), menu_equip_height, actor.GetId()));
+	help_window = std::make_unique<Window_Help>(this, Player::menu_offset_x, Player::menu_offset_y, MENU_WIDTH, menu_help_height);
+	equipstatus_window = std::make_unique<Window_EquipStatus>(this, Player::menu_offset_x, Player::menu_offset_y + menu_help_height, menu_equip_status_width, menu_equip_status_height, actor.GetId());
+	equip_window = std::make_unique<Window_Equip>(this, Player::menu_offset_x + menu_equip_status_width, Player::menu_offset_y + menu_help_height, (MENU_WIDTH - menu_equip_status_width), menu_equip_height, actor.GetId());
 
 	equip_window->SetIndex(equip_index);
 
 	for (int i = 0; i < 5; ++i) {
-		item_windows.push_back(std::make_shared<Window_EquipItem>(Player::menu_offset_x, Player::menu_offset_y + menu_help_height + menu_equip_status_height, MENU_WIDTH, MENU_HEIGHT - menu_help_height - menu_equip_status_height,actor.GetId(), i));
+		item_windows.push_back(std::make_shared<Window_EquipItem>(this, Player::menu_offset_x, Player::menu_offset_y + menu_help_height + menu_equip_status_height, MENU_WIDTH, MENU_HEIGHT - menu_help_height - menu_equip_status_height,actor.GetId(), i));
 	}
 
 	// Assign the help windows

--- a/src/scene_equip.cpp
+++ b/src/scene_equip.cpp
@@ -75,12 +75,14 @@ void Scene_Equip::vUpdate() {
 }
 
 void Scene_Equip::UpdateItemWindows() {
-	for (size_t i = 0; i < item_windows.size(); ++i) {
-		item_windows[i]->SetVisible((unsigned)equip_window->GetIndex() == i);
-		item_windows[i]->Update();
-	}
+	if (equip_window->GetIndex() < item_windows.size()) {
+		for (size_t i = 0; i < item_windows.size(); ++i) {
+			item_windows[i]->SetVisible((unsigned)equip_window->GetIndex() == i);
+			item_windows[i]->Update();
+		}
 
-	item_window = item_windows[equip_window->GetIndex()];
+		item_window = item_windows[equip_window->GetIndex()];
+	}
 }
 
 void Scene_Equip::UpdateEquipWindow() {
@@ -166,7 +168,7 @@ void Scene_Equip::UpdateEquipSelection() {
 	if (Input::IsTriggered(Input::CANCEL)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
 		Scene::Pop();
-	} else if (Input::IsTriggered(Input::DECISION)) {
+	} else if (Input::IsTriggered(Input::DECISION) && equip_window->GetIndex() >= 0) {
 		if (!CanRemoveEquipment(actor, equip_window->GetIndex())) {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 			return;
@@ -195,7 +197,7 @@ void Scene_Equip::UpdateItemSelection() {
 		equip_window->SetActive(true);
 		item_window->SetActive(false);
 		item_window->SetIndex(-1);
-	} else if (Input::IsTriggered(Input::DECISION)) {
+	} else if (Input::IsTriggered(Input::DECISION) && item_window->GetIndex() >= 0) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 
 		const lcf::rpg::Item* current_item = item_window->GetItem();

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<Sprite> Scene_File::MakeArrowSprite(bool down) {
 }
 
 void Scene_File::CreateHelpWindow() {
-	help_window.reset(new Window_Help(Player::menu_offset_x, 0, MENU_WIDTH, 32));
+	help_window = std::make_unique<Window_Help>(this, Player::menu_offset_x, 0, MENU_WIDTH, 32);
 	help_window->SetText(message);
 	help_window->SetZ(Priority_Window + 1);
 }
@@ -125,7 +125,7 @@ void Scene_File::Start() {
 
 	for (int i = 0; i < Utils::Clamp<int32_t>(lcf::Data::system.easyrpg_max_savefiles, 3, 99); i++) {
 		std::shared_ptr<Window_SaveFile>
-			w(new Window_SaveFile(Player::menu_offset_x, 40 + i * 64, MENU_WIDTH, 64));
+			w = std::make_unique<Window_SaveFile>(this, Player::menu_offset_x, 40 + i * 64, MENU_WIDTH, 64);
 		w->SetIndex(i);
 		w->SetZ(Priority_Window);
 		PopulateSaveWindow(*w, i);
@@ -154,7 +154,7 @@ void Scene_File::Start() {
 	commands.emplace_back("Download Savegame");
 	commands.emplace_back("Upload Savegame");
 #endif
-	extra_commands_window = std::make_unique<Window_Command>(commands);
+	extra_commands_window = std::make_unique<Window_Command>(this, commands);
 	extra_commands_window->SetZ(Priority_Window + 100);
 	extra_commands_window->SetVisible(false);
 }

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -238,7 +238,7 @@ void Scene_File::vUpdate() {
 						DisplayUi->ChangeCursor(1);
 
 						//if (Input::IsPressed(Input::MOUSE_LEFT)) {
-						if (Input::mouseHover()) {
+						if (Input::MouseMoved()) {
 							mouseOutside = false;
 							if (oldIndex != i)
 								Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
@@ -255,7 +255,7 @@ void Scene_File::vUpdate() {
 		}
 
 		//if (Input::IsPressed(Input::MOUSE_LEFT) && mouseOutside) {
-		if (Input::mouseHover() && mouseOutside) {
+		if (Input::MouseMoved() && mouseOutside) {
 			disabledByMouse = true;
 			Refresh();
 		}

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -283,13 +283,13 @@ void Scene_File::vUpdate() {
 	}
 
 	if (disabledByMouse) {
-		if (Input::IsRepeated(Input::DOWN) || Input::IsRepeated(Input::SCROLL_DOWN)) {
+		if (Input::IsRepeated(Input::DOWN) || (Input::IsRepeated(Input::SCROLL_DOWN) && !Input::GetUseMouseButton())) {
 				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 				disabledByMouse = false;
 				index = oldIndex;
 				Refresh();
 		}
-		if (Input::IsRepeated(Input::UP) || Input::IsRepeated(Input::SCROLL_UP)) {
+		if (Input::IsRepeated(Input::UP) || (Input::IsRepeated(Input::SCROLL_UP) && !Input::GetUseMouseButton())) {
 				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 				disabledByMouse = false;
 				index = oldIndex;
@@ -297,8 +297,8 @@ void Scene_File::vUpdate() {
 		}
 	}
 	else {
-		if (Input::IsRepeated(Input::DOWN) || Input::IsTriggered(Input::SCROLL_DOWN)) {
-			if (Input::IsTriggered(Input::DOWN) || Input::IsTriggered(Input::SCROLL_DOWN)
+		if (Input::IsRepeated(Input::DOWN) || (Input::IsTriggered(Input::SCROLL_DOWN) && !Input::GetUseMouseButton())) {
+			if (Input::IsTriggered(Input::DOWN) || (Input::IsTriggered(Input::SCROLL_DOWN) && !Input::GetUseMouseButton())
 				|| index < max_index) {
 				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 				index = (index + 1) % file_windows.size();
@@ -306,8 +306,8 @@ void Scene_File::vUpdate() {
 
 			//top_index = std::max(top_index, index - 3 + 1);
 		}
-		if (Input::IsRepeated(Input::UP) || Input::IsTriggered(Input::SCROLL_UP)) {
-			if (Input::IsTriggered(Input::UP) || Input::IsTriggered(Input::SCROLL_UP)
+		if (Input::IsRepeated(Input::UP) || (Input::IsTriggered(Input::SCROLL_UP) && !Input::GetUseMouseButton())) {
+			if (Input::IsTriggered(Input::UP) || (Input::IsTriggered(Input::SCROLL_UP) && !Input::GetUseMouseButton())
 				|| index >= 1) {
 				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 				index = (index + max_index) % file_windows.size();
@@ -323,6 +323,28 @@ void Scene_File::vUpdate() {
 		if (Input::IsRepeated(Input::PAGE_UP) && index >= 1) {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 			index = (index > 3) ? index - 3 : 0;
+		}
+	}
+
+	if (Input::GetUseMouseButton()) {
+
+		bool show_up_arrow = (top_index > 0);
+		bool show_down_arrow = (top_index < max_index - 2);
+
+		if (Input::IsTriggered(Input::SCROLL_DOWN) && show_down_arrow) {
+
+			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+			index = (index + 1) % file_windows.size();
+			top_index += 1;
+
+			//top_index = std::max(top_index, index - 3 + 1);
+		}
+		if (Input::IsTriggered(Input::SCROLL_UP) && show_up_arrow) {
+			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+			index = (index + max_index) % file_windows.size();
+			top_index -= 1;
+
+			//top_index = std::min(top_index, index);
 		}
 	}
 

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -237,7 +237,8 @@ void Scene_File::vUpdate() {
 						// Change cursor (Hand)
 						DisplayUi->ChangeCursor(1);
 
-						if (Input::IsPressed(Input::MOUSE_LEFT)) {
+						//if (Input::IsPressed(Input::MOUSE_LEFT)) {
+						if (Input::mouseHover()) {
 							mouseOutside = false;
 							if (oldIndex != i)
 								Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
@@ -253,7 +254,8 @@ void Scene_File::vUpdate() {
 			}
 		}
 
-		if (Input::IsPressed(Input::MOUSE_LEFT) && mouseOutside) {
+		//if (Input::IsPressed(Input::MOUSE_LEFT) && mouseOutside) {
+		if (Input::mouseHover() && mouseOutside) {
 			disabledByMouse = true;
 			Refresh();
 		}

--- a/src/scene_file.h
+++ b/src/scene_file.h
@@ -83,6 +83,8 @@ protected:
 
 	int arrow_frame = 0;
 
+	int oldIndex = 0;
+	bool disabledByMouse = false;
 };
 
 #endif

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -85,14 +85,6 @@ void Scene_GameBrowser::vUpdate() {
 	}
 }
 
-Span<Window_Selectable*> Scene_GameBrowser::GetWindowSelectables() {
-	auto arr = Utils::MakeArray<Window_Selectable*>(
-		command_window.get(),
-		gamelist_window.get()
-	);
-	return MakeSpan(arr);
-}
-
 void Scene_GameBrowser::CreateWindows() {
 	// Create Options Window
 	std::vector<std::string> options;
@@ -102,25 +94,25 @@ void Scene_GameBrowser::CreateWindows() {
 	options.push_back("About");
 	options.push_back("Exit");
 
-	command_window = std::make_unique<Window_Command_Horizontal>(options, Player::screen_width);
+	command_window = std::make_unique<Window_Command_Horizontal>(this, options, Player::screen_width);
 	command_window->SetY(32);
 	command_window->SetIndex(0);
 
-	gamelist_window = std::make_unique<Window_GameList>(0, 64, Player::screen_width, Player::screen_height - 64);
+	gamelist_window = std::make_unique<Window_GameList>(this, 0, 64, Player::screen_width, Player::screen_height - 64);
 	gamelist_window->Refresh(stack.back().filesystem, false);
 
 	if (stack.size() == 1 && !gamelist_window->HasValidEntry()) {
 		command_window->DisableItem(0);
 	}
 
-	help_window = std::make_unique<Window_Help>(0, 0, Player::screen_width, 32);
+	help_window = std::make_unique<Window_Help>(this, 0, 0, Player::screen_width, 32);
 	help_window->SetText("EasyRPG Player - RPG Maker 2000/2003 interpreter");
 
-	load_window = std::make_unique<Window_Help>(Player::screen_width / 4, Player::screen_height / 2 - 16, Player::screen_width / 2, 32);
+	load_window = std::make_unique<Window_Help>(this, Player::screen_width / 4, Player::screen_height / 2 - 16, Player::screen_width / 2, 32);
 	load_window->SetText("Loading...");
 	load_window->SetVisible(false);
 
-	about_window = std::make_unique<Window_About>(0, 64, Player::screen_width, Player::screen_height - 64);
+	about_window = std::make_unique<Window_About>(this, 0, 64, Player::screen_width, Player::screen_height - 64);
 	about_window->Refresh();
 	about_window->SetVisible(false);
 }

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -85,6 +85,14 @@ void Scene_GameBrowser::vUpdate() {
 	}
 }
 
+Span<Window_Selectable*> Scene_GameBrowser::GetWindowSelectables() {
+	auto arr = Utils::MakeArray<Window_Selectable*>(
+		command_window.get(),
+		gamelist_window.get()
+	);
+	return MakeSpan(arr);
+}
+
 void Scene_GameBrowser::CreateWindows() {
 	// Create Options Window
 	std::vector<std::string> options;

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -103,10 +103,12 @@ void Scene_GameBrowser::CreateWindows() {
 	command_window = std::make_unique<Window_Command_Horizontal>(this, options, Player::screen_width);
 	command_window->SetY(32);
 	command_window->SetIndex(0);
+	command_window->SetHalfActive(true);
 
 	gamelist_window = std::make_unique<Window_GameList>(this, 0, 64, Player::screen_width, Player::screen_height - 64);
 	gamelist_window->Refresh(stack.back().filesystem, false);
 	gamelist_window->SetActive(false);
+	gamelist_window->SetHalfActive(true);
 
 	if (stack.size() == 1 && !gamelist_window->HasValidEntry()) {
 		command_window->DisableItem(0);

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -32,6 +32,7 @@
 #include "bitmap.h"
 #include "audio.h"
 #include "output.h"
+#include <baseui.h>
 
 Scene_GameBrowser::Scene_GameBrowser() {
 	type = Scene::GameBrowser;
@@ -44,6 +45,8 @@ void Scene_GameBrowser::Start() {
 	stack.push_back({ FileFinder::Game(), 0 });
 	CreateWindows();
 	Game_Clock::ResetFrame(Game_Clock::now());
+
+	DisplayUi->Load_Cursor("mouseCursor", -1);
 }
 
 void Scene_GameBrowser::Continue(SceneType /* prev_scene */) {
@@ -66,6 +69,10 @@ void Scene_GameBrowser::Continue(SceneType /* prev_scene */) {
 	Main_Data::game_system->SetSystemGraphic(CACHE_DEFAULT_BITMAP, lcf::rpg::System::Stretch_stretch, lcf::rpg::System::Font_gothic);
 
 	Player::debug_flag = initial_debug_flag;
+
+	Input::SetForceUseMouse(0);
+	DisplayUi->Load_Cursor("mouseCursor", -1);
+	DisplayUi->ChangeCursor(0);
 }
 
 void Scene_GameBrowser::vUpdate() {
@@ -73,7 +80,7 @@ void Scene_GameBrowser::vUpdate() {
 		BootGame();
 		return;
 	}
-	Input::SetUseMouse(false);
+	
 	command_window->Update();
 	gamelist_window->Update();
 
@@ -100,6 +107,7 @@ void Scene_GameBrowser::CreateWindows() {
 
 	gamelist_window = std::make_unique<Window_GameList>(this, 0, 64, Player::screen_width, Player::screen_height - 64);
 	gamelist_window->Refresh(stack.back().filesystem, false);
+	gamelist_window->SetActive(false);
 
 	if (stack.size() == 1 && !gamelist_window->HasValidEntry()) {
 		command_window->DisableItem(0);
@@ -136,7 +144,7 @@ void Scene_GameBrowser::UpdateCommand() {
 	if (Input::IsTriggered(Input::CANCEL)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
 		Scene::Pop();
-	} else if (Input::IsTriggered(Input::DECISION)) {
+	} else if (Input::IsTriggered(Input::DECISION) && menu_index != -999) {
 
 		switch (menu_index) {
 			case GameList:
@@ -166,7 +174,7 @@ void Scene_GameBrowser::UpdateGameListSelection() {
 		gamelist_window->SetActive(false);
 		old_gamelist_index = gamelist_window->GetIndex();
 		gamelist_window->SetIndex(-1);
-	} else if (Input::IsTriggered(Input::DECISION)) {
+	} else if (Input::IsTriggered(Input::DECISION) && gamelist_window->GetIndex() != -999) {
 		load_window->SetVisible(true);
 		game_loading = true;
 	} else if (Input::IsTriggered(Input::DEBUG_MENU) || Input::IsTriggered(Input::SHIFT)) {

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -73,7 +73,7 @@ void Scene_GameBrowser::vUpdate() {
 		BootGame();
 		return;
 	}
-
+	Input::SetUseMouse(false);
 	command_window->Update();
 	gamelist_window->Update();
 

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -86,8 +86,7 @@ void Scene_GameBrowser::vUpdate() {
 
 	if (command_window->GetActive()) {
 		UpdateCommand();
-	}
-	else if (gamelist_window->GetActive()) {
+	} else 	if (gamelist_window->GetActive()) {
 		UpdateGameListSelection();
 	}
 }
@@ -177,7 +176,7 @@ void Scene_GameBrowser::UpdateGameListSelection() {
 	} else if (Input::IsTriggered(Input::DECISION) && gamelist_window->GetIndex() != -999) {
 		load_window->SetVisible(true);
 		game_loading = true;
-	} else if (Input::IsTriggered(Input::DEBUG_MENU) || Input::IsTriggered(Input::SHIFT)) {
+	} else if ((Input::IsTriggered(Input::DEBUG_MENU) || Input::IsTriggered(Input::SHIFT)) && gamelist_window->GetIndex() != -999) {
 		Player::debug_flag = true;
 		load_window->SetVisible(true);
 		game_loading = true;

--- a/src/scene_gamebrowser.h
+++ b/src/scene_gamebrowser.h
@@ -39,8 +39,6 @@ public:
 	void Continue(SceneType prev_scene) override;
 	void vUpdate() override;
 
-	Span<Window_Selectable*> GetWindowSelectables() override;
-
 	/**
 	 * Creates the window displaying the options.
 	 */

--- a/src/scene_gamebrowser.h
+++ b/src/scene_gamebrowser.h
@@ -39,6 +39,8 @@ public:
 	void Continue(SceneType prev_scene) override;
 	void vUpdate() override;
 
+	Span<Window_Selectable*> GetWindowSelectables() override;
+
 	/**
 	 * Creates the window displaying the options.
 	 */

--- a/src/scene_import.cpp
+++ b/src/scene_import.cpp
@@ -58,7 +58,7 @@ void Scene_Import::Start() {
 	// We don't populate them until later (once we've loaded all potential importable files).
 	for (int i = 0; i < 15; i++) {
 		std::shared_ptr<Window_SaveFile>
-			w(new Window_SaveFile(0, 40 + i * 64, Player::screen_width, 64));
+			w = std::make_unique<Window_SaveFile>(this, 0, 40 + i * 64, Player::screen_width, 64);
 		w->SetIndex(i);
 		w->SetVisible(false);
 		w->SetZ(Priority_Window);
@@ -67,7 +67,7 @@ void Scene_Import::Start() {
 	}
 
 	// Create a window to show scanning progress, since this can take a while.
-	progress_window.reset(new Window_ImportProgress(Player::screen_width/4, 40 + 64, Player::screen_width/2, 64));
+	progress_window = std::make_unique<Window_ImportProgress>(this, Player::screen_width/4, 40 + 64, Player::screen_width/2, 64);
 	progress_window->SetZ(Priority_Window + 1);
 
 	border_bottom = Scene_File::MakeBorderSprite(232);

--- a/src/scene_item.cpp
+++ b/src/scene_item.cpp
@@ -39,8 +39,8 @@ Scene_Item::Scene_Item(int item_index) :
 void Scene_Item::Start() {
 	// Create the windows
 	int menu_help_height = 32;
-	help_window.reset(new Window_Help(Player::menu_offset_x, Player::menu_offset_y, MENU_WIDTH, menu_help_height));
-	item_window.reset(new Window_Item(Player::menu_offset_x, Player::menu_offset_y + menu_help_height, MENU_WIDTH, MENU_HEIGHT - menu_help_height));
+	help_window = std::make_unique<Window_Help>(this, Player::menu_offset_x, Player::menu_offset_y, MENU_WIDTH, menu_help_height);
+	item_window = std::make_unique<Window_Item>(this, Player::menu_offset_x, Player::menu_offset_y + menu_help_height, MENU_WIDTH, MENU_HEIGHT - menu_help_height);
 	item_window->SetHelpWindow(help_window.get());
 	item_window->Refresh();
 	item_window->SetIndex(item_index);

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -74,7 +74,7 @@ Scene_Map::~Scene_Map() {
 void Scene_Map::Start() {
 	Scene_Debug::ResetPrevIndices();
 	spriteset.reset(new Spriteset_Map());
-	message_window.reset(new Window_Message(Player::message_box_offset_x, Player::screen_height - MESSAGE_BOX_HEIGHT, MESSAGE_BOX_WIDTH, MESSAGE_BOX_HEIGHT));
+	message_window = std::make_unique<Window_Message>(this, Player::message_box_offset_x, Player::screen_height - MESSAGE_BOX_HEIGHT, MESSAGE_BOX_WIDTH, MESSAGE_BOX_HEIGHT);
 
 	Game_Message::SetWindow(message_window.get());
 

--- a/src/scene_menu.cpp
+++ b/src/scene_menu.cpp
@@ -49,10 +49,10 @@ void Scene_Menu::Start() {
 	CreateCommandWindow();
 
 	// Gold Window
-	gold_window.reset(new Window_Gold(Player::menu_offset_x, (Player::screen_height - gold_window_height - Player::menu_offset_y), gold_window_width, gold_window_height));
+	gold_window = std::make_unique<Window_Gold>(this, Player::menu_offset_x, (Player::screen_height - gold_window_height - Player::menu_offset_y), gold_window_width, gold_window_height);
 
 	// Status Window
-	menustatus_window.reset(new Window_MenuStatus(Player::menu_offset_x + menu_command_width, Player::menu_offset_y, (MENU_WIDTH - menu_command_width), MENU_HEIGHT));
+	menustatus_window = std::make_unique<Window_MenuStatus>(this, Player::menu_offset_x + menu_command_width, Player::menu_offset_y, (MENU_WIDTH - menu_command_width), MENU_HEIGHT);
 	menustatus_window->SetActive(false);
 }
 
@@ -158,7 +158,7 @@ void Scene_Menu::CreateCommandWindow() {
 		}
 	}
 
-	command_window.reset(new Window_Command(options, menu_command_width));
+	command_window = std::make_unique<Window_Command>(this, options, menu_command_width);
 	command_window->SetX(Player::menu_offset_x);
 	command_window->SetY(Player::menu_offset_y);
 	command_window->SetIndex(menu_index);

--- a/src/scene_menu.cpp
+++ b/src/scene_menu.cpp
@@ -196,64 +196,64 @@ void Scene_Menu::UpdateCommand() {
 		Scene::Pop();
 	} else if (Input::IsTriggered(Input::DECISION)) {
 		menu_index = command_window->GetIndex();
-
-		switch (command_options[menu_index]) {
-		case Item:
-			if (Main_Data::game_party->GetActors().empty()) {
-				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
-			} else {
+		if (menu_index >= 0 && menu_index < command_options.size())
+			switch (command_options[menu_index]) {
+			case Item:
+				if (Main_Data::game_party->GetActors().empty()) {
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
+				} else {
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
+					Scene::Push(std::make_shared<Scene_Item>());
+				}
+				break;
+			case Skill:
+			case Equipment:
+			case Status:
+			case Row:
+				if (Main_Data::game_party->GetActors().empty()) {
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
+				} else {
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
+					command_window->SetActive(false);
+					menustatus_window->SetActive(true);
+					menustatus_window->SetIndex(0);
+				}
+				break;
+			case Save:
+				if (!Main_Data::game_system->GetAllowSave()) {
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
+				} else {
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
+					Scene::Push(std::make_shared<Scene_Save>());
+				}
+				break;
+			case Order:
+				if (Main_Data::game_party->GetActors().size() <= 1) {
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
+				} else {
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
+					Scene::Push(std::make_shared<Scene_Order>());
+				}
+				break;
+			case Wait:
 				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
-				Scene::Push(std::make_shared<Scene_Item>());
-			}
-			break;
-		case Skill:
-		case Equipment:
-		case Status:
-		case Row:
-			if (Main_Data::game_party->GetActors().empty()) {
-				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
-			} else {
+				Main_Data::game_system->ToggleAtbMode();
+				command_window->SetItemText(menu_index,
+					Main_Data::game_system->GetAtbMode() == lcf::rpg::SaveSystem::AtbMode_atb_wait ? lcf::Data::terms.wait_on : lcf::Data::terms.wait_off);
+				break;
+			case Settings:
+				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Game_System::SFX_Decision));
+				Scene::Push(std::make_shared<Scene_Settings>());
+				break;
+			case Debug:
 				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
-				command_window->SetActive(false);
-				menustatus_window->SetActive(true);
-				menustatus_window->SetIndex(0);
-			}
-			break;
-		case Save:
-			if (!Main_Data::game_system->GetAllowSave()) {
-				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
-			} else {
+				Scene::Push(std::make_shared<Scene_Debug>());
+				break;
+			case Quit:
 				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
-				Scene::Push(std::make_shared<Scene_Save>());
+				Scene::Push(std::make_shared<Scene_End>());
+				break;
 			}
-			break;
-		case Order:
-			if (Main_Data::game_party->GetActors().size() <= 1) {
-				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
-			} else {
-				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
-				Scene::Push(std::make_shared<Scene_Order>());
-			}
-			break;
-		case Wait:
-			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
-			Main_Data::game_system->ToggleAtbMode();
-			command_window->SetItemText(menu_index,
-				Main_Data::game_system->GetAtbMode() == lcf::rpg::SaveSystem::AtbMode_atb_wait ? lcf::Data::terms.wait_on : lcf::Data::terms.wait_off);
-			break;
-		case Settings:
-			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Game_System::SFX_Decision));
-			Scene::Push(std::make_shared<Scene_Settings>());
-			break;
-		case Debug:
-			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
-			Scene::Push(std::make_shared<Scene_Debug>());
-			break;
-		case Quit:
-			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
-			Scene::Push(std::make_shared<Scene_End>());
-			break;
-		}
 	}
 }
 
@@ -263,7 +263,7 @@ void Scene_Menu::UpdateActorSelection() {
 		command_window->SetActive(true);
 		menustatus_window->SetActive(false);
 		menustatus_window->SetIndex(-1);
-	} else if (Input::IsTriggered(Input::DECISION)) {
+	} else if (Input::IsTriggered(Input::DECISION) && command_window->GetIndex() < command_options.size() && command_window->GetIndex() >= 0 && menustatus_window->GetIndex() >= 0) {
 		switch (command_options[command_window->GetIndex()]) {
 		case Skill:
 			if (!menustatus_window->GetActor()->CanAct()) {

--- a/src/scene_menu.cpp
+++ b/src/scene_menu.cpp
@@ -35,6 +35,7 @@
 #include "scene_status.h"
 #include "bitmap.h"
 #include "feature.h"
+#include <output.h>
 
 constexpr int menu_command_width = 88;
 constexpr int gold_window_width = 88;
@@ -162,6 +163,7 @@ void Scene_Menu::CreateCommandWindow() {
 	command_window->SetX(Player::menu_offset_x);
 	command_window->SetY(Player::menu_offset_y);
 	command_window->SetIndex(menu_index);
+	//command_window->SetHalfActive(true);
 
 	// Disable items
 	for (it = command_options.begin(); it != command_options.end(); ++it) {
@@ -258,6 +260,20 @@ void Scene_Menu::UpdateCommand() {
 }
 
 void Scene_Menu::UpdateActorSelection() {
+
+	Point mouse_pos = Input::GetMousePosition();
+	int index = command_window->CursorHitTest({ mouse_pos.x - command_window->GetX(), mouse_pos.y - command_window->GetY() });
+	if (index == -1) {
+		isOutSideCommands = true;
+	}
+	else if (isOutSideCommands){
+		command_window->SetActive(true);
+		menustatus_window->SetActive(false);
+		menustatus_window->SetIndex(-1);
+		command_window->SetIndex(index);
+		isOutSideCommands = false;
+	}
+
 	if (Input::IsTriggered(Input::CANCEL)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
 		command_window->SetActive(true);

--- a/src/scene_menu.h
+++ b/src/scene_menu.h
@@ -75,6 +75,8 @@ private:
 	/** Selected index on startup. */
 	int menu_index;
 
+	bool isOutSideCommands = false;
+
 	/** Window displaying the commands. */
 	std::unique_ptr<Window_Command> command_window;
 

--- a/src/scene_name.cpp
+++ b/src/scene_name.cpp
@@ -50,11 +50,11 @@ void Scene_Name::Start() {
 	int window_keyboard_width = 256;
 	int window_keyboard_height = 160;
 
-	face_window.reset(new Window_Face(Player::menu_offset_x + margin_x, Player::menu_offset_y + margin_y, window_face_width, window_face_height));
+	face_window = std::make_unique<Window_Face>(this, Player::menu_offset_x + margin_x, Player::menu_offset_y + margin_y, window_face_width, window_face_height);
 	face_window->Set(actor_id);
 	face_window->Refresh();
 
-	name_window.reset(new Window_Name(Player::menu_offset_x + window_face_width + margin_x, Player::menu_offset_y + margin_y + 32, window_name_width, window_name_height));
+	name_window = std::make_unique<Window_Name>(this, Player::menu_offset_x + window_face_width + margin_x, Player::menu_offset_y + margin_y + 32, window_name_width, window_name_height);
 	name_window->Set(use_default_name ? ToString(actor->GetName()) : "");
 	name_window->Refresh();
 
@@ -88,7 +88,7 @@ void Scene_Name::Start() {
 	// Letter and symbol pages are used everywhere
 	layouts.push_back(Window_Keyboard::Letter);
 	layouts.push_back(Window_Keyboard::Symbol);
-	kbd_window.reset(new Window_Keyboard(Player::menu_offset_x + margin_x, Player::menu_offset_y + window_face_height + margin_y, window_keyboard_width, window_keyboard_height, done));
+	kbd_window = std::make_unique<Window_Keyboard>(this, Player::menu_offset_x + margin_x, Player::menu_offset_y + window_face_height + margin_y, window_keyboard_width, window_keyboard_height, done);
 
 	auto next_index = layout_index + 1;
 	if (next_index >= static_cast<int>(layouts.size())) {

--- a/src/scene_name.cpp
+++ b/src/scene_name.cpp
@@ -111,7 +111,7 @@ void Scene_Name::vUpdate() {
 		} else {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 		}
-	} else if (Input::IsTriggered(Input::DECISION)) {
+	} else if (Input::IsTriggered(Input::DECISION) && !kbd_window->mouseOutside) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 		std::string const& s = kbd_window->GetSelected();
 

--- a/src/scene_name.cpp
+++ b/src/scene_name.cpp
@@ -145,4 +145,8 @@ void Scene_Name::vUpdate() {
 			name_window->Append(s);
 		}
 	}
+	else if (Input::IsTriggered(Input::DECISION) && !Input::IsReleased(Input::MOUSE_LEFT) && kbd_window->mouseOutside) {
+		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+		kbd_window->mouseOutside = false;
+	}
 }

--- a/src/scene_order.cpp
+++ b/src/scene_order.cpp
@@ -112,17 +112,17 @@ void Scene_Order::CreateCommandWindow() {
 	options_confirm.push_back(lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_order_scene_confirm, "Confirm"));
 	options_confirm.push_back(lcf::rpg::Terms::TermOrDefault(lcf::Data::terms.easyrpg_order_scene_redo, "Redo"));
 
-	window_left.reset(new Window_Command(options_left, 88, 4));
+	window_left = std::make_unique<Window_Command>(this, options_left, 88, 4);
 	window_left->SetX(Player::menu_offset_x + 68);
 	window_left->SetY(Player::menu_offset_y + 48);
 
-	window_right.reset(new Window_Command(options_right, 88, 4));
+	window_right = std::make_unique<Window_Command>(this, options_right, 88, 4);
 	window_right->SetX(Player::menu_offset_x + 164);
 	window_right->SetY(Player::menu_offset_y + 48);
 	window_right->SetActive(false);
 	window_right->SetIndex(-1);
 
-	window_confirm.reset(new Window_Command(options_confirm, 80));
+	window_confirm = std::make_unique<Window_Command>(this, options_confirm, 80);
 	window_confirm->SetX(Player::menu_offset_x + 120);
 	window_confirm->SetY(Player::menu_offset_y + 144);
 	window_confirm->SetActive(false);

--- a/src/scene_order.cpp
+++ b/src/scene_order.cpp
@@ -61,7 +61,7 @@ void Scene_Order::UpdateOrder() {
 			window_right->SetItemText(actor_counter, "");
 			actors[actor_counter] = 0;
 		}
-	} else if (Input::IsTriggered(Input::DECISION)) {
+	} else if (Input::IsTriggered(Input::DECISION) && window_left->GetIndex() < Main_Data::game_party->GetActors().size()) {
 		if (std::find(actors.begin(), actors.end(), window_left->GetIndex() + 1) != actors.end()) {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
 		} else {
@@ -92,7 +92,7 @@ void Scene_Order::UpdateConfirm() {
 		if (window_confirm->GetIndex() == 0) {
 			Confirm();
 			Scene::Pop();
-		} else {
+		} else if(window_confirm->GetIndex() == 1) {
 			Redo();
 		}
 	}

--- a/src/scene_settings.cpp
+++ b/src/scene_settings.cpp
@@ -266,6 +266,17 @@ void Scene_Settings::vUpdate() {
 	}
 }
 
+Span<Window_Selectable*> Scene_Settings::GetWindowSelectables() {
+	auto arr = Utils::MakeArray<Window_Selectable*>(
+		main_window.get(),
+		options_window.get(),
+		input_window.get(),
+		input_mode_window.get(),
+		picker_window.get()
+	);
+	return MakeSpan(arr);
+}
+
 void Scene_Settings::OnTitleSpriteReady(FileRequestResult* result) {
 	BitmapRef bitmapRef = Cache::Title(result->file);
 

--- a/src/scene_settings.cpp
+++ b/src/scene_settings.cpp
@@ -73,7 +73,7 @@ void Scene_Settings::CreateMainWindow() {
 		options.push_back("<Exit Game>");
 	}
 
-	main_window = std::make_unique<Window_Command>(std::move(options));
+	main_window = std::make_unique<Window_Command>(this, std::move(options));
 	main_window->SetHeight(176);
 	main_window->SetY((Player::screen_height - main_window->GetHeight()) / 2);
 	main_window->SetX((Player::screen_width - main_window->GetWidth()) / 2);
@@ -87,15 +87,15 @@ void Scene_Settings::CreateMainWindow() {
 }
 
 void Scene_Settings::CreateOptionsWindow() {
-	help_window.reset(new Window_Help(Player::menu_offset_x, 0, MENU_WIDTH, 32));
-	options_window = std::make_unique<Window_Settings>(Player::menu_offset_x + 32, 32, MENU_WIDTH - 64, Player::screen_height - 32 * 2);
+	help_window = std::make_unique<Window_Help>(this, Player::menu_offset_x, 0, MENU_WIDTH, 32);
+	options_window = std::make_unique<Window_Settings>(this, Player::menu_offset_x + 32, 32, MENU_WIDTH - 64, Player::screen_height - 32 * 2);
 	options_window->SetHelpWindow(help_window.get());
 
-	input_window = std::make_unique<Window_InputSettings>(Player::menu_offset_x, 32, MENU_WIDTH, Player::screen_height - 32 * 3);
+	input_window = std::make_unique<Window_InputSettings>(this, Player::menu_offset_x, 32, MENU_WIDTH, Player::screen_height - 32 * 3);
 	input_window->SetHelpWindow(help_window.get());
 
 	std::vector<std::string> input_mode_items = {"Add", "Remove", "Reset"};
-	input_mode_window = std::make_unique<Window_Command_Horizontal>(input_mode_items, MENU_WIDTH - 32 * 2);
+	input_mode_window = std::make_unique<Window_Command_Horizontal>(this, input_mode_items, MENU_WIDTH - 32 * 2);
 	input_mode_window->SetX(Player::menu_offset_x + 32);
 	input_mode_window->SetY(Player::screen_height - 32);
 	input_mode_window->SetHelpWindow(help_window.get());
@@ -109,9 +109,9 @@ void Scene_Settings::CreateOptionsWindow() {
 		}
 	};
 
-	input_help_window = std::make_unique<Window_Help>(Player::menu_offset_x, Player::screen_height - 64, MENU_WIDTH, 32);
+	input_help_window = std::make_unique<Window_Help>(this, Player::menu_offset_x, Player::screen_height - 64, MENU_WIDTH, 32);
 
-	about_window = std::make_unique<Window_About>(Player::menu_offset_x, Player::menu_offset_y + 32, MENU_WIDTH, MENU_HEIGHT - 64);
+	about_window = std::make_unique<Window_About>(this, Player::menu_offset_x, Player::menu_offset_y + 32, MENU_WIDTH, MENU_HEIGHT - 64);
 	about_window->Refresh();
 }
 
@@ -266,17 +266,6 @@ void Scene_Settings::vUpdate() {
 	}
 }
 
-Span<Window_Selectable*> Scene_Settings::GetWindowSelectables() {
-	auto arr = Utils::MakeArray<Window_Selectable*>(
-		main_window.get(),
-		options_window.get(),
-		input_window.get(),
-		input_mode_window.get(),
-		picker_window.get()
-	);
-	return MakeSpan(arr);
-}
-
 void Scene_Settings::OnTitleSpriteReady(FileRequestResult* result) {
 	BitmapRef bitmapRef = Cache::Title(result->file);
 
@@ -414,7 +403,7 @@ void Scene_Settings::UpdateOptions() {
 				option.action();
 				options_window->Refresh();
 			} else if (option.mode == Window_Settings::eOptionRangeInput) {
-				number_window.reset(new Window_NumberInput(0, 0, 128, 32));
+				number_window = std::make_unique<Window_NumberInput>(this, 0, 0, 128, 32);
 				number_window->SetNumber(option.current_value);
 				number_window->SetMaxDigits(std::log10(option.max_value) + 1);
 				number_window->SetX(options_window->GetX() + options_window->GetWidth() / 2 - number_window->GetWidth() / 2);
@@ -425,7 +414,7 @@ void Scene_Settings::UpdateOptions() {
 				help_window->SetText(fmt::format("Input a value from {} to {}", option.min_value, option.max_value));
 				options_window->SetActive(false);
 			} else if (option.mode == Window_Settings::eOptionPicker) {
-				picker_window.reset(new Window_Command(option.options_text));
+				picker_window = std::make_unique<Window_Command>(this, option.options_text);
 				picker_window->SetX(options_window->GetX() + options_window->GetWidth() / 2 - picker_window->GetWidth() / 2);
 				picker_window->SetY(options_window->GetY() + options_window->GetHeight() / 2 - picker_window->GetHeight() / 2);
 				picker_window->SetZ(options_window->GetZ() + 1);

--- a/src/scene_settings.cpp
+++ b/src/scene_settings.cpp
@@ -292,7 +292,7 @@ void Scene_Settings::UpdateMain() {
 	);
 
 	if (Input::IsTriggered(Input::DECISION)) {
-		if (main_window->GetIndex() > 0) {
+		if (main_window->GetIndex() >= 0) {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Game_System::SFX_Decision));
 			auto idx = main_window->GetIndex();
 
@@ -380,7 +380,7 @@ void Scene_Settings::UpdateOptions() {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Game_System::SFX_Decision));
 		}
 		return;
-	} else if (picker_window) {
+	} else if (picker_window && picker_window->GetIndex() != -999) {
 		picker_window->Update();
 		auto& option = options_window->GetCurrentOption();
 		option.current_value = option.options_index[picker_window->GetIndex()];
@@ -403,7 +403,7 @@ void Scene_Settings::UpdateOptions() {
 				option.action();
 				options_window->Refresh();
 			} else if (option.mode == Window_Settings::eOptionRangeInput) {
-				number_window = std::make_unique<Window_NumberInput>(this, 0, 0, 128, 32);
+				number_window = std::make_unique<Window_NumberInput>(this, 0, 0, 128 + 16, 32);
 				number_window->SetNumber(option.current_value);
 				number_window->SetMaxDigits(std::log10(option.max_value) + 1);
 				number_window->SetX(options_window->GetX() + options_window->GetWidth() / 2 - number_window->GetWidth() / 2);

--- a/src/scene_settings.cpp
+++ b/src/scene_settings.cpp
@@ -331,7 +331,49 @@ void Scene_Settings::UpdateOptions() {
 		option.current_value = Utils::Clamp(number_window->GetNumber(), option.min_value, option.max_value);
 		option.action();
 
-		if (Input::IsTriggered(Input::DECISION)) {
+		if (Input::GetUseMouseButton()) {
+			Point mouseP = Input::GetMousePosition();
+
+			int new_index = (mouseP.x - number_window->GetX() - number_window->GetBorderX() - number_window->GetItemRect(0).x + 4) / (12) - 1;
+
+			if (new_index >= 0 && new_index < number_window->GetMaxDigits()) {
+				// Change cursor (Hand)
+				DisplayUi->ChangeCursor(1);
+				if (Input::IsPressed(Input::MOUSE_LEFT)) {
+
+					number_window->SetIndex(-999);
+					// Output::Debug("{} {} {}", new_index, number_input_window->GetIndex(), number_input_window->GetMouseOldIndex());
+
+					if (new_index != number_window->GetMouseOldIndex())
+						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+
+					if (number_window->GetIndex() != -999 && number_window->GetIndex() != -1)
+						number_window->SetMouseOldIndex(number_window->GetIndex());
+
+					number_window->SetIndex(new_index);
+
+				}
+			}
+
+			number_window->UpdateCursorRect();
+
+			int dx = number_window->GetMaxDigits() * 12 + 32 + 12;
+			if ((mouseP.x >= number_window->GetX() + number_window->GetBorderX() + dx && mouseP.x <= number_window->GetX() + number_window->GetBorderX() + dx + 14 &&
+				mouseP.y >= number_window->GetY() + number_window->GetBorderY() && mouseP.y < number_window->GetY() + number_window->GetBorderY() + number_window->GetItemRect(0).height)) {
+
+				// Change cursor (Hand)
+				DisplayUi->ChangeCursor(1);
+
+				if (Input::IsReleased(Input::MOUSE_LEFT)) {
+					options_window->Refresh();
+					number_window.reset();
+					options_window->SetActive(true);
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Game_System::SFX_Decision));
+				}
+			}
+		}
+
+		if (Input::IsTriggered(Input::DECISION) && !Input::IsReleased(Input::MOUSE_LEFT)) {
 			options_window->Refresh();
 			number_window.reset();
 			options_window->SetActive(true);

--- a/src/scene_settings.cpp
+++ b/src/scene_settings.cpp
@@ -292,30 +292,35 @@ void Scene_Settings::UpdateMain() {
 	);
 
 	if (Input::IsTriggered(Input::DECISION)) {
-		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Game_System::SFX_Decision));
-		auto idx = main_window->GetIndex();
-
-		if (main_window->IsItemEnabled(idx)) {
+		if (main_window->GetIndex() > 0) {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Game_System::SFX_Decision));
-		} else {
-			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Game_System::SFX_Buzzer));
-			return;
-		}
+			auto idx = main_window->GetIndex();
 
-		if (modes[idx] == Window_Settings::eSave) {
-			SaveConfig();
-			return;
-		} else if (modes[idx] == Window_Settings::eEnd) {
-			if (Scene::Find(Scene::GameBrowser)) {
-				Scene::Push(std::make_unique<Scene_End>(Scene::GameBrowser));
+			if (main_window->IsItemEnabled(idx)) {
+				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Game_System::SFX_Decision));
 			} else {
-				Scene::Push(std::make_unique<Scene_End>(Scene::Null));
+				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Game_System::SFX_Buzzer));
+				return;
 			}
-			return;
-		}
 
-		SetMode(modes[idx]);
-		options_window->Push(modes[idx]);
+
+			if (modes[idx] == Window_Settings::eSave) {
+				SaveConfig();
+				return;
+			}
+			else if (modes[idx] == Window_Settings::eEnd) {
+				if (Scene::Find(Scene::GameBrowser)) {
+					Scene::Push(std::make_unique<Scene_End>(Scene::GameBrowser));
+				}
+				else {
+					Scene::Push(std::make_unique<Scene_End>(Scene::Null));
+				}
+				return;
+			}
+
+			SetMode(modes[idx]);
+			options_window->Push(modes[idx]);
+		}
 	}
 }
 
@@ -348,7 +353,7 @@ void Scene_Settings::UpdateOptions() {
 		return;
 	}
 
-	if (Input::IsTriggered(Input::DECISION)) {
+	if (Input::IsTriggered(Input::DECISION) && options_window->GetIndex() >= 0) {
 		if (options_window->IsCurrentActionEnabled()) {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Game_System::SFX_Decision));
 			auto& option = options_window->GetCurrentOption();

--- a/src/scene_settings.h
+++ b/src/scene_settings.h
@@ -45,8 +45,6 @@ public:
 	void Start() override;
 	void vUpdate() override;
 
-	Span<Window_Selectable*> GetWindowSelectables() override;
-
 	/**
 	 * Saves the configuration to the global config file.
 	 * @param silent When true only log messages instead of displaying them

--- a/src/scene_settings.h
+++ b/src/scene_settings.h
@@ -45,6 +45,8 @@ public:
 	void Start() override;
 	void vUpdate() override;
 
+	Span<Window_Selectable*> GetWindowSelectables() override;
+
 	/**
 	 * Saves the configuration to the global config file.
 	 * @param silent When true only log messages instead of displaying them

--- a/src/scene_shop.cpp
+++ b/src/scene_shop.cpp
@@ -61,16 +61,16 @@ void Scene_Shop::Start() {
 	int window_gold_height = 32;
 	int window_shop_height = 80;
 
-	help_window.reset(new Window_Help(Player::menu_offset_x, Player::menu_offset_y, MENU_WIDTH, window_help_height));
-	buy_window.reset(new Window_ShopBuy(goods, Player::menu_offset_x, Player::menu_offset_y + window_help_height, window_buy_width, window_buy_height));
-	number_window.reset(new Window_ShopNumber(Player::menu_offset_x, Player::menu_offset_y + window_help_height, window_buy_width, window_buy_height));
-	party_window.reset(new Window_ShopParty(Player::menu_offset_x + window_buy_width, Player::menu_offset_y + window_help_height, window_party_width, window_party_height));
-	status_window.reset(new Window_ShopStatus(Player::menu_offset_x + window_buy_width, Player::menu_offset_y + window_help_height + window_party_height, window_status_width, window_status_height));
-	gold_window.reset(new Window_Gold(Player::menu_offset_x + window_buy_width, Player::menu_offset_y + window_help_height + window_party_height + window_status_height, window_gold_width, window_gold_height));
-	shop_window.reset(new Window_Shop(shop_type, Player::menu_offset_x, Player::menu_offset_y + window_help_height + window_party_height + window_status_height + window_gold_height, MENU_WIDTH, window_shop_height));
-	sell_window.reset(new Window_ShopSell(Player::menu_offset_x, Player::menu_offset_y + window_help_height, MENU_WIDTH, window_buy_height));
-	empty_window.reset(new Window_Base(Player::menu_offset_x, Player::menu_offset_y + window_help_height, MENU_WIDTH, window_buy_height));
-	empty_window2.reset(new Window_Base(Player::menu_offset_x, Player::menu_offset_y + window_help_height, window_buy_width, window_buy_height));
+	help_window = std::make_unique<Window_Help>(this, Player::menu_offset_x, Player::menu_offset_y, MENU_WIDTH, window_help_height);
+	buy_window = std::make_unique<Window_ShopBuy>(this, goods, Player::menu_offset_x, Player::menu_offset_y + window_help_height, window_buy_width, window_buy_height);
+	number_window = std::make_unique<Window_ShopNumber>(this, Player::menu_offset_x, Player::menu_offset_y + window_help_height, window_buy_width, window_buy_height);
+	party_window = std::make_unique<Window_ShopParty>(this, Player::menu_offset_x + window_buy_width, Player::menu_offset_y + window_help_height, window_party_width, window_party_height);
+	status_window = std::make_unique<Window_ShopStatus>(this, Player::menu_offset_x + window_buy_width, Player::menu_offset_y + window_help_height + window_party_height, window_status_width, window_status_height);
+	gold_window = std::make_unique<Window_Gold>(this, Player::menu_offset_x + window_buy_width, Player::menu_offset_y + window_help_height + window_party_height + window_status_height, window_gold_width, window_gold_height);
+	shop_window = std::make_unique<Window_Shop>(this, shop_type, Player::menu_offset_x, Player::menu_offset_y + window_help_height + window_party_height + window_status_height + window_gold_height, MENU_WIDTH, window_shop_height);
+	sell_window = std::make_unique<Window_ShopSell>(this, Player::menu_offset_x, Player::menu_offset_y + window_help_height, MENU_WIDTH, window_buy_height);
+	empty_window = std::make_unique<Window_Base>(this, Player::menu_offset_x, Player::menu_offset_y + window_help_height, MENU_WIDTH, window_buy_height);
+	empty_window2 = std::make_unique<Window_Base>(this, Player::menu_offset_x, Player::menu_offset_y + window_help_height, window_buy_width, window_buy_height);
 
 	buy_window->SetActive(false);
 	buy_window->SetVisible(false);

--- a/src/scene_shop.cpp
+++ b/src/scene_shop.cpp
@@ -230,7 +230,7 @@ void Scene_Shop::UpdateCommandSelection() {
 	if (Input::IsTriggered(Input::CANCEL)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
 		Scene::Pop();
-	} else if (Input::IsTriggered(Input::DECISION)) {
+	} else if (Input::IsTriggered(Input::DECISION) && shop_window->GetIndex() >= 0) {
 		switch (shop_window->GetChoice()) {
 			case Buy:
 			case Sell:
@@ -272,7 +272,7 @@ void Scene_Shop::UpdateBuySelection() {
 
 			SetMode(BuyHowMany);
 		}
-		else {
+		else if (buy_window->GetIndex() >= 0) {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 		}
 	}
@@ -296,9 +296,11 @@ void Scene_Shop::UpdateSellSelection() {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 			number_window->SetData(item->ID, Main_Data::game_party->GetItemCount(item->ID), item->price / 2);
 			SetMode(SellHowMany);
-		} else {
+		}
+		else if (sell_window->GetIndex() >= 0) {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 		}
+		
 	}
 }
 

--- a/src/scene_shop.cpp
+++ b/src/scene_shop.cpp
@@ -244,8 +244,14 @@ void Scene_Shop::UpdateCommandSelection() {
 }
 
 void Scene_Shop::UpdateBuySelection() {
-	status_window->SetItemId(buy_window->GetItemId());
-	party_window->SetItemId(buy_window->GetItemId());
+	if (buy_window->GetIndex() >= 0) {
+		status_window->SetItemId(buy_window->GetItemId());
+		party_window->SetItemId(buy_window->GetItemId());
+	}
+	else {
+		status_window->SetItemId(-1);
+		party_window->SetItemId(-1);
+	}
 
 	if (Input::IsTriggered(Input::CANCEL)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
@@ -254,7 +260,7 @@ void Scene_Shop::UpdateBuySelection() {
 		} else {
 			Scene::Pop();
 		}
-	} else if (Input::IsTriggered(Input::DECISION)) {
+	} else if (Input::IsTriggered(Input::DECISION) && buy_window->GetIndex() >= 0) {
 		int item_id = buy_window->GetItemId();
 
 		// checks the money and number of items possessed before buy
@@ -272,7 +278,7 @@ void Scene_Shop::UpdateBuySelection() {
 
 			SetMode(BuyHowMany);
 		}
-		else if (buy_window->GetIndex() >= 0) {
+		else {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 		}
 	}
@@ -286,7 +292,7 @@ void Scene_Shop::UpdateSellSelection() {
 		} else {
 			Scene::Pop();
 		}
-	} else if (Input::IsTriggered(Input::DECISION)) {
+	} else if (Input::IsTriggered(Input::DECISION) && sell_window->GetIndex() >= 0) {
 		const lcf::rpg::Item* item = sell_window->GetItem();
 		int item_id = (item != nullptr) ? item->ID : 0;
 		status_window->SetItemId(item_id);
@@ -297,7 +303,7 @@ void Scene_Shop::UpdateSellSelection() {
 			number_window->SetData(item->ID, Main_Data::game_party->GetItemCount(item->ID), item->price / 2);
 			SetMode(SellHowMany);
 		}
-		else if (sell_window->GetIndex() >= 0) {
+		else {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 		}
 		
@@ -313,7 +319,7 @@ void Scene_Shop::UpdateNumberInput() {
 		case Sell:
 			SetMode(Sell); break;
 		}
-	} else if (Input::IsTriggered(Input::DECISION)) {
+	} else if (Input::IsTriggered(Input::DECISION) && !number_window->disabledByMouse) {
 		int item_id;
 		switch (shop_window->GetChoice()) {
 		case Buy:

--- a/src/scene_skill.cpp
+++ b/src/scene_skill.cpp
@@ -37,9 +37,9 @@ void Scene_Skill::Start() {
 	// Create the windows
 	int window_help_height = 32;
 	int window_skillstatus_height = 32;
-	help_window.reset(new Window_Help(Player::menu_offset_x, Player::menu_offset_y, MENU_WIDTH, window_help_height));
-	skillstatus_window.reset(new Window_SkillStatus(Player::menu_offset_x, Player::menu_offset_y + window_help_height, MENU_WIDTH, window_skillstatus_height));
-	skill_window.reset(new Window_Skill(Player::menu_offset_x, Player::menu_offset_y + window_help_height + window_skillstatus_height, MENU_WIDTH, MENU_HEIGHT - (window_help_height + window_skillstatus_height)));
+	help_window = std::make_unique<Window_Help>(this, Player::menu_offset_x, Player::menu_offset_y, MENU_WIDTH, window_help_height);
+	skillstatus_window = std::make_unique<Window_SkillStatus>(this, Player::menu_offset_x, Player::menu_offset_y + window_help_height, MENU_WIDTH, window_skillstatus_height);
+	skill_window = std::make_unique<Window_Skill>(this, Player::menu_offset_x, Player::menu_offset_y + window_help_height + window_skillstatus_height, MENU_WIDTH, MENU_HEIGHT - (window_help_height + window_skillstatus_height));
 
 	// Assign actors and help to windows
 	skill_window->SetActor(Main_Data::game_party->GetActors()[actor_index]->GetId());

--- a/src/scene_status.cpp
+++ b/src/scene_status.cpp
@@ -43,11 +43,11 @@ void Scene_Status::Start() {
 
 	int actor = Main_Data::game_party->GetActors()[actor_index]->GetId();
 
-	actorinfo_window.reset(new Window_ActorInfo(Player::menu_offset_x, Player::menu_offset_y, window_actor_info_width, window_actor_info_height, actor));
-	gold_window.reset(new Window_Gold(Player::menu_offset_x, Player::menu_offset_y + window_actor_info_height, window_gold_width, window_gold_height));
-	actorstatus_window.reset(new Window_ActorStatus(Player::menu_offset_x + window_actor_info_width, Player::menu_offset_y, window_actor_status_width, window_actor_status_height, actor));
-	paramstatus_window.reset(new Window_ParamStatus(Player::menu_offset_x + window_actor_info_width, Player::menu_offset_y + window_actor_status_height, window_param_status_width, window_param_status_height, actor));
-	equip_window.reset(new Window_Equip(Player::menu_offset_x + window_actor_info_width, Player::menu_offset_y + window_actor_status_height + window_param_status_height, window_equip_width, window_equip_height, actor));
+	actorinfo_window = std::make_unique<Window_ActorInfo>(this, Player::menu_offset_x, Player::menu_offset_y, window_actor_info_width, window_actor_info_height, actor);
+	gold_window = std::make_unique<Window_Gold>(this, Player::menu_offset_x, Player::menu_offset_y + window_actor_info_height, window_gold_width, window_gold_height);
+	actorstatus_window = std::make_unique<Window_ActorStatus>(this, Player::menu_offset_x + window_actor_info_width, Player::menu_offset_y, window_actor_status_width, window_actor_status_height, actor);
+	paramstatus_window = std::make_unique<Window_ParamStatus>(this, Player::menu_offset_x + window_actor_info_width, Player::menu_offset_y + window_actor_status_height, window_param_status_width, window_param_status_height, actor);
+	equip_window = std::make_unique<Window_Equip>(this, Player::menu_offset_x + window_actor_info_width, Player::menu_offset_y + window_actor_status_height + window_param_status_height, window_equip_width, window_equip_height, actor);
 
 	equip_window->SetActive(false);
 	paramstatus_window->SetActive(false);

--- a/src/scene_teleport.cpp
+++ b/src/scene_teleport.cpp
@@ -36,7 +36,7 @@ Scene_Teleport::Scene_Teleport(const lcf::rpg::Item& item, const lcf::rpg::Skill
 }
 
 void Scene_Teleport::Start() {
-	teleport_window.reset(new Window_Teleport(0, Player::screen_height - 80, Player::screen_width, 80));
+	teleport_window = std::make_unique<Window_Teleport>(this, 0, Player::screen_height - 80, Player::screen_width, 80);
 	teleport_window->SetActive(true);
 	teleport_window->SetIndex(0);
 }

--- a/src/scene_teleport.cpp
+++ b/src/scene_teleport.cpp
@@ -44,7 +44,7 @@ void Scene_Teleport::Start() {
 void Scene_Teleport::vUpdate() {
 	teleport_window->Update();
 
-	if (Input::IsTriggered(Input::DECISION)) {
+	if (Input::IsTriggered(Input::DECISION) && teleport_window->GetIndex() >= 0) {
 		if (item) {
 			Main_Data::game_party->ConsumeItemUse(item->ID);
 		} else {

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -206,6 +206,11 @@ void Scene_Title::OnTranslationChanged() {
 	Scene::OnTranslationChanged();
 }
 
+Span<Window_Selectable*> Scene_Title::GetWindowSelectables() {
+	auto arr = Utils::MakeArray<Window_Selectable*>(command_window.get());
+	return MakeSpan(arr);
+}
+
 void Scene_Title::CreateTitleGraphic() {
 	// Load Title Graphic
 	if (!lcf::Data::system.title_name.empty()) {

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -82,7 +82,7 @@ void Scene_Title::Start() {
 }
 
 void Scene_Title::CreateHelpWindow() {
-	help_window.reset(new Window_Help(0, 0, Player::screen_width, 32));
+	help_window = std::make_unique<Window_Help>(this, 0, 0, Player::screen_width, 32);
 
 	if (Player::IsRPG2k3E() && lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent) {
 		help_window->SetBackOpacity(160);
@@ -206,11 +206,6 @@ void Scene_Title::OnTranslationChanged() {
 	Scene::OnTranslationChanged();
 }
 
-Span<Window_Selectable*> Scene_Title::GetWindowSelectables() {
-	auto arr = Utils::MakeArray<Window_Selectable*>(command_window.get());
-	return MakeSpan(arr);
-}
-
 void Scene_Title::CreateTitleGraphic() {
 	// Load Title Graphic
 	if (!lcf::Data::system.title_name.empty()) {
@@ -268,7 +263,7 @@ void Scene_Title::CreateCommandWindow() {
 
 	options.push_back(ToString(lcf::Data::terms.exit_game));
 
-	command_window.reset(new Window_Command(options));
+	command_window = std::make_unique<Window_Command>(this, options);
 	RepositionWindow(*command_window, Player::hide_title_flag);
 
 	Refresh();
@@ -308,7 +303,7 @@ void Scene_Title::CreateTranslationWindow() {
 		lang_helps.front() = def.lang_desc;
 	}
 
-	translate_window = std::make_unique<Window_Command>(lang_names, -1, lang_names.size() > 9 ? 9 : lang_names.size());
+	translate_window = std::make_unique<Window_Command>(this, lang_names, -1, lang_names.size() > 9 ? 9 : lang_names.size());
 	translate_window->UpdateHelpFn = [this](Window_Help& win, int index) {
 		if (index >= 0 && index < static_cast<int>(lang_helps.size())) {
 			win.SetText(lang_helps[index]);

--- a/src/scene_title.h
+++ b/src/scene_title.h
@@ -42,8 +42,6 @@ public:
 	void vUpdate() override;
 	void Refresh() override;
 
-	Span<Window_Selectable*> GetWindowSelectables() override;
-
 	void OnTranslationChanged() override;
 
 	/**

--- a/src/scene_title.h
+++ b/src/scene_title.h
@@ -42,6 +42,8 @@ public:
 	void vUpdate() override;
 	void Refresh() override;
 
+	Span<Window_Selectable*> GetWindowSelectables() override;
+
 	void OnTranslationChanged() override;
 
 	/**

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -24,12 +24,21 @@
 #include "window.h"
 #include "bitmap.h"
 #include "drawable_mgr.h"
+#include "scene.h"
 
 constexpr int pause_animation_frames = 20;
 
-Window::Window(Drawable::Flags flags): Drawable(Priority_Window, flags)
+Window::Window(Scene* parent, WindowType type, Drawable::Flags flags):
+	type(type), Drawable(Priority_Window, flags)
 {
 	DrawableMgr::Register(this);
+	SetScene(parent);
+}
+
+Window::~Window() {
+	if (scene) {
+		scene->RemoveWindow(this);
+	}
 }
 
 void Window::SetOpenAnimation(int frames) {
@@ -54,6 +63,21 @@ void Window::SetCloseAnimation(int frames) {
 		animation_increment = - animation_count / frames;
 	} else {
 		SetVisible(false);
+	}
+}
+
+Scene* Window::GetScene() const {
+	return scene;
+}
+
+void Window::SetScene(Scene* scene) {
+	if (this->scene) {
+		this->scene->RemoveWindow(this);
+	}
+
+	this->scene = nullptr;
+	if (scene) {
+		scene->RegisterWindow(this);
 	}
 }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -377,5 +377,3 @@ void Window::SetHeight(int nheight) {
 	}
 	height = nheight;
 }
-
-

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -377,3 +377,26 @@ void Window::SetHeight(int nheight) {
 	}
 	height = nheight;
 }
+
+bool Window::GetHalfActive() {
+	return half_active;
+}
+
+void Window::SetHalfActive(bool nactive) {
+	half_active = nactive;
+}
+
+int Window::GetHalfIndex() {
+	return half_index;
+}
+
+void Window::SetHalfIndex(int i) {
+	half_index = i;
+}
+
+bool Window::GetMouseOutside() {
+	return mouseOutside;
+}
+void Window::SetMouseOutside(bool nactive) {
+	mouseOutside = nactive;
+}

--- a/src/window.h
+++ b/src/window.h
@@ -23,12 +23,20 @@
 #include "drawable.h"
 #include "rect.h"
 
+class Scene;
+
 /**
  * Window class.
  */
 class Window : public Drawable {
 public:
-	Window(Drawable::Flags flags = Drawable::Flags::Default);
+	enum class WindowType {
+		Selectable, // Currently the only type that matters (for mouse selection)
+		Unknown
+	};
+
+	Window(Scene* parent, WindowType type = WindowType::Unknown, Drawable::Flags flags = Drawable::Flags::Default);
+	virtual ~Window();
 
 	void Draw(Bitmap& dst) override;
 
@@ -79,6 +87,9 @@ public:
 	void SetContentsOpacity(int ncontents_opacity);
 	void SetOpenAnimation(int frames);
 	void SetCloseAnimation(int frames);
+	Scene* GetScene() const;
+	void SetScene(Scene* scene);
+	WindowType GetType() const;
 
 	bool IsOpening() const;
 	bool IsClosing() const;
@@ -109,6 +120,7 @@ protected:
 	int frame_opacity = 255;
 	int back_opacity = 255;
 	int contents_opacity = 255;
+	Scene* scene = nullptr;
 
 private:
 	BitmapRef
@@ -129,6 +141,7 @@ private:
 	int animation_frames = 0;
 	double animation_count = 0.0;
 	double animation_increment = 0.0;
+	WindowType type = WindowType::Unknown;
 };
 
 inline bool Window::IsOpening() const {
@@ -302,6 +315,10 @@ inline void Window::SetContentsOpacity(int ncontents_opacity) {
 
 inline bool Window::IsSystemGraphicUpdateAllowed() const {
 	return !IsClosing();
+}
+
+inline Window::WindowType Window::GetType() const {
+	return type;
 }
 
 #endif

--- a/src/window.h
+++ b/src/window.h
@@ -99,6 +99,13 @@ public:
 		return false;
 	}
 
+	bool GetHalfActive();
+	void SetHalfActive(bool nactive);
+	int GetHalfIndex();
+	void SetHalfIndex(int i);
+	bool GetMouseOutside();
+	void SetMouseOutside(bool nactive);
+
 protected:
 	virtual bool IsSystemGraphicUpdateAllowed() const;
 
@@ -125,6 +132,10 @@ protected:
 	int back_opacity = 255;
 	int contents_opacity = 255;
 	Scene* scene = nullptr;
+
+	bool half_active = false;
+	int half_index = -999;
+	bool mouseOutside = false;
 
 private:
 	BitmapRef

--- a/src/window.h
+++ b/src/window.h
@@ -95,6 +95,10 @@ public:
 	bool IsClosing() const;
 	bool IsOpeningOrClosing() const;
 
+	virtual bool ExcludeForMouse() const {
+		return false;
+	}
+
 protected:
 	virtual bool IsSystemGraphicUpdateAllowed() const;
 

--- a/src/window_about.cpp
+++ b/src/window_about.cpp
@@ -24,8 +24,8 @@
 #include "font.h"
 #include "version.h"
 
-Window_About::Window_About(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight) {
+Window_About::Window_About(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Base(parent, ix, iy, iwidth, iheight) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 }

--- a/src/window_about.h
+++ b/src/window_about.h
@@ -31,7 +31,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_About(int ix, int iy, int iwidth, int iheight);
+	Window_About(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	void Refresh();
 };

--- a/src/window_actorinfo.cpp
+++ b/src/window_actorinfo.cpp
@@ -25,8 +25,8 @@
 #include "font.h"
 #include "feature.h"
 
-Window_ActorInfo::Window_ActorInfo(int ix, int iy, int iwidth, int iheight, int actor_id) :
-	Window_Base(ix, iy, iwidth, iheight),
+Window_ActorInfo::Window_ActorInfo(Scene* parent, int ix, int iy, int iwidth, int iheight, int actor_id) :
+	Window_Base(parent, ix, iy, iwidth, iheight),
 	actor_id(actor_id) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));

--- a/src/window_actorinfo.h
+++ b/src/window_actorinfo.h
@@ -31,7 +31,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_ActorInfo(int ix, int iy, int iwidth, int iheight, int actor_id);
+	Window_ActorInfo(Scene* parent, int ix, int iy, int iwidth, int iheight, int actor_id);
 
 	/**
 	 * Renders the stats on the window.

--- a/src/window_actorsp.cpp
+++ b/src/window_actorsp.cpp
@@ -20,8 +20,8 @@
 #include "bitmap.h"
 #include "font.h"
 
-Window_ActorSp::Window_ActorSp(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight) {
+Window_ActorSp::Window_ActorSp(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Base(parent, ix, iy, iwidth, iheight) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 

--- a/src/window_actorsp.h
+++ b/src/window_actorsp.h
@@ -32,7 +32,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_ActorSp(int ix, int iy, int iwidth, int iheight);
+	Window_ActorSp(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Sets the battler whose SP will be shown.

--- a/src/window_actorstatus.cpp
+++ b/src/window_actorstatus.cpp
@@ -24,8 +24,8 @@
 #include "bitmap.h"
 #include "font.h"
 
-Window_ActorStatus::Window_ActorStatus(int ix, int iy, int iwidth, int iheight, int actor_id) :
-	Window_Base(ix, iy, iwidth, iheight),
+Window_ActorStatus::Window_ActorStatus(Scene* parent, int ix, int iy, int iwidth, int iheight, int actor_id) :
+	Window_Base(parent, ix, iy, iwidth, iheight),
 	actor_id(actor_id) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));

--- a/src/window_actorstatus.h
+++ b/src/window_actorstatus.h
@@ -32,7 +32,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_ActorStatus(int ix, int iy, int iwidth, int iheight, int actor_id);
+	Window_ActorStatus(Scene* parent, int ix, int iy, int iwidth, int iheight, int actor_id);
 
 	/**
 	 * Renders the stats on the window.

--- a/src/window_actortarget.cpp
+++ b/src/window_actortarget.cpp
@@ -22,8 +22,8 @@
 #include "bitmap.h"
 #include "player.h"
 
-Window_ActorTarget::Window_ActorTarget(int ix, int iy, int iwidth, int iheight) :
-	Window_Selectable(ix, iy, iwidth, iheight) {
+Window_ActorTarget::Window_ActorTarget(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Selectable(parent, ix, iy, iwidth, iheight) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 

--- a/src/window_actortarget.h
+++ b/src/window_actortarget.h
@@ -32,7 +32,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_ActorTarget(int ix, int iy, int iwidth, int iheight);
+	Window_ActorTarget(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	void Refresh();
 	void UpdateCursorRect() override;

--- a/src/window_base.cpp
+++ b/src/window_base.cpp
@@ -26,8 +26,21 @@
 #include "font.h"
 #include "player.h"
 
-Window_Base::Window_Base(int x, int y, int width, int height, Drawable::Flags flags)
-	: Window(flags)
+Window_Base::Window_Base(Scene* parent, WindowType type, int x, int y, int width, int height, Drawable::Flags flags)
+	: Window(parent, type, flags)
+{
+	SetWindowskin(Cache::SystemOrBlack());
+
+	SetX(x);
+	SetY(y);
+	SetWidth(width);
+	SetHeight(height);
+	SetStretch(Main_Data::game_system->GetMessageStretch() == lcf::rpg::System::Stretch_stretch);
+	SetZ(Priority_Window);
+}
+
+Window_Base::Window_Base(Scene* parent, int x, int y, int width, int height, Drawable::Flags flags)
+	: Window(parent, WindowType::Unknown, flags)
 {
 	SetWindowskin(Cache::SystemOrBlack());
 

--- a/src/window_base.h
+++ b/src/window_base.h
@@ -41,7 +41,8 @@ public:
 	 * @param height window height.
 	 * @param flags flags to pass to drawable base class
 	 */
-	Window_Base(int x, int y, int width, int height, Drawable::Flags flags = Drawable::Flags::Default);
+	Window_Base(Scene* parent, WindowType type, int x, int y, int width, int height, Drawable::Flags flags = Drawable::Flags::Default);
+	Window_Base(Scene* parent, int x, int y, int width, int height, Drawable::Flags flags = Drawable::Flags::Default);
 
 	/**
 	 * Updates the window.

--- a/src/window_battlecommand.cpp
+++ b/src/window_battlecommand.cpp
@@ -27,8 +27,8 @@
 #include "bitmap.h"
 #include "feature.h"
 
-Window_BattleCommand::Window_BattleCommand(int x, int y, int width, int height) :
-	Window_Base(x, y, width, height) {
+Window_BattleCommand::Window_BattleCommand(Scene* parent, int x, int y, int width, int height) :
+	Window_Base(parent, x, y, width, height) {
 
 	SetActor(0);
 

--- a/src/window_battlecommand.h
+++ b/src/window_battlecommand.h
@@ -33,7 +33,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_BattleCommand(int x, int y, int width, int height);
+	Window_BattleCommand(Scene* parent, int x, int y, int width, int height);
 
 	/**
 	 * Refreshes the window contents.

--- a/src/window_battlemessage.cpp
+++ b/src/window_battlemessage.cpp
@@ -26,8 +26,8 @@
 #include "output.h"
 #include "feature.h"
 
-Window_BattleMessage::Window_BattleMessage(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight)
+Window_BattleMessage::Window_BattleMessage(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Base(parent, ix, iy, iwidth, iheight)
 {
 	SetContents(Bitmap::Create(width - 20, height - 16));
 

--- a/src/window_battlemessage.h
+++ b/src/window_battlemessage.h
@@ -27,7 +27,7 @@
 class Window_BattleMessage : public Window_Base {
 
 public:
-	Window_BattleMessage(int ix, int iy, int iwidth, int iheight);
+	Window_BattleMessage(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Adds message to be displayed.

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -283,17 +283,27 @@ void Window_BattleStatus::Update() {
 		RefreshGauge();
 	}
 
-	if (Input::GetUseMouseButton() && active && IsVisible()) {
+	if (Input::GetUseMouseButton() && active && IsVisible() && lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_gauge) {
 
-		
 		Point mouseP = Input::GetMousePosition();
 		if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_gauge) {
 				
 			if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
 				mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
 
-				int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * GetCursorRect().height - startCursorY * 16) / GetCursorRect().height * column_max;
-				new_index += (mouseP.x - GetBorderX() - GetX()) / GetCursorRect().width;
+				int h = 1;
+				int w = 1;
+				if (!GetCursorRect().IsEmpty()) {
+					h = GetCursorRect().height;
+					w = GetCursorRect().width;
+				}
+				else if (!GetItemRect(0).IsEmpty()) {
+					h = GetItemRect(0).height + 4;
+					w = GetItemRect(0).width;
+				}
+
+				int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * h - startCursorY * 16) / h * column_max;
+				new_index += (mouseP.x - GetBorderX() - GetX()) / w;
 
 				if (new_index >= 0 && new_index < GetItemMax()) {
 					// Change cursor (Hand)
@@ -311,8 +321,11 @@ void Window_BattleStatus::Update() {
 					}
 				}
 			}
+			else if (Input::IsPressed(Input::MOUSE_LEFT)) {
+				mouseOutside = true;
+			}
 		}
-		else if (!(Input::IsPressed(Input::MOUSE_LEFT) || Input::IsReleased(Input::MOUSE_LEFT)) && Input::IsTriggered(Input::DECISION))
+		else if (!(Input::IsPressed(Input::MOUSE_LEFT) || !Input::IsReleased(Input::MOUSE_LEFT)) && Input::IsTriggered(Input::DECISION))
 		{
 			mouseOutside = false;
 		}
@@ -341,8 +354,11 @@ void Window_BattleStatus::Update() {
 			}
 		}
 	}
-
-	UpdateCursorRect();
+	if (mouseOutside) {
+		Rect r;
+		SetCursorRect(r);
+	} else
+		UpdateCursorRect();
 }
 
 void Window_BattleStatus::UpdateCursorRect() {
@@ -396,4 +412,9 @@ void Window_BattleStatus::RefreshActiveFromValid() {
 		SetActive(false);
 	}
 	UpdateCursorRect();
+}
+
+
+void Window_BattleStatus::SetMouseOutside(bool b) {
+	mouseOutside = b;
 }

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -30,6 +30,7 @@
 #include "output.h"
 #include "window_battlestatus.h"
 #include "feature.h"
+#include <baseui.h>
 
 Window_BattleStatus::Window_BattleStatus(int ix, int iy, int iwidth, int iheight, bool enemy) :
 	Window_Selectable(ix, iy, iwidth, iheight), mode(ChoiceMode_All), enemy(enemy) {
@@ -284,20 +285,23 @@ void Window_BattleStatus::Update() {
 
 	if (Input::GetUseMouseButton() && active && IsVisible()) {
 
-		if (Input::IsPressed(Input::MOUSE_LEFT)) {
-			Point mouseP = Input::GetMousePosition();
-			mouseOutside = true;
-
-			if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_gauge) {
+		
+		Point mouseP = Input::GetMousePosition();
+		if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_gauge) {
 				
-				if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
-					mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
+			if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
+				mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
 
-					int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * GetCursorRect().height - startCursorY * 16) / GetCursorRect().height * column_max;
-					new_index += (mouseP.x - GetBorderX() - GetX()) / GetCursorRect().width;
+				int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * GetCursorRect().height - startCursorY * 16) / GetCursorRect().height * column_max;
+				new_index += (mouseP.x - GetBorderX() - GetX()) / GetCursorRect().width;
 
-					// Output::Debug("Index : {} {} {}", new_index, 0, GetIndex());
-
+				if (new_index >= 0 && new_index < GetItemMax()) {
+					// Change cursor (Hand)
+					DisplayUi->ChangeCursor(1);
+				}
+				// Output::Debug("Index : {} {} {}", new_index, 0, GetIndex());
+				if (Input::IsPressed(Input::MOUSE_LEFT)) {
+					mouseOutside = true;
 					if (new_index < GetItemMax() && new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max) {
 						if (new_index != mouseOldIndex)
 							Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
@@ -306,10 +310,6 @@ void Window_BattleStatus::Update() {
 						mouseOutside = false;
 					}
 				}
-			}
-			else
-			{
-
 			}
 		}
 		else if (!(Input::IsPressed(Input::MOUSE_LEFT) || Input::IsReleased(Input::MOUSE_LEFT)) && Input::IsTriggered(Input::DECISION))

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -310,7 +310,8 @@ void Window_BattleStatus::Update() {
 					DisplayUi->ChangeCursor(1);
 				}
 				// Output::Debug("Index : {} {} {}", new_index, 0, GetIndex());
-				if (Input::IsPressed(Input::MOUSE_LEFT)) {
+				//if (Input::IsPressed(Input::MOUSE_LEFT)) {
+				if (Input::mouseHover()) {
 					mouseOutside = true;
 					if (new_index < GetItemMax() && new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max) {
 						if (new_index != mouseOldIndex)

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -32,8 +32,8 @@
 #include "feature.h"
 #include <baseui.h>
 
-Window_BattleStatus::Window_BattleStatus(int ix, int iy, int iwidth, int iheight, bool enemy) :
-	Window_Selectable(ix, iy, iwidth, iheight), mode(ChoiceMode_All), enemy(enemy) {
+Window_BattleStatus::Window_BattleStatus(Scene* parent, int ix, int iy, int iwidth, int iheight, bool enemy) :
+	Window_Selectable(parent, ix, iy, iwidth, iheight), mode(ChoiceMode_All), enemy(enemy) {
 
 	SetBorderX(4);
 

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -282,8 +282,45 @@ void Window_BattleStatus::Update() {
 		RefreshGauge();
 	}
 
+	if (Input::GetUseMouseButton() && active && IsVisible()) {
+
+		if (Input::IsPressed(Input::MOUSE_LEFT)) {
+			Point mouseP = Input::GetMousePosition();
+			mouseOutside = true;
+
+			if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_gauge) {
+				
+				if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
+					mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
+
+					int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * GetCursorRect().height - startCursorY * 16) / GetCursorRect().height * column_max;
+					new_index += (mouseP.x - GetBorderX() - GetX()) / GetCursorRect().width;
+
+					// Output::Debug("Index : {} {} {}", new_index, 0, GetIndex());
+
+					if (new_index < GetItemMax() && new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max) {
+						if (new_index != mouseOldIndex)
+							Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+						SetIndex(new_index);
+						mouseOldIndex = new_index;
+						mouseOutside = false;
+					}
+				}
+			}
+			else
+			{
+
+			}
+		}
+		else if (!(Input::IsPressed(Input::MOUSE_LEFT) || Input::IsReleased(Input::MOUSE_LEFT)) && Input::IsTriggered(Input::DECISION))
+		{
+			mouseOutside = false;
+		}
+	}
+
 	if (active && index >= 0) {
-		if (Input::IsRepeated(Input::DOWN) || Input::IsRepeated(Input::RIGHT) || Input::IsTriggered(Input::SCROLL_DOWN)) {
+
+		if (Input::IsRepeated(Input::DOWN) || Input::IsTriggered(Input::SCROLL_DOWN)) {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 			for (int i = 1; i < item_max; i++) {
 				int new_index = (index + i) % item_max;

--- a/src/window_battlestatus.cpp
+++ b/src/window_battlestatus.cpp
@@ -293,9 +293,9 @@ void Window_BattleStatus::Update() {
 
 				int h = 1;
 				int w = 1;
-				if (!GetCursorRect().IsEmpty()) {
-					h = GetCursorRect().height;
-					w = GetCursorRect().width;
+				if (!GetCursorRect(0).IsEmpty()) {
+					h = GetCursorRect(0).height;
+					w = GetCursorRect(0).width;
 				}
 				else if (!GetItemRect(0).IsEmpty()) {
 					h = GetItemRect(0).height + 4;

--- a/src/window_battlestatus.h
+++ b/src/window_battlestatus.h
@@ -70,6 +70,8 @@ public:
 
 	void RefreshActiveFromValid();
 
+	bool mouseOutside = false;
+
 protected:
 	/**
 	 * Updates the cursor rectangle.

--- a/src/window_battlestatus.h
+++ b/src/window_battlestatus.h
@@ -70,6 +70,7 @@ public:
 
 	void RefreshActiveFromValid();
 
+	void SetMouseOutside(bool b);
 	bool mouseOutside = false;
 
 protected:

--- a/src/window_battlestatus.h
+++ b/src/window_battlestatus.h
@@ -73,6 +73,12 @@ public:
 	void SetMouseOutside(bool b);
 	bool mouseOutside = false;
 
+	bool UpdateMouse(bool activeAllies);
+
+	virtual bool ExcludeForMouse() const {
+		return true;
+	}
+
 protected:
 	/**
 	 * Updates the cursor rectangle.

--- a/src/window_battlestatus.h
+++ b/src/window_battlestatus.h
@@ -44,7 +44,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_BattleStatus(int ix, int iy, int iwidth, int iheight, bool enemy = false);
+	Window_BattleStatus(Scene* parent, int ix, int iy, int iwidth, int iheight, bool enemy = false);
 
 	/**
 	 * Renders the current status on the window.
@@ -90,7 +90,7 @@ protected:
 	/**
 	 * Tests whether actor is selectable in current ChoiceMode.
 	 *
-	 * @return true: selection possible 
+	 * @return true: selection possible
 	 */
 	bool IsChoiceValid(const Game_Battler& battler) const;
 

--- a/src/window_command.cpp
+++ b/src/window_command.cpp
@@ -33,8 +33,8 @@ static int CalculateWidth(const std::vector<std::string>& commands, int width) {
 	}
 }
 
-Window_Command::Window_Command(std::vector<std::string> in_commands, int width, int max_item) :
-	Window_Selectable(0, 0, CalculateWidth(in_commands, width), (max_item < 0 ? in_commands.size() : max_item) * 16 + 16)
+Window_Command::Window_Command(Scene* parent, std::vector<std::string> in_commands, int width, int max_item) :
+	Window_Selectable(parent, 0, 0, CalculateWidth(in_commands, width), (max_item < 0 ? in_commands.size() : max_item) * 16 + 16)
 {
 	ReplaceCommands(std::move(in_commands));
 }

--- a/src/window_command.h
+++ b/src/window_command.h
@@ -38,7 +38,7 @@ public:
 	 *                 items, if no height is passed
 	 *                 the height is autocalculated.
 	 */
-	Window_Command(std::vector<std::string> commands, int width = -1, int max_item = -1);
+	Window_Command(Scene* parent, std::vector<std::string> commands, int width = -1, int max_item = -1);
 
 	/**
 	 * Refreshes the window contents.

--- a/src/window_command_horizontal.cpp
+++ b/src/window_command_horizontal.cpp
@@ -31,8 +31,8 @@ static int CalculateWidth(const std::vector<std::string>& commands, int width) {
 	return width;
 }
 
-Window_Command_Horizontal::Window_Command_Horizontal(std::vector<std::string> in_commands, int width) :
-	Window_Command(in_commands, -1)
+Window_Command_Horizontal::Window_Command_Horizontal(Scene* parent, std::vector<std::string> in_commands, int width) :
+	Window_Command(parent, in_commands, -1)
 {
 	SetWidth(CalculateWidth(in_commands, width));
 	SetHeight(32);

--- a/src/window_command_horizontal.h
+++ b/src/window_command_horizontal.h
@@ -35,7 +35,7 @@ public:
 	 * @param width window width, if no width is passed
 	 *              the width is autocalculated.
 	 */
-	Window_Command_Horizontal(std::vector<std::string> commands, int width = -1);
+	Window_Command_Horizontal(Scene* parent, std::vector<std::string> commands, int width = -1);
 
 	/**
 	 * Replace all commands with a new command set.

--- a/src/window_equip.cpp
+++ b/src/window_equip.cpp
@@ -22,8 +22,8 @@
 #include <lcf/reader_util.h>
 #include "output.h"
 
-Window_Equip::Window_Equip(int ix, int iy, int iwidth, int iheight, int actor_id) :
-	Window_Selectable(ix, iy, iwidth, iheight),
+Window_Equip::Window_Equip(Scene* parent, int ix, int iy, int iwidth, int iheight, int actor_id) :
+	Window_Selectable(parent, ix, iy, iwidth, iheight),
 	actor_id(actor_id) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));

--- a/src/window_equip.h
+++ b/src/window_equip.h
@@ -36,7 +36,7 @@ public:
 	 * @param iheight window height.
 	 * @param actor_id actor whose inventory is displayed.
 	 */
-	Window_Equip(int ix, int iy, int iwidth, int iheight, int actor_id);
+	Window_Equip(Scene* parent, int ix, int iy, int iwidth, int iheight, int actor_id);
 
 	/**
 	 * Refreshes.

--- a/src/window_equipitem.cpp
+++ b/src/window_equipitem.cpp
@@ -22,8 +22,8 @@
 #include <lcf/reader_util.h>
 #include "output.h"
 
-Window_EquipItem::Window_EquipItem(int ix, int iy, int iwidth, int iheight, int actor_id, int equip_type) :
-	Window_Item(ix, iy, iwidth, iheight),
+Window_EquipItem::Window_EquipItem(Scene* parent, int ix, int iy, int iwidth, int iheight, int actor_id, int equip_type) :
+	Window_Item(parent, ix, iy, iwidth, iheight),
 	actor_id(actor_id) {
 	this->equip_type = equip_type;
 	if (equip_type > 4 || equip_type < 0) {

--- a/src/window_equipitem.h
+++ b/src/window_equipitem.h
@@ -43,7 +43,7 @@ public:
 	 * @param actor_id actor whos equipment is displayed.
 	 * @param equip_type type of equipment to show.
 	 */
-	Window_EquipItem(int ix, int iy, int iwidth, int iheight, int actor_id, int equip_type);
+	Window_EquipItem(Scene* parent, int ix, int iy, int iwidth, int iheight, int actor_id, int equip_type);
 
 	/**
 	 * Checks if the item should be in the list based on

--- a/src/window_equipstatus.cpp
+++ b/src/window_equipstatus.cpp
@@ -24,8 +24,8 @@
 #include "font.h"
 #include "player.h"
 
-Window_EquipStatus::Window_EquipStatus(int ix, int iy, int iwidth, int iheight, int actor_id) :
-	Window_Base(ix, iy, iwidth, iheight),
+Window_EquipStatus::Window_EquipStatus(Scene* parent, int ix, int iy, int iwidth, int iheight, int actor_id) :
+	Window_Base(parent, ix, iy, iwidth, iheight),
 	actor_id(actor_id),
 	draw_params(false),
 	dirty(true) {

--- a/src/window_equipstatus.h
+++ b/src/window_equipstatus.h
@@ -37,7 +37,7 @@ public:
 	 * @param iheight window height.
 	 * @param actor_id actor whose stats are displayed.
 	 */
-	Window_EquipStatus(int ix, int iy, int iwidth, int iheight, int actor_id);
+	Window_EquipStatus(Scene* parent, int ix, int iy, int iwidth, int iheight, int actor_id);
 
 	/**
 	 * Refreshes screen.

--- a/src/window_face.cpp
+++ b/src/window_face.cpp
@@ -20,8 +20,8 @@
 #include "game_actors.h"
 #include "window_face.h"
 
-Window_Face::Window_Face(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight), actor_id(1) {
+Window_Face::Window_Face(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Base(parent, ix, iy, iwidth, iheight), actor_id(1) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 }

--- a/src/window_face.h
+++ b/src/window_face.h
@@ -30,7 +30,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_Face(int ix, int iy, int iwidth, int iheight);
+	Window_Face(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Renders the current face on the window.

--- a/src/window_gamelist.cpp
+++ b/src/window_gamelist.cpp
@@ -23,8 +23,8 @@
 #include "bitmap.h"
 #include "font.h"
 
-Window_GameList::Window_GameList(int ix, int iy, int iwidth, int iheight) :
-	Window_Selectable(ix, iy, iwidth, iheight) {
+Window_GameList::Window_GameList(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Selectable(parent, ix, iy, iwidth, iheight) {
 	column_max = 1;
 }
 

--- a/src/window_gamelist.h
+++ b/src/window_gamelist.h
@@ -33,7 +33,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_GameList(int ix, int iy, int iwidth, int iheight);
+	Window_GameList(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Refreshes the game list.

--- a/src/window_gold.cpp
+++ b/src/window_gold.cpp
@@ -23,8 +23,8 @@
 #include "main_data.h"
 #include "bitmap.h"
 
-Window_Gold::Window_Gold(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight) {
+Window_Gold::Window_Gold(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Base(parent, ix, iy, iwidth, iheight) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 

--- a/src/window_gold.h
+++ b/src/window_gold.h
@@ -29,7 +29,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_Gold(int ix, int iy, int iwidth, int iheight);
+	Window_Gold(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Renders the current gold amount on the window.

--- a/src/window_help.cpp
+++ b/src/window_help.cpp
@@ -20,8 +20,8 @@
 #include "bitmap.h"
 #include "font.h"
 
-Window_Help::Window_Help(int ix, int iy, int iwidth, int iheight, Drawable::Flags flags) :
-	Window_Base(ix, iy, iwidth, iheight, flags),
+Window_Help::Window_Help(Scene* parent, int ix, int iy, int iwidth, int iheight, Drawable::Flags flags) :
+	Window_Base(parent, ix, iy, iwidth, iheight, flags),
 	align(Text::AlignLeft) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));

--- a/src/window_help.h
+++ b/src/window_help.h
@@ -33,7 +33,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_Help(int ix, int iy, int iwidth, int iheight, Drawable::Flags flags = Drawable::Flags::Default);
+	Window_Help(Scene* parent, int ix, int iy, int iwidth, int iheight, Drawable::Flags flags = Drawable::Flags::Default);
 
 	/**
 	 * Sets the text that will be shown.

--- a/src/window_import_progress.cpp
+++ b/src/window_import_progress.cpp
@@ -21,8 +21,8 @@
 #include "color.h"
 #include "font.h"
 
-Window_ImportProgress::Window_ImportProgress(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight) {
+Window_ImportProgress::Window_ImportProgress(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Base(parent, ix, iy, iwidth, iheight) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 	Refresh();

--- a/src/window_import_progress.h
+++ b/src/window_import_progress.h
@@ -36,7 +36,7 @@ public:
 	 * @param iwidth width of the window
 	 * @param iheight height of the window
 	 */
-	Window_ImportProgress(int ix, int iy, int iwidth, int iheight);
+	Window_ImportProgress(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Update to display scanning progress and the directory currently being scanned
@@ -44,7 +44,7 @@ public:
 	 * @param path current directory being scanned
 	 */
 	void SetProgress(int pct, const std::string& path);
-	
+
 private:
 	void Refresh();
 

--- a/src/window_input_settings.cpp
+++ b/src/window_input_settings.cpp
@@ -22,8 +22,8 @@
 #include "window_selectable.h"
 
 
-Window_InputSettings::Window_InputSettings(int ix, int iy, int iwidth, int iheight) :
-	Window_Selectable(ix, iy, iwidth, iheight) {
+Window_InputSettings::Window_InputSettings(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Selectable(parent, ix, iy, iwidth, iheight) {
 	column_max = 2;
 
 	SetContents(Bitmap::Create(width - 16, height - 16));

--- a/src/window_input_settings.h
+++ b/src/window_input_settings.h
@@ -33,7 +33,7 @@ public:
 	static constexpr int mapping_limit = 16;
 
 	/** Constructor  */
-	Window_InputSettings(int ix, int iy, int iwidth, int iheight);
+	Window_InputSettings(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	Input::InputButton GetInputButton() const;
 	void SetInputButton(Input::InputButton button);

--- a/src/window_item.cpp
+++ b/src/window_item.cpp
@@ -26,8 +26,8 @@
 #include "game_battle.h"
 #include "output.h"
 
-Window_Item::Window_Item(int ix, int iy, int iwidth, int iheight) :
-	Window_Selectable(ix, iy, iwidth, iheight) {
+Window_Item::Window_Item(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Selectable(parent, ix, iy, iwidth, iheight) {
 	column_max = 2;
 }
 

--- a/src/window_item.h
+++ b/src/window_item.h
@@ -32,7 +32,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_Item(int ix, int iy, int iwidth, int iheight);
+	Window_Item(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Gets item.

--- a/src/window_keyboard.cpp
+++ b/src/window_keyboard.cpp
@@ -23,6 +23,7 @@
 #include "input.h"
 #include "bitmap.h"
 #include "font.h"
+#include <output.h>
 
 const char* const Window_Keyboard::DONE = "<Done>";
 const char* const Window_Keyboard::SPACE = "SPACE";
@@ -269,6 +270,34 @@ void Window_Keyboard::Update() {
 
 	// move left on wide fields
 	int skip_dir = -1;
+
+	if (Input::GetUseMouseButton() && IsVisible() && active) {
+		if (Input::IsPressed(Input::MOUSE_LEFT)) {
+			mouseOutside = true;
+			for (int j = 0; j < row_max; j++) {
+				for (int i = 0; i < col_max; i++) {
+					Point mouseP = Input::GetMousePosition();
+					mouseP.x -= x + GetBorderX();
+					mouseP.y -= y + GetBorderY();
+					int minx = GetItemRect(j, i).x;
+					int maxx = GetItemRect(j, i).x + GetItemRect(j, i).width;
+					int miny = GetItemRect(j, i).y;
+					int maxy = GetItemRect(j, i).y + GetItemRect(j, i).height;
+					if (mouseP.x >= minx && mouseP.x <= maxx &&
+						mouseP.y >= miny && mouseP.y <= maxy) {
+						if (GetKey(j, i) != "") {
+							col = i;
+							row = j;
+							// Output::Debug("{} {}", i, j);
+							mouseOutside = false;
+							break;
+						}
+					}
+					
+				}
+			}
+		}
+	}
 
 	if (active) {
 		if (Input::IsRepeated(Input::DOWN)) {

--- a/src/window_keyboard.cpp
+++ b/src/window_keyboard.cpp
@@ -24,6 +24,7 @@
 #include "bitmap.h"
 #include "font.h"
 #include <output.h>
+#include <baseui.h>
 
 const char* const Window_Keyboard::DONE = "<Done>";
 const char* const Window_Keyboard::SPACE = "SPACE";
@@ -274,18 +275,27 @@ void Window_Keyboard::Update() {
 	if (Input::GetUseMouseButton() && IsVisible() && active) {
 		if (Input::IsPressed(Input::MOUSE_LEFT)) {
 			mouseOutside = true;
-			for (int j = 0; j < row_max; j++) {
-				for (int i = 0; i < col_max; i++) {
-					Point mouseP = Input::GetMousePosition();
-					mouseP.x -= x + GetBorderX();
-					mouseP.y -= y + GetBorderY();
-					int minx = GetItemRect(j, i).x;
-					int maxx = GetItemRect(j, i).x + GetItemRect(j, i).width;
-					int miny = GetItemRect(j, i).y;
-					int maxy = GetItemRect(j, i).y + GetItemRect(j, i).height;
-					if (mouseP.x >= minx && mouseP.x <= maxx &&
-						mouseP.y >= miny && mouseP.y <= maxy) {
+		}
+		for (int j = 0; j < row_max; j++) {
+			for (int i = 0; i < col_max; i++) {
+				Point mouseP = Input::GetMousePosition();
+				mouseP.x -= x + GetBorderX();
+				mouseP.y -= y + GetBorderY();
+				int minx = GetItemRect(j, i).x;
+				int maxx = GetItemRect(j, i).x + GetItemRect(j, i).width;
+				int miny = GetItemRect(j, i).y;
+				int maxy = GetItemRect(j, i).y + GetItemRect(j, i).height;
+				if (mouseP.x >= minx && mouseP.x <= maxx &&
+					mouseP.y >= miny && mouseP.y <= maxy) {
+
+					// Change cursor (Hand)
+					DisplayUi->ChangeCursor(1);
+
+					if (Input::IsPressed(Input::MOUSE_LEFT)) {
 						if (GetKey(j, i) != "") {
+							if (i != col || j != row) {
+								play_cursor = true;
+							}
 							col = i;
 							row = j;
 							// Output::Debug("{} {}", i, j);
@@ -300,22 +310,42 @@ void Window_Keyboard::Update() {
 	}
 
 	if (active) {
-		if (Input::IsRepeated(Input::DOWN)) {
-			play_cursor = true;
-			row = (row + 1) % row_max;
+		if (mouseOutside) {
+			if (Input::IsRepeated(Input::DOWN)) {
+				play_cursor = true;
+				mouseOutside = false;
+			}
+			if (Input::IsRepeated(Input::UP)) {
+				play_cursor = true;
+				mouseOutside = false;
+			}
+			if (Input::IsRepeated(Input::RIGHT)) {
+				play_cursor = true;
+				mouseOutside = false;
+			}
+			if (Input::IsRepeated(Input::LEFT)) {
+				play_cursor = true;
+				mouseOutside = false;
+			}
 		}
-		if (Input::IsRepeated(Input::UP)) {
-			play_cursor = true;
-			row = (row + row_max - 1) % row_max;
-		}
-		if (Input::IsRepeated(Input::RIGHT)) {
-			play_cursor = true;
-			col = (col + 1) % col_max;
-			skip_dir = 1;
-		}
-		if (Input::IsRepeated(Input::LEFT)) {
-			play_cursor = true;
-			col = (col + col_max - 1) % col_max;
+		else {
+			if (Input::IsRepeated(Input::DOWN)) {
+				play_cursor = true;
+				row = (row + 1) % row_max;
+			}
+			if (Input::IsRepeated(Input::UP)) {
+				play_cursor = true;
+				row = (row + row_max - 1) % row_max;
+			}
+			if (Input::IsRepeated(Input::RIGHT)) {
+				play_cursor = true;
+				col = (col + 1) % col_max;
+				skip_dir = 1;
+			}
+			if (Input::IsRepeated(Input::LEFT)) {
+				play_cursor = true;
+				col = (col + col_max - 1) % col_max;
+			}
 		}
 	}
 
@@ -338,4 +368,9 @@ void Window_Keyboard::Update() {
 		play_cursor = false;
 	}
 	UpdateCursorRect();
+	if (mouseOutside)
+	{
+		Rect r;
+		SetCursorRect(r);
+	}
 }

--- a/src/window_keyboard.cpp
+++ b/src/window_keyboard.cpp
@@ -198,8 +198,8 @@ Keyboard_Layout Window_Keyboard::layouts[Window_Keyboard::MODE_END] = {
 	}
 };
 
-Window_Keyboard::Window_Keyboard(int ix, int iy, int iwidth, int iheight, const char* ndone_text)
-		: Window_Base(ix, iy, iwidth, iheight)
+Window_Keyboard::Window_Keyboard(Scene* parent, int ix, int iy, int iwidth, int iheight, const char* ndone_text)
+		: Window_Base(parent, ix, iy, iwidth, iheight)
 		, done_text(ndone_text)
 		, play_cursor(false)
 {

--- a/src/window_keyboard.cpp
+++ b/src/window_keyboard.cpp
@@ -292,6 +292,10 @@ void Window_Keyboard::Update() {
 					DisplayUi->ChangeCursor(1);
 
 					if (Input::IsPressed(Input::MOUSE_LEFT)) {
+						mouseOutside = false;
+						break;
+					}
+					if (Input::MouseMoved()) {
 						if (GetKey(j, i) != "") {
 							if (i != col || j != row) {
 								play_cursor = true;

--- a/src/window_keyboard.h
+++ b/src/window_keyboard.h
@@ -37,7 +37,7 @@ public:
 	 * @param iheight window height.
 	 * @param ndone_text text for the "Done" button.
 	 */
-	Window_Keyboard(int ix, int iy, int iwidth = 320, int iheight = 80, const char* ndone_text = DONE);
+	Window_Keyboard(Scene* parent, int ix, int iy, int iwidth = 320, int iheight = 80, const char* ndone_text = DONE);
 
 	enum Mode {
 		Hiragana,

--- a/src/window_keyboard.h
+++ b/src/window_keyboard.h
@@ -75,6 +75,8 @@ public:
 	static const int col_max = 10;
 	static Keyboard_Layout layouts[MODE_END];
 
+	bool mouseOutside = false;
+
 protected:
 	static const int border_x = 8;
 	static const int border_y = 4;

--- a/src/window_menustatus.cpp
+++ b/src/window_menustatus.cpp
@@ -23,8 +23,8 @@
 #include "bitmap.h"
 #include "feature.h"
 
-Window_MenuStatus::Window_MenuStatus(int ix, int iy, int iwidth, int iheight) :
-	Window_Selectable(ix, iy, iwidth, iheight) {
+Window_MenuStatus::Window_MenuStatus(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Selectable(parent, ix, iy, iwidth, iheight) {
 
 	if (Player::IsRPG2k3()) {
 		SetContents(Bitmap::Create(width - 12, height - 16));

--- a/src/window_menustatus.cpp
+++ b/src/window_menustatus.cpp
@@ -33,6 +33,7 @@ Window_MenuStatus::Window_MenuStatus(int ix, int iy, int iwidth, int iheight) :
 	} else {
 		SetContents(Bitmap::Create(width - 16, height - 16));
 	}
+	menu_item_height = 48;
 
 	Refresh();
 }

--- a/src/window_menustatus.cpp
+++ b/src/window_menustatus.cpp
@@ -80,6 +80,28 @@ void Window_MenuStatus::UpdateCursorRect()
 	}
 }
 
+Rect Window_MenuStatus::GetCursorRect(int index) const {
+	int cursor_width = 0;
+	int x = 0;
+	if (index < 0) {
+		return {};
+	}
+	int row = index / column_max;
+	if (row < GetTopRow()) {
+		return {};
+	}
+	else if (row > GetTopRow() + (GetPageRowMax() - 1)) {
+		return {};
+	}
+
+	cursor_width = (width / column_max - 16) + 8;
+	x = (index % column_max * (cursor_width + 8)) - 4;
+
+	int y = index / column_max * (menu_item_height + 10) - oy;
+
+	return { x, y, cursor_width, menu_item_height };
+}
+
 Game_Actor* Window_MenuStatus::GetActor() const {
 	return &(*Main_Data::game_party)[GetIndex()];
 }

--- a/src/window_menustatus.h
+++ b/src/window_menustatus.h
@@ -26,7 +26,7 @@
  */
 class Window_MenuStatus : public Window_Selectable {
 public:
-	Window_MenuStatus(int ix, int iy, int iwidth, int iheight);
+	Window_MenuStatus(Scene* parent, int ix, int iy, int iwidth, int iheight);
 	void Refresh();
 	void UpdateCursorRect() override;
 

--- a/src/window_menustatus.h
+++ b/src/window_menustatus.h
@@ -30,6 +30,8 @@ public:
 	void Refresh();
 	void UpdateCursorRect() override;
 
+	Rect GetCursorRect(int i) const override;
+
 	Game_Actor* GetActor() const;
 
 protected:

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -89,10 +89,10 @@ void DebugLogText(const char*, Args&&...) { }
 #pragma warning (disable : 4428)
 #endif
 
-Window_Message::Window_Message(int ix, int iy, int iwidth, int iheight) :
-	Window_Selectable(ix, iy, iwidth, iheight),
-	number_input_window(new Window_NumberInput(0, 0)),
-	gold_window(new Window_Gold(Player::screen_width - Player::menu_offset_x - gold_window_width, Player::menu_offset_y, gold_window_width, gold_window_height)),
+Window_Message::Window_Message(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Selectable(parent, ix, iy, iwidth, iheight),
+	number_input_window(new Window_NumberInput(parent, 0, 0)),
+	gold_window(new Window_Gold(parent, Player::screen_width - Player::menu_offset_x - gold_window_width, Player::menu_offset_y, gold_window_width, gold_window_height)),
 	pending_message(Game_Message::CommandCodeInserter)
 {
 	SetContents(Bitmap::Create(width - 16, height - 16));

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -412,17 +412,30 @@ void Window_Message::Update() {
 				}
 				if (!(mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() * 2 &&
 					mouseP.y >= GetY() + GetBorderY() + startChoiceY && mouseP.y < GetY() + GetHeight() - GetBorderY() + startChoiceY - maxChoiceY)) {
-					if (Input::IsPressed(Input::MOUSE_LEFT)) {
+					if (!this->IsOpeningOrClosing() && this->GetPause()) {
 						if (index != -999 && index != -1)
 							mouseOldIndex = index;
 						index = -999;
 					}
 				}
 				else {
-					if (Input::IsPressed(Input::MOUSE_LEFT)) {
+
+					if (pending_message.HasChoices()) {
+
+						Output::Debug("{}", this->IsOpening());
+
 						if (index != -999 && index != -1)
 							mouseOldIndex = index;
-						//index = -1;
+						int i = CursorHitTest({ mouseP.x - GetX(), mouseP.y - GetY() });
+
+						// Bug is here. We need to wait until all text is draw
+						if (i != index) {
+							Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+							index = i;
+						}
+					}
+					else {
+						index = -1;
 					}
 					// Change cursor (Hand)
 					DisplayUi->ChangeCursor(1);
@@ -956,11 +969,12 @@ void Window_Message::InputNumber() {
 				number_input_window->SetActive(false);
 
 				index = -1;
+				return;
 			}
 		}
-		return;
 	}
-	if (Input::IsTriggered(Input::DECISION)) {
+
+	if (Input::IsTriggered(Input::DECISION) && index != -999) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 		Main_Data::game_variables->Set(pending_message.GetNumberInputVariable(), number_input_window->GetNumber());
 		Game_Map::SetNeedRefresh(true);

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -184,6 +184,7 @@ void Window_Message::StartMessageProcessing(PendingMessage pm) {
 	}
 
 	item_max = min(4, pending_message.GetNumChoices());
+	startCursorY = pending_message.GetChoiceStartLine();
 
 	text_index = text.data();
 
@@ -398,7 +399,37 @@ void Window_Message::Update() {
 
 	const bool was_closing = IsClosing();
 
+	if (Input::GetUseMouseButton()) {
+		if (Input::IsRawKeyPressed(Input::Keys::MOUSE_LEFT)) {
+			Point mouseP = Input::GetMousePosition();
+			int startChoiceY = 0;
+			int maxChoiceY = 0;
+			if (pending_message.HasChoices()) {
+				startChoiceY = pending_message.GetChoiceStartLine() * 16;
+				maxChoiceY = pending_message.GetNumChoices() * 16;
+			}
+			if (!(mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() * 2 &&
+				mouseP.y >= GetY() + GetBorderY() + startChoiceY && mouseP.y < GetY() + GetHeight() - GetBorderY() + startChoiceY - maxChoiceY)) {
+				index = -999;
+			}
+			else {
+				index = -1;
+			}
+		}
+		else if (Input::IsPressed(Input::DECISION)) {
+			index = -1;
+		}
+		if (index == -999) {
+			UpdateArrows();
+			Window_Base::Update();
+			number_input_window->Update();
+			return;
+		}
+	}
+
 	Window_Selectable::Update();
+
+
 	number_input_window->Update();
 	gold_window->Update();
 

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -422,7 +422,7 @@ void Window_Message::Update() {
 					if (Input::IsPressed(Input::MOUSE_LEFT)) {
 						if (index != -999 && index != -1)
 							mouseOldIndex = index;
-						index = -1;
+						//index = -1;
 					}
 					// Change cursor (Hand)
 					DisplayUi->ChangeCursor(1);
@@ -503,7 +503,8 @@ void Window_Message::Update() {
 					index = mouseOldIndex;
 				}
 				UpdateArrows();
-				Window_Base::Update();
+				//Window_Base::Update();
+				Window_Selectable::Update();
 				return;
 			}
 		}
@@ -515,7 +516,8 @@ void Window_Message::Update() {
 
 		if (index == -999) {
 			UpdateArrows();
-			Window_Base::Update();
+			//Window_Base::Update();
+			Window_Selectable::Update();
 			number_input_window->Update();
 			return;
 		}

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -410,35 +410,57 @@ void Window_Message::Update() {
 					startChoiceY = pending_message.GetChoiceStartLine() * 16;
 					maxChoiceY = pending_message.GetNumChoices() * 16;
 				}
-				if (!(mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() * 2 &&
-					mouseP.y >= GetY() + GetBorderY() + startChoiceY && mouseP.y < GetY() + GetHeight() - GetBorderY() + startChoiceY - maxChoiceY)) {
-					if (!this->IsOpeningOrClosing() && this->GetPause()) {
-						if (index != -999 && index != -1)
-							mouseOldIndex = index;
-						index = -999;
-					}
+				int minX = GetX() + GetBorderX();
+				int maxX = GetX() + GetWidth() - GetBorderX() * 2;
+				int minY = GetY() + GetBorderY() + startChoiceY;
+				int maxY = GetY() + GetHeight() + startChoiceY + maxChoiceY;
+				if (!(mouseP.x >= minX && mouseP.x <= maxX &&
+					mouseP.y >= minY && mouseP.y < maxY)) {
+					if (Input::MouseMoved()) {
+						const auto* end = text.data() + text.size();
+
+						auto tret = Utils::TextNext(text_index, end, Player::escape_char);
+						auto text_prev = text_index;
+						const auto ch = tret.ch;
+
+						if (ch == '\f') {
+							if (index != -999 && index != -1)
+								mouseOldIndex = index;
+							index = -999;
+						}
+					} 
 				}
 				else {
-
 					if (pending_message.HasChoices()) {
-
-						Output::Debug("{}", this->IsOpening());
 
 						if (index != -999 && index != -1)
 							mouseOldIndex = index;
 						int i = CursorHitTest({ mouseP.x - GetX(), mouseP.y - GetY() });
+						if (i == -1)
+							i = -999;
 
-						// Bug is here. We need to wait until all text is draw
-						if (i != index) {
-							Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
-							index = i;
+						const auto* end = text.data() + text.size();
+						auto tret = Utils::TextNext(text_index, end, Player::escape_char);
+						auto text_prev = text_index;
+						const auto ch = tret.ch;
+
+						if (ch == '\f') {
+							// Change cursor (Hand)
+							if (i != -999)
+								DisplayUi->ChangeCursor(1);
+							if (Input::MouseMoved()) {
+								if (i != index) {
+									if (i != -999)
+										Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+									index = i;
+								}
+							}
 						}
 					}
 					else {
 						index = -1;
 					}
-					// Change cursor (Hand)
-					DisplayUi->ChangeCursor(1);
+					
 				}
 				UpdateCursorRect();
 			}
@@ -519,6 +541,32 @@ void Window_Message::Update() {
 				//Window_Base::Update();
 				Window_Selectable::Update();
 				return;
+			}
+		}
+		else if ( number_input_window->GetActive())
+		{
+			if (index == -999) {
+				if (Input::IsTriggered(Input::DECISION) && !Input::IsReleased(Input::MOUSE_LEFT)) {
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+					index = -1;
+				}
+				if (Input::IsTriggered(Input::DOWN)) {
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+					index = -1;
+				}
+				if (Input::IsTriggered(Input::UP)) {
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+					index = -1;
+				}
+				if (Input::IsTriggered(Input::RIGHT)) {
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+					index = -1;
+				}
+				if (Input::IsTriggered(Input::LEFT)) {
+					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+					index = -1;
+				}
+
 			}
 		}
 		else {

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -33,7 +33,7 @@
  */
 class Window_Message: public Window_Selectable {
 public:
-	Window_Message(int ix, int iy, int iwidth, int iheight);
+	Window_Message(Scene* parent, int ix, int iy, int iwidth, int iheight);
 	~Window_Message() override;
 
 	enum WindowMessageValues {

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -138,6 +138,10 @@ public:
 	 **/
 	void SetMaxLinesPerPage(int lines);
 
+	virtual bool ExcludeForMouse() const {
+		return true;
+	}
+
 protected:
 	/** Async operation */
 	AsyncOp aop;

--- a/src/window_name.cpp
+++ b/src/window_name.cpp
@@ -23,8 +23,8 @@
 #include <lcf/data.h>
 #include "game_system.h"
 
-Window_Name::Window_Name(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight) {
+Window_Name::Window_Name(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Base(parent, ix, iy, iwidth, iheight) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 

--- a/src/window_name.h
+++ b/src/window_name.h
@@ -31,7 +31,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_Name(int ix, int iy, int iwidth, int iheight);
+	Window_Name(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Renders the current name on the window.

--- a/src/window_numberinput.cpp
+++ b/src/window_numberinput.cpp
@@ -140,7 +140,7 @@ void Window_NumberInput::Update() {
 	if (active) {
 
 		if (Input::GetUseMouseButton()) {
-			if (Input::IsRawKeyPressed(Input::Keys::MOUSE_LEFT)) {
+			if (Input::IsPressed(Input::MOUSE_LEFT)) {
 				waitMouseControl++;
 				if (waitMouseControl == 1 || (waitMouseControl >= Input::start_repeat_time && waitMouseControl % Input::repeat_time == 1)) {
 					Point mouseP = Input::GetMousePosition();
@@ -148,6 +148,8 @@ void Window_NumberInput::Update() {
 					int x = digits_max * (cursor_width - 2) + (show_operator ? 2 : 12);
 					if (mouseP.x >= GetX() + GetBorderX() + x && mouseP.x <= GetX() + GetBorderX() + x + 14 &&
 						mouseP.y >= GetY() + GetBorderY() - 2 && mouseP.y < GetY() + 32 - GetBorderY() + 2) {
+
+						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 
 						int place = 1;
 						for (int i = 0; i < (digits_max - 1 - (int)index + (int)show_operator); ++i) {
@@ -241,7 +243,9 @@ void Window_NumberInput::ResetIndex() {
 }
 
 void Window_NumberInput::SetIndex(int nindex) {
+	mouseOldIndex = index;
 	index = min(nindex, digits_max - 1);
 	index = max(index, 0);
+	//index = nindex;
 	UpdateCursorRect();
 }

--- a/src/window_numberinput.cpp
+++ b/src/window_numberinput.cpp
@@ -30,6 +30,7 @@
 #include <fmt/format.h>
 #include <output.h>
 #include <input.h>
+#include <baseui.h>
 
 Window_NumberInput::Window_NumberInput(int ix, int iy, int iwidth, int iheight) :
 	Window_Selectable(ix, iy, iwidth, iheight),
@@ -140,15 +141,19 @@ void Window_NumberInput::Update() {
 	if (active) {
 
 		if (Input::GetUseMouseButton()) {
-			if (Input::IsPressed(Input::MOUSE_LEFT)) {
-				waitMouseControl++;
-				if (waitMouseControl == 1 || (waitMouseControl >= Input::start_repeat_time && waitMouseControl % Input::repeat_time == 1)) {
-					Point mouseP = Input::GetMousePosition();
+			
+			Point mouseP = Input::GetMousePosition();
 
-					int x = digits_max * (cursor_width - 2) + (show_operator ? 2 : 12);
-					if (mouseP.x >= GetX() + GetBorderX() + x && mouseP.x <= GetX() + GetBorderX() + x + 14 &&
-						mouseP.y >= GetY() + GetBorderY() - 2 && mouseP.y < GetY() + 32 - GetBorderY() + 2) {
+			int x = digits_max * (cursor_width - 2) + (show_operator ? 2 : 12);
+			if (mouseP.x >= GetX() + GetBorderX() + x && mouseP.x <= GetX() + GetBorderX() + x + 14 &&
+				mouseP.y >= GetY() + GetBorderY() - 2 && mouseP.y < GetY() + 32 - GetBorderY() + 2) {
 
+				// Change cursor (Hand)
+				DisplayUi->ChangeCursor(1);
+
+				if (Input::IsPressed(Input::MOUSE_LEFT)) {
+					waitMouseControl++;
+					if (waitMouseControl == 1 || (waitMouseControl >= Input::start_repeat_time && waitMouseControl % Input::repeat_time == 1)) {
 						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 
 						int place = 1;
@@ -169,9 +174,9 @@ void Window_NumberInput::Update() {
 						Refresh();
 					}
 				}
-			}
-			else {
-				waitMouseControl = 0;
+				else {
+					waitMouseControl = 0;
+				}
 			}
 		}
 

--- a/src/window_numberinput.cpp
+++ b/src/window_numberinput.cpp
@@ -32,8 +32,8 @@
 #include <input.h>
 #include <baseui.h>
 
-Window_NumberInput::Window_NumberInput(int ix, int iy, int iwidth, int iheight) :
-	Window_Selectable(ix, iy, iwidth, iheight),
+Window_NumberInput::Window_NumberInput(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Selectable(parent, ix, iy, iwidth, iheight),
 	digits_max(10) {
 	number = 0;
 	plus = true;

--- a/src/window_numberinput.cpp
+++ b/src/window_numberinput.cpp
@@ -65,7 +65,7 @@ void Window_NumberInput::Refresh() {
 	}
 
 	if (Input::GetUseMouseButton()) {
-		int x = digits_max * (cursor_width - 2) + (show_operator ? 2 : 12);
+		int x = digits_max * (cursor_width - 2) + (show_operator ? 2 : 12) + 16;
 
 		Rect src_rectUp(40, 8, 16, 8);
 		contents->Blit(x, 0, *windowskin, src_rectUp, 255);
@@ -74,7 +74,7 @@ void Window_NumberInput::Refresh() {
 		contents->Blit(x, 8, *windowskin, src_rectDown, 255);
 
 
-		contents->TextDraw(x + 32, 2, Font::ColorDefault, "OK");
+		contents->TextDraw(x + 16, 2, Font::ColorDefault, "OK");
 	}
 }
 
@@ -144,7 +144,8 @@ void Window_NumberInput::Update() {
 			
 			Point mouseP = Input::GetMousePosition();
 
-			int x = digits_max * (cursor_width - 2) + (show_operator ? 2 : 12);
+			int x = digits_max * (cursor_width - 2) + (show_operator ? 2 : 12) + 16;
+
 			if (mouseP.x >= GetX() + GetBorderX() + x && mouseP.x <= GetX() + GetBorderX() + x + 14 &&
 				mouseP.y >= GetY() + GetBorderY() - 2 && mouseP.y < GetY() + 32 - GetBorderY() + 2) {
 
@@ -249,8 +250,11 @@ void Window_NumberInput::ResetIndex() {
 
 void Window_NumberInput::SetIndex(int nindex) {
 	mouseOldIndex = index;
-	index = min(nindex, digits_max - 1);
-	index = max(index, 0);
-	//index = nindex;
+	//int i = 1;
+	//if (show_operator)
+	//	i++;
+	//index = min(nindex, digits_max - i);
+	//index = max(index, 0);
+	index = nindex;
 	UpdateCursorRect();
 }

--- a/src/window_numberinput.h
+++ b/src/window_numberinput.h
@@ -36,7 +36,7 @@ public:
 	 * @param iwidth window width.
 	 * @param iheight window height.
 	 */
-	Window_NumberInput(int ix, int iy, int iwidth = 320, int iheight = 80);
+	Window_NumberInput(Scene* parent, int ix, int iy, int iwidth = 320, int iheight = 80);
 
 	/**
 	 * Updates the Window's contents.

--- a/src/window_numberinput.h
+++ b/src/window_numberinput.h
@@ -97,6 +97,8 @@ public:
 	 */
 	void Update() override;
 
+	void SetIndex(int nindex);
+
 protected:
 	int64_t number;
 	int digits_max;
@@ -106,6 +108,8 @@ protected:
 	bool plus;
 
 	void ResetIndex();
+
+	int waitMouseControl = 0;
 };
 
 #endif

--- a/src/window_numberinput.h
+++ b/src/window_numberinput.h
@@ -99,6 +99,10 @@ public:
 
 	void SetIndex(int nindex);
 
+	virtual bool ExcludeForMouse() const {
+		return true;
+	}
+
 protected:
 	int64_t number;
 	int digits_max;

--- a/src/window_paramstatus.cpp
+++ b/src/window_paramstatus.cpp
@@ -23,8 +23,8 @@
 #include "bitmap.h"
 #include "font.h"
 
-Window_ParamStatus::Window_ParamStatus(int ix, int iy, int iwidth, int iheight, int actor_id) :
-	Window_Base(ix, iy, iwidth, iheight),
+Window_ParamStatus::Window_ParamStatus(Scene* parent, int ix, int iy, int iwidth, int iheight, int actor_id) :
+	Window_Base(parent, ix, iy, iwidth, iheight),
 	actor_id(actor_id)
 {
 

--- a/src/window_paramstatus.h
+++ b/src/window_paramstatus.h
@@ -37,7 +37,7 @@ public:
 	 * @param iheight window height.
 	 * @param actor_id actor whose stats are displayed.
 	 */
-	Window_ParamStatus(int ix, int iy, int iwidth, int iheight, int actor_id);
+	Window_ParamStatus(Scene* parent, int ix, int iy, int iwidth, int iheight, int actor_id);
 
 	/**
 	 * Refreshes screen.

--- a/src/window_savefile.cpp
+++ b/src/window_savefile.cpp
@@ -26,8 +26,8 @@
 #include "font.h"
 #include "player.h"
 
-Window_SaveFile::Window_SaveFile(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight) {
+Window_SaveFile::Window_SaveFile(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Base(parent, ix, iy, iwidth, iheight) {
 
 	SetBorderX(4);
 	SetContents(Bitmap::Create(width - 8, height - 16));

--- a/src/window_savefile.h
+++ b/src/window_savefile.h
@@ -31,7 +31,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_SaveFile(int ix, int iy, int iwidth, int iheight);
+	Window_SaveFile(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Renders the current save on the window.

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -154,6 +154,8 @@ void Window_Selectable::Update() {
 				UpdateCursorRect();
 			}
 			else {
+				if (index != -999)
+					mouseOldIndex = index;
 				index = -999;
 				if (GetTopRow() < (GetRowMax() - GetPageRowMax()))
 					if (mouseP.x >= GetX() + GetBorderX() && mouseP.x < GetX() + GetWidth() - GetBorderX() &&
@@ -165,7 +167,7 @@ void Window_Selectable::Update() {
 				if (GetTopRow() > 0)
 					if (mouseP.x >= GetX() + GetBorderX() && mouseP.x < GetX() + GetWidth() - GetBorderX() &&
 						mouseP.y >= GetY() && mouseP.y < GetY() + GetBorderY()) {
-						if (mouseTimeArrow == 1 || (mouseTimeArrow >= 15 && mouseTimeArrow % 5 == 1)) {
+						if (mouseTimeArrow == 1 || (mouseTimeArrow >= Input::start_repeat_time && mouseTimeArrow % Input::repeat_time == 1)) {
 							SetTopRow(GetTopRow() - 1);
 						}
 					}
@@ -204,13 +206,10 @@ void Window_Selectable::Update() {
 			if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
 				mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
 
-				if (index != -999)	
-					mouseOldIndex = index;
-
 				int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * GetCursorRect().height - startCursorY * 16) / GetCursorRect().height * column_max;
 				new_index += (mouseP.x - GetBorderX() - GetX()) / GetCursorRect().width;
 
-				//Output::Debug("Index : {} {} {} {}", GetTopRow(), new_index, GetPageRowMax(), GetItemMax());
+				//Output::Debug("Index : {} {} {} {} {}", GetTopRow(), new_index, GetPageRowMax(), GetItemMax(), mouseOldIndex);
 
 				if (new_index < GetItemMax() && new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max)
 					index = new_index;

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -22,6 +22,7 @@
 #include "util_macro.h"
 #include "bitmap.h"
 #include <output.h>
+#include <baseui.h>
 
 constexpr int arrow_animation_frames = 20;
 
@@ -141,11 +142,39 @@ void Window_Selectable::Update() {
 	Window_Base::Update();
 
 	if (Input::GetUseMouseButton() && IsVisible() && active && GetItemMax() > 0) {
+
+		Point mouseP = Input::GetMousePosition();
+
+		if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
+			mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
+			int h = 1;
+			int w = 1;
+			if (!GetCursorRect().IsEmpty()) {
+				h = GetCursorRect().height;
+				w = GetCursorRect().width;
+			}
+			else if (!GetItemRect(0).IsEmpty()) {
+				h = GetItemRect(0).height + 4;
+				w = GetItemRect(0).width;
+			}
+
+			//Output::Debug("Cursor height {}", h);
+
+			int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * h + startCursorY * 16) / h * column_max;
+			new_index += (mouseP.x - GetBorderX() - GetX()) / w;
+
+			if (new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max) {
+
+				if (new_index < GetItemMax() && new_index >= 0) {
+					// Change cursor (Hand)
+					DisplayUi->ChangeCursor(1);
+				}
+			}
+		}
+
 		if (Input::IsPressed(Input::MOUSE_LEFT)) {
 
 			mouseTimeArrow++;
-
-			Point mouseP = Input::GetMousePosition();
 
 			if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
 				mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
@@ -155,7 +184,7 @@ void Window_Selectable::Update() {
 				else
 					index = GetTopRow();
 				UpdateCursorRect();
-				
+
 			}
 			else {
 				if (index != -999 && index != -1)
@@ -177,11 +206,13 @@ void Window_Selectable::Update() {
 					}
 			}
 		}
-		else
+		else {
 			mouseTimeArrow = 0;
+		}
 	}
-	else
+	else {
 		mouseTimeArrow = 0;
+	}
 
 	if (active && item_max > 0 && index >= 0) {
 		if (scroll_dir != 0) {
@@ -215,10 +246,17 @@ void Window_Selectable::Update() {
 
 				//Output::Debug("Index : {} {} {}", new_index, old_index, GetIndex());
 
-				if (new_index < GetItemMax() && new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max) {
-					if (new_index != mouseOldIndex)
-						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
-					SetIndex(new_index);
+				if (new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max) {
+					if (new_index < GetItemMax()) {
+						if (new_index != mouseOldIndex)
+							Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+						SetIndex(new_index);
+					}
+					else {
+						if (index != -999 && index != -1)
+							mouseOldIndex = index;
+						index = -999;
+					}
 				}
 			}
 		}

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -21,6 +21,7 @@
 #include "input.h"
 #include "util_macro.h"
 #include "bitmap.h"
+#include <output.h>
 
 constexpr int arrow_animation_frames = 20;
 
@@ -36,6 +37,10 @@ void Window_Selectable::CreateContents() {
 }
 
 // Properties
+
+int Window_Selectable::GetItemMax() const {
+	return item_max;
+}
 
 int Window_Selectable::GetIndex() const {
 	return index;
@@ -134,6 +139,44 @@ void Window_Selectable::UpdateArrows() {
 // Update
 void Window_Selectable::Update() {
 	Window_Base::Update();
+
+	if (Input::GetUseMouseButton() && IsVisible() && active && GetItemMax() > 0) {
+		if (Input::IsRawKeyPressed(Input::Keys::MOUSE_LEFT)) {
+
+			mouseTimeArrow++;
+
+			Point mouseP = Input::GetMousePosition();
+
+			if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
+				mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
+
+				index = GetTopRow();
+				UpdateCursorRect();
+			}
+			else {
+				index = -999;
+				if (GetTopRow() < (GetRowMax() - GetPageRowMax()))
+					if (mouseP.x >= GetX() + GetBorderX() && mouseP.x < GetX() + GetWidth() - GetBorderX() &&
+						mouseP.y >= GetY() + GetHeight() - GetBorderY() && mouseP.y < GetY() + GetHeight()) {
+						if (mouseTimeArrow == 1 || (mouseTimeArrow >= 15 && mouseTimeArrow % 5 == 1)) {
+							SetTopRow(GetTopRow() + 1);
+						}
+					}
+				if (GetTopRow() > 0)
+					if (mouseP.x >= GetX() + GetBorderX() && mouseP.x < GetX() + GetWidth() - GetBorderX() &&
+						mouseP.y >= GetY() && mouseP.y < GetY() + GetBorderY()) {
+						if (mouseTimeArrow == 1 || (mouseTimeArrow >= 15 && mouseTimeArrow % 5 == 1)) {
+							SetTopRow(GetTopRow() - 1);
+						}
+					}
+			}
+		}
+		else
+			mouseTimeArrow = 0;
+	}
+	else
+		mouseTimeArrow = 0;
+
 	if (active && item_max > 0 && index >= 0) {
 		if (scroll_dir != 0) {
 			scroll_progress++;
@@ -152,6 +195,28 @@ void Window_Selectable::Update() {
 		}
 
 		int old_index = index;
+
+		if (Input::GetUseMouseButton() && Input::IsRawKeyPressed(Input::Keys::MOUSE_LEFT) && IsVisible() && GetItemMax() > 0) {
+			Point mouseP = Input::GetMousePosition();
+			//Output::Debug("Mouse : {} {} {} {} {} {}", mouseP.x, mouseP.y, GetX() +  GetBorderX(), GetY() + GetBorderY(), GetX() +  GetBorderX() + GetWidth(), GetY() + GetBorderY() + GetHeight());
+			//Output::Debug("Mouse : {}", GetItemMax());
+
+			if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
+				mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
+
+				if (index != -999)	
+					mouseOldIndex = index;
+
+				int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * GetCursorRect().height - startCursorY * 16) / GetCursorRect().height * column_max;
+				new_index += (mouseP.x - GetBorderX() - GetX()) / GetCursorRect().width;
+
+				//Output::Debug("Index : {} {} {} {}", GetTopRow(), new_index, GetPageRowMax(), GetItemMax());
+
+				if (new_index < GetItemMax() && new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max)
+					index = new_index;
+
+			}
+		}
 
 		auto move_down = [&]() {
 			if (index < item_max - column_max || column_max == 1 ) {
@@ -223,6 +288,25 @@ void Window_Selectable::Update() {
 	}
 	UpdateCursorRect();
 	UpdateArrows();
+
+	if (index == -999) {
+		if (Input::IsTriggered(Input::DOWN)) {
+			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+			index = mouseOldIndex;
+		}
+		if (Input::IsTriggered(Input::UP)) {
+			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+			index = mouseOldIndex;
+		}
+		if (Input::IsTriggered(Input::RIGHT)) {
+			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+			index = mouseOldIndex;
+		}
+		if (Input::IsTriggered(Input::LEFT)) {
+			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+			index = mouseOldIndex;
+		}
+	}
 }
 
 // Set endless scrolling state

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -141,6 +141,8 @@ void Window_Selectable::UpdateArrows() {
 void Window_Selectable::Update() {
 	Window_Base::Update();
 
+	int old_index = index;
+
 	if (Input::GetUseMouseButton() && IsVisible() && active && GetItemMax() > 0) {
 
 		Point mouseP = Input::GetMousePosition();
@@ -173,6 +175,7 @@ void Window_Selectable::Update() {
 		}
 
 		if (Input::IsPressed(Input::MOUSE_LEFT)) {
+		//if (Input::mouseHover()) {
 
 			mouseTimeArrow++;
 
@@ -209,6 +212,46 @@ void Window_Selectable::Update() {
 		else {
 			mouseTimeArrow = 0;
 		}
+
+		//Output::Debug("Mouse : {} {} {} {} {} {}", mouseP.x, mouseP.y, GetX() +  GetBorderX(), GetY() + GetBorderY(), GetX() +  GetBorderX() + GetWidth(), GetY() + GetBorderY() + GetHeight());
+		//Output::Debug("Mouse : {}", GetItemMax());
+		//if (Input::IsPressed(Input::DECISION)) {
+		if (Input::mouseHover()) {
+			if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
+				mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
+
+				int w = 1;
+				int h = 1;
+				if (!GetCursorRect().IsEmpty()) {
+					h = GetCursorRect().height;
+					w = GetCursorRect().width;
+				}
+				else if (!GetItemRect(0).IsEmpty()) {
+					h = GetItemRect(0).height;
+					w = GetItemRect(0).width;
+				}
+				int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * h - startCursorY * 16) / h * column_max;
+				new_index += (mouseP.x - GetBorderX() - GetX()) / w;
+
+				// Output::Debug("Index : {} {} {}", new_index, old_index, GetIndex());
+				
+				if (new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max) {
+					if (new_index < GetItemMax() && !IsOpeningOrClosing()) {
+						if (new_index != mouseOldIndex)
+							Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+						if (index != -999 && index != -1)
+							mouseOldIndex = new_index;
+						SetIndex(new_index);
+					}
+					else if (!IsOpeningOrClosing()) {
+						if (index != -999 && index != -1)
+							mouseOldIndex = index;
+						index = -999;
+					}
+				}
+				
+			}
+		}
 	}
 	else {
 		mouseTimeArrow = 0;
@@ -228,36 +271,6 @@ void Window_Selectable::Update() {
 					UpdateHelp();
 				}
 				UpdateCursorRect();
-			}
-		}
-
-		int old_index = index;
-
-		if (Input::GetUseMouseButton() && Input::IsPressed(Input::MOUSE_LEFT) && IsVisible() && GetItemMax() > 0) {
-			Point mouseP = Input::GetMousePosition();
-			//Output::Debug("Mouse : {} {} {} {} {} {}", mouseP.x, mouseP.y, GetX() +  GetBorderX(), GetY() + GetBorderY(), GetX() +  GetBorderX() + GetWidth(), GetY() + GetBorderY() + GetHeight());
-			//Output::Debug("Mouse : {}", GetItemMax());
-
-			if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
-				mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
-
-				int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * GetCursorRect().height - startCursorY * 16) / GetCursorRect().height * column_max;
-				new_index += (mouseP.x - GetBorderX() - GetX()) / GetCursorRect().width;
-
-				//Output::Debug("Index : {} {} {}", new_index, old_index, GetIndex());
-
-				if (new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max) {
-					if (new_index < GetItemMax()) {
-						if (new_index != mouseOldIndex)
-							Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
-						SetIndex(new_index);
-					}
-					else {
-						if (index != -999 && index != -1)
-							mouseOldIndex = index;
-						index = -999;
-					}
-				}
 			}
 		}
 
@@ -329,6 +342,7 @@ void Window_Selectable::Update() {
 	if (active && help_window != NULL) {
 		UpdateHelp();
 	}
+
 	UpdateCursorRect();
 	UpdateArrows();
 

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -163,119 +163,6 @@ void Window_Selectable::Update() {
 
 	int old_index = index;
 
-	//if (Input::GetUseMouseButton() && IsVisible() && active && GetItemMax() > 0) {
-
-	//	Point mouseP = Input::GetMousePosition();
-
-	//	if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
-	//		mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
-	//		int h = 1;
-	//		int w = 1;
-	//		if (!GetCursorRect(0).IsEmpty()) {
-	//			h = GetCursorRect(0).height;
-	//			w = GetCursorRect(0).width;
-	//		}
-	//		else if (!GetItemRect(0).IsEmpty()) {
-	//			h = GetItemRect(0).height + 4;
-	//			w = GetItemRect(0).width;
-	//		}
-
-	//		//Output::Debug("Cursor height {}", h);
-
-	//		int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * h + startCursorY * 16) / h * column_max;
-	//		new_index += (mouseP.x - GetBorderX() - GetX()) / w;
-
-	//		if (new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max) {
-
-	//			if (new_index < GetItemMax() && new_index >= 0) {
-	//				// Change cursor (Hand)
-	//				DisplayUi->ChangeCursor(1);
-	//			}
-	//		}
-	//	}
-
-	//	if (Input::IsPressed(Input::MOUSE_LEFT)) {
-	//	//if (Input::mouseHover()) {
-
-	//		mouseTimeArrow++;
-
-	//		if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
-	//			mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
-
-	//			if (index != -999 && index != -1)
-	//				mouseOldIndex = index;
-	//			else
-	//				index = GetTopRow();
-	//			UpdateCursorRect();
-
-	//		}
-	//		else {
-	//			if (index != -999 && index != -1)
-	//				mouseOldIndex = index;
-	//			index = -999;
-	//			if (GetTopRow() < (GetRowMax() - GetPageRowMax()))
-	//				if (mouseP.x >= GetX() + GetBorderX() && mouseP.x < GetX() + GetWidth() - GetBorderX() &&
-	//					mouseP.y >= GetY() + GetHeight() - GetBorderY() && mouseP.y < GetY() + GetHeight()) {
-	//					if (mouseTimeArrow == 1 || (mouseTimeArrow >= 15 && mouseTimeArrow % 5 == 1)) {
-	//						SetTopRow(GetTopRow() + 1);
-	//					}
-	//				}
-	//			if (GetTopRow() > 0)
-	//				if (mouseP.x >= GetX() + GetBorderX() && mouseP.x < GetX() + GetWidth() - GetBorderX() &&
-	//					mouseP.y >= GetY() && mouseP.y < GetY() + GetBorderY()) {
-	//					if (mouseTimeArrow == 1 || (mouseTimeArrow >= Input::start_repeat_time && mouseTimeArrow % Input::repeat_time == 1)) {
-	//						SetTopRow(GetTopRow() - 1);
-	//					}
-	//				}
-	//		}
-	//	}
-	//	else {
-	//		mouseTimeArrow = 0;
-	//	}
-
-	//	//Output::Debug("Mouse : {} {} {} {} {} {}", mouseP.x, mouseP.y, GetX() +  GetBorderX(), GetY() + GetBorderY(), GetX() +  GetBorderX() + GetWidth(), GetY() + GetBorderY() + GetHeight());
-	//	//Output::Debug("Mouse : {}", GetItemMax());
-	//	//if (Input::IsPressed(Input::DECISION)) {
-	//	if (Input::mouseHover()) {
-	//		if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
-	//			mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
-
-	//			int w = 1;
-	//			int h = 1;
-	//			if (!GetCursorRect(0).IsEmpty()) {
-	//				h = GetCursorRect(0).height;
-	//				w = GetCursorRect(0).width;
-	//			}
-	//			else if (!GetItemRect(0).IsEmpty()) {
-	//				h = GetItemRect(0).height;
-	//				w = GetItemRect(0).width;
-	//			}
-	//			int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * h - startCursorY * 16) / h * column_max;
-	//			new_index += (mouseP.x - GetBorderX() - GetX()) / w;
-
-	//			// Output::Debug("Index : {} {} {}", new_index, old_index, GetIndex());
-	//			
-	//			if (new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max) {
-	//				if (new_index < GetItemMax() && !IsOpeningOrClosing()) {
-	//					if (new_index != mouseOldIndex)
-	//						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
-	//					if (index != -999 && index != -1)
-	//						mouseOldIndex = new_index;
-	//					SetIndex(new_index);
-	//				}
-	//				else if (!IsOpeningOrClosing()) {
-	//					if (index != -999 && index != -1)
-	//						mouseOldIndex = index;
-	//					index = -999;
-	//				}
-	//			}
-	//			
-	//		}
-	//	}
-	//}
-	//else {
-	//	mouseTimeArrow = 0;
-	//}
 
 	if (active && item_max > 0 && index >= 0) {
 		if (scroll_dir != 0) {
@@ -300,7 +187,7 @@ void Window_Selectable::Update() {
 				index = (index + column_max) % item_max;
 			}
 		};
-		if (Input::IsTriggered(Input::DOWN) || Input::IsTriggered(Input::SCROLL_DOWN)) {
+		if (Input::IsTriggered(Input::DOWN) || (Input::IsTriggered(Input::SCROLL_DOWN) && !Input::GetUseMouseButton())) {
 			move_down();
 		} else if (Input::IsRepeated(Input::DOWN)) {
 			if (endless_scrolling || (index + column_max) % item_max > index) {
@@ -314,7 +201,7 @@ void Window_Selectable::Update() {
 				index = (index - column_max + item_max) % item_max;
 			}
 		};
-		if (Input::IsTriggered(Input::UP) || Input::IsTriggered(Input::SCROLL_UP)) {
+		if (Input::IsTriggered(Input::UP) || (Input::IsTriggered(Input::SCROLL_UP) && !Input::GetUseMouseButton())) {
 			move_up();
 		} else if (Input::IsRepeated(Input::UP)) {
 			if (endless_scrolling || (index - column_max + item_max) % item_max < index) {
@@ -359,6 +246,70 @@ void Window_Selectable::Update() {
 			}
 		}
 	}
+	if (Input::GetUseMouseButton()) {
+		if (index == -999)
+			if (scroll_dir != 0) {
+				scroll_progress++;
+				SetOy(GetOy() + (menu_item_height * scroll_progress / 4 - menu_item_height * (scroll_progress - 1) / 4) * scroll_dir);
+				UpdateArrows();
+				if (scroll_progress < 4) {
+					return;
+				}
+				else {
+					scroll_dir = 0;
+					scroll_progress = 0;
+					if (active && help_window != NULL) {
+						UpdateHelp();
+					}
+					UpdateCursorRect();
+				}
+			}
+		bool show_down_arrow = (GetTopRow() < (GetRowMax() - GetPageRowMax()));
+		if (show_down_arrow) {
+			bool b = false;
+			Point mouseP = Input::GetMousePosition();
+			int dx = x + width / 2 - 8;
+			int dy = y + height - 8;
+			if (mouseP.x > dx && mouseP.x < dx + 16 && mouseP.y > dy && mouseP.y < dy + 8) {
+				b = true;
+				DisplayUi->ChangeCursor(1);
+			}
+			if (Input::IsRepeated(Input::MOUSE_LEFT) && b) {
+				scroll_dir = 1;
+				//index++;
+				return;
+			}
+			else if (Input::IsRepeated(Input::SCROLL_DOWN) && Input::GetUseMouseButton()) {
+				scroll_dir = 1;
+				index++;
+				return;
+			}
+		}
+
+		bool show_up_arrow = (GetTopRow() > 0);
+		if (show_up_arrow) {
+			bool b = false;
+			Point mouseP = Input::GetMousePosition();
+			int dx = x + width / 2 - 8;
+			int dy = y;
+			if (mouseP.x > dx && mouseP.x < dx + 16 && mouseP.y > dy && mouseP.y < dy + 8) {
+				b = true;
+				DisplayUi->ChangeCursor(1);
+			}
+			if (Input::IsRepeated(Input::MOUSE_LEFT) && b) {
+				Output::Debug("{} {} {} {}", dx, mouseP.x, dy, mouseP.y);
+				scroll_dir = -1;
+				//index++;
+				return;
+			}
+			else if (Input::IsRepeated(Input::SCROLL_UP) && Input::GetUseMouseButton()) {
+				scroll_dir = -1;
+				index--;
+				return;
+			}
+		}
+	}
+
 	if (active && help_window != NULL) {
 		UpdateHelp();
 	}

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -163,119 +163,119 @@ void Window_Selectable::Update() {
 
 	int old_index = index;
 
-	if (Input::GetUseMouseButton() && IsVisible() && active && GetItemMax() > 0) {
+	//if (Input::GetUseMouseButton() && IsVisible() && active && GetItemMax() > 0) {
 
-		Point mouseP = Input::GetMousePosition();
+	//	Point mouseP = Input::GetMousePosition();
 
-		if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
-			mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
-			int h = 1;
-			int w = 1;
-			if (!GetCursorRect(0).IsEmpty()) {
-				h = GetCursorRect(0).height;
-				w = GetCursorRect(0).width;
-			}
-			else if (!GetItemRect(0).IsEmpty()) {
-				h = GetItemRect(0).height + 4;
-				w = GetItemRect(0).width;
-			}
+	//	if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
+	//		mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
+	//		int h = 1;
+	//		int w = 1;
+	//		if (!GetCursorRect(0).IsEmpty()) {
+	//			h = GetCursorRect(0).height;
+	//			w = GetCursorRect(0).width;
+	//		}
+	//		else if (!GetItemRect(0).IsEmpty()) {
+	//			h = GetItemRect(0).height + 4;
+	//			w = GetItemRect(0).width;
+	//		}
 
-			//Output::Debug("Cursor height {}", h);
+	//		//Output::Debug("Cursor height {}", h);
 
-			int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * h + startCursorY * 16) / h * column_max;
-			new_index += (mouseP.x - GetBorderX() - GetX()) / w;
+	//		int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * h + startCursorY * 16) / h * column_max;
+	//		new_index += (mouseP.x - GetBorderX() - GetX()) / w;
 
-			if (new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max) {
+	//		if (new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max) {
 
-				if (new_index < GetItemMax() && new_index >= 0) {
-					// Change cursor (Hand)
-					DisplayUi->ChangeCursor(1);
-				}
-			}
-		}
+	//			if (new_index < GetItemMax() && new_index >= 0) {
+	//				// Change cursor (Hand)
+	//				DisplayUi->ChangeCursor(1);
+	//			}
+	//		}
+	//	}
 
-		if (Input::IsPressed(Input::MOUSE_LEFT)) {
-		//if (Input::mouseHover()) {
+	//	if (Input::IsPressed(Input::MOUSE_LEFT)) {
+	//	//if (Input::mouseHover()) {
 
-			mouseTimeArrow++;
+	//		mouseTimeArrow++;
 
-			if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
-				mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
+	//		if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
+	//			mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
 
-				if (index != -999 && index != -1)
-					mouseOldIndex = index;
-				else
-					index = GetTopRow();
-				UpdateCursorRect();
+	//			if (index != -999 && index != -1)
+	//				mouseOldIndex = index;
+	//			else
+	//				index = GetTopRow();
+	//			UpdateCursorRect();
 
-			}
-			else {
-				if (index != -999 && index != -1)
-					mouseOldIndex = index;
-				index = -999;
-				if (GetTopRow() < (GetRowMax() - GetPageRowMax()))
-					if (mouseP.x >= GetX() + GetBorderX() && mouseP.x < GetX() + GetWidth() - GetBorderX() &&
-						mouseP.y >= GetY() + GetHeight() - GetBorderY() && mouseP.y < GetY() + GetHeight()) {
-						if (mouseTimeArrow == 1 || (mouseTimeArrow >= 15 && mouseTimeArrow % 5 == 1)) {
-							SetTopRow(GetTopRow() + 1);
-						}
-					}
-				if (GetTopRow() > 0)
-					if (mouseP.x >= GetX() + GetBorderX() && mouseP.x < GetX() + GetWidth() - GetBorderX() &&
-						mouseP.y >= GetY() && mouseP.y < GetY() + GetBorderY()) {
-						if (mouseTimeArrow == 1 || (mouseTimeArrow >= Input::start_repeat_time && mouseTimeArrow % Input::repeat_time == 1)) {
-							SetTopRow(GetTopRow() - 1);
-						}
-					}
-			}
-		}
-		else {
-			mouseTimeArrow = 0;
-		}
+	//		}
+	//		else {
+	//			if (index != -999 && index != -1)
+	//				mouseOldIndex = index;
+	//			index = -999;
+	//			if (GetTopRow() < (GetRowMax() - GetPageRowMax()))
+	//				if (mouseP.x >= GetX() + GetBorderX() && mouseP.x < GetX() + GetWidth() - GetBorderX() &&
+	//					mouseP.y >= GetY() + GetHeight() - GetBorderY() && mouseP.y < GetY() + GetHeight()) {
+	//					if (mouseTimeArrow == 1 || (mouseTimeArrow >= 15 && mouseTimeArrow % 5 == 1)) {
+	//						SetTopRow(GetTopRow() + 1);
+	//					}
+	//				}
+	//			if (GetTopRow() > 0)
+	//				if (mouseP.x >= GetX() + GetBorderX() && mouseP.x < GetX() + GetWidth() - GetBorderX() &&
+	//					mouseP.y >= GetY() && mouseP.y < GetY() + GetBorderY()) {
+	//					if (mouseTimeArrow == 1 || (mouseTimeArrow >= Input::start_repeat_time && mouseTimeArrow % Input::repeat_time == 1)) {
+	//						SetTopRow(GetTopRow() - 1);
+	//					}
+	//				}
+	//		}
+	//	}
+	//	else {
+	//		mouseTimeArrow = 0;
+	//	}
 
-		//Output::Debug("Mouse : {} {} {} {} {} {}", mouseP.x, mouseP.y, GetX() +  GetBorderX(), GetY() + GetBorderY(), GetX() +  GetBorderX() + GetWidth(), GetY() + GetBorderY() + GetHeight());
-		//Output::Debug("Mouse : {}", GetItemMax());
-		//if (Input::IsPressed(Input::DECISION)) {
-		if (Input::mouseHover()) {
-			if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
-				mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
+	//	//Output::Debug("Mouse : {} {} {} {} {} {}", mouseP.x, mouseP.y, GetX() +  GetBorderX(), GetY() + GetBorderY(), GetX() +  GetBorderX() + GetWidth(), GetY() + GetBorderY() + GetHeight());
+	//	//Output::Debug("Mouse : {}", GetItemMax());
+	//	//if (Input::IsPressed(Input::DECISION)) {
+	//	if (Input::mouseHover()) {
+	//		if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
+	//			mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
 
-				int w = 1;
-				int h = 1;
-				if (!GetCursorRect(0).IsEmpty()) {
-					h = GetCursorRect(0).height;
-					w = GetCursorRect(0).width;
-				}
-				else if (!GetItemRect(0).IsEmpty()) {
-					h = GetItemRect(0).height;
-					w = GetItemRect(0).width;
-				}
-				int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * h - startCursorY * 16) / h * column_max;
-				new_index += (mouseP.x - GetBorderX() - GetX()) / w;
+	//			int w = 1;
+	//			int h = 1;
+	//			if (!GetCursorRect(0).IsEmpty()) {
+	//				h = GetCursorRect(0).height;
+	//				w = GetCursorRect(0).width;
+	//			}
+	//			else if (!GetItemRect(0).IsEmpty()) {
+	//				h = GetItemRect(0).height;
+	//				w = GetItemRect(0).width;
+	//			}
+	//			int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * h - startCursorY * 16) / h * column_max;
+	//			new_index += (mouseP.x - GetBorderX() - GetX()) / w;
 
-				// Output::Debug("Index : {} {} {}", new_index, old_index, GetIndex());
-				
-				if (new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max) {
-					if (new_index < GetItemMax() && !IsOpeningOrClosing()) {
-						if (new_index != mouseOldIndex)
-							Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
-						if (index != -999 && index != -1)
-							mouseOldIndex = new_index;
-						SetIndex(new_index);
-					}
-					else if (!IsOpeningOrClosing()) {
-						if (index != -999 && index != -1)
-							mouseOldIndex = index;
-						index = -999;
-					}
-				}
-				
-			}
-		}
-	}
-	else {
-		mouseTimeArrow = 0;
-	}
+	//			// Output::Debug("Index : {} {} {}", new_index, old_index, GetIndex());
+	//			
+	//			if (new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max) {
+	//				if (new_index < GetItemMax() && !IsOpeningOrClosing()) {
+	//					if (new_index != mouseOldIndex)
+	//						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+	//					if (index != -999 && index != -1)
+	//						mouseOldIndex = new_index;
+	//					SetIndex(new_index);
+	//				}
+	//				else if (!IsOpeningOrClosing()) {
+	//					if (index != -999 && index != -1)
+	//						mouseOldIndex = index;
+	//					index = -999;
+	//				}
+	//			}
+	//			
+	//		}
+	//	}
+	//}
+	//else {
+	//	mouseTimeArrow = 0;
+	//}
 
 	if (active && item_max > 0 && index >= 0) {
 		if (scroll_dir != 0) {
@@ -388,12 +388,12 @@ void Window_Selectable::Update() {
 
 #include "output.h"
 int Window_Selectable::CursorHitTest(Point position) const {
-	Output::Debug("{} {}", position.x, position.y);
+	// Output::Debug("{} {}", position.x, position.y);
 	for (int i = 0; i < item_max; ++i) {
 		Rect cursor_rect = GetCursorRect(i);
 		cursor_rect.x += GetBorderX();
 		cursor_rect.y += GetBorderY();
-		Output::Debug("{} {} {} {}", cursor_rect.x, cursor_rect.y, cursor_rect.width, cursor_rect.height);
+		// Output::Debug("{} {} {} {}", cursor_rect.x, cursor_rect.y, cursor_rect.width, cursor_rect.height);
 		if (cursor_rect != Rect()) {
 			if (position.x >= cursor_rect.x && position.x <= cursor_rect.x + cursor_rect.width &&
 				position.y >= cursor_rect.y && position.y <= cursor_rect.y + cursor_rect.height) {

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -103,7 +103,27 @@ void Window_Selectable::UpdateHelp() {
 	}
 }
 
-// Update Cursor Rect
+Rect Window_Selectable::GetCursorRect(int index) const {
+	int cursor_width = 0;
+	int x = 0;
+	if (index < 0) {
+		return {};
+	}
+	int row = index / column_max;
+	if (row < GetTopRow()) {
+		return {};
+	} else if (row > GetTopRow() + (GetPageRowMax() - 1)) {
+		return {};
+	}
+
+	cursor_width = (width / column_max - 16) + 8;
+	x = (index % column_max * (cursor_width + 8)) - 4;
+
+	int y = index / column_max * menu_item_height - oy;
+
+	return {x, y, cursor_width, menu_item_height};
+}
+
 void Window_Selectable::UpdateCursorRect() {
 	int cursor_width = 0;
 	int x = 0;
@@ -365,6 +385,26 @@ void Window_Selectable::Update() {
 		}
 	}
 }
+
+#include "output.h"
+int Window_Selectable::CursorHitTest(Point position) const {
+	Output::Debug("{} {}", position.x, position.y);
+	for (int i = 0; i < item_max; ++i) {
+		Rect cursor_rect = GetCursorRect(i);
+		cursor_rect.x += GetBorderX();
+		cursor_rect.y += GetBorderY();
+		Output::Debug("{} {} {} {}", cursor_rect.x, cursor_rect.y, cursor_rect.width, cursor_rect.height);
+		if (cursor_rect != Rect()) {
+			if (position.x >= cursor_rect.x && position.x <= cursor_rect.x + cursor_rect.width &&
+				position.y >= cursor_rect.y && position.y <= cursor_rect.y + cursor_rect.height) {
+
+				return i;
+			}
+		}
+	}
+	return -1;
+}
+
 
 // Set endless scrolling state
 void Window_Selectable::SetEndlessScrolling(bool state) {

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -27,8 +27,8 @@
 constexpr int arrow_animation_frames = 20;
 
 // Constructor
-Window_Selectable::Window_Selectable(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight) { }
+Window_Selectable::Window_Selectable(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Base(parent, WindowType::Selectable, ix, iy, iwidth, iheight) { }
 
 void Window_Selectable::CreateContents() {
 	int w = std::max(0, width - border_x * 2);

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -171,9 +171,9 @@ void Window_Selectable::Update() {
 			mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
 			int h = 1;
 			int w = 1;
-			if (!GetCursorRect().IsEmpty()) {
-				h = GetCursorRect().height;
-				w = GetCursorRect().width;
+			if (!GetCursorRect(0).IsEmpty()) {
+				h = GetCursorRect(0).height;
+				w = GetCursorRect(0).width;
 			}
 			else if (!GetItemRect(0).IsEmpty()) {
 				h = GetItemRect(0).height + 4;
@@ -242,9 +242,9 @@ void Window_Selectable::Update() {
 
 				int w = 1;
 				int h = 1;
-				if (!GetCursorRect().IsEmpty()) {
-					h = GetCursorRect().height;
-					w = GetCursorRect().width;
+				if (!GetCursorRect(0).IsEmpty()) {
+					h = GetCursorRect(0).height;
+					w = GetCursorRect(0).width;
 				}
 				else if (!GetItemRect(0).IsEmpty()) {
 					h = GetItemRect(0).height;

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -98,7 +98,7 @@ void Window_Selectable::SetHelpWindow(Window_Help* nhelp_window) {
 }
 
 void Window_Selectable::UpdateHelp() {
-	if (UpdateHelpFn && help_window != nullptr) {
+	if (UpdateHelpFn && help_window != nullptr && index != -999) {
 		UpdateHelpFn(*help_window, index);
 	}
 }

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -141,7 +141,7 @@ void Window_Selectable::Update() {
 	Window_Base::Update();
 
 	if (Input::GetUseMouseButton() && IsVisible() && active && GetItemMax() > 0) {
-		if (Input::IsRawKeyPressed(Input::Keys::MOUSE_LEFT)) {
+		if (Input::IsPressed(Input::MOUSE_LEFT)) {
 
 			mouseTimeArrow++;
 
@@ -150,11 +150,15 @@ void Window_Selectable::Update() {
 			if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
 				mouseP.y >= GetY() + GetBorderY() && mouseP.y < GetY() + GetHeight() - GetBorderY()) {
 
-				index = GetTopRow();
+				if (index != -999 && index != -1)
+					mouseOldIndex = index;
+				else
+					index = GetTopRow();
 				UpdateCursorRect();
+				
 			}
 			else {
-				if (index != -999)
+				if (index != -999 && index != -1)
 					mouseOldIndex = index;
 				index = -999;
 				if (GetTopRow() < (GetRowMax() - GetPageRowMax()))
@@ -198,7 +202,7 @@ void Window_Selectable::Update() {
 
 		int old_index = index;
 
-		if (Input::GetUseMouseButton() && Input::IsRawKeyPressed(Input::Keys::MOUSE_LEFT) && IsVisible() && GetItemMax() > 0) {
+		if (Input::GetUseMouseButton() && Input::IsPressed(Input::MOUSE_LEFT) && IsVisible() && GetItemMax() > 0) {
 			Point mouseP = Input::GetMousePosition();
 			//Output::Debug("Mouse : {} {} {} {} {} {}", mouseP.x, mouseP.y, GetX() +  GetBorderX(), GetY() + GetBorderY(), GetX() +  GetBorderX() + GetWidth(), GetY() + GetBorderY() + GetHeight());
 			//Output::Debug("Mouse : {}", GetItemMax());
@@ -209,11 +213,13 @@ void Window_Selectable::Update() {
 				int new_index = (mouseP.y - GetBorderY() - GetY() + GetTopRow() * GetCursorRect().height - startCursorY * 16) / GetCursorRect().height * column_max;
 				new_index += (mouseP.x - GetBorderX() - GetX()) / GetCursorRect().width;
 
-				//Output::Debug("Index : {} {} {} {} {}", GetTopRow(), new_index, GetPageRowMax(), GetItemMax(), mouseOldIndex);
+				//Output::Debug("Index : {} {} {}", new_index, old_index, GetIndex());
 
-				if (new_index < GetItemMax() && new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max)
-					index = new_index;
-
+				if (new_index < GetItemMax() && new_index >= GetTopRow() && new_index < GetTopRow() + GetPageRowMax() * column_max) {
+					if (new_index != mouseOldIndex)
+						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+					SetIndex(new_index);
+				}
 			}
 		}
 
@@ -288,7 +294,7 @@ void Window_Selectable::Update() {
 	UpdateCursorRect();
 	UpdateArrows();
 
-	if (index == -999) {
+	if (index == -999 && active) {
 		if (Input::IsTriggered(Input::DOWN)) {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 			index = mouseOldIndex;
@@ -321,3 +327,9 @@ void Window_Selectable::SetMenuItemHeight(int height) {
 void Window_Selectable::SetSingleColumnWrapping(bool wrap) {
 	wrap_limit = wrap ? 1 : 2;
 }
+void Window_Selectable::SetMouseOldIndex(int i) {
+	mouseOldIndex = i;
+}
+int Window_Selectable::GetMouseOldIndex() {
+	return mouseOldIndex;
+ }

--- a/src/window_selectable.h
+++ b/src/window_selectable.h
@@ -28,7 +28,7 @@
  */
 class Window_Selectable: public Window_Base {
 public:
-	Window_Selectable(int ix, int iy, int iwidth, int iheight);
+	Window_Selectable(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Creates the contents based on how many items
@@ -142,7 +142,7 @@ protected:
 	int mouseOldIndex = 0;
 };
 
-inline void Window_Selectable::SetItemMax(int value) {
+inline void	Window_Selectable::SetItemMax(int value) {
 	item_max = value;
 }
 

--- a/src/window_selectable.h
+++ b/src/window_selectable.h
@@ -74,10 +74,27 @@ public:
 	 * @param nhelp_window the help window.
 	 */
 	void SetHelpWindow(Window_Help* nhelp_window);
+
+
+	/**
+	 * Returns a rectangle indicating the cursor location for the passed index.
+	 *
+	 * @param index cursor index
+	 * @return cursor rectangle
+	 */
+	virtual Rect GetCursorRect(int index) const;
 	virtual void UpdateCursorRect();
 	void Update() override;
 
 	virtual void UpdateHelp();
+
+	/**
+	 * Returns the index of the item that is at the passed position or -1 if there is nothing.
+	 *
+	 * @param position Position to check. Relative to the content.
+	 * @return index of the item or -1 if nothing was found.
+	 */
+	virtual int CursorHitTest(Point position) const;
 
 	/**
 	 * Sets if endless scrolling is enabled.

--- a/src/window_selectable.h
+++ b/src/window_selectable.h
@@ -36,6 +36,7 @@ public:
 	 */
 	void CreateContents();
 
+	int GetItemMax() const;
 	int GetIndex() const;
 	void SetIndex(int nindex);
 	int GetColumnMax() const;
@@ -117,6 +118,9 @@ protected:
 	int scroll_progress = 0;
 
 	int wrap_limit = 2;
+	int mouseTimeArrow;
+	int startCursorY = 0;
+	int mouseOldIndex = 0;
 };
 
 inline void Window_Selectable::SetItemMax(int value) {

--- a/src/window_selectable.h
+++ b/src/window_selectable.h
@@ -100,6 +100,8 @@ public:
 	 * @param wrap enable/disable single column wrap
 	 */
 	void SetSingleColumnWrapping(bool wrap);
+	void SetMouseOldIndex(int i);
+	int GetMouseOldIndex();
 
 protected:
 	void UpdateArrows();

--- a/src/window_settings.cpp
+++ b/src/window_settings.cpp
@@ -39,8 +39,8 @@ public:
 	}
 };
 
-Window_Settings::Window_Settings(int ix, int iy, int iwidth, int iheight) :
-	Window_Selectable(ix, iy, iwidth, iheight) {
+Window_Settings::Window_Settings(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Selectable(parent, ix, iy, iwidth, iheight) {
 	column_max = 1;
 }
 

--- a/src/window_settings.cpp
+++ b/src/window_settings.cpp
@@ -382,6 +382,7 @@ void Window_Settings::RefreshInput() {
 	AddOption(cfg.gamepad_swap_dpad_with_buttons, [&cfg](){ cfg.gamepad_swap_dpad_with_buttons.Toggle(); Input::ResetTriggerKeys(); });
 	AddOption(cfg.speed_modifier_a, [this, &cfg](){ auto tmp = GetCurrentOption().current_value; Player::speed_modifier_a = tmp; cfg.speed_modifier_a.Set(tmp); });
 	AddOption(cfg.speed_modifier_b, [this, &cfg](){ auto tmp = GetCurrentOption().current_value; Player::speed_modifier_b = tmp; cfg.speed_modifier_b.Set(tmp); });
+	AddOption(cfg.mouse_control, [this, &cfg]() {cfg.mouse_control.Toggle(); bool tmp = cfg.mouse_control.Get(); Input::SetUseMouse(tmp); });
 }
 
 void Window_Settings::RefreshButtonCategory() {

--- a/src/window_settings.h
+++ b/src/window_settings.h
@@ -79,7 +79,7 @@ public:
 	};
 
 	/** Constructor  */
-	Window_Settings(int ix, int iy, int iwidth, int iheight);
+	Window_Settings(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/** @return true if the index points to an enabled action */
 	bool IsCurrentActionEnabled() const {

--- a/src/window_shop.cpp
+++ b/src/window_shop.cpp
@@ -25,6 +25,7 @@
 #include "window_shop.h"
 #include "bitmap.h"
 #include "font.h"
+#include <output.h>
 
 Window_Shop::Window_Shop(int shop_type, int ix, int iy, int iwidth, int iheight) :
 	Window_Base(ix, iy, iwidth, iheight) {
@@ -176,12 +177,36 @@ void Window_Shop::Update() {
 	Window_Base::Update();
 
 	if (active) {
+		if (Input::GetUseMouseButton() && Input::IsRawKeyPressed(Input::Keys::MOUSE_LEFT) && IsVisible() && leave_index > 0 && GetCursorRect().height > 0) {
+			Point mouseP = Input::GetMousePosition();
+			//Output::Debug("Mouse : {} {} {} {} {} {}", mouseP.x, mouseP.y, GetX() +  GetBorderX(), GetY() + GetBorderY(), GetX() +  GetBorderX() + GetWidth(), GetY() + GetBorderY() + GetHeight());
+			//Output::Debug("Mouse : {}", GetItemMax());
+
+			if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
+				mouseP.y >= GetY() + GetBorderY() + 16 && mouseP.y < GetY() + GetHeight() - GetBorderY() + 16) {
+
+
+				int new_index = (mouseP.y - GetBorderY() - GetY()) / GetCursorRect().height;
+
+				//Output::Debug("Index : {} {}", new_index, leave_index);
+
+				if (new_index <= leave_index && new_index >= 0)
+					index = new_index;
+
+			}
+			else {
+				index = -999;
+			}
+		}
 		switch (mode) {
 			case Scene_Shop::BuySellLeave:
 			case Scene_Shop::BuySellLeave2:
 				if (Input::IsRepeated(Input::DOWN) || Input::IsTriggered(Input::SCROLL_DOWN)) {
 					if (index < leave_index) {
-						index++;
+						if (index == -999)
+							index = 1;
+						else
+							index++;
 					}
 					else {
 						index = 1;
@@ -197,7 +222,7 @@ void Window_Shop::Update() {
 					}
 					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 				}
-				if (Input::IsTriggered(Input::DECISION)) {
+				if (Input::IsTriggered(Input::DECISION) && index >= 0) {
 					Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 					if (index == buy_index)
 						choice = Scene_Shop::Buy;

--- a/src/window_shop.cpp
+++ b/src/window_shop.cpp
@@ -26,6 +26,7 @@
 #include "bitmap.h"
 #include "font.h"
 #include <output.h>
+#include <baseui.h>
 
 Window_Shop::Window_Shop(int shop_type, int ix, int iy, int iwidth, int iheight) :
 	Window_Base(ix, iy, iwidth, iheight) {
@@ -177,7 +178,8 @@ void Window_Shop::Update() {
 	Window_Base::Update();
 
 	if (active) {
-		if (Input::GetUseMouseButton() && Input::IsRawKeyPressed(Input::Keys::MOUSE_LEFT) && IsVisible() && leave_index > 0 && GetCursorRect().height > 0) {
+
+		if (Input::GetUseMouseButton() && IsVisible() && leave_index > 0 && GetCursorRect().height > 0) {
 			Point mouseP = Input::GetMousePosition();
 			//Output::Debug("Mouse : {} {} {} {} {} {}", mouseP.x, mouseP.y, GetX() +  GetBorderX(), GetY() + GetBorderY(), GetX() +  GetBorderX() + GetWidth(), GetY() + GetBorderY() + GetHeight());
 			//Output::Debug("Mouse : {}", GetItemMax());
@@ -185,16 +187,24 @@ void Window_Shop::Update() {
 			if (mouseP.x >= GetX() + GetBorderX() && mouseP.x <= GetX() + GetWidth() - GetBorderX() &&
 				mouseP.y >= GetY() + GetBorderY() + 16 && mouseP.y < GetY() + GetHeight() - GetBorderY() + 16) {
 
-
 				int new_index = (mouseP.y - GetBorderY() - GetY()) / GetCursorRect().height;
 
 				//Output::Debug("Index : {} {}", new_index, leave_index);
 
-				if (new_index <= leave_index && new_index >= 0)
-					index = new_index;
+				if (new_index <= leave_index && new_index >= 0) {
+
+					// Change cursor (Hand)
+					DisplayUi->ChangeCursor(1);
+
+					if (Input::IsPressed(Input::MOUSE_LEFT)) {
+						if (index != new_index)
+							Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+						index = new_index;
+					}
+				}
 
 			}
-			else {
+			else if (Input::IsPressed(Input::MOUSE_LEFT)) {
 				index = -999;
 			}
 		}
@@ -236,4 +246,8 @@ void Window_Shop::Update() {
 	}
 
 	UpdateCursorRect();
+}
+
+int Window_Shop::GetIndex() const {
+	return index;
 }

--- a/src/window_shop.cpp
+++ b/src/window_shop.cpp
@@ -196,7 +196,8 @@ void Window_Shop::Update() {
 					// Change cursor (Hand)
 					DisplayUi->ChangeCursor(1);
 
-					if (Input::IsPressed(Input::MOUSE_LEFT)) {
+					//if (Input::IsPressed(Input::MOUSE_LEFT)) {
+					if (Input::mouseHover()) {
 						if (index != new_index)
 							Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 						index = new_index;

--- a/src/window_shop.cpp
+++ b/src/window_shop.cpp
@@ -197,7 +197,7 @@ void Window_Shop::Update() {
 					DisplayUi->ChangeCursor(1);
 
 					//if (Input::IsPressed(Input::MOUSE_LEFT)) {
-					if (Input::mouseHover()) {
+					if (Input::MouseMoved()) {
 						if (index != new_index)
 							Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
 						index = new_index;

--- a/src/window_shop.cpp
+++ b/src/window_shop.cpp
@@ -28,8 +28,8 @@
 #include <output.h>
 #include <baseui.h>
 
-Window_Shop::Window_Shop(int shop_type, int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight) {
+Window_Shop::Window_Shop(Scene* parent, int shop_type, int ix, int iy, int iwidth, int iheight) :
+	Window_Base(parent, ix, iy, iwidth, iheight) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 

--- a/src/window_shop.h
+++ b/src/window_shop.h
@@ -30,7 +30,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_Shop(int shop_type, int ix, int iy, int iwidth, int iheight);
+	Window_Shop(Scene* parent, int shop_type, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Renders the current shop on the window.

--- a/src/window_shop.h
+++ b/src/window_shop.h
@@ -42,6 +42,8 @@ public:
 	 */
 	void Update() override;
 
+	int GetIndex() const;
+
 	void SetMode(int nmode);
 	int GetChoice() const;
 	void SetChoice(int nchoice);

--- a/src/window_shopbuy.cpp
+++ b/src/window_shopbuy.cpp
@@ -27,9 +27,9 @@
 #include "output.h"
 #include <lcf/reader_util.h>
 
-Window_ShopBuy::Window_ShopBuy(const std::vector<int>& goods,
+Window_ShopBuy::Window_ShopBuy(Scene* parent, const std::vector<int>& goods,
 		int ix, int iy, int iwidth, int iheight)
-	: Window_Selectable(ix, iy, iwidth, iheight)
+	: Window_Selectable(parent, ix, iy, iwidth, iheight)
 	  , data(goods)
 {
 	index = 0;

--- a/src/window_shopbuy.cpp
+++ b/src/window_shopbuy.cpp
@@ -82,7 +82,7 @@ void Window_ShopBuy::DrawItem(int index) {
 
 void Window_ShopBuy::UpdateHelp() {
 	std::string help_text = "";
-	if (!data.empty()) {
+	if (!data.empty() && index < data.size()) {
 		const lcf::rpg::Item* item = lcf::ReaderUtil::GetElement(lcf::Data::items, data[index]);
 		if (item) {
 			help_text = ToString(item->description);

--- a/src/window_shopbuy.h
+++ b/src/window_shopbuy.h
@@ -32,7 +32,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_ShopBuy(const std::vector<int>& goods,
+	Window_ShopBuy(Scene* parent, const std::vector<int>& goods,
 			int ix, int iy, int iwidth = Player::screen_width, int iheight = 80);
 
 	/**

--- a/src/window_shopnumber.cpp
+++ b/src/window_shopnumber.cpp
@@ -24,6 +24,8 @@
 #include "bitmap.h"
 #include "font.h"
 #include <lcf/reader_util.h>
+#include <baseui.h>
+#include <output.h>
 
 Window_ShopNumber::Window_ShopNumber(int ix, int iy, int iwidth, int iheight) :
 	Window_Base(ix, iy, iwidth, iheight),
@@ -59,6 +61,16 @@ void Window_ShopNumber::Refresh() {
 	}
 
 	DrawCurrencyValue(GetTotal(), contents->GetWidth(), y + 32);
+
+	if (Input::GetUseMouseButton()) {
+
+		Rect src_rectUp(40, 8, 16, 8);
+		contents->Blit(132 + 16, y + 3 - 16, *windowskin, src_rectUp, 255);
+
+		Rect src_rectDown(40, 16, 16, 8);
+		contents->Blit(132 + 16, y + 3 + 16, *windowskin, src_rectDown, 255);
+
+	}
 }
 
 int Window_ShopNumber::GetNumber() const {
@@ -68,8 +80,58 @@ int Window_ShopNumber::GetNumber() const {
 void Window_ShopNumber::Update() {
 	Window_Base::Update();
 
+	int last_number = number;
+
+	if (Input::GetUseMouseButton() && IsVisible()) {
+		Point mouseP = Input::GetMousePosition();
+
+		if (Input::IsPressed(Input::MOUSE_LEFT)) {
+			disabledByMouse = true;
+		}
+		
+		// Up Arrow
+		if (mouseP.x >= GetX() + GetBorderX() + 132 + 14 && mouseP.x <= GetX() + GetBorderX() + 132 + 14 + 14 &&
+			mouseP.y >= GetY() + GetBorderY() + 37 - 16 && mouseP.y < GetY() + GetBorderY() + 37 - 16 + 8) {
+
+			// Change cursor (Hand)
+			DisplayUi->ChangeCursor(1);
+
+			if (Input::IsRepeated(Input::MOUSE_LEFT) && number < item_max) {
+				number++;
+			}
+		}
+
+		// Down Arrow
+		if (mouseP.x >= GetX() + GetBorderX() + 132 + 14 && mouseP.x <= GetX() + GetBorderX() + 132 + 14 + 14 &&
+			mouseP.y >= GetY() + GetBorderY() + 37 + 16 && mouseP.y < GetY() + GetBorderY() + 37 + 16 + 8) {
+
+			// Change cursor (Hand)
+			DisplayUi->ChangeCursor(1);
+
+			if (Input::IsRepeated(Input::MOUSE_LEFT) && number > 1) {
+				number--;
+			}
+		}
+
+		// Validate
+		if (mouseP.x >= GetX() + GetBorderX() + GetCursorRect().x && mouseP.x <= GetX() + GetBorderX() + GetCursorRect().x + GetCursorRect().width &&
+			mouseP.y >= GetY() + GetBorderY() + GetCursorRect().y && mouseP.y < GetY() + GetBorderY() + GetCursorRect().y + GetCursorRect().height) {
+
+			// Change cursor (Hand)
+			DisplayUi->ChangeCursor(1);
+
+			if (Input::IsReleased(Input::MOUSE_LEFT)) {
+				disabledByMouse = false;
+			}
+		}
+
+
+		if (Input::IsTriggered(Input::DECISION) && (!Input::IsReleased(Input::MOUSE_LEFT))) {
+			disabledByMouse = false;
+		}
+	}
+
 	if (active) {
-		int last_number = number;
 		if (Input::IsRepeated(Input::RIGHT) && number < item_max) {
 			number++;
 		} else if (Input::IsRepeated(Input::LEFT) && number > 1) {

--- a/src/window_shopnumber.cpp
+++ b/src/window_shopnumber.cpp
@@ -27,8 +27,8 @@
 #include <baseui.h>
 #include <output.h>
 
-Window_ShopNumber::Window_ShopNumber(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight),
+Window_ShopNumber::Window_ShopNumber(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Base(parent, ix, iy, iwidth, iheight),
 	item_max(1), price(0), number(1), item_id(0) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));

--- a/src/window_shopnumber.h
+++ b/src/window_shopnumber.h
@@ -36,8 +36,8 @@ public:
 	 * @param iwidth window width.
 	 * @param iheight window height.
 	 */
-	Window_ShopNumber(int ix, int iy, int iwidth, int iheight);
-	
+	Window_ShopNumber(Scene* parent, int ix, int iy, int iwidth, int iheight);
+
 	/**
 	 * Updates the Windows contents.
 	 */
@@ -47,7 +47,7 @@ public:
 	 * Updates number value according to user input.
 	 */
 	void Update() override;
-	
+
 	/**
 	 * Returns the number value.
 	 *

--- a/src/window_shopnumber.h
+++ b/src/window_shopnumber.h
@@ -72,6 +72,8 @@ public:
 	 */
 	int GetTotal() const;
 
+	int disabledByMouse = false;
+
 protected:
 	int item_max;
 	int price;

--- a/src/window_shopparty.cpp
+++ b/src/window_shopparty.cpp
@@ -25,8 +25,8 @@
 #include <lcf/reader_util.h>
 #include "sprite_character.h"
 
-Window_ShopParty::Window_ShopParty(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight) {
+Window_ShopParty::Window_ShopParty(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Base(parent, ix, iy, iwidth, iheight) {
 
 	SetBorderX(4);
 	SetBorderY(4);

--- a/src/window_shopparty.cpp
+++ b/src/window_shopparty.cpp
@@ -125,6 +125,27 @@ void Window_ShopParty::Refresh() {
 	contents->Clear();
 
 	BitmapRef system = Cache::SystemOrBlack();
+	if (item_id == -1) {
+
+		const std::vector<Game_Actor*>& actors = Main_Data::game_party->GetActors();
+		for (int i = 0; i < static_cast<int>(actors.size()) && i < 4; i++) {
+			Game_Actor* actor = actors[i];
+			int phase = (cycle / anim_rate) % 4;
+			int phasecmp = phase;
+			if (phase == 3) {
+				phase = 1;
+			}
+			// RPG_RT displays the actors in an empty shop.
+			bool usable = false;
+			BitmapRef bm = bitmaps[i][usable ? phase : 1][usable ? 1 : 0];
+
+			if (bm) {
+				contents->Blit(i * 32, 0, *bm, bm->GetRect(), 255);
+			}
+		}
+
+		return;
+	}
 
 	if (item_id < 0 || item_id > static_cast<int>(lcf::Data::items.size()))
 		return;

--- a/src/window_shopparty.h
+++ b/src/window_shopparty.h
@@ -31,7 +31,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_ShopParty(int ix, int iy, int iwidth, int iheight);
+	Window_ShopParty(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Renders the current party on the window.

--- a/src/window_shopsell.cpp
+++ b/src/window_shopsell.cpp
@@ -23,8 +23,8 @@
 #include "output.h"
 #include <lcf/reader_util.h>
 
-Window_ShopSell::Window_ShopSell(int ix, int iy, int iwidth, int iheight) :
-	Window_Item(ix, iy, iwidth, iheight) {}
+Window_ShopSell::Window_ShopSell(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Item(parent, ix, iy, iwidth, iheight) {}
 
 bool Window_ShopSell::CheckEnable(int item_id) {
 	// Items are guaranteed to be valid

--- a/src/window_shopsell.h
+++ b/src/window_shopsell.h
@@ -32,7 +32,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_ShopSell(int ix, int iy, int iwidth, int iheight);
+	Window_ShopSell(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Chechs if item should be enabled.

--- a/src/window_shopstatus.cpp
+++ b/src/window_shopstatus.cpp
@@ -23,8 +23,8 @@
 #include "bitmap.h"
 #include "font.h"
 
-Window_ShopStatus::Window_ShopStatus(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight), item_id(0) {
+Window_ShopStatus::Window_ShopStatus(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Base(parent, ix, iy, iwidth, iheight), item_id(0) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 

--- a/src/window_shopstatus.h
+++ b/src/window_shopstatus.h
@@ -31,7 +31,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_ShopStatus(int ix, int iy, int iwidth, int iheight);
+	Window_ShopStatus(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Renders the current total on the window.

--- a/src/window_skill.cpp
+++ b/src/window_skill.cpp
@@ -29,8 +29,8 @@
 #include <lcf/reader_util.h>
 #include "game_battle.h"
 
-Window_Skill::Window_Skill(int ix, int iy, int iwidth, int iheight) :
-	Window_Selectable(ix, iy, iwidth, iheight), actor_id(-1), subset(0) {
+Window_Skill::Window_Skill(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Selectable(parent, ix, iy, iwidth, iheight), actor_id(-1), subset(0) {
 	column_max = 2;
 }
 

--- a/src/window_skill.h
+++ b/src/window_skill.h
@@ -31,7 +31,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_Skill(int ix, int iy, int iwidth, int iheight);
+	Window_Skill(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Sets the actor whose skills are displayed.

--- a/src/window_skillstatus.cpp
+++ b/src/window_skillstatus.cpp
@@ -23,8 +23,8 @@
 #include "font.h"
 #include "player.h"
 
-Window_SkillStatus::Window_SkillStatus(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight), actor_id(-1) {
+Window_SkillStatus::Window_SkillStatus(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Base(parent, ix, iy, iwidth, iheight), actor_id(-1) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 }

--- a/src/window_skillstatus.h
+++ b/src/window_skillstatus.h
@@ -30,7 +30,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_SkillStatus(int ix, int iy, int iwidth, int iheight);
+	Window_SkillStatus(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Sets the actor whose stats are displayed.

--- a/src/window_target.cpp
+++ b/src/window_target.cpp
@@ -1,0 +1,70 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Headers
+#include <iomanip>
+#include <sstream>
+#include "window_target.h"
+#include "window_command.h"
+#include <input.h>
+#include "main_data.h"
+#include <baseui.h>
+#include "game_system.h"
+
+static int CalculateWidth(const std::vector<std::string>& commands, int width) {
+	if (width < 0) {
+		int max = 0;
+		for (size_t i = 0; i < commands.size(); ++i) {
+			max = std::max(max, Text::GetSize(*Font::Default(), commands[i]).width);
+		}
+		return max + 16;
+	}
+	else {
+		return width;
+	}
+}
+
+Window_Target::Window_Target(Scene* parent, std::vector<std::string> in_commands, int width, int max_item) :
+	Window_Command(parent, in_commands, width, max_item)
+{
+	ReplaceCommands(std::move(in_commands));
+}
+
+void Window_Target::Update() {
+	// Window Selectable update logic skipped on purpose
+	// (breaks up/down-logic)
+	Window_Command::Update();
+
+	if (Input::GetUseMouseButton()) {
+		if (GetActive() && IsVisible()) {
+			Point mouse_pos = Input::GetMousePosition();
+			int index = CursorHitTest({ mouse_pos.x - GetX(), mouse_pos.y - GetY() });
+			if (index >= 0)
+				DisplayUi->ChangeCursor(1);
+			if (index >= 0 && index != GetIndex() && Input::MouseMoved()) {
+				// FIXME: Index changed callback?
+				SetIndex(index);
+				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+			}
+
+			if (GetIndex() == -999 && (Input::IsRepeated(Input::DOWN) || Input::IsRepeated(Input::RIGHT) || Input::IsTriggered(Input::SCROLL_DOWN) ||
+				Input::IsRepeated(Input::UP) || Input::IsRepeated(Input::LEFT) || Input::IsTriggered(Input::SCROLL_UP))) {
+				SetIndex(GetMouseOldIndex());
+			}
+		}
+	}
+}

--- a/src/window_target.h
+++ b/src/window_target.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_WINDOW_ACTORINFO_H
+#define EP_WINDOW_ACTORINFO_H
+
+// Headers
+#include "window_command.h"
+
+/**
+ * Window ActorInfo Class.
+ * Displays the left hand information window in the status
+ * scene.
+ */
+class Window_Target : public Window_Command {
+public:
+	/**
+	 * Constructor.
+	 */
+	Window_Target(Scene* parent, std::vector<std::string> commands, int width = -1, int max_item = -1);
+
+	virtual bool ExcludeForMouse() const {
+		return true;
+	}
+
+	/**
+	 * Updates the window state.
+	 */
+	void Update() override;
+};
+
+#endif

--- a/src/window_targetstatus.cpp
+++ b/src/window_targetstatus.cpp
@@ -23,8 +23,8 @@
 #include "font.h"
 #include <lcf/reader_util.h>
 
-Window_TargetStatus::Window_TargetStatus(int ix, int iy, int iwidth, int iheight) :
-	Window_Base(ix, iy, iwidth, iheight), id(-1), use_item(false) {
+Window_TargetStatus::Window_TargetStatus(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Base(parent, ix, iy, iwidth, iheight), id(-1), use_item(false) {
 
 	SetContents(Bitmap::Create(width - 16, height - 16));
 }

--- a/src/window_targetstatus.h
+++ b/src/window_targetstatus.h
@@ -32,7 +32,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_TargetStatus(int ix, int iy, int iwidth, int iheight);
+	Window_TargetStatus(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Renders the current item quantity/spell costs on

--- a/src/window_teleport.cpp
+++ b/src/window_teleport.cpp
@@ -23,8 +23,8 @@
 #include "game_map.h"
 #include "game_targets.h"
 
-Window_Teleport::Window_Teleport(int ix, int iy, int iwidth, int iheight) :
-	Window_Selectable(ix, iy, iwidth, iheight) {
+Window_Teleport::Window_Teleport(Scene* parent, int ix, int iy, int iwidth, int iheight) :
+	Window_Selectable(parent, ix, iy, iwidth, iheight) {
 	column_max = 2;
 
 	Refresh();

--- a/src/window_teleport.h
+++ b/src/window_teleport.h
@@ -32,7 +32,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	Window_Teleport(int ix, int iy, int iwidth, int iheight);
+	Window_Teleport(Scene* parent, int ix, int iy, int iwidth, int iheight);
 
 	/**
 	 * Gets target.

--- a/src/window_varlist.cpp
+++ b/src/window_varlist.cpp
@@ -28,8 +28,8 @@
 #include "game_party.h"
 #include "game_map.h"
 
-Window_VarList::Window_VarList(std::vector<std::string> commands) :
-Window_Command(commands, 224, 10) {
+Window_VarList::Window_VarList(Scene* parent, std::vector<std::string> commands) :
+	Window_Command(parent, commands, 224, 10) {
 	SetX(0);
 	SetY(32);
 	SetHeight(176);

--- a/src/window_varlist.h
+++ b/src/window_varlist.h
@@ -42,12 +42,12 @@ public:
 	 *
 	 * @param commands commands to display.
 	 */
-	Window_VarList(std::vector<std::string> commands);
+	Window_VarList(Scene* parent, std::vector<std::string> commands);
 	~Window_VarList() override;
 
 	/**
 	 * UpdateList.
-	 * 
+	 *
 	 * @param first_value starting value.
 	 */
 	void UpdateList(int first_value);


### PR DESCRIPTION
Code from both @MackValentine and @Ghabry.

Those are changes in menu navigation. Through it, the user is able to:
- Hover options with mouse.
- Select an option with Left Click/ Touch Input
- Cancel Selection through Right Click / Double Touch Input
- Scroll through options using mouse wheel or by clicking on the arrow icons.

It's also possible to:
- Change Mouse PNG
- Change MouseHover PNG

Mack is working on this feature, we need help on testing and pointing out the best outcome to certain interactions.
So we are opening a PR for testing and change suggestions.