### PR TITLE
Show string pic selectable

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -5238,11 +5238,12 @@ bool Game_Interpreter::CommandShowStringPicSelectable(lcf::rpg::EventCommand con
 
 	if (mode == 0) { // ENABLE MENU
 		if (!is_menu_active) {
+			InitializeMenu(strpic_index);
+
 			if (window->GetIndex() == -1)
 				window->SetIndex(0);
 
 			window->SetActive(true);
-			InitializeMenu(strpic_index);
 			return false;
 		}
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -5318,15 +5318,22 @@ bool Game_Interpreter::CommandStringPicMenu(const lcf::rpg::EventCommand& com) {
 		if (!window->GetActive()) {
 			int max_item = 0;
 			for (const auto& text_data : data.texts) {
-				std::stringstream ss(ToString(text_data.text));
-				std::string out;
-				while (Utils::ReadLine(ss, out)) {
-					max_item++;
+				auto pending_message = Main_Data::game_windows->GeneratePendingMessage(ToString(text_data.text));
+				const auto& lines = pending_message.GetLines();
+
+				for (const auto& line : lines) {
+					std::stringstream ss(line);
+					std::string sub_line;
+
+					while (Utils::ReadLine(ss, sub_line)) {
+						max_item++;
+						// Output::Warning("{}", sub_line);
+					}
 				}
 			}
 
 			window->SetItemMax(max_item);
-			//window->SetColumnMax(2);
+			//window->SetColumnMax(2); // TODO: is there an easy way to put text near cursor rects?
 			if (data.texts.empty()) {
 				Output::Warning("String Picture Menu - String Picture {} is not valid", strpic_index);
 				return true;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -5327,8 +5327,17 @@ bool Game_Interpreter::CommandStringPicMenu(const lcf::rpg::EventCommand& com) {
 
 			window->SetItemMax(max_item);
 			//window->SetColumnMax(2);
-			window->SetMenuItemHeight(data.texts[0].font_size + 4); // TODO: item area with bigger font-sizes could look better...
-			window->SetMenuItemLineSpacing(data.texts[0].line_spacing);
+			if (data.texts.empty()) {
+				Output::Warning("String Picture Menu - String Picture {} is not valid", strpic_index);
+				return true;
+			}
+
+			int item_height = data.texts[0].font_size + 4;
+			int item_spacing = data.texts[0].line_spacing;
+
+			window->SetMenuItemHeight(item_height);
+			window->SetMenuItemLineSpacing(item_spacing);
+
 			if (window->GetIndex() == -1) window->SetIndex(0);
 
 			window->SetActive(true);
@@ -5340,6 +5349,7 @@ bool Game_Interpreter::CommandStringPicMenu(const lcf::rpg::EventCommand& com) {
 		game_system->SetSystemGraphic(strpic_system.name, strpic_system.stretch, strpic_system.font);
 		window->Update();
 		game_system->SetSystemGraphic(current_system.name, current_system.stretch, current_system.font);
+
 		window->SetStretch(strpic_system.stretch);
 		return HandleMenuSelection();
 	}

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -5267,7 +5267,8 @@ bool Game_Interpreter::CommandShowStringPicSelectable(lcf::rpg::EventCommand con
 }
 
 void Game_Interpreter::InitializeMenu(int strpic_index) {
-	auto data = Main_Data::game_windows->GetWindow(strpic_index).data;
+	auto& window_data = Main_Data::game_windows->GetWindow(strpic_index);
+	auto data = window_data.data;
 	int max_item = 0;
 	for (const auto& texts : data.texts) {
 		std::stringstream ss(ToString(texts.text));
@@ -5276,8 +5277,8 @@ void Game_Interpreter::InitializeMenu(int strpic_index) {
 			max_item++;
 		}
 	}
-	Main_Data::game_windows->GetWindow(strpic_index).window->SetItemMax(max_item);
-	Main_Data::game_windows->GetWindow(strpic_index).window->SetMenuItemLineSpacing(data.texts[0].line_spacing);
+	window_data.window->SetItemMax(max_item);
+	window_data.window->SetMenuItemLineSpacing(data.texts[0].line_spacing);
 }
 
 bool Game_Interpreter::HandleMenuSelection(int strpic_index, int output_variable) {

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -5276,6 +5276,7 @@ void Game_Interpreter::InitializeMenu(int strpic_index) {
 		}
 	}
 	Main_Data::game_windows->GetWindow(strpic_index).window->SetItemMax(max_item);
+	Main_Data::game_windows->GetWindow(strpic_index).window->SetMenuItemLineSpacing(data.texts[0].line_spacing);
 }
 
 bool Game_Interpreter::HandleMenuSelection(int strpic_index, int output_variable) {

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -298,6 +298,8 @@ protected:
 	bool CommandManiacCallCommand(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgSetInterpreterFlag(lcf::rpg::EventCommand const& com);
 
+	bool CommandShowStringPicSelectable(lcf::rpg::EventCommand const& com);
+
 	int DecodeInt(lcf::DBArray<int32_t>::const_iterator& it);
 	const std::string DecodeString(lcf::DBArray<int32_t>::const_iterator& it);
 	lcf::rpg::MoveCommand DecodeMove(lcf::DBArray<int32_t>::const_iterator& it);

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -299,6 +299,9 @@ protected:
 	bool CommandEasyRpgSetInterpreterFlag(lcf::rpg::EventCommand const& com);
 
 	bool CommandShowStringPicSelectable(lcf::rpg::EventCommand const& com);
+	
+	void InitializeMenu(int strpic_index);
+	bool HandleMenuSelection(int strpic_index, int output_variable);
 
 	int DecodeInt(lcf::DBArray<int32_t>::const_iterator& it);
 	const std::string DecodeString(lcf::DBArray<int32_t>::const_iterator& it);

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -298,10 +298,7 @@ protected:
 	bool CommandManiacCallCommand(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgSetInterpreterFlag(lcf::rpg::EventCommand const& com);
 
-	bool CommandShowStringPicSelectable(lcf::rpg::EventCommand const& com);
-	
-	void InitializeMenu(int strpic_index);
-	bool HandleMenuSelection(int strpic_index, int output_variable);
+	bool CommandStringPicMenu(lcf::rpg::EventCommand const& com);
 
 	int DecodeInt(lcf::DBArray<int32_t>::const_iterator& it);
 	const std::string DecodeString(lcf::DBArray<int32_t>::const_iterator& it);

--- a/src/game_windows.cpp
+++ b/src/game_windows.cpp
@@ -46,6 +46,16 @@ Game_Windows::Window_User::Window_User(lcf::rpg::SaveEasyRpgWindow save)
 
 }
 
+PendingMessage Game_Windows::GeneratePendingMessage(const std::string& text) {
+	std::stringstream ss(text);
+	std::string out;
+	PendingMessage pm(CommandCodeInserter);
+	while (Utils::ReadLine(ss, out)) {
+		pm.PushLine(out);
+	}
+	return pm;
+}
+
 void Game_Windows::SetSaveData(std::vector<lcf::rpg::SaveEasyRpgWindow> save) {
 	windows.clear();
 
@@ -218,12 +228,7 @@ void Game_Windows::Window_User::Refresh(bool& async_wait) {
 		fonts.emplace_back(font);
 
 		std::stringstream ss(ToString(text.text));
-		std::string out;
-		PendingMessage pm(CommandCodeInserter);
-		while (Utils::ReadLine(ss, out)) {
-			pm.PushLine(out);
-		}
-		messages.emplace_back(pm);
+		messages.emplace_back(GeneratePendingMessage(ToString(text.text)));
 	}
 
 	auto apply_style = [](auto& font, const auto& text) {

--- a/src/game_windows.cpp
+++ b/src/game_windows.cpp
@@ -354,6 +354,8 @@ void Game_Windows::Window_User::Refresh(bool& async_wait) {
 	window->CreateContents();
 	window->SetVisible(false);
 
+	window->SetActive(false);
+
 	BitmapRef system;
 	// FIXME: Transparency setting is currently not applied to the system graphic
 	// Disabling transparency breaks the rendering of the system graphic

--- a/src/game_windows.cpp
+++ b/src/game_windows.cpp
@@ -238,11 +238,11 @@ void Game_Windows::Window_User::Refresh(bool& async_wait) {
 		return font->ApplyStyle(style);
 	};
 
-	if (data.width == 0 || data.height == 0) {
-		// Automatic window size
-		int x_max = 0;
-		int y_max = 0;
+	// Automatic window size
+	int x_max = 0;
+	int y_max = 0;
 
+	if (true) {//(data.width == 0 || data.height == 0) {
 		for (size_t i = 0; i < data.texts.size(); ++i) {
 			// Lots of duplication with the rendering code below but cannot be easily reduced more
 			auto& font = fonts[i];
@@ -351,7 +351,13 @@ void Game_Windows::Window_User::Refresh(bool& async_wait) {
 		// FIXME: Figure out why 0 does not work here (bug in Window class)
 		window->SetBorderY(-3);
 	}
+
+	if (data.width != 0) window->SetWidth(x_max);
+	if (data.height != 0) window->SetHeight(y_max);
 	window->CreateContents();
+	if (data.width != 0) window->SetWidth(data.width);
+	if (data.height != 0) window->SetHeight(data.height);
+
 	window->SetVisible(false);
 
 	window->SetActive(false);

--- a/src/game_windows.h
+++ b/src/game_windows.h
@@ -41,6 +41,8 @@ class Game_Windows {
 public:
 	Game_Windows() = default;
 
+	static PendingMessage GeneratePendingMessage(const std::string& text);
+
 	void SetSaveData(std::vector<lcf::rpg::SaveEasyRpgWindow> save);
 	std::vector<lcf::rpg::SaveEasyRpgWindow> GetSaveData() const;
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -61,6 +61,8 @@ void Window::Draw(Bitmap& dst) {
 	if (width <= 0 || height <= 0) return;
 	if (x < -width || x > dst.GetWidth() || y < -height || y > dst.GetHeight()) return;
 
+	if (back_opacity == 0) dst.ClearRect(Rect(0, 0, width, height)); // WORKAROUND: This may be exclusive to stringPic without backgrounds.
+
 	if (windowskin) {
 		if (width > 4 && height > 4 && (back_opacity * opacity / 255 > 0)) {
 			if (background_needs_refresh) RefreshBackground();

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -117,7 +117,15 @@ void Window_Selectable::UpdateCursorRect() {
 
 	int y = index / column_max * menu_item_height - oy;
 	y += ( menu_item_line_spacing * index ) - (4 * index); // calculate spacing between lines
-	SetCursorRect(Rect(x, y, cursor_width, menu_item_height));
+
+	int item_height = menu_item_height;
+	if (border_x == 0) { // When margin doesn't exist
+		x += 4;
+		cursor_width += 8;
+		if (index == 0) item_height += 3;
+	}
+
+	SetCursorRect(Rect(x, y, cursor_width, item_height));
 }
 
 void Window_Selectable::UpdateArrows() {

--- a/src/window_selectable.cpp
+++ b/src/window_selectable.cpp
@@ -116,6 +116,7 @@ void Window_Selectable::UpdateCursorRect() {
 	x = (index % column_max * (cursor_width + 8)) - 4;
 
 	int y = index / column_max * menu_item_height - oy;
+	y += ( menu_item_line_spacing * index ) - (4 * index); // calculate spacing between lines
 	SetCursorRect(Rect(x, y, cursor_width, menu_item_height));
 }
 
@@ -233,6 +234,10 @@ void Window_Selectable::SetEndlessScrolling(bool state) {
 // Set menu item height
 void Window_Selectable::SetMenuItemHeight(int height) {
 	menu_item_height = height;
+}
+
+void Window_Selectable::SetMenuItemLineSpacing(int spacing) {
+	menu_item_line_spacing = spacing;
 }
 
 void Window_Selectable::SetSingleColumnWrapping(bool wrap) {

--- a/src/window_selectable.h
+++ b/src/window_selectable.h
@@ -93,6 +93,13 @@ public:
 	void SetMenuItemHeight(int height);
 
 	/**
+	 * Sets the menu item height.
+	*
+	* @param spacing between menu items.
+	*/
+	void SetMenuItemLineSpacing(int spacing);
+
+	/**
 	 * Allow left/right input to move cursor up/down when the selectable has only one column.
 	 * By default this behaviour is only enabled for two and more columns.
 	 *
@@ -112,6 +119,7 @@ protected:
 	bool endless_scrolling = true;
 
 	int menu_item_height = 16;
+	int menu_item_line_spacing = 4;
 
 	int scroll_dir = 0;
 	int scroll_progress = 0;


### PR DESCRIPTION
Transforms a String Picture into a menu.
![image](https://github.com/user-attachments/assets/063fb809-7449-4507-9def-4b0d06d1ede3)

MAP DEMO: [StringPicMenu.zip](https://github.com/user-attachments/files/16338736/StringPicMenu.zip)
Paste it inside a new project.

----------------------------

You can control the outputs from the menu through two approaches:
- A - Points it to variables that will receive `Menu's cursor position` and `Menu's cursor state`.

- B - Add a `Show Choices Command` right bellow the `String Picture Menu Command`. 
The Menu will replace the Show Choices UI, while reproducing its behavior.

------------------------

#### Syntax (TPC):

`Some of the parameters comes in pairs. The first parameter of each pair indicates whether you are using a direct value or a variable/indirect variable, through ValueOrVariable().`

```js
@raw 2056,
     "",           // [NOT USED. YOU CAN LEAVE IT BLANK]
      0,           // Mode [0: Enable Menu || 1: Disable Menu]
      0, 1,        // String Picture's ID
      0, 2,        // A variable that will store the current Cursor Position [Optional] 
      0, 3         // A variable that will store the current Cursor State [Optional]
                   // 👆 State Outputs: 0 means 'idle', 1 means 'confirm' and -1 means 'cancel'
```

------------------------------------


Thanks to @MackValentine, for the initial commits.
