### PR TITLE
Interpreter Refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,8 @@ add_library(${PROJECT_NAME} OBJECT
 	src/game_interpreter.h
 	src/game_interpreter_map.cpp
 	src/game_interpreter_map.h
+	src/game_interpreter_shared.cpp
+	src/game_interpreter_shared.h
 	src/game_map.cpp
 	src/game_map.h
 	src/game_message.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -157,6 +157,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/game_interpreter_control_variables.h \
 	src/game_interpreter_map.cpp \
 	src/game_interpreter_map.h \
+	src/game_interpreter_shared.cpp \
+	src/game_interpreter_shared.h \
 	src/game_map.cpp \
 	src/game_map.h \
 	src/game_message.cpp \

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -256,33 +256,9 @@ bool Game_Event::AreConditionsMet(const lcf::rpg::EventPage& page) {
 			return false;
 		}
 	} else {
-		if (page.condition.flags.variable) {
-			switch (page.condition.compare_operator) {
-			case 0: // ==
-				if (!(Main_Data::game_variables->Get(page.condition.variable_id) == page.condition.variable_value))
-					return false;
-				break;
-			case 1: // >=
-				if (!(Main_Data::game_variables->Get(page.condition.variable_id) >= page.condition.variable_value))
-					return false;
-				break;
-			case 2: // <=
-				if (!(Main_Data::game_variables->Get(page.condition.variable_id) <= page.condition.variable_value))
-					return false;
-				break;
-			case 3: // >
-				if (!(Main_Data::game_variables->Get(page.condition.variable_id) > page.condition.variable_value))
-					return false;
-				break;
-			case 4: // <
-				if (!(Main_Data::game_variables->Get(page.condition.variable_id) < page.condition.variable_value))
-					return false;
-				break;
-			case 5: // !=
-				if (!(Main_Data::game_variables->Get(page.condition.variable_id) != page.condition.variable_value))
-					return false;
-				break;
-			}
+		if (page.condition.flags.variable && page.condition.compare_operator >= 0 && page.condition.compare_operator <= 5) {
+			if (!Game_Interpreter_Shared::CheckOperator(Main_Data::game_variables->Get(page.condition.variable_id), page.condition.variable_value, page.condition.compare_operator))
+				return false;
 		}
 	}
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -573,56 +573,6 @@ void Game_Interpreter::SkipToNextConditional(std::initializer_list<Cmd> codes, i
 	}
 }
 
-int Game_Interpreter::DecodeInt(lcf::DBArray<int32_t>::const_iterator& it) {
-	int value = 0;
-
-	for (;;) {
-		int x = *it++;
-		value <<= 7;
-		value |= x & 0x7F;
-		if (!(x & 0x80))
-			break;
-	}
-
-	return value;
-}
-
-const std::string Game_Interpreter::DecodeString(lcf::DBArray<int32_t>::const_iterator& it) {
-	std::ostringstream out;
-	int len = DecodeInt(it);
-
-	for (int i = 0; i < len; i++)
-		out << (char)*it++;
-
-	std::string result = lcf::ReaderUtil::Recode(out.str(), Player::encoding);
-
-	return result;
-}
-
-lcf::rpg::MoveCommand Game_Interpreter::DecodeMove(lcf::DBArray<int32_t>::const_iterator& it) {
-	lcf::rpg::MoveCommand cmd;
-	cmd.command_id = *it++;
-
-	switch (cmd.command_id) {
-	case 32:	// Switch ON
-	case 33:	// Switch OFF
-		cmd.parameter_a = DecodeInt(it);
-		break;
-	case 34:	// Change Graphic
-		cmd.parameter_string = lcf::DBString(DecodeString(it));
-		cmd.parameter_a = DecodeInt(it);
-		break;
-	case 35:	// Play Sound Effect
-		cmd.parameter_string = lcf::DBString(DecodeString(it));
-		cmd.parameter_a = DecodeInt(it);
-		cmd.parameter_b = DecodeInt(it);
-		cmd.parameter_c = DecodeInt(it);
-		break;
-	}
-
-	return cmd;
-}
-
 // Execute Command.
 bool Game_Interpreter::ExecuteCommand() {
 	auto& frame = GetFrame();
@@ -5061,23 +5011,6 @@ Game_Interpreter& Game_Interpreter::GetForegroundInterpreter() {
 
 bool Game_Interpreter::IsWaitingForWaitCommand() const {
 	return (_state.wait_time > 0) || _state.wait_key_enter;
-}
-
-bool Game_Interpreter::ManiacCheckContinueLoop(int val, int val2, int type, int op) const {
-	switch (type) {
-		case 0: // Infinite loop
-			return true;
-		case 1: // X times
-		case 2: // Count up
-			return val <= val2;
-		case 3: // Count down
-			return val >= val2;
-		case 4: // While
-		case 5: // Do While
-			return CheckOperator(val, val2, op);
-		default:
-			return false;
-	}
 }
 
 int Game_Interpreter::ManiacBitmask(int value, int mask) const {

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -69,6 +69,8 @@
 #include "algo.h"
 #include "rand.h"
 
+using namespace Game_Interpreter_Shared;
+
 enum BranchSubcommand {
 	eOptionBranchElse = 1
 };
@@ -1062,12 +1064,20 @@ bool Game_Interpreter::CommandInputNumber(lcf::rpg::EventCommand const& com) { /
 }
 
 bool Game_Interpreter::CommandControlSwitches(lcf::rpg::EventCommand const& com) { // code 10210
-	if (com.parameters[0] >= 0 && com.parameters[0] <= 2) {
-		// Param0: 0: Single, 1: Range, 2: Indirect
-		// For Range set end to param 2, otherwise to start, this way the loop runs exactly once
+	{
+		int start, end;
+		bool target_eval_result = DecodeTargetEvaluationMode<
+			/* validate_patches */ true,
+			/* support_range_indirect */ false,
+			/* support_expressions */ false,
+			/* support_bitmask */ false,
+			/* support_scopes */ false
+		>(com, start, end);
+		if (!target_eval_result) {
+			Output::Warning("ControlSwitches: Unsupported target evaluation mode {}", com.parameters[0]);
+			return true;
+		}
 
-		int start = com.parameters[0] == 2 ? Main_Data::game_variables->Get(com.parameters[1]) : com.parameters[1];
-		int end = com.parameters[0] == 1 ? com.parameters[2] : start;
 		int val = com.parameters[3];
 
 		if (start == end) {
@@ -1086,7 +1096,6 @@ bool Game_Interpreter::CommandControlSwitches(lcf::rpg::EventCommand const& com)
 			Game_Map::SetNeedRefresh(true);
 		}
 	}
-
 	return true;
 }
 
@@ -1270,41 +1279,20 @@ bool Game_Interpreter::CommandControlVariables(lcf::rpg::EventCommand const& com
 			return true;
 	}
 
-	int target = com.parameters[0];
-	if (target >= 0 && target <= 4) {
-		// For Range set end to param 2, otherwise to start, this way the loop runs exactly once
+	int start, end;
+	bool target_eval_result = DecodeTargetEvaluationMode<
+		/* validate_patches */ true,
+		/* support_range_indirect */ true,
+		/* support_expressions */ true,
+		/* support_bitmask */ false,
+		/* support_scopes */ false
+	>(com, start, end);
+	if (!target_eval_result) {
+		Output::Warning("ControlVariables: Unsupported target evaluation mode {}", com.parameters[0]);
+		return true;
+	}
 
-		int start, end;
-		if (target == 0) {
-			// Single
-			start = com.parameters[1];
-			end = start;
-		} else if (target == 1) {
-			// Range
-			start = com.parameters[1];
-			end = com.parameters[2];
-		} else if (target == 2) {
-			// Indirect
-			start = Main_Data::game_variables->Get(com.parameters[1]);
-			end = start;
-		} else if (target == 3 && Player::IsPatchManiac()) {
-			// Range Indirect (Maniac)
-			start = Main_Data::game_variables->Get(com.parameters[1]);
-			end = Main_Data::game_variables->Get(com.parameters[2]);
-		} else if (target == 4 && Player::IsPatchManiac()) {
-			// Expression (Maniac)
-			int idx = com.parameters[1];
-			start = ManiacPatch::ParseExpression(MakeSpan(com.parameters).subspan(idx + 1, com.parameters[idx]), *this);
-			end = start;
-		} else {
-			return true;
-		}
-
-		if (Player::IsPatchManiac() && end < start) {
-			// Vanilla does not support end..start, Maniac does
-			std::swap(start, end);
-		}
-
+	{
 		int operation = com.parameters[3];
 		if (EP_UNLIKELY(operation >= 6 && !Player::IsPatchManiac())) {
 			Output::Warning("ControlVariables: Unsupported operation {}", operation);
@@ -1747,77 +1735,6 @@ bool Game_Interpreter::CommandChangeLevel(lcf::rpg::EventCommand const& com) { /
 		ForegroundTextPush(std::move(pm));
 	}
 	return true;
-}
-
-int Game_Interpreter::ValueOrVariable(int mode, int val) {
-	if (mode == 0) {
-		return val;
-	} else if (mode == 1) {
-		return Main_Data::game_variables->Get(val);
-	} else if (Player::IsPatchManiac()) {
-		// Maniac Patch does not implement all modes for all commands
-		// For simplicity it is enabled for all here
-		if (mode == 2) {
-			// Variable indirect
-			return Main_Data::game_variables->GetIndirect(val);
-		} else if (mode == 3) {
-			// Switch (F = 0, T = 1)
-			return Main_Data::game_switches->GetInt(val);
-		} else if (mode == 4) {
-			// Switch through Variable (F = 0, T = 1)
-			return Main_Data::game_switches->GetInt(Main_Data::game_variables->Get(val));
-		}
-	}
-	return -1;
-}
-
-int Game_Interpreter::ValueOrVariableBitfield(int mode, int shift, int val) {
-	return ValueOrVariable((mode & (0xF << shift * 4)) >> shift * 4, val);
-}
-
-int Game_Interpreter::ValueOrVariableBitfield(lcf::rpg::EventCommand const& com, int mode_idx, int shift, int val_idx) {
-	assert(static_cast<int>(com.parameters.size()) > val_idx);
-
-	if (!Player::IsPatchManiac()) {
-		return com.parameters[val_idx];
-	}
-
-	assert(mode_idx != val_idx);
-
-	if (static_cast<int>(com.parameters.size()) > std::max(mode_idx, val_idx)) {
-		return ValueOrVariableBitfield(com.parameters[mode_idx], shift, com.parameters[val_idx]);
-	}
-
-	return com.parameters[val_idx];
-}
-
-StringView Game_Interpreter::CommandStringOrVariable(lcf::rpg::EventCommand const& com, int mode_idx, int val_idx) {
-	if (!Player::IsPatchManiac()) {
-		return com.string;
-	}
-
-	assert(mode_idx != val_idx);
-
-	if (static_cast<int>(com.parameters.size()) > std::max(mode_idx, val_idx)) {
-		return Main_Data::game_strings->GetWithMode(ToString(com.string), com.parameters[mode_idx], com.parameters[val_idx], *Main_Data::game_variables);
-	}
-
-	return com.string;
-}
-
-StringView Game_Interpreter::CommandStringOrVariableBitfield(lcf::rpg::EventCommand const& com, int mode_idx, int shift, int val_idx) {
-	if (!Player::IsPatchManiac()) {
-		return com.string;
-	}
-
-	assert(mode_idx != val_idx);
-
-	if (static_cast<int>(com.parameters.size()) >= std::max(mode_idx, val_idx) + 1) {
-		int mode = com.parameters[mode_idx];
-		return Main_Data::game_strings->GetWithMode(ToString(com.string), (mode & (0xF << shift * 4)) >> shift * 4, com.parameters[val_idx], *Main_Data::game_variables);
-	}
-
-	return com.string;
 }
 
 bool Game_Interpreter::CommandChangeParameters(lcf::rpg::EventCommand const& com) { // Code 10430
@@ -4811,18 +4728,9 @@ bool Game_Interpreter::CommandManiacControlStrings(lcf::rpg::EventCommand const&
 	//		Flags, such as: extract, hex... There is also an edge case where the last argument of exRep is here
 	//
 	//*parameters 4..n - arguments
-	int string_mode = com.parameters[0] & 15;
-	int string_id_0 = com.parameters[1];
-	int string_id_1 = com.parameters[2]; //for ranges
-
-	int is_range = string_mode & 1;
-
-	if (string_mode >= 2) {
-		string_id_0 = Main_Data::game_variables->Get(string_id_0);
-	}
-	if (string_mode == 3) {
-		string_id_1 = Main_Data::game_variables->Get(string_id_1);
-	}
+	bool is_range = com.parameters[0] & 1;
+	int string_id_0, string_id_1;
+	DecodeTargetEvaluationMode<false, true, false, true, false>(com, string_id_0, string_id_1);
 
 	int op = (com.parameters[3] >>  0) & 255;
 	int fn = (com.parameters[3] >>  8) & 255;
@@ -5153,25 +5061,6 @@ Game_Interpreter& Game_Interpreter::GetForegroundInterpreter() {
 
 bool Game_Interpreter::IsWaitingForWaitCommand() const {
 	return (_state.wait_time > 0) || _state.wait_key_enter;
-}
-
-bool Game_Interpreter::CheckOperator(int val, int val2, int op) const {
-	switch (op) {
-		case 0:
-			return val == val2;
-		case 1:
-			return val >= val2;
-		case 2:
-			return val <= val2;
-		case 3:
-			return val > val2;
-		case 4:
-			return val < val2;
-		case 5:
-			return val != val2;
-		default:
-			return false;
-	}
 }
 
 bool Game_Interpreter::ManiacCheckContinueLoop(int val, int val2, int type, int op) const {

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -25,6 +25,7 @@
 #include "async_handler.h"
 #include "game_character.h"
 #include "game_actor.h"
+#include "game_interpreter_shared.h"
 #include <lcf/dbarray.h>
 #include <lcf/rpg/fwd.h>
 #include <lcf/rpg/eventcommand.h>
@@ -40,7 +41,7 @@ class PendingMessage;
 /**
  * Game_Interpreter class
  */
-class Game_Interpreter
+class Game_Interpreter : public Game_BaseInterpreterContext
 {
 public:
 	using Cmd = lcf::rpg::EventCommand::Code;
@@ -94,13 +95,13 @@ public:
 	lcf::rpg::SaveEventExecState GetSaveState();
 
 	/** @return Game_Character of the passed event_id */
-	Game_Character* GetCharacter(int event_id) const;
+	Game_Character* GetCharacter(int event_id) const override;
 
 	/** @return the event_id of the current frame */
 	int GetCurrentEventId() const;
 
 	/** @return the event_id used by "ThisEvent" in commands */
-	int GetThisEventId() const;
+	int GetThisEventId() const override;
 
 	/** @return the event_id of the event at the base of the call stack */
 	int GetOriginalEventId() const;
@@ -119,7 +120,7 @@ protected:
 	static constexpr int call_stack_limit = 1000;
 	static constexpr int subcommand_sentinel = 255;
 
-	const lcf::rpg::SaveEventExecFrame& GetFrame() const;
+	const lcf::rpg::SaveEventExecFrame& GetFrame() const override;
 	lcf::rpg::SaveEventExecFrame& GetFrame();
 	const lcf::rpg::SaveEventExecFrame* GetFramePtr() const;
 	lcf::rpg::SaveEventExecFrame* GetFramePtr();
@@ -175,12 +176,6 @@ protected:
 	 * @param id actor ID (mode = 1) or variable ID (mode = 2).
 	 */
 	static std::vector<Game_Actor*> GetActors(int mode, int id);
-	static int ValueOrVariable(int mode, int val);
-	static int ValueOrVariableBitfield(int mode, int shift, int val);
-	// Range checked, conditional version (slower) of ValueOrVariableBitfield
-	static int ValueOrVariableBitfield(lcf::rpg::EventCommand const& com, int mode_idx, int shift, int val_idx);
-	static StringView CommandStringOrVariable(lcf::rpg::EventCommand const& com, int mode_idx, int val_idx);
-	static StringView CommandStringOrVariableBitfield(lcf::rpg::EventCommand const& com, int mode_idx, int shift, int val_idx);
 
 	/**
 	 * When current frame finishes executing we pop the stack
@@ -341,7 +336,6 @@ protected:
 		void toSave(lcf::rpg::SaveEventExecState& save) const;
 	};
 
-	bool CheckOperator(int val, int val2, int op) const;
 	bool ManiacCheckContinueLoop(int val, int val2, int type, int op) const;
 	int ManiacBitmask(int value, int mask) const;
 

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -293,10 +293,6 @@ protected:
 	bool CommandManiacCallCommand(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgSetInterpreterFlag(lcf::rpg::EventCommand const& com);
 
-	int DecodeInt(lcf::DBArray<int32_t>::const_iterator& it);
-	const std::string DecodeString(lcf::DBArray<int32_t>::const_iterator& it);
-	lcf::rpg::MoveCommand DecodeMove(lcf::DBArray<int32_t>::const_iterator& it);
-
 	void SetSubcommandIndex(int indent, int idx);
 	uint8_t& ReserveSubcommandIndex(int indent);
 	int GetSubcommandIndex(int indent) const;
@@ -336,7 +332,6 @@ protected:
 		void toSave(lcf::rpg::SaveEventExecState& save) const;
 	};
 
-	bool ManiacCheckContinueLoop(int val, int val2, int type, int op) const;
 	int ManiacBitmask(int value, int mask) const;
 
 	lcf::rpg::SaveEventExecState _state;

--- a/src/game_interpreter_control_variables.cpp
+++ b/src/game_interpreter_control_variables.cpp
@@ -15,6 +15,7 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "game_interpreter_shared.h"
 #include "game_interpreter_control_variables.h"
 #include "game_actors.h"
 #include "game_enemyparty.h"
@@ -154,7 +155,7 @@ int ControlVariables::Party(int op, int party_idx) {
 	return ControlVariables::Actor(op, actor->GetId());
 }
 
-int ControlVariables::Event(int op, int event_id, const Game_Interpreter& interpreter) {
+int ControlVariables::Event(int op, int event_id, const Game_BaseInterpreterContext& interpreter) {
 	auto character = interpreter.GetCharacter(event_id);
 	if (character) {
 		switch (op) {

--- a/src/game_interpreter_control_variables.h
+++ b/src/game_interpreter_control_variables.h
@@ -21,14 +21,14 @@
 
 #include <lcf/rpg/eventcommand.h>
 
-class Game_Interpreter;
+class Game_BaseInterpreterContext;
 
 namespace ControlVariables {
 	int Random(int value, int value2);
 	int Item(int op, int item);
 	int Actor(int op, int actor_id);
 	int Party(int op, int party_idx);
-	int Event(int op, int event_id, const Game_Interpreter& interpreter);
+	int Event(int op, int event_id, const Game_BaseInterpreterContext& interpreter);
 	int Other(int op);
 	int Enemy(int op, int enemy_idx);
 	int Pow(int arg1, int arg2);

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -76,6 +76,8 @@ enum InnSubcommand {
 	eOptionInnNoStay = 1,
 };
 
+using namespace Game_Interpreter_Shared;
+
 void Game_Interpreter_Map::SetState(const lcf::rpg::SaveEventExecState& save) {
 	Clear();
 	_state = save;

--- a/src/game_interpreter_shared.cpp
+++ b/src/game_interpreter_shared.cpp
@@ -1,0 +1,187 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "game_interpreter_shared.h"
+#include "game_actors.h"
+#include "game_enemyparty.h"
+#include "game_ineluki.h"
+#include "game_map.h"
+#include "game_party.h"
+#include "game_player.h"
+#include "game_switches.h"
+#include "game_system.h"
+#include "maniac_patch.h"
+#include "main_data.h"
+#include "output.h"
+#include "player.h"
+#include "rand.h"
+#include "util_macro.h"
+#include "utils.h"
+#include "audio.h"
+#include "baseui.h"
+#include <cmath>
+#include <cstdint>
+#include <lcf/rpg/savepartylocation.h>
+
+using Main_Data::game_switches, Main_Data::game_variables, Main_Data::game_strings;
+
+template<bool validate_patches, bool support_range_indirect, bool support_expressions, bool support_bitmask, bool support_scopes, bool support_named>
+inline bool Game_Interpreter_Shared::DecodeTargetEvaluationMode(lcf::rpg::EventCommand const& com, int& id_0, int& id_1, Game_BaseInterpreterContext const& interpreter) {
+	int mode = com.parameters[0];
+
+	if constexpr (support_bitmask) {
+		mode = com.parameters[0] & 15;
+	}
+
+	switch (mode) {
+		case TargetEvalMode::eTargetEval_Single:
+			id_0 = com.parameters[1];
+			id_1 = id_0;
+			break;
+		case TargetEvalMode::eTargetEval_Range:
+			id_0 = com.parameters[1];
+			id_1 = com.parameters[2];
+			break;
+		case TargetEvalMode::eTargetEval_IndirectSingle:
+			id_0 = game_variables->Get(com.parameters[1]);
+			id_1 = id_0;
+			break;
+		case TargetEvalMode::eTargetEval_IndirectRange:
+			if constexpr (!support_range_indirect) {
+				return false;
+			}
+			if constexpr (validate_patches) {
+				if (!Player::IsPatchManiac()) {
+					return false;
+				}
+			}
+			id_0 = game_variables->Get(com.parameters[1]);
+			id_1 = game_variables->Get(com.parameters[2]);
+			break;
+		case TargetEvalMode::eTargetEval_Expression:
+			if constexpr (!support_expressions) {
+				return false;
+			}
+			if constexpr (validate_patches) {
+				if (!Player::IsPatchManiac()) {
+					return false;
+				}
+			}
+			{
+				// Expression (Maniac)
+				int idx = com.parameters[1];
+				id_0 = ManiacPatch::ParseExpression(MakeSpan(com.parameters).subspan(idx + 1, com.parameters[idx]), interpreter);
+				id_1 = id_0;
+				return true;
+			}
+			break;
+	}
+
+	if constexpr (validate_patches) {
+		if (Player::IsPatchManiac() && id_1 < id_0) {
+			// Vanilla does not support end..start, Maniac does
+			std::swap(id_0, id_1);
+		}
+	} else {
+		if (id_1 < id_0) {
+			std::swap(id_0, id_1);
+		}
+	}
+
+	return true;
+}
+
+template<bool validate_patches, bool support_indirect_and_switch, bool support_scopes, bool support_named>
+int Game_Interpreter_Shared::ValueOrVariable(int mode, int val, Game_BaseInterpreterContext const& interpreter) {
+	if (mode == ValueEvalMode::eValueEval_Constant) {
+		return val;
+	} else if (mode == ValueEvalMode::eValueEval_Variable) {
+		return game_variables->Get(val);
+	} else {
+		if constexpr (support_indirect_and_switch) {
+			if constexpr (validate_patches) {
+				if (!Player::IsPatchManiac())
+					return -1;
+			}
+			// Maniac Patch does not implement all modes for all commands
+			// For simplicity it is enabled for all here
+			if (mode == ValueEvalMode::eValueEval_VariableIndirect) {
+				// Variable indirect
+				return game_variables->GetIndirect(val);
+			} else if (mode == ValueEvalMode::eValueEval_Switch) {
+				// Switch (F = 0, T = 1)
+				return game_switches->GetInt(val);
+			} else if (mode == ValueEvalMode::eValueEval_SwitchIndirect) {
+				// Switch through Variable (F = 0, T = 1)
+				return game_switches->GetInt(game_variables->Get(val));
+			}
+		}
+	}
+	return -1;
+}
+
+template<bool validate_patches, bool support_indirect_and_switch, bool support_scopes, bool support_named>
+int Game_Interpreter_Shared::ValueOrVariableBitfield(int mode, int shift, int val, Game_BaseInterpreterContext const& interpreter) {
+	return ValueOrVariable<validate_patches, support_indirect_and_switch, support_scopes, support_named>((mode & (0xF << shift * 4)) >> shift * 4, val, interpreter);
+}
+
+template<bool validate_patches, bool support_indirect_and_switch, bool support_scopes, bool support_named>
+int Game_Interpreter_Shared::ValueOrVariableBitfield(lcf::rpg::EventCommand const& com, int mode_idx, int shift, int val_idx, Game_BaseInterpreterContext const& interpreter) {
+	assert(com.parameters.size() > val_idx);
+
+	if (!Player::IsPatchManiac()) {
+		return com.parameters[val_idx];
+	}
+
+	assert(mode_idx != val_idx);
+
+	if (com.parameters.size() > std::max(mode_idx, val_idx)) {
+		int mode = com.parameters[mode_idx];
+		return ValueOrVariableBitfield<validate_patches, support_indirect_and_switch, support_scopes, support_named>(com.parameters[mode_idx], shift, com.parameters[val_idx], interpreter);
+	}
+
+	return com.parameters[val_idx];
+}
+
+StringView Game_Interpreter_Shared::CommandStringOrVariable(lcf::rpg::EventCommand const& com, int mode_idx, int val_idx) {
+	if (!Player::IsPatchManiac()) {
+		return com.string;
+	}
+
+	assert(mode_idx != val_idx);
+
+	if (com.parameters.size() > std::max(mode_idx, val_idx)) {
+		return game_strings->GetWithMode(ToString(com.string), com.parameters[mode_idx], com.parameters[val_idx], *game_variables);
+	}
+
+	return com.string;
+}
+
+StringView Game_Interpreter_Shared::CommandStringOrVariableBitfield(lcf::rpg::EventCommand const& com, int mode_idx, int shift, int val_idx) {
+	if (!Player::IsPatchManiac()) {
+		return com.string;
+	}
+
+	assert(mode_idx != val_idx);
+
+	if (com.parameters.size() >= std::max(mode_idx, val_idx) + 1) {
+		int mode = com.parameters[mode_idx];
+		return game_strings->GetWithMode(ToString(com.string), (mode & (0xF << shift * 4)) >> shift * 4, com.parameters[val_idx], *game_variables);
+	}
+
+	return com.string;
+}

--- a/src/game_interpreter_shared.cpp
+++ b/src/game_interpreter_shared.cpp
@@ -239,12 +239,12 @@ lcf::rpg::MoveCommand Game_Interpreter_Shared::DecodeMove(lcf::DBArray<int32_t>:
 }
 
 //explicit declarations for target evaluation logic shared between ControlSwitches/ControlVariables/ControlStrings
-template bool Game_BaseInterpreterContext::DecodeTargetEvaluationMode<true, false, false, false, false>(lcf::rpg::EventCommand const&, int&, int&) const;
-template bool Game_BaseInterpreterContext::DecodeTargetEvaluationMode<true, true, true, false, false>(lcf::rpg::EventCommand const&, int&, int&) const;
-template bool Game_BaseInterpreterContext::DecodeTargetEvaluationMode<false, true, false, true, false>(lcf::rpg::EventCommand const&, int&, int&) const;
+template bool Game_Interpreter_Shared::DecodeTargetEvaluationMode<true, false, false, false, false>(lcf::rpg::EventCommand const&, int&, int&, Game_BaseInterpreterContext const&);
+template bool Game_Interpreter_Shared::DecodeTargetEvaluationMode<true, true, true, false, false>(lcf::rpg::EventCommand const&, int&, int&, Game_BaseInterpreterContext const&);
+template bool Game_Interpreter_Shared::DecodeTargetEvaluationMode<false, true, false, true, false>(lcf::rpg::EventCommand const&, int&, int&, Game_BaseInterpreterContext const&);
 
 //common variant for suggested "Ex" commands
-template bool Game_BaseInterpreterContext::DecodeTargetEvaluationMode<false, true, true, true, true, true>(lcf::rpg::EventCommand const&, int&, int&) const;
+template bool Game_Interpreter_Shared::DecodeTargetEvaluationMode<false, true, true, true, true, true>(lcf::rpg::EventCommand const&, int&, int&, Game_BaseInterpreterContext const&);
 
 //explicit declarations for default value evaluation logic
 template int Game_Interpreter_Shared::ValueOrVariable<true, true, false, false>(int, int, const Game_BaseInterpreterContext&);

--- a/src/game_interpreter_shared.cpp
+++ b/src/game_interpreter_shared.cpp
@@ -142,7 +142,7 @@ int Game_Interpreter_Shared::ValueOrVariableBitfield(int mode, int shift, int va
 
 template<bool validate_patches, bool support_indirect_and_switch, bool support_scopes, bool support_named>
 int Game_Interpreter_Shared::ValueOrVariableBitfield(lcf::rpg::EventCommand const& com, int mode_idx, int shift, int val_idx, Game_BaseInterpreterContext const& interpreter) {
-	assert(com.parameters.size() > val_idx);
+	assert(static_cast<int>(com.parameters.size()) > val_idx);
 
 	if (!Player::IsPatchManiac()) {
 		return com.parameters[val_idx];
@@ -150,7 +150,7 @@ int Game_Interpreter_Shared::ValueOrVariableBitfield(lcf::rpg::EventCommand cons
 
 	assert(mode_idx != val_idx);
 
-	if (com.parameters.size() > std::max(mode_idx, val_idx)) {
+	if (static_cast<int>(com.parameters.size()) > std::max(mode_idx, val_idx)) {
 		int mode = com.parameters[mode_idx];
 		return ValueOrVariableBitfield<validate_patches, support_indirect_and_switch, support_scopes, support_named>(com.parameters[mode_idx], shift, com.parameters[val_idx], interpreter);
 	}
@@ -165,7 +165,7 @@ StringView Game_Interpreter_Shared::CommandStringOrVariable(lcf::rpg::EventComma
 
 	assert(mode_idx != val_idx);
 
-	if (com.parameters.size() > std::max(mode_idx, val_idx)) {
+	if (static_cast<int>(com.parameters.size()) > std::max(mode_idx, val_idx)) {
 		return game_strings->GetWithMode(ToString(com.string), com.parameters[mode_idx], com.parameters[val_idx], *game_variables);
 	}
 
@@ -179,7 +179,7 @@ StringView Game_Interpreter_Shared::CommandStringOrVariableBitfield(lcf::rpg::Ev
 
 	assert(mode_idx != val_idx);
 
-	if (com.parameters.size() >= std::max(mode_idx, val_idx) + 1) {
+	if (static_cast<int>(com.parameters.size()) >= std::max(mode_idx, val_idx) + 1) {
 		int mode = com.parameters[mode_idx];
 		return game_strings->GetWithMode(ToString(com.string), (mode & (0xF << shift * 4)) >> shift * 4, com.parameters[val_idx], *game_variables);
 	}

--- a/src/game_interpreter_shared.cpp
+++ b/src/game_interpreter_shared.cpp
@@ -237,3 +237,19 @@ lcf::rpg::MoveCommand Game_Interpreter_Shared::DecodeMove(lcf::DBArray<int32_t>:
 
 	return cmd;
 }
+
+//explicit declarations for target evaluation logic shared between ControlSwitches/ControlVariables/ControlStrings
+template bool Game_BaseInterpreterContext::DecodeTargetEvaluationMode<true, false, false, false, false>(lcf::rpg::EventCommand const&, int&, int&) const;
+template bool Game_BaseInterpreterContext::DecodeTargetEvaluationMode<true, true, true, false, false>(lcf::rpg::EventCommand const&, int&, int&) const;
+template bool Game_BaseInterpreterContext::DecodeTargetEvaluationMode<false, true, false, true, false>(lcf::rpg::EventCommand const&, int&, int&) const;
+
+//common variant for suggested "Ex" commands
+template bool Game_BaseInterpreterContext::DecodeTargetEvaluationMode<false, true, true, true, true, true>(lcf::rpg::EventCommand const&, int&, int&) const;
+
+//explicit declarations for default value evaluation logic
+template int Game_Interpreter_Shared::ValueOrVariable<true, true, false, false>(int, int, const Game_BaseInterpreterContext&);
+template int Game_Interpreter_Shared::ValueOrVariableBitfield<true, true, false, false>(int, int, int, const Game_BaseInterpreterContext&);
+template int Game_Interpreter_Shared::ValueOrVariableBitfield<true, true, false, false>(lcf::rpg::EventCommand const&, int, int, int, const Game_BaseInterpreterContext&);
+
+//variant for "Ex" commands
+template int Game_Interpreter_Shared::ValueOrVariableBitfield<false, true, true, true>(int, int, int, const Game_BaseInterpreterContext&);

--- a/src/game_interpreter_shared.h
+++ b/src/game_interpreter_shared.h
@@ -25,35 +25,7 @@
 #include <string_view.h>
 
 class Game_Character;
-
-class Game_BaseInterpreterContext {
-public:
-	virtual ~Game_BaseInterpreterContext() {}
-
-	virtual int GetThisEventId() const = 0;
-	virtual Game_Character* GetCharacter(int event_id) const = 0;
-	virtual const lcf::rpg::SaveEventExecFrame& GetFrame() const = 0;
-
-protected:
-	template<bool validate_patches, bool support_range_indirect, bool support_expressions, bool support_bitmask, bool support_scopes, bool support_named = false>
-	inline bool DecodeTargetEvaluationMode(lcf::rpg::EventCommand const& com, int& id_0, int& id_1) const {
-		return Game_Interpreter_Shared::DecodeTargetEvaluationMode<validate_patches, support_range_indirect, support_expressions, support_bitmask, support_scopes, support_named>(com, id_0, id_1, *this);
-	}
-
-	template<bool validate_patches = true, bool support_indirect_and_switch = true, bool support_scopes = false, bool support_named = false>
-	inline int ValueOrVariable(int mode, int val) const {
-		return Game_Interpreter_Shared::ValueOrVariable<validate_patches, support_indirect_and_switch, support_scopes, support_named>(mode, val, *this);
-	}
-	template<bool validate_patches = true, bool support_indirect_and_switch = true, bool support_scopes = false, bool support_named = false>
-	inline int ValueOrVariableBitfield(int mode, int shift, int val) const {
-		return Game_Interpreter_Shared::ValueOrVariableBitfield<validate_patches, support_indirect_and_switch, support_scopes, support_named>(mode, shift, val, *this);
-	}
-
-	template<bool validate_patches = true, bool support_indirect_and_switch = true, bool support_scopes = false, bool support_named = false>
-	inline int ValueOrVariableBitfield(lcf::rpg::EventCommand const& com, int mode_idx, int shift, int val_idx) const {
-		return Game_Interpreter_Shared::ValueOrVariableBitfield<validate_patches, support_indirect_and_switch, support_scopes, support_named>(com, mode_idx, shift, val_idx, *this);
-	}
-};
+class Game_BaseInterpreterContext;
 
 namespace Game_Interpreter_Shared {
 
@@ -168,20 +140,33 @@ inline bool Game_Interpreter_Shared::ManiacCheckContinueLoop(int val, int val2, 
 	}
 }
 
-//explicit declarations for target evaluation logic shared between ControlSwitches/ControlVariables/ControlStrings
-template bool Game_BaseInterpreterContext::DecodeTargetEvaluationMode<true, false, false, false, false>(lcf::rpg::EventCommand const&, int&, int&) const;
-template bool Game_BaseInterpreterContext::DecodeTargetEvaluationMode<true, true, true, false, false>(lcf::rpg::EventCommand const&, int&, int&) const;
-template bool Game_BaseInterpreterContext::DecodeTargetEvaluationMode<false, true, false, true, false>(lcf::rpg::EventCommand const&, int&, int&) const;
+class Game_BaseInterpreterContext {
+public:
+	virtual ~Game_BaseInterpreterContext() {}
 
-//common variant for suggested "Ex" commands
-template bool Game_BaseInterpreterContext::DecodeTargetEvaluationMode<false, true, true, true, true, true>(lcf::rpg::EventCommand const&, int&, int&) const;
+	virtual int GetThisEventId() const = 0;
+	virtual Game_Character* GetCharacter(int event_id) const = 0;
+	virtual const lcf::rpg::SaveEventExecFrame& GetFrame() const = 0;
 
-//explicit declarations for default value evaluation logic
-template int Game_Interpreter_Shared::ValueOrVariable<true, true, false, false>(int, int, const Game_BaseInterpreterContext&);
-template int Game_Interpreter_Shared::ValueOrVariableBitfield<true, true, false, false>(int, int, int, const Game_BaseInterpreterContext&);
-template int Game_Interpreter_Shared::ValueOrVariableBitfield<true, true, false, false>(lcf::rpg::EventCommand const&, int, int, int, const Game_BaseInterpreterContext&);
+protected:
+	template<bool validate_patches, bool support_range_indirect, bool support_expressions, bool support_bitmask, bool support_scopes, bool support_named = false>
+	inline bool DecodeTargetEvaluationMode(lcf::rpg::EventCommand const& com, int& id_0, int& id_1) const {
+		return Game_Interpreter_Shared::DecodeTargetEvaluationMode<validate_patches, support_range_indirect, support_expressions, support_bitmask, support_scopes, support_named>(com, id_0, id_1, *this);
+	}
 
-//variant for "Ex" commands
-template int Game_Interpreter_Shared::ValueOrVariableBitfield<false, true, true, true>(int, int, int, const Game_BaseInterpreterContext&);
+	template<bool validate_patches = true, bool support_indirect_and_switch = true, bool support_scopes = false, bool support_named = false>
+	inline int ValueOrVariable(int mode, int val) const {
+		return Game_Interpreter_Shared::ValueOrVariable<validate_patches, support_indirect_and_switch, support_scopes, support_named>(mode, val, *this);
+	}
+	template<bool validate_patches = true, bool support_indirect_and_switch = true, bool support_scopes = false, bool support_named = false>
+	inline int ValueOrVariableBitfield(int mode, int shift, int val) const {
+		return Game_Interpreter_Shared::ValueOrVariableBitfield<validate_patches, support_indirect_and_switch, support_scopes, support_named>(mode, shift, val, *this);
+	}
+
+	template<bool validate_patches = true, bool support_indirect_and_switch = true, bool support_scopes = false, bool support_named = false>
+	inline int ValueOrVariableBitfield(lcf::rpg::EventCommand const& com, int mode_idx, int shift, int val_idx) const {
+		return Game_Interpreter_Shared::ValueOrVariableBitfield<validate_patches, support_indirect_and_switch, support_scopes, support_named>(com, mode_idx, shift, val_idx, *this);
+	}
+};
 
 #endif

--- a/src/game_interpreter_shared.h
+++ b/src/game_interpreter_shared.h
@@ -1,0 +1,163 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef EP_GAME_INTERPRETER_SHARED
+#define EP_GAME_INTERPRETER_SHARED
+
+#include <lcf/rpg/eventcommand.h>
+#include <lcf/rpg/saveeventexecframe.h>
+#include <string_view.h>
+
+class Game_Character;
+
+class Game_BaseInterpreterContext {
+public:
+	virtual ~Game_BaseInterpreterContext() {}
+
+	virtual int GetThisEventId() const = 0;
+	virtual Game_Character* GetCharacter(int event_id) const = 0;
+	virtual const lcf::rpg::SaveEventExecFrame& GetFrame() const = 0;
+
+protected:
+	template<bool validate_patches, bool support_range_indirect, bool support_expressions, bool support_bitmask, bool support_scopes, bool support_named = false>
+	inline bool DecodeTargetEvaluationMode(lcf::rpg::EventCommand const& com, int& id_0, int& id_1) const {
+		return Game_Interpreter_Shared::DecodeTargetEvaluationMode<validate_patches, support_range_indirect, support_expressions, support_bitmask, support_scopes, support_named>(com, id_0, id_1, *this);
+	}
+
+	template<bool validate_patches = true, bool support_indirect_and_switch = true, bool support_scopes = false, bool support_named = false>
+	inline int ValueOrVariable(int mode, int val) const {
+		return Game_Interpreter_Shared::ValueOrVariable<validate_patches, support_indirect_and_switch, support_scopes, support_named>(mode, val, *this);
+	}
+	template<bool validate_patches = true, bool support_indirect_and_switch = true, bool support_scopes = false, bool support_named = false>
+	inline int ValueOrVariableBitfield(int mode, int shift, int val) const {
+		return Game_Interpreter_Shared::ValueOrVariableBitfield<validate_patches, support_indirect_and_switch, support_scopes, support_named>(mode, shift, val, *this);
+	}
+
+	template<bool validate_patches = true, bool support_indirect_and_switch = true, bool support_scopes = false, bool support_named = false>
+	inline int ValueOrVariableBitfield(lcf::rpg::EventCommand const& com, int mode_idx, int shift, int val_idx) const {
+		return Game_Interpreter_Shared::ValueOrVariableBitfield<validate_patches, support_indirect_and_switch, support_scopes, support_named>(com, mode_idx, shift, val_idx, *this);
+	}
+};
+
+namespace Game_Interpreter_Shared {
+
+	/*
+	* Indicates how the target of an interpreter operation (lvalue) should be evaluated.
+	*/
+	enum TargetEvalMode : std::int8_t { // 4 bits
+		eTargetEval_Single = 0,			// v[x]
+		eTargetEval_Range = 1,			// v[x...y]
+		eTargetEval_IndirectSingle = 2, // v[v[x]]
+		eTargetEval_IndirectRange = 3,	// v[v[x]...v[y]] (ManiacPatch)
+		eTargetEval_Expression = 4		// ManiacPatch expression
+	};
+
+	/*
+	* Indicates how an operand of an interpreter operation (rvalue) should be evaluted.
+	*/
+	enum ValueEvalMode : std::int8_t { // 4 bits
+		eValueEval_Constant = 0,				// Constant value is given
+		eValueEval_Variable = 1,
+		eValueEval_VariableIndirect = 2,
+		eValueEval_Switch = 3,
+		eValueEval_SwitchIndirect = 4
+	};
+
+	/*
+	* Decodes how the target of an interpreter operation (or 'lvalue' in programming terms) should be evaluated
+	* and returns the extracted variable ids.
+	*
+	* @tparam validate_patches Indicates if this template variant should validate for patch support (Maniac, EasyRPG-Commands)
+	* @tparam support_range_indirect Indicates if indirect range operations should be supported (ManiacPatch)
+	* @tparam support_expressions Indicates if Expressions (Mode=4) should be supported (ManiacPatch)
+	* @tparam support_bitmask Indicates if the target mode should be derived from a bitmask (LSB bits) of the mode parameter
+		(ManiacPatch string command encodes more info about other arguments in com.parameters[0])
+	* @tparam support_scopes Indicates if ScopedVariables should be supported (EasyRPG-Commands - not implemented yet)
+	* @tparam support_named Indicates if NamedVariables should be supported (EasyRPG-Commands - not implemented yet)
+	* @param com \
+	*	com.parameters[0]: Modifier for the operation target (lvalue) -> @see TargetEvalMode
+	*	com.parameters[1]: The value from which id_0 (start) is decoded. This can be a constant, a variable id, or for special modes, packed information about scoped or named variables.
+	*	com.parameters[2]: The value from which id_1 (end) is decoded, in case the operation is a range op. (see com.parameters[1])
+	* @param id_0 Output parameter for the decoded, first variable id
+	* @param id_1 Output parameter for the decoded, second variable id (for range operations)
+	* @return True if the the parameters were successfully decoded
+	*/
+	template<bool validate_patches, bool support_range_indirect, bool support_expressions, bool support_bitmask, bool support_scopes, bool support_named = false>
+	bool DecodeTargetEvaluationMode(lcf::rpg::EventCommand const& com, int& id_0, int& id_1, Game_BaseInterpreterContext const& interpreter);
+
+	/*
+	* Decodes how an operand of an interpreter operation (or 'rvalue' in programming terms) should be evaluated
+	* and returns the its value
+	*
+	* @tparam validate_patches Indicates if this template variant should validate for patch support (Maniac, EasyRPG-Commands)
+	* @tparam support_indirect_and_switch Indicates if indirect and switch evaluation should be supported (ManiacPatch)
+	* @tparam support_scopes Indicates if ScopedVariables should be supported (EasyRPG-Commands - not implemented yet)
+	* @tparam support_named Indicates if NamedVariables should be supported (EasyRPG-Commands - not implemented yet)
+	* @param mode Modifier for the operand target (rvalue) -> @see ValueEvalMode
+	* @param val The raw value extracted from the interpreter command which is to be evaluated
+	*/
+	template<bool validate_patches = true, bool support_indirect_and_switch = true, bool support_scopes = false, bool support_named = false>
+	int ValueOrVariable(int mode, int val, Game_BaseInterpreterContext const& interpreter);
+	template<bool validate_patches = true, bool support_indirect_and_switch = true, bool support_scopes = false, bool support_named = false>
+	int ValueOrVariableBitfield(int mode, int shift, int val, Game_BaseInterpreterContext const& interpreter);
+	// Range checked, conditional version (slower) of ValueOrVariableBitfield
+	template<bool validate_patches = true, bool support_indirect_and_switch = true, bool support_scopes = false, bool support_named = false>
+	int ValueOrVariableBitfield(lcf::rpg::EventCommand const& com, int mode_idx, int shift, int val_idx, Game_BaseInterpreterContext const& interpreter);
+
+	StringView CommandStringOrVariable(lcf::rpg::EventCommand const& com, int mode_idx, int val_idx);
+	StringView CommandStringOrVariableBitfield(lcf::rpg::EventCommand const& com, int mode_idx, int shift, int val_idx);
+
+	bool CheckOperator(int val, int val2, int op);
+}
+
+inline bool Game_Interpreter_Shared::CheckOperator(int val, int val2, int op) {
+	switch (op) {
+		case 0:
+			return val == val2;
+		case 1:
+			return val >= val2;
+		case 2:
+			return val <= val2;
+		case 3:
+			return val > val2;
+		case 4:
+			return val < val2;
+		case 5:
+			return val != val2;
+		default:
+			return false;
+	}
+}
+
+//explicit declarations for target evaluation logic shared between ControlSwitches/ControlVariables/ControlStrings
+template bool Game_BaseInterpreterContext::DecodeTargetEvaluationMode<true, false, false, false, false>(lcf::rpg::EventCommand const&, int&, int&) const;
+template bool Game_BaseInterpreterContext::DecodeTargetEvaluationMode<true, true, true, false, false>(lcf::rpg::EventCommand const&, int&, int&) const;
+template bool Game_BaseInterpreterContext::DecodeTargetEvaluationMode<false, true, false, true, false>(lcf::rpg::EventCommand const&, int&, int&) const;
+
+//common variant for suggested "Ex" commands
+template bool Game_BaseInterpreterContext::DecodeTargetEvaluationMode<false, true, true, true, true, true>(lcf::rpg::EventCommand const&, int&, int&) const;
+
+//explicit declarations for default value evaluation logic
+template int Game_Interpreter_Shared::ValueOrVariable<true, true, false, false>(int, int, const Game_BaseInterpreterContext&);
+template int Game_Interpreter_Shared::ValueOrVariableBitfield<true, true, false, false>(int, int, int, const Game_BaseInterpreterContext&);
+template int Game_Interpreter_Shared::ValueOrVariableBitfield<true, true, false, false>(lcf::rpg::EventCommand const&, int, int, int, const Game_BaseInterpreterContext&);
+
+//variant for "Ex" commands
+template int Game_Interpreter_Shared::ValueOrVariableBitfield<false, true, true, true>(int, int, int, const Game_BaseInterpreterContext&);
+
+#endif

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -359,7 +359,7 @@ void Game_Map::SetupCommon() {
 	}
 
 	map_cache->Clear();
-	using Op = Caching::ObservervedVarOps;
+	using Op = Caching::ObservedVarOps;
 
 	// Create the map events
 	events.reserve(map->events.size());
@@ -381,7 +381,7 @@ void Game_Map::SetupCommon() {
 }
 
 void Game_Map::Caching::MapCache::Clear() {
-	for (int i = 0; i < static_cast<int>(ObservervedVarOps_END); i++) {
+	for (int i = 0; i < static_cast<int>(ObservedVarOps_END); i++) {
 		refresh_targets_by_varid[i].clear();
 	}
 }
@@ -1552,14 +1552,14 @@ void Game_Map::SetNeedRefresh(bool refresh) {
 void Game_Map::SetNeedRefreshForSwitchChange(int switch_id) {
 	if (need_refresh)
 		return;
-	if (map_cache->GetNeedRefresh<Caching::ObservervedVarOps::SwitchSet>(switch_id))
+	if (map_cache->GetNeedRefresh<Caching::ObservedVarOps::SwitchSet>(switch_id))
 		SetNeedRefresh(true);
 }
 
 void Game_Map::SetNeedRefreshForVarChange(int var_id) {
 	if (need_refresh)
 		return;
-	if (map_cache->GetNeedRefresh<Caching::ObservervedVarOps::VarSet>(var_id))
+	if (map_cache->GetNeedRefresh<Caching::ObservedVarOps::VarSet>(var_id))
 		SetNeedRefresh(true);
 }
 

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -74,14 +74,6 @@ private:
 	bool message = false;
 };
 
-class MapEventCache {
-public:
-	void AddEvent(lcf::rpg::Event& ev);
-
-private:
-	std::vector<int> event_ids;
-};
-
 /**
  * Game_Map namespace
  */
@@ -688,13 +680,43 @@ namespace Game_Map {
 
 	FileRequestAsync* RequestMap(int map_id);
 
+	namespace Caching {
+		class MapEventCache {
+		public:
+			void AddEvent(lcf::rpg::Event& ev);
+
+		private:
+			std::vector<int> event_ids;
+		};
+
+		using MapEventCacheData_t = std::unordered_map<int, MapEventCache>;
+
+		enum ObservervedVarOps {
+			SwitchSet = 0,
+			VarSet,
+
+			ObservervedVarOps_END
+		};
+
+		class MapCache {
+		public:
+			template <ObservervedVarOps Op>
+			void AddEventAsRefreshTarget(int var_id, lcf::rpg::Event& ev);
+
+			template <ObservervedVarOps Op>
+			bool GetNeedRefresh(int var_id);
+
+			void Clear();
+		private:
+			MapEventCacheData_t refresh_targets_by_varid[ObservervedVarOps_END];
+		};
+	}
+
 	void SetNeedRefreshForSwitchChange(int switch_id);
 	void SetNeedRefreshForVarChange(int var_id);
 	void SetNeedRefreshForSwitchChange(std::initializer_list<int> switch_ids);
 	void SetNeedRefreshForVarChange(std::initializer_list<int> var_ids);
 
-	void AddEventToSwitchCache(lcf::rpg::Event& ev, int switch_id);
-	void AddEventToVariableCache(lcf::rpg::Event& ev, int var_id);
 
 	namespace Parallax {
 		struct Params {
@@ -845,6 +867,30 @@ inline bool MapUpdateAsyncContext::IsMessage() const {
 
 inline bool MapUpdateAsyncContext::IsActive() const {
 	return GetAsyncOp().IsActive();
+}
+
+inline void Game_Map::Caching::MapEventCache::AddEvent(lcf::rpg::Event& ev) {
+	auto id = ev.ID;
+
+	if (std::find(event_ids.begin(), event_ids.end(), id) == event_ids.end()) {
+		event_ids.emplace_back(id);
+	}
+}
+
+template <Game_Map::Caching::ObservervedVarOps Op>
+inline void Game_Map::Caching::MapCache::AddEventAsRefreshTarget(int var_id, lcf::rpg::Event& ev) {
+	static_assert(static_cast<int>(Op) >= 0 && Op < ObservervedVarOps_END);
+
+	auto& events_cache = refresh_targets_by_varid[static_cast<int>(Op)];
+	events_cache[var_id].AddEvent(ev);
+}
+
+template <Game_Map::Caching::ObservervedVarOps Op>
+inline bool Game_Map::Caching::MapCache::GetNeedRefresh(int var_id) {
+	static_assert(static_cast<int>(Op) >= 0 && Op < ObservervedVarOps_END);
+
+	auto& events_cache = refresh_targets_by_varid[static_cast<int>(Op)];
+	return events_cache.find(var_id) != events_cache.end();
 }
 
 #endif

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -691,24 +691,24 @@ namespace Game_Map {
 
 		using MapEventCacheData_t = std::unordered_map<int, MapEventCache>;
 
-		enum ObservervedVarOps {
+		enum ObservedVarOps {
 			SwitchSet = 0,
 			VarSet,
 
-			ObservervedVarOps_END
+			ObservedVarOps_END
 		};
 
 		class MapCache {
 		public:
-			template <ObservervedVarOps Op>
+			template <ObservedVarOps Op>
 			void AddEventAsRefreshTarget(int var_id, lcf::rpg::Event& ev);
 
-			template <ObservervedVarOps Op>
+			template <ObservedVarOps Op>
 			bool GetNeedRefresh(int var_id);
 
 			void Clear();
 		private:
-			MapEventCacheData_t refresh_targets_by_varid[ObservervedVarOps_END];
+			MapEventCacheData_t refresh_targets_by_varid[ObservedVarOps_END];
 		};
 	}
 
@@ -877,17 +877,17 @@ inline void Game_Map::Caching::MapEventCache::AddEvent(lcf::rpg::Event& ev) {
 	}
 }
 
-template <Game_Map::Caching::ObservervedVarOps Op>
+template <Game_Map::Caching::ObservedVarOps Op>
 inline void Game_Map::Caching::MapCache::AddEventAsRefreshTarget(int var_id, lcf::rpg::Event& ev) {
-	static_assert(static_cast<int>(Op) >= 0 && Op < ObservervedVarOps_END);
+	static_assert(static_cast<int>(Op) >= 0 && Op < ObservedVarOps_END);
 
 	auto& events_cache = refresh_targets_by_varid[static_cast<int>(Op)];
 	events_cache[var_id].AddEvent(ev);
 }
 
-template <Game_Map::Caching::ObservervedVarOps Op>
+template <Game_Map::Caching::ObservedVarOps Op>
 inline bool Game_Map::Caching::MapCache::GetNeedRefresh(int var_id) {
-	static_assert(static_cast<int>(Op) >= 0 && Op < ObservervedVarOps_END);
+	static_assert(static_cast<int>(Op) >= 0 && Op < ObservedVarOps_END);
 
 	auto& events_cache = refresh_targets_by_varid[static_cast<int>(Op)];
 	return events_cache.find(var_id) != events_cache.end();

--- a/src/game_strings.h
+++ b/src/game_strings.h
@@ -41,6 +41,12 @@ public:
 		int string_id = 0, hex = 0, extract = 0;
 	};
 
+	enum StringEvalMode : std::int8_t { // 4 bits
+		eStringEval_Text = 0, // String is taken from com.string
+		eStringEval_Direct = 1, // String is referenced directly by string id
+		eStringEval_Indirect = 2 // String is referenced indirectly by variable id
+	};
+
 	Game_Strings() = default;
 
 	void SetData(Strings_t s);
@@ -158,9 +164,9 @@ inline StringView Game_Strings::GetIndirect(int id, const Game_Variables& variab
 
 inline StringView Game_Strings::GetWithMode(StringView str_data, int mode, int arg, const Game_Variables& variables) const {
 	switch (mode) {
-	case 1: // direct string reference
+	case StringEvalMode::eStringEval_Direct:
 		return Get(arg);
-	case 2: // indirect string reference
+	case StringEvalMode::eStringEval_Indirect:
 		return GetIndirect(arg, variables);
 	default:
 		return str_data;
@@ -170,16 +176,16 @@ inline StringView Game_Strings::GetWithMode(StringView str_data, int mode, int a
 inline StringView Game_Strings::GetWithModeAndPos(StringView str_data, int mode, int arg, int* pos, const Game_Variables& variables) {
 	StringView ret;
 	switch (mode) {
-	case 0:
-		assert(pos);
-		ret = str_data.substr(*pos, arg);
-		*pos += arg;
-		return ret;
-	case 1: // direct string reference
-		return Get(arg);
-	case 2: // indirect string reference
-		return GetIndirect(arg, variables);
-	default:
-		return ret;
+		case StringEvalMode::eStringEval_Text:
+			assert(pos);
+			ret = str_data.substr(*pos, arg);
+			*pos += arg;
+			return ret;
+		case StringEvalMode::eStringEval_Direct:
+			return Get(arg);
+		case StringEvalMode::eStringEval_Indirect:
+			return GetIndirect(arg, variables);
+		default:
+			return ret;
 	}
 }

--- a/src/maniac_patch.cpp
+++ b/src/maniac_patch.cpp
@@ -117,7 +117,7 @@ namespace {
 	};
 }
 
-int process(std::vector<int32_t>::iterator& it, std::vector<int32_t>::iterator end, const Game_Interpreter& ip) {
+int process(std::vector<int32_t>::iterator& it, std::vector<int32_t>::iterator end, const Game_BaseInterpreterContext& ip) {
 	int value = 0;
 	int imm = 0;
 	int imm2 = 0;
@@ -413,7 +413,7 @@ int process(std::vector<int32_t>::iterator& it, std::vector<int32_t>::iterator e
 	}
 }
 
-int32_t ManiacPatch::ParseExpression(Span<const int32_t> op_codes, const Game_Interpreter& interpreter) {
+int32_t ManiacPatch::ParseExpression(Span<const int32_t> op_codes, const Game_BaseInterpreterContext& interpreter) {
 	std::vector<int32_t> ops;
 	for (auto &o: op_codes) {
 		auto uo = static_cast<uint32_t>(o);

--- a/src/maniac_patch.h
+++ b/src/maniac_patch.h
@@ -25,10 +25,10 @@
 
 #include "game_strings.h"
 
-class Game_Interpreter;
+class Game_BaseInterpreterContext;
 
 namespace ManiacPatch {
-	int32_t ParseExpression(Span<const int32_t> op_codes, const Game_Interpreter& interpreter);
+	int32_t ParseExpression(Span<const int32_t> op_codes, const Game_BaseInterpreterContext& interpreter);
 
 	std::array<bool, 50> GetKeyRange();
 


### PR DESCRIPTION

- Refactors & restructures some of the logic of my "AntiLag" branch into a new "Caching" namespace.
- Moves some of the common helper function from the interpreter class to a new file "game_interpreter_shared.cpp"
- Adds a new abstract base class for the interpreter: "Game_BaseInterpreterContext"
  -  This class holds the declarations for a few member functions which are used for evaluation logic across different sorts of commands
  - All the moved helper functions (CheckOperator, ValueOrVariable, CommandStringOrVariable & others) are agnostic to the actual implementation of the interpreter itself
- Refactors "ValueOrVariable" & "ValueOrVariableBitfield" into template methods
  - Might save some unecessary branching depending on the context in which they are used

New helper function: "DecodeTargetEvaluationMode"
- Unifies some of the commonly seen logic that was responsible for decoding command arguments into either a single variable id or a set range of variables.
- Used in ControlSwitches, ControlVariables & ControlStrings with different template parameters (these specify the supported variable accessing modes). E.g.: A hypothethical new "ControlVariablesEx" command could just set all of these parameters to true and share the rest of its logic with the original command.
- Used in my ScopedVars branch for these new commands:
  - ControlSwitchesEx
  - ControlVariablesEx
  - ControlScopedSwitches
  - ControlScopedVariables 

This should be most of the easier-to-verify-and-merge changes, my "ScopedVars" depends on.

The current draft for ScopedVars also contains some more changes for the "ControlVariables" & "ConditionalBranch" commands, moving all of the operand switching logic into game_interpreter_control_variables.cpp. Basically I reinvented dispatching tables for this, to share this logic between the different new command spin-offs, but I have yet to confirm with benchmarks that this really a good solution. I don't want to slow any of the existing commands down by even a single cycle. :D  
https://github.com/florianessl/Player/tree/ScopedVars
Best possible way to implement all this switching would likely be a mix of computed go-tos & tail recursion (see #1919 for the suggestion of implementing computed go-tos; but it´s debatable, if any of these changes would create any speed-ups in current-year & aren't already part of common compiler optimizations.)