### PR TITLE
Maniacs Feature - Remove scaling restrictions for pictures

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2857,9 +2857,9 @@ bool Game_Interpreter::CommandShowPicture(lcf::rpg::EventCommand const& com) { /
 		}
 
 		params.magnify_width = ValueOrVariableBitfield(com.parameters[20], 0, params.magnify_width);
-		if (Player::IsPatchManiac() && com.parameters.size() > 31 && com.parameters[20] >= 16 && params.effect_mode == 0) {
+		if (Player::IsPatchManiac() && com.parameters.size() > 31 && com.parameters[20] >= 16) {
 			// The >= 16 check is needed because this bit is set when independent width/height scaling is used
-			// When using special effects on Maniacs, Height is set to Width
+			// Since version 240423, Maniacs supports width/height scaling for special effects pictures.
 			params.magnify_height = ValueOrVariableBitfield((com.parameters[20] >> 1), 1, com.parameters[31]);
 		} else {
 			params.magnify_height = params.magnify_width;
@@ -2984,9 +2984,9 @@ bool Game_Interpreter::CommandMovePicture(lcf::rpg::EventCommand const& com) { /
 			}
 
 			params.magnify_width = ValueOrVariableBitfield(com.parameters[20], 0, params.magnify_width);
-			if (Player::IsPatchManiac() && com.parameters.size() > 18 && com.parameters[20] >= 16 && params.effect_mode == 0) {
+			if (Player::IsPatchManiac() && com.parameters.size() > 18 && com.parameters[20] >= 16) {
 				// The >= 16 check is needed because this bit is set when independent width/height scaling is used
-				// When using special effects on Maniacs, Height is set to Width
+				// Since version 240423, Maniacs supports width/height scaling for special effects pictures.
 				params.magnify_height = ValueOrVariableBitfield((com.parameters[20] >> 1), 1, com.parameters[18]);
 			} else {
 				params.magnify_height = params.magnify_width;

--- a/src/sprite_picture.cpp
+++ b/src/sprite_picture.cpp
@@ -165,6 +165,10 @@ void Sprite_Picture::Draw(Bitmap& dst) {
 	SetFlipY((data.easyrpg_flip & lcf::rpg::SavePicture::EasyRpgFlip_y) == lcf::rpg::SavePicture::EasyRpgFlip_y);
 	SetBlendType(data.easyrpg_blend_mode);
 
+	// Don't draw anything if zoom is at zero, helps avoid a glitchy rotated sprite in the top left corner
+	if (GetZoomX() <= 0.0 || GetZoomY() <= 0.0) {
+		return;
+	}
 	Sprite::Draw(dst);
 }
 


### PR DESCRIPTION
From Maniac Patch version 240423:
```
[RPG_RT.exe]
Support for different magnification rates for special drawing of pictures (rotation, waveform, angle).
```

+ Added check if sprite's width/height is at zero. If so, skip the draw routine (helps avoid a glitchy sprite at the top-left when rotating an infinitely thin picture)
- Removed check for effect mode when setting zoom or width/height.

One thing to note when comparing Maniac and EasyRPG: the former doesn't seem to properly clip the sprite in the corners when rotating the sprite.