### PR TITLE
New Command 2055 - Process JSON Code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,8 @@ add_library(${PROJECT_NAME} OBJECT
 	src/input_source.h
 	src/instrumentation.cpp
 	src/instrumentation.h
+	src/json_helper.cpp
+	src/json_helper.h
 	src/keys.h
 	src/main_data.cpp
 	src/main_data.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -217,6 +217,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/input_source.h \
 	src/instrumentation.cpp \
 	src/instrumentation.h \
+	src/json_helper.cpp \
+	src/json_helper.h \
 	src/keys.h \
 	src/main_data.cpp \
 	src/main_data.h \

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -5080,7 +5080,12 @@ bool Game_Interpreter::CommandEasyRpgProcessJson(lcf::rpg::EventCommand const& c
 	int target_var_id = ValueOrVariable(com.parameters[6], com.parameters[7]);
 
 	std::string json_path = ToString(CommandStringOrVariable(com, 8, 9));
-	std::string json_data = ToString(Main_Data::game_strings->Get(source_var_id));
+	auto* json_data = Main_Data::game_strings->ParseJson(source_var_id);
+
+	if (!json_data) {
+		Output::Warning("JSON Parse error for {}", Main_Data::game_strings->Get(source_var_id));
+		return true;
+	}
 
 	if (target_var_type == 2 && !Player::IsPatchManiac()) {
 		Output::Warning("CommandEasyRpgProcessJson: String operations require Maniac Patch support");
@@ -5090,7 +5095,7 @@ bool Game_Interpreter::CommandEasyRpgProcessJson(lcf::rpg::EventCommand const& c
 	std::optional<std::string> result;
 
 	if (operation == 0) { // Get operation: Extract a value from JSON data
-		result = Json_Helper::GetValue(json_data, json_path);
+		result = Json_Helper::GetValue(*json_data, json_path);
 
 		if (result) {
 			switch (target_var_type) {
@@ -5127,7 +5132,7 @@ bool Game_Interpreter::CommandEasyRpgProcessJson(lcf::rpg::EventCommand const& c
 			return true;
 		}
 
-		result = Json_Helper::SetValue(json_data, json_path, new_value);
+		result = Json_Helper::SetValue(*json_data, json_path, new_value);
 
 		if (result) {
 			Main_Data::game_strings->Asg({ source_var_id }, *result);

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -5058,7 +5058,6 @@ bool Game_Interpreter::CommandEasyRpgSetInterpreterFlag(lcf::rpg::EventCommand c
 		Player::game_config.patch_key_patch.Set(flag_value);
 	if (flag_name == "rpg2k3-cmds" || flag_name == "rpg2k3-commands")
 		Player::game_config.patch_rpg2k3_commands.Set(flag_value);
-
 	if (flag_name == "rpg2k-battle")
 		lcf::Data::system.easyrpg_use_rpg2k_battle_system = flag_value;
 
@@ -5066,7 +5065,13 @@ bool Game_Interpreter::CommandEasyRpgSetInterpreterFlag(lcf::rpg::EventCommand c
 }
 
 bool Game_Interpreter::CommandEasyRpgProcessJson(lcf::rpg::EventCommand const& com) {
+#ifndef HAVE_NLOHMANN_JSON
+	Output::Warning("CommandProcessJson: JSON not supported on this platform");
+	return true;
+#else
+
 	if (!Player::IsPatchManiac()) {
+		Output::Warning("CommandProcessJson: This command needs Maniac Patch support");
 		return true;
 	}
 
@@ -5133,6 +5138,8 @@ bool Game_Interpreter::CommandEasyRpgProcessJson(lcf::rpg::EventCommand const& c
 	}
 
 	return true;
+
+#endif // !HAVE_NLOHMANN_JSON
 }
 
 bool Game_Interpreter::CommandEasyRpgCloneMapEvent(lcf::rpg::EventCommand const& com) {

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -298,6 +298,7 @@ protected:
 	bool CommandManiacControlStrings(lcf::rpg::EventCommand const& com);
 	bool CommandManiacCallCommand(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgSetInterpreterFlag(lcf::rpg::EventCommand const& com);
+	bool CommandEasyRpgProcessJson(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgCloneMapEvent(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgDestroyMapEvent(lcf::rpg::EventCommand const& com);
 

--- a/src/game_strings.cpp
+++ b/src/game_strings.cpp
@@ -28,10 +28,33 @@
 #include "player.h"
 #include "utils.h"
 
+#ifdef HAVE_NLOHMANN_JSON
+#include "json_helper.h"
+#endif
+
 void Game_Strings::WarnGet(int id) const {
 	Output::Debug("Invalid read strvar[{}]!", id);
 	--_warnings;
 }
+
+#ifdef HAVE_NLOHMANN_JSON
+nlohmann::json* Game_Strings::ParseJson(int id) {
+	auto it = _json_cache.find(id);
+	if (it != _json_cache.end()) {
+		return &(it->second);
+	}
+
+	auto str = ToString(Get(id));
+	auto res = Json_Helper::Parse(str);
+
+	if (!res) {
+		return nullptr;
+	} else {
+		_json_cache[id] = *res;
+		return &_json_cache[id];
+	}
+}
+#endif
 
 StringView Game_Strings::Asg(Str_Params params, StringView string) {
 	Set(params, string);

--- a/src/game_strings.h
+++ b/src/game_strings.h
@@ -15,7 +15,8 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
- // Headers
+// Headers
+#include "system.h"
 #include <cstdint>
 #include <string>
 #include <lcf/data.h>
@@ -26,6 +27,10 @@
 #include "pending_message.h"
 #include "player.h"
 #include "string_view.h"
+
+#ifdef HAVE_NLOHMANN_JSON
+#include <nlohmann/json.hpp>
+#endif
 
 /**
  * Game_Strings class.
@@ -59,6 +64,10 @@ public:
 	StringView GetWithMode(StringView str_data, int mode, int arg, const Game_Variables& variables) const;
 	StringView GetWithModeAndPos(StringView str_data, int mode, int arg, int* pos, const Game_Variables& variables);
 
+#ifdef HAVE_NLOHMANN_JSON
+	nlohmann::json* ParseJson(int id);
+#endif
+
 	StringView Asg(Str_Params params, StringView string);
 	StringView Cat(Str_Params params, StringView string);
 	int ToNum(Str_Params params, int var_id, Game_Variables& variables);
@@ -85,8 +94,11 @@ private:
 
 	Strings_t _strings;
 	mutable int _warnings = max_warnings;
-};
 
+#ifdef HAVE_NLOHMANN_JSON
+	std::unordered_map<int, nlohmann::json> _json_cache;
+#endif
+};
 
 inline void Game_Strings::Set(Str_Params params, StringView string) {
 	if (params.string_id <= 0) {
@@ -108,10 +120,18 @@ inline void Game_Strings::Set(Str_Params params, StringView string) {
 	} else {
 		it->second = ins_string;
 	}
+
+#ifdef HAVE_NLOHMANN_JSON
+	_json_cache.erase(params.string_id);
+#endif
 }
 
 inline void Game_Strings::SetData(Strings_t s) {
 	_strings = std::move(s);
+
+#ifdef HAVE_NLOHMANN_JSON
+	_json_cache.clear();
+#endif
 }
 
 inline void Game_Strings::SetData(const std::vector<lcf::DBString>& s) {
@@ -122,6 +142,10 @@ inline void Game_Strings::SetData(const std::vector<lcf::DBString>& s) {
 		}
 		++i;
 	}
+
+#ifdef HAVE_NLOHMANN_JSON
+	_json_cache.clear();
+#endif
 }
 
 inline const Game_Strings::Strings_t& Game_Strings::GetData() const {

--- a/src/json_helper.cpp
+++ b/src/json_helper.cpp
@@ -1,0 +1,159 @@
+#include "json_helper.h"
+#include "external/picojson.h"
+#include "output.h"
+#include <vector>
+
+namespace Json_Helper {
+	const std::string kInvalidOutput = "<<INVALID_OUTPUT>>";
+
+	std::vector<std::string> SplitPath(const std::string& jsonPath) {
+		std::istringstream iss(jsonPath);
+		std::vector<std::string> pathParts;
+		std::string part;
+		while (std::getline(iss, part, '.')) {
+			pathParts.push_back(part);
+		}
+		return pathParts;
+	}
+
+	picojson::value* GetValuePointer(picojson::value& jsonValue, const std::vector<std::string>& pathParts, bool allowCreation) {
+		picojson::value* currentValue = &jsonValue;
+
+		for (const auto& part : pathParts) {
+			std::string arrayName;
+			int arrayIndex = -1;
+			bool inArray = false;
+
+			for (char c : part) {
+				if (!inArray) {
+					if (c == '[') {
+						inArray = true;
+						arrayIndex = 0;
+					}
+					else {
+						arrayName += c;
+					}
+				}
+				else {
+					if (c == ']') {
+						break;
+					}
+					else {
+						arrayIndex = arrayIndex * 10 + (c - '0');
+					}
+				}
+			}
+
+			if (inArray) {
+				if (!currentValue->is<picojson::object>()) {
+					if (allowCreation) {
+						*currentValue = picojson::value(picojson::object());
+					}
+					else {
+						Output::Warning("JSON_ERROR - Invalid JSON type for array: {}", arrayName);
+						return nullptr;
+					}
+				}
+
+				auto& obj = currentValue->get<picojson::object>();
+				auto arrayIt = obj.find(arrayName);
+
+				if (arrayIt == obj.end()) {
+					if (allowCreation) {
+						obj.emplace(arrayName, picojson::value(picojson::array()));
+						arrayIt = obj.find(arrayName);
+					}
+					else {
+						Output::Warning("JSON_ERROR - Array not found: {}", arrayName);
+						return nullptr;
+					}
+				}
+
+				auto& arr = arrayIt->second.get<picojson::array>();
+
+				if (arrayIndex >= static_cast<int>(arr.size())) {
+					if (allowCreation) {
+						arr.resize(arrayIndex + 1);
+					}
+					else {
+						Output::Warning("JSON_ERROR - Array index out of bounds: {}", part);
+						return nullptr;
+					}
+				}
+
+				currentValue = &arr[arrayIndex];
+			}
+			else {
+				if (!currentValue->is<picojson::object>()) {
+					if (allowCreation) {
+						*currentValue = picojson::value(picojson::object());
+					}
+					else {
+						Output::Warning("JSON_ERROR - Invalid JSON type for path: {}", part);
+						return nullptr;
+					}
+				}
+
+				auto& obj = currentValue->get<picojson::object>();
+				auto objIt = obj.find(arrayName);
+
+				if (objIt == obj.end()) {
+					if (allowCreation) {
+						obj.emplace(arrayName, picojson::value(picojson::object()));
+						objIt = obj.find(arrayName);
+					}
+					else {
+						Output::Warning("JSON_ERROR - Object key not found: {}", part);
+						return nullptr;
+					}
+				}
+
+				currentValue = &objIt->second;
+			}
+		}
+
+		return currentValue;
+	}
+
+	std::string GetValue(const std::string& jsonData, const std::string& jsonPath) {
+		picojson::value jsonValue;
+		std::string err = picojson::parse(jsonValue, jsonData);
+
+		if (!err.empty()) {
+			Output::Warning("JSON_ERROR - JSON parsing error: {}", err);
+			return kInvalidOutput;
+		}
+
+		auto pathParts = SplitPath(jsonPath);
+		auto valuePtr = GetValuePointer(jsonValue, pathParts, false);
+
+		if (valuePtr == nullptr || !valuePtr->is<std::string>()) {
+			Output::Warning("JSON_ERROR - Value not found or not a string");
+			return kInvalidOutput;
+		}
+
+		return valuePtr->get<std::string>();
+	}
+
+	std::string SetValue(const std::string& jsonData, const std::string& jsonPath, const std::string& value) {
+		picojson::value jsonValue;
+		std::string err = picojson::parse(jsonValue, jsonData);
+
+		if (!err.empty()) {
+			Output::Warning("JSON_ERROR - JSON parsing error: {}", err);
+			return kInvalidOutput;
+		}
+
+		auto pathParts = SplitPath(jsonPath);
+		auto valuePtr = GetValuePointer(jsonValue, pathParts, true);
+
+		if (valuePtr == nullptr) {
+			Output::Warning("JSON_ERROR - Unable to create value");
+			return kInvalidOutput;
+		}
+
+		*valuePtr = picojson::value(value);
+
+		return picojson::value(jsonValue).serialize();
+	}
+}

--- a/src/json_helper.cpp
+++ b/src/json_helper.cpp
@@ -1,4 +1,24 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "json_helper.h"
+
+#ifdef HAVE_NLOHMANN_JSON
+
 #include "output.h"
 #include <sstream>
 #include <unordered_map>
@@ -148,3 +168,5 @@ namespace Json_Helper {
 	}
 
 }
+
+#endif // HAVE_NLOHMANN_JSON

--- a/src/json_helper.cpp
+++ b/src/json_helper.cpp
@@ -61,14 +61,7 @@ namespace Json_Helper {
 		return json_obj;
 	}
 
-	std::optional<std::string> GetValue(std::string_view json_data, std::string_view json_path) {
-		auto json_obj = Parse(json_data);
-
-		if (!json_obj) {
-			Output::Warning("JSON: Parse error for {}", json_data);
-    		return {};
-		}
-
+	std::optional<std::string> GetValue(nlohmann::json& json_obj, std::string_view json_path) {
 		json::json_pointer ptr((std::string(json_path)));
 
 		if (ptr.empty()) {
@@ -76,21 +69,14 @@ namespace Json_Helper {
 			return {};
 		}
 
-		if (!json_obj->contains(ptr)) {
+		if (!json_obj.contains(ptr)) {
 			return "";
 		}
 
-		return GetValueAsString((*json_obj)[ptr]);
+		return GetValueAsString(json_obj[ptr]);
 	}
 
-	std::string SetValue(std::string_view json_data, std::string_view json_path, std::string_view value) {
-		auto json_obj = Parse(json_data);
-
-		if (!json_obj) {
-			Output::Warning("JSON Parse error for {}", json_data);
-    		return std::string(json_data);
-		}
-
+	std::string SetValue(nlohmann::json& json_obj, std::string_view json_path, std::string_view value) {
 		json::json_pointer ptr((std::string(json_path)));
 
 		if (ptr.empty()) {
@@ -102,12 +88,12 @@ namespace Json_Helper {
 
 		if (obj_value.is_discarded()) {
 			// If parsing fails, treat it as a string value
-			(*json_obj)[ptr] = std::string(value);
+			json_obj[ptr] = std::string(value);
 		} else {
-			(*json_obj)[ptr] = obj_value;
+			json_obj[ptr] = obj_value;
 		}
 
-		return (*json_obj).dump();
+		return json_obj.dump();
 	}
 }
 

--- a/src/json_helper.h
+++ b/src/json_helper.h
@@ -1,5 +1,26 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef JSON_HELPER_H
 #define JSON_HELPER_H
+
+#include "system.h"
+
+#ifdef HAVE_NLOHMANN_JSON
 
 #include <string>
 #include <nlohmann/json.hpp>
@@ -9,4 +30,5 @@ namespace Json_Helper {
 	std::string SetValue(std::string_view json_data, std::string_view json_path, std::string_view value);
 }
 
+#endif // HAVE_NLOHMANN_JSON
 #endif // JSON_HELPER_H

--- a/src/json_helper.h
+++ b/src/json_helper.h
@@ -1,0 +1,11 @@
+#ifndef JSON_HELPER_H
+#define JSON_HELPER_H
+
+#include <string>
+
+namespace Json_Helper {
+	std::string GetValue(const std::string& jsonData, const std::string& jsonPath);
+	std::string SetValue(const std::string& jsonData, const std::string& jsonPath, const std::string& value);
+}
+
+#endif // JSON_HELPER_H

--- a/src/json_helper.h
+++ b/src/json_helper.h
@@ -2,10 +2,11 @@
 #define JSON_HELPER_H
 
 #include <string>
+#include <nlohmann/json.hpp>
 
 namespace Json_Helper {
-	std::string GetValue(const std::string& jsonData, const std::string& jsonPath);
-	std::string SetValue(const std::string& jsonData, const std::string& jsonPath, const std::string& value);
+	std::string GetValue(std::string_view json_data, std::string_view json_path);
+	std::string SetValue(std::string_view json_data, std::string_view json_path, std::string_view value);
 }
 
 #endif // JSON_HELPER_H

--- a/src/json_helper.h
+++ b/src/json_helper.h
@@ -28,8 +28,8 @@
 
 namespace Json_Helper {
 	std::optional<nlohmann::json> Parse(std::string_view json_data);
-	std::optional<std::string> GetValue(std::string_view json_data, std::string_view json_path);
-	std::string SetValue(std::string_view json_data, std::string_view json_path, std::string_view value);
+	std::optional<std::string> GetValue(nlohmann::json& json_obj, std::string_view json_path);
+	std::string SetValue(nlohmann::json& json_obj, std::string_view json_path, std::string_view value);
 }
 
 #endif // HAVE_NLOHMANN_JSON

--- a/src/json_helper.h
+++ b/src/json_helper.h
@@ -22,11 +22,13 @@
 
 #ifdef HAVE_NLOHMANN_JSON
 
-#include <string>
+#include <optional>
+#include <string_view>
 #include <nlohmann/json.hpp>
 
 namespace Json_Helper {
-	std::string GetValue(std::string_view json_data, std::string_view json_path);
+	std::optional<nlohmann::json> Parse(std::string_view json_data);
+	std::optional<std::string> GetValue(std::string_view json_data, std::string_view json_path);
 	std::string SetValue(std::string_view json_data, std::string_view json_path, std::string_view value);
 }
 


### PR DESCRIPTION
This command allows you to Get or Set values inside a JSON string.
(Requires Maniacs Patch)

`The syntax always comes in pairs. The first parameter of each pair indicates whether you are using a direct value or a variable/indirect variable, through ValueOrVariable().`

------------------------

#### Syntax (TPC):
```js
@raw 2055,
      "",          // Path to the target value within the JSON data
      0, 0,        // Operation (0-1) -  0: Get (extract value), 1: Set (update value)
      0, 5,        // Source string variable ID containing the JSON data
      0, 2,        // Target variable Type (0-2) - 0: Switch, 1: Variable, 2: StringVariable
      0, 1,        // Target variable ID to receive data (for Get) or contain new value (for Set)
      0, 100,      // Usage of string variable instead of the path string.
```

#### Get Example:
- Extract the value of `"d"` from the JSON data `{"a":{"b":{"c":[{"d":"result"},"not_result"]}}}` and store it in the string variable with `ID 1`.

```js
@raw 2055,
      "a.b.c[0].d", // Path to the target value
      0, 0,         // Operation: Get
      0, 5,         // Source variable ID containing the JSON data
      0, 2,        // Target variable is a StringVar
      0, 1,         // Target variable ID to receive the extracted value
      0, 0          // Use literal path string
```

#### Set Example:
- Update the value of `"d"` in the JSON data stored in the string variable with `ID 5`, using the value from the string variable with `ID 2`.

```js
@raw 2055,
      "a.b.c[0].d", // Path to the target value
      1, 0,         // Operation: Set
      0, 5,         // Source variable ID containing the JSON data that will be modified
      0, 2,        // Target variable is a StringVar
      0, 2,         // Target variable ID containing the new value for "d"
      0, 0          // Use literal path string
```
-------------------------------------

This command works nice until you deal with a json string with more than 2mb:
![image](https://github.com/EasyRPG/Player/assets/45118493/4995ecd6-329a-462f-aacd-572e237685f7)

Every time I call it, the engine freezes for some frames.
That may happen due to how I keep parsing and deleting entire JSON objects every time I call it. Maybe there's a way to keep it stored in memory for some time, to deal with multiple calls in sequence.


Here's a JSON file I used for testing bigger strings:
[JSONdatabase.txt](https://github.com/EasyRPG/Player/files/15196282/JSONdatabase.txt)
