### PR TITLE
Add EasyRPG "Patch" Flag to conditionally enable/disable some of our extensions

### DIFF
--- a/resources/unix/easyrpg-player.6.adoc
+++ b/resources/unix/easyrpg-player.6.adoc
@@ -95,8 +95,14 @@ NOTE: For games that only use ASCII (English games) use '1252'.
 *--patch-key-patch*::
   Enable support for the Key Patch by Ineluki.
 
-*--patch-maniac*::
+*--patch-maniac*:: _[N]_
   Enable support for the Maniac Patch by BingShan.
+  Values for N:
+   - 1: Enable the patch (default)
+   - 2: Enable the patch but do not adjust variable ranges to 32 bit.
+
+  Not adjusting the variable ranges is useful if you are adding the patch to an
+  existing game, as this reduces the likelihood that the game will stop working.
 
 *--patch-pic-unlock*::
   Picture movement is not interrupted by messages in any version of the engine.

--- a/resources/unix/easyrpg-player.6.adoc
+++ b/resources/unix/easyrpg-player.6.adoc
@@ -89,6 +89,9 @@ NOTE: For games that only use ASCII (English games) use '1252'.
   Enable limited support for the DynRPG patch from Cherry. The patches are not
   loaded from DLL files, but re-implemented by the engine.
 
+*--patch-easyrpg*::
+  Enable EasyRPG extensions such as support for 32 bit images and large charsets.
+
 *--patch-key-patch*::
   Enable support for the Key Patch by Ineluki.
 

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -264,7 +264,7 @@ void BattleAnimationMap::DrawSingle(Bitmap& dst) {
 	}
 	const int character_height = 24;
 	int x_off = target.GetScreenX();
-	int y_off = target.GetScreenY(false, false);
+	int y_off = target.GetScreenY(false);
 	if (Scene::instance->type == Scene::Map) {
 		x_off += static_cast<Scene_Map*>(Scene::instance.get())->spriteset->GetRenderOx();
 		y_off += static_cast<Scene_Map*>(Scene::instance.get())->spriteset->GetRenderOy();

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -224,6 +224,13 @@ public:
 	 */
 	StringView GetFilename() const;
 
+	/**
+	 * Gets bpp of the source image.
+	 *
+	 * @return Bpp
+	 */
+	int GetOriginalBpp() const;
+
 	void CheckPixels(uint32_t flags);
 
 	/**
@@ -599,6 +606,9 @@ protected:
 
 	std::string filename;
 
+	/** Bpp of the source image */
+	int original_bpp;
+
 	/** Bitmap data. */
 	PixmanImagePtr bitmap;
 	pixman_format_code_t pixman_format;
@@ -636,6 +646,13 @@ protected:
 	bool read_only = false;
 };
 
+struct ImageOut {
+	int width = 0;
+	int height = 0;
+	void* pixels = nullptr;
+	int bpp = 0;
+};
+
 inline ImageOpacity Bitmap::GetImageOpacity() const {
 	return image_opacity;
 }
@@ -670,6 +687,10 @@ inline bool Bitmap::GetTransparent() const {
 
 inline StringView Bitmap::GetFilename() const {
 	return filename;
+}
+
+inline int Bitmap::GetOriginalBpp() const {
+	return original_bpp;
 }
 
 #endif

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -35,6 +35,7 @@
 #include "player.h"
 #include <lcf/data.h>
 #include "game_clock.h"
+#include "translation.h"
 
 using namespace std::chrono_literals;
 
@@ -272,6 +273,14 @@ namespace {
 					bmp = Bitmap::Create(std::move(is), transparent, flags);
 					if (!bmp) {
 						Output::Warning("Invalid image: {}/{}", s.directory, filename);
+					} else {
+						if (bmp->GetOriginalBpp() > 8) {
+							if (!Player::HasEasyRpgExtensions() && !Player::IsPatchManiac() && !Tr::HasActiveTranslation()) {
+								Output::Warning("Image {}/{} has a bit depth of {} that is not supported by RPG_RT. Enable EasyRPG Extensions or Maniac Patch to load such images.", s.directory, filename, bmp->GetOriginalBpp());
+							}
+
+							bmp.reset();
+						}
 					}
 				}
 			}

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -71,7 +71,7 @@ int Game_Character::GetJumpHeight() const {
 	return 0;
 }
 
-int Game_Character::GetScreenX(bool apply_shift) const {
+int Game_Character::GetScreenX() const {
 	int x = GetSpriteX() / TILE_SIZE - Game_Map::GetDisplayX() / TILE_SIZE + TILE_SIZE;
 
 	if (Game_Map::LoopHorizontal()) {
@@ -79,14 +79,10 @@ int Game_Character::GetScreenX(bool apply_shift) const {
 	}
 	x -= TILE_SIZE / 2;
 
-	if (apply_shift) {
-		x += Game_Map::GetTilesX() * TILE_SIZE;
-	}
-
 	return x;
 }
 
-int Game_Character::GetScreenY(bool apply_shift, bool apply_jump) const {
+int Game_Character::GetScreenY(bool apply_jump) const {
 	int y = GetSpriteY() / TILE_SIZE - Game_Map::GetDisplayY() / TILE_SIZE + TILE_SIZE;
 
 	if (apply_jump) {
@@ -97,14 +93,10 @@ int Game_Character::GetScreenY(bool apply_shift, bool apply_jump) const {
 		y = Utils::PositiveModulo(y, Game_Map::GetTilesY() * TILE_SIZE);
 	}
 
-	if (apply_shift) {
-		y += Game_Map::GetTilesY() * TILE_SIZE;
-	}
-
 	return y;
 }
 
-Drawable::Z_t Game_Character::GetScreenZ(bool apply_shift) const {
+Drawable::Z_t Game_Character::GetScreenZ(int x_offset, int y_offset) const {
 	Drawable::Z_t z = 0;
 
 	if (IsFlying()) {
@@ -118,8 +110,8 @@ Drawable::Z_t Game_Character::GetScreenZ(bool apply_shift) const {
 	}
 
 	// 0x8000 (32768) is added to shift negative numbers into the positive range
-	Drawable::Z_t y = static_cast<Drawable::Z_t>(GetScreenY(apply_shift, false) + 0x8000);
-	Drawable::Z_t x = static_cast<Drawable::Z_t>(GetScreenX(apply_shift) + 0x8000);
+	Drawable::Z_t y = static_cast<Drawable::Z_t>(GetScreenY(false) + y_offset + 0x8000);
+	Drawable::Z_t x = static_cast<Drawable::Z_t>(GetScreenX() + x_offset + 0x8000);
 
 	// The rendering order of characters is: Highest Y-coordinate, Highest X-coordinate, Highest ID
 	// To encode this behaviour all of them get 16 Bit in the Z value

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -693,27 +693,26 @@ public:
 	/**
 	 * Gets sprite x coordinate transformed to screen coordinate in pixels.
 	 *
-	 * @param apply_shift When true the coordinate is shifted by the map width (for looping maps)
 	 * @return screen x coordinate in pixels.
 	 */
-	virtual int GetScreenX(bool apply_shift = false) const;
+	virtual int GetScreenX() const;
 
 	/**
 	 * Gets sprite y coordinate transformed to screen coordinate in pixels.
 	 *
-	 * @param apply_shift When true the coordinate is shifted by the map height (for looping maps)
 	 * @param apply_jump Apply jump height modifier if character is jumping
 	 * @return screen y coordinate in pixels.
 	 */
-	virtual int GetScreenY(bool apply_shift = false, bool apply_jump = true) const;
+	virtual int GetScreenY(bool apply_jump = true) const;
 
 	/**
 	 * Gets screen z coordinate
 	 *
-	 * @param apply_shift Forwarded to GetScreenY
+	 * @param x_offset Offset to apply to the X coordinate
+	 * @param y_offset Offset to apply to the Y coordinate
 	 * @return screen z coordinate
 	 */
-	virtual Drawable::Z_t GetScreenZ(bool apply_shift = false) const;
+	virtual Drawable::Z_t GetScreenZ(int x_offset, int y_offset) const;
 
 	/**
 	 * Gets tile graphic ID.

--- a/src/game_config_game.cpp
+++ b/src/game_config_game.cpp
@@ -89,6 +89,11 @@ void Game_ConfigGame::LoadFromArgs(CmdlineParser& cp) {
 			patch_override = true;
 			continue;
 		}
+		if (cp.ParseNext(arg, 0, {"--patch-easyrpg", "--no-patch-easyrpg"})) {
+			patch_easyrpg.Set(arg.ArgIsOn());
+			patch_override = true;
+			continue;
+		}
 		if (cp.ParseNext(arg, 0, {"--patch-dynrpg", "--no-patch-dynrpg"})) {
 			patch_dynrpg.Set(arg.ArgIsOn());
 			patch_override = true;
@@ -169,6 +174,10 @@ void Game_ConfigGame::LoadFromStream(Filesystem_Stream::InputStream& is) {
 	new_game.FromIni(ini);
 	engine_str.FromIni(ini);
 	fake_resolution.FromIni(ini);
+
+	if (patch_easyrpg.FromIni(ini)) {
+		patch_override = true;
+	}
 
 	if (patch_dynrpg.FromIni(ini)) {
 		patch_override = true;

--- a/src/game_config_game.cpp
+++ b/src/game_config_game.cpp
@@ -99,8 +99,13 @@ void Game_ConfigGame::LoadFromArgs(CmdlineParser& cp) {
 			patch_override = true;
 			continue;
 		}
-		if (cp.ParseNext(arg, 0, {"--patch-maniac", "--no-patch-maniac"})) {
+		if (cp.ParseNext(arg, 1, {"--patch-maniac", "--no-patch-maniac"})) {
 			patch_maniac.Set(arg.ArgIsOn());
+
+			if (arg.ArgIsOn() && arg.ParseValue(0, li_value)) {
+				patch_maniac.Set(li_value);
+			}
+
 			patch_override = true;
 			continue;
 		}

--- a/src/game_config_game.h
+++ b/src/game_config_game.h
@@ -38,6 +38,7 @@ struct Game_ConfigGame {
 	BoolConfigParam new_game{ "Start new game", "Skips the title screen and starts a new game directly", "Game", "NewGame", false };
 	StringConfigParam engine_str{ "Engine", "", "Game", "Engine", std::string() };
 	BoolConfigParam fake_resolution{ "Fake Metrics", "Makes games run on higher resolutions (with some success)", "Game", "FakeResolution", false };
+	BoolConfigParam patch_easyrpg{ "EasyRPG", "EasyRPG Engine Extensions", "Patch", "EasyRPG", false };
 	BoolConfigParam patch_dynrpg{ "DynRPG", "", "Patch", "DynRPG", false };
 	BoolConfigParam patch_maniac{ "Maniac Patch", "", "Patch", "Maniac", false };
 	BoolConfigParam patch_common_this_event{ "Common This Event", "Support \"This Event\" in Common Events", "Patch", "CommonThisEvent", false };

--- a/src/game_config_game.h
+++ b/src/game_config_game.h
@@ -40,7 +40,7 @@ struct Game_ConfigGame {
 	BoolConfigParam fake_resolution{ "Fake Metrics", "Makes games run on higher resolutions (with some success)", "Game", "FakeResolution", false };
 	BoolConfigParam patch_easyrpg{ "EasyRPG", "EasyRPG Engine Extensions", "Patch", "EasyRPG", false };
 	BoolConfigParam patch_dynrpg{ "DynRPG", "", "Patch", "DynRPG", false };
-	BoolConfigParam patch_maniac{ "Maniac Patch", "", "Patch", "Maniac", false };
+	ConfigParam<int> patch_maniac{ "Maniac Patch", "", "Patch", "Maniac", 0 };
 	BoolConfigParam patch_common_this_event{ "Common This Event", "Support \"This Event\" in Common Events", "Patch", "CommonThisEvent", false };
 	BoolConfigParam patch_unlock_pics{ "Unlock Pictures", "Allow picture commands while a message is shown", "Patch", "PicUnlock", false };
 	BoolConfigParam patch_key_patch{ "Ineluki Key Patch", "Support \"Ineluki Key Patch\"", "Patch", "KeyPatch", false };

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -115,10 +115,10 @@ lcf::rpg::SaveMapEvent Game_Event::GetSaveData() const {
 	return save;
 }
 
-Drawable::Z_t Game_Event::GetScreenZ(bool apply_shift) const {
+Drawable::Z_t Game_Event::GetScreenZ(int x_offset, int y_offset) const {
 	// Lowest 16 bit are reserved for the ID
 	// See base function for full explanation
-	return Game_Character::GetScreenZ(apply_shift) + GetId();
+	return Game_Character::GetScreenZ(x_offset, y_offset) + GetId();
 }
 
 int Game_Event::GetOriginalMoveRouteIndex() const {

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -49,7 +49,7 @@ public:
 	 * Implementation of abstract methods
 	 */
 	/** @{ */
-	Drawable::Z_t GetScreenZ(bool apply_shift = false) const override;
+	Drawable::Z_t GetScreenZ(int x_offset, int y_offset) const override;
 	bool Move(int dir) override;
 	void UpdateNextMovementAction() override;
 	bool IsVisible() const override;

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -678,6 +678,10 @@ bool Game_Interpreter_Map::CommandToggleAtbMode(lcf::rpg::EventCommand const& /*
 }
 
 bool Game_Interpreter_Map::CommandEasyRpgTriggerEventAt(lcf::rpg::EventCommand const& com) {
+	if (!Player::HasEasyRpgExtensions()) {
+		return true;
+	}
+
 	int x = ValueOrVariable(com.parameters[0], com.parameters[1]);
 	int y = ValueOrVariable(com.parameters[2], com.parameters[3]);
 

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -65,13 +65,13 @@ lcf::rpg::SavePartyLocation Game_Player::GetSaveData() const {
 	return *data();
 }
 
-Drawable::Z_t Game_Player::GetScreenZ(bool apply_shift) const {
+Drawable::Z_t Game_Player::GetScreenZ(int x_offset, int y_offset) const {
 	// Player is always "same layer as hero".
 	// When the Player is on the same Y-coordinate as an event the Player is always rendered first.
 	// This is different to events where, when Y is the same, the highest X-coordinate is rendered first.
 	// To ensure this, fake a very high X-coordinate of 65535 (all bits set)
 	// See base function for full explanation of the bitmask
-	return Game_Character::GetScreenZ(apply_shift) | (0xFFFFu << 16u);
+	return Game_Character::GetScreenZ(x_offset, y_offset) | (0xFFFFu << 16u);
 }
 
 void Game_Player::ReserveTeleport(int map_id, int x, int y, int direction, TeleportTarget::Type tt) {

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -47,7 +47,7 @@ public:
 	 * Implementation of abstract methods
 	 */
 	/** @{ */
-	Drawable::Z_t GetScreenZ(bool apply_shift = false) const override;
+	Drawable::Z_t GetScreenZ(int x_offset, int y_offset) const override;
 	bool IsVisible() const override;
 	bool MakeWay(int from_x, int from_y, int to_x, int to_y) override;
 	void UpdateNextMovementAction() override;

--- a/src/game_strings.cpp
+++ b/src/game_strings.cpp
@@ -25,6 +25,7 @@
 #include "game_switches.h"
 #include "game_variables.h"
 #include "output.h"
+#include "player.h"
 #include "utils.h"
 
 void Game_Strings::WarnGet(int id) const {
@@ -186,7 +187,7 @@ StringView Game_Strings::ToFile(Str_Params params, std::string filename, int enc
 	filename = "Text/" + filename;
 	
 	// EasyRPG Extension: When "*" is at the end of filename, ".txt" is not appended
-	if (filename.back() == '*') {
+	if (Player::HasEasyRpgExtensions() && filename.back() == '*') {
 		filename.pop_back();
 	} else {
 		filename += ".txt";

--- a/src/game_vehicle.cpp
+++ b/src/game_vehicle.cpp
@@ -147,8 +147,8 @@ int Game_Vehicle::GetAltitude() const {
 		return SCREEN_TILE_SIZE / (SCREEN_TILE_SIZE / TILE_SIZE);
 }
 
-int Game_Vehicle::GetScreenY(bool apply_shift, bool apply_jump) const {
-	return Game_Character::GetScreenY(apply_shift, apply_jump) - GetAltitude();
+int Game_Vehicle::GetScreenY(bool apply_jump) const {
+	return Game_Character::GetScreenY(apply_jump) - GetAltitude();
 }
 
 bool Game_Vehicle::CanLand() const {

--- a/src/game_vehicle.h
+++ b/src/game_vehicle.h
@@ -72,7 +72,7 @@ public:
 	bool IsAboard() const;
 	void SyncWithRider(const Game_Character* rider);
 	bool AnimateAscentDescent();
-	int GetScreenY(bool apply_shift = false, bool apply_jump = true) const override;
+	int GetScreenY(bool apply_jump = true) const override;
 	bool CanLand() const;
 	void StartAscent();
 	void StartDescent();

--- a/src/image_bmp.h
+++ b/src/image_bmp.h
@@ -19,6 +19,7 @@
 #define EP_IMAGE_BMP_H
 
 #include <cstdint>
+#include "bitmap.h"
 #include "filesystem_stream.h"
 
 namespace ImageBMP {
@@ -33,8 +34,8 @@ namespace ImageBMP {
 		int palette_size = 0;
 	};
 
-	bool ReadBMP(const uint8_t* data, unsigned len, bool transparent, int& width, int& height, void*& pixels);
-	bool ReadBMP(Filesystem_Stream::InputStream& stream, bool transparent, int& width, int& height, void*& pixels);
+	bool Read(const uint8_t* data, unsigned len, bool transparent, ImageOut& output);
+	bool Read(Filesystem_Stream::InputStream& stream, bool transparent, ImageOut& output);
 
 	BitmapHeader ParseHeader(const uint8_t*& ptr, uint8_t const* e);
 }

--- a/src/image_png.h
+++ b/src/image_png.h
@@ -19,12 +19,13 @@
 #define EP_IMAGE_PNG_H
 
 #include <cstdint>
+#include "bitmap.h"
 #include "filesystem_stream.h"
 
 namespace ImagePNG {
-	bool ReadPNG(const void* buffer, bool transparent, int& width, int& height, void*& pixels);
-	bool ReadPNG(Filesystem_Stream::InputStream& is, bool transparent, int& width, int& height, void*& pixels);
-	bool WritePNG(std::ostream& os, uint32_t width, uint32_t height, uint32_t* data);
+	bool Read(const void* buffer, bool transparent, ImageOut& output);
+	bool Read(Filesystem_Stream::InputStream& is, bool transparent, ImageOut& output);
+	bool Write(std::ostream& os, uint32_t width, uint32_t height, uint32_t* data);
 }
 
 #endif

--- a/src/image_xyz.cpp
+++ b/src/image_xyz.cpp
@@ -24,9 +24,8 @@
 #include "output.h"
 #include "image_xyz.h"
 
-bool ImageXYZ::ReadXYZ(const uint8_t* data, unsigned len, bool transparent,
-					   int& width, int& height, void*& pixels) {
-	pixels = nullptr;
+bool ImageXYZ::Read(const uint8_t* data, unsigned len, bool transparent, ImageOut& output) {
+	output.pixels = nullptr;
 
 	if (len < 8) {
 		Output::Warning("Not a valid XYZ file.");
@@ -47,13 +46,13 @@ bool ImageXYZ::ReadXYZ(const uint8_t* data, unsigned len, bool transparent,
 	}
 	const uint8_t (*palette)[3] = (const uint8_t(*)[3]) &dst_buffer.front();
 
-	pixels = malloc(w * h * 4);
-	if (!pixels) {
+	output.pixels = malloc(w * h * 4);
+	if (!output.pixels) {
 		Output::Warning("Error allocating XYZ pixel buffer.");
 		return false;
 	}
 
-	uint8_t* dst = (uint8_t*) pixels;
+	uint8_t* dst = (uint8_t*) output.pixels;
 	const uint8_t* src = (const uint8_t*) &dst_buffer[768];
 	for (int y = 0; y < h; y++) {
 		for (int x = 0; x < w; x++) {
@@ -66,13 +65,14 @@ bool ImageXYZ::ReadXYZ(const uint8_t* data, unsigned len, bool transparent,
 		}
 	}
 
-	width = w;
-	height = h;
+	output.width = w;
+	output.height = h;
+	output.bpp = 8;
+
 	return true;
 }
 
-bool ImageXYZ::ReadXYZ(Filesystem_Stream::InputStream& stream, bool transparent,
-					   int& width, int& height, void*& pixels) {
+bool ImageXYZ::Read(Filesystem_Stream::InputStream& stream, bool transparent, ImageOut& output) {
 	std::vector<uint8_t> buffer = Utils::ReadStream(stream);
-	return ReadXYZ(&buffer.front(), (unsigned) buffer.size(), transparent, width, height, pixels);
+	return Read(&buffer.front(), (unsigned) buffer.size(), transparent, output);
 }

--- a/src/image_xyz.h
+++ b/src/image_xyz.h
@@ -20,11 +20,12 @@
 
 #include <cstdio>
 #include <cstdint>
+#include "bitmap.h"
 #include "filesystem_stream.h"
 
 namespace ImageXYZ {
-	bool ReadXYZ(const uint8_t* data, unsigned len, bool transparent, int& width, int& height, void*& pixels);
-	bool ReadXYZ(Filesystem_Stream::InputStream& stream, bool transparent, int& width, int& height, void*& pixels);
+	bool Read(const uint8_t* data, unsigned len, bool transparent, ImageOut& output);
+	bool Read(Filesystem_Stream::InputStream& stream, bool transparent, ImageOut& output);
 }
 
 #endif

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -880,7 +880,7 @@ void Player::ResetGameObjects() {
 
 	auto min_var = lcf::Data::system.easyrpg_variable_min_value;
 	if (min_var == 0) {
-		if (Player::IsPatchManiac()) {
+		if ((Player::game_config.patch_maniac.Get() & 1) == 1) {
 			min_var = std::numeric_limits<Game_Variables::Var_t>::min();
 		} else {
 			min_var = Player::IsRPG2k3() ? Game_Variables::min_2k3 : Game_Variables::min_2k;
@@ -888,7 +888,7 @@ void Player::ResetGameObjects() {
 	}
 	auto max_var = lcf::Data::system.easyrpg_variable_max_value;
 	if (max_var == 0) {
-		if (Player::IsPatchManiac()) {
+		if ((Player::game_config.patch_maniac.Get() & 1) == 1) {
 			max_var = std::numeric_limits<Game_Variables::Var_t>::max();
 		} else {
 			max_var = Player::IsRPG2k3() ? Game_Variables::max_2k3 : Game_Variables::max_2k;
@@ -1402,7 +1402,10 @@ Engine options:
  --patch-dynrpg       Enable support of DynRPG patch by Cherry (very limited).
  --patch-easyrpg      Enable EasyRPG extensions.
  --patch-key-patch    Enable Key Patch by Ineluki.
- --patch-maniac       Enable Maniac Patch by BingShan.
+ --patch-maniac [N]   Enable Maniac Patch by BingShan. Values for N:
+                       - 1: Enable the patch (default)
+                       - 2: Enable the patch but do not adjust variable ranges
+                            to 32 bit.
  --patch-pic-unlock   Picture movement is not interrupted by messages in any
                       version of the engine.
  --patch-rpg2k3-cmds  Support all RPG Maker 2003 event commands in any version

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -825,8 +825,9 @@ void Player::CreateGameObjects() {
 		}
 	}
 
-	Output::Debug("Patch configuration: dynrpg={} maniac={} key-patch={} common-this={} pic-unlock={} 2k3-commands={} anti-lag-switch={}",
-		Player::IsPatchDynRpg(), Player::IsPatchManiac(), Player::IsPatchKeyPatch(), game_config.patch_common_this_event.Get(), game_config.patch_unlock_pics.Get(), game_config.patch_rpg2k3_commands.Get(), game_config.patch_anti_lag_switch.Get());
+	Output::Debug("Patch configuration: easyrpg={} dynrpg={} maniac={} key-patch={} common-this={} pic-unlock={} 2k3-commands={} anti-lag-switch={}",
+		Player::HasEasyRpgExtensions(), Player::IsPatchDynRpg(), Player::IsPatchManiac(), Player::IsPatchKeyPatch(), game_config.patch_common_this_event.Get(),
+		game_config.patch_unlock_pics.Get(), game_config.patch_rpg2k3_commands.Get(), game_config.patch_anti_lag_switch.Get());
 
 	ResetGameObjects();
 
@@ -1399,6 +1400,7 @@ Engine options:
  --patch-common-this  Enable usage of "This Event" in common events in any
                       version of the engine.
  --patch-dynrpg       Enable support of DynRPG patch by Cherry (very limited).
+ --patch-easyrpg      Enable EasyRPG extensions.
  --patch-key-patch    Enable Key Patch by Ineluki.
  --patch-maniac       Enable Maniac Patch by BingShan.
  --patch-pic-unlock   Picture movement is not interrupted by messages in any
@@ -1549,4 +1551,3 @@ std::string Player::GetEngineVersion() {
 	if (EngineVersion() > 0) return std::to_string(EngineVersion());
 	return std::string();
 }
-

--- a/src/player.h
+++ b/src/player.h
@@ -478,7 +478,7 @@ inline bool Player::IsPatchDynRpg() {
 }
 
 inline bool Player::IsPatchManiac() {
-	return game_config.patch_maniac.Get();
+	return game_config.patch_maniac.Get() > 0;
 }
 
 inline bool Player::IsPatchKeyPatch() {

--- a/src/player.h
+++ b/src/player.h
@@ -293,6 +293,11 @@ namespace Player {
 	bool IsPatchKeyPatch();
 
 	/**
+	 * @return True when EasyRpg extensions are on
+	 */
+	bool HasEasyRpgExtensions();
+
+	/**
 	 * @return Running engine version. 2000 for RPG2k and 2003 for RPG2k3
 	 */
 	int EngineVersion();
@@ -478,6 +483,10 @@ inline bool Player::IsPatchManiac() {
 
 inline bool Player::IsPatchKeyPatch() {
 	return game_config.patch_key_patch.Get();
+}
+
+inline bool Player::HasEasyRpgExtensions() {
+	return game_config.patch_easyrpg.Get();
 }
 
 #endif

--- a/src/sprite_airshipshadow.cpp
+++ b/src/sprite_airshipshadow.cpp
@@ -25,16 +25,14 @@
 #include "sprite_airshipshadow.h"
 #include <string>
 
-Sprite_AirshipShadow::Sprite_AirshipShadow(CloneType type) {
+Sprite_AirshipShadow::Sprite_AirshipShadow(int x_offset, int y_offset) :
+	x_offset(x_offset), y_offset(y_offset) {
 	SetBitmap(Bitmap::Create(16,16));
 
 	SetOx(TILE_SIZE/2);
 	SetOy(TILE_SIZE);
 
 	RecreateShadow();
-
-	x_shift = ((type & XClone) == XClone);
-	y_shift = ((type & YClone) == YClone);
 }
 
 // Draws the two shadow sprites to a single intermediate bitmap to be blit to the map
@@ -70,8 +68,8 @@ void Sprite_AirshipShadow::Update() {
 	const double opacity = (double)altitude / max_altitude;
 	SetOpacity(opacity * 255);
 
-	SetX(Main_Data::game_player->GetScreenX(x_shift));
-	SetY(Main_Data::game_player->GetScreenY(y_shift) + Main_Data::game_player->GetJumpHeight());
+	SetX(Main_Data::game_player->GetScreenX() + x_offset);
+	SetY(Main_Data::game_player->GetScreenY() + y_offset + Main_Data::game_player->GetJumpHeight());
 	// Synchronized with airship priority
-	SetZ(airship->GetScreenZ(y_shift) - 1);
+	SetZ(airship->GetScreenZ(x_offset, y_offset) - 1);
 }

--- a/src/sprite_airshipshadow.cpp
+++ b/src/sprite_airshipshadow.cpp
@@ -54,6 +54,19 @@ void Sprite_AirshipShadow::RecreateShadow() {
 	GetBitmap()->Blit(0, 0, *system, Rect(128+16,32,16,16), opacity);
 }
 
+void Sprite_AirshipShadow::Draw(Bitmap &dst) {
+	Game_Vehicle* airship = Game_Map::GetVehicle(Game_Vehicle::Airship);
+	const int altitude = airship->GetAltitude();
+	const int max_altitude = TILE_SIZE;
+	const double opacity = (double)altitude / max_altitude;
+	SetOpacity(opacity * 255);
+
+	SetX(Main_Data::game_player->GetScreenX() + x_offset);
+	SetY(Main_Data::game_player->GetScreenY() + y_offset + Main_Data::game_player->GetJumpHeight());
+
+	Sprite::Draw(dst);
+}
+
 void Sprite_AirshipShadow::Update() {
 	if (!Main_Data::game_player->InAirship()) {
 		SetVisible(false);
@@ -63,13 +76,6 @@ void Sprite_AirshipShadow::Update() {
 
 	Game_Vehicle* airship = Game_Map::GetVehicle(Game_Vehicle::Airship);
 
-	const int altitude = airship->GetAltitude();
-	const int max_altitude = TILE_SIZE;
-	const double opacity = (double)altitude / max_altitude;
-	SetOpacity(opacity * 255);
-
-	SetX(Main_Data::game_player->GetScreenX() + x_offset);
-	SetY(Main_Data::game_player->GetScreenY() + y_offset + Main_Data::game_player->GetJumpHeight());
 	// Synchronized with airship priority
 	SetZ(airship->GetScreenZ(x_offset, y_offset) - 1);
 }

--- a/src/sprite_airshipshadow.h
+++ b/src/sprite_airshipshadow.h
@@ -38,6 +38,7 @@ public:
 	};
 
 	Sprite_AirshipShadow(int x_offset = 0, int y_offset = 0);
+	void Draw(Bitmap& dst) override;
 	void Update();
 	void RecreateShadow();
 

--- a/src/sprite_airshipshadow.h
+++ b/src/sprite_airshipshadow.h
@@ -37,13 +37,13 @@ public:
 		YClone = 4
 	};
 
-	Sprite_AirshipShadow(CloneType type = CloneType::Original);
+	Sprite_AirshipShadow(int x_offset = 0, int y_offset = 0);
 	void Update();
 	void RecreateShadow();
 
 private:
-	bool x_shift = false;
-	bool y_shift = false;
+	int x_offset = 0;
+	int y_offset = 0;
 };
 
 #endif

--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -34,6 +34,27 @@ Sprite_Character::Sprite_Character(Game_Character* character, int x_offset, int 
 	Update();
 }
 
+void Sprite_Character::Draw(Bitmap &dst) {
+	if (UsesCharset()) {
+		int row = character->GetFacing();
+		auto frame = character->GetAnimFrame();
+		if (frame >= lcf::rpg::EventPage::Frame_middle2) frame = lcf::rpg::EventPage::Frame_middle;
+		SetSrcRect({frame * chara_width, row * chara_height, chara_width, chara_height});
+	}
+
+	SetFlashEffect(character->GetFlashColor());
+
+	SetOpacity(character->GetOpacity());
+
+	SetX(character->GetScreenX() + x_offset);
+	SetY(character->GetScreenY() + y_offset);
+
+	int bush_split = 4 - character->GetBushDepth();
+	SetBushDepth(bush_split > 3 ? 0 : GetHeight() / bush_split);
+
+	Sprite::Draw(dst);
+}
+
 void Sprite_Character::Update() {
 	if (tile_id != character->GetTileId() ||
 		character_name != character->GetSpriteName() ||
@@ -63,29 +84,14 @@ void Sprite_Character::Update() {
 		}
 	}
 
-	if (UsesCharset()) {
-		int row = character->GetFacing();
-		auto frame = character->GetAnimFrame();
-		if (frame >= lcf::rpg::EventPage::Frame_middle2) frame = lcf::rpg::EventPage::Frame_middle;
-		SetSrcRect({frame * chara_width, row * chara_height, chara_width, chara_height});
-	}
-
-	SetFlashEffect(character->GetFlashColor());
-
-	SetOpacity(character->GetOpacity());
 	SetVisible(character->IsVisible());
-
-	SetX(character->GetScreenX() + x_offset);
-	SetY(character->GetScreenY() + y_offset);
 	SetZ(character->GetScreenZ(x_offset, y_offset));
-
-	int bush_split = 4 - character->GetBushDepth();
-	SetBushDepth(bush_split > 3 ? 0 : GetHeight() / bush_split);
 }
 
 Game_Character* Sprite_Character::GetCharacter() {
 	return character;
 }
+
 void Sprite_Character::SetCharacter(Game_Character* new_character) {
 	character = new_character;
 }

--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -22,15 +22,14 @@
 #include "bitmap.h"
 #include "output.h"
 
-Sprite_Character::Sprite_Character(Game_Character* character, CloneType type) :
+Sprite_Character::Sprite_Character(Game_Character* character, int x_offset, int y_offset) :
 	character(character),
 	tile_id(-1),
 	character_index(0),
 	chara_width(0),
-	chara_height(0) {
-
-	x_shift = ((type & XClone) == XClone);
-	y_shift = ((type & YClone) == YClone);
+	chara_height(0),
+	x_offset(x_offset),
+	y_offset(y_offset) {
 
 	Update();
 }
@@ -76,10 +75,9 @@ void Sprite_Character::Update() {
 	SetOpacity(character->GetOpacity());
 	SetVisible(character->IsVisible());
 
-	SetX(character->GetScreenX(x_shift));
-	SetY(character->GetScreenY(y_shift));
-	// y_shift because Z is calculated via the screen Y position
-	SetZ(character->GetScreenZ(y_shift));
+	SetX(character->GetScreenX() + x_offset);
+	SetY(character->GetScreenY() + y_offset);
+	SetZ(character->GetScreenZ(x_offset, y_offset));
 
 	int bush_split = 4 - character->GetBushDepth();
 	SetBushDepth(bush_split > 3 ? 0 : GetHeight() / bush_split);
@@ -134,7 +132,7 @@ Rect Sprite_Character::GetCharacterRect(StringView name, int index, const Rect b
 	// VX Ace uses a single 1x1 spriteset of 3x4 sprites.
 	if (!name.empty() && name.front() == '$') {
 		if (!Player::HasEasyRpgExtensions()) {
-			Output::Debug("Ignoring large charset {}. EasyRPG Extension not enabled.");
+			Output::Debug("Ignoring large charset {}. EasyRPG Extension not enabled.", name);
 		} else {
 			rect.width = bitmap_rect.width * (TILE_SIZE / 16) / 4;
 			rect.height = bitmap_rect.height * (TILE_SIZE / 16) / 2;

--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -20,6 +20,7 @@
 #include "cache.h"
 #include "game_map.h"
 #include "bitmap.h"
+#include "output.h"
 
 Sprite_Character::Sprite_Character(Game_Character* character, CloneType type) :
 	character(character),
@@ -124,16 +125,20 @@ void Sprite_Character::ChipsetUpdated() {
 
 Rect Sprite_Character::GetCharacterRect(StringView name, int index, const Rect bitmap_rect) {
 	Rect rect;
+	rect.width = 24 * (TILE_SIZE / 16) * 3;
+	rect.height = 32 * (TILE_SIZE / 16) * 4;
+
 	// Allow large 4x2 spriteset of 3x4 sprites
 	// when the character name starts with a $ sign.
 	// This is not exactly the VX Ace way because
 	// VX Ace uses a single 1x1 spriteset of 3x4 sprites.
 	if (!name.empty() && name.front() == '$') {
-		rect.width = bitmap_rect.width * (TILE_SIZE / 16) / 4;
-		rect.height = bitmap_rect.height * (TILE_SIZE / 16) / 2;
-	} else {
-		rect.width = 24 * (TILE_SIZE / 16) * 3;;
-		rect.height = 32 * (TILE_SIZE / 16) * 4;
+		if (!Player::HasEasyRpgExtensions()) {
+			Output::Debug("Ignoring large charset {}. EasyRPG Extension not enabled.");
+		} else {
+			rect.width = bitmap_rect.width * (TILE_SIZE / 16) / 4;
+			rect.height = bitmap_rect.height * (TILE_SIZE / 16) / 2;
+		}
 	}
 	rect.x = (index % 4) * rect.width;
 	rect.y = (index / 4) * rect.height;

--- a/src/sprite_character.h
+++ b/src/sprite_character.h
@@ -47,6 +47,8 @@ public:
 	 */
 	Sprite_Character(Game_Character* character, int x_offset = 0, int y_offset = 0);
 
+	void Draw(Bitmap& dst) override;
+
 	/**
 	 * Updates sprite state.
 	 */

--- a/src/sprite_character.h
+++ b/src/sprite_character.h
@@ -42,9 +42,10 @@ public:
 	 * Constructor.
 	 *
 	 * @param character game character to display
-	 * @param type Type of the sprite for multiple renderings on looping maps
+	 * @param x_offset X Render offset when being a clone
+	 * @param y_offset Y Render offset when being a clone
 	 */
-	Sprite_Character(Game_Character* character, CloneType type = CloneType::Original);
+	Sprite_Character(Game_Character* character, int x_offset = 0, int y_offset = 0);
 
 	/**
 	 * Updates sprite state.
@@ -94,8 +95,8 @@ private:
 	/** Returns true for charset sprites; false for tiles. */
 	bool UsesCharset() const;
 
-	bool x_shift = false;
-	bool y_shift = false;
+	int x_offset = 0;
+	int y_offset = 0;
 	bool refresh_bitmap = false;
 
 	void OnTileSpriteReady(FileRequestResult*);

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -218,14 +218,18 @@ void Spriteset_Map::CreateSprite(Game_Character* character, bool create_x_clone,
 
 	add_sprite(std::make_unique<Sprite_Character>(character));
 	if (create_x_clone) {
-		add_sprite(std::make_unique<Sprite_Character>(character, CloneType::XClone));
+		add_sprite(std::make_unique<Sprite_Character>(character, -map_tiles_x, 0));
+		add_sprite(std::make_unique<Sprite_Character>(character, map_tiles_x, 0));
 	}
 	if (create_y_clone) {
-		add_sprite(std::make_unique<Sprite_Character>(character, CloneType::YClone));
+		add_sprite(std::make_unique<Sprite_Character>(character, 0, -map_tiles_y));
+		add_sprite(std::make_unique<Sprite_Character>(character, 0, map_tiles_y));
 	}
 	if (create_x_clone && create_y_clone) {
-		add_sprite(std::make_unique<Sprite_Character>(character,
-			(CloneType)(CloneType::XClone | CloneType::YClone)));
+		add_sprite(std::make_unique<Sprite_Character>(character, map_tiles_x, map_tiles_y));
+		add_sprite(std::make_unique<Sprite_Character>(character, -map_tiles_x, map_tiles_y));
+		add_sprite(std::make_unique<Sprite_Character>(character, map_tiles_x, -map_tiles_y));
+		add_sprite(std::make_unique<Sprite_Character>(character, -map_tiles_x, -map_tiles_y));
 	}
 }
 
@@ -240,14 +244,18 @@ void Spriteset_Map::CreateAirshipShadowSprite(bool create_x_clone, bool create_y
 
 	add_sprite(std::make_unique<Sprite_AirshipShadow>());
 	if (create_x_clone) {
-		add_sprite(std::make_unique<Sprite_AirshipShadow>(CloneType::XClone));
+		add_sprite(std::make_unique<Sprite_AirshipShadow>(-map_tiles_x, 0));
+		add_sprite(std::make_unique<Sprite_AirshipShadow>(map_tiles_x, 0));
 	}
 	if (create_y_clone) {
-		add_sprite(std::make_unique<Sprite_AirshipShadow>(CloneType::YClone));
+		add_sprite(std::make_unique<Sprite_AirshipShadow>(0, -map_tiles_y));
+		add_sprite(std::make_unique<Sprite_AirshipShadow>(0, map_tiles_y));
 	}
 	if (create_x_clone && create_y_clone) {
-		add_sprite(std::make_unique<Sprite_AirshipShadow>(
-			(CloneType)(CloneType::XClone | CloneType::YClone)));
+		add_sprite(std::make_unique<Sprite_AirshipShadow>(map_tiles_x, map_tiles_y));
+		add_sprite(std::make_unique<Sprite_AirshipShadow>(-map_tiles_x, map_tiles_y));
+		add_sprite(std::make_unique<Sprite_AirshipShadow>(map_tiles_x, -map_tiles_y));
+		add_sprite(std::make_unique<Sprite_AirshipShadow>(-map_tiles_x, -map_tiles_y));
 	}
 }
 
@@ -277,8 +285,10 @@ void Spriteset_Map::OnPanoramaSpriteReady(FileRequestResult* result) {
 void Spriteset_Map::CalculateMapRenderOffset() {
 	map_render_ox = 0;
 	map_render_oy = 0;
-	map_tiles_x = 0;
-	map_tiles_y = 0;
+
+	// Smallest possible map. Smaller maps are hacked
+	map_tiles_x = std::max<int>(Game_Map::GetTilesX(), 20) * TILE_SIZE;
+	map_tiles_y = std::max<int>(Game_Map::GetTilesY(), 15) * TILE_SIZE;
 
 	panorama->SetRenderOx(0);
 	panorama->SetRenderOy(0);
@@ -286,7 +296,6 @@ void Spriteset_Map::CalculateMapRenderOffset() {
 
 	if (Player::game_config.fake_resolution.Get()) {
 		// Resolution hack for tiles and sprites
-		// Smallest possible map. Smaller maps are hacked
 		map_tiles_x = std::max<int>(Game_Map::GetTilesX(), 20) * TILE_SIZE;
 		map_tiles_y = std::max<int>(Game_Map::GetTilesY(), 15) * TILE_SIZE;
 

--- a/tests/cmdline_parser.cpp
+++ b/tests/cmdline_parser.cpp
@@ -69,6 +69,23 @@ TEST_CASE("ParseMulti") {
 	REQUIRE_EQ(li, 2);
 }
 
+TEST_CASE("Parse Optional Value") {
+	std::vector<std::string> args = { "testapp", "--arg1", "--arg2", "1", "--arg3", "a", "b" };
+
+	CmdlineParser cp(args);
+
+	CmdlineArg arg;
+
+	REQUIRE(cp.ParseNext(arg, 1, "--arg1"));
+	REQUIRE(arg.NumValues() == 0);
+
+	REQUIRE(cp.ParseNext(arg, 2, "--arg2"));
+	REQUIRE(arg.NumValues() == 1);
+
+	REQUIRE(cp.ParseNext(arg, 3, "--arg3"));
+	REQUIRE(arg.NumValues() == 2);
+}
+
 TEST_CASE("ParseNull") {
 	std::vector<std::string> args;
 	CmdlineParser cp(args);

--- a/tests/game_character.cpp
+++ b/tests/game_character.cpp
@@ -77,20 +77,6 @@ static_assert(Game_Character::IsDirectionFixedAnimationType(lcf::rpg::EventPage:
 static_assert(!Game_Character::IsDirectionFixedAnimationType(lcf::rpg::EventPage::AnimType_spin), "DirFixedBroken");
 static_assert(!Game_Character::IsDirectionFixedAnimationType(lcf::rpg::EventPage::AnimType_step_frame_fix), "DirFixedBroken");
 
-#if 0
-
-	/** @return the direction we would need to face the hero. */
-	int GetDirectionToHero();
-
-	/** @return the direction we would need to face away from hero. */
-	int GetDirectionAwayHero();
-
-	virtual Drawable::Z_t GetScreenZ(bool apply_shift = false) const;
-
-	int DistanceXfromPlayer() const;
-	int DistanceYfromPlayer() const;
-#endif
-
 TEST_SUITE_BEGIN("Game_Character");
 
 static void testInit(Game_Character& ch, int max_stop_count = 0) {


### PR DESCRIPTION
I added a new ``--patch-easyrpg`` flag for enabling EasyRPG Extensions. For now I consider EasyRPG a "patch". This engine vs. patch split should be revised some day with a "features" system. 

**Commit 2 is worth a discussion:**

1. What is imo obvious is locking our custom event commands behind this flag. That is consistent with all the other commands we have.
2. I locked the big charset "$" feature behind the flag. Currently I only know two games that use this: Deep8 and CU. Deep8 uses a fork of the Player, so doesn't matter. CU is still in development. -> Do not think this will break games if we notify CU in-advance.
3. Only EasyRPG and Maniac Patch like 32 bit PNGs. I print now a warning when such an image is loaded without these patches on. I got this idea when there was a discussion about a bogus patch for Yume2kki: The dev only used EasyRPG Player for testing and when it was published they received reports that the game crashes in RPG_RT because of 32 bit images :sweat_smile: -> Not 100% sure if this will break games. For Deep8 and CU same as above. This restriction could be relaxed, e.g. only report about it in TestPlay mode and ignore it in "normal mode". I just think this is useful for gamedev.
4. Is there anything else that should be "locked" behind the EasyRPG flag? Imo the flag should be only for features that can _break_ games. **What will stay enabled**: The translation feature as you cannot run into this by accident (also this would break games, it is widely used already). Custom resolution is also always on because it is used by the setting scene (and you can already opt-out via ``WinW=320,WinH=240`` as Yume2kki does).

---

Less controversial (I could split them in a different PR, only added them here because I touched big charset by the easy-flag).

About Commit 1: Obtaining the bpp (depth) is for this 32 bit warning message mentioned above. That output struct API is based on support for animated bitmaps (APNG, Asesprite). That struct will get more fields to support this. Keeps the argument list short.

Commit 3 fixes big charsets on looping maps. Commit 4 makes it a bit faster. Imo the solution is not _that_ great. It works by creating even more "clones" also in negative direction, not just positive. The performance impact should be minimal as they are usually culled when they are out of bounds.

