### PR TITLE
Android: Fix common crashes / various improvements

### DIFF
--- a/builds/android/app/build.gradle
+++ b/builds/android/app/build.gradle
@@ -5,9 +5,9 @@ android {
     assetPacks = [":assets"]
     defaultConfig {
         applicationId "org.easyrpg.player"
-        compileSdk 34
+        compileSdk 35
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionName VERSION_NAME
         versionCode Integer.parseInt(VERSION_CODE)
     }

--- a/builds/android/app/build.gradle
+++ b/builds/android/app/build.gradle
@@ -53,12 +53,14 @@ android {
                         "-DBUILD_SHARED_LIBS=ON",
                         "-DPLAYER_ENABLE_TESTS=OFF"
 
-                if (project.hasProperty("toolchainDirs")) {
-                    arguments.add('-DPLAYER_ANDROID_TOOLCHAIN_PATH=' + project.properties['toolchainDirs'])
+                if (project.hasProperty("toolchainDirs") && project.toolchainDirs) {
+                    arguments.add('-DPLAYER_ANDROID_TOOLCHAIN_PATH=' + project.toolchainDirs)
+                } else if (System.getenv('EASYRPG_BUILDSCRIPTS')) {
+                    arguments.add('-DPLAYER_ANDROID_TOOLCHAIN_PATH=' + System.getenv('EASYRPG_BUILDSCRIPTS') + '/android')
                 }
 
                 if (project.hasProperty("cmakeOptions")) {
-                    arguments.addAll(project.properties['cmakeOptions'].split(" "))
+                    arguments.addAll(project.cmakeOptions.split(" "))
                 }
             }
         }

--- a/builds/android/app/src/main/AndroidManifest.xml
+++ b/builds/android/app/src/main/AndroidManifest.xml
@@ -106,6 +106,17 @@
         <activity
             android:name=".button_mapping.ButtonMappingActivity"
             android:configChanges="orientation|screenSize" />
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/builds/android/app/src/main/java/org/easyrpg/player/BaseActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/BaseActivity.java
@@ -1,0 +1,23 @@
+package org.easyrpg.player;
+
+import android.os.Bundle;
+import androidx.appcompat.app.AppCompatActivity;
+import org.easyrpg.player.settings.SettingsManager;
+
+public class BaseActivity  extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // Retrieve User's preferences
+        SettingsManager.init(getApplicationContext());
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        // Retrieve User's preferences
+        SettingsManager.init(getApplicationContext());
+    }
+}

--- a/builds/android/app/src/main/java/org/easyrpg/player/Helper.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/Helper.java
@@ -288,6 +288,10 @@ public class Helper {
     }
 
     public static DocumentFile getFileFromURI (Context context, Uri fileURI) {
+        if (fileURI == null) {
+            return null;
+        }
+
         try {
             return DocumentFile.fromTreeUri(context, fileURI);
         } catch (Exception e) {

--- a/builds/android/app/src/main/java/org/easyrpg/player/InitActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/InitActivity.java
@@ -26,7 +26,7 @@ import java.io.File;
  * To start the standalone mode : put your project in assets/games
  * ("game" is the project directory, no sub folder)
  */
-public class InitActivity extends AppCompatActivity {
+public class InitActivity extends BaseActivity {
     private boolean standaloneMode = false;
     private GameBrowserHelper.SafError safError = GameBrowserHelper.SafError.OK;
 
@@ -36,9 +36,6 @@ public class InitActivity extends AppCompatActivity {
         setContentView(R.layout.activity_init);
 
         safError = GameBrowserHelper.SafError.OK;
-
-        // Retrieve User's preferences
-        SettingsManager.init(getApplicationContext());
 
         Activity thisActivity = this;
         (findViewById(R.id.set_games_folder)).setOnClickListener(v -> GameBrowserHelper.pickAGamesFolder(thisActivity));

--- a/builds/android/app/src/main/java/org/easyrpg/player/button_mapping/ButtonMappingActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/button_mapping/ButtonMappingActivity.java
@@ -43,6 +43,8 @@ public class ButtonMappingActivity extends Activity implements NavigationView.On
         super.onCreate(savedInstanceState);
         setContentView(R.layout.button_mapping_activity);
 
+        SettingsManager.init(getApplicationContext());
+
         // Menu configuration
         this.drawer = findViewById(R.id.drawer_layout);
         drawer.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
@@ -79,6 +81,14 @@ public class ButtonMappingActivity extends Activity implements NavigationView.On
 
             drawButtons();
         }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        // Retrieve User's preferences
+        SettingsManager.init(getApplicationContext());
     }
 
     @Override

--- a/builds/android/app/src/main/java/org/easyrpg/player/button_mapping/VirtualButton.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/button_mapping/VirtualButton.java
@@ -205,16 +205,16 @@ public class VirtualButton extends View {
         char charButton;
 
         if (keyCode == ENTER) {
-            if (SettingsManager.getShowZXasAB()) {
-                charButton = 'A';
-            } else {
+            if (SettingsManager.getShowABasZX()) {
                 charButton = 'Z';
+            } else {
+                charButton = 'A';
             }
         } else if (keyCode == CANCEL) {
-            if (SettingsManager.getShowZXasAB()) {
-                charButton = 'B';
-            } else {
+            if (SettingsManager.getShowABasZX()) {
                 charButton = 'X';
+            } else {
+                charButton = 'B';
             }
         } else if (keyCode == SHIFT) {
             charButton = 'S';

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
@@ -35,6 +35,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.navigation.NavigationView;
 
+import org.easyrpg.player.BaseActivity;
 import org.easyrpg.player.R;
 import org.easyrpg.player.settings.SettingsManager;
 import org.libsdl.app.SDL;
@@ -42,7 +43,7 @@ import org.libsdl.app.SDL;
 import java.util.Collections;
 import java.util.List;
 
-public class GameBrowserActivity extends AppCompatActivity
+public class GameBrowserActivity extends BaseActivity
         implements NavigationView.OnNavigationItemSelectedListener {
     public static Boolean libraryLoaded = false;
 
@@ -178,7 +179,10 @@ public class GameBrowserActivity extends AppCompatActivity
             .setPositiveButton(R.string.ok, (dialog, id) -> {
                 int selectedPosition = ((AlertDialog) dialog).getListView().getCheckedItemPosition();
                 SettingsManager.setGameBrowserLabelMode(selectedPosition);
-                displayGamesList();
+                if (displayedGamesList != null) {
+                    // handle error case (no games displayed)
+                    displayGamesList();
+                }
             })
             .setNegativeButton(R.string.cancel, null);
         builder.show();

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserHelper.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserHelper.java
@@ -58,13 +58,19 @@ public class GameBrowserHelper {
 
         String savePath = path;
         if (!game.getSavePath().isEmpty()) {
-            DocumentFile saveFolder = Helper.createFolderInSave(context, game.getSavePath());
-
-            // In error case the native code will try to put a save folder next to the zip
-            if (saveFolder != null) {
-                savePath = saveFolder.getUri().toString();
+            if (game.isStandalone()) {
+                savePath = game.getSavePath();
                 args.add("--save-path");
                 args.add(savePath);
+            } else {
+                DocumentFile saveFolder = Helper.createFolderInSave(context, game.getSavePath());
+
+                // In error case the native code will try to put a save folder next to the zip
+                if (saveFolder != null) {
+                    savePath = saveFolder.getUri().toString();
+                    args.add("--save-path");
+                    args.add(savePath);
+                }
             }
         }
 

--- a/builds/android/app/src/main/java/org/easyrpg/player/player/EasyRpgPlayerActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/player/EasyRpgPlayerActivity.java
@@ -47,6 +47,7 @@ import android.widget.RelativeLayout;
 import android.widget.RelativeLayout.LayoutParams;
 import android.widget.TextView;
 
+import androidx.core.content.FileProvider;
 import androidx.core.view.GravityCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 
@@ -65,6 +66,7 @@ import org.libsdl.app.SDLActivity;
 import java.io.File;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Locale;
 
 /**
  * EasyRPG Player for Android (inheriting from SDLActivity)
@@ -239,12 +241,27 @@ public class EasyRpgPlayerActivity extends SDLActivity implements NavigationView
                 .setPositiveButton(R.string.ok, (dialog, id) -> {
                     // Attach to the email : the easyrpg log file and savefiles
                     ArrayList<Uri> files = new ArrayList<>();
-                    // The easyrpg_log.txt
+
                     String savepath = getIntent().getStringExtra(TAG_SAVE_PATH);
 
                     if (getIntent().getBooleanExtra(TAG_STANDALONE, false)) {
-                        // FIXME: Attaching files does not work because the files are in /data and
-                        // other apps have no permission
+                        File logFile = new File(savepath, "easyrpg_log.txt");
+                        if (logFile.exists()) {
+                            Uri logUri = FileProvider.getUriForFile(this, getPackageName() + ".fileprovider", logFile);
+                            if (logUri != null) {
+                                files.add(logUri);
+                            }
+                        }
+
+                        for (int i = 1; i <= 15; ++i) {
+                            File saveFile = new File(savepath, String.format(Locale.ROOT, "Save%02d.lsd", i));
+                            if (saveFile.exists()) {
+                                Uri saveUri = FileProvider.getUriForFile(this, getPackageName() + ".fileprovider", saveFile);
+                                if (saveUri != null) {
+                                    files.add(saveUri);
+                                }
+                            }
+                        }
                     } else {
                         Uri saveFolder = Uri.parse(savepath);
                         Uri log = Helper.findFileUri(getContext(), saveFolder, "easyrpg_log.txt");

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsAudioActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsAudioActivity.java
@@ -16,13 +16,14 @@ import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.documentfile.provider.DocumentFile;
 
+import org.easyrpg.player.BaseActivity;
 import org.easyrpg.player.Helper;
 import org.easyrpg.player.R;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class SettingsAudioActivity extends AppCompatActivity {
+public class SettingsAudioActivity extends BaseActivity {
     private LinearLayout soundfontsListLayout;
     List<SoundfontItemList> soundfontList;
 
@@ -32,8 +33,6 @@ public class SettingsAudioActivity extends AppCompatActivity {
         setContentView(R.layout.activity_settings_audio);
 
         soundfontsListLayout = findViewById(R.id.settings_sound_fonts_list);
-
-        SettingsManager.init(getApplicationContext());
 
         // Setup UI components
         // The Soundfont Button

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsEnum.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsEnum.java
@@ -29,7 +29,7 @@ enum SettingsEnum {
     FONT1_SIZE("Font1Size"),
     FONT2_SIZE("Font2Size"),
     GAME_BROWSER_LABEL_MODE("GAME_BROWSER_LABEL_MODE"),
-    SHOW_ZX_AS_AB("SHOW_ZX_AS_AB")
+    SHOW_AB_AS_ZX("SHOW_AB_AS_ZX")
     ;
 
 

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsFontActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsFontActivity.java
@@ -19,6 +19,7 @@ import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.documentfile.provider.DocumentFile;
 
+import org.easyrpg.player.BaseActivity;
 import org.easyrpg.player.Helper;
 import org.easyrpg.player.R;
 import org.libsdl.app.SDL;
@@ -26,7 +27,7 @@ import org.libsdl.app.SDL;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SettingsFontActivity extends AppCompatActivity {
+public class SettingsFontActivity extends BaseActivity {
     private LinearLayout fonts1ListLayout;
     private LinearLayout fonts2ListLayout;
     private String[] extensions = new String[] {".fon", ".fnt", ".bdf", ".ttf", ".ttc", ".otf", ".woff2", ".woff"};
@@ -43,7 +44,6 @@ public class SettingsFontActivity extends AppCompatActivity {
         fonts1ListLayout = findViewById(R.id.settings_font1_list);
         fonts2ListLayout = findViewById(R.id.settings_font2_list);
 
-        SettingsManager.init(getApplicationContext());
         SDL.setContext(getApplicationContext());
 
         // Setup UI components

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsGamesFolderActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsGamesFolderActivity.java
@@ -12,12 +12,13 @@ import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import org.easyrpg.player.BaseActivity;
 import org.easyrpg.player.R;
 import org.easyrpg.player.game_browser.GameBrowserActivity;
 import org.easyrpg.player.game_browser.GameBrowserHelper;
 import org.libsdl.app.SDL;
 
-public class SettingsGamesFolderActivity extends AppCompatActivity {
+public class SettingsGamesFolderActivity extends BaseActivity {
     private GameBrowserHelper.SafError safError = GameBrowserHelper.SafError.OK;
 
     @Override
@@ -27,8 +28,6 @@ public class SettingsGamesFolderActivity extends AppCompatActivity {
         SDL.setContext(getApplicationContext());
 
         safError = GameBrowserHelper.SafError.OK;
-
-        SettingsManager.init(getApplicationContext());
 
         Activity thisActivity = this;
         Button setGamesFolderButton = findViewById(R.id.set_games_folder);

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsInputActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsInputActivity.java
@@ -12,11 +12,12 @@ import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.AppCompatSpinner;
 
+import org.easyrpg.player.BaseActivity;
 import org.easyrpg.player.R;
 import org.easyrpg.player.button_mapping.ButtonMappingActivity;
 import org.easyrpg.player.button_mapping.InputLayout;
 
-public class SettingsInputActivity extends AppCompatActivity implements View.OnClickListener {
+public class SettingsInputActivity extends BaseActivity implements View.OnClickListener {
     private CheckBox enableVibrateWhenSlidingCheckbox;
     private SeekBar layoutTransparencyLayout, layoutSizeSeekBar, fastForwardMultiplierSeekBar;
     private TextView layoutTransparencyTextView, layoutSizeTextView, fastForwardMultiplierTextView;
@@ -25,8 +26,6 @@ public class SettingsInputActivity extends AppCompatActivity implements View.OnC
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         this.setContentView(R.layout.activity_settings_inputs);
-
-        SettingsManager.init(getApplicationContext());
 
         // Setting UI components
         CheckBox enableVibrationCheckBox = findViewById(R.id.settings_enable_vibration);

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsInputActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsInputActivity.java
@@ -9,7 +9,6 @@ import android.widget.ImageButton;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.AppCompatSpinner;
 
 import org.easyrpg.player.BaseActivity;
@@ -36,9 +35,9 @@ public class SettingsInputActivity extends BaseActivity implements View.OnClickL
         enableVibrateWhenSlidingCheckbox.setChecked(SettingsManager.isVibrateWhenSlidingDirectionEnabled());
         enableVibrateWhenSlidingCheckbox.setOnClickListener(this);
 
-        CheckBox showZXasABcheckbox = findViewById(R.id.settings_show_zx_as_ab);
-        showZXasABcheckbox.setChecked(SettingsManager.getShowZXasAB());
-        showZXasABcheckbox.setOnClickListener(this);
+        CheckBox showABasZXcheckbox = findViewById(R.id.settings_show_ab_as_zx);
+        showABasZXcheckbox.setChecked(SettingsManager.getShowABasZX());
+        showABasZXcheckbox.setOnClickListener(this);
 
         configureFastForwardButton();
         configureLayoutTransparencySystem();
@@ -60,8 +59,8 @@ public class SettingsInputActivity extends BaseActivity implements View.OnClickL
             enableVibrateWhenSlidingCheckbox.setEnabled(c.isChecked());
         } else if (id == R.id.settings_vibrate_when_sliding){
             SettingsManager.setVibrateWhenSlidingDirectionEnabled(((CheckBox) v).isChecked());
-        } else if (id == R.id.settings_show_zx_as_ab) {
-            SettingsManager.setShowZXasAB(((CheckBox)v).isChecked());
+        } else if (id == R.id.settings_show_ab_as_zx) {
+            SettingsManager.setShowABasZX(((CheckBox)v).isChecked());
         }
     }
 

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsMainActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsMainActivity.java
@@ -7,9 +7,10 @@ import android.widget.Button;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import org.easyrpg.player.BaseActivity;
 import org.easyrpg.player.R;
 
-public class SettingsMainActivity extends AppCompatActivity implements View.OnClickListener {
+public class SettingsMainActivity extends BaseActivity implements View.OnClickListener {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsManager.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsManager.java
@@ -51,7 +51,7 @@ public class SettingsManager {
         FONTS_FOLDER_NAME = "fonts";
     public static int FAST_FORWARD_MODE_HOLD = 0, FAST_FORWARD_MODE_TAP = 1;
     private static int gameBrowserLabelMode = 0;
-    private static boolean showZXasAB = false;
+    private static boolean showABasZX = false;
 
     private static List<String> imageSizeOption = Arrays.asList("nearest", "integer", "bilinear");
     private static List<String> gameResolutionOption = Arrays.asList("original", "widescreen", "ultrawide");
@@ -107,7 +107,7 @@ public class SettingsManager {
 
         gameBrowserLabelMode = sharedPref.getInt(GAME_BROWSER_LABEL_MODE.toString(), 0);
 
-        showZXasAB = sharedPref.getBoolean(SHOW_ZX_AS_AB.toString(), false);
+        showABasZX = sharedPref.getBoolean(SHOW_AB_AS_ZX.toString(), false);
     }
 
     public static Set<String> getFavoriteGamesList() {
@@ -505,13 +505,13 @@ public class SettingsManager {
         editor.commit();
     }
 
-    public static boolean getShowZXasAB() {
-        return showZXasAB;
+    public static boolean getShowABasZX() {
+        return showABasZX;
     }
 
-    public static void setShowZXasAB(boolean b) {
-        showZXasAB = b;
-        editor.putBoolean(SHOW_ZX_AS_AB.toString(), b);
+    public static void setShowABasZX(boolean b) {
+        showABasZX = b;
+        editor.putBoolean(SHOW_AB_AS_ZX.toString(), b);
         editor.commit();
     }
 }

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsManager.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsManager.java
@@ -309,7 +309,7 @@ public class SettingsManager {
     }
 
     public static Uri getGamesFolderURI(Context context) {
-        DocumentFile easyRPGFolder = Helper.getFileFromURI(context, easyRPGFolderURI);
+        DocumentFile easyRPGFolder = Helper.getFileFromURI(context, getEasyRPGFolderURI(context));
         if (easyRPGFolder != null) {
             return Helper.findFileUri(context, easyRPGFolder.getUri(), GAMES_FOLDER_NAME);
         } else {
@@ -318,7 +318,7 @@ public class SettingsManager {
     }
 
     public static Uri getRTPFolderURI(Context context) {
-        DocumentFile easyRPGFolder = Helper.getFileFromURI(context, easyRPGFolderURI);
+        DocumentFile easyRPGFolder = Helper.getFileFromURI(context, getEasyRPGFolderURI(context));
         if (easyRPGFolder != null) {
             return Helper.findFileUri(context, easyRPGFolder.getUri(), RTP_FOLDER_NAME);
         } else {
@@ -327,7 +327,7 @@ public class SettingsManager {
     }
 
     public static Uri getFontsFolderURI(Context context) {
-        DocumentFile easyRPGFolder = Helper.getFileFromURI(context, easyRPGFolderURI);
+        DocumentFile easyRPGFolder = Helper.getFileFromURI(context, getEasyRPGFolderURI(context));
         if (easyRPGFolder != null) {
             return Helper.findFileUri(context, easyRPGFolder.getUri(), FONTS_FOLDER_NAME);
         } else {
@@ -336,7 +336,7 @@ public class SettingsManager {
     }
 
     public static Uri getSoundFontsFolderURI(Context context) {
-        DocumentFile easyRPGFolder = Helper.getFileFromURI(context, easyRPGFolderURI);
+        DocumentFile easyRPGFolder = Helper.getFileFromURI(context, getEasyRPGFolderURI(context));
         if (easyRPGFolder != null) {
             return Helper.findFileUri(context, easyRPGFolder.getUri(), SOUND_FONTS_FOLDER_NAME);
         } else {

--- a/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsVideoActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/settings/SettingsVideoActivity.java
@@ -7,13 +7,14 @@ import android.widget.RadioButton;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import org.easyrpg.player.BaseActivity;
 import org.easyrpg.player.R;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class SettingsVideoActivity extends AppCompatActivity implements View.OnClickListener {
+public class SettingsVideoActivity extends BaseActivity implements View.OnClickListener {
     List<RadioButton> imageSizeRadioButtonList;
     List<RadioButton> gameResolutionRadioButtonList;
 
@@ -21,8 +22,6 @@ public class SettingsVideoActivity extends AppCompatActivity implements View.OnC
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         this.setContentView(R.layout.activity_settings_video);
-
-        SettingsManager.init(getApplicationContext());
 
         // Setting UI components
         CheckBox forceLandscapeModeCheckbox = findViewById(R.id.force_landscape_mode);

--- a/builds/android/app/src/main/res/layout/activity_settings_inputs.xml
+++ b/builds/android/app/src/main/res/layout/activity_settings_inputs.xml
@@ -26,10 +26,10 @@
             android:textSize="20sp"/>
 
         <CheckBox
-            android:id="@+id/settings_show_zx_as_ab"
+            android:id="@+id/settings_show_ab_as_zx"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/settings_input_show_zx_as_ab"
+            android:text="@string/settings_input_show_ab_as_zx"
             android:textSize="20sp"/>
 
         <include layout="@layout/separator"/>

--- a/builds/android/app/src/main/res/values/strings.xml
+++ b/builds/android/app/src/main/res/values/strings.xml
@@ -97,7 +97,7 @@ Please tell us in detail what went wrong.\n\n
     <string name="sound_volume">Sound effect volume</string>
     <string name="input_layout_transparency">Input layout transparency:</string>
     <string name="ignore_size_settings">Ignore button size settings and use this instead:</string>
-    <string name="settings_input_show_zx_as_ab">Display Z and X buttons as A and B</string>
+    <string name="settings_input_show_ab_as_zx">Display A and B buttons as Z and X</string>
     <string name="no_read_access_on_dir">No read access on %1$s</string>
     <string name="quick_access">Quick access</string>
     <string name="fast_forward">Fast-forward button mode:</string>

--- a/builds/android/app/src/main/res/xml/file_paths.xml
+++ b/builds/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,3 @@
+<paths>
+    <external-path name="external_files" path="."/>
+</paths>

--- a/builds/android/build.gradle
+++ b/builds/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.4.2'
+        classpath 'com.android.tools.build:gradle:8.7.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/builds/android/gradle.properties
+++ b/builds/android/gradle.properties
@@ -10,7 +10,7 @@ VERSION_NAME=0.8
 VERSION_CODE=8843
 
 # Architectures to build for when developing (debug)
-ABI_FILTERS_DEBUG=armeabi-v7a
+ABI_FILTERS_DEBUG=arm64-v8a
 
 # Architectures to build for when creating a release
 ABI_FILTERS_RELEASE=armeabi-v7a,arm64-v8a,x86,x86_64

--- a/src/platform/android/org_easyrpg_player_player_EasyRpgPlayerActivity.cpp
+++ b/src/platform/android/org_easyrpg_player_player_EasyRpgPlayerActivity.cpp
@@ -57,7 +57,7 @@ JNIEXPORT void JNICALL Java_org_easyrpg_player_player_EasyRpgPlayerActivity_togg
 JNIEXPORT void JNICALL
 Java_org_easyrpg_player_player_EasyRpgPlayerActivity_openSettings(JNIEnv *, jclass) {
 	EpAndroid::schedule([]() {
-		if (Scene::instance->type != Scene::Logo && !Scene::Find(Scene::Settings)) {
+		if (Scene::instance->type != Scene::Logo && !Scene::Find(Scene::Settings) && !Scene::IsAsyncPending()) {
 			Scene::Push(std::make_shared<Scene_Settings>());
 		}
 	});


### PR DESCRIPTION
- Bumped the SDK so Google will annoy us one year later about SDK updates ;)
- Fixed crashes existing since 0.8 (none of them was critical but good to have them resolved)
  - Most crashes are related to the settings becoming null because the app restarts, I was able to simulate this and hopefully fixed it everywhere (by adding a new class which does this automatically)
  - After a game crash the game list was empty, fixed this by refetching the easyrpgURI (which was also null...)
  - Fixed a crash when opening the settings while another scene was currently opening (race condition)
- Fixed crashes reported after the latest APK update
  - Fixed a crash in the new "sorting" option when the game list was empty
- Upon feedback the Z/X buttons are reverted back to A/B buttons but the setting is still available, just a different default
- Standalone mode fixes
