### PR TITLE
Implemented Maniacs Command 3012: GetBattleInfo

### DIFF
--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -445,6 +445,11 @@ public:
 	bool IsHidden() const;
 	virtual bool IsImmortal() const;
 
+	int GetAtkModifier() const;
+	int GetDefModifier() const;
+	int GetSpiModifier() const;
+	int GetAgiModifier() const;
+
 	/** @return true if this battler is in it's party */
 	virtual bool IsInParty() const = 0;
 
@@ -1047,6 +1052,22 @@ inline bool Game_Battler::IsHidden() const {
 
 inline bool Game_Battler::IsImmortal() const {
 	return false;
+}
+
+inline int Game_Battler::GetAtkModifier() const {
+	return atk_modifier;
+}
+
+inline int Game_Battler::GetDefModifier() const {
+	return def_modifier;
+}
+
+inline int Game_Battler::GetSpiModifier() const {
+	return spi_modifier;
+}
+
+inline int Game_Battler::GetAgiModifier() const {
+	return agi_modifier;
 }
 
 constexpr int Game_Battler::GetMaxAtbGauge() {

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -732,12 +732,125 @@ bool Game_Interpreter_Battle::CommandManiacChangeBattleCommandEx(lcf::rpg::Event
 	return true;
 }
 
-bool Game_Interpreter_Battle::CommandManiacGetBattleInfo(lcf::rpg::EventCommand const&) {
+bool Game_Interpreter_Battle::CommandManiacGetBattleInfo(lcf::rpg::EventCommand const& com) {
 	if (!Player::IsPatchManiac()) {
 		return true;
 	}
 
-	Output::Warning("Maniac Patch: Command GetBattleInfo not supported");
+	int target_flags = com.parameters[0];
+	int target_reference_flags = com.parameters[2];
+	int target_reference_identifier = com.parameters[3];
+	int information_flags = com.parameters[1];
+	int information_identifier = com.parameters[4];
+
+	int target_id = ValueOrVariable(target_reference_flags, target_reference_identifier);
+
+	auto executeOperationSingle = [information_flags, information_identifier, target_id](Game_Battler* battler, TargetType battler_type) {
+		if (!battler) {
+			MissingTargetWarning("CommandManiacGetBattleInfo", battler_type, target_id);
+			return;
+		}
+
+		switch (information_flags)
+		{
+			case 0:
+				// parameter buffs: attack, defense, mind, agility
+				Main_Data::game_variables->Set(information_identifier, battler->GetAtkModifier());
+				Main_Data::game_variables->Set(information_identifier + 1, battler->GetDefModifier());
+				Main_Data::game_variables->Set(information_identifier + 2, battler->GetSpiModifier());
+				Main_Data::game_variables->Set(information_identifier + 3, battler->GetAgiModifier());
+				break;
+			case 1:
+			{
+				// states: size, [...state_id]
+				auto states = lcf::Data::states.size();
+				Main_Data::game_variables->Set(information_identifier, states);
+				for (size_t i = 0; i < states; i++)
+				{
+					Main_Data::game_variables->Set(information_identifier + i + 1, battler->HasState(lcf::Data::states.at(i).ID));
+				}
+				break;
+			}
+			case 2:
+			{
+				// elements: size, [...element_id]
+				auto elements = lcf::Data::attributes.size();
+				Main_Data::game_variables->Set(information_identifier, elements);
+				for (size_t i = 0; i < elements; i++)
+				{
+					Main_Data::game_variables->Set(information_identifier + i + 1, battler->GetAttributeRateShift(lcf::Data::attributes.at(i).ID) + 1);
+				}
+				break;
+				break;
+			}
+			case 3:
+				// others: x, y, can move, defending, charging, appeared
+				Main_Data::game_variables->Set(information_identifier, battler->GetBattlePosition().x);
+				Main_Data::game_variables->Set(information_identifier + 1, battler->GetBattlePosition().y);
+				Main_Data::game_variables->Set(information_identifier + 2, battler->CanAct());
+				Main_Data::game_variables->Set(information_identifier + 3, battler->IsDefending());
+				Main_Data::game_variables->Set(information_identifier + 4, battler->IsCharged());
+				Main_Data::game_variables->Set(information_identifier + 5, !battler->IsHidden());
+				break;
+		}
+	};
+
+	auto executeOperationMany = [information_flags](Game_Battler* battler) {
+		switch (information_flags)
+		{
+			case 0:
+				// list of members
+				return true;
+			case 1:
+				// list of members alive
+				return !battler->IsDead();
+			case 2:
+				// list of members who can move
+				return battler->CanAct();
+		}
+
+		return false;
+	};
+
+	switch (target_flags) {
+		case 0:
+			// actor
+			if (target_id > 0) {
+				executeOperationSingle(Main_Data::game_actors->GetActor(target_id), Actor);
+			}
+			break;
+		case 1:
+			// party member
+			executeOperationSingle(Main_Data::game_party->GetActor(target_id), Member);
+			break;
+		case 2:
+		{
+			// entire party
+			auto count = 0;
+			for (Game_Battler* member : Main_Data::game_party->GetActors()) {
+				count += executeOperationMany(member);
+			}
+			Main_Data::game_variables->Set(information_identifier, count);
+			break;
+		}
+		case 3:
+			// troop member
+			if (target_id > 0) {
+				executeOperationSingle(Main_Data::game_enemyparty->GetEnemy(target_id), Enemy);
+			}
+			break;
+		case 4:
+		{
+			// entire troop
+			auto count = 0;
+			for (Game_Battler* member : Main_Data::game_enemyparty->GetEnemies()) {
+				count += executeOperationMany(member);
+			}
+			Main_Data::game_variables->Set(information_identifier, count);
+			break;
+		}
+	}
+
 	return true;
 }
 

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -767,7 +767,7 @@ bool Game_Interpreter_Battle::CommandManiacGetBattleInfo(lcf::rpg::EventCommand 
 				Main_Data::game_variables->Set(information_identifier, states);
 				for (size_t i = 0; i < states; i++)
 				{
-					Main_Data::game_variables->Set(information_identifier + i + 1, battler->HasState(lcf::Data::states.at(i).ID));
+					Main_Data::game_variables->Set(information_identifier + i + 1, battler->HasState(lcf::Data::states[i].ID));
 				}
 				break;
 			}
@@ -778,9 +778,8 @@ bool Game_Interpreter_Battle::CommandManiacGetBattleInfo(lcf::rpg::EventCommand 
 				Main_Data::game_variables->Set(information_identifier, elements);
 				for (size_t i = 0; i < elements; i++)
 				{
-					Main_Data::game_variables->Set(information_identifier + i + 1, battler->GetAttributeRateShift(lcf::Data::attributes.at(i).ID) + 1);
+					Main_Data::game_variables->Set(information_identifier + i + 1, battler->GetAttributeRateShift(lcf::Data::attributes[i].ID) + 1);
 				}
-				break;
 				break;
 			}
 			case 3:


### PR DESCRIPTION
When we use the Maniacs GetBattleInfo command with settings like these:
![image](https://github.com/user-attachments/assets/4b10d5fd-0749-4d0c-8c6e-f7f8da329f18)

And we setup our event to display to a picture command like this:
![image](https://github.com/user-attachments/assets/2ddcf8db-097e-42d5-8c33-e986d9c4d603)

We get the exact same result in EasyRPG as we do in the Maniacs Exe:
![image](https://github.com/user-attachments/assets/bd0541a7-94eb-43b5-bf75-29281f0b9bc5)

All combination of event commands were thoroughly tested with different combinations, including:

- Target Types: Actor ID, Party Member, Entire Party, Enemy, Entire Enemy.
- Information Types: Parameter Buffs, States, Elements, Others
- Also tested with variables that are outside the defined range: this seems without error in both EasyRPG and Maniacs (surprisingly)