### PR TITLE
New Command 2056/2057 - Clone/Destroy Map Event

### DIFF
--- a/src/async_op.h
+++ b/src/async_op.h
@@ -45,7 +45,8 @@ class AsyncOp {
 			eLoad,
 			eYield,
 			eYieldRepeat,
-			eCloneMapEvent
+			eCloneMapEvent,
+			eDestroyMapEvent
 		};
 
 		AsyncOp() = default;
@@ -85,6 +86,9 @@ class AsyncOp {
 
 		/** @return a clone map event async operation */
 		static AsyncOp MakeCloneMapEvent(std::string name, int src_event_id, int target_event_id, int map_id, int x, int y);
+
+		/** @return a destroy map event async operation */
+		static AsyncOp MakeDestroyMapEvent(int target_event_id);
 
 		/** @return the type of async operation */
 		Type GetType() const;
@@ -142,7 +146,7 @@ class AsyncOp {
 
 		/**
 		 * @return the event id of the event being created
-		 * @pre If GetType() is not eCloneMapEvent, the return value is undefined.
+		 * @pre If GetType() is not eCloneMapEvent or eDestroyMapEvent, the return value is undefined.
 		 */
 		int GetTargetEventId() const;
 
@@ -231,7 +235,7 @@ inline int AsyncOp::GetSourceEventId() const {
 }
 
 inline int AsyncOp::GetTargetEventId() const {
-	assert(GetType() == eCloneMapEvent);
+	assert(GetType() == eCloneMapEvent || GetType() == eDestroyMapEvent);
 	return _args[1];
 }
 
@@ -311,6 +315,10 @@ inline AsyncOp AsyncOp::MakeYieldRepeat() {
 
 inline AsyncOp AsyncOp::MakeCloneMapEvent(std::string name, int src_event_id, int target_event_id, int map_id, int x, int y) {
 	return AsyncOp(eCloneMapEvent, name, src_event_id, target_event_id, map_id, x, y);
+}
+
+inline AsyncOp AsyncOp::MakeDestroyMapEvent(int target_event_id) {
+	return AsyncOp(eDestroyMapEvent, 0, target_event_id);
 }
 
 #endif

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -230,8 +230,12 @@ static int CalculateOffset(int pos, int target_height) {
 /////////
 
 BattleAnimationMap::BattleAnimationMap(const lcf::rpg::Animation& anim, Game_Character& target, bool global) :
-	BattleAnimation(anim), target(target), global(global)
+	BattleAnimation(anim), target(&target), global(global)
 {
+}
+
+void BattleAnimationMap::SetTarget(Game_Character& target) {
+	this->target = &target;
 }
 
 void BattleAnimationMap::Draw(Bitmap& dst) {
@@ -263,8 +267,8 @@ void BattleAnimationMap::DrawSingle(Bitmap& dst) {
 		return;
 	}
 	const int character_height = 24;
-	int x_off = target.GetScreenX();
-	int y_off = target.GetScreenY(false);
+	int x_off = target->GetScreenX();
+	int y_off = target->GetScreenY(false);
 	if (Scene::instance->type == Scene::Map) {
 		x_off += static_cast<Scene_Map*>(Scene::instance.get())->spriteset->GetRenderOx();
 		y_off += static_cast<Scene_Map*>(Scene::instance.get())->spriteset->GetRenderOy();
@@ -276,7 +280,7 @@ void BattleAnimationMap::DrawSingle(Bitmap& dst) {
 }
 
 void BattleAnimationMap::FlashTargets(int r, int g, int b, int p) {
-	target.Flash(r, g, b, p, 0);
+	target->Flash(r, g, b, p, 0);
 }
 
 void BattleAnimationMap::ShakeTargets(int /* str */, int /* spd */, int /* time */) {

--- a/src/battle_animation.h
+++ b/src/battle_animation.h
@@ -108,6 +108,7 @@ protected:
 class BattleAnimationMap : public BattleAnimation {
 public:
 	BattleAnimationMap(const lcf::rpg::Animation& anim, Game_Character& target, bool global);
+	void SetTarget(Game_Character& target);
 	void Draw(Bitmap& dst) override;
 protected:
 	void FlashTargets(int r, int g, int b, int p) override;
@@ -115,7 +116,7 @@ protected:
 	void DrawSingle(Bitmap& dst);
 	void DrawGlobal(Bitmap& dst);
 
-	Game_Character& target;
+	Game_Character* target;
 	bool global = false;
 };
 

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -1379,7 +1379,6 @@ inline Game_CharacterDataStorage<T>::Game_CharacterDataStorage(Game_CharacterDat
 template <typename T>
 inline Game_CharacterDataStorage<T>& Game_CharacterDataStorage<T>::operator=(Game_CharacterDataStorage&& o) noexcept
 {
-	static_cast<Game_Character*>(this) = std::move(o);
 	if (this != &o) {
 		_data = std::move(o._data);
 		Game_Character::_data = &this->_data;

--- a/src/game_character.h
+++ b/src/game_character.h
@@ -1379,6 +1379,9 @@ inline Game_CharacterDataStorage<T>::Game_CharacterDataStorage(Game_CharacterDat
 template <typename T>
 inline Game_CharacterDataStorage<T>& Game_CharacterDataStorage<T>::operator=(Game_CharacterDataStorage&& o) noexcept
 {
+	auto* base = static_cast<Game_Character*>(this);
+	*base = std::move(o);
+
 	if (this != &o) {
 		_data = std::move(o._data);
 		Game_Character::_data = &this->_data;

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -39,6 +39,10 @@ public:
 	 */
 	Game_Event(int map_id, const lcf::rpg::Event* event);
 
+	void SetUnderlyingEvent(const lcf::rpg::Event* ev) {
+		event = ev;
+	}
+
 	/** Load from saved game */
 	void SetSaveData(lcf::rpg::SaveMapEvent save);
 

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -39,6 +39,7 @@ public:
 	 */
 	Game_Event(int map_id, const lcf::rpg::Event* event);
 
+	/** @param ev Event referenced */
 	void SetUnderlyingEvent(const lcf::rpg::Event* ev) {
 		event = ev;
 	}

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -810,10 +810,7 @@ bool Game_Interpreter::OnFinishStackFrame() {
 	if (is_base_frame && event_id > 0) {
 		Game_Event* evnt = Game_Map::GetEvent(event_id);
 		if (!evnt) {
-			if (!Player::HasEasyRpgExtensions()) {
-				// Destroy Map Event triggers this sanity check
-				Output::Error("Call stack finished with invalid event id {}. This can be caused by a vehicle teleport?", event_id);
-			}
+			Output::Error("Call stack finished with invalid event id {}. This can be caused by a vehicle teleport?", event_id);
 		} else if (main_flag) {
 			evnt->OnFinishForegroundEvent();
 		}

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -5018,10 +5018,11 @@ bool Game_Interpreter::CommandSpawnMapEvent(lcf::rpg::EventCommand const& com) {
 	int src_event = ValueOrVariable(com.parameters[2], com.parameters[3]);
 	int target_x = ValueOrVariable(com.parameters[4], com.parameters[5]);
 	int target_y = ValueOrVariable(com.parameters[6], com.parameters[7]);
+	int target_event = ValueOrVariable(com.parameters[8], com.parameters[9]);
 
 	if (src_map == 0) src_map = Game_Map::GetMapId();
 
-	Game_Map::CloneMapEvent(src_map, src_event, target_x, target_y);
+	Game_Map::CloneMapEvent(src_map, src_event, target_x, target_y, target_event);
 	return true;
 }
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -787,6 +787,8 @@ bool Game_Interpreter::ExecuteCommand(lcf::rpg::EventCommand const& com) {
 			return CommandManiacCallCommand(com);
 		case Cmd::EasyRpg_SetInterpreterFlag:
 			return CommandEasyRpgSetInterpreterFlag(com);
+		case static_cast<Cmd>(2056): //EasyRPG_SpawnMapEvent
+			return CommandSpawnMapEvent(com);
 		default:
 			return true;
 	}
@@ -5007,7 +5009,17 @@ bool Game_Interpreter::CommandEasyRpgSetInterpreterFlag(lcf::rpg::EventCommand c
 
 	if (flag_name == "rpg2k-battle")
 		lcf::Data::system.easyrpg_use_rpg2k_battle_system = flag_value;
+	
+	return true;
+}
 
+bool Game_Interpreter::CommandSpawnMapEvent(lcf::rpg::EventCommand const& com) {
+	int src_map = ValueOrVariable(com.parameters[0], com.parameters[1]);	
+	int src_event = ValueOrVariable(com.parameters[2], com.parameters[3]);
+	int target_x = ValueOrVariable(com.parameters[4], com.parameters[5]);
+	int target_y = ValueOrVariable(com.parameters[6], com.parameters[7]);
+
+	Game_Map::CloneMapEvent(src_map, src_event, target_x, target_y);
 	return true;
 }
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -5019,6 +5019,8 @@ bool Game_Interpreter::CommandSpawnMapEvent(lcf::rpg::EventCommand const& com) {
 	int target_x = ValueOrVariable(com.parameters[4], com.parameters[5]);
 	int target_y = ValueOrVariable(com.parameters[6], com.parameters[7]);
 
+	if (src_map == 0) src_map = Game_Map::GetMapId();
+
 	Game_Map::CloneMapEvent(src_map, src_event, target_x, target_y);
 	return true;
 }

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -5009,20 +5009,22 @@ bool Game_Interpreter::CommandEasyRpgSetInterpreterFlag(lcf::rpg::EventCommand c
 
 	if (flag_name == "rpg2k-battle")
 		lcf::Data::system.easyrpg_use_rpg2k_battle_system = flag_value;
-	
+
 	return true;
 }
 
 bool Game_Interpreter::CommandSpawnMapEvent(lcf::rpg::EventCommand const& com) {
-	int src_map = ValueOrVariable(com.parameters[0], com.parameters[1]);	
+	int src_map = ValueOrVariable(com.parameters[0], com.parameters[1]);
 	int src_event = ValueOrVariable(com.parameters[2], com.parameters[3]);
 	int target_x = ValueOrVariable(com.parameters[4], com.parameters[5]);
 	int target_y = ValueOrVariable(com.parameters[6], com.parameters[7]);
 	int target_event = ValueOrVariable(com.parameters[8], com.parameters[9]);
 
+	std::string target_name = ToString(CommandStringOrVariable(com, 10, 11));
+
 	if (src_map == 0) src_map = Game_Map::GetMapId();
 
-	Game_Map::CloneMapEvent(src_map, src_event, target_x, target_y, target_event);
+	Game_Map::CloneMapEvent(src_map, src_event, target_x, target_y, target_event, target_name);
 	return true;
 }
 

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -292,6 +292,7 @@ protected:
 	bool CommandManiacControlStrings(lcf::rpg::EventCommand const& com);
 	bool CommandManiacCallCommand(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgSetInterpreterFlag(lcf::rpg::EventCommand const& com);
+	bool CommandSpawnMapEvent(lcf::rpg::EventCommand const& com);
 
 	void SetSubcommandIndex(int indent, int idx);
 	uint8_t& ReserveSubcommandIndex(int indent);

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -292,7 +292,8 @@ protected:
 	bool CommandManiacControlStrings(lcf::rpg::EventCommand const& com);
 	bool CommandManiacCallCommand(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgSetInterpreterFlag(lcf::rpg::EventCommand const& com);
-	bool CommandCloneMapEvent(lcf::rpg::EventCommand const& com);
+	bool CommandEasyRpgCloneMapEvent(lcf::rpg::EventCommand const& com);
+	bool CommandEasyRpgDestroyMapEvent(lcf::rpg::EventCommand const& com);
 
 	void SetSubcommandIndex(int indent, int idx);
 	uint8_t& ReserveSubcommandIndex(int indent);

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -292,7 +292,7 @@ protected:
 	bool CommandManiacControlStrings(lcf::rpg::EventCommand const& com);
 	bool CommandManiacCallCommand(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgSetInterpreterFlag(lcf::rpg::EventCommand const& com);
-	bool CommandSpawnMapEvent(lcf::rpg::EventCommand const& com);
+	bool CommandCloneMapEvent(lcf::rpg::EventCommand const& com);
 
 	void SetSubcommandIndex(int indent, int idx);
 	uint8_t& ReserveSubcommandIndex(int indent);

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -106,6 +106,12 @@ public:
 	/** @return the event_id of the event at the base of the call stack */
 	int GetOriginalEventId() const;
 
+	/**
+	 * Sets the ID of the event at the base of the call stack to 0.
+	 * Used by DestroyMapEvent to prevent triggering a sanity check when the event is destroyed.
+	 */
+	void ClearOriginalEventId();
+
 	/** Return true if the interpreter is waiting for an async operation and needs to be resumed */
 	bool IsAsyncPending();
 
@@ -370,6 +376,12 @@ inline int Game_Interpreter::GetCurrentEventId() const {
 
 inline int Game_Interpreter::GetOriginalEventId() const {
 	return !_state.stack.empty() ? _state.stack.front().event_id : 0;
+}
+
+inline void Game_Interpreter::ClearOriginalEventId() {
+	if (!_state.stack.empty()) {
+		_state.stack.front().event_id = 0;
+	}
 }
 
 inline int Game_Interpreter::GetLoopCount() const {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -387,14 +387,20 @@ void Game_Map::Caching::MapCache::Clear() {
 }
 
 bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y) {
-	auto source_map = Game_Map::loadMapFile(src_map_id);
-	if (source_map == nullptr) {
-		Output::Warning("CloneMapEvent: Invalid source map ID {}", src_map_id);
-		return true;
-	}
+	std::unique_ptr<lcf::rpg::Map> source_map;
 
-	if (!Tr::GetCurrentTranslationId().empty()) {
-		TranslateMapMessages(src_map_id, *source_map);
+	if (src_map_id == GetMapId()) source_map = std::make_unique<lcf::rpg::Map>(GetMap());
+	else {
+		source_map = Game_Map::loadMapFile(src_map_id);
+
+		if (source_map == nullptr) {
+			Output::Warning("CloneMapEvent: Invalid source map ID {}", src_map_id);
+			return true;
+		}
+
+		if (!Tr::GetCurrentTranslationId().empty()) {
+			TranslateMapMessages(src_map_id, *source_map);
+		}
 	}
 
 	const lcf::rpg::Event* source_event = FindEventById(source_map->events, src_event_id);

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -386,7 +386,7 @@ void Game_Map::Caching::MapCache::Clear() {
 	}
 }
 
-bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y, int target_event_id = 0, std::string target_name = "") {
+bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y, int target_event_id, StringView target_name) {
 	std::unique_ptr<lcf::rpg::Map> source_map_storage;
 	const lcf::rpg::Map* source_map;
 
@@ -432,6 +432,9 @@ bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int
 	});
 
 	events.emplace_back(GetMapId(), &map->events.back());
+	std::sort(events.begin(), events.end(), [](const auto& e, const auto& e2) {
+		return e.GetId() < e2.GetId();
+	});
 
 	FixUnderlyingEventReferences();
 
@@ -466,15 +469,11 @@ bool Game_Map::DestroyMapEvent(const int event_id) {
 	//	}
 
 	// Remove event from events vector
-	auto it = events.end();
-	for (auto iter = events.begin(); iter != events.end(); ++iter) {
-		if (iter->GetId() == event_id) {
-			it = iter;
+	for (auto it = events.begin(); it != events.end(); ++it) {
+		if (it->GetId() == event_id) {
+			events.erase(it);
 			break;
 		}
-	}
-	if (it != events.end()) {
-		events.erase(it);
 	}
 
 	// Remove event from map

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -291,7 +291,7 @@ void Game_Map::SetupFromSave(
 	Game_Map::Parallax::ChangeBG(GetParallaxParams());
 }
 
-std::unique_ptr<lcf::rpg::Map> Game_Map::loadMapFile(int map_id) {
+std::unique_ptr<lcf::rpg::Map> Game_Map::LoadMapFile(int map_id) {
 	std::unique_ptr<lcf::rpg::Map> map;
 
 	// Try loading EasyRPG map files first, then fallback to normal RPG Maker
@@ -391,7 +391,7 @@ bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int
 
 	if (src_map_id == GetMapId()) source_map = std::make_unique<lcf::rpg::Map>(GetMap());
 	else {
-		source_map = Game_Map::loadMapFile(src_map_id);
+		source_map = Game_Map::LoadMapFile(src_map_id);
 
 		if (source_map == nullptr) {
 			Output::Warning("CloneMapEvent: Invalid source map ID {}", src_map_id);
@@ -1873,7 +1873,9 @@ FileRequestAsync* Game_Map::RequestMap(int map_id) {
 	Player::translation.RequestAndAddMap(map_id);
 #endif
 
-	return AsyncHandler::RequestFile(Game_Map::ConstructMapName(map_id, false));
+	auto* request = AsyncHandler::RequestFile(Game_Map::ConstructMapName(map_id, false));
+	request->SetImportantFile(true);
+	return request;
 }
 
 // Parallax

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -426,15 +426,17 @@ bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int
 		new_event.name = lcf::DBString(target_name);
 	}
 
-	map->events.push_back(new_event);
-	std::sort(map->events.begin(), map->events.end(), [](const auto& e, const auto& e2) {
-		return e.ID < e2.ID;
-	});
+	// sorted insert
+	auto insert_it = map->events.insert(
+		std::upper_bound(map->events.begin(), map->events.end(), new_event, [](const auto& e, const auto& e2) {
+			return e.ID < e2.ID;
+		}), new_event);
 
-	events.emplace_back(GetMapId(), &map->events.back());
-	std::sort(events.begin(), events.end(), [](const auto& e, const auto& e2) {
-		return e.GetId() < e2.GetId();
-	});
+	auto game_event = Game_Event(GetMapId(), &*insert_it);
+	events.insert(
+		std::upper_bound(events.begin(), events.end(), game_event, [](const auto& e, const auto& e2) {
+			return e.GetId() < e2.GetId();
+		}), Game_Event(GetMapId(), &*insert_it));
 
 	UpdateUnderlyingEventReferences();
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -486,6 +486,11 @@ bool Game_Map::DestroyMapEvent(const int event_id) {
 
 	FixUnderlyingEventReferences();
 
+	if (GetInterpreter().GetOriginalEventId() == event_id) {
+		// Prevent triggering "invalid event on stack" sanity check
+		GetInterpreter().ClearOriginalEventId();
+	}
+
 	Scene_Map* scene = (Scene_Map*)Scene::Find(Scene::Map).get();
 	scene->spriteset->Refresh();
 	SetNeedRefresh(true);

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -386,7 +386,7 @@ void Game_Map::Caching::MapCache::Clear() {
 	}
 }
 
-bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y, int target_event_id = 0) {
+bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y, int target_event_id = 0, std::string target_name = "") {
 	std::unique_ptr<lcf::rpg::Map> source_map;
 
 	if (src_map_id == GetMapId()) source_map = std::make_unique<lcf::rpg::Map>(GetMap());
@@ -417,6 +417,8 @@ bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int
 	else new_event.ID = GetNextAvailableEventId();
 	new_event.x = target_x;
 	new_event.y = target_y;
+
+	if (!target_name.empty()) new_event.name = lcf::DBString(target_name);
 
 	map->events.push_back(new_event);
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -341,41 +341,41 @@ std::unique_ptr<lcf::rpg::Map> Game_Map::loadMapFile(int map_id) {
 
 void Game_Map::SetupCommon() {
 	if (!Tr::GetCurrentTranslationId().empty()) {
-		// Build our map translation id.
-		std::stringstream ss;
-		ss << "map" << std::setfill('0') << std::setw(4) << GetMapId() << ".po";
-
-		// Translate all messages for this map
-		Player::translation.RewriteMapMessages(ss.str(), *map);
+		TranslateMapMessages(GetMapId(), *map);
 	}
 	SetNeedRefresh(true);
 
 	PrintPathToMap();
 
-	// Restart all common events after translation change
-	// Otherwise new strings are not applied
 	if (translation_changed) {
 		InitCommonEvents();
 	}
 
 	map_cache->Clear();
-	using Op = Caching::ObservedVarOps;
 
-	// Create the map events
+	CreateMapEvents();
+}
+
+void Game_Map::CreateMapEvents() {
 	events.reserve(map->events.size());
 	for (auto& ev : map->events) {
 		events.emplace_back(GetMapId(), &ev);
+		AddEventToCache(ev);
+	}
+}
 
-		for (const auto& pg : ev.pages) {
-			if (pg.condition.flags.switch_a) {
-				map_cache->AddEventAsRefreshTarget<Op::SwitchSet>(pg.condition.switch_a_id, ev);
-			}
-			if (pg.condition.flags.switch_b) {
-				map_cache->AddEventAsRefreshTarget<Op::SwitchSet>(pg.condition.switch_b_id, ev);
-			}
-			if (pg.condition.flags.variable) {
-				map_cache->AddEventAsRefreshTarget<Op::VarSet>(pg.condition.variable_id, ev);
-			}
+void Game_Map::AddEventToCache(lcf::rpg::Event& ev) {
+	using Op = Caching::ObservedVarOps;
+
+	for (const auto& pg : ev.pages) {
+		if (pg.condition.flags.switch_a) {
+			map_cache->AddEventAsRefreshTarget<Op::SwitchSet>(pg.condition.switch_a_id, ev);
+		}
+		if (pg.condition.flags.switch_b) {
+			map_cache->AddEventAsRefreshTarget<Op::SwitchSet>(pg.condition.switch_b_id, ev);
+		}
+		if (pg.condition.flags.variable) {
+			map_cache->AddEventAsRefreshTarget<Op::VarSet>(pg.condition.variable_id, ev);
 		}
 	}
 }
@@ -384,6 +384,72 @@ void Game_Map::Caching::MapCache::Clear() {
 	for (int i = 0; i < static_cast<int>(ObservedVarOps_END); i++) {
 		refresh_targets_by_varid[i].clear();
 	}
+}
+
+bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y) {
+	auto source_map = Game_Map::loadMapFile(src_map_id);
+	if (source_map == nullptr) {
+		Output::Warning("CloneMapEvent: Invalid source map ID {}", src_map_id);
+		return true;
+	}
+
+	if (!Tr::GetCurrentTranslationId().empty()) {
+		TranslateMapMessages(src_map_id, *source_map);
+	}
+
+	const lcf::rpg::Event* source_event = FindEventById(source_map->events, src_event_id);
+	if (source_event == nullptr) {
+		Output::Warning("CloneMapEvent: Event ID {} not found on source map {}", src_event_id, src_map_id);
+		return true;
+	}
+
+	lcf::rpg::Event new_event = *source_event;
+	new_event.ID = GetNextAvailableEventId();
+	new_event.x = target_x;
+	new_event.y = target_y;
+
+	map->events.push_back(new_event);
+
+	events.emplace_back(GetMapId(), &map->events.back());
+	FixUnderlyingEventReferences();
+
+	AddEventToCache(new_event);
+
+	Scene_Map* scene = (Scene_Map*)Scene::Find(Scene::Map).get();
+	scene->spriteset->Refresh();
+
+	return true;
+}
+
+void Game_Map::TranslateMapMessages(int mapId, lcf::rpg::Map& map) {
+	std::stringstream ss;
+	ss << "map" << std::setfill('0') << std::setw(4) << mapId << ".po";
+	Player::translation.RewriteMapMessages(ss.str(), map);
+}
+
+
+inline void Game_Map::FixUnderlyingEventReferences() {
+	size_t idx = 0;
+	for (auto& ev : events) {
+		ev.SetUnderlyingEvent(&map->events.at(idx++));
+	}
+}
+
+const lcf::rpg::Event* Game_Map::FindEventById(const std::vector<lcf::rpg::Event>& events, int eventId) {
+	for (const auto& ev : events) {
+		if (ev.ID == eventId) {
+			return &ev;
+		}
+	}
+	return nullptr;
+}
+
+int Game_Map::GetNextAvailableEventId() {
+	int maxEventId = 0;
+	for (const auto& ev : map->events) {
+		maxEventId = std::max(maxEventId, ev.ID);
+	}
+	return maxEventId + 1;
 }
 
 void Game_Map::PrepareSave(lcf::rpg::Save& save) {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -430,7 +430,7 @@ bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int
 
 	lcf::rpg::Event new_event = *source_event;
 	if (target_event_id > 0) {
-		DestroyMapEvent(target_event_id, false);
+		DestroyMapEvent(target_event_id, true);
 		new_event.ID = target_event_id;
 	} else {
 		new_event.ID = GetNextAvailableEventId();
@@ -465,11 +465,13 @@ bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int
 	return true;
 }
 
-bool Game_Map::DestroyMapEvent(const int event_id, bool update_references) {
+bool Game_Map::DestroyMapEvent(const int event_id, bool from_clone) {
 	const lcf::rpg::Event* event = FindEventById(map->events, event_id);
 
 	if (event == nullptr) {
-		Output::Warning("DestroyMapEvent: Event ID {} not found on current map", event_id);
+		if (!from_clone) {
+			Output::Warning("DestroyMapEvent: Event ID {} not found on current map", event_id);
+		}
 		return true;
 	}
 
@@ -492,7 +494,7 @@ bool Game_Map::DestroyMapEvent(const int event_id, bool update_references) {
 		}
 	}
 
-	if (update_references) {
+	if (!from_clone) {
 		UpdateUnderlyingEventReferences();
 
 		Scene_Map* scene = (Scene_Map*)Scene::Find(Scene::Map).get();

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -386,7 +386,7 @@ void Game_Map::Caching::MapCache::Clear() {
 	}
 }
 
-bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y) {
+bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y, int target_event_id = 0) {
 	std::unique_ptr<lcf::rpg::Map> source_map;
 
 	if (src_map_id == GetMapId()) source_map = std::make_unique<lcf::rpg::Map>(GetMap());
@@ -410,7 +410,11 @@ bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int
 	}
 
 	lcf::rpg::Event new_event = *source_event;
-	new_event.ID = GetNextAvailableEventId();
+	if (target_event_id > 0) {
+		DestroyMapEvent(target_event_id);
+		new_event.ID = target_event_id;
+	}
+	else new_event.ID = GetNextAvailableEventId();
 	new_event.x = target_x;
 	new_event.y = target_y;
 
@@ -423,6 +427,58 @@ bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int
 
 	Scene_Map* scene = (Scene_Map*)Scene::Find(Scene::Map).get();
 	scene->spriteset->Refresh();
+	SetNeedRefresh(true);
+
+	return true;
+}
+
+bool Game_Map::DestroyMapEvent(const int event_id) {
+	const lcf::rpg::Event* event = FindEventById(map->events, event_id);
+
+	if (event == nullptr) {
+		Output::Warning("DestroyMapEvent: Event ID {} not found on current map", event_id);
+		return true;
+	}
+
+	// Remove event from cache
+	//	for (auto& pg : event->pages) {
+	//		if (pg.condition.flags.switch_a) {
+	//			events_cache_by_switch[pg.condition.switch_a_id].RemoveEvent(*event);
+	//		}
+	//		if (pg.condition.flags.switch_b) {
+	//			events_cache_by_switch[pg.condition.switch_b_id].RemoveEvent(*event);
+	//		}
+	//		if (pg.condition.flags.variable) {
+	//			events_cache_by_variable[pg.condition.variable_id].RemoveEvent(*event);
+	//		}
+	//	}
+
+
+	// Remove event from events vector
+	auto it = events.end();
+	for (auto iter = events.begin(); iter != events.end(); ++iter) {
+		if (iter->GetId() == event_id) {
+			it = iter;
+			break;
+		}
+	}
+	if (it != events.end()) {
+		events.erase(it);
+	}
+
+	// Remove event from map
+	for (auto it = map->events.begin(); it != map->events.end(); ++it) {
+		if (it->ID == event_id) {
+			map->events.erase(it);
+			break;
+		}
+	}
+
+	FixUnderlyingEventReferences();
+
+	Scene_Map* scene = (Scene_Map*)Scene::Find(Scene::Map).get();
+	scene->spriteset->Refresh();
+	SetNeedRefresh(true);
 
 	return true;
 }

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -96,7 +96,7 @@ namespace Game_Map {
 	/** Disposes Game_Map. */
 	void Dispose();
 
-	bool CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y, int target_event_id, std::string target_name);
+	bool CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y, int target_event_id, StringView target_name);
 	bool DestroyMapEvent(const int event_id);
 
 	void TranslateMapMessages(int mapId, lcf::rpg::Map& map);

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -101,9 +101,9 @@ namespace Game_Map {
 
 	void TranslateMapMessages(int mapId, lcf::rpg::Map& map);
 	void CreateMapEvents();
-	inline void FixUnderlyingEventReferences();
-	void AddEventToCache(lcf::rpg::Event& ev);
-	const lcf::rpg::Event* FindEventById(const std::vector<lcf::rpg::Event>& events, int eventId);
+	void FixUnderlyingEventReferences();
+	void AddEventToCache(const lcf::rpg::Event& ev);
+	const lcf::rpg::Event* FindEventById(const std::vector<lcf::rpg::Event>& events, int event_id);
 	int GetNextAvailableEventId();
 
 	/**
@@ -691,7 +691,7 @@ namespace Game_Map {
 	namespace Caching {
 		class MapEventCache {
 		public:
-			void AddEvent(lcf::rpg::Event& ev);
+			void AddEvent(const lcf::rpg::Event& ev);
 
 		private:
 			std::vector<int> event_ids;
@@ -709,7 +709,7 @@ namespace Game_Map {
 		class MapCache {
 		public:
 			template <ObservedVarOps Op>
-			void AddEventAsRefreshTarget(int var_id, lcf::rpg::Event& ev);
+			void AddEventAsRefreshTarget(int var_id, const lcf::rpg::Event& ev);
 
 			template <ObservedVarOps Op>
 			bool GetNeedRefresh(int var_id);
@@ -877,7 +877,7 @@ inline bool MapUpdateAsyncContext::IsActive() const {
 	return GetAsyncOp().IsActive();
 }
 
-inline void Game_Map::Caching::MapEventCache::AddEvent(lcf::rpg::Event& ev) {
+inline void Game_Map::Caching::MapEventCache::AddEvent(const lcf::rpg::Event& ev) {
 	auto id = ev.ID;
 
 	if (std::find(event_ids.begin(), event_ids.end(), id) == event_ids.end()) {
@@ -886,7 +886,7 @@ inline void Game_Map::Caching::MapEventCache::AddEvent(lcf::rpg::Event& ev) {
 }
 
 template <Game_Map::Caching::ObservedVarOps Op>
-inline void Game_Map::Caching::MapCache::AddEventAsRefreshTarget(int var_id, lcf::rpg::Event& ev) {
+inline void Game_Map::Caching::MapCache::AddEventAsRefreshTarget(int var_id, const lcf::rpg::Event& ev) {
 	static_assert(static_cast<int>(Op) >= 0 && Op < ObservedVarOps_END);
 
 	auto& events_cache = refresh_targets_by_varid[static_cast<int>(Op)];

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -96,8 +96,27 @@ namespace Game_Map {
 	/** Disposes Game_Map. */
 	void Dispose();
 
+	/**
+	 * Clones a map event.
+	 *
+	 * @param src_map_id Source map where to clone the event from
+	 * @param src_event_id Source event ID to clone
+	 * @param target_x Where to place the new event (X coordinate)
+	 * @param target_y Where to place the new event (Y coordinate)
+	 * @param target_event_id New event ID. When <= 0 a free ID is selected. When the ID exists the event is overwritten.
+	 * @param target_name New name of the event. When empty the original name is used.
+	 * @return Whether the cloning was successful. It will fail when source map or the src/target event do not exist.
+	 */
 	bool CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y, int target_event_id, StringView target_name);
-	bool DestroyMapEvent(const int event_id, bool update_references = true);
+
+	/**
+	 * Deletes a map event.
+	 *
+	 * @param event_id Event ID to delete
+	 * @param from_clone When true this function was invoked by CloneMapEvent. This silences warnings and skips refreshes.
+	 * @return Whether the event was deleted. This will fail when the event does not exist.
+	 */
+	bool DestroyMapEvent(const int event_id, bool from_clone = false);
 
 	void TranslateMapMessages(int mapId, lcf::rpg::Map& map);
 	void CreateMapEvents();

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -96,6 +96,14 @@ namespace Game_Map {
 	/** Disposes Game_Map. */
 	void Dispose();
 
+	bool CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y);
+	void TranslateMapMessages(int mapId, lcf::rpg::Map& map);
+	void CreateMapEvents();
+	inline void FixUnderlyingEventReferences();
+	void AddEventToCache(lcf::rpg::Event& ev);
+	const lcf::rpg::Event* FindEventById(const std::vector<lcf::rpg::Event>& events, int eventId);
+	int GetNextAvailableEventId();
+
 	/**
 	 * Loads the map from disk
 	 *

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -96,7 +96,9 @@ namespace Game_Map {
 	/** Disposes Game_Map. */
 	void Dispose();
 
-	bool CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y);
+	bool CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y, int target_event_id);
+	bool DestroyMapEvent(const int event_id);
+
 	void TranslateMapMessages(int mapId, lcf::rpg::Map& map);
 	void CreateMapEvents();
 	inline void FixUnderlyingEventReferences();

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <unordered_set>
+#include "async_op.h"
 #include "system.h"
 #include "game_commonevent.h"
 #include "game_event.h"
@@ -38,8 +39,6 @@
 #include <lcf/rpg/savepartylocation.h>
 #include <lcf/rpg/savevehiclelocation.h>
 #include <lcf/rpg/savecommonevent.h>
-#include "async_op.h"
-#include <player.h>
 
 class FileRequestAsync;
 struct BattleArgs;
@@ -97,11 +96,11 @@ namespace Game_Map {
 	void Dispose();
 
 	bool CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y, int target_event_id, StringView target_name);
-	bool DestroyMapEvent(const int event_id);
+	bool DestroyMapEvent(const int event_id, bool update_references = true);
 
 	void TranslateMapMessages(int mapId, lcf::rpg::Map& map);
 	void CreateMapEvents();
-	void FixUnderlyingEventReferences();
+	void UpdateUnderlyingEventReferences();
 	void AddEventToCache(const lcf::rpg::Event& ev);
 	const lcf::rpg::Event* FindEventById(const std::vector<lcf::rpg::Event>& events, int event_id);
 	int GetNextAvailableEventId();
@@ -681,10 +680,10 @@ namespace Game_Map {
 	 * Construct a map name, either for EasyRPG or RPG Maker projects
 	 *
 	 * @param map_id The ID of the map to construct
-	 * @param isEasyRpg Is the an easyrpg (emu) project, or an RPG Maker (lmu) one?
+	 * @param is_easyrpg Is the an easyrpg (emu) project, or an RPG Maker (lmu) one?
 	 * @return The map name, as Map<map_id>.<map_extension>
 	 */
-	std::string ConstructMapName(int map_id, bool isEasyRpg);
+	std::string ConstructMapName(int map_id, bool is_easyrpg);
 
 	FileRequestAsync* RequestMap(int map_id);
 

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -96,7 +96,7 @@ namespace Game_Map {
 	/** Disposes Game_Map. */
 	void Dispose();
 
-	bool CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y, int target_event_id);
+	bool CloneMapEvent(int src_map_id, int src_event_id, int target_x, int target_y, int target_event_id, std::string target_name);
 	bool DestroyMapEvent(const int event_id);
 
 	void TranslateMapMessages(int mapId, lcf::rpg::Map& map);

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -112,7 +112,7 @@ namespace Game_Map {
 	 * @param map_id the id of the map to load
 	 * @return the map, or nullptr if it couldn't be loaded
 	 */
-	std::unique_ptr<lcf::rpg::Map> loadMapFile(int map_id);
+	std::unique_ptr<lcf::rpg::Map> LoadMapFile(int map_id);
 
 	/**
 	 * Setups a new map.

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -78,7 +78,6 @@ void Game_Player::ReserveTeleport(int map_id, int x, int y, int direction, Telep
 	teleport_target = TeleportTarget(map_id, x, y, direction, tt);
 
 	FileRequestAsync* request = Game_Map::RequestMap(map_id);
-	request->SetImportantFile(true);
 	request->Start();
 }
 
@@ -152,7 +151,7 @@ void Game_Player::MoveTo(int map_id, int x, int y) {
 
 		ResetAnimation();
 
-		auto map = Game_Map::loadMapFile(GetMapId());
+		auto map = Game_Map::LoadMapFile(GetMapId());
 
 		Game_Map::Setup(std::move(map));
 		Game_Map::PlayBgm();

--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -408,3 +408,16 @@ void Game_Screen::CancelBattleAnimation() {
 	animation.reset();
 }
 
+void Game_Screen::UpdateUnderlyingEventReferences() {
+	if (!IsBattleAnimationWaiting()) {
+		return;
+	}
+
+	auto* chara = Game_Character::GetCharacter(data.battleanim_target, data.battleanim_target);
+	if (!chara) {
+		// Event was deleted
+		CancelBattleAnimation();
+	} else {
+		animation->SetTarget(*chara);
+	}
+}

--- a/src/game_screen.h
+++ b/src/game_screen.h
@@ -137,6 +137,11 @@ public:
 	 */
 	bool IsBattleAnimationWaiting();
 
+	/**
+	 * Updates the event reference when the event vector was altered e.g. by SpawnMapEvent.
+	 */
+	void UpdateUnderlyingEventReferences();
+
 	/** @return current pan_x offset for screen effects in 1/16 pixels */
 	int GetPanX() const;
 
@@ -173,7 +178,7 @@ public:
 	void OnMapScrolled(int dx, int dy);
 
 private:
-	std::unique_ptr<BattleAnimation> animation;
+	std::unique_ptr<BattleAnimationMap> animation;
 	std::unique_ptr<Weather> weather;
 
 	lcf::rpg::SaveScreen data;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1083,7 +1083,7 @@ void Player::LoadFonts() {
 }
 
 static void OnMapSaveFileReady(FileRequestResult*, lcf::rpg::Save save) {
-	auto map = Game_Map::loadMapFile(Main_Data::game_player->GetMapId());
+	auto map = Game_Map::LoadMapFile(Main_Data::game_player->GetMapId());
 	Game_Map::SetupFromSave(
 			std::move(map),
 			std::move(save.map_info),
@@ -1181,7 +1181,6 @@ void Player::LoadSavegame(const std::string& save_name, int save_id) {
 
 	FileRequestAsync* map = Game_Map::RequestMap(map_id);
 	save_request_id = map->Bind([save=std::move(*save)](auto* request) { OnMapSaveFileReady(request, std::move(save)); });
-	map->SetImportantFile(true);
 
 	Main_Data::game_system->ReloadSystemGraphic();
 
@@ -1233,7 +1232,6 @@ void Player::SetupPlayerSpawn() {
 
 	FileRequestAsync* request = Game_Map::RequestMap(map_id);
 	map_request_id = request->Bind(&OnMapFileReady);
-	request->SetImportantFile(true);
 	request->Start();
 }
 

--- a/src/scene_item.cpp
+++ b/src/scene_item.cpp
@@ -30,6 +30,7 @@
 #include "scene_teleport.h"
 #include "output.h"
 #include "transition.h"
+#include "player.h"
 
 Scene_Item::Scene_Item(int item_index) :
 	item_index(item_index) {

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -413,6 +413,10 @@ void Scene_Map::OnAsyncSuspend(F&& f, AsyncOp aop, bool is_preupdate) {
 		Player::LoadSavegame(save_name, aop.GetSaveSlot());
 	}
 
+	if (aop.GetType() == AsyncOp::eCloneMapEvent) {
+		Game_Map::CloneMapEvent(aop.GetMapId(), aop.GetSourceEventId(), aop.GetX(), aop.GetY(), aop.GetTargetEventId(), aop.GetEventName());
+	}
+
 	auto& transition = Transition::instance();
 
 	if (aop.GetType() == AsyncOp::eEraseScreen) {

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -417,6 +417,10 @@ void Scene_Map::OnAsyncSuspend(F&& f, AsyncOp aop, bool is_preupdate) {
 		Game_Map::CloneMapEvent(aop.GetMapId(), aop.GetSourceEventId(), aop.GetX(), aop.GetY(), aop.GetTargetEventId(), aop.GetEventName());
 	}
 
+	if (aop.GetType() == AsyncOp::eDestroyMapEvent) {
+		Game_Map::DestroyMapEvent(aop.GetTargetEventId());
+	}
+
 	auto& transition = Transition::instance();
 
 	if (aop.GetType() == AsyncOp::eEraseScreen) {

--- a/src/scene_order.cpp
+++ b/src/scene_order.cpp
@@ -26,6 +26,7 @@
 #include "game_system.h"
 #include "input.h"
 #include "scene_map.h"
+#include "player.h"
 
 Scene_Order::Scene_Order() :
 	actor_counter(0) {

--- a/src/scene_skill.cpp
+++ b/src/scene_skill.cpp
@@ -28,6 +28,7 @@
 #include "scene_actortarget.h"
 #include "scene_teleport.h"
 #include "transition.h"
+#include "player.h"
 
 Scene_Skill::Scene_Skill(std::vector<Game_Actor*> actors, int actor_index, int skill_index) :
 	actors(actors), actor_index(actor_index), skill_index(skill_index) {

--- a/src/sprite_character.cpp
+++ b/src/sprite_character.cpp
@@ -21,6 +21,7 @@
 #include "game_map.h"
 #include "bitmap.h"
 #include "output.h"
+#include "player.h"
 
 Sprite_Character::Sprite_Character(Game_Character* character, int x_offset, int y_offset) :
 	character(character),


### PR DESCRIPTION
Command that clones Events from any map inside the current map.

`The syntax always comes in pairs. The first parameter of each pair indicates whether you are using a direct value or a variable/indirect variable, through ValueOrVariable().`

------------------------

#### Syntax (TPC):
```js
@raw 2056,
     "",           // Rename the Target Event [Optional]
      0, 1,        // Source Map's ID.
      0, 2,        // Source Event's ID
      0, 3,        // Target's x coordinate
      0, 4,        // Target's y coordinate
      0, 5,        // Target's Event's ID [Optional] 
                   // 👆 if a value is defined, it will replace an existing event.
```
