### PR TITLE
Implement Maniacs Battle Common Events

### DIFF
--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -411,6 +411,7 @@ inline void Game_Interpreter::Push(Game_Event* ev, const lcf::rpg::EventPage* pa
 template<InterpreterExecutionType type_ex>
 inline void Game_Interpreter::Push(Game_CommonEvent* ev) {
 	static_assert(type_ex == InterpreterExecutionType::AutoStart || type_ex == InterpreterExecutionType::Parallel
+		|| type_ex == InterpreterExecutionType::BattleStart || type_ex == InterpreterExecutionType::BattleParallel
 		|| type_ex == InterpreterExecutionType::Call || type_ex == InterpreterExecutionType::DeathHandler
 		|| type_ex == InterpreterExecutionType::DebugCall || type_ex == InterpreterExecutionType::ManiacHook, "Unexpected ExecutionType for CommonEvent"
 	);

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -979,7 +979,7 @@ void Scene_Battle_Rpg2k3::vUpdate() {
 			if (!parallel_interpreter.IsRunning()) {
 				for (auto common_event : battle_parallel_events)
 				{
-					parallel_interpreter.Push<InterpreterExecutionType::Parallel>(common_event);
+					parallel_interpreter.Push<InterpreterExecutionType::BattleParallel>(common_event);
 				}
 			}
 		}
@@ -1132,7 +1132,7 @@ void Scene_Battle_Rpg2k3::CallBattleBeginCommonEvents() {
 			if (data_common_event.trigger == data_common_event.Trigger_maniac_battle_start) {
 				Game_CommonEvent* common_event = lcf::ReaderUtil::GetElement(Game_Map::GetCommonEvents(), data_common_event.ID);
 
-				Game_Battle::GetInterpreterBattle().Push<InterpreterExecutionType::Parallel>(common_event);
+				Game_Battle::GetInterpreterBattle().Push<InterpreterExecutionType::BattleParallel>(common_event);
 			}
 			else if (data_common_event.trigger == data_common_event.Trigger_maniac_battle_parallel) {
 				Game_CommonEvent* common_event = lcf::ReaderUtil::GetElement(Game_Map::GetCommonEvents(), data_common_event.ID);

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -34,11 +34,13 @@
 #include "game_party.h"
 #include "game_enemy.h"
 #include "game_enemyparty.h"
+#include "game_map.h"
 #include "game_message.h"
 #include "game_battle.h"
 #include "game_interpreter_battle.h"
 #include "game_battlealgorithm.h"
 #include "game_screen.h"
+#include "game_switches.h"
 #include <lcf/reader_util.h>
 #include "scene_gameover.h"
 #include "utils.h"
@@ -972,6 +974,16 @@ void Scene_Battle_Rpg2k3::vUpdate() {
 			break;
 		}
 
+		if (state != State_Victory && state != State_Defeat) {
+			parallel_interpreter.Update();
+			if (!parallel_interpreter.IsRunning()) {
+				for (auto common_event : battle_parallel_events)
+				{
+					parallel_interpreter.Push(common_event);
+				}
+			}
+		}
+
 		// this is checked separately because we want normal events to be processed
 		// just not sub-events called by maniacs battle hooks.
 		if (state != State_Victory && state != State_Defeat && Game_Battle::ManiacProcessSubEvents()) {
@@ -1114,6 +1126,23 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneAction()
 	return SceneActionReturn::eWaitTillNextFrame;
 }
 
+void Scene_Battle_Rpg2k3::CallBattleBeginCommonEvents() {
+	for (auto data_common_event : lcf::Data::commonevents) {
+		if ((!data_common_event.switch_flag || Main_Data::game_switches->Get(data_common_event.switch_id))) {
+			if (data_common_event.trigger == data_common_event.Trigger_battle_begin) {
+				Game_CommonEvent* common_event = lcf::ReaderUtil::GetElement(Game_Map::GetCommonEvents(), data_common_event.ID);
+
+				Game_Battle::GetInterpreterBattle().Push(common_event);
+			}
+			else if (data_common_event.trigger == data_common_event.Trigger_battle_parallel) {
+				Game_CommonEvent* common_event = lcf::ReaderUtil::GetElement(Game_Map::GetCommonEvents(), data_common_event.ID);
+
+				battle_parallel_events.push_back(common_event);
+			}
+		}
+	}
+}
+
 Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionStart() {
 	enum SubState {
 		eStartMessage,
@@ -1153,6 +1182,7 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionSt
 		EndNotification();
 		UpdateEnemiesDirection();
 		UpdateActorsDirection();
+		CallBattleBeginCommonEvents();
 		SetSceneActionSubState(eUpdateEvents);
 		return SceneActionReturn::eContinueThisFrame;
 	}

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -979,7 +979,7 @@ void Scene_Battle_Rpg2k3::vUpdate() {
 			if (!parallel_interpreter.IsRunning()) {
 				for (auto common_event : battle_parallel_events)
 				{
-					parallel_interpreter.Push(common_event);
+					parallel_interpreter.Push<InterpreterExecutionType::Parallel>(common_event);
 				}
 			}
 		}
@@ -1129,12 +1129,12 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneAction()
 void Scene_Battle_Rpg2k3::CallBattleBeginCommonEvents() {
 	for (auto data_common_event : lcf::Data::commonevents) {
 		if ((!data_common_event.switch_flag || Main_Data::game_switches->Get(data_common_event.switch_id))) {
-			if (data_common_event.trigger == data_common_event.Trigger_battle_begin) {
+			if (data_common_event.trigger == data_common_event.Trigger_maniac_battle_start) {
 				Game_CommonEvent* common_event = lcf::ReaderUtil::GetElement(Game_Map::GetCommonEvents(), data_common_event.ID);
 
-				Game_Battle::GetInterpreterBattle().Push(common_event);
+				Game_Battle::GetInterpreterBattle().Push<InterpreterExecutionType::Parallel>(common_event);
 			}
-			else if (data_common_event.trigger == data_common_event.Trigger_battle_parallel) {
+			else if (data_common_event.trigger == data_common_event.Trigger_maniac_battle_parallel) {
 				Game_CommonEvent* common_event = lcf::ReaderUtil::GetElement(Game_Map::GetCommonEvents(), data_common_event.ID);
 
 				battle_parallel_events.push_back(common_event);

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -164,6 +164,8 @@ protected:
 	void SetSceneActionSubState(int substate);
 	void ReturnToMainBattleState();
 
+	void CallBattleBeginCommonEvents();
+
 	// SceneAction State Machine Driver
 	SceneActionReturn ProcessSceneAction();
 
@@ -260,6 +262,9 @@ protected:
 	int GetNextReadyActor();
 
 	std::vector<int> atb_order;
+
+	std::vector<Game_CommonEvent*> battle_parallel_events;
+	Game_Interpreter_Battle parallel_interpreter;
 };
 
 #endif


### PR DESCRIPTION
When using maniacs patch and we have a "Battle Begin" trigger set in the editor like this:
![image](https://github.com/user-attachments/assets/4f826401-4933-405f-b020-9b1c0981d9fb)

In battle we now have it get triggered like this:
![image](https://github.com/user-attachments/assets/3817ccfc-6b4d-4878-b9bb-516dd600bce7)

When we use a "Battle (Parallel)" trigger in the editor like this:
![image](https://github.com/user-attachments/assets/a1991dd8-131c-4c47-9e8a-af5a24776a4e)

In battle it will result in a repeated common event getting triggered every 5 seconds (since that is what my wait time it set to in the above image) like this:
![EasyRPG-ManiacsBattleCommonEvents](https://github.com/user-attachments/assets/3adf43db-db32-461a-8e62-077f284f1eb8)
