### PR TITLE
Debug Menu extensions: Display strings & interpreter stacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,6 +453,8 @@ add_library(${PROJECT_NAME} OBJECT
 	src/window_skill.h
 	src/window_skillstatus.cpp
 	src/window_skillstatus.h
+	src/window_stringview.cpp
+	src/window_stringview.h
 	src/window_targetstatus.cpp
 	src/window_targetstatus.h
 	src/window_teleport.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,6 +419,8 @@ add_library(${PROJECT_NAME} OBJECT
 	src/window_input_settings.h
 	src/window_item.cpp
 	src/window_item.h
+	src/window_interpreter.cpp
+	src/window_interpreter.h
 	src/window_keyboard.cpp
 	src/window_keyboard.h
 	src/window_menustatus.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -398,6 +398,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/window_input_settings.h \
 	src/window_item.cpp \
 	src/window_item.h \
+	src/window_interpreter.cpp \
+	src/window_interpreter.h \
 	src/window_keyboard.cpp \
 	src/window_keyboard.h \
 	src/window_menustatus.cpp \
@@ -432,6 +434,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/window_skill.h \
 	src/window_skillstatus.cpp \
 	src/window_skillstatus.h \
+	src/window_stringview.cpp \
+	src/window_stringview.h \
 	src/window_targetstatus.cpp \
 	src/window_targetstatus.h \
 	src/window_teleport.cpp \

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -92,7 +92,7 @@ std::vector<lcf::rpg::EventCommand>& Game_CommonEvent::GetList() {
 lcf::rpg::SaveEventExecState Game_CommonEvent::GetSaveData() {
 	lcf::rpg::SaveEventExecState state;
 	if (interpreter) {
-		state = interpreter->GetState();
+		state = interpreter->GetSaveState();
 	}
 	if (GetTrigger() == lcf::rpg::EventPage::Trigger_parallel && state.stack.empty()) {
 		// RPG_RT always stores an empty stack frame for parallel events.

--- a/src/game_commonevent.h
+++ b/src/game_commonevent.h
@@ -112,6 +112,8 @@ private:
 
 	/** Interpreter for parallel common events. */
 	std::unique_ptr<Game_Interpreter_Map> interpreter;
+
+	friend class Scene_Debug;
 };
 
 #endif

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -100,7 +100,7 @@ lcf::rpg::SaveMapEvent Game_Event::GetSaveData() const {
 	lcf::rpg::SaveEventExecState state;
 	if (page && page->trigger == lcf::rpg::EventPage::Trigger_parallel) {
 		if (interpreter) {
-			state = interpreter->GetState();
+			state = interpreter->GetSaveState();
 		}
 
 		if (state.stack.empty() && page->event_commands.empty()) {

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -212,6 +212,8 @@ private:
 	const lcf::rpg::Event* event = nullptr;
 	const lcf::rpg::EventPage* page = nullptr;
 	std::unique_ptr<Game_Interpreter_Map> interpreter;
+
+	friend class Scene_Debug;
 };
 
 inline int Game_Event::GetNumPages() const {

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -274,7 +274,11 @@ void Game_Interpreter::KeyInputState::toSave(lcf::rpg::SaveEventExecState& save)
 }
 
 
-lcf::rpg::SaveEventExecState Game_Interpreter::GetState() const {
+const lcf::rpg::SaveEventExecState& Game_Interpreter::GetState() const {
+	return _state;
+}
+
+lcf::rpg::SaveEventExecState Game_Interpreter::GetSaveState() {
 	auto save = _state;
 	_keyinput.toSave(save);
 	return save;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -102,7 +102,8 @@ bool Game_Interpreter::IsRunning() const {
 void Game_Interpreter::Push(
 	std::vector<lcf::rpg::EventCommand> _list,
 	int event_id,
-	bool started_by_decision_key
+	bool started_by_decision_key,
+	int event_page_id
 ) {
 	if (_list.empty()) {
 		return;
@@ -118,6 +119,10 @@ void Game_Interpreter::Push(
 	frame.current_command = 0;
 	frame.triggered_by_decision_key = started_by_decision_key;
 	frame.event_id = event_id;
+	if (Player::IsPatchManiac() || Player::HasEasyRpgExtensions()) {
+		frame.maniac_event_id = event_id;
+		frame.maniac_event_page_id = event_page_id;
+	}
 
 	if (_state.stack.empty() && main_flag && !Game_Battle::IsBattleRunning()) {
 		Main_Data::game_system->ClearMessageFace();
@@ -526,11 +531,11 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 
 // Setup Starting Event
 void Game_Interpreter::Push(Game_Event* ev) {
-	Push(ev->GetList(), ev->GetId(), ev->WasStartedByDecisionKey());
+	Push(ev->GetList(), ev->GetId(), ev->WasStartedByDecisionKey(), ev->GetActivePage() ? ev->GetActivePage()->ID : 0);
 }
 
 void Game_Interpreter::Push(Game_Event* ev, const lcf::rpg::EventPage* page, bool triggered_by_decision_key) {
-	Push(page->event_commands, ev->GetId(), triggered_by_decision_key);
+	Push(page->event_commands, ev->GetId(), triggered_by_decision_key, page->ID);
 }
 
 void Game_Interpreter::Push(Game_CommonEvent* ev) {
@@ -4001,7 +4006,7 @@ bool Game_Interpreter::CommandCallEvent(lcf::rpg::EventCommand const& com) { // 
 		return true;
 	}
 
-	Push(page->event_commands, event->GetId(), false);
+	Push(page->event_commands, event->GetId(), false, page->ID);
 
 	return true;
 }
@@ -5109,7 +5114,7 @@ bool Game_Interpreter::CommandManiacCallCommand(lcf::rpg::EventCommand const& co
 
 	// Our implementation pushes a new frame containing the command instead of invoking it directly.
 	// This is incompatible to Maniacs but has a better compatibility with our code.
-	Push({ cmd }, GetCurrentEventId(), false);
+	Push({ cmd }, GetCurrentEventId(), false); //FIXME: add some new flag, so the interpreter debug view (window_interpreter) can differentiate this frame from normal ones
 
 	return true;
 }

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -119,10 +119,8 @@ void Game_Interpreter::Push(
 	frame.current_command = 0;
 	frame.triggered_by_decision_key = started_by_decision_key;
 	frame.event_id = event_id;
-	if (Player::IsPatchManiac() || Player::HasEasyRpgExtensions()) {
-		frame.maniac_event_id = event_id;
-		frame.maniac_event_page_id = event_page_id;
-	}
+	frame.maniac_event_id = event_id;
+	frame.maniac_event_page_id = event_page_id;
 
 	if (_state.stack.empty() && main_flag && !Game_Battle::IsBattleRunning()) {
 		Main_Data::game_system->ClearMessageFace();

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -347,6 +347,8 @@ protected:
 	lcf::rpg::SaveEventExecState _state;
 	KeyInputState _keyinput;
 	AsyncOp _async_op = {};
+
+	friend class Scene_Debug;
 };
 
 inline const lcf::rpg::SaveEventExecFrame* Game_Interpreter::GetFramePtr() const {

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -66,7 +66,8 @@ public:
 	void Push(
 			std::vector<lcf::rpg::EventCommand> _list,
 			int _event_id,
-			bool started_by_decision_key = false
+			bool started_by_decision_key = false,
+			int event_page_id = 0
 	);
 	void Push(Game_Event* ev);
 	void Push(Game_Event* ev, const lcf::rpg::EventPage* page, bool triggered_by_decision_key);

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -80,11 +80,17 @@ public:
 
 
 	/**
+	 * Returns the interpreters current state information.
+	 * For saving state into a save file, use GetSaveState instead.
+	 */
+	const lcf::rpg::SaveEventExecState& GetState() const;
+
+	/**
 	 * Returns a SaveEventExecState needed for the savefile.
 	 *
 	 * @return interpreter commands stored in SaveEventCommands
 	 */
-	lcf::rpg::SaveEventExecState GetState() const;
+	lcf::rpg::SaveEventExecState GetSaveState();
 
 	/** @return Game_Character of the passed event_id */
 	Game_Character* GetCharacter(int event_id) const;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -387,7 +387,7 @@ void Game_Map::AddEventToVariableCache(lcf::rpg::Event& ev, int var_id) {
 }
 
 void Game_Map::PrepareSave(lcf::rpg::Save& save) {
-	save.foreground_event_execstate = interpreter->GetState();
+	save.foreground_event_execstate = interpreter->GetSaveState();
 
 	save.airship_location = GetVehicle(Game_Vehicle::Airship)->GetSaveData();
 	save.ship_location = GetVehicle(Game_Vehicle::Ship)->GetSaveData();

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -1244,13 +1244,14 @@ void Scene_Debug::UpdateInterpreterWindow(int index) {
 	lcf::rpg::SaveEventExecState state;
 	std::string first_line = "";
 	bool valid = false;
+	int evt_id = 0;
 
 	if (index == 1) {
 		state = Game_Interpreter::GetForegroundInterpreter().GetState();
 		first_line = Game_Battle::IsBattleRunning() ? "Foreground (Battle)" : "Foreground (Map)";
 		valid = true;
 	} else if (index <= state_interpreter.ev.size()) {
-		int evt_id = state_interpreter.ev[index - 1];
+		evt_id = state_interpreter.ev[index - 1];
 		state = state_interpreter.state_ev[index - 1];
 		first_line = fmt::format("EV{:04d}: {}", evt_id, Game_Map::GetEvent(evt_id)->GetName());
 		valid = true;
@@ -1260,6 +1261,7 @@ void Scene_Debug::UpdateInterpreterWindow(int index) {
 		for (auto& ce : Game_Map::GetCommonEvents()) {
 			if (ce.common_event_id == ce_id) {
 				first_line = fmt::format("CE{:04d}: {}", ce_id, ce.GetName());
+				evt_id = ce_id;
 				valid = true;
 				break;
 			}
@@ -1268,10 +1270,10 @@ void Scene_Debug::UpdateInterpreterWindow(int index) {
 
 	if (valid) {
 		state_interpreter.selected_state = index;
-		interpreter_window->SetStackState(index > state_interpreter.ev.size(), first_line, state);
+		interpreter_window->SetStackState(index > state_interpreter.ev.size(), evt_id, first_line, state);
 	} else {
 		state_interpreter.selected_state = -1;
-		interpreter_window->SetStackState(0, "", {});
+		interpreter_window->SetStackState(0, 0, "", {});
 	}
 }
 

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -451,23 +451,31 @@ void Scene_Debug::vUpdate() {
 		}
 		Game_Map::SetNeedRefresh(true);
 	} else if (range_window->GetActive() && Input::IsRepeated(Input::RIGHT)) {
+		int range_page_prev = range_page;
 		if (range_page < GetLastPage()) {
 			++range_page;
 		} else {
 			range_page = 0;
 		}
-		var_window->UpdateList(range_page * 100 + range_index * 10 + 1);
-		UpdateRangeListWindow();
-		var_window->Refresh();
+		if (range_page != range_page_prev) {
+			var_window->UpdateList(range_page * 100 + range_index * 10 + 1);
+			UpdateRangeListWindow();
+			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+			var_window->Refresh();
+		}
 	} else if (range_window->GetActive() && Input::IsRepeated(Input::LEFT)) {
+		int range_page_prev = range_page;
 		if (range_page > 0) {
 			--range_page;
 		} else {
 			range_page = GetLastPage();
 		}
-		var_window->UpdateList(range_page * 100 + range_index * 10 + 1);
-		UpdateRangeListWindow();
-		var_window->Refresh();
+		if (range_page != range_page_prev) {
+			var_window->UpdateList(range_page * 100 + range_index * 10 + 1);
+			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cursor));
+			UpdateRangeListWindow();
+			var_window->Refresh();
+		}
 	}
 
 	UpdateArrows();

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -363,7 +363,7 @@ void Scene_Debug::Pop() {
 			break;
 		case eUiInterpreterView:
 			interpreter_window->SetActive(true);
-			numberinput_window->SetNumber(frame.value);
+			interpreter_window->SetIndex(frame.value - 1);
 			var_window->SetVisible(false);
 			interpreter_window->SetVisible(true);
 			break;

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -325,7 +325,7 @@ void Scene_Debug::PushUiInterpreterView() {
 	var_window->SetVisible(false);
 
 	interpreter_window->SetActive(true);
-	interpreter_window->SetIndex(idx.range_page_index);
+	interpreter_window->SetIndex(0);
 
 	UpdateRangeListWindow();
 	interpreter_window->Refresh();

--- a/src/scene_debug.h
+++ b/src/scene_debug.h
@@ -25,6 +25,7 @@
 #include "window_numberinput.h"
 #include "window_varlist.h"
 #include "window_stringview.h"
+#include "window_interpreter.h"
 
 /**
  * Scene Equip class.
@@ -70,6 +71,7 @@ public:
 		eCallMapEvent,
 		eCallBattleEvent,
 		eString,
+		eInterpreter,
 		eOpenMenu,
 		eLastMainMenuOption,
 	};
@@ -79,7 +81,8 @@ public:
 		eUiRangeList,
 		eUiVarList,
 		eUiNumberInput,
-		eUiStringView
+		eUiStringView,
+		eUiInterpreterView
 	};
 private:
 	Mode mode = eMain;
@@ -101,8 +104,15 @@ private:
 	/** Creates string view window. */
 	void CreateStringViewWindow();
 
+	/** Creates interpreter window. */
+	void CreateInterpreterWindow();
+
+
 	/** Get the last page for the current mode */
 	int GetLastPage();
+
+	/* Get the first item number for the selected range */
+	int GetSelectedIndexFromRange() const;
 
 	int GetNumMainMenuItems() const;
 
@@ -128,6 +138,8 @@ private:
 	std::unique_ptr<Window_NumberInput> numberinput_window;
 	/** Windows for displaying multiline strings. */
 	std::unique_ptr<Window_StringView> stringview_window;
+	/** Displays the currently running inteprreters. */
+	std::unique_ptr<Window_Interpreter> interpreter_window;
 
 	struct StackFrame {
 		UiMode uimode = eUiMain;
@@ -149,9 +161,11 @@ private:
 	void PushUiVarList();
 	void PushUiNumberInput(int init_value, int digits, bool show_operator);
 	void PushUiStringView();
+	void PushUiInterpreterView();
 
 	Window_VarList::Mode GetWindowMode() const;
 	void UpdateFrameValueFromUi();
+	void UpdateDetailWindow();
 
 	bool IsValidMapId(int map_id) const;
 
@@ -160,6 +174,15 @@ private:
 
 	bool strings_cached = false;
 	std::vector<lcf::DBString> strings;
+
+	bool interpreter_states_cached = false;
+
+	void UpdateInterpreterWindow(int index);
+	void GetBackgroundInterpreters();
+	std::vector<int> interpreters_ev;
+	std::vector<int> interpreters_ce;
+	std::vector<lcf::rpg::SaveEventExecState> interpreters_state_ev;
+	std::vector<lcf::rpg::SaveEventExecState> interpreters_state_ce;
 };
 
 #endif

--- a/src/scene_debug.h
+++ b/src/scene_debug.h
@@ -82,6 +82,7 @@ public:
 		eUiVarList,
 		eUiNumberInput,
 		eUiStringView,
+		eUiChoices,
 		eUiInterpreterView
 	};
 private:
@@ -100,6 +101,9 @@ private:
 
 	/** Creates number input window. */
 	void CreateNumberInputWindow();
+
+	/** Creates choices window. */
+	void CreateChoicesWindow();
 
 	/** Creates string view window. */
 	void CreateStringViewWindow();
@@ -132,12 +136,16 @@ private:
 	void DoCallBattleEvent();
 	void DoOpenMenu();
 
+	const int choice_window_width = 120;
+
 	/** Displays a range selection for mode. */
 	std::unique_ptr<Window_Command> range_window;
 	/** Displays the vars inside the current range. */
 	std::unique_ptr<Window_VarList> var_window;
 	/** Number Editor. */
 	std::unique_ptr<Window_NumberInput> numberinput_window;
+	/** Choices window. */
+	std::unique_ptr<Window_Command> choices_window;
 	/** Windows for displaying multiline strings. */
 	std::unique_ptr<Window_StringView> stringview_window;
 	/** Displays the currently running inteprreters. */
@@ -162,6 +170,7 @@ private:
 	void PushUiRangeList();
 	void PushUiVarList();
 	void PushUiNumberInput(int init_value, int digits, bool show_operator);
+	void PushUiChoices(std::vector<std::string> choices, std::vector<bool> choices_enabled);
 	void PushUiStringView();
 	void PushUiInterpreterView();
 
@@ -181,11 +190,20 @@ private:
 	bool interpreter_states_cached = false;
 
 	void UpdateInterpreterWindow(int index);
-	void GetBackgroundInterpreters();
-	std::vector<int> interpreters_ev;
-	std::vector<int> interpreters_ce;
-	std::vector<lcf::rpg::SaveEventExecState> interpreters_state_ev;
-	std::vector<lcf::rpg::SaveEventExecState> interpreters_state_ce;
+	lcf::rpg::SaveEventExecFrame& GetSelectedInterpreterFrameFromUiState() const;
+	void CacheBackgroundInterpreterStates();
+	struct {
+		std::vector<int> ev;
+		std::vector<int> ce;
+		std::vector<lcf::rpg::SaveEventExecState> state_ev;
+		std::vector<lcf::rpg::SaveEventExecState> state_ce;
+
+		// Frame-scoped data types introduced in 'ScopedVars' branch
+		// bool show_frame_switches = false;
+		// bool show_frame_vars = false;
+		int selected_state = -1;
+		int selected_frame = -1;
+	} state_interpreter;
 };
 
 #endif

--- a/src/scene_debug.h
+++ b/src/scene_debug.h
@@ -111,8 +111,10 @@ private:
 	/** Get the last page for the current mode */
 	int GetLastPage();
 
-	/* Get the first item number for the selected range */
+	/** Get the first item number for the selected range */
 	int GetSelectedIndexFromRange() const;
+
+	void RestoreRangeSelectionFromSelectedValue(int value);
 
 	int GetNumMainMenuItems() const;
 
@@ -166,6 +168,7 @@ private:
 	Window_VarList::Mode GetWindowMode() const;
 	void UpdateFrameValueFromUi();
 	void UpdateDetailWindow();
+	void RefreshDetailWindow();
 
 	bool IsValidMapId(int map_id) const;
 

--- a/src/scene_debug.h
+++ b/src/scene_debug.h
@@ -24,6 +24,7 @@
 #include "window_command.h"
 #include "window_numberinput.h"
 #include "window_varlist.h"
+#include "window_stringview.h"
 
 /**
  * Scene Equip class.
@@ -68,6 +69,7 @@ public:
 		eCallCommonEvent,
 		eCallMapEvent,
 		eCallBattleEvent,
+		eString,
 		eOpenMenu,
 		eLastMainMenuOption,
 	};
@@ -76,7 +78,8 @@ public:
 		eUiMain,
 		eUiRangeList,
 		eUiVarList,
-		eUiNumberInput
+		eUiNumberInput,
+		eUiStringView
 	};
 private:
 	Mode mode = eMain;
@@ -94,6 +97,9 @@ private:
 
 	/** Creates number input window. */
 	void CreateNumberInputWindow();
+
+	/** Creates string view window. */
+	void CreateStringViewWindow();
 
 	/** Get the last page for the current mode */
 	int GetLastPage();
@@ -120,6 +126,8 @@ private:
 	std::unique_ptr<Window_VarList> var_window;
 	/** Number Editor. */
 	std::unique_ptr<Window_NumberInput> numberinput_window;
+	/** Windows for displaying multiline strings. */
+	std::unique_ptr<Window_StringView> stringview_window;
 
 	struct StackFrame {
 		UiMode uimode = eUiMain;
@@ -140,6 +148,7 @@ private:
 	void PushUiRangeList();
 	void PushUiVarList();
 	void PushUiNumberInput(int init_value, int digits, bool show_operator);
+	void PushUiStringView();
 
 	Window_VarList::Mode GetWindowMode() const;
 	void UpdateFrameValueFromUi();
@@ -148,6 +157,9 @@ private:
 
 	void UpdateArrows();
 	int arrow_frame = 0;
+
+	bool strings_cached = false;
+	std::vector<lcf::DBString> strings;
 };
 
 #endif

--- a/src/window_interpreter.cpp
+++ b/src/window_interpreter.cpp
@@ -172,3 +172,10 @@ void Window_Interpreter::DrawStackLine(int index) {
 	contents->TextDraw(rect.x + (digits_stackitemno * 6) + 56, rect.y, Font::ColorDefault, name, Text::AlignLeft);
 	contents->TextDraw(GetWidth() - 16, rect.y, Font::ColorDefault, fmt::format("{:0" + std::to_string(digits_cmdcount) + "d}/{:0" + std::to_string(digits_cmdcount) + "d}", item.cmd_current, item.cmd_count), Text::AlignRight);
 }
+
+int Window_Interpreter::GetSelectedStackFrameLine() {
+	if (GetIndex() < lines_without_stack) {
+		return -1;
+	}
+	return state.stack.size() - (GetIndex() - lines_without_stack) - 1;
+}

--- a/src/window_interpreter.cpp
+++ b/src/window_interpreter.cpp
@@ -1,0 +1,166 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Headers
+#include <vector>
+#include "window_interpreter.h"
+#include "bitmap.h"
+#include "game_map.h"
+#include "game_message.h"
+#include "game_system.h"
+#include "game_variables.h"
+#include "input.h"
+#include "player.h"
+#include "lcf/reader_util.h"
+
+namespace {
+	std::vector<std::string> CreateEmptyLines(int c) {		
+		std::vector<std::string> vars;
+		for (int i = 0; i < c; i++)
+			vars.push_back("");
+		return vars;
+	}
+}
+
+Window_Interpreter::Window_Interpreter(int ix, int iy, int iwidth, int iheight) :
+	Window_Selectable(ix, iy, iwidth, iheight) {
+	column_max = 1;
+}
+
+Window_Interpreter::~Window_Interpreter() {
+
+}
+
+void Window_Interpreter::SetStackState(bool is_ce, std::string interpreter_desc, lcf::rpg::SaveEventExecState state) {
+	this->interpreter_desc = interpreter_desc;
+	this->state = state;
+	this->is_ce = is_ce;
+}
+
+void Window_Interpreter::Refresh() {
+	stack_display_items.clear();
+
+	int max_cmd_count = 0;
+
+	for (int i = state.stack.size() - 1; i >= 0; i--) {
+		int evt_id = state.stack[i].event_id;
+		bool is_calling_ev_ce = false;
+
+		if (evt_id == 0 && i > 0) {
+			auto& prev_frame = state.stack[i - 1];
+			auto& com = prev_frame.commands[prev_frame.current_command - 1];
+			if (com.code == 12330) { // CallEvent
+				is_calling_ev_ce = true;
+				if (com.parameters[0] == 0) {
+					evt_id = com.parameters[1];
+				} else if (com.parameters[0] == 3 && Player::IsPatchManiac()) {
+					evt_id = Main_Data::game_variables->Get(com.parameters[1]);
+				} else if (com.parameters[0] == 4 && Player::IsPatchManiac()) {
+					evt_id = Main_Data::game_variables->GetIndirect(com.parameters[1]);
+				}
+			}
+		}
+		StackItem item = StackItem();
+		item.is_ce = is_calling_ev_ce || (i == 0 && this->is_ce);
+		item.evt_id = evt_id;
+		item.name = "";
+		item.cmd_current = state.stack[i].current_command;
+		item.cmd_count = state.stack[i].commands.size();
+
+		if (item.is_ce) {
+			auto* ce = lcf::ReaderUtil::GetElement(lcf::Data::commonevents, item.evt_id);
+			if (ce) {
+				item.name = ToString(ce->name);
+			}
+		} else {
+			auto* ev = Game_Map::GetEvent(evt_id);
+			if (ev) {
+				//TODO: map could have changed, but map_id isn't available
+				item.name = ToString(ev->GetName());
+			}
+		}
+
+		if (state.stack[i].commands.size() > max_cmd_count)
+			max_cmd_count = state.stack[i].commands.size();
+
+		stack_display_items.push_back(item);
+	}
+
+	item_max = stack_display_items.size() + lines_without_stack;
+	lines_without_stack = lines_without_stack_fixed;
+
+	if (state.wait_movement) {
+		item_max++;
+		lines_without_stack++;
+	}
+
+	digits_stackitemno = std::log10(stack_display_items.size()) + 1;
+	digits_cmdcount = std::log10(max_cmd_count) + 1;
+
+	CreateContents();
+	contents->Clear();
+	DrawDescriptionLines();
+
+	for (int i = 0; i < stack_display_items.size(); ++i) {
+		DrawStackLine(i);
+	}
+}
+
+void Window_Interpreter::Update() {
+	Window_Selectable::Update();
+}
+
+void Window_Interpreter::DrawDescriptionLines() {
+	int i = 0;
+	Rect rect = GetItemRect(i++);
+	contents->ClearRect(rect);
+
+	contents->TextDraw(rect.x, rect.y, Font::ColorDefault, interpreter_desc);
+
+	if (state.wait_movement) {
+		rect = GetItemRect(i++);
+		contents->ClearRect(rect);
+		contents->TextDraw(rect.x, rect.y, Font::ColorCritical, "[WAITING for EV movement!]");
+	}
+	
+	rect = GetItemRect(i++);
+	contents->ClearRect(rect);
+
+	contents->TextDraw(rect.x, rect.y, Font::ColorDefault, "Stack Size: ");
+	contents->TextDraw(GetWidth() - 16, rect.y, Font::ColorCritical, std::to_string(state.stack.size()), Text::AlignRight);
+}
+
+void Window_Interpreter::DrawStackLine(int index) {
+
+	Rect rect = GetItemRect(index + lines_without_stack);
+	contents->ClearRect(rect);
+
+	StackItem& item = stack_display_items[index];
+
+	contents->TextDraw(rect.x, rect.y, Font::ColorDisabled, fmt::format("[{:0" + std::to_string(digits_stackitemno) + "d}]", state.stack.size() - index));
+	contents->TextDraw(rect.x + (digits_stackitemno * 6) + 16, rect.y, Font::ColorDefault, fmt::format("{}{:04d}", item.is_ce ? "CE" : "EV", item.evt_id));
+
+	std::string name = item.name;
+	int max_length = 22;
+	max_length -= digits_stackitemno;
+	max_length -= digits_cmdcount * 2;
+	if (name.length() > max_length) {
+		name = name.substr(0, max_length - 3) + "...";
+	}
+	contents->TextDraw(rect.x + (digits_stackitemno * 6) + 56, rect.y, Font::ColorDefault, name, Text::AlignLeft);
+	contents->TextDraw(GetWidth() - 16, rect.y, Font::ColorDefault, fmt::format("{:0" + std::to_string(digits_cmdcount) + "d}/{:0" + std::to_string(digits_cmdcount) + "d}", item.cmd_current, item.cmd_count), Text::AlignRight);
+}

--- a/src/window_interpreter.cpp
+++ b/src/window_interpreter.cpp
@@ -113,11 +113,19 @@ void Window_Interpreter::Refresh() {
 
 	CreateContents();
 	contents->Clear();
+
+	if (!IsValid())
+		return;
+
 	DrawDescriptionLines();
 
 	for (int i = 0; i < stack_display_items.size(); ++i) {
 		DrawStackLine(i);
 	}
+}
+
+bool Window_Interpreter::IsValid() {
+	return !interpreter_desc.empty();
 }
 
 void Window_Interpreter::Update() {

--- a/src/window_interpreter.cpp
+++ b/src/window_interpreter.cpp
@@ -58,7 +58,7 @@ void Window_Interpreter::Refresh() {
 	for (int i = state.stack.size() - 1; i >= 0; i--) {
 		int evt_id = state.stack[i].event_id;
 		int page_id = 0;
-		if ((Player::IsPatchManiac() || Player::HasEasyRpgExtensions()) && state.stack[i].maniac_event_id > 0) {
+		if (state.stack[i].maniac_event_id > 0) {
 			evt_id = state.stack[i].maniac_event_id;
 			page_id = state.stack[i].maniac_event_page_id;
 		}

--- a/src/window_interpreter.h
+++ b/src/window_interpreter.h
@@ -21,6 +21,7 @@
 // Headers
 #include "window_command.h"
 #include "lcf/rpg/saveeventexecstate.h"
+#include "lcf/rpg/saveeventexecframe.h"
 
 class Window_Interpreter : public Window_Selectable {
 public:
@@ -32,6 +33,8 @@ public:
 	void SetStackState(bool is_ce, std::string interpreter_desc, lcf::rpg::SaveEventExecState state);
 	void Refresh();
 	bool IsValid();
+
+	int GetSelectedStackFrameLine();
 protected:
 	void DrawDescriptionLines();
 	void DrawStackLine(int index);

--- a/src/window_interpreter.h
+++ b/src/window_interpreter.h
@@ -41,7 +41,7 @@ protected:
 private:
 	struct StackItem {
 		bool is_ce;
-		int evt_id;
+		int evt_id, page_id;
 		std::string name;
 		int cmd_current, cmd_count;
 	};
@@ -53,8 +53,7 @@ private:
 	std::string interpreter_desc;
 	int lines_without_stack = 0;
 
-	int digits_stackitemno = 0, digits_cmdcount = 0;
-	
+	int digits_stackitemno = 0, digits_evt_id = 0, digits_page_id = 0, digits_evt_combined_id = 0, digits_cmdcount = 0;
 	std::vector<StackItem> stack_display_items;
 };
 

--- a/src/window_interpreter.h
+++ b/src/window_interpreter.h
@@ -31,6 +31,7 @@ public:
 
 	void SetStackState(bool is_ce, std::string interpreter_desc, lcf::rpg::SaveEventExecState state);
 	void Refresh();
+	bool IsValid();
 protected:
 	void DrawDescriptionLines();
 	void DrawStackLine(int index);

--- a/src/window_interpreter.h
+++ b/src/window_interpreter.h
@@ -30,7 +30,7 @@ public:
 
 	void Update() override;
 
-	void SetStackState(bool is_ce, std::string interpreter_desc, lcf::rpg::SaveEventExecState state);
+	void SetStackState(bool is_ce, int owner_evt_id, std::string interpreter_desc, lcf::rpg::SaveEventExecState state);
 	void Refresh();
 	bool IsValid();
 
@@ -39,6 +39,12 @@ protected:
 	void DrawDescriptionLines();
 	void DrawStackLine(int index);
 private:
+	struct InterpDisplayItem {
+		bool is_ce;
+		int owner_evt_id;
+		std::string desc;
+	};
+
 	struct StackItem {
 		bool is_ce;
 		int evt_id, page_id;
@@ -48,12 +54,12 @@ private:
 
 	const int lines_without_stack_fixed = 3;
 	
-	bool is_ce = false;
 	lcf::rpg::SaveEventExecState state;
-	std::string interpreter_desc;
 	int lines_without_stack = 0;
 
 	int digits_stackitemno = 0, digits_evt_id = 0, digits_page_id = 0, digits_evt_combined_id = 0, digits_cmdcount = 0;
+
+	InterpDisplayItem display_item;
 	std::vector<StackItem> stack_display_items;
 };
 

--- a/src/window_interpreter.h
+++ b/src/window_interpreter.h
@@ -15,36 +15,43 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef EP_WINDOW_STRINGVIEW_H
-#define EP_WINDOW_STRINGVIEW_H
+#ifndef EP_WINDOW_INTERPRETER_H
+#define EP_WINDOW_INTERPRETER_H
 
 // Headers
 #include "window_command.h"
+#include "lcf/rpg/saveeventexecstate.h"
 
-class Window_StringView : public Window_Selectable {
+class Window_Interpreter : public Window_Selectable {
 public:
-	Window_StringView(int ix, int iy, int iwidth, int iheight);
-	~Window_StringView() override;
+	Window_Interpreter(int ix, int iy, int iwidth, int iheight);
+	~Window_Interpreter() override;
 
 	void Update() override;
 
-	void SetDisplayData(StringView data);
-	std::string GetDisplayData(bool eval_cmds);
-
+	void SetStackState(bool is_ce, std::string interpreter_desc, lcf::rpg::SaveEventExecState state);
 	void Refresh();
 protected:
-	void DrawCmdLines();
-	void DrawLine(int index);
+	void DrawDescriptionLines();
+	void DrawStackLine(int index);
 private:
-	const int top_lines_reserved = 2, max_str_length = 42;
-	bool auto_linebreak = false, cmd_eval = false;
+	struct StackItem {
+		bool is_ce;
+		int evt_id;
+		std::string name;
+		int cmd_current, cmd_count;
+	};
 
-	std::string display_data_raw;
+	const int lines_without_stack_fixed = 3;
+	
+	bool is_ce = false;
+	lcf::rpg::SaveEventExecState state;
+	std::string interpreter_desc;
+	int lines_without_stack = 0;
 
-	std::vector<std::string> lines;
-	std::vector<bool> lines_numbered;
-
-	int line_count = 0, line_no_max_digits = 0;
+	int digits_stackitemno = 0, digits_cmdcount = 0;
+	
+	std::vector<StackItem> stack_display_items;
 };
 
 #endif

--- a/src/window_stringview.cpp
+++ b/src/window_stringview.cpp
@@ -45,7 +45,7 @@ std::string Window_StringView::GetDisplayData(bool eval_cmds) {
 
 void Window_StringView::Refresh() {
 	lines.clear();
-	lines_numbered.clear();
+	line_numbers.clear();
 	line_count = 0;
 
 	std::string value = GetDisplayData(cmd_eval);
@@ -68,13 +68,14 @@ void Window_StringView::Refresh() {
 
 	//create vector of display lines
 	pos = 0;
+	int c = 0;
 	while ((pos = value.find("\n", pos)) != std::string::npos) {
 		std::string new_line = value.substr(0, pos);
-		lines_numbered.push_back(true);
+		line_numbers.push_back(++c);
 
 		while (auto_linebreak && new_line.size() > (max_str_length - line_no_max_digits)) {
 			lines.push_back(new_line.substr(0, (max_str_length - line_no_max_digits)));
-			lines_numbered.push_back(false);
+			line_numbers.push_back(0);
 			new_line = new_line.substr((max_str_length - line_no_max_digits));
 		}
 		lines.push_back(new_line);
@@ -83,7 +84,7 @@ void Window_StringView::Refresh() {
 	}
 	if (!value.empty()) {
 		lines.push_back(value);
-		lines_numbered.push_back(true);
+		line_numbers.push_back(++c);
 	}
 
 	item_max = lines.size() + top_lines_reserved;
@@ -131,8 +132,8 @@ void Window_StringView::DrawLine(int index) {
 	std::string line = lines[index];
 
 	if (!line.empty()) {
-		if (lines_numbered[index]) {
-			contents->TextDraw(rect.x, rect.y, Font::ColorDisabled, fmt::format("{:0" + std::to_string(line_no_max_digits) + "d}", index + 1));
+		if (line_numbers[index]) {
+			contents->TextDraw(rect.x, rect.y, Font::ColorDisabled, fmt::format("{:0" + std::to_string(line_no_max_digits) + "d}", line_numbers[index]));
 		}
 		contents->TextDraw(rect.x + line_no_max_digits * 6 + 6, rect.y, Font::ColorDefault, line);
 	}

--- a/src/window_stringview.cpp
+++ b/src/window_stringview.cpp
@@ -63,7 +63,6 @@ void Window_StringView::Refresh() {
 
 	//compute how many digits there are needed for the line numbers
 	line_no_max_digits = std::log10(line_count) + 1;
-	line_no_tpl = fmt::format("{{:0{}d}}:", line_no_max_digits);
 
 	value = GetDisplayData(cmd_eval);
 
@@ -133,8 +132,8 @@ void Window_StringView::DrawLine(int index) {
 
 	if (!line.empty()) {
 		if (lines_numbered[index]) {
-			contents->TextDraw(rect.x, rect.y, Font::ColorDisabled, fmt::format(line_no_tpl, index + 1));
+			contents->TextDraw(rect.x, rect.y, Font::ColorDisabled, fmt::format("{:0" + std::to_string(line_no_max_digits) + "d}", index + 1));
 		}
-		contents->TextDraw(rect.x + line_no_max_digits * 8 + 8, rect.y, Font::ColorDefault, line);
+		contents->TextDraw(rect.x + line_no_max_digits * 6 + 6, rect.y, Font::ColorDefault, line);
 	}
 }

--- a/src/window_stringview.cpp
+++ b/src/window_stringview.cpp
@@ -1,0 +1,140 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Headers
+#include <vector>
+#include "window_stringview.h"
+#include "bitmap.h"
+#include "game_message.h"
+#include "game_system.h"
+#include "input.h"
+#include "player.h"
+
+Window_StringView::Window_StringView(int ix, int iy, int iwidth, int iheight) :
+	Window_Selectable(ix, iy, iwidth, iheight) {
+	column_max = 1;
+}
+
+Window_StringView::~Window_StringView() {
+
+}
+
+void Window_StringView::SetDisplayData(StringView data) {
+	display_data_raw = ToString(data);
+}
+
+std::string Window_StringView::GetDisplayData(bool eval_cmds) {
+	if (eval_cmds)
+		return PendingMessage::ApplyTextInsertingCommands(display_data_raw, Player::escape_char, Game_Message::CommandCodeInserter);
+	return display_data_raw;
+}
+
+void Window_StringView::Refresh() {
+	lines.clear();
+	lines_numbered.clear();
+	line_count = 0;
+
+	std::string value = GetDisplayData(cmd_eval);
+
+	// determine line count
+	size_t pos = 0;
+	while ((pos = value.find("\n", pos)) != std::string::npos) {
+		value = value.substr(pos + 1);
+		pos = 0;
+		line_count++;
+	}
+	if (!value.empty()) {
+		line_count++;
+	}
+
+	//compute how many digits there are needed for the line numbers
+	line_no_max_digits = std::log10(line_count) + 1;
+	line_no_tpl = fmt::format("{{:0{}d}}:", line_no_max_digits);
+
+	value = GetDisplayData(cmd_eval);
+
+	//create vector of display lines
+	pos = 0;
+	while ((pos = value.find("\n", pos)) != std::string::npos) {
+		std::string new_line = value.substr(0, pos);
+		lines_numbered.push_back(true);
+
+		while (auto_linebreak && new_line.size() > (max_str_length - line_no_max_digits)) {
+			lines.push_back(new_line.substr(0, (max_str_length - line_no_max_digits)));
+			lines_numbered.push_back(false);
+			new_line = new_line.substr((max_str_length - line_no_max_digits));
+		}
+		lines.push_back(new_line);
+		value = value.substr(pos + 1);
+		pos = 0;
+	}
+	if (!value.empty()) {
+		lines.push_back(value);
+		lines_numbered.push_back(true);
+	}
+
+	item_max = lines.size() + top_lines_reserved;
+
+	CreateContents();
+	contents->Clear();
+	DrawCmdLines();
+
+	for (int i = 0; i < item_max - top_lines_reserved; ++i) {
+		DrawLine(i);
+	}
+}
+
+void Window_StringView::Update() {
+	Window_Selectable::Update();
+	if (active && index >= 0 && index <= 1 && Input::IsTriggered(Input::DECISION)) {
+		if (index == 0)
+			auto_linebreak = !auto_linebreak;
+		else
+			cmd_eval = !cmd_eval;
+
+		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
+		Refresh();
+	}
+}
+
+void Window_StringView::DrawCmdLines() {
+	Rect rect = GetItemRect(0);
+	contents->ClearRect(rect);
+
+	contents->TextDraw(rect.x, rect.y, Font::ColorHeal, "Automatic line break: ");
+	contents->TextDraw(GetWidth() - 16, rect.y, Font::ColorCritical, auto_linebreak ? "[ON]" : "[OFF]", Text::AlignRight);
+
+	rect = GetItemRect(1);
+	contents->ClearRect(rect);
+
+	contents->TextDraw(rect.x, rect.y, Font::ColorHeal, "Command evaluation: ");
+	contents->TextDraw(GetWidth() - 16, rect.y, Font::ColorCritical, cmd_eval ? "[ON]" : "[OFF]", Text::AlignRight);
+}
+
+void Window_StringView::DrawLine(int index) {
+	Rect rect = GetItemRect(index + top_lines_reserved);
+	contents->ClearRect(rect);
+
+	std::string line = lines[index];
+
+	if (!line.empty()) {
+		if (lines_numbered[index]) {
+			contents->TextDraw(rect.x, rect.y, Font::ColorDisabled, fmt::format(line_no_tpl, index + 1));
+		}
+		contents->TextDraw(rect.x + line_no_max_digits * 8 + 8, rect.y, Font::ColorDefault, line);
+	}
+}

--- a/src/window_stringview.cpp
+++ b/src/window_stringview.cpp
@@ -69,16 +69,23 @@ void Window_StringView::Refresh() {
 	//create vector of display lines
 	pos = 0;
 	int c = 0;
+	int limit = 6 * (max_str_length - line_no_max_digits);
+
 	while ((pos = value.find("\n", pos)) != std::string::npos) {
 		std::string new_line = value.substr(0, pos);
-		line_numbers.push_back(++c);
 
-		while (auto_linebreak && new_line.size() > (max_str_length - line_no_max_digits)) {
-			lines.push_back(new_line.substr(0, (max_str_length - line_no_max_digits)));
-			line_numbers.push_back(0);
-			new_line = new_line.substr((max_str_length - line_no_max_digits));
+		line_numbers.push_back(++c);
+		if (auto_linebreak) {
+			bool skipFirstNo = true;
+			Game_Message::WordWrap(new_line, limit, [&](StringView line) {
+				if (!skipFirstNo)
+					line_numbers.push_back(0);
+				skipFirstNo = false;
+				lines.push_back(std::string(line));
+			}, *Font::DefaultBitmapFont());
+		} else {
+			lines.push_back(new_line);
 		}
-		lines.push_back(new_line);
 		value = value.substr(pos + 1);
 		pos = 0;
 	}

--- a/src/window_stringview.h
+++ b/src/window_stringview.h
@@ -42,7 +42,7 @@ private:
 	std::string display_data_raw;
 
 	std::vector<std::string> lines;
-	std::vector<bool> lines_numbered;
+	std::vector<int> line_numbers;
 
 	int line_count = 0, line_no_max_digits = 0;
 };

--- a/src/window_stringview.h
+++ b/src/window_stringview.h
@@ -1,0 +1,51 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_WINDOW_STRINGVIEW_H
+#define EP_WINDOW_STRINGVIEW_H
+
+// Headers
+#include "window_command.h"
+
+class Window_StringView : public Window_Selectable {
+public:
+	Window_StringView(int ix, int iy, int iwidth, int iheight);
+	~Window_StringView() override;
+
+	void Update() override;
+
+	void SetDisplayData(StringView data);
+	std::string GetDisplayData(bool eval_cmds);
+
+	void Refresh();
+protected:
+	void DrawCmdLines();
+	void DrawLine(int index);
+private:
+	const int top_lines_reserved = 2, max_str_length = 42;
+	bool auto_linebreak = false, cmd_eval = false;
+
+	std::string display_data_raw;
+
+	std::vector<std::string> lines;
+	std::vector<bool> lines_numbered;
+
+	int line_count = 0, line_no_max_digits = 0;
+	std::string line_no_tpl = "";
+};
+
+#endif

--- a/src/window_varlist.h
+++ b/src/window_varlist.h
@@ -35,6 +35,7 @@ public:
 		eLevel,
 		eCommonEvent,
 		eMapEvent,
+		eString
 	};
 
 	/**
@@ -61,8 +62,9 @@ public:
 	 * Indicate what to display.
 	 *
 	 * @param mode the mode to set.
+	 * @param max_length_strings maximum size for items (Used for Strings)
 	 */
-	void SetMode(Mode mode);
+	void SetMode(Mode mode, int max_length_strings = 0);
 
 	/**
 	 * Returns the current mode.
@@ -79,7 +81,7 @@ private:
 	void DrawItemValue(int index);
 
 	Mode mode = eNone;
-	int first_var = 0;
+	int first_var = 0, max_length_strings = 0;
 
 	bool DataIsValid(int range_index);
 


### PR DESCRIPTION
Adds two new items to the F9 Debug Menu:
- "Strings"
- "Interpreter"

String display supports viewing multiline strings through a special new window "Window_StringView"
Two options can be toggled:
- Automatic linebreaks
- Command Evaluation ( default inserter with \v, \n, \t )

![screenshot_160](https://github.com/EasyRPG/Player/assets/42896817/b3821b19-7671-4d83-a967-03da85422c86)

Viewing the current interpreter stacks
(right side: [current command] / [commands_size])
![screenshot_161](https://github.com/EasyRPG/Player/assets/42896817/2c01a762-e96e-4659-9fea-c1bce15632ad)
