### PR TITLE
Rewrite map fixes

### DIFF
--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -175,13 +175,15 @@ void Spriteset_Map::SubstituteUp(int old_id, int new_id) {
 }
 
 void Spriteset_Map::ReplaceDownAt(int x, int y, int tile_index, bool disable_autotile) {
+	if (tile_index >= BLOCK_F_INDEX) tile_index = BLOCK_F_INDEX - 1;
+
 	auto tile_id = IndexToChipId(tile_index);
 	tilemap->SetMapTileDataDownAt(x, y, tile_id, disable_autotile);
 }
 
 void Spriteset_Map::ReplaceUpAt(int x, int y, int tile_index) {
 	tile_index += BLOCK_F_INDEX;
-	if (tile_index >= NUM_UPPER_TILES + BLOCK_F_INDEX) tile_index = 0;
+	if (tile_index >= NUM_UPPER_TILES + BLOCK_F_INDEX) tile_index = BLOCK_F_INDEX;
 
 	auto tile_id = IndexToChipId(tile_index);
 	tilemap->SetMapTileDataUpAt(x, y, tile_id);

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -180,6 +180,9 @@ void Spriteset_Map::ReplaceDownAt(int x, int y, int tile_index, bool disable_aut
 }
 
 void Spriteset_Map::ReplaceUpAt(int x, int y, int tile_index) {
+	tile_index += BLOCK_F_INDEX;
+	if (tile_index >= NUM_UPPER_TILES + BLOCK_F_INDEX) tile_index = 0;
+
 	auto tile_id = IndexToChipId(tile_index);
 	tilemap->SetMapTileDataUpAt(x, y, tile_id);
 }

--- a/src/tilemap.h
+++ b/src/tilemap.h
@@ -96,7 +96,7 @@ inline void Tilemap::SetMapDataUp(std::vector<short> up) {
 }
 
 inline void Tilemap::SetMapTileDataUpAt(int x, int y, int tile_id) {
-	layer_down.SetMapTileDataAt(x, y, tile_id, true);
+	layer_up.SetMapTileDataAt(x, y, tile_id, true);
 }
 
 inline const std::vector<unsigned char>& Tilemap::GetPassableDown() const {


### PR DESCRIPTION
Fixed the issues described at #3323 

------------------

Also I Discovered one last quirk, from toggling autotiles ON/OFF: 
- On EasyRPG the autotile is changing a buch of its own neighbour tiles.
- On maniacs it changes only the closest to itsef.

This Quirk is not a dealbreakers, so didn't look at the code of it yet. 

---------------

Things are now very closer to the Maniacs version now, only missing that fix and the AB lower tiles support.