### PR TITLE
Windows: Fix touch input, disable window rounding

### DIFF
--- a/.github/workflows/stable-compilation.yml
+++ b/.github/workflows/stable-compilation.yml
@@ -42,9 +42,10 @@ jobs:
           apt-get update
           apt-get install -yqq --no-install-recommends --no-install-suggests \
             ca-certificates build-essential cmake ninja-build git \
-            libicu-dev libexpat1-dev libsdl2-dev libpng-dev libpixman-1-dev \
-            libfmt-dev libfreetype6-dev libharfbuzz-dev libmpg123-dev \
-            libsndfile-dev libvorbis-dev libopusfile-dev libspeexdsp-dev \
+            libicu-dev libexpat1-dev libinih-dev \
+            libsdl2-dev libpng-dev libpixman-1-dev libfmt-dev \
+            libfreetype6-dev libharfbuzz-dev libmpg123-dev libsndfile-dev \
+            libvorbis-dev libopusfile-dev libspeexdsp-dev \
             libdrm-dev libgbm-dev # only needed for sdl2 on debian 11
 
       - name: Clone Repository

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,6 +578,10 @@ if(${PLAYER_TARGET_PLATFORM} STREQUAL "SDL2")
 		target_sources(${PROJECT_NAME} PRIVATE
 			src/platform/wiiu/input_buttons.cpp)
 	endif()
+
+	if(WIN32)
+		target_link_libraries(${PROJECT_NAME} "Dwmapi")
+	endif()
 elseif(${PLAYER_TARGET_PLATFORM} STREQUAL "SDL1")
 	target_sources(${PROJECT_NAME} PRIVATE
 		src/platform/sdl/sdl_audio.cpp

--- a/src/input_source.cpp
+++ b/src/input_source.cpp
@@ -334,4 +334,13 @@ void Input::LogSource::UpdateSystem() {
 	// input log does not record actions outside of logical frames.
 }
 
+void Input::TouchInput::Down(int id, int x, int y) {
+	this->id = id;
+	this->position = { x, y };
+	this->pressed = true;
+}
 
+void Input::TouchInput::Up() {
+	id = -1;
+	pressed = false;
+}

--- a/src/input_source.h
+++ b/src/input_source.h
@@ -59,10 +59,13 @@ namespace Input {
 	};
 
 	struct TouchInput {
-		bool pressed = false;
-		Point position;
+		void Down(int id, int x, int y);
+		void Up();
 
-		// Fields for use by InputSource. Do not modify in Ui!
+		// Do not alter the fields from the Ui class, use Down and Up
+		int id = -1;
+		Point position;
+		bool pressed = false;
 		bool prev_frame_pressed = false;
 		Game_Clock::time_point touch_begin;
 		Game_Clock::time_point touch_end;

--- a/src/platform/sdl/main.cpp
+++ b/src/platform/sdl/main.cpp
@@ -64,7 +64,7 @@ static void LogCallback(LogLevel lvl, std::string const& msg, LogCallbackUserDat
 extern "C" int main(int argc, char* argv[]) {
 	std::vector<std::string> args;
 
-#if defined(_WIN32) && !defined(__WINRT__)
+#if defined(_WIN32)
 	// Use widestring args
 	int argc_w;
 	LPWSTR *argv_w = CommandLineToArgvW(GetCommandLineW(), &argc_w);

--- a/src/platform/sdl/sdl2_ui.cpp
+++ b/src/platform/sdl/sdl2_ui.cpp
@@ -647,15 +647,10 @@ void Sdl2Ui::SetTitle(const std::string &title) {
 }
 
 bool Sdl2Ui::ShowCursor(bool flag) {
-#ifdef __WINRT__
-	// Prevent cursor hide in WinRT because it is hidden everywhere while the app runs...
-	return flag;
-#else
 	bool temp_flag = cursor_visible;
 	cursor_visible = flag;
 	SDL_ShowCursor(flag ? SDL_ENABLE : SDL_DISABLE);
 	return temp_flag;
-#endif
 }
 
 void Sdl2Ui::ProcessEvent(SDL_Event &evnt) {
@@ -975,7 +970,7 @@ void Sdl2Ui::ProcessFingerEvent(SDL_Event& evnt) {
 }
 
 void Sdl2Ui::SetAppIcon() {
-#if defined(__WINRT__) || defined(__MORPHOS__)
+#if defined(__MORPHOS__)
 	// do nothing
 #elif defined(_WIN32)
 	SDL_SysWMinfo wminfo;


### PR DESCRIPTION
The finger IDs sent seem to be different based on which device you use.

My Surface 4 sent 0 - 4 as ID. This Asus Laptop here increments the ID everytime. Removed the assumption from the code that the IDs are 0 - 4.

----

Disabled the window rounding on Win11 because its not nice when a few pixels of the game are simply lost...