### PR TITLE
String Variables: Operate on Codepoints

### DIFF
--- a/src/game_interpreter_shared.cpp
+++ b/src/game_interpreter_shared.cpp
@@ -166,7 +166,7 @@ StringView Game_Interpreter_Shared::CommandStringOrVariable(lcf::rpg::EventComma
 	assert(mode_idx != val_idx);
 
 	if (static_cast<int>(com.parameters.size()) > std::max(mode_idx, val_idx)) {
-		return game_strings->GetWithMode(ToString(com.string), com.parameters[mode_idx], com.parameters[val_idx], *game_variables);
+		return game_strings->GetWithMode(com.string, com.parameters[mode_idx], com.parameters[val_idx], *game_variables);
 	}
 
 	return com.string;
@@ -181,7 +181,7 @@ StringView Game_Interpreter_Shared::CommandStringOrVariableBitfield(lcf::rpg::Ev
 
 	if (static_cast<int>(com.parameters.size()) >= std::max(mode_idx, val_idx) + 1) {
 		int mode = com.parameters[mode_idx];
-		return game_strings->GetWithMode(ToString(com.string), (mode & (0xF << shift * 4)) >> shift * 4, com.parameters[val_idx], *game_variables);
+		return game_strings->GetWithMode(com.string, (mode & (0xF << shift * 4)) >> shift * 4, com.parameters[val_idx], *game_variables);
 	}
 
 	return com.string;

--- a/src/game_strings.cpp
+++ b/src/game_strings.cpp
@@ -92,20 +92,22 @@ int Game_Strings::ToNum(Str_Params params, int var_id, Game_Variables& variables
 		num = static_cast<int>(std::strtol(it->second.c_str(), nullptr, 0));
 
 	variables.Set(var_id, num);
-	Game_Map::SetNeedRefresh(true);
+
+	Game_Map::SetNeedRefreshForVarChange(var_id);
+
 	return num;
 }
 
 int Game_Strings::GetLen(Str_Params params, int var_id, Game_Variables& variables) const {
-	// Note: The length differs between Maniac and EasyRPG due to different internal encoding (utf-8 vs. ansi)
-
 	if (params.string_id <= 0) {
 		return -1;
 	}
 
-	int len = Get(params.string_id).length();
+	int len = Utils::UTF8Length(Get(params.string_id));
 	variables.Set(var_id, len);
-	Game_Map::SetNeedRefresh(true);
+
+	Game_Map::SetNeedRefreshForVarChange(var_id);
+
 	return len;
 }
 
@@ -118,9 +120,14 @@ int Game_Strings::InStr(Str_Params params, std::string search, int var_id, int b
 		search = Extract(search, params.hex);
 	}
 
-	int index = Get(params.string_id).find(search, begin);
+	auto search32 = Utils::DecodeUTF32(search);
+	auto string32 = Utils::DecodeUTF32(Get(params.string_id));
+
+	int index = string32.find(search32, begin);
 	variables.Set(var_id, index);
-	Game_Map::SetNeedRefresh(true);
+
+	Game_Map::SetNeedRefreshForVarChange(var_id);
+
 	return index;
 }
 
@@ -161,6 +168,7 @@ int Game_Strings::Split(Str_Params params, const std::string& delimiter, int str
 		if (str.find(delimiter) == std::string::npos) {
 			// token not found
 		} else {
+			// This works for UTF-8
 			std::string token;
 			for (auto index = str.find(delimiter); index != std::string::npos; index = str.find(delimiter)) {
 				token = str.substr(0, index);
@@ -175,6 +183,9 @@ int Game_Strings::Split(Str_Params params, const std::string& delimiter, int str
 	// set the remaining string
 	Set(params, str);
 	variables.Set(var_id, components);
+
+	Game_Map::SetNeedRefreshForVarChange(var_id);
+
 	return components;
 }
 
@@ -277,24 +288,30 @@ StringView Game_Strings::PopLine(Str_Params params, int offset, int string_out_i
 }
 
 StringView Game_Strings::ExMatch(Str_Params params, std::string expr, int var_id, int begin, int string_out_id, Game_Variables& variables) {
+	// std::regex only works with char and wchar, not char32
+	// For full Unicode support requires the w-API, even on non-Windows systems
 	int var_result;
 	std::string str_result;
-	std::smatch match;
 
 	if (params.extract) {
 		expr = Extract(expr, params.hex);
 	}
 
-	std::string base = ToString(Get(params.string_id)).erase(0, begin);
-	std::regex r(expr);
+	std::string base = Substring(Get(params.string_id), begin);
 
-	std::regex_search(base, match, r);
+	std::wsmatch match;
+	auto wbase = Utils::ToWideString(base);
+	auto wexpr = Utils::ToWideString(expr);
+
+	std::wregex r(wexpr);
+
+	std::regex_search(wbase, match, r);
+	str_result = Utils::FromWideString(match.str());
 
 	var_result = match.position() + begin;
 	variables.Set(var_id, var_result);
-	Game_Map::SetNeedRefresh(true);
+	Game_Map::SetNeedRefreshForVarChange(var_id);
 
-	str_result = match.str();
 	if (string_out_id > 0) {
 		params.string_id = string_out_id;
 		Set(params, str_result);
@@ -337,8 +354,10 @@ const Game_Strings::Strings_t& Game_Strings::RangeOp(Str_Params params, int stri
 }
 
 std::string Game_Strings::PrependMin(StringView string, int min_size, char c) {
-	if (static_cast<int>(string.size()) < min_size) {
-		int s = min_size - string.size();
+	int len = Utils::UTF8Length(string);
+
+	if (len < min_size) {
+		int s = min_size - len;
 		return std::string(s, c) + ToString(string);
 	}
 	return ToString(string);
@@ -354,6 +373,69 @@ std::string Game_Strings::Extract(StringView string, bool as_hex) {
 	}
 
 	return PendingMessage::ApplyTextInsertingCommands(ToString(string), Player::escape_char, cmd_fn);
+}
+
+std::string Game_Strings::Substring(StringView source, int begin, int length) {
+	const char* iter = source.data();
+	const auto end = source.data() + source.size();
+
+	if (length == -1) {
+		length = Utils::UTF8Length(source) - begin;
+	}
+
+	// Points at start of the substring
+	auto left = Utils::UTF8Skip(iter, end, begin);
+
+	// Points at end of the substring
+	auto right = Utils::UTF8Skip(left.next, end, length);
+
+	if (right.next == nullptr) {
+		return std::string(left.next, end);
+	} else {
+		return std::string(left.next, right.next);
+	}
+}
+
+std::string Game_Strings::Insert(StringView source, StringView what, int where) {
+	const char* iter = source.data();
+	const auto end = source.data() + source.size();
+
+	// Points at insertion location
+	auto ret = Utils::UTF8Skip(iter, end, where);
+
+	return std::string(source.data(), ret.next) + ToString(what) + std::string(ret.next, end);
+}
+
+std::string Game_Strings::Erase(StringView source, int begin, int length) {
+	const char* iter = source.data();
+	const auto end = source.data() + source.size();
+
+	// Points at start of deletion
+	auto left = Utils::UTF8Skip(iter, end, begin);
+
+	// Points at end of deletion
+	auto right = Utils::UTF8Skip(left.next, end, length);
+
+	std::string ret = std::string(source.data(), left.next);
+	if (right.next != nullptr) {
+		ret += std::string(right.next, end);
+	}
+
+	return ret;
+}
+
+std::string Game_Strings::RegExReplace(StringView str, StringView search, StringView replace, std::regex_constants::match_flag_type flags) {
+	// std::regex only works with char and wchar, not char32
+	// For full Unicode support requires the w-API, even on non-Windows systems
+	auto wstr = Utils::ToWideString(str);
+	auto wsearch = Utils::ToWideString(search);
+	auto wreplace = Utils::ToWideString(replace);
+
+	std::wregex rexp(wsearch);
+
+	auto result = std::regex_replace(wstr, rexp, wreplace, flags);
+
+	return Utils::FromWideString(result);
 }
 
 std::optional<std::string> Game_Strings::ManiacsCommandInserter(char ch, const char** iter, const char* end, uint32_t escape_char) {

--- a/src/game_strings.h
+++ b/src/game_strings.h
@@ -93,10 +93,11 @@ public:
 
 	static std::string PrependMin(StringView string, int min_size, char c);
 	static std::string Extract(StringView string, bool as_hex);
-	static std::string Substring(StringView source, int begin, int length = -1);
+	static std::string Substring(StringView source, int begin, int length);
 	static std::string Insert(StringView source, StringView what, int where);
 	static std::string Erase(StringView source, int begin, int length);
 	static std::string RegExReplace(StringView str, StringView search, StringView replace, std::regex_constants::match_flag_type flags = std::regex_constants::match_default);
+	static int AdjustIndex(StringView str, int index);
 
 	static std::optional<std::string> ManiacsCommandInserter(char ch, const char** iter, const char* end, uint32_t escape_char);
 	static std::optional<std::string> ManiacsCommandInserterHex(char ch, const char** iter, const char* end, uint32_t escape_char);

--- a/src/maniac_patch.cpp
+++ b/src/maniac_patch.cpp
@@ -780,7 +780,7 @@ bool ManiacPatch::CheckString(StringView str_l, StringView str_r, int op, bool i
 }
 
 StringView ManiacPatch::GetLcfName(int data_type, int id, bool is_dynamic) {
-	auto get_name = [id](StringView type, const auto& vec) -> StringView {
+	auto get_name = [&id](StringView type, const auto& vec) -> StringView {
 		auto* data = lcf::ReaderUtil::GetElement(vec, id);
 		if (!data) {
 			Output::Warning("Unable to read {} name: {}", type, id);
@@ -833,7 +833,7 @@ StringView ManiacPatch::GetLcfName(int data_type, int id, bool is_dynamic) {
 		}
 		break;
 	}
-	case 18: //.member[a].name
+	case 18: //.member[a].name, index starts from 0
 	{
 		auto actor = Main_Data::game_party->GetActor(id);
 		if (actor != nullptr) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -424,8 +424,7 @@ Utils::TextRet Utils::TextNext(const char* iter, const char* end, char32_t escap
 	return ret;
 }
 
-#if _WIN32
-
+// Please report an issue when you get a compile error here because your toolchain is broken and lacks wchar_t
 template<size_t WideSize>
 static std::wstring ToWideStringImpl(StringView);
 #if __SIZEOF_WCHAR_T__ == 4 || __WCHAR_MAX__ > 0x10000
@@ -463,8 +462,6 @@ std::string FromWideStringImpl<2>(const std::wstring& str) {
 std::string Utils::FromWideString(const std::wstring& str) {
 	return FromWideStringImpl<sizeof(wchar_t)>(str);
 }
-
-#endif
 
 int Utils::PositiveModulo(int i, int m) {
 	return (i % m + m) % m;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -377,6 +377,36 @@ Utils::UtfNextResult Utils::UTF8Next(const char* iter, const char* const end) {
 	return { iter, 0 };
 }
 
+Utils::UtfNextResult Utils::UTF8Skip(const char* iter, const char* end, int skip) {
+	UtfNextResult ret;
+
+	if (skip == 0) {
+		ret = UTF8Next(iter, end);
+		return { iter, ret.ch };
+	}
+
+	for (int i = skip; iter < end && skip > 0; --skip) {
+		ret = UTF8Next(iter, end);
+		iter = ret.next;
+	}
+
+	return ret;
+}
+
+int Utils::UTF8Length(StringView str) {
+	size_t len = 0;
+
+	const char* iter = str.data();
+	const char* const e = str.data() + str.size();
+	while (iter < e) {
+		auto ret = Utils::UTF8Next(iter, e);
+		iter = ret.next;
+		++len;
+	}
+
+	return len;
+}
+
 Utils::ExFontRet Utils::ExFontNext(const char* iter, const char* end) {
 	ExFontRet ret;
 	if (end - iter >= 2 && *iter == '$') {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -610,6 +610,10 @@ uint32_t Utils::CRC32(std::istream& stream) {
 
 // via https://stackoverflow.com/q/3418231/
 std::string Utils::ReplaceAll(std::string str, const std::string& search, const std::string& replace) {
+	if (search.empty()) {
+		return str;
+	}
+
 	size_t start_pos = 0;
 	while((start_pos = str.find(search, start_pos)) != std::string::npos) {
 		str.replace(start_pos, search.length(), replace);

--- a/src/utils.h
+++ b/src/utils.h
@@ -127,9 +127,27 @@ namespace Utils {
 	 *
 	 * @param iter begginning of the range to convert from
 	 * @param end end of the range to convert from
-	 * @return the converted string.
+	 * @return iter to the next character and codepoint number
 	 */
 	UtfNextResult UTF8Next(const char* iter, const char* end);
+
+	/**
+	 * Like UTF8Next but skips "skip" characters.
+	 *
+	 * @param iter begginning of the range to convert from
+	 * @param end end of the range to convert from
+	 * @param skip how many characters to skip
+	 * @return iter to the next character and codepoint number
+	 */
+	UtfNextResult UTF8Skip(const char* iter, const char* end, int skip);
+
+	/**
+	 * Determines how many codepoints are in the passed string.
+	 *
+	 * @param str unicode string
+	 * @return amount of codepoints
+	 */
+	int UTF8Length(StringView str);
 
 	// Please report an issue when you get a compile error here because your toolchain is broken and lacks wchar_t
 	/**

--- a/src/utils.h
+++ b/src/utils.h
@@ -131,9 +131,7 @@ namespace Utils {
 	 */
 	UtfNextResult UTF8Next(const char* iter, const char* end);
 
-// Some platforms do not like UTF16
-#if _WIN32
-
+	// Please report an issue when you get a compile error here because your toolchain is broken and lacks wchar_t
 	/**
 	 * Converts UTF-8 string to std::wstring.
 	 *
@@ -149,8 +147,6 @@ namespace Utils {
 	 * @return the converted string.
 	 */
 	std::string FromWideString(const std::wstring& str);
-
-#endif
 
 	struct ExFontRet {
 		const char* next = nullptr;

--- a/tests/utf.cpp
+++ b/tests/utf.cpp
@@ -86,6 +86,29 @@ TEST_CASE("next") {
 	}
 }
 
+TEST_CASE("length") {
+	for (auto& ts: tests) {
+		REQUIRE_EQ(Utils::UTF8Length(ts.u8), ts.u32.length());
+	}
+}
+
+TEST_CASE("skip") {
+	auto test = tests[0];
+
+	// First 3 characters
+	auto res = Utils::UTF8Skip(test.u8.data(), test.u8.data() + test.u8.size(), 3);
+	REQUIRE_EQ(std::string((const char*)test.u8.data(), res.next), "κόσ");
+
+	// 2 - 4
+	auto beg = Utils::UTF8Skip(test.u8.data(), test.u8.data() + test.u8.size(), 1);
+	auto end = Utils::UTF8Skip(beg.next, test.u8.data() + test.u8.size(), 3);
+	REQUIRE_EQ(std::string(beg.next, end.next), "όσμ");
+
+	// 0 characters (return iter to start)
+	res = Utils::UTF8Skip(test.u8.data(), test.u8.data() + test.u8.size(), 0);
+	REQUIRE_EQ(res.ch, tests[0].u32[0]);
+}
+
 TEST_CASE("TextNext") {
 	std::string text = u8"H $A$B\\\\\\^\\n\nぽ";
 	const auto* iter = text.data();


### PR DESCRIPTION
Updated the test game by @enewey to use extended latin characters like é everywhere:

https://easyrpg.org/play/pr3303/?game=string-var

In UTF-8 they require 2 bytes and 1 codepoint.

Correct is using 1 codepoint here (which matches the legacy encoding = 1 byte)

For あ it is 3 bytes UTF-8 or 1 codepoint. When running in shift-jis RPG_RT seems to use a multibyte character so it also reports 1. There is no shift-jis case in the project but I tested this locally.

Sooo we are just extremely lucky here that it _just works_ even though our encoding is completely different :)