### PR TITLE
Implemented Maniacs Command 3010: ControlATBGauge

### DIFF
--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -45,7 +45,7 @@ enum TargetType {
 
 static const char* target_text[] = { "actor", "party member", "enemy" };
 
-static const void MissingTargetWarning(char* command_name, TargetType target_type, int target_id) {
+static const void MissingTargetWarning(const char* command_name, TargetType target_type, int target_id) {
 	Output::Warning("{}: Invalid {} ID: {}", command_name, target_text[target_type], target_id);
 }
 


### PR DESCRIPTION
Using the maniacs patch ControlATBGauge with something like this:
![image](https://github.com/user-attachments/assets/d00cb041-7343-4427-b579-b0393bfac1c0)

Will result in all party members having 1/3rd of a full gauge. 
![image](https://github.com/user-attachments/assets/652a94bf-cb66-4571-9cbe-2c63106b3835)

Or using it with 100% ATB for the first party member:
![image](https://github.com/user-attachments/assets/87390361-5c58-4966-8249-3a1b75feb1e3)

Would result in this:
![image](https://github.com/user-attachments/assets/c104c72b-4bfd-4513-8464-8132baf1b8fd)

Of course developers can use any combination of parameters, I've tested all of them individually with all combinations. 

I've also recreated the functionality from maniacs where when a 0 index is passed in as an actor id, it just ignores the command entirely.