### PR TITLE
ExeReader: Support 64 Bit executables

### DIFF
--- a/src/exe_reader.h
+++ b/src/exe_reader.h
@@ -43,6 +43,18 @@ public:
 	std::vector<uint8_t> GetExFont();
 	std::vector<std::vector<uint8_t>> GetLogos();
 
+	enum class MachineType {
+		Unknown,
+		i386,
+		amd64
+	};
+
+	static constexpr auto kMachineTypes = lcf::makeEnumTags<MachineType>(
+		"Unknown",
+		"i386",
+		"amd64"
+	);
+
 	struct FileInfo {
 		uint64_t version = 0;
 		int logos = 0;
@@ -50,7 +62,7 @@ public:
 		uint32_t code_size = 0;
 		uint32_t cherry_size = 0;
 		uint32_t geep_size = 0;
-		bool is_i386 = true;
+		MachineType machine_type = MachineType::Unknown;
 		bool is_easyrpg_player = false;
 
 		int GetEngineType(bool& is_maniac_patch) const;


### PR DESCRIPTION
Maniac Patch is now detected when the new exe is used.

----

The difference between 32bit PE and 64 bit PE is actually not _that_ huge when you only care about the resources.

The differences:

- The machine type is 0x8664
- In the optional header the magic at the beginning is 0x20b instead of 0x10b (0x20b is a "PE32+" header, 0x10b is a "PE32" header)
- The data direction offset is different because the PE32+ image file header is larger

The offset calculation was the major change:

Before the resource offset was hardcoded to ``0x88`` (136) which is actually ``size_of_optional_header (24) + size_of_image_file_header (96/112 [PE+]) + 16``.

All the resource format itself is the same. (lucky for us).

----

Tested it with:

Player.exe, both 32 Bit and 64 Bit: PASSED

Maniac exe: PASSED

Various RPG_RT (32 bit): PASSED