### PR TITLE
QoL: detect unsupported engines

### DIFF
--- a/builds/android/app/src/gamebrowser/org_easyrpg_player_game_browser.cpp
+++ b/builds/android/app/src/gamebrowser/org_easyrpg_player_game_browser.cpp
@@ -189,7 +189,7 @@ Java_org_easyrpg_player_game_1browser_GameScanner_findGames(JNIEnv *env, jclass,
 	auto root = FileFinder::Root().Create(spath);
 	root.ClearCache();
 
-	std::vector<FilesystemView> fs_list = FileFinder::FindGames(root);
+	std::vector<FileFinder::GameEntry> fs_list = FileFinder::FindGames(root);
 
 	jclass jgame_class = env->FindClass("org/easyrpg/player/game_browser/Game");
 	jobjectArray jgame_array = env->NewObjectArray(fs_list.size(), jgame_class, nullptr);
@@ -204,13 +204,19 @@ Java_org_easyrpg_player_game_1browser_GameScanner_findGames(JNIEnv *env, jclass,
 	std::string root_path = FileFinder::GetFullFilesystemPath(root);
 	bool game_in_main_dir = false;
 	if (fs_list.size() == 1) {
-		if (root_path == FileFinder::GetFullFilesystemPath(fs_list[0])) {
-			game_in_main_dir = true;
-		}
+        if (fs_list[0].type == FileFinder::ProjectType::Supported &&
+            root_path == FileFinder::GetFullFilesystemPath(fs_list[0].fs)) {
+            game_in_main_dir = true;
+        }
 	}
 
 	for (size_t i = 0; i < fs_list.size(); ++i) {
-		auto& fs = fs_list[i];
+		auto& ge = fs_list[i];
+        if (ge.type > FileFinder::ProjectType::Supported) {
+            continue;
+        }
+
+        auto& fs = ge.fs;
 
 		std::string full_path = FileFinder::GetFullFilesystemPath(fs);
 		std::string game_dir_name;

--- a/builds/android/app/src/gamebrowser/org_easyrpg_player_game_browser.cpp
+++ b/builds/android/app/src/gamebrowser/org_easyrpg_player_game_browser.cpp
@@ -189,7 +189,7 @@ Java_org_easyrpg_player_game_1browser_GameScanner_findGames(JNIEnv *env, jclass,
 	auto root = FileFinder::Root().Create(spath);
 	root.ClearCache();
 
-	std::vector<FileFinder::GameEntry> ge_list = FileFinder::FindGames(root);
+	auto ge_list = FileFinder::FindGames(root);
 
 	jclass jgame_class = env->FindClass("org/easyrpg/player/game_browser/Game");
 	jobjectArray jgame_array = env->NewObjectArray(ge_list.size(), jgame_class, nullptr);

--- a/builds/android/app/src/gamebrowser/org_easyrpg_player_game_browser.cpp
+++ b/builds/android/app/src/gamebrowser/org_easyrpg_player_game_browser.cpp
@@ -189,12 +189,12 @@ Java_org_easyrpg_player_game_1browser_GameScanner_findGames(JNIEnv *env, jclass,
 	auto root = FileFinder::Root().Create(spath);
 	root.ClearCache();
 
-	std::vector<FileFinder::GameEntry> fs_list = FileFinder::FindGames(root);
+	std::vector<FileFinder::GameEntry> ge_list = FileFinder::FindGames(root);
 
 	jclass jgame_class = env->FindClass("org/easyrpg/player/game_browser/Game");
-	jobjectArray jgame_array = env->NewObjectArray(fs_list.size(), jgame_class, nullptr);
+	jobjectArray jgame_array = env->NewObjectArray(ge_list.size(), jgame_class, nullptr);
 
-	if (fs_list.empty()) {
+	if (ge_list.empty()) {
 		// No games found
 		return jgame_array;
 	}
@@ -204,15 +204,15 @@ Java_org_easyrpg_player_game_1browser_GameScanner_findGames(JNIEnv *env, jclass,
 
 	std::string root_path = FileFinder::GetFullFilesystemPath(root);
 	bool game_in_main_dir = false;
-	if (fs_list.size() == 1) {
-        if (fs_list[0].type == FileFinder::ProjectType::Supported &&
-            root_path == FileFinder::GetFullFilesystemPath(fs_list[0].fs)) {
+	if (ge_list.size() == 1) {
+        if (ge_list[0].type == FileFinder::ProjectType::Supported &&
+            root_path == FileFinder::GetFullFilesystemPath(ge_list[0].fs)) {
             game_in_main_dir = true;
         }
 	}
 
-	for (size_t i = 0; i < fs_list.size(); ++i) {
-		auto& ge = fs_list[i];
+	for (size_t i = 0; i < ge_list.size(); ++i) {
+		auto& ge = ge_list[i];
         auto& fs = ge.fs;
 
         // If game is unsupported, create a Game object with only directory name as title and project type id and continue early
@@ -253,7 +253,7 @@ Java_org_easyrpg_player_game_1browser_GameScanner_findGames(JNIEnv *env, jclass,
 			}
 
 			// Append subdirectory when the archive contains more than one game
-			if (fs_list.size() > 1) {
+			if (ge_list.size() > 1) {
 				save_path += FileFinder::GetFullFilesystemPath(fs).substr(root_path.size());
 			}
 

--- a/builds/android/app/src/main/java/org/easyrpg/player/InitActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/InitActivity.java
@@ -15,6 +15,7 @@ import androidx.documentfile.provider.DocumentFile;
 import org.easyrpg.player.game_browser.Game;
 import org.easyrpg.player.game_browser.GameBrowserActivity;
 import org.easyrpg.player.game_browser.GameBrowserHelper;
+import org.easyrpg.player.game_browser.ProjectType;
 import org.easyrpg.player.player.AssetUtils;
 import org.easyrpg.player.settings.SettingsManager;
 
@@ -122,7 +123,7 @@ public class InitActivity extends BaseActivity {
             String saveDir = getExternalFilesDir(null).getAbsolutePath() + "/Save";
             new File(saveDir).mkdirs();
 
-            Game project = new Game(gameDir, saveDir, null);
+            Game project = new Game(gameDir, saveDir, null, ProjectType.SUPPORTED.ordinal());
             project.setStandalone(true);
             GameBrowserHelper.launchGame(this, project);
             finish();

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/Game.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/Game.java
@@ -191,7 +191,10 @@ public class Game implements Comparable<Game> {
 
         int parsedProjectType = Integer.parseInt(entries[7]);
         if (parsedProjectType > ProjectType.SUPPORTED.ordinal()) {
-            return new Game(parsedProjectType);
+            Game g = new Game(parsedProjectType);
+            g.setTitle(entries[4]);
+
+            return g;
         }
 
         String savePath = entries[1];

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/Game.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/Game.java
@@ -261,4 +261,11 @@ public class Game implements Comparable<Game> {
         return sb.toString();
     }
 
+    public boolean isProjectTypeUnsupported() {
+        return this.projectType.ordinal() > ProjectType.SUPPORTED.ordinal();
+    }
+
+    public String getProjectTypeLabel() {
+        return this.projectType.getLabel();
+    }
 }

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/Game.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/Game.java
@@ -130,6 +130,14 @@ public class Game implements Comparable<Game> {
 
     @Override
     public int compareTo(Game game) {
+        // Unsupported games last
+        if (this.projectType == ProjectType.SUPPORTED && game.projectType.ordinal() > ProjectType.SUPPORTED.ordinal()) {
+            return -1;
+        }
+        if (this.projectType.ordinal() > ProjectType.SUPPORTED.ordinal() && game.projectType == ProjectType.SUPPORTED) {
+            return 1;
+        }
+        // Favorites first
         if (this.isFavorite() && !game.isFavorite()) {
             return -1;
         }

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
@@ -333,6 +333,18 @@ public class GameBrowserActivity extends BaseActivity
         public void onBindViewHolder(final ViewHolder holder, final int position) {
             final Game game = gameList.get(position);
 
+            if (game.isProjectTypeUnsupported()) {
+                // Title
+                holder.title.setText(game.getDisplayTitle());
+
+                // Subtitle - engine unsupported message
+                holder.subtitle.setText(String.format("%s\n%s", activity.getResources().getString(R.string.unsupported_engine), game.getProjectTypeLabel()));
+
+                // Hide settings button
+                holder.settingsButton.setVisibility(View.INVISIBLE);
+                return;
+            }
+
             // Title
             holder.title.setText(game.getDisplayTitle());
             holder.title.setOnClickListener(v -> launchGame(position, false));
@@ -450,12 +462,14 @@ public class GameBrowserActivity extends BaseActivity
 
         public static class ViewHolder extends RecyclerView.ViewHolder {
             public TextView title;
+            public TextView subtitle;
             public ImageView titleScreen;
             public ImageButton settingsButton, favoriteButton;
 
             public ViewHolder(View v) {
                 super(v);
                 this.title = v.findViewById(R.id.title);
+                this.subtitle = v.findViewById(R.id.subtitle);
                 this.titleScreen = v.findViewById(R.id.screen);
                 this.settingsButton = v.findViewById(R.id.game_browser_thumbnail_option_button);
                 this.favoriteButton = v.findViewById(R.id.game_browser_thumbnail_favorite_button);

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
@@ -7,7 +7,6 @@ import android.content.Intent;
 import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
-import android.provider.DocumentsContract;
 import android.text.InputType;
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -16,13 +15,11 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBarDrawerToggle;
@@ -344,9 +341,9 @@ public class GameBrowserActivity extends BaseActivity
                 holder.settingsButton.setVisibility(View.INVISIBLE);
 
                 // Add click listeners
-                holder.title.setOnClickListener(v -> showUnsupportedProjectTypeExplaination(activity, game.getProjectTypeLabel()));
-                holder.subtitle.setOnClickListener(v -> showUnsupportedProjectTypeExplaination(activity, game.getProjectTypeLabel()));
-                holder.titleScreen.setOnClickListener(v -> showUnsupportedProjectTypeExplaination(activity, game.getProjectTypeLabel()));
+                holder.title.setOnClickListener(v -> showUnsupportedProjectTypeExplanation(activity, game.getProjectTypeLabel()));
+                holder.subtitle.setOnClickListener(v -> showUnsupportedProjectTypeExplanation(activity, game.getProjectTypeLabel()));
+                holder.titleScreen.setOnClickListener(v -> showUnsupportedProjectTypeExplanation(activity, game.getProjectTypeLabel()));
 
                 return;
             }
@@ -466,16 +463,16 @@ public class GameBrowserActivity extends BaseActivity
             builder.show();
         }
 
-        private void showUnsupportedProjectTypeExplaination(final Context context, String projectType) {
+        private void showUnsupportedProjectTypeExplanation(final Context context, String projectType) {
             AlertDialog.Builder builder = new AlertDialog.Builder(context);
 
             String part1 = context.getString(R.string.unsupported_engine_explanation_1).replace("$ENGINE", projectType);
             String part2 = context.getString(R.string.unsupported_engine_explanation_2);
             String part3 = context.getString(R.string.unsupported_engine_explanation_3);
-            
+
             builder
                 .setTitle(R.string.information)
-                .setMessage(part1 + '\n' + part2 + '\n' + part3)
+                .setMessage(part1 + '\n' + '\n' + part2 + '\n' + '\n' + part3)
                 .setNeutralButton(R.string.ok, null);
             builder.show();
         }

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
@@ -342,6 +342,12 @@ public class GameBrowserActivity extends BaseActivity
 
                 // Hide settings button
                 holder.settingsButton.setVisibility(View.INVISIBLE);
+
+                // Add click listeners
+                holder.title.setOnClickListener(v -> showUnsupportedProjectTypeExplaination(activity, game.getProjectTypeLabel()));
+                holder.subtitle.setOnClickListener(v -> showUnsupportedProjectTypeExplaination(activity, game.getProjectTypeLabel()));
+                holder.titleScreen.setOnClickListener(v -> showUnsupportedProjectTypeExplaination(activity, game.getProjectTypeLabel()));
+
                 return;
             }
 
@@ -457,6 +463,18 @@ public class GameBrowserActivity extends BaseActivity
                     game.setCustomTitle("");
                     holder.title.setText(game.getDisplayTitle());
                 });
+            builder.show();
+        }
+
+        private void showUnsupportedProjectTypeExplaination(final Context context, String projectType) {
+            AlertDialog.Builder builder = new AlertDialog.Builder(context);
+
+            String message = context.getString(R.string.unsupported_engine_explanation)
+                    .replace("$ENGINE", projectType);
+            builder
+                .setTitle(R.string.information)
+                .setMessage(message)
+                .setNeutralButton(R.string.ok, null);
             builder.show();
         }
 

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
@@ -469,11 +469,13 @@ public class GameBrowserActivity extends BaseActivity
         private void showUnsupportedProjectTypeExplaination(final Context context, String projectType) {
             AlertDialog.Builder builder = new AlertDialog.Builder(context);
 
-            String message = context.getString(R.string.unsupported_engine_explanation)
-                    .replace("$ENGINE", projectType);
+            String part1 = context.getString(R.string.unsupported_engine_explanation_1).replace("$ENGINE", projectType);
+            String part2 = context.getString(R.string.unsupported_engine_explanation_2);
+            String part3 = context.getString(R.string.unsupported_engine_explanation_3);
+            
             builder
                 .setTitle(R.string.information)
-                .setMessage(message)
+                .setMessage(part1 + '\n' + part2 + '\n' + part3)
                 .setNeutralButton(R.string.ok, null);
             builder.show();
         }

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
@@ -335,7 +335,7 @@ public class GameBrowserActivity extends BaseActivity
                 holder.title.setText(game.getDisplayTitle());
 
                 // Subtitle - engine unsupported message
-                holder.subtitle.setText(String.format("%s\n%s", activity.getResources().getString(R.string.unsupported_engine), game.getProjectTypeLabel()));
+                holder.subtitle.setText(activity.getResources().getString(R.string.unsupported_engine_card).replace("$ENGINE", game.getProjectTypeLabel()));
 
                 // Hide settings button
                 holder.settingsButton.setVisibility(View.INVISIBLE);
@@ -466,13 +466,11 @@ public class GameBrowserActivity extends BaseActivity
         private void showUnsupportedProjectTypeExplanation(final Context context, String projectType) {
             AlertDialog.Builder builder = new AlertDialog.Builder(context);
 
-            String part1 = context.getString(R.string.unsupported_engine_explanation_1).replace("$ENGINE", projectType);
-            String part2 = context.getString(R.string.unsupported_engine_explanation_2);
-            String part3 = context.getString(R.string.unsupported_engine_explanation_3);
+            String message = context.getString(R.string.unsupported_engine_explanation).replace("$ENGINE", projectType);
 
             builder
-                .setTitle(R.string.information)
-                .setMessage(part1 + '\n' + '\n' + part2 + '\n' + '\n' + part3)
+                .setTitle(R.string.unsupported_engine_title)
+                .setMessage(message)
                 .setNeutralButton(R.string.ok, null);
             builder.show();
         }

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameScanner.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameScanner.java
@@ -127,7 +127,7 @@ public class GameScanner {
     private int scanFolderHash(Context context, Uri folderURI) {
         StringBuilder sb = new StringBuilder();
 
-        sb.append("2"); // Bump this when the cache layout changes
+        sb.append("3"); // Bump this when the cache layout changes
         for (String[] array : Helper.listChildrenDocuments(context, folderURI)) {
             sb.append(array[0]);
             sb.append(array[1]);

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/ProjectType.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/ProjectType.java
@@ -1,0 +1,29 @@
+package org.easyrpg.player.game_browser;
+
+import android.content.Context;
+
+import org.easyrpg.player.R;
+
+public enum ProjectType {
+    UNKNOWN("Unknown")
+    , SUPPORTED("Supported")
+    , RPG_MAKER_XP("RPG Maker XP")
+    , RPG_MAKER_VX("RPG Maker VX")
+    , RPG_MAKER_VX_ACE("RPG Maker VX Ace")
+    , RPG_MAKER_MV_MZ("RPG Maker MV/MZ")
+    , WOLF_RPG_EDITOR("Wolf RPG Editor");
+
+    private final String label;
+
+    ProjectType(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return this.label;
+    }
+
+    public static ProjectType getProjectType(int i) {
+        return ProjectType.values()[i];
+    }
+}

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/ProjectType.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/ProjectType.java
@@ -5,14 +5,16 @@ import android.content.Context;
 import org.easyrpg.player.R;
 
 public enum ProjectType {
-    UNKNOWN("Unknown")
-    , SUPPORTED("Supported")
-    , RPG_MAKER_XP("RPG Maker XP")
-    , RPG_MAKER_VX("RPG Maker VX")
-    , RPG_MAKER_VX_ACE("RPG Maker VX Ace")
-    , RPG_MAKER_MV_MZ("RPG Maker MV/MZ")
-    , WOLF_RPG_EDITOR("Wolf RPG Editor")
-    , ENCRYPTED_2K3_MANIACS("Encrypted 2k3 (Maniacs Patch)");
+    UNKNOWN("Unknown"),
+    SUPPORTED("Supported"),
+    RPG_MAKER_XP("RPG Maker XP"),
+    RPG_MAKER_VX("RPG Maker VX"),
+    RPG_MAKER_VX_ACE("RPG Maker VX Ace"),
+    RPG_MAKER_MV_MZ("RPG Maker MV/MZ"),
+    WOLF_RPG_EDITOR("Wolf RPG Editor"),
+    ENCRYPTED_2K3_MANIACS("Encrypted 2k3 (Maniacs Patch)"),
+    RPG_MAKER_95("RPG Maker 95"),
+    SIM_RPG_MAKER_95("Sim RPG Maker 95");
 
     private final String label;
 

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/ProjectType.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/ProjectType.java
@@ -11,7 +11,8 @@ public enum ProjectType {
     , RPG_MAKER_VX("RPG Maker VX")
     , RPG_MAKER_VX_ACE("RPG Maker VX Ace")
     , RPG_MAKER_MV_MZ("RPG Maker MV/MZ")
-    , WOLF_RPG_EDITOR("Wolf RPG Editor");
+    , WOLF_RPG_EDITOR("Wolf RPG Editor")
+    , ENCRYPTED_2K3_MANIACS("Encrypted 2k3 (Maniacs Patch)");
 
     private final String label;
 

--- a/builds/android/app/src/main/res/layout/browser_game_card_landscape.xml
+++ b/builds/android/app/src/main/res/layout/browser_game_card_landscape.xml
@@ -55,6 +55,21 @@
             android:gravity="center_horizontal"
             />
 
+        <TextView
+            android:id="@+id/subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+
+            android:layout_alignParentStart="true"
+
+            android:layout_centerVertical="true"
+            android:gravity="center_horizontal"
+            android:padding="8dp"
+            android:textAlignment="center"
+            android:textColor="#000000"
+            android:textSize="16sp"
+            android:textStyle="normal" />
+
         <ImageButton
             android:id="@+id/game_browser_thumbnail_favorite_button"
             android:background="@android:color/transparent"

--- a/builds/android/app/src/main/res/layout/browser_game_card_portrait.xml
+++ b/builds/android/app/src/main/res/layout/browser_game_card_portrait.xml
@@ -36,6 +36,22 @@
             android:textColor="#222"
             android:textSize="20sp"
             android:textStyle="bold"/>
+
+        <TextView
+            android:id="@+id/subtitle"
+
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+
+            android:layout_below="@id/title"
+            android:layout_toStartOf="@+id/game_browser_thumbnail_option_button"
+            android:layout_toEndOf="@+id/screen"
+            android:padding="4dp"
+
+            android:textColor="#666"
+            android:textSize="14sp"
+            android:textStyle="normal" />
+
         <ImageButton
             android:id="@+id/game_browser_thumbnail_option_button"
 

--- a/builds/android/app/src/main/res/values/strings.xml
+++ b/builds/android/app/src/main/res/values/strings.xml
@@ -151,4 +151,5 @@ Please tell us in detail what went wrong.\n\n
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
     <string name="menu">Open Android menu</string>
+    <string name="unsupported_engine">Unsupported engine:</string>
 </resources>

--- a/builds/android/app/src/main/res/values/strings.xml
+++ b/builds/android/app/src/main/res/values/strings.xml
@@ -151,9 +151,7 @@ Please tell us in detail what went wrong.\n\n
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
     <string name="menu">Open Android menu</string>
-    <string name="unsupported_engine">Unsupported engine:</string>
-    <string name="unsupported_engine_explanation_1">This game cannot be played in EasyRPG because it was created with $ENGINE.</string>
-    <string name="unsupported_engine_explanation_2">EasyRPG is designed to support only RPG Maker 2000 and 2003 games, with no plans to expand to other engines.</string>
-    <string name="unsupported_engine_explanation_3">For software capable of launching this game, please check the Play Store.</string>
-    <string name="information">Information</string>
+    <string name="unsupported_engine_card">$ENGINE is unsupported</string>
+    <string name="unsupported_engine_title">Unsupported engine</string>
+    <string name="unsupported_engine_explanation">This game cannot be played in EasyRPG Player because it was created with $ENGINE.\n\nEasyRPG Player is designed to support only RPG Maker 2000 and 2003 games, with no plans to expand to other engines.\n\nFor software capable of launching this game, please check the Play Store.</string>
 </resources>

--- a/builds/android/app/src/main/res/values/strings.xml
+++ b/builds/android/app/src/main/res/values/strings.xml
@@ -152,4 +152,6 @@ Please tell us in detail what went wrong.\n\n
     <string name="navigation_drawer_close">Close navigation drawer</string>
     <string name="menu">Open Android menu</string>
     <string name="unsupported_engine">Unsupported engine:</string>
+    <string name="unsupported_engine_explanation">The selected game cannot be launched because it uses an unsupported engine: $ENGINE. EasyRPG supports ONLY games made in RPG Maker 2000 and 2003, other engines are out of scope of the project. For games created in newer versions of RPG Maker (XP and up), consider using alternative emulators available on the Play Store.</string>
+    <string name="information">Information</string>
 </resources>

--- a/builds/android/app/src/main/res/values/strings.xml
+++ b/builds/android/app/src/main/res/values/strings.xml
@@ -152,6 +152,8 @@ Please tell us in detail what went wrong.\n\n
     <string name="navigation_drawer_close">Close navigation drawer</string>
     <string name="menu">Open Android menu</string>
     <string name="unsupported_engine">Unsupported engine:</string>
-    <string name="unsupported_engine_explanation">The selected game cannot be launched because it uses an unsupported engine: $ENGINE. EasyRPG supports ONLY games made in RPG Maker 2000 and 2003, other engines are out of scope of the project. For games created in newer versions of RPG Maker (XP and up), consider using alternative emulators available on the Play Store.</string>
+    <string name="unsupported_engine_explanation_1">This game cannot be played in EasyRPG because it was created with $ENGINE.</string>
+    <string name="unsupported_engine_explanation_2">EasyRPG is designed to support only RPG Maker 2000 and 2003 games, with no plans to expand to other engines.</string>
+    <string name="unsupported_engine_explanation_3">For software capable of launching this game, please check the Play Store.</string>
     <string name="information">Information</string>
 </resources>

--- a/src/directory_tree.cpp
+++ b/src/directory_tree.cpp
@@ -223,12 +223,12 @@ std::string DirectoryTree::FindFile(const DirectoryTree::Args& args) const {
 	}
 
 	std::string dir_key = make_key(dir);
-	auto dir_it = Find(dir_cache, dir_key);
+	auto dir_it = Find(dir_cache, dir_key, args.process_wildcards);
 	assert(dir_it != dir_cache.end());
 
 	std::string name_key = make_key(name);
 	if (args.exts.empty()) {
-		auto entry_it = Find(*entries, name_key);
+		auto entry_it = Find(*entries, name_key, args.process_wildcards);
 		if (entry_it != entries->end() && entry_it->second.type == FileType::Regular) {
 			auto full_path = FileFinder::MakePath(dir_it->second, entry_it->second.name);
 			DebugLog("FindFile Found: {} | {} | {}", dir, name, full_path);
@@ -237,7 +237,7 @@ std::string DirectoryTree::FindFile(const DirectoryTree::Args& args) const {
 	} else {
 		for (const auto& ext : args.exts) {
 			auto full_name_key = name_key + ToString(ext);
-			auto entry_it = Find(*entries, full_name_key);
+			auto entry_it = Find(*entries, full_name_key, args.process_wildcards);
 			if (entry_it != entries->end() && entry_it->second.type == FileType::Regular) {
 				auto full_path = FileFinder::MakePath(dir_it->second, entry_it->second.name);
 				DebugLog("FindFile Found: {} | {} | {}", dir, name, full_path);

--- a/src/directory_tree.cpp
+++ b/src/directory_tree.cpp
@@ -51,6 +51,21 @@ std::unique_ptr<DirectoryTree> DirectoryTree::Create(Filesystem& fs) {
 	return tree;
 }
 
+bool DirectoryTree::WildcardMatch(const StringView& pattern, const StringView& text) {
+	if (pattern.length() != text.length()) {
+		return false;
+	}
+
+	std::string pattern_norm = make_key(pattern);
+	std::string text_norm = make_key(text);
+
+	return std::equal(pattern_norm.begin(), pattern_norm.end(),
+					  text_norm.begin(),
+					  [](char p, char t) {
+						  return p == '?' || p == t;
+					  });
+}
+
 DirectoryTree::DirectoryListType* DirectoryTree::ListDirectory(StringView path) const {
 	std::vector<Entry> entries;
 	std::string fs_path = ToString(path);

--- a/src/directory_tree.h
+++ b/src/directory_tree.h
@@ -73,6 +73,10 @@ public:
 		 * Off by default because file probing would spam the terminal alot.
 		 */
 		bool file_not_found_warning = false;
+		/**
+		 * Processes ? in filenames as placeholders
+		 */
+		bool process_wildcards = false;
 	};
 
 	using DirectoryListType = std::vector<std::pair<std::string, Entry>>;
@@ -148,9 +152,9 @@ private:
 	static bool WildcardMatch(const StringView& pattern, const StringView& text);
 
 	template<class T>
-	auto Find(T& cache, StringView what) const {
-		// No wildcard - binary search
-		if (what.find('?') == StringView::npos) {
+	auto Find(T& cache, StringView what, bool process_wildcards = false) const {
+		if (!process_wildcards) {
+			// No wildcard - binary search
 			auto it = std::lower_bound(cache.begin(), cache.end(), what, [](const auto& e, const auto& w) {
 				return e.first < w;
 			});
@@ -158,14 +162,15 @@ private:
 				return it;
 			}
 			return cache.end();
-		}
-
-		// Has wildcard - linear search
-		for (auto it = cache.begin(); it != cache.end(); ++it) {
-			if (WildcardMatch(what, it->first)) {
-				return it;
+		} else {
+			// Has wildcard - linear search
+			for (auto it = cache.begin(); it != cache.end(); ++it) {
+				if (WildcardMatch(what, it->first)) {
+					return it;
+				}
 			}
 		}
+
 		return cache.end();
 	}
 

--- a/src/directory_tree.h
+++ b/src/directory_tree.h
@@ -145,15 +145,27 @@ private:
 	/** lowered dir (full path from root) of missing directories */
 	mutable std::vector<std::string> dir_missing_cache;
 
+	static bool WildcardMatch(const StringView& pattern, const StringView& text);
+
 	template<class T>
 	auto Find(T& cache, StringView what) const {
-		auto it = std::lower_bound(cache.begin(), cache.end(), what, [](const auto& e, const auto& w) {
-			return e.first < w;
-		});
-		if (it != cache.end() && it->first == what) {
-			return it;
+		// No wildcard - binary search
+		if (what.find('?') == StringView::npos) {
+			auto it = std::lower_bound(cache.begin(), cache.end(), what, [](const auto& e, const auto& w) {
+				return e.first < w;
+			});
+			if (it != cache.end() && it->first == what) {
+				return it;
+			}
+			return cache.end();
 		}
 
+		// Has wildcard - linear search
+		for (auto it = cache.begin(); it != cache.end(); ++it) {
+			if (WildcardMatch(what, it->first)) {
+				return it;
+			}
+		}
 		return cache.end();
 	}
 

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -579,8 +579,8 @@ void FileFinder::DumpFilesystem(FilesystemView fs) {
 	}
 }
 
-std::vector<FileFinder::GameEntry> FileFinder::FindGames(FilesystemView fs, int recursion_limit, int game_limit) {
-	std::vector<FileFinder::GameEntry> games;
+std::vector<FileFinder::FsEntry> FileFinder::FindGames(FilesystemView fs, int recursion_limit, int game_limit) {
+	std::vector<FileFinder::FsEntry> games;
 
 	std::function<void(FilesystemView, int)> find_recursive = [&](FilesystemView subfs, int rec_limit) -> void {
 		if (!subfs || rec_limit == 0 || static_cast<int>(games.size()) >= game_limit) {

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -317,15 +317,21 @@ FileFinder::ProjectType FileFinder::GetProjectType(const FilesystemView &fs) {
 		return FileFinder::ProjectType::Supported;
 	}
 
-	if (!fs.FindFile("RGSS10??.dll").empty()) {
+	DirectoryTree::Args args;
+	args.process_wildcards = true;
+	args.path = "RGSS10??.dll";
+
+	if (!fs.FindFile(args).empty()) {
 		return FileFinder::ProjectType::RpgMakerXp;
 	}
 
-	if (!fs.FindFile("RGSS20??.dll").empty()) {
+	args.path = "RGSS20??.dll";
+	if (!fs.FindFile(args).empty()) {
 		return FileFinder::ProjectType::RpgMakerVx;
 	}
 
-	if (!fs.FindFile("System", "RGSS30?.dll").empty()) {
+	args.path = "System/RGSS30?.dll";
+	if (!fs.FindFile(args).empty()) {
 		return FileFinder::ProjectType::RpgMakerVxAce;
 	}
 
@@ -339,6 +345,14 @@ FileFinder::ProjectType FileFinder::GetProjectType(const FilesystemView &fs) {
 
 	if (!fs.FindFile("RPG_RT.rs1").empty()) {
 		return FileFinder::ProjectType::Encrypted2k3Maniacs;
+	}
+
+	if (!fs.FindFile("Game.RPG").empty()) {
+		return FileFinder::ProjectType::RpgMaker95;
+	}
+
+	if (!fs.FindFile("Game.DAT").empty()) {
+		return FileFinder::ProjectType::SimRpgMaker95;
 	}
 
 	return FileFinder::ProjectType::Unknown;

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -347,12 +347,12 @@ FileFinder::ProjectType FileFinder::GetProjectType(const FilesystemView &fs) {
 		return FileFinder::ProjectType::Encrypted2k3Maniacs;
 	}
 
-	if (!fs.FindFile("Game.RPG").empty()) {
-		return FileFinder::ProjectType::RpgMaker95;
-	}
-
-	if (!fs.FindFile("Game.DAT").empty()) {
-		return FileFinder::ProjectType::SimRpgMaker95;
+	if (!fs.FindFile("SWNAME.DAT").empty()) {
+		if (!fs.FindFile("GEOLOGY.DAT").empty()) {
+			return FileFinder::ProjectType::SimRpgMaker95;
+		} else if (args.path = "*.RPG"; !fs.FindFile(args).empty()) {
+			return FileFinder::ProjectType::RpgMaker95;
+		}
 	}
 
 	return FileFinder::ProjectType::Unknown;

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -312,6 +312,35 @@ bool FileFinder::IsRPG2kProjectWithRenames(const FilesystemView& fs) {
 	return !FileExtGuesser::GetRPG2kProjectWithRenames(fs).Empty();
 }
 
+FileFinder::ProjectType FileFinder::GetProjectType(const FilesystemView &fs) {
+    if (IsValidProject(fs)) {
+        return FileFinder::ProjectType::Supported;
+    }
+
+    // TODO: Find remaining RGSS dlls
+    if (!fs.FindFile("RGSS104E.dll").empty()) {
+        return FileFinder::ProjectType::RpgMakerXp;
+    }
+
+    if (!fs.FindFile("RGSS202E.dll").empty()) {
+        return FileFinder::ProjectType::RpgMakerVx;
+    }
+
+    if (!fs.FindFile("System", "RGSS301.dll").empty()) {
+        return FileFinder::ProjectType::RpgMakerVxAce;
+    }
+
+    if (!fs.FindFile("nw.dll").empty()) {
+        return FileFinder::ProjectType::RpgMakerMvMz;
+    }
+
+    if (!fs.FindFile("GuruGuruSMF4.dll").empty()) {
+        return FileFinder::ProjectType::WolfRpgEditor;
+    }
+
+    return FileFinder::ProjectType::Unknown;
+}
+
 bool FileFinder::OpenViewToEasyRpgFile(FilesystemView& fs) {
 	auto files = fs.ListDirectory();
 	if (!files) {

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -317,16 +317,15 @@ FileFinder::ProjectType FileFinder::GetProjectType(const FilesystemView &fs) {
         return FileFinder::ProjectType::Supported;
     }
 
-    // TODO: Find remaining RGSS dlls
-    if (!fs.FindFile("RGSS104E.dll").empty()) {
+    if (!fs.FindFile("RGSS10??.dll").empty()) {
         return FileFinder::ProjectType::RpgMakerXp;
     }
 
-    if (!fs.FindFile("RGSS202E.dll").empty()) {
+    if (!fs.FindFile("RGSS20??.dll").empty()) {
         return FileFinder::ProjectType::RpgMakerVx;
     }
 
-    if (!fs.FindFile("System", "RGSS301.dll").empty()) {
+    if (!fs.FindFile("System", "RGSS30?.dll").empty()) {
         return FileFinder::ProjectType::RpgMakerVxAce;
     }
 

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -313,31 +313,35 @@ bool FileFinder::IsRPG2kProjectWithRenames(const FilesystemView& fs) {
 }
 
 FileFinder::ProjectType FileFinder::GetProjectType(const FilesystemView &fs) {
-    if (IsValidProject(fs)) {
-        return FileFinder::ProjectType::Supported;
-    }
+	if (IsValidProject(fs)) {
+		return FileFinder::ProjectType::Supported;
+	}
 
-    if (!fs.FindFile("RGSS10??.dll").empty()) {
-        return FileFinder::ProjectType::RpgMakerXp;
-    }
+	if (!fs.FindFile("RGSS10??.dll").empty()) {
+		return FileFinder::ProjectType::RpgMakerXp;
+	}
 
-    if (!fs.FindFile("RGSS20??.dll").empty()) {
-        return FileFinder::ProjectType::RpgMakerVx;
-    }
+	if (!fs.FindFile("RGSS20??.dll").empty()) {
+		return FileFinder::ProjectType::RpgMakerVx;
+	}
 
-    if (!fs.FindFile("System", "RGSS30?.dll").empty()) {
-        return FileFinder::ProjectType::RpgMakerVxAce;
-    }
+	if (!fs.FindFile("System", "RGSS30?.dll").empty()) {
+		return FileFinder::ProjectType::RpgMakerVxAce;
+	}
 
-    if (!fs.FindFile("nw.dll").empty()) {
-        return FileFinder::ProjectType::RpgMakerMvMz;
-    }
+	if (!fs.FindFile("nw.dll").empty()) {
+		return FileFinder::ProjectType::RpgMakerMvMz;
+	}
 
-    if (!fs.FindFile("GuruGuruSMF4.dll").empty()) {
-        return FileFinder::ProjectType::WolfRpgEditor;
-    }
+	if (!fs.FindFile("GuruGuruSMF4.dll").empty()) {
+		return FileFinder::ProjectType::WolfRpgEditor;
+	}
 
-    return FileFinder::ProjectType::Unknown;
+	if (!fs.FindFile("RPG_RT.rs1").empty()) {
+		return FileFinder::ProjectType::Encrypted2k3Maniacs;
+	}
+
+	return FileFinder::ProjectType::Unknown;
 }
 
 bool FileFinder::OpenViewToEasyRpgFile(FilesystemView& fs) {
@@ -569,11 +573,11 @@ std::vector<FileFinder::GameEntry> FileFinder::FindGames(FilesystemView fs, int 
 			return;
 		}
 
-        auto project_type = GetProjectType(subfs);
-        if (project_type != ProjectType::Unknown) {
-            games.push_back({ subfs, project_type });
-            return;
-        }
+		auto project_type = GetProjectType(subfs);
+		if (project_type != ProjectType::Unknown) {
+			games.push_back({ subfs, project_type });
+			return;
+		}
 
 		auto entries = subfs.ListDirectory();
 

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -562,18 +562,19 @@ void FileFinder::DumpFilesystem(FilesystemView fs) {
 	}
 }
 
-std::vector<FilesystemView> FileFinder::FindGames(FilesystemView fs, int recursion_limit, int game_limit) {
-	std::vector<FilesystemView> games;
+std::vector<FileFinder::GameEntry> FileFinder::FindGames(FilesystemView fs, int recursion_limit, int game_limit) {
+	std::vector<FileFinder::GameEntry> games;
 
 	std::function<void(FilesystemView, int)> find_recursive = [&](FilesystemView subfs, int rec_limit) -> void {
 		if (!subfs || rec_limit == 0 || static_cast<int>(games.size()) >= game_limit) {
 			return;
 		}
 
-		if (IsValidProject(subfs)) {
-			games.push_back(subfs);
-			return;
-		}
+        auto project_type = GetProjectType(subfs);
+        if (project_type != ProjectType::Unknown) {
+            games.push_back({ subfs, project_type });
+            return;
+        }
 
 		auto entries = subfs.ListDirectory();
 

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -390,9 +390,9 @@ namespace FileFinder {
 	 * @param fs Filesystem where the search starts
 	 * @param recursion_limit Recursion depth
 	 * @param game_limit Abort the search when this amount of games was found.
-	 * @return Vector of views to the found game directories
+	 * @return Vector of game entries (filesystem view + project type) found
 	 */
-	std::vector<FilesystemView> FindGames(FilesystemView fs, int recursion_limit = 3, int game_limit = 5);
+	std::vector<GameEntry> FindGames(FilesystemView fs, int recursion_limit = 3, int game_limit = 5);
 } // namespace FileFinder
 
 template<typename T>

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -79,9 +79,17 @@ namespace FileFinder {
 	);
 
 	/**
-	 * Helper struct combining the project's directory and its type.
+	 * Helper struct combining the project's directory and its type (used by Game Browser)
 	 */
 	struct GameEntry {
+		std::string dir_name;
+		ProjectType type;
+	};
+
+	/**
+	 * Helper struct combining project type and filesystem (used by Android Game Browser)
+	 */
+	struct FsEntry {
 		FilesystemView fs;
 		ProjectType type;
 	};
@@ -409,7 +417,7 @@ namespace FileFinder {
 	 * @param game_limit Abort the search when this amount of games was found.
 	 * @return Vector of game entries (filesystem view + project type) found
 	 */
-	std::vector<GameEntry> FindGames(FilesystemView fs, int recursion_limit = 3, int game_limit = 5);
+	std::vector<FsEntry> FindGames(FilesystemView fs, int recursion_limit = 3, int game_limit = 5);
 } // namespace FileFinder
 
 template<typename T>

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -45,34 +45,35 @@ namespace FileFinder {
 	constexpr const auto FONTS_TYPES = Utils::MakeSvArray(".fon", ".fnt", ".bdf", ".ttf", ".ttc", ".otf", ".woff2", ".woff");
 	constexpr const auto TEXT_TYPES = Utils::MakeSvArray(".txt", ".csv", ""); // "" = Complete Filename (incl. extension) provided by the user
 
-    /**
-     * Type of the project. Used to differentiate between supported games (2kX or EasyRPG)
-     * and known but unsupported (i.e. newer RPG Makers).
-     */
-    enum ProjectType {
-        Unknown,
-        // 2kX or EasyRPG
-        Supported,
-        // Known unsupported engines
-        RpgMakerXp,
-        RpgMakerVx,
-        RpgMakerVxAce,
-        RpgMakerMvMz,
-        WolfRpgEditor,
-    };
+	/**
+	 * Type of the project. Used to differentiate between supported games (2kX or EasyRPG)
+	 * and known but unsupported (i.e. newer RPG Makers).
+	 */
+	enum ProjectType {
+		Unknown,
+		// 2kX or EasyRPG
+		Supported,
+		// Known unsupported engines
+		RpgMakerXp,
+		RpgMakerVx,
+		RpgMakerVxAce,
+		RpgMakerMvMz,
+		WolfRpgEditor,
+		Encrypted2k3Maniacs,
+	};
 
-    /**
-     * Helper struct combining the project's directory and its type.
-     */
-    struct GameEntry {
-        FilesystemView fs;
-        ProjectType type;
-    };
+	/**
+	 * Helper struct combining the project's directory and its type.
+	 */
+	struct GameEntry {
+		FilesystemView fs;
+		ProjectType type;
+	};
 
-    /** @return Human readable project type label */
-    static const char* GetProjectTypeLabel(ProjectType pt);
+	/** @return Human readable project type label */
+	static const char* GetProjectTypeLabel(ProjectType pt);
 
-    /**
+	/**
 	 * Quits FileFinder.
 	 */
 	void Quit();
@@ -314,11 +315,11 @@ namespace FileFinder {
 	 */
 	bool IsRPG2kProjectWithRenames(const FilesystemView& fs);
 
-    /**
-     * @param p fs Tree to check
-     * @return Project type whether the tree contains a supported project type, known but unsupported engines, or something unknown
-     */
-    ProjectType GetProjectType(const FilesystemView& fs);
+	/**
+	 * @param p fs Tree to check
+	 * @return Project type whether the tree contains a supported project type, known but unsupported engines, or something unknown
+	 */
+	ProjectType GetProjectType(const FilesystemView& fs);
 
 	/**
 	 * Determines if the directory contains a single file/directory ending in ".easyrpg" for use in the
@@ -355,18 +356,18 @@ namespace FileFinder {
 	bool IsMajorUpdatedTree();
 
 	/** RPG_RT.exe file size thresholds
-         *
-         * 2k v1.51 (Japanese)    : 746496
-         * 2k v1.50 (Japanese)    : 745984
-         *  -- threshold (2k) --  : 735000
-         * 2k v1.10 (Japanese)    : 726016
-         *
-         * 2k3 v1.09a (Japanese)  : 950784
-         * 2k3 v1.06 (Japanese)   : 949248
-         * 2k3 v1.05 (Japanese)   : unknown
-         *  -- threshold (2k3) -- : 927000
-         * 2k3 v1.04 (Japanese)   : 913408
-         */
+		 *
+		 * 2k v1.51 (Japanese)    : 746496
+		 * 2k v1.50 (Japanese)    : 745984
+		 *  -- threshold (2k) --  : 735000
+		 * 2k v1.10 (Japanese)    : 726016
+		 *
+		 * 2k3 v1.09a (Japanese)  : 950784
+		 * 2k3 v1.06 (Japanese)   : 949248
+		 * 2k3 v1.05 (Japanese)   : unknown
+		 *  -- threshold (2k3) -- : 927000
+		 * 2k3 v1.04 (Japanese)   : 913408
+		 */
 	enum RpgrtMajorUpdateThreshold {
 		RPG2K = 735000,
 		RPG2K3 = 927000,
@@ -408,22 +409,24 @@ std::string FileFinder::MakePath(lcf::Span<T> components) {
 }
 
 static inline const char* FileFinder::GetProjectTypeLabel(ProjectType pt) {
-    switch (pt) {
-        case Supported:
-            return "Supported";
-        case RpgMakerXp:
-            return "RPG Maker XP";
-        case RpgMakerVx:
-            return "RPG Maker VX";
-        case RpgMakerVxAce:
-            return "RPG Maker VX Ace";
-        case RpgMakerMvMz:
-            return "RPG Maker MV/MZ";
-        case WolfRpgEditor:
-            return "Wolf RPG Editor";
+	switch (pt) {
+		case Supported:
+			return "Supported";
+		case RpgMakerXp:
+			return "RPG Maker XP";
+		case RpgMakerVx:
+			return "RPG Maker VX";
+		case RpgMakerVxAce:
+			return "RPG Maker VX Ace";
+		case RpgMakerMvMz:
+			return "RPG Maker MV/MZ";
+		case WolfRpgEditor:
+			return "Wolf RPG Editor";
+		case Encrypted2k3Maniacs:
+			return "Encrypted 2k3MP";
 		default:
 			return "Unknown";
-    }
+	}
 }
 
 #endif

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -69,7 +69,10 @@ namespace FileFinder {
         ProjectType type;
     };
 
-	/**
+    /** @return Human readable project type label */
+    static const char* GetProjectTypeLabel(ProjectType pt);
+
+    /**
 	 * Quits FileFinder.
 	 */
 	void Quit();
@@ -402,6 +405,25 @@ std::string FileFinder::MakePath(lcf::Span<T> components) {
 		path = MakePath(path, c);
 	}
 	return path;
+}
+
+static inline const char* FileFinder::GetProjectTypeLabel(ProjectType pt) {
+    switch (pt) {
+        case Supported:
+            return "Supported";
+        case RpgMakerXp:
+            return "RPG Maker XP";
+        case RpgMakerVx:
+            return "RPG Maker VX";
+        case RpgMakerVxAce:
+            return "RPG Maker VX Ace";
+        case RpgMakerMvMz:
+            return "RPG Maker MV/MZ";
+        case WolfRpgEditor:
+            return "Wolf RPG Editor";
+		default:
+			return "Unknown";
+    }
 }
 
 #endif

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -25,6 +25,7 @@
 #include "string_view.h"
 #include "directory_tree.h"
 
+#include <lcf/enum_tags.h>
 #include <string>
 #include <cstdio>
 #include <ios>
@@ -60,7 +61,22 @@ namespace FileFinder {
 		RpgMakerMvMz,
 		WolfRpgEditor,
 		Encrypted2k3Maniacs,
+		RpgMaker95,
+		SimRpgMaker95
 	};
+
+	constexpr auto kProjectType = lcf::makeEnumTags<ProjectType>(
+		"Unknown",
+		"Supported",
+		"RPG Maker XP",
+		"RPG Maker VX",
+		"RPG Maker VX Ace",
+		"RPG Maker MV/MZ",
+		"Wolf RPG Editor",
+		"Encrypted 2k3MP",
+		"RPG Maker 95",
+		"Sim RPG Maker 95"
+	);
 
 	/**
 	 * Helper struct combining the project's directory and its type.
@@ -69,9 +85,6 @@ namespace FileFinder {
 		FilesystemView fs;
 		ProjectType type;
 	};
-
-	/** @return Human readable project type label */
-	static const char* GetProjectTypeLabel(ProjectType pt);
 
 	/**
 	 * Quits FileFinder.
@@ -356,18 +369,18 @@ namespace FileFinder {
 	bool IsMajorUpdatedTree();
 
 	/** RPG_RT.exe file size thresholds
-		 *
-		 * 2k v1.51 (Japanese)    : 746496
-		 * 2k v1.50 (Japanese)    : 745984
-		 *  -- threshold (2k) --  : 735000
-		 * 2k v1.10 (Japanese)    : 726016
-		 *
-		 * 2k3 v1.09a (Japanese)  : 950784
-		 * 2k3 v1.06 (Japanese)   : 949248
-		 * 2k3 v1.05 (Japanese)   : unknown
-		 *  -- threshold (2k3) -- : 927000
-		 * 2k3 v1.04 (Japanese)   : 913408
-		 */
+	 *
+	 * 2k v1.51 (Japanese)    : 746496
+	 * 2k v1.50 (Japanese)    : 745984
+	 *  -- threshold (2k) --  : 735000
+	 * 2k v1.10 (Japanese)    : 726016
+	 *
+	 * 2k3 v1.09a (Japanese)  : 950784
+	 * 2k3 v1.06 (Japanese)   : 949248
+	 * 2k3 v1.05 (Japanese)   : unknown
+	 *  -- threshold (2k3) -- : 927000
+	 * 2k3 v1.04 (Japanese)   : 913408
+	 */
 	enum RpgrtMajorUpdateThreshold {
 		RPG2K = 735000,
 		RPG2K3 = 927000,
@@ -406,27 +419,6 @@ std::string FileFinder::MakePath(lcf::Span<T> components) {
 		path = MakePath(path, c);
 	}
 	return path;
-}
-
-static inline const char* FileFinder::GetProjectTypeLabel(ProjectType pt) {
-	switch (pt) {
-		case Supported:
-			return "Supported";
-		case RpgMakerXp:
-			return "RPG Maker XP";
-		case RpgMakerVx:
-			return "RPG Maker VX";
-		case RpgMakerVxAce:
-			return "RPG Maker VX Ace";
-		case RpgMakerMvMz:
-			return "RPG Maker MV/MZ";
-		case WolfRpgEditor:
-			return "Wolf RPG Editor";
-		case Encrypted2k3Maniacs:
-			return "Encrypted 2k3MP";
-		default:
-			return "Unknown";
-	}
 }
 
 #endif

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -45,6 +45,30 @@ namespace FileFinder {
 	constexpr const auto FONTS_TYPES = Utils::MakeSvArray(".fon", ".fnt", ".bdf", ".ttf", ".ttc", ".otf", ".woff2", ".woff");
 	constexpr const auto TEXT_TYPES = Utils::MakeSvArray(".txt", ".csv", ""); // "" = Complete Filename (incl. extension) provided by the user
 
+    /**
+     * Type of the project. Used to differentiate between supported games (2kX or EasyRPG)
+     * and known but unsupported (i.e. newer RPG Makers).
+     */
+    enum ProjectType {
+        Unknown,
+        // 2kX or EasyRPG
+        Supported,
+        // Known unsupported engines
+        RpgMakerXp,
+        RpgMakerVx,
+        RpgMakerVxAce,
+        RpgMakerMvMz,
+        WolfRpgEditor,
+    };
+
+    /**
+     * Helper struct combining the project's directory and its type.
+     */
+    struct GameEntry {
+        FilesystemView fs;
+        ProjectType type;
+    };
+
 	/**
 	 * Quits FileFinder.
 	 */
@@ -286,6 +310,12 @@ namespace FileFinder {
 	 * @return true if this is likely an RPG2k project; false otherwise
 	 */
 	bool IsRPG2kProjectWithRenames(const FilesystemView& fs);
+
+    /**
+     * @param p fs Tree to check
+     * @return Project type whether the tree contains a supported project type, known but unsupported engines, or something unknown
+     */
+    ProjectType GetProjectType(const FilesystemView& fs);
 
 	/**
 	 * Determines if the directory contains a single file/directory ending in ".easyrpg" for use in the

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -188,43 +188,48 @@ void Scene_GameBrowser::BootGame() {
 		return;
 	}
 
-	auto ge = gamelist_window->GetGameEntry();
+	auto entry = gamelist_window->GetFilesystemEntry();
 
-	if (!ge.fs) {
+	if (!entry.fs) {
 		Output::Warning("The selected file or directory cannot be opened");
 		load_window->SetVisible(false);
 		game_loading = false;
 		return;
 	}
 
-	if (ge.type > FileFinder::ProjectType::Supported) {
+	if (entry.type == FileFinder::ProjectType::Unknown) {
+		// Fetched again for platforms where the type is not populated due to bad IO performance
+		entry.type = FileFinder::GetProjectType(entry.fs);
+	}
+
+	if (entry.type > FileFinder::ProjectType::Supported) {
 		// Game is using a known unsupported engine
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 		Output::Warning(
-				"[{}] Detected an unsupported game engine: {}",
-				FileFinder::GetPathAndFilename(ge.fs.GetFullPath()).second,
-				FileFinder::kProjectType.tag(ge.type)
+				"{} has unsupported engine {}",
+				FileFinder::GetPathAndFilename(entry.fs.GetFullPath()).second,
+				FileFinder::kProjectType.tag(entry.type)
 		);
 		load_window->SetVisible(false);
 		game_loading = false;
 		return;
 	}
 
-	if (ge.type == FileFinder::ProjectType::Unknown && !FileFinder::OpenViewToEasyRpgFile(ge.fs)) {
+	if (entry.type == FileFinder::ProjectType::Unknown && !FileFinder::OpenViewToEasyRpgFile(entry.fs)) {
 		// Not a game: Open as directory
 		load_window->SetVisible(false);
 		game_loading = false;
-		if (!gamelist_window->Refresh(ge.fs, true)) {
+		if (!gamelist_window->Refresh(entry.fs, true)) {
 			Output::Warning("The selected file or directory cannot be opened");
 			return;
 		}
-		stack.push_back({ ge.fs, gamelist_window->GetIndex() });
+		stack.push_back({ entry.fs, gamelist_window->GetIndex() });
 		gamelist_window->SetIndex(0);
 
 		return;
 	}
 
-	FileFinder::SetGameFilesystem(ge.fs);
+	FileFinder::SetGameFilesystem(entry.fs);
 	Player::CreateGameObjects();
 
 	game_loading = false;

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -197,18 +197,18 @@ void Scene_GameBrowser::BootGame() {
 		return;
 	}
 
-    if (ge.type > FileFinder::ProjectType::Supported) {
-        // Game is using a known unsupported engine
-        Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
-        Output::Warning(
-                "[{}] Detected an unsupported game engine: {}",
-                FileFinder::GetPathAndFilename(ge.fs.GetFullPath()).second,
-                FileFinder::GetProjectTypeLabel(ge.type)
-        );
-        load_window->SetVisible(false);
-        game_loading = false;
-        return;
-    }
+	if (ge.type > FileFinder::ProjectType::Supported) {
+		// Game is using a known unsupported engine
+		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
+		Output::Warning(
+				"[{}] Detected an unsupported game engine: {}",
+				FileFinder::GetPathAndFilename(ge.fs.GetFullPath()).second,
+				FileFinder::kProjectType.tag(ge.type)
+		);
+		load_window->SetVisible(false);
+		game_loading = false;
+		return;
+	}
 
 	if (ge.type == FileFinder::ProjectType::Unknown && !FileFinder::OpenViewToEasyRpgFile(ge.fs)) {
 		// Not a game: Open as directory

--- a/src/window_gamelist.cpp
+++ b/src/window_gamelist.cpp
@@ -154,6 +154,7 @@ bool Window_GameList::HasValidEntry() {
 	return game_directories.size() > minval;
 }
 
-std::pair<FilesystemView, std::string> Window_GameList::GetGameFilesystem() const {
-	return { base_fs.Create(game_directories[GetIndex()]), game_directories[GetIndex()] };
+FileFinder::GameEntry Window_GameList::GetGameEntry() const {
+	auto fs = base_fs.Create(game_directories[GetIndex()]);
+	return { fs, FileFinder::GetProjectType(fs) };
 }

--- a/src/window_gamelist.cpp
+++ b/src/window_gamelist.cpp
@@ -19,6 +19,7 @@
 #include <iomanip>
 #include <sstream>
 #include "window_gamelist.h"
+#include "filefinder.h"
 #include "game_party.h"
 #include "bitmap.h"
 #include "font.h"
@@ -110,7 +111,7 @@ void Window_GameList::DrawItem(int index) {
 	contents->TextDraw(rect.x, rect.y, Font::ColorDefault, dir_name);
 
 	if (ge.type > FileFinder::ProjectType::Supported) {
-		auto notice = fmt::format("Unsupported: {}", FileFinder::GetProjectTypeLabel(ge.type));
+		auto notice = fmt::format("Unsupported: {}", FileFinder::kProjectType.tag(ge.type));
 		contents->TextDraw(rect.width, rect.y, Font::ColorDisabled, notice, Text::AlignRight);
 	}
 }

--- a/src/window_gamelist.h
+++ b/src/window_gamelist.h
@@ -61,7 +61,7 @@ public:
 
 private:
 	FilesystemView base_fs;
-	std::vector<std::string> game_directories;
+	std::vector<FileFinder::GameEntry> game_entries;
 
 	bool show_dotdot = false;
 };

--- a/src/window_gamelist.h
+++ b/src/window_gamelist.h
@@ -20,7 +20,6 @@
 
 // Headers
 #include <vector>
-#include "window_help.h"
 #include "window_selectable.h"
 #include "filefinder.h"
 
@@ -55,9 +54,9 @@ public:
 	bool HasValidEntry();
 
 	/**
-	 * @return game entry containing filesystem view and project type
+	 * @return fs entry containing filesystem view and project type
 	 */
-	FileFinder::GameEntry GetGameEntry() const;
+	FileFinder::FsEntry GetFilesystemEntry() const;
 
 private:
 	FilesystemView base_fs;

--- a/src/window_gamelist.h
+++ b/src/window_gamelist.h
@@ -55,9 +55,9 @@ public:
 	bool HasValidEntry();
 
 	/**
-	 * @return filesystem and entry name of the selected game
+	 * @return game entry containing filesystem view and project type
 	 */
-	std::pair<FilesystemView, std::string> GetGameFilesystem() const;
+	FileFinder::GameEntry GetGameEntry() const;
 
 private:
 	FilesystemView base_fs;


### PR DESCRIPTION
Fix #3198 

Some users, particularly on mobile, struggle to understand why EasyRPG doesn't detect any playable content when trying to run games made with unsupported engines like RPG Maker versions other than 2kX or similar software (e.g. Wolf RPG Editor).

This PR addresses this issue by implementing a feature that detects games created with commonly encountered unsupported engines. Affects both regular and Android version of the player. The list of known engines consists of:
- RPG Maker XP
- RPG Maker VX
- RPG Maker VX Ace
- RPG Maker MV/MZ
- Wolf RPG Editor

A few screenshots demonstrating the feature:
![Player_20250107-152146](https://github.com/user-attachments/assets/07afad65-b0fb-4e74-aceb-790d9a3e1e58)
![image](https://github.com/user-attachments/assets/1edb4134-a385-4ff7-8769-3ca03d18f519)
![image-1](https://github.com/user-attachments/assets/7b3ced35-3bb3-4359-ab88-eb4cd1b7b036)
![image](https://github.com/user-attachments/assets/f3734f10-d7d3-4ca8-bf33-0da4e6042740)
![image-1](https://github.com/user-attachments/assets/89544266-88d7-4f48-bee3-9917d0c22c6c)
