### PR TITLE
CommandTeleport (10810) - Allow com.string as map filename

### DIFF
--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -475,6 +475,8 @@ bool Game_Interpreter_Map::CommandEnterHeroName(lcf::rpg::EventCommand const& co
 
 bool Game_Interpreter_Map::CommandTeleport(lcf::rpg::EventCommand const& com) { // Code 10810
 																		   // TODO: if in battle return true
+	if (com.string != "") Game_Map::SetCustomMapName(com.string);
+
 	if (Game_Message::IsMessageActive()) {
 		return false;
 	}

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -57,6 +57,8 @@
 #include "feature.h"
 
 namespace {
+	std::string customMapName = "";
+
 	// Intended bad value, Game_Map::Init sets them correctly
 	int screen_width = -1;
 	int screen_height = -1;
@@ -327,6 +329,8 @@ std::unique_ptr<lcf::rpg::Map> Game_Map::loadMapFile(int map_id) {
 	}
 
 	Output::Debug("Loaded Map {}", map_name);
+	Output::Warning("{}", map_name);
+	customMapName = "";
 
 	if (map.get() == NULL) {
 		Output::ErrorStr(lcf::LcfReader::GetError());
@@ -1281,6 +1285,16 @@ int Game_Map::GetMapId() {
 	return Main_Data::game_player->GetMapId();
 }
 
+std::string Game_Map::GetCustomMapName() {
+	return customMapName;
+}
+
+void Game_Map::SetCustomMapName(lcf::DBString mapName) {
+	customMapName = mapName.c_str();
+
+	return;
+}
+
 void Game_Map::PrintPathToMap() {
 	const auto* current_info = &GetMapInfo();
 	std::ostringstream ss;
@@ -1682,7 +1696,13 @@ int Game_Map::SubstituteUp(int old_id, int new_id) {
 
 std::string Game_Map::ConstructMapName(int map_id, bool is_easyrpg) {
 	std::stringstream ss;
-	ss << "Map" << std::setfill('0') << std::setw(4) << map_id;
+	
+	if (customMapName == "") {
+		ss << "Map" << std::setfill('0') << std::setw(4) << map_id;
+	} else {
+		ss << customMapName;
+	}
+
 	if (is_easyrpg) {
 		return Player::fileext_map.MakeFilename(ss.str(), SUFFIX_EMU);
 	} else {
@@ -1694,8 +1714,8 @@ FileRequestAsync* Game_Map::RequestMap(int map_id) {
 #ifdef EMSCRIPTEN
 	Player::translation.RequestAndAddMap(map_id);
 #endif
-
-	return AsyncHandler::RequestFile(Game_Map::ConstructMapName(map_id, false));
+	auto map_name = Game_Map::ConstructMapName(map_id, false);
+	return AsyncHandler::RequestFile(map_name);
 }
 
 // Parallax

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -381,6 +381,10 @@ namespace Game_Map {
 	 */
 	int GetMapId();
 
+	std::string GetCustomMapName();
+
+	void SetCustomMapName(lcf::DBString mapName);
+
 	/**
 	 * Outputs the path in the map tree to reach the current map.
 	 */

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -104,7 +104,7 @@ void Game_Player::PerformTeleport() {
 		return;
 	}
 
-	if (teleport_target.GetMapId() <= 0) {
+	if (Game_Map::GetCustomMapName() == "" && teleport_target.GetMapId() <= 0) {
 		Output::Error("Invalid Teleport map id! mapid={} x={} y={} d={}", teleport_target.GetMapId(),
 				teleport_target.GetX(), teleport_target.GetY(), teleport_target.GetDirection());
 	}


### PR DESCRIPTION
![image](https://github.com/EasyRPG/Player/assets/45118493/a80581d2-090b-4ca0-bf22-26f892060754)


You can teleport to a custom-named map, by filling `com.string`:
```js
@raw 10810, "./Map/test", 0,0,0,3
```
It Even considers custom folder structure.

It still lacks some changes to support:
- .po files from translations
- Manipulate save data.

I have to learn how to implement those.