### PR TITLE
Fix compiling OpenDingux code path with SDL 1.2

### DIFF
--- a/src/platform/opendingux/opendingux_input_buttons.cpp
+++ b/src/platform/opendingux/opendingux_input_buttons.cpp
@@ -45,4 +45,12 @@ Input::KeyNamesArray Input::GetInputKeyNames() {
 
 void Input::GetSupportedConfig(Game_ConfigInput& cfg) {}
 
+
+#include "platform/sdl/axis.h"
+SdlAxis Input::GetSdlAxis() {
+	return {
+		0, 1, 2, 3, 4, 5, false, false
+	};
+}
+
 #endif


### PR DESCRIPTION
Otherwise, it will complain about undefined references to GetSdlAxis.
As far as i'm aware, this file is only being used if you specifically use SDL 1.2 together with OPENDINGUX flag. (OD builds now use SDL2 so this path is normally never used besides yours truly)