### PR TITLE
Partially implement Maniacs Command 3015: RewriteMap

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -4564,17 +4564,6 @@ bool Game_Interpreter::CommandManiacRewriteMap(lcf::rpg::EventCommand const& com
 
 	bool disable_autotile = com.parameters[8] != 0;
 
-	Output::Debug("RewriteMap | Mode: {}, SingleRange: {}, Layer: {}, IdOrArrayStart: {}, LeftEnd: {}, TopValue: {}, Width: {}, Height: {}, Autotile: {}",
-				  mode,
-				  is_replace_range,
-				  is_upper_layer,
-				  tile_index,
-				  x_start,
-				  y_start,
-				  width,
-				  height,
-				  disable_autotile);
-
 	Scene_Map* scene = (Scene_Map*)Scene::Find(Scene::Map).get();
 	if (!scene)
 		return true;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -4547,12 +4547,52 @@ bool Game_Interpreter::CommandManiacKeyInputProcEx(lcf::rpg::EventCommand const&
 	return true;
 }
 
-bool Game_Interpreter::CommandManiacRewriteMap(lcf::rpg::EventCommand const&) {
+bool Game_Interpreter::CommandManiacRewriteMap(lcf::rpg::EventCommand const& com) {
 	if (!Player::IsPatchManiac()) {
 		return true;
 	}
 
-	Output::Warning("Maniac Patch: Command RewriteMap not supported");
+	int mode = com.parameters[0];
+	bool is_replace_range = com.parameters[1] != 0;
+	bool is_upper_layer = com.parameters[2] != 0;
+
+	int tile_index = ValueOrVariableBitfield(mode, 0, com.parameters[3]);
+	int x_start = ValueOrVariableBitfield(mode, 1, com.parameters[4]);
+	int y_start = ValueOrVariableBitfield(mode, 2, com.parameters[5]);
+	int width = ValueOrVariableBitfield(mode, 3, com.parameters[6]);
+	int height = ValueOrVariableBitfield(mode, 4, com.parameters[7]);
+
+	bool disable_autotile = com.parameters[8] != 0;
+
+	Output::Debug("RewriteMap | Mode: {}, SingleRange: {}, Layer: {}, IdOrArrayStart: {}, LeftEnd: {}, TopValue: {}, Width: {}, Height: {}, Autotile: {}",
+				  mode,
+				  is_replace_range,
+				  is_upper_layer,
+				  tile_index,
+				  x_start,
+				  y_start,
+				  width,
+				  height,
+				  disable_autotile);
+
+	Scene_Map* scene = (Scene_Map*)Scene::Find(Scene::Map).get();
+	if (!scene)
+		return true;
+
+	if (is_upper_layer) {
+		for (auto y = y_start; y < y_start + height; ++y) {
+			for (auto x = x_start; x < x_start + width; ++x) {
+				scene->spriteset->ReplaceUpAt(x, y, tile_index);
+			}
+		}
+	} else {
+		for (auto y = y_start; y < y_start + height; ++y) {
+			for (auto x = x_start; x < x_start + width; ++x) {
+				scene->spriteset->ReplaceDownAt(x, y, tile_index, disable_autotile);
+			}
+		}
+	}
+
 	return true;
 }
 

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1879,17 +1879,10 @@ int Game_Map::SubstituteUp(int old_id, int new_id) {
 	return DoSubstitute(map_info.upper_tiles, old_id, new_id);
 }
 
-static void DoReplaceAt(std::vector<int16_t>& layer, int x, int y, int new_id, int map_width) {
-	auto pos = x + y * map_width;
-	layer[pos] = static_cast<int16_t>(new_id);
-}
-
-void Game_Map::ReplaceDownAt(int x, int y, int new_id) {
-	DoReplaceAt(map->lower_layer, x, y, new_id, map->width);
-}
-
-void Game_Map::ReplaceUpAt(int x, int y, int new_id) {
-	DoReplaceAt(map->upper_layer, x, y, new_id, map->width);
+void Game_Map::ReplaceTileAt(int x, int y, int new_id, int layer) {
+	auto pos = x + y * map->width;
+	auto& layer_vec = layer >= 1 ? map->upper_layer : map->lower_layer;
+	layer_vec[pos] = static_cast<int16_t>(new_id);
 }
 
 std::string Game_Map::ConstructMapName(int map_id, bool is_easyrpg) {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1879,6 +1879,19 @@ int Game_Map::SubstituteUp(int old_id, int new_id) {
 	return DoSubstitute(map_info.upper_tiles, old_id, new_id);
 }
 
+static void DoReplaceAt(std::vector<int16_t>& layer, int x, int y, int new_id, int map_width) {
+	auto pos = x + y * map_width;
+	layer[pos] = static_cast<int16_t>(new_id);
+}
+
+void Game_Map::ReplaceDownAt(int x, int y, int new_id) {
+	DoReplaceAt(map->lower_layer, x, y, new_id, map->width);
+}
+
+void Game_Map::ReplaceUpAt(int x, int y, int new_id) {
+	DoReplaceAt(map->upper_layer, x, y, new_id, map->width);
+}
+
 std::string Game_Map::ConstructMapName(int map_id, bool is_easyrpg) {
 	std::stringstream ss;
 	ss << "Map" << std::setfill('0') << std::setw(4) << map_id;

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -641,8 +641,7 @@ namespace Game_Map {
 	Game_Vehicle* GetVehicle(Game_Vehicle::Type which);
 	int SubstituteDown(int old_id, int new_id);
 	int SubstituteUp(int old_id, int new_id);
-	void ReplaceDownAt(int x, int y, int new_id);
-	void ReplaceUpAt(int x, int y, int new_id);
+	void ReplaceTileAt(int x, int y, int new_id, int layer);
 
 	/**
 	 * Checks if its possible to step onto the tile at (x,y)

--- a/src/game_map.h
+++ b/src/game_map.h
@@ -641,6 +641,8 @@ namespace Game_Map {
 	Game_Vehicle* GetVehicle(Game_Vehicle::Type which);
 	int SubstituteDown(int old_id, int new_id);
 	int SubstituteUp(int old_id, int new_id);
+	void ReplaceDownAt(int x, int y, int new_id);
+	void ReplaceUpAt(int x, int y, int new_id);
 
 	/**
 	 * Checks if its possible to step onto the tile at (x,y)

--- a/src/map_data.h
+++ b/src/map_data.h
@@ -59,6 +59,17 @@ static constexpr int NUM_LOWER_TILES = BLOCK_F_INDEX;
 static constexpr int NUM_UPPER_TILES = BLOCK_F_TILES;
 static constexpr int NUM_TILES = NUM_LOWER_TILES + NUM_UPPER_TILES;
 
+// Bit positions for neighbors
+static constexpr uint8_t NEIGHBOR_NW = 0x80; // 0b10000000
+static constexpr uint8_t NEIGHBOR_N  = 0x40; // 0b01000000
+static constexpr uint8_t NEIGHBOR_NE = 0x20; // 0b00100000
+static constexpr uint8_t NEIGHBOR_W  = 0x10; // 0b00010000
+static constexpr uint8_t NEIGHBOR_E  = 0x08; // 0b00001000
+static constexpr uint8_t NEIGHBOR_SW = 0x04; // 0b00000100
+static constexpr uint8_t NEIGHBOR_S  = 0x02; // 0b00000010
+static constexpr uint8_t NEIGHBOR_SE = 0x01; // 0b00000001
+
+
 /** Passability flags. */
 namespace Passable {
 	enum Passable {

--- a/src/map_data.h
+++ b/src/map_data.h
@@ -94,4 +94,26 @@ inline int ChipIdToIndex(int chip_id) {
 	return 0;
 }
 
+inline int IndexToChipId(int index) {
+	if (index >= BLOCK_A_INDEX && index < BLOCK_B_INDEX) {
+		return BLOCK_A + (index - BLOCK_A_INDEX) * BLOCK_A_STRIDE;
+	}
+	else if (index >= BLOCK_B_INDEX && index < BLOCK_C_INDEX) {
+		return BLOCK_B + (index - BLOCK_B_INDEX) * BLOCK_B_STRIDE;
+	}
+	else if (index >= BLOCK_C_INDEX && index < BLOCK_D_INDEX) {
+		return BLOCK_C + (index - BLOCK_C_INDEX) * BLOCK_C_STRIDE;
+	}
+	else if (index >= BLOCK_D_INDEX && index < BLOCK_E_INDEX) {
+		return BLOCK_D + (index - BLOCK_D_INDEX) * BLOCK_D_STRIDE;
+	}
+	else if (index >= BLOCK_E_INDEX && index < BLOCK_F_INDEX) {
+		return BLOCK_E + (index - BLOCK_E_INDEX) * BLOCK_E_STRIDE;
+	}
+	else if (index >= BLOCK_F_INDEX) {
+		return BLOCK_F + (index - BLOCK_F_INDEX) * BLOCK_F_STRIDE;
+	}
+	return 0;
+}
+
 #endif

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -30,6 +30,7 @@
 #include "bitmap.h"
 #include "player.h"
 #include "drawable_list.h"
+#include "map_data.h"
 
 Spriteset_Map::Spriteset_Map() {
 	panorama = std::make_unique<Plane>();
@@ -171,6 +172,18 @@ void Spriteset_Map::SubstituteUp(int old_id, int new_id) {
 	if (num_subst) {
 		tilemap->OnSubstituteUp();
 	}
+}
+
+void Spriteset_Map::ReplaceDownAt(int x, int y, int tile_index, bool disable_autotile) {
+	auto tile_id = IndexToChipId(tile_index);
+	Game_Map::ReplaceDownAt(x, y, tile_id);
+	tilemap->SetMapTileDataDownAt(x, y, tile_id, disable_autotile);
+}
+
+void Spriteset_Map::ReplaceUpAt(int x, int y, int tile_index) {
+	auto tile_id = IndexToChipId(tile_index);
+	Game_Map::ReplaceUpAt(x, y, tile_id);
+	tilemap->SetMapTileDataUpAt(x, y, tile_id);
 }
 
 bool Spriteset_Map::RequireClear(DrawableList& drawable_list) {

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -176,13 +176,11 @@ void Spriteset_Map::SubstituteUp(int old_id, int new_id) {
 
 void Spriteset_Map::ReplaceDownAt(int x, int y, int tile_index, bool disable_autotile) {
 	auto tile_id = IndexToChipId(tile_index);
-	Game_Map::ReplaceDownAt(x, y, tile_id);
 	tilemap->SetMapTileDataDownAt(x, y, tile_id, disable_autotile);
 }
 
 void Spriteset_Map::ReplaceUpAt(int x, int y, int tile_index) {
 	auto tile_id = IndexToChipId(tile_index);
-	Game_Map::ReplaceUpAt(x, y, tile_id);
 	tilemap->SetMapTileDataUpAt(x, y, tile_id);
 }
 

--- a/src/spriteset_map.h
+++ b/src/spriteset_map.h
@@ -72,6 +72,16 @@ public:
 	void SubstituteUp(int old_id, int new_id);
 
 	/**
+	 * Replaces a single tile in lower layer at the given coordinates.
+	 */
+	void ReplaceDownAt(int x, int y, int tile_index, bool disable_autotile);
+
+	/**
+	 * Replaces a single tile in upper layer at the given coordinates.
+	 */
+	void ReplaceUpAt(int x, int y, int tile_index);
+
+	/**
 	 * @return true if we should clear the screen before drawing the map
 	 */
 	bool RequireClear(DrawableList& drawable_list);

--- a/src/tilemap.h
+++ b/src/tilemap.h
@@ -36,9 +36,11 @@ public:
 
 	const std::vector<short>& GetMapDataDown() const;
 	void SetMapDataDown(std::vector<short> down);
+	void SetMapTileDataDownAt(int x, int y, int tile_id, bool disable_autotile);
 
 	const std::vector<short>& GetMapDataUp() const;
 	void SetMapDataUp(std::vector<short> up);
+	void SetMapTileDataUpAt(int x, int y, int tile_id);
 
 	const std::vector<unsigned char>& GetPassableUp() const;
 	void SetPassableUp(std::vector<unsigned char> up);
@@ -81,12 +83,20 @@ inline void Tilemap::SetMapDataDown(std::vector<short> down) {
 	layer_down.SetMapData(std::move(down));
 }
 
+inline void Tilemap::SetMapTileDataDownAt(int x, int y, int tile_id, bool disable_autotile) {
+	layer_down.SetMapTileDataAt(x, y, tile_id, disable_autotile);
+}
+
 inline const std::vector<short>& Tilemap::GetMapDataUp() const {
 	return layer_up.GetMapData();
 }
 
 inline void Tilemap::SetMapDataUp(std::vector<short> up) {
 	layer_up.SetMapData(std::move(up));
+}
+
+inline void Tilemap::SetMapTileDataUpAt(int x, int y, int tile_id) {
+	layer_down.SetMapTileDataAt(x, y, tile_id, true);
 }
 
 inline const std::vector<unsigned char>& Tilemap::GetPassableDown() const {

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -140,6 +140,59 @@ static constexpr uint8_t BlockD_Subtiles_IDS[50][2][2][2] = {
     {{{0, 0}, {0, 0}}, {{0, 0}, {0, 0}}}
 };
 
+// Set of neighboring autotiles -> autotile variant
+// Each neighbor is represented by a single bit (1 - same autotile, 0 - any other case)
+// The bits are ordered as follows (from most to least significant bit): NW N NE W E SW S SE
+static const std::unordered_map<uint8_t, int> AUTOTILE_VARIANTS_MAP = {
+	{0b11111111, 0},
+	{0b01111111, 1},
+	{0b11011111, 2},
+	{0b01011111, 3},
+	{0b11111110, 4},
+	{0b01111110, 5},
+	{0b11011110, 6},
+	{0b01011110, 7},
+	{0b11111011, 8},
+	{0b01111011, 9},
+	{0b11011011, 10},
+	{0b01011011, 11},
+	{0b11111010, 12},
+	{0b01111010, 13},
+	{0b11011010, 14},
+	{0b01011010, 15},
+	{0b01101011, 16},
+	{0b01001011, 17},
+	{0b01101010, 18},
+	{0b01001010, 19},
+	{0b00011111, 20},
+	{0b00011110, 21},
+	{0b00011011, 22},
+	{0b00011010, 23},
+	{0b11010110, 24},
+	{0b11010010, 25},
+	{0b01010110, 26},
+	{0b01010010, 27},
+	{0b11111000, 28},
+	{0b01111000, 29},
+	{0b11011000, 30},
+	{0b01011000, 31},
+	{0b01000010, 32},
+	{0b00011000, 33},
+	{0b00001011, 34},
+	{0b00001010, 35},
+	{0b00010110, 36},
+	{0b00010010, 37},
+	{0b11010000, 38},
+	{0b01010000, 39},
+	{0b01101000, 40},
+	{0b01001000, 41},
+	{0b00000010, 42},
+	{0b00001000, 43},
+	{0b01000000, 44},
+	{0b00010000, 45},
+	{0b00000000, 46}
+};
+
 TilemapLayer::TilemapLayer(int ilayer) :
 	substitutions(Game_Map::GetTilesLayer(ilayer)),
 	layer(ilayer),

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -742,7 +742,14 @@ void TilemapLayer::SetMapTileDataAt(int x, int y, int tile_id, bool disable_auto
 				{-1,  1}, { 0,  1}, { 1,  1}
 		};
 
-		RecalculateAutotile(x, y, tile_id);
+		// TODO: make it work for AB autotiles
+		if (IsAutotileAB(tile_id)) {
+			RecreateTileDataAt(x, y, tile_id);
+			Output::Warning("Maniac Patch: Command RewriteMap is only partially supported.");
+		} else {
+			RecalculateAutotile(x, y, tile_id);
+		}
+
 		for (const auto& adj : adjacent) {
 			auto nx = x + adj.dx;
 			auto ny = y + adj.dy;

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -745,7 +745,7 @@ void TilemapLayer::SetMapTileDataAt(int x, int y, int tile_id, bool disable_auto
 		// TODO: make it work for AB autotiles
 		if (IsAutotileAB(tile_id)) {
 			RecreateTileDataAt(x, y, tile_id);
-			Output::Warning("Maniac Patch: Command RewriteMap is only partially supported.");
+			Output::Warning("Maniac Patch: Autotiles A and B in RewriteMap are only partially supported.");
 		} else {
 			RecalculateAutotile(x, y, tile_id);
 		}
@@ -795,7 +795,7 @@ static inline void ApplyCornerFixups(uint8_t& neighbors) {
 void TilemapLayer::RecalculateAutotile(int x, int y, int tile_id) {
 	// TODO: make it work for AB autotiles
 	if (IsAutotileAB(tile_id)) {
-		Output::Warning("Maniac Patch: Command RewriteMap is only partially supported.");
+		Output::Warning("Maniac Patch: Autotiles A and B in RewriteMap are only partially supported.");
 		return;
 	}
 

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -143,7 +143,7 @@ static constexpr uint8_t BlockD_Subtiles_IDS[50][2][2][2] = {
 // Set of neighboring autotiles -> autotile variant
 // Each neighbor is represented by a single bit (1 - same autotile, 0 - any other case)
 // The bits are ordered as follows (from most to least significant bit): NW N NE W E SW S SE
-static const std::unordered_map<uint8_t, int> AUTOTILE_VARIANTS_MAP = {
+static const std::unordered_map<uint8_t, int> AUTOTILE_D_VARIANTS_MAP = {
 	{0b11111111, 0},
 	{0b01111111, 1},
 	{0b11011111, 2},
@@ -814,7 +814,7 @@ void TilemapLayer::RecalculateAutotile(int x, int y, int tile_id) {
 	ApplyCornerFixups(neighbors);
 
 	// Recalculate tile id using the neighbors -> variant map
-	const int new_tile_id = BLOCK_D + block * BLOCK_D_STRIDE + AUTOTILE_VARIANTS_MAP.at(neighbors);
+	const int new_tile_id = BLOCK_D + block * BLOCK_D_STRIDE + AUTOTILE_D_VARIANTS_MAP.at(neighbors);
 	map_data[x + y * width] = static_cast<short>(new_tile_id);
 	Game_Map::ReplaceTileAt(x, y, new_tile_id, layer);
 	CreateTileCacheAt(x, y, tile_id);

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -121,6 +121,7 @@ private:
 	void GenerateAutotileD(short ID);
 	void DrawTile(Bitmap& dst, Bitmap& tile, Bitmap& tone_tile, int x, int y, int row, int col, uint32_t tone_hash, bool allow_fast_blit = true);
 	void DrawTileImpl(Bitmap& dst, Bitmap& tile, Bitmap& tone_tile, int x, int y, int row, int col, uint32_t tone_hash, ImageOpacity op, bool allow_fast_blit);
+	void RecalculateAutotile(int x, int y, int tile_id);
 
 	static const int TILES_PER_ROW = 64;
 
@@ -163,6 +164,8 @@ private:
 	TilemapSubLayer upper_layer;
 
 	Tone tone;
+
+	bool IsInMapBounds(int x, int y) const;
 };
 
 inline BitmapRef const& TilemapLayer::GetChipset() const {
@@ -261,5 +264,8 @@ inline TilemapLayer::TileData& TilemapLayer::GetDataCache(int x, int y) {
 	return data_cache_vec[x + y * width];
 }
 
+inline bool TilemapLayer::IsInMapBounds(int x, int y) const {
+	return x >= 0 && x < width && y >= 0 && y < height;
+}
 
 #endif

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -117,6 +117,7 @@ private:
 
 	void CreateTileCache(const std::vector<short>& nmap_data);
 	void CreateTileCacheAt(int x, int y, int tile_id);
+	void RecreateTileDataAt(int x, int y, int tile_id);
 	void GenerateAutotileAB(short ID, short animID);
 	void GenerateAutotileD(short ID);
 	void DrawTile(Bitmap& dst, Bitmap& tile, Bitmap& tone_tile, int x, int y, int row, int col, uint32_t tone_hash, bool allow_fast_blit = true);

--- a/src/tilemap_layer.h
+++ b/src/tilemap_layer.h
@@ -66,6 +66,7 @@ public:
 	void SetChipset(BitmapRef const& nchipset);
 	const std::vector<short>& GetMapData() const;
 	void SetMapData(std::vector<short> nmap_data);
+	void SetMapTileDataAt(int x, int y, int tile_id, bool disable_autotile);
 	const std::vector<unsigned char>& GetPassable() const;
 	void SetPassable(std::vector<unsigned char> npassable);
 	bool IsVisible() const;
@@ -115,6 +116,7 @@ private:
 	bool fast_blit = false;
 
 	void CreateTileCache(const std::vector<short>& nmap_data);
+	void CreateTileCacheAt(int x, int y, int tile_id);
 	void GenerateAutotileAB(short ID, short animID);
 	void GenerateAutotileD(short ID);
 	void DrawTile(Bitmap& dst, Bitmap& tile, Bitmap& tone_tile, int x, int y, int row, int col, uint32_t tone_hash, bool allow_fast_blit = true);


### PR DESCRIPTION
This PR introduces the Rewrite Map command from Maniacs Patch that enables changing selected map tiles. Unlike the vanilla Change Tile command, which only replaces one tile ID with another, the Rewrite Map command offers greater flexibility in modifying tiles. Changes applied by the command do not persist between save and load.

The implementation covers most of the command’s functionality, with the exception of AB autotile sprite fixups. Despite this limitation, games will remain playable as intended.