### PR TITLE
Implemented Maniacs Command 3011: ChangeBattleCommandEx

### DIFF
--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -31,7 +31,7 @@
 #include "game_map.h"
 #include "spriteset_battle.h"
 #include <cassert>
-#include <scene_battle.h>
+#include "scene_battle.h"
 
 enum BranchBattleSubcommand {
 	eOptionBranchBattleElse = 1
@@ -612,34 +612,31 @@ bool Game_Interpreter_Battle::CommandManiacChangeBattleCommandEx(lcf::rpg::Event
 	}
 
 	// 1 row removed
-	bool actorCommandFlags = com.parameters[0];
+	bool actor_command_flags = com.parameters[0];
 
-	lcf::Data::battlecommands.easyrpg_disable_row_feature = actorCommandFlags;
+	lcf::Data::battlecommands.easyrpg_disable_row_feature = actor_command_flags;
 
 	// 10000 lose added
 	// 01000 win added
 	// 00100 escape removed
 	// 00010 auto removed
 	// 00001 fight removed
-	int partyCommandFlags = com.parameters[1];
+	int party_command_flags = com.parameters[1];
 
 	lcf::Data::system.easyrpg_battle_options.clear();
-	for (size_t i = 0; i < Scene_Battle::BattleOptionType::Lose + 1; i++)
-	{
-		bool partyCommandFlag = partyCommandFlags & (1 << i);
-		bool flagIsSet = i > 2;
+	for (size_t i = 0; i < Scene_Battle::BattleOptionType::Lose + 1; i++) {
+		bool party_command_flag = party_command_flags & (1 << i);
+		bool flag_is_set = i > 2;
 
-		if (partyCommandFlag == flagIsSet)
-		{
+		if (party_command_flag == flag_is_set) {
 			lcf::Data::system.easyrpg_battle_options.push_back(i);
 		}
 	}
 
-	auto& scene = Scene::instance;
-	Scene_Battle* sceneBattle = dynamic_cast<Scene_Battle*>(scene.get());
+	auto* scene_battle = static_cast<Scene_Battle*>(Scene::instance.get());
 
-	if (sceneBattle) {
-		sceneBattle->CreateOptions();
+	if (scene_battle) {
+		scene_battle->CreateOptions();
 	}
 
 	return true;

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -31,6 +31,7 @@
 #include "game_map.h"
 #include "spriteset_battle.h"
 #include <cassert>
+#include <scene_battle.h>
 
 enum BranchBattleSubcommand {
 	eOptionBranchBattleElse = 1
@@ -605,12 +606,42 @@ bool Game_Interpreter_Battle::CommandManiacControlAtbGauge(lcf::rpg::EventComman
 	return true;
 }
 
-bool Game_Interpreter_Battle::CommandManiacChangeBattleCommandEx(lcf::rpg::EventCommand const&) {
+bool Game_Interpreter_Battle::CommandManiacChangeBattleCommandEx(lcf::rpg::EventCommand const& com) {
 	if (!Player::IsPatchManiac()) {
 		return true;
 	}
 
-	Output::Warning("Maniac Patch: Command ChangeBattleCommandEx not supported");
+	// 1 row removed
+	bool actorCommandFlags = com.parameters[0];
+
+	lcf::Data::battlecommands.easyrpg_disable_row_feature = actorCommandFlags;
+
+	// 10000 lose added
+	// 01000 win added
+	// 00100 escape removed
+	// 00010 auto removed
+	// 00001 fight removed
+	int partyCommandFlags = com.parameters[1];
+
+	lcf::Data::system.easyrpg_battle_options.clear();
+	for (size_t i = 0; i < Scene_Battle::BattleOptionType::Lose + 1; i++)
+	{
+		bool partyCommandFlag = partyCommandFlags & (1 << i);
+		bool flagIsSet = i > 2;
+
+		if (partyCommandFlag == flagIsSet)
+		{
+			lcf::Data::system.easyrpg_battle_options.push_back(i);
+		}
+	}
+
+	auto& scene = Scene::instance;
+	Scene_Battle* sceneBattle = dynamic_cast<Scene_Battle*>(scene.get());
+
+	if (sceneBattle) {
+		sceneBattle->CreateOptions();
+	}
+
 	return true;
 }
 

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -189,16 +189,18 @@ void Scene_Battle::DrawBackground(Bitmap& dst) {
 	dst.Clear();
 }
 
-void Scene_Battle::CreateUi() {
+void Scene_Battle::CreateOptions() {
 	std::vector<std::string> commands;
 
-	for (auto option: lcf::Data::system.easyrpg_battle_options) {
+	battle_options.clear();
+
+	for (auto option : lcf::Data::system.easyrpg_battle_options) {
 		battle_options.push_back((BattleOptionType)option);
 	}
 
 	// Add all menu items
-	for (auto option: battle_options) {
-		switch(option) {
+	for (auto option : battle_options) {
+		switch (option) {
 		case Battle:
 			commands.push_back(ToString(lcf::Data::terms.battle_fight));
 			break;
@@ -208,6 +210,12 @@ void Scene_Battle::CreateUi() {
 		case Escape:
 			commands.push_back(ToString(lcf::Data::terms.battle_escape));
 			break;
+		case Win:
+			commands.push_back("Win");
+			break;
+		case Lose:
+			commands.push_back("Lose");
+			break;
 		}
 	}
 
@@ -215,6 +223,10 @@ void Scene_Battle::CreateUi() {
 	options_window->SetHeight(80);
 	options_window->SetX(Player::menu_offset_x);
 	options_window->SetY(Player::menu_offset_y + MENU_HEIGHT - 80);
+}
+
+void Scene_Battle::CreateUi() {
+	CreateOptions();
 
 	help_window.reset(new Window_Help(Player::menu_offset_x, Player::menu_offset_y, MENU_WIDTH, 32));
 	help_window->SetVisible(false);

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -80,6 +80,8 @@ public:
 
 	void Start() override;
 
+	void CreateOptions();
+
 	void UpdateScreen();
 	void UpdateBattlers();
 	void UpdateUi();
@@ -125,7 +127,9 @@ public:
 	enum BattleOptionType {
 		Battle,
 		AutoBattle,
-		Escape
+		Escape,
+		Win,
+		Lose
 	};
 
 	static void SelectionFlash(Game_Battler* battler);

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1155,9 +1155,14 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionFi
 		ResetWindows(true);
 		target_window->SetIndex(-1);
 
-		if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional || ((std::find(battle_options.begin(), battle_options.end(), AutoBattle) == battle_options.end()) && !IsEscapeAllowedFromOptionWindow())) {
+		if (lcf::Data::battlecommands.battle_type == lcf::rpg::BattleCommands::BattleType_traditional
+				|| ((std::find(battle_options.begin(), battle_options.end(), AutoBattle) == battle_options.end()) && (std::find(battle_options.begin(), battle_options.end(), Win) == battle_options.end()) && (std::find(battle_options.begin(), battle_options.end(), Lose) == battle_options.end()) && !IsEscapeAllowedFromOptionWindow())) {
 			if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) MoveCommandWindows(Player::menu_offset_x - options_window->GetWidth(), 1);
 			SetState(State_SelectActor);
+			return SceneActionReturn::eContinueThisFrame;
+		} else if (battle_options.size() == 1 && (std::find(battle_options.begin(), battle_options.end(), AutoBattle) != battle_options.end())) {
+			if (lcf::Data::battlecommands.battle_type != lcf::rpg::BattleCommands::BattleType_traditional) MoveCommandWindows(Player::menu_offset_x - options_window->GetWidth(), 1);
+			SetState(State_AutoBattle);
 			return SceneActionReturn::eContinueThisFrame;
 		}
 

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1163,13 +1163,12 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionFi
 
 		options_window->SetActive(true);
 
+		auto it = std::find(battle_options.begin(), battle_options.end(), Escape);
 		if (IsEscapeAllowedFromOptionWindow()) {
-			auto it = std::find(battle_options.begin(), battle_options.end(), Escape);
 			if (it != battle_options.end()) {
 				options_window->EnableItem(std::distance(battle_options.begin(), it));
 			}
 		} else {
-			auto it = std::find(battle_options.begin(), battle_options.end(), Escape);
 			if (it != battle_options.end()) {
 				options_window->DisableItem(std::distance(battle_options.begin(), it));
 			}
@@ -1216,6 +1215,16 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionFi
 					} else {
 						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 					}
+					break;
+				case Win: // Win
+					for each (Game_Enemy* enemy in Main_Data::game_enemyparty->GetEnemies())
+					{
+						enemy->Kill();
+					}
+					SetState(State_Victory);
+					break;
+				case Lose: // Lose
+					SetState(State_Defeat);
 					break;
 			}
 		}

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1222,8 +1222,7 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionFi
 					}
 					break;
 				case Win: // Win
-					for each (Game_Enemy* enemy in Main_Data::game_enemyparty->GetEnemies())
-					{
+					for (Game_Enemy* enemy : Main_Data::game_enemyparty->GetEnemies()) {
 						enemy->Kill();
 					}
 					SetState(State_Victory);


### PR DESCRIPTION
Using the maniacs patch ChangeBaltteCommandEx with something like this:
![image](https://github.com/user-attachments/assets/ac3dccc1-d91d-41bc-8272-50f0748a88de)

Will now give you the expected behavior in EasyRPG:
![image](https://github.com/user-attachments/assets/1e0357d4-5daf-41a6-8598-83ddadc0c180)

And for the actors themselves (in my example the row command is turned off):
![image](https://github.com/user-attachments/assets/4b0c5648-4592-49c7-b240-c4df36c1f6e7)

Developers can mix and match these features and all commands are supported. Including the "Win" and "Lose" commands.