### PR TITLE
New Feature - Local Settings

### DIFF
--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -94,6 +94,9 @@ Game_Config Game_Config::Create(CmdlineParser& cp) {
 	if (!config_path.empty()) {
 		config_file = FileFinder::MakePath(config_path, config_name);
 	}
+	else if (FileFinder::Root().Exists(config_name)) {
+		config_file = ToString(config_name);
+	}
 
 	auto cli_config = FileFinder::Root().OpenOrCreateInputStream(config_file);
 	if (!cli_config) {


### PR DESCRIPTION
If you have a copy of config.ini saved at the same folder as the player app, it will load the game settings from it, instead of the global folder.

-------------------------------------

~~I used `std::filesystem` because couldn't figure another way of extracting the apps absolute path.~~