### PR TITLE
Variable Substitution: Options for enabling substution in command strings & for applying {fmt}-style number formatting

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1786,7 +1786,11 @@ int Game_Interpreter::ValueOrVariableBitfield(lcf::rpg::EventCommand const& com,
 }
 
 std::string Game_Interpreter::CommandString(lcf::rpg::EventCommand const& com) {
+#ifdef LIBLCF_STUB_COMSTRING_VARSUBSTITUTION
+	if (!Player::HasEasyRpgExtensions()) {
+#else
 	if (!Player::HasEasyRpgExtensions() || !lcf::Data::system.easyrpg_var_substitution_in_commands) {
+#endif
 		return ToString(com.string);
 	}
 	return PendingMessage::ApplyTextInsertingCommands(ToString(com.string), Player::escape_char, Game_Message::CommandCodeInserter);

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2245,7 +2245,7 @@ bool Game_Interpreter::CommandChangeVehicleGraphic(lcf::rpg::EventCommand const&
 		return true;
 	}
 
-	std::string& name = CommandString(com);
+	std::string name = CommandString(com);
 	int vehicle_index = com.parameters[1];
 
 	vehicle->SetSpriteGraphic(name, vehicle_index);
@@ -3562,7 +3562,7 @@ bool Game_Interpreter::CommandConditionalBranch(lcf::rpg::EventCommand const& co
 		case 1:
 		{
 			// Name
-			std::string& name = CommandString(com);
+			std::string name = CommandString(com);
 			result = (actor->GetName() == name);
 			break;
 		}

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1793,7 +1793,9 @@ std::string Game_Interpreter::CommandString(lcf::rpg::EventCommand const& com) {
 #endif
 		return ToString(com.string);
 	}
-	return PendingMessage::ApplyTextInsertingCommands(ToString(com.string), Player::escape_char, Game_Message::CommandCodeInserter);
+	std::string command_string = ToString(com.string);
+	PendingMessage::ApplyTextInsertingCommands(command_string, Player::escape_char, Game_Message::CommandCodeInserter);
+	return command_string;
 }
 
 

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -172,8 +172,11 @@ protected:
 	static int ValueOrVariableBitfield(int mode, int shift, int val);
 	// Range checked, conditional version (slower) of ValueOrVariableBitfield
 	static int ValueOrVariableBitfield(lcf::rpg::EventCommand const& com, int mode_idx, int shift, int val_idx);
-	static StringView CommandStringOrVariable(lcf::rpg::EventCommand const& com, int mode_idx, int val_idx);
-	static StringView CommandStringOrVariableBitfield(lcf::rpg::EventCommand const& com, int mode_idx, int shift, int val_idx);
+
+	static std::string CommandString(lcf::rpg::EventCommand const& com);
+	static std::string CommandStringOrVariable(lcf::rpg::EventCommand const& com, int mode_idx, int val_idx);
+	static std::string CommandStringOrVariableBitfield(lcf::rpg::EventCommand const& com, int mode_idx, int shift, int val_idx);
+
 
 	/**
 	 * When current frame finishes executing we pop the stack

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -421,7 +421,7 @@ bool Game_Interpreter_Battle::CommandShowHiddenMonster(lcf::rpg::EventCommand co
 }
 
 bool Game_Interpreter_Battle::CommandChangeBattleBG(lcf::rpg::EventCommand const& com) {
-	Game_Battle::ChangeBackground(ToString(com.string));
+	Game_Battle::ChangeBackground(CommandString(com));
 	return true;
 }
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -283,7 +283,7 @@ bool Game_Interpreter_Map::CommandEnemyEncounter(lcf::rpg::EventCommand const& c
 		Game_Map::SetupBattle(args);
 		break;
 	case 1:
-		args.background = ToString(com.string);
+		args.background = CommandString(com);
 
 		if (Player::IsRPG2k3()) {
 			args.formation = static_cast<lcf::rpg::System::BattleFormation>(com.parameters[7]);
@@ -699,7 +699,7 @@ bool Game_Interpreter_Map::CommandPlayMovie(lcf::rpg::EventCommand const& com) {
 		return false;
 	}
 
-	auto filename = ToString(com.string);
+	auto filename = CommandString(com);
 	int pos_x = ValueOrVariable(com.parameters[0], com.parameters[1]);
 	int pos_y = ValueOrVariable(com.parameters[0], com.parameters[2]);
 	int res_x = com.parameters[3];

--- a/src/game_message.cpp
+++ b/src/game_message.cpp
@@ -164,7 +164,8 @@ static std::optional<std::string> CommandCodeInserterNoRecurse(char ch, const ch
 		std::string str = ToString(Main_Data::game_strings->Get(value));
 
 		// \t[] is evaluated but command codes inside it are not evaluated again
-		return PendingMessage::ApplyTextInsertingCommands(str, escape_char, PendingMessage::DefaultCommandInserter);
+		PendingMessage::ApplyTextInsertingCommands(str, escape_char, PendingMessage::DefaultCommandInserter);
+		return str;
 	}
 
 	return PendingMessage::DefaultCommandInserter(ch, iter, end, escape_char);
@@ -179,7 +180,8 @@ std::optional<std::string> Game_Message::CommandCodeInserter(char ch, const char
 		std::string str = ToString(Main_Data::game_strings->Get(value));
 
 		// Command codes in \t[] are evaluated once.
-		return PendingMessage::ApplyTextInsertingCommands(str, escape_char, CommandCodeInserterNoRecurse);
+		PendingMessage::ApplyTextInsertingCommands(str, escape_char, CommandCodeInserterNoRecurse);
+		return str;
 	}
 
 	return PendingMessage::DefaultCommandInserter(ch, iter, end, escape_char);

--- a/src/game_message.h
+++ b/src/game_message.h
@@ -122,6 +122,16 @@ namespace Game_Message {
 		std::string value;
 	};
 
+	/** Struct returned by parameter parsing methods */
+	struct ParseFormattedParamResult {
+		/** iterator to the next character after parsed content */
+		const char* next = nullptr;
+		/** value that was parsed */
+		int value = 0;
+		/** the format string according to fmt::format specifications */
+		std::string format_string;
+	};
+
 	/** Parse a \v[] variable string
 	 *
 	 * @param iter start of utf8 string
@@ -133,6 +143,18 @@ namespace Game_Message {
 	 * @return \refer ParseParamResult
 	 */
 	ParseParamResult ParseVariable(const char* iter, const char* end, uint32_t escape_char, bool skip_prefix = false, int max_recursion = default_max_recursion);
+
+	/** Parse a \v[] variable string with format specifiers
+	 *
+	 * @param iter start of utf8 string
+	 * @param end end of utf8 string
+	 * @param escape_char the escape character to use
+	 * @param skip_prefix if true, assume prefix was already parsed and iter starts at the first left bracket.
+	 * @param max_recursion How many times to allow recursive variable lookups.
+	 *
+	 * @return \refer ParseFormattedParamResult
+	 */
+	ParseFormattedParamResult ParseFormattedVariable(const char* iter, const char* end, uint32_t escape_char, bool skip_prefix = false, int max_recursion = default_max_recursion);
 
 	/** Parse a \t[] variable string
 	 *
@@ -185,6 +207,10 @@ namespace Game_Message {
 	Game_Message::ParseParamResult ParseParam(char upper, char lower, const char* iter, const char* end, uint32_t escape_char, bool skip_prefix = false, int max_recursion = default_max_recursion);
 	// same as ParseParam but the parameter is of structure \x[some_word] instead of \x[1]
 	Game_Message::ParseParamStringResult ParseStringParam(char upper, char lower, const char* iter, const char* end, uint32_t escape_char, bool skip_prefix = false, int max_recursion = default_max_recursion);
+
+	Game_Message::ParseFormattedParamResult ParseFormattedParam(char upper, char lower, const char* iter, const char* end, uint32_t escape_char, bool skip_prefix = false, int max_recursion = default_max_recursion);
+
+	const char* ParseNumberFormat(const char* iter, const char* end);
 }
 
 #endif

--- a/src/game_strings.cpp
+++ b/src/game_strings.cpp
@@ -322,7 +322,9 @@ std::string Game_Strings::Extract(StringView string, bool as_hex) {
 		cmd_fn = ManiacsCommandInserter;
 	}
 
-	return PendingMessage::ApplyTextInsertingCommands(ToString(string), Player::escape_char, cmd_fn);
+	std::string str = ToString(string);
+	PendingMessage::ApplyTextInsertingCommands(str, Player::escape_char, cmd_fn);
+	return str;
 }
 
 std::optional<std::string> Game_Strings::ManiacsCommandInserter(char ch, const char** iter, const char* end, uint32_t escape_char) {

--- a/src/lcf/data.h
+++ b/src/lcf/data.h
@@ -34,6 +34,8 @@
 #include "lcf/rpg/treemap.h"
 #include "lcf/rpg/database.h"
 
+#define LIBLCF_STUB_COMSTRING_VARSUBSTITUTION
+
 namespace lcf {
 
 /**

--- a/src/pending_message.cpp
+++ b/src/pending_message.cpp
@@ -159,12 +159,25 @@ std::optional<std::string> PendingMessage::DefaultCommandInserter(char ch, const
 			return ToString(actor->GetName());
 		}
 	} else if (ch == 'V' || ch == 'v') {
-		auto parse_ret = Game_Message::ParseVariable(*iter, end, escape_char, true);
-		*iter = parse_ret.next;
-		int value = parse_ret.value;
+		if (!Player::HasEasyRpgExtensions()) {
+			auto parse_ret = Game_Message::ParseVariable(*iter, end, escape_char, true);
+			*iter = parse_ret.next;
+			int value = parse_ret.value;
 
-		int variable_value = Main_Data::game_variables->Get(value);
-		return std::to_string(variable_value);
+			int variable_value = Main_Data::game_variables->Get(value);
+			return std::to_string(variable_value);
+		} else {
+			auto parse_ret = Game_Message::ParseFormattedVariable(*iter, end, escape_char, true);
+			*iter = parse_ret.next;
+			int value = parse_ret.value;
+			int variable_value = Main_Data::game_variables->Get(value);
+
+			if (!parse_ret.format_string.empty()) {
+				return fmt::format(parse_ret.format_string, variable_value);
+			}
+
+			return std::to_string(variable_value);
+		}
 	}
 
 	return std::nullopt;

--- a/src/pending_message.cpp
+++ b/src/pending_message.cpp
@@ -159,7 +159,7 @@ std::optional<std::string> PendingMessage::DefaultCommandInserter(char ch, const
 			return ToString(actor->GetName());
 		}
 	} else if (ch == 'V' || ch == 'v') {
-		if (!Player::HasEasyRpgExtensions()) {
+		if (!Player::HasEasyRpgExtensions() || !lcf::Data::system.easyrpg_var_substitution_formatting) {
 			auto parse_ret = Game_Message::ParseVariable(*iter, end, escape_char, true);
 			*iter = parse_ret.next;
 			int value = parse_ret.value;

--- a/src/pending_message.cpp
+++ b/src/pending_message.cpp
@@ -159,7 +159,11 @@ std::optional<std::string> PendingMessage::DefaultCommandInserter(char ch, const
 			return ToString(actor->GetName());
 		}
 	} else if (ch == 'V' || ch == 'v') {
+#ifdef LIBLCF_STUB_COMSTRING_VARSUBSTITUTION
+		if (!Player::HasEasyRpgExtensions()) {
+#else
 		if (!Player::HasEasyRpgExtensions() || !lcf::Data::system.easyrpg_var_substitution_formatting) {
+#endif
 			auto parse_ret = Game_Message::ParseVariable(*iter, end, escape_char, true);
 			*iter = parse_ret.next;
 			int value = parse_ret.value;

--- a/src/pending_message.h
+++ b/src/pending_message.h
@@ -68,7 +68,7 @@ class PendingMessage {
 
 		void SetIsEventMessage(bool value) { is_event_message = value; }
 		bool IsEventMessage() const { return is_event_message; }
-		static std::string ApplyTextInsertingCommands(std::string input, uint32_t escape_char, const CommandInserter& cmd_fn);
+		static void ApplyTextInsertingCommands(std::string& input, uint32_t escape_char, const CommandInserter& cmd_fn);
 
 	private:
 		int PushLineImpl(std::string msg);


### PR DESCRIPTION
This PR enables two new features:
- Variable substitution in interpreter command strings (default CommandCodeInserter is used -> \v, \n, \t)
- Number formatting using {fmt} 
  just write the format specification after a ':'
  the parser will ignore anything that is not valid fmt syntax (also decimal types & 'precision' are not supported)

These two features require setting new liblcfs fields which are specified as follows:

```
System,easyrpg_var_substitution_in_commands,f,Boolean,0xDC,False,0,0,Enables substitution of '\v' '\n' '\a' inside string parameters of interpreter commands
System,easyrpg_var_substitution_formatting,f,Boolean,0xDD,False,0,0,Enables '{fmt}'-style format specifiers for usage inside variable substitution
```


### Example: Graphics customization
Consider you want to dynamically change an actor graphic or faceset depending on some settings.

With this branch you can just use any pre-existing command like this:

`com.string: "Actor\v[123:02d]"
`

... which evaluates to "Actor01.png", "Actor02.png", ..., "Actor[xx].png" depending on the value of Variable '123'