### PR TITLE
Android: Add game label configuration, rename buttons to X/Z

### DIFF
--- a/builds/android/app/src/gamebrowser/org_easyrpg_player_game_browser.cpp
+++ b/builds/android/app/src/gamebrowser/org_easyrpg_player_game_browser.cpp
@@ -364,6 +364,11 @@ Java_org_easyrpg_player_game_1browser_GameScanner_findGames(JNIEnv *env, jclass,
 			env->CallVoidMethod(jgame_object, jset_title_method, jtitle);
 		}
 
+		// Set folder name
+		jstring jfolder = env->NewStringUTF(game_dir_name.c_str());
+		jmethodID jset_folder_name_method = env->GetMethodID(jgame_class, "setGameFolderName", "(Ljava/lang/String;)V");
+		env->CallVoidMethod(jgame_object, jset_folder_name_method, jfolder);
+
 		env->SetObjectArrayElement(jgame_array, i, jgame_object);
 	}
 

--- a/builds/android/app/src/gamebrowser/org_easyrpg_player_game_browser.cpp
+++ b/builds/android/app/src/gamebrowser/org_easyrpg_player_game_browser.cpp
@@ -402,11 +402,6 @@ Java_org_easyrpg_player_game_1browser_Game_reencodeTitle(JNIEnv *env, jobject th
 	if (encoding == "auto") {
 		auto det_encodings = lcf::ReaderUtil::DetectEncodings(title);
 		for (auto &det_enc: det_encodings) {
-			if (det_enc == "UTF-16BE" || det_enc == "UTF-16LE") {
-				// Skip obviously wrong title encodings
-				continue;
-			}
-
 			if (lcf::Encoder encoder(det_enc); encoder.IsOk()) {
 				encoder.Encode(title);
 				break;

--- a/builds/android/app/src/main/java/org/easyrpg/player/button_mapping/VirtualButton.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/button_mapping/VirtualButton.java
@@ -205,9 +205,17 @@ public class VirtualButton extends View {
         char charButton;
 
         if (keyCode == ENTER) {
-            charButton = 'A';
+            if (SettingsManager.getShowZXasAB()) {
+                charButton = 'A';
+            } else {
+                charButton = 'Z';
+            }
         } else if (keyCode == CANCEL) {
-            charButton = 'B';
+            if (SettingsManager.getShowZXasAB()) {
+                charButton = 'B';
+            } else {
+                charButton = 'X';
+            }
         } else if (keyCode == SHIFT) {
             charButton = 'S';
         } else if (keyCode == KEY_0) {

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
@@ -131,7 +131,10 @@ public class GameBrowserActivity extends AppCompatActivity
         // as you specify a parent activity in AndroidManifest.xml.
         int id = item.getItemId();
 
-        if (id == R.id.refresh) {
+        if (id == R.id.view) {
+            openView();
+            return true;
+        } else if (id == R.id.refresh) {
             scanGamesAndDisplayResult(true);
             return true;
         } else if (id == R.id.menu) {
@@ -159,6 +162,26 @@ public class GameBrowserActivity extends AppCompatActivity
         DrawerLayout drawer = findViewById(R.id.drawer_layout);
         drawer.closeDrawer(GravityCompat.START);
         return true;
+    }
+
+    public void openView() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+
+        String[] choices_list = {
+            this.getResources().getString(R.string.view_show_game_title),
+            this.getResources().getString(R.string.view_show_game_folder)
+        };
+
+        builder
+            .setTitle(R.string.view_show_title_desc)
+            .setSingleChoiceItems(choices_list, SettingsManager.getGameBrowserLabelMode(), null)
+            .setPositiveButton(R.string.ok, (dialog, id) -> {
+                int selectedPosition = ((AlertDialog) dialog).getListView().getCheckedItemPosition();
+                SettingsManager.setGameBrowserLabelMode(selectedPosition);
+                displayGamesList();
+            })
+            .setNegativeButton(R.string.cancel, null);
+        builder.show();
     }
 
     public void scanGamesAndDisplayResult(boolean forceScan) {
@@ -307,7 +330,7 @@ public class GameBrowserActivity extends AppCompatActivity
             final Game game = gameList.get(position);
 
             // Title
-            holder.title.setText(game.getTitle());
+            holder.title.setText(game.getDisplayTitle());
             holder.title.setOnClickListener(v -> launchGame(position, false));
 
             // TitleScreen Image
@@ -391,7 +414,7 @@ public class GameBrowserActivity extends AppCompatActivity
 
                     if (!selectedEncoding.equals(encoding)) {
                         game.setEncoding(selectedEncoding);
-                        holder.title.setText(game.getTitle());
+                        holder.title.setText(game.getDisplayTitle());
                     }
                 })
                 .setNegativeButton(R.string.cancel, null);
@@ -411,12 +434,12 @@ public class GameBrowserActivity extends AppCompatActivity
                 .setTitle(R.string.game_rename)
                 .setPositiveButton(R.string.ok, (dialog, id) -> {
                     game.setCustomTitle(input.getText().toString());
-                    holder.title.setText(game.getTitle());
+                    holder.title.setText(game.getDisplayTitle());
                 })
                 .setNegativeButton(R.string.cancel, null)
                 .setNeutralButton(R.string.revert, (dialog, id) -> {
                     game.setCustomTitle("");
-                    holder.title.setText(game.getTitle());
+                    holder.title.setText(game.getDisplayTitle());
                 });
             builder.show();
         }

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsEnum.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsEnum.java
@@ -29,6 +29,7 @@ enum SettingsEnum {
     FONT1_SIZE("Font1Size"),
     FONT2_SIZE("Font2Size"),
     GAME_BROWSER_LABEL_MODE("GAME_BROWSER_LABEL_MODE"),
+    SHOW_ZX_AS_AB("SHOW_ZX_AS_AB")
     ;
 
 

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsEnum.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsEnum.java
@@ -27,8 +27,8 @@ enum SettingsEnum {
     FONT1_URI("Font1"),
     FONT2_URI("Font2"),
     FONT1_SIZE("Font1Size"),
-    FONT2_SIZE("Font2Size")
-
+    FONT2_SIZE("Font2Size"),
+    GAME_BROWSER_LABEL_MODE("GAME_BROWSER_LABEL_MODE"),
     ;
 
 

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsInputActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsInputActivity.java
@@ -37,6 +37,10 @@ public class SettingsInputActivity extends AppCompatActivity implements View.OnC
         enableVibrateWhenSlidingCheckbox.setChecked(SettingsManager.isVibrateWhenSlidingDirectionEnabled());
         enableVibrateWhenSlidingCheckbox.setOnClickListener(this);
 
+        CheckBox showZXasABcheckbox = findViewById(R.id.settings_show_zx_as_ab);
+        showZXasABcheckbox.setChecked(SettingsManager.getShowZXasAB());
+        showZXasABcheckbox.setOnClickListener(this);
+
         configureFastForwardButton();
         configureLayoutTransparencySystem();
         configureLayoutSizeSystem();
@@ -57,6 +61,8 @@ public class SettingsInputActivity extends AppCompatActivity implements View.OnC
             enableVibrateWhenSlidingCheckbox.setEnabled(c.isChecked());
         } else if (id == R.id.settings_vibrate_when_sliding){
             SettingsManager.setVibrateWhenSlidingDirectionEnabled(((CheckBox) v).isChecked());
+        } else if (id == R.id.settings_show_zx_as_ab) {
+            SettingsManager.setShowZXasAB(((CheckBox)v).isChecked());
         }
     }
 

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsManager.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsManager.java
@@ -51,6 +51,7 @@ public class SettingsManager {
         FONTS_FOLDER_NAME = "fonts";
     public static int FAST_FORWARD_MODE_HOLD = 0, FAST_FORWARD_MODE_TAP = 1;
     private static int gameBrowserLabelMode = 0;
+    private static boolean showZXasAB = false;
 
     private static List<String> imageSizeOption = Arrays.asList("nearest", "integer", "bilinear");
     private static List<String> gameResolutionOption = Arrays.asList("original", "widescreen", "ultrawide");
@@ -105,6 +106,8 @@ public class SettingsManager {
         }
 
         gameBrowserLabelMode = sharedPref.getInt(GAME_BROWSER_LABEL_MODE.toString(), 0);
+
+        showZXasAB = sharedPref.getBoolean(SHOW_ZX_AS_AB.toString(), false);
     }
 
     public static Set<String> getFavoriteGamesList() {
@@ -499,6 +502,16 @@ public class SettingsManager {
     public static void setGameBrowserLabelMode(int i) {
         gameBrowserLabelMode = i;
         editor.putInt(SettingsEnum.GAME_BROWSER_LABEL_MODE.toString(), i);
+        editor.commit();
+    }
+
+    public static boolean getShowZXasAB() {
+        return showZXasAB;
+    }
+
+    public static void setShowZXasAB(boolean b) {
+        showZXasAB = b;
+        editor.putBoolean(SHOW_ZX_AS_AB.toString(), b);
         editor.commit();
     }
 }

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsManager.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsManager.java
@@ -50,6 +50,7 @@ public class SettingsManager {
         GAMES_FOLDER_NAME = "games", SAVES_FOLDER_NAME = "saves",
         FONTS_FOLDER_NAME = "fonts";
     public static int FAST_FORWARD_MODE_HOLD = 0, FAST_FORWARD_MODE_TAP = 1;
+    private static int gameBrowserLabelMode = 0;
 
     private static List<String> imageSizeOption = Arrays.asList("nearest", "integer", "bilinear");
     private static List<String> gameResolutionOption = Arrays.asList("original", "widescreen", "ultrawide");
@@ -102,6 +103,8 @@ public class SettingsManager {
         if (gameResolution == -1) {
             gameResolution = 0;
         }
+
+        gameBrowserLabelMode = sharedPref.getInt(GAME_BROWSER_LABEL_MODE.toString(), 0);
     }
 
     public static Set<String> getFavoriteGamesList() {
@@ -487,5 +490,15 @@ public class SettingsManager {
         SettingsManager.speedModifierA = speedModifierA;
         configIni.input.set(SPEED_MODIFIER_A.toString(), speedModifierA);
         configIni.save();
+    }
+
+    public static int getGameBrowserLabelMode() {
+        return gameBrowserLabelMode;
+    }
+
+    public static void setGameBrowserLabelMode(int i) {
+        gameBrowserLabelMode = i;
+        editor.putInt(SettingsEnum.GAME_BROWSER_LABEL_MODE.toString(), i);
+        editor.commit();
     }
 }

--- a/builds/android/app/src/main/res/drawable/ic_view_list_black.xml
+++ b/builds/android/app/src/main/res/drawable/ic_view_list_black.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M360,800h440q33,0 56.5,-23.5T880,720v-80L360,640v160ZM80,320h200v-160L160,160q-33,0 -56.5,23.5T80,240v80ZM80,560h200v-160L80,400v160ZM160,800h120v-160L80,640v80q0,33 23.5,56.5T160,800ZM360,560h520v-160L360,400v160ZM360,320h520v-80q0,-33 -23.5,-56.5T800,160L360,160v160Z"
+      android:fillColor="#5f6368"/>
+</vector>

--- a/builds/android/app/src/main/res/drawable/ic_view_list_white.xml
+++ b/builds/android/app/src/main/res/drawable/ic_view_list_white.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M360,800h440q33,0 56.5,-23.5T880,720v-80L360,640v160ZM80,320h200v-160L160,160q-33,0 -56.5,23.5T80,240v80ZM80,560h200v-160L80,400v160ZM160,800h120v-160L80,640v80q0,33 23.5,56.5T160,800ZM360,560h520v-160L360,400v160ZM360,320h520v-80q0,-33 -23.5,-56.5T800,160L360,160v160Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/builds/android/app/src/main/res/layout/activity_settings_inputs.xml
+++ b/builds/android/app/src/main/res/layout/activity_settings_inputs.xml
@@ -25,6 +25,13 @@
             android:text="@string/vibrate_when_sliding_direction"
             android:textSize="20sp"/>
 
+        <CheckBox
+            android:id="@+id/settings_show_zx_as_ab"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/settings_input_show_zx_as_ab"
+            android:textSize="20sp"/>
+
         <include layout="@layout/separator"/>
 
         <RelativeLayout

--- a/builds/android/app/src/main/res/menu/game_browser.xml
+++ b/builds/android/app/src/main/res/menu/game_browser.xml
@@ -12,7 +12,7 @@
         android:orderInCategory="100"
         android:title="@string/view"
         app:showAsAction="ifRoom"
-        android:icon="@drawable/ic_refresh_white"/>
+        android:icon="@drawable/ic_view_list_white"/>
     <item
         android:id="@+id/menu"
         android:orderInCategory="100"

--- a/builds/android/app/src/main/res/menu/game_browser.xml
+++ b/builds/android/app/src/main/res/menu/game_browser.xml
@@ -8,9 +8,15 @@
         app:showAsAction="ifRoom"
         android:icon="@drawable/ic_refresh_white"/>
     <item
+        android:id="@+id/view"
+        android:orderInCategory="100"
+        android:title="@string/view"
+        app:showAsAction="ifRoom"
+        android:icon="@drawable/ic_refresh_white"/>
+    <item
         android:id="@+id/menu"
         android:orderInCategory="100"
-        android:title="@string/refresh"
+        android:title="@string/settings"
         app:showAsAction="ifRoom"
         android:icon="@drawable/ic_settings_white"/>
 </menu>

--- a/builds/android/app/src/main/res/values/strings.xml
+++ b/builds/android/app/src/main/res/values/strings.xml
@@ -97,6 +97,7 @@ Please tell us in detail what went wrong.\n\n
     <string name="sound_volume">Sound effect volume</string>
     <string name="input_layout_transparency">Input layout transparency:</string>
     <string name="ignore_size_settings">Ignore button size settings and use this instead:</string>
+    <string name="settings_input_show_zx_as_ab">Display Z and X buttons as A and B</string>
     <string name="no_read_access_on_dir">No read access on %1$s</string>
     <string name="quick_access">Quick access</string>
     <string name="fast_forward">Fast-forward button mode:</string>

--- a/builds/android/app/src/main/res/values/strings.xml
+++ b/builds/android/app/src/main/res/values/strings.xml
@@ -50,6 +50,10 @@
     <string name="error_saf_download_selected">The Download folder cannot be used as the EasyRPG folder.</string>
     <string name="error_saf_folder_not_empty">The selected folder contains other files and cannot be used as the EasyRPG folder. When you remove all files inside the folder you can use it as the EasyRPG folder.</string>
     <string name="error_saf_bad_content_provider">The selected folder cannot be used as the EasyRPG folder. This problem can occur for various reasons, for example if you have selected the root directory or a storage location in the cloud.\n\n</string>
+    <string name="view">View</string>
+    <string name="view_show_title_desc">Choose how games are named</string>
+    <string name="view_show_game_title">Use the title</string>
+    <string name="view_show_game_folder">Use the folder name</string>
 
     <!--Ingame menu-->
     <string name="toggle_ui">Toggle virtual buttons</string>

--- a/src/exe_reader.cpp
+++ b/src/exe_reader.cpp
@@ -39,7 +39,7 @@ EXEReader::EXEReader(Filesystem_Stream::InputStream core) : corefile(std::move(c
 
 	switch (machine) {
 		case 0x14c:
-			file_info.machine_type = MachineType::i386;
+			file_info.machine_type = MachineType::x86;
 			break;
 		case 0x8664:
 			file_info.machine_type = MachineType::amd64;

--- a/src/exe_reader.h
+++ b/src/exe_reader.h
@@ -45,13 +45,13 @@ public:
 
 	enum class MachineType {
 		Unknown,
-		i386,
+		x86,
 		amd64
 	};
 
 	static constexpr auto kMachineTypes = lcf::makeEnumTags<MachineType>(
 		"Unknown",
-		"i386",
+		"x86",
 		"amd64"
 	);
 


### PR DESCRIPTION
The displayed game name can now be configured:

- Use title from RPG_RT.ini (default), this is now more reliable in combination with https://github.com/EasyRPG/liblcf/pull/488
- In the chat somebody disliked this behaviour because they use the game name to differentiate between different versions of the game, so you can revert back to the old behaviour now

In #3311 they considered A and B confusing because all games use Z and X in dialogs. This is the new default but you can revert it in the settings if you dislike it.
