### PR TITLE
Erase Event - Erase By ID + Recreate Event Option (Maniac Patch Feature)

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -3850,11 +3850,21 @@ bool Game_Interpreter::CommandEndLoop(lcf::rpg::EventCommand const& com) { // co
 	return true;
 }
 
-bool Game_Interpreter::CommandEraseEvent(lcf::rpg::EventCommand const& /* com */) { // code 12320
+bool Game_Interpreter::CommandEraseEvent(lcf::rpg::EventCommand const& com) { // code 12320
+	int event_id = 0; // default rm values
+	bool is_active = 0; // In Vanilla RM event is always itself and it always becomes inactive
+
+	if (Player::IsPatchManiac()) {
+		event_id = ValueOrVariableBitfield(com.parameters[0], 1, com.parameters[2]);
+		is_active = com.parameters[1];
+	}
+
 	auto& frame = GetFrame();
 	auto& index = frame.current_command;
 
-	auto event_id = GetThisEventId();
+	if (event_id == 0) {
+		event_id = GetThisEventId();
+	}
 
 	// When a common event and not RPG2k3E engine ignore the call, otherwise
 	// operate on last map_event
@@ -3863,7 +3873,7 @@ bool Game_Interpreter::CommandEraseEvent(lcf::rpg::EventCommand const& /* com */
 
 	Game_Event* evnt = Game_Map::GetEvent(event_id);
 	if (evnt) {
-		evnt->SetActive(false);
+		evnt->SetActive(is_active);
 
 		// Parallel map events shall stop immediately
 		if (!main_flag) {

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -3854,7 +3854,7 @@ bool Game_Interpreter::CommandEraseEvent(lcf::rpg::EventCommand const& com) { //
 	int event_id = 0; // default rm values
 	bool is_active = 0; // In Vanilla RM event is always itself and it always becomes inactive
 
-	if (Player::IsPatchManiac()) {
+	if (Player::IsPatchManiac() && com.parameters.size() >= 3) {
 		event_id = ValueOrVariableBitfield(com.parameters[0], 1, com.parameters[2]);
 		is_active = com.parameters[1];
 	}


### PR DESCRIPTION
Another smaller update:
Events can be disabled and enabled again through maniacs patch.
 It also allows targeting an event by ID instead of only erasing the caller itself.

```js
//TPC SYNTAX

@ev[2].erase
@wait .input
v[1] = 2
@ev[ v[1] ].return
```