### PR TITLE
Wii: Add SDL2 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,7 +555,10 @@ elseif(NINTENDO_SWITCH)
 elseif(VITA)
 	set(PLAYER_TARGET_PLATFORM "psvita" CACHE STRING "Platform to compile for.")
 elseif(NINTENDO_WII)
-	set(PLAYER_TARGET_PLATFORM "wii" CACHE STRING "Platform to compile for.")
+	set(PLAYER_TARGET_PLATFORM "SDL2" CACHE STRING "Platform to compile for. Options: SDL2 SDL1")
+	set(PLAYER_AUDIO_BACKEND "AESND" CACHE STRING "Audio system to use. Options: SDL2 SDL1 AESND OFF")
+	set_property(CACHE PLAYER_TARGET_PLATFORM PROPERTY STRINGS SDL2 SDL1)
+	set_property(CACHE PLAYER_AUDIO_BACKEND PROPERTY STRINGS SDL2 SDL1 AESND)
 elseif(NINTENDO_WIIU)
 	set(PLAYER_TARGET_PLATFORM "SDL2" CACHE STRING "Platform to compile for.")
 elseif(AMIGA)
@@ -578,8 +581,6 @@ endif()
 
 if(${PLAYER_TARGET_PLATFORM} STREQUAL "SDL2")
 	target_sources(${PROJECT_NAME} PRIVATE
-		src/platform/sdl/sdl_audio.cpp
-		src/platform/sdl/sdl_audio.h
 		src/platform/sdl/sdl2_ui.cpp
 		src/platform/sdl/sdl2_ui.h)
 	target_compile_definitions(${PROJECT_NAME} PUBLIC USE_SDL=2)
@@ -597,9 +598,13 @@ if(${PLAYER_TARGET_PLATFORM} STREQUAL "SDL2")
 
 	if(ANDROID)
 		set(PLAYER_BUILD_EXECUTABLE OFF)
-	endif()
-
-	if(NINTENDO_WIIU)
+	elseif(NINTENDO_WII)
+		target_compile_definitions(${PROJECT_NAME} PUBLIC PLAYER_NINTENDO)
+		target_sources(${PROJECT_NAME} PRIVATE
+			src/platform/wii/clock.cpp
+			src/platform/wii/clock.h
+			src/platform/wii/input_buttons.cpp)
+	elseif(NINTENDO_WIIU)
 		target_compile_definitions(${PROJECT_NAME} PUBLIC PLAYER_NINTENDO)
 		target_sources(${PROJECT_NAME} PRIVATE
 			src/platform/wiiu/main.h
@@ -610,15 +615,26 @@ if(${PLAYER_TARGET_PLATFORM} STREQUAL "SDL2")
 		target_link_libraries(${PROJECT_NAME} "Dwmapi")
 	endif()
 elseif(${PLAYER_TARGET_PLATFORM} STREQUAL "SDL1")
+	if(NINTENDO_WII)
+		find_package(SDL REQUIRED)
+		target_compile_definitions(${PROJECT_NAME} PUBLIC PLAYER_NINTENDO)
+		target_include_directories(${PROJECT_NAME} PUBLIC ${SDL_INCLUDE_DIR})
+		target_sources(${PROJECT_NAME} PRIVATE
+			src/platform/wii/clock.cpp
+			src/platform/wii/clock.h
+			src/platform/wii/input_buttons.cpp)
+	else()
+		player_find_package(NAME SDL1 TARGET SDL::SDLmain REQUIRED)
+	endif()
+
 	target_sources(${PROJECT_NAME} PRIVATE
-		src/platform/sdl/sdl_audio.cpp
-		src/platform/sdl/sdl_audio.h
 		src/platform/sdl/axis.h
 		src/platform/sdl/sdl_ui.cpp
 		src/platform/sdl/sdl_ui.h)
-	target_compile_definitions(${PROJECT_NAME} PUBLIC USE_SDL=1)
-
-	player_find_package(NAME SDL1 TARGET SDL::SDLmain REQUIRED)
+	target_compile_definitions(${PROJECT_NAME} PUBLIC
+		USE_SDL=1
+		EASYRPG_CONFIG_NAME="config_sdl1.ini"
+	)
 elseif(${PLAYER_TARGET_PLATFORM} STREQUAL "libretro")
 	target_compile_definitions(${PROJECT_NAME} PUBLIC PLAYER_UI=LibretroUi USE_LIBRETRO=1)
 	set(PLAYER_BUILD_EXECUTABLE OFF)
@@ -682,31 +698,63 @@ elseif(${PLAYER_TARGET_PLATFORM} STREQUAL "switch")
 		src/platform/switch/ui.cpp
 		src/platform/switch/ui.h)
 	target_link_libraries(${PROJECT_NAME} switch-assets)
-elseif(${PLAYER_TARGET_PLATFORM} STREQUAL "wii")
-	find_package(SDL REQUIRED)
-	target_compile_definitions(${PROJECT_NAME} PUBLIC USE_SDL=1 PLAYER_NINTENDO)
-	target_include_directories(${PROJECT_NAME} PUBLIC ${SDL_INCLUDE_DIR})
-	target_sources(${PROJECT_NAME} PRIVATE
-		src/platform/wii/audio.cpp
-		src/platform/wii/audio.h
-		src/platform/wii/clock.h
-		src/platform/wii/input_buttons.cpp
-		src/platform/sdl/axis.h
-		src/platform/sdl/sdl_ui.cpp
-		src/platform/sdl/sdl_ui.h)
 else()
 	message(FATAL_ERROR "Invalid target platform")
 endif()
 
+# Sound system to use
+if(PLAYER_AUDIO_BACKEND)
+	# already set earlier in the platform config
+elseif(${PLAYER_TARGET_PLATFORM} STREQUAL "SDL2")
+	set(PLAYER_AUDIO_BACKEND "SDL2" CACHE STRING "Audio system to use. Options: SDL2 OFF")
+	set_property(CACHE PLAYER_AUDIO_BACKEND PROPERTY STRINGS SDL2 OFF)
+
+	if(${PLAYER_AUDIO_BACKEND} STREQUAL "SDL2_mixer")
+		message(FATAL_ERROR "SDL2_mixer is not supported anymore. Use SDL2 instead.")
+	endif()
+elseif(${PLAYER_TARGET_PLATFORM} STREQUAL "SDL1")
+	set(PLAYER_AUDIO_BACKEND "SDL1" CACHE STRING "Audio system to use. Options: SDL1 OFF")
+	set_property(CACHE PLAYER_AUDIO_BACKEND PROPERTY STRINGS SDL1 OFF)
+else()
+	# Assuming that all platforms not targeting SDL have only one audio backend
+	set(PLAYER_AUDIO_BACKEND ${PLAYER_TARGET_PLATFORM} CACHE STRING "Audio system to use. Options: ${PLAYER_TARGET_PLATFORM} OFF")
+	set_property(CACHE PLAYER_AUDIO_BACKEND PROPERTY STRINGS ${PLAYER_TARGET_PLATFORM} OFF)
+endif()
+
+set(PLAYER_HAS_AUDIO ON)
+if(${PLAYER_AUDIO_BACKEND} STREQUAL "SDL1")
+	target_sources(${PROJECT_NAME} PRIVATE
+		src/platform/sdl/sdl_audio.cpp
+		src/platform/sdl/sdl_audio.h)
+elseif(${PLAYER_AUDIO_BACKEND} STREQUAL "SDL2")
+	target_sources(${PROJECT_NAME} PRIVATE
+		src/platform/sdl/sdl_audio.cpp
+		src/platform/sdl/sdl_audio.h)
+elseif(${PLAYER_AUDIO_BACKEND} STREQUAL "AESND")
+	target_sources(${PROJECT_NAME} PRIVATE
+		src/platform/wii/audio.cpp
+		src/platform/wii/audio.h)
+	target_compile_definitions(${PROJECT_NAME} PUBLIC AUDIO_AESND=1)
+elseif(${PLAYER_AUDIO_BACKEND} STREQUAL ${PLAYER_TARGET_PLATFORM})
+
+elseif(${PLAYER_AUDIO_BACKED} STREQUAL "OFF")
+	set(PLAYER_HAS_AUDIO OFF)
+else()
+	message(FATAL_ERROR "Invalid Audio Backend ${PLAYER_AUDIO_BACKEND}")
+endif()
+
 # Shared by homebrew platforms
-if(${PLAYER_TARGET_PLATFORM} MATCHES "^(3ds|psvita|switch|wii)$" OR NINTENDO_WIIU)
+if(NINTENDO_3DS OR NINTENDO_WII OR NINTENDO_WIIU OR NINTENDO_WIIU OR NINTENDO_SWITCH OR VITA)
 	target_compile_options(${PROJECT_NAME} PUBLIC -fno-exceptions -fno-rtti)
 	set(CMAKE_DL_LIBS "") # hack4icu!
 	set(PLAYER_ENABLE_TESTS OFF)
 	option(PLAYER_VERSIONED_PACKAGES "Create zip packages with versioned name (for internal use)" ON)
+	set(PLAYER_CONSOLE_PORT ON)
+else()
+	set(PLAYER_CONSOLE_PORT OFF)
 endif()
 # Make content available (romfs/wuhb bundle)
-if(${PLAYER_TARGET_PLATFORM} MATCHES "^(3ds|switch)$" OR NINTENDO_WIIU)
+if(NINTENDO_3DS OR NINTENDO_WIIU OR NINTENDO_SWITCH)
 	option(PLAYER_BUNDLE "Embed a directory in the executable" OFF)
 	set(PLAYER_BUNDLE_PATH "content" CACHE PATH "Directory to include in executable")
 	set(BUNDLE_ARG "_IGNORE_ME")
@@ -851,8 +899,7 @@ target_link_libraries(${PROJECT_NAME} PIXMAN::PIXMAN)
 
 # Always enable Wine registry support on non-Windows, but not for console ports
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows"
-	AND NOT ${PLAYER_TARGET_PLATFORM} MATCHES "^(psvita|3ds|switch|wii)$"
-	AND NOT NINTENDO_WIIU)
+	AND NOT PLAYER_CONSOLE)
 	target_compile_definitions(${PROJECT_NAME} PUBLIC HAVE_WINE=1)
 endif()
 
@@ -903,26 +950,8 @@ else()
 	)
 endif()
 
-# Sound system to use
-if(${PLAYER_TARGET_PLATFORM} STREQUAL "SDL2")
-	set(PLAYER_AUDIO_BACKEND "SDL2" CACHE STRING "Audio system to use. Options: SDL2 OFF")
-	set_property(CACHE PLAYER_AUDIO_BACKEND PROPERTY STRINGS SDL2 OFF)
-
-	if(${PLAYER_AUDIO_BACKEND} STREQUAL "SDL2_mixer")
-		message(FATAL_ERROR "SDL2_mixer is not supported anymore. Use SDL2 instead.")
-	endif()
-elseif(${PLAYER_TARGET_PLATFORM} STREQUAL "SDL1")
-	set(PLAYER_AUDIO_BACKEND "SDL1" CACHE STRING "Audio system to use. Options: SDL1 OFF")
-	set_property(CACHE PLAYER_AUDIO_BACKEND PROPERTY STRINGS SDL1 OFF)
-else()
-	# Assuming that all platforms not targeting SDL have only one audio backend
-	set(PLAYER_AUDIO_BACKEND "Default" CACHE STRING "Audio system to use. Options: Default OFF")
-	set_property(CACHE PLAYER_AUDIO_BACKEND PROPERTY STRINGS Default OFF)
-endif()
-
 # Configure Audio backends
-if(${PLAYER_AUDIO_BACKEND} MATCHES "^(SDL[12]|Default)$")
-	set(PLAYER_HAS_AUDIO ON)
+if(PLAYER_HAS_AUDIO)
 	target_compile_definitions(${PROJECT_NAME} PUBLIC SUPPORT_AUDIO=1)
 
 	if(${PLAYER_TARGET_PLATFORM} STREQUAL "libretro")
@@ -964,10 +993,6 @@ if(${PLAYER_AUDIO_BACKEND} MATCHES "^(SDL[12]|Default)$")
 	if(PLAYER_ENABLE_FMMIDI)
 		target_compile_definitions(${PROJECT_NAME} PUBLIC WANT_FMMIDI=1)
 	endif()
-elseif(NOT PLAYER_AUDIO_BACKEND)
-	set(PLAYER_HAS_AUDIO OFF)
-else()
-	message(FATAL_ERROR "Invalid Audio Backend ${PLAYER_AUDIO_BACKEND}")
 endif()
 
 CMAKE_DEPENDENT_OPTION(PLAYER_WITH_MPG123 "Play MP3 audio with libmpg123" ON "PLAYER_HAS_AUDIO" OFF)
@@ -980,7 +1005,7 @@ CMAKE_DEPENDENT_OPTION(PLAYER_WITH_FLUIDLITE "Play MIDI audio with fluidlite" ON
 CMAKE_DEPENDENT_OPTION(PLAYER_WITH_XMP "Play MOD audio with libxmp" ON "PLAYER_HAS_AUDIO" OFF)
 CMAKE_DEPENDENT_OPTION(PLAYER_ENABLE_DRWAV "Play WAV audio with dr_wav (built-in). Unsupported files are played by libsndfile." ON "PLAYER_HAS_AUDIO" OFF)
 
-if(${PLAYER_AUDIO_BACKEND} MATCHES "^(SDL[12]|Default)$")
+if(PLAYER_HAS_AUDIO)
 	set(PLAYER_AUDIO_RESAMPLER "Auto" CACHE STRING "Audio resampler to use. Options: Auto speexdsp samplerate OFF")
 	set_property(CACHE PLAYER_AUDIO_RESAMPLER PROPERTY STRINGS Auto speexdsp samplerate OFF)
 
@@ -1096,7 +1121,7 @@ if(${PLAYER_AUDIO_BACKEND} MATCHES "^(SDL[12]|Default)$")
 endif()
 
 # Executable
-if(${PLAYER_BUILD_EXECUTABLE} AND ${PLAYER_TARGET_PLATFORM} MATCHES "^SDL[12]$" AND NOT NINTENDO_WIIU)
+if(${PLAYER_BUILD_EXECUTABLE} AND ${PLAYER_TARGET_PLATFORM} MATCHES "^SDL.*$" AND NOT PLAYER_CONSOLE_PORT)
 	if(APPLE)
 		set(EXE_NAME "EasyRPG-Player.app")
 		set_source_files_properties(${${PROJECT_NAME}_BUNDLE_ICON} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
@@ -1198,7 +1223,7 @@ if(${PLAYER_BUILD_EXECUTABLE} AND ${PLAYER_TARGET_PLATFORM} MATCHES "^SDL[12]$" 
 		endif()
 		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PLAYER_JS_OUTPUT_NAME}.wasm DESTINATION ${CMAKE_INSTALL_BINDIR})
 	endif()
-elseif(${PLAYER_TARGET_PLATFORM} MATCHES "^(psvita|3ds|switch|wii)$" OR NINTENDO_WIIU)
+elseif(PLAYER_CONSOLE_PORT)
 	set(CPACK_PLATFORM "${PLAYER_TARGET_PLATFORM}")
 	if(NINTENDO_3DS)
 		add_executable(easyrpg-player src/platform/3ds/main.cpp)
@@ -1240,6 +1265,10 @@ elseif(${PLAYER_TARGET_PLATFORM} MATCHES "^(psvita|3ds|switch|wii)$" OR NINTENDO
 			-laesnd
 			-lfat
 			-lwiikeyboard)
+		if(TARGET SDL2::SDL2main)
+			# Missing dependency?
+			target_link_libraries(SDL2::SDL2main INTERFACE -lfat)
+		endif()
 		ogc_create_dol(easyrpg-player)
 		string(TIMESTAMP WII_DATE "%Y%m%d000000")
 		configure_file(resources/wii/meta.xml.in resources/wii/meta.xml @ONLY)
@@ -1299,7 +1328,7 @@ elseif(${PLAYER_TARGET_PLATFORM} MATCHES "^(psvita|3ds|switch|wii)$" OR NINTENDO
 	endif()
 	install(TARGETS easyrpg-player RUNTIME DESTINATION . COMPONENT debug)
 	# debug information
-	if(${PLAYER_TARGET_PLATFORM} MATCHES "^(3ds|switch|wii)$" OR NINTENDO_WIIU)
+	if(NINTENDO_3DS OR NINTENDO_WII OR NINTENDO_WIIU OR NINTENDO_SWITCH)
 		dkp_target_generate_symbol_list(easyrpg-player)
 		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/easyrpg-player.map
 				${CMAKE_CURRENT_BINARY_DIR}/easyrpg-player.lst
@@ -1506,7 +1535,7 @@ if(PLAYER_BUILD_LIBLCF)
 endif()
 
 message(STATUS "Audio backend: ${PLAYER_AUDIO_BACKEND}")
-if(${PLAYER_AUDIO_BACKEND} MATCHES "^(SDL[12]|Default)$")
+if(PLAYER_HAS_AUDIO)
 	message(STATUS "")
 
 	set(WAV_LIBS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,7 +601,6 @@ if(${PLAYER_TARGET_PLATFORM} STREQUAL "SDL2")
 	elseif(NINTENDO_WII)
 		target_compile_definitions(${PROJECT_NAME} PUBLIC PLAYER_NINTENDO)
 		target_sources(${PROJECT_NAME} PRIVATE
-			src/platform/wii/clock.cpp
 			src/platform/wii/clock.h
 			src/platform/wii/input_buttons.cpp)
 	elseif(NINTENDO_WIIU)
@@ -620,7 +619,6 @@ elseif(${PLAYER_TARGET_PLATFORM} STREQUAL "SDL1")
 		target_compile_definitions(${PROJECT_NAME} PUBLIC PLAYER_NINTENDO)
 		target_include_directories(${PROJECT_NAME} PUBLIC ${SDL_INCLUDE_DIR})
 		target_sources(${PROJECT_NAME} PRIVATE
-			src/platform/wii/clock.cpp
 			src/platform/wii/clock.h
 			src/platform/wii/input_buttons.cpp)
 	else()

--- a/src/decoder_oggvorbis.cpp
+++ b/src/decoder_oggvorbis.cpp
@@ -207,7 +207,14 @@ int OggVorbisDecoder::FillBuffer(uint8_t* buffer, int length) {
 #ifdef HAVE_TREMOR
 		read = ov_read(ovf, reinterpret_cast<char*>(buffer + length - to_read), to_read, &section);
 #else
-		read = ov_read(ovf, reinterpret_cast<char*>(buffer + length - to_read), to_read, 0/*LE*/, 2/*16bit*/, 1/*signed*/, &section);
+#  if defined(__WIIU__)
+		// FIXME: This is the endianess of the audio and not of the host but the byteswapping in ov_read does
+		// not sound like it works
+		int byte_order = 1; // BE
+#  else
+		int byte_order = 0; // LE
+#endif
+		read = ov_read(ovf, reinterpret_cast<char*>(buffer + length - to_read), to_read, byte_order, 2/*16bit*/, 1/*signed*/, &section);
 #endif
 		// stop decoding when error or end of file
 		if (read <= 0)

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -37,7 +37,7 @@ namespace {
 	std::string config_path;
 	std::string soundfont_path;
 	std::string font_path;
-	StringView config_name = "config.ini";
+	StringView config_name = EASYRPG_CONFIG_NAME;
 }
 
 void Game_ConfigPlayer::Hide() {

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -37,7 +37,12 @@ namespace {
 	std::string config_path;
 	std::string soundfont_path;
 	std::string font_path;
+#if USE_SDL == 1
+	// For SDL1 hardcode a different config file because it uses a completely different mapping for gamepads
+	StringView config_name = "config_sdl1.ini";
+#else
 	StringView config_name = EASYRPG_CONFIG_NAME;
+#endif
 }
 
 void Game_ConfigPlayer::Hide() {
@@ -92,7 +97,6 @@ Game_Config Game_Config::Create(CmdlineParser& cp) {
 #if defined(__WIIU__)
 	cfg.input.gamepad_swap_ab_and_xy.Set(true);
 #endif
-
 
 	cp.Rewind();
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -4041,6 +4041,12 @@ bool Game_Interpreter::CommandToggleFullscreen(lcf::rpg::EventCommand const& /* 
 		return true;
 	}
 
+	auto cfg = DisplayUi->GetConfig();
+	if (!cfg.fullscreen.IsOptionVisible() || cfg.fullscreen.IsLocked()) {
+		Output::Debug("ToggleFullscreen: Not supported on this platform");
+		return true;
+	}
+
 	DisplayUi->ToggleFullscreen();
 	return true;
 }

--- a/src/options.h
+++ b/src/options.h
@@ -56,6 +56,10 @@
 #define INI_NAME "RPG_RT.ini"
 #define EASYRPG_INI_NAME "EasyRPG.ini"
 
+#ifndef EASYRPG_CONFIG_NAME
+#  define EASYRPG_CONFIG_NAME "config.ini"
+#endif
+
 /** Prefix for .ldb and .lmt files; used when guessing non-standard extensions. */
 #define RPG_RT_PREFIX "RPG_RT"
 #define EASY_RT_PREFIX "EASY_RT"

--- a/src/platform/sdl/sdl2_ui.cpp
+++ b/src/platform/sdl/sdl2_ui.cpp
@@ -48,7 +48,11 @@
 #endif
 
 #ifdef SUPPORT_AUDIO
-#  include "sdl_audio.h"
+#  if AUDIO_AESND
+#    include "platform/wii/audio.h"
+#  else
+#    include "sdl_audio.h"
+#  endif
 
 AudioInterface& Sdl2Ui::GetAudio() {
 	return *audio_;
@@ -198,10 +202,11 @@ Sdl2Ui::Sdl2Ui(long width, long height, const Game_Config& cfg) : BaseUi(cfg)
 #endif
 
 #ifdef SUPPORT_AUDIO
-	if (!Player::no_audio_flag) {
+#  ifdef AUDIO_AESND
+		audio_ = std::make_unique<WiiAudio>(cfg.audio);
+#  else
 		audio_ = std::make_unique<SdlAudio>(cfg.audio);
-		return;
-	}
+#  endif
 #endif
 }
 
@@ -1263,6 +1268,8 @@ int FilterUntilFocus(const SDL_Event* evnt) {
 void Sdl2Ui::vGetConfig(Game_ConfigVideo& cfg) const {
 #ifdef EMSCRIPTEN
 	cfg.renderer.Lock("SDL2 (Software, Emscripten)");
+#elif defined(__wii__)
+	cfg.renderer.Lock("SDL2 (Software, Wii)");	
 #elif defined(__WIIU__)
 	cfg.renderer.Lock("SDL2 (Software, Wii U)");
 #else
@@ -1296,6 +1303,8 @@ void Sdl2Ui::vGetConfig(Game_ConfigVideo& cfg) const {
 	cfg.vsync.SetOptionVisible(false);
 	cfg.pause_when_focus_lost.Lock(false);
 	cfg.pause_when_focus_lost.SetOptionVisible(false);
+#elif defined(__wii__)
+	cfg.fullscreen.SetOptionVisible(false);	
 #elif defined(__WIIU__)
 	// Only makes the screen flicker
 	cfg.fullscreen.SetOptionVisible(false);

--- a/src/platform/sdl/sdl_ui.cpp
+++ b/src/platform/sdl/sdl_ui.cpp
@@ -29,7 +29,7 @@
 #include "bitmap.h"
 
 #ifdef SUPPORT_AUDIO
-#  ifdef __wii__
+#  if AUDIO_AESND
 #    include "platform/wii/audio.h"
 #  else
 #    include "sdl_audio.h"
@@ -167,7 +167,7 @@ SdlUi::SdlUi(long width, long height, const Game_Config& cfg) : BaseUi(cfg)
 
 #ifdef SUPPORT_AUDIO
 	if (!Player::no_audio_flag) {
-#  ifdef __wii__
+#  ifdef AUDIO_AESND
 		audio_ = std::make_unique<WiiAudio>(cfg.audio);
 #  else
 		audio_ = std::make_unique<SdlAudio>(cfg.audio);

--- a/src/platform/wii/audio.cpp
+++ b/src/platform/wii/audio.cpp
@@ -53,15 +53,17 @@ static void VoiceStreamCallback(AESNDPB *pb, u32 state) {
 
 static void *AudioThread (void *) {
 	while (!stopaudio) {
+		instance->LockMutex();
+
 		// clear old data
 		memset(buffer[cur_buf], 0, SNDBUFFERSIZE);
 
-		instance->LockMutex();
 		instance->Decode(buffer[cur_buf], SNDBUFFERSIZE);
-		instance->UnlockMutex();
 
 		// make sure data is in main memory
 		DCFlushRange(buffer[cur_buf], SNDBUFFERSIZE);
+
+		instance->UnlockMutex();
 
 		LWP_ThreadSleep(audioqueue);
 	}

--- a/src/platform/wii/input_buttons.cpp
+++ b/src/platform/wii/input_buttons.cpp
@@ -50,16 +50,15 @@ Input::ButtonMappingArray Input::GetDefaultButtonMappings() {
 		{DOWN, Keys::JOY_DPAD_DOWN},
 		{LEFT, Keys::JOY_DPAD_LEFT},
 		{RIGHT, Keys::JOY_DPAD_RIGHT},
-		{DECISION, Keys::JOY_B},
-		{CANCEL, Keys::JOY_A},
-		{CANCEL, Keys::JOY_Y},
-		{SHIFT, Keys::JOY_X},
-		{N0, Keys::JOY_LSTICK},
-		{N5, Keys::JOY_RSTICK},
+		{DECISION, Keys::JOY_A},
+		{CANCEL, Keys::JOY_B},
+		{CANCEL, Keys::JOY_X},
+		{SHIFT, Keys::JOY_Y},
 		{DEBUG_ABORT_EVENT, Keys::JOY_SHOULDER_LEFT},
 		{TOGGLE_FPS, Keys::JOY_SHOULDER_RIGHT},
-		{SETTINGS_MENU, Keys::JOY_START},
-		{RESET, Keys::JOY_BACK},
+		{SETTINGS_MENU, Keys::JOY_BACK},
+		{RESET, Keys::JOY_GUIDE},
+		{N5, Keys::N5},
 #endif
 
 #if defined(USE_JOYSTICK_AXIS)  && defined(SUPPORT_JOYSTICK_AXIS)
@@ -109,15 +108,16 @@ Input::ButtonMappingArray Input::GetDefaultButtonMappings() {
 
 Input::KeyNamesArray Input::GetInputKeyNames() {
 	return {
+		// SDL1
 		{Keys::JOY_OTHER_0, "A (Wiimote / CC)"},
 		{Keys::JOY_OTHER_1, "B (Wiimote / CC)"},
-		{Keys::JOY_OTHER_2, "1 (Wiimote"},
+		{Keys::JOY_OTHER_2, "1 (Wiimote)"},
 		{Keys::JOY_OTHER_3, "2 (Wiimote)"},
-		{Keys::JOY_OTHER_4, "- (Wiimote /CC )"},
+		{Keys::JOY_OTHER_4, "- (Wiimote / CC)"},
 		{Keys::JOY_OTHER_5, "+ (Wiimote / CC)"},
 		{Keys::JOY_OTHER_6, "Home (Wiimote / CC)"},
 		{Keys::JOY_OTHER_7, "Z (Nunchuck)"},
-		{Keys::JOY_OTHER_8, "C (Wiimote)"},
+		{Keys::JOY_OTHER_8, "C (Nunchuck)"},
 		{Keys::JOY_OTHER_9, "X (CC)"},
 		{Keys::JOY_OTHER_10, "Y (CC)"},
 		{Keys::JOY_OTHER_11, "L (CC)"},
@@ -125,10 +125,40 @@ Input::KeyNamesArray Input::GetInputKeyNames() {
 		{Keys::JOY_OTHER_13, "ZL (CC)"},
 		{Keys::JOY_OTHER_14, "ZR (CC)"},
 
+		// SDL2
+		// FIXME: The ABXY buttons are swapped when a CC is connected, automatically handle this?
+		// For Wiimote the reported buttons change depending whether a Nunchuck is connected
+		// When only a Wiimote is connected it is handled like a sideways Wiimote
+		// With Nunchuck/CC connected the buttons 1 and 2 report nothing
+		{Keys::JOY_A, "A"}, // 1 (Wiimote), A (+Nunchuck), B (+CC)
+		{Keys::JOY_B, "B"}, // 2 (Wiimote), B (+Nunchuck), A (+CC)
+		{Keys::JOY_X, "X (CC) / Z (Nunchuck)"}, // B (Wiimote)
+		{Keys::JOY_Y, "Y (CC) / C (Nunchuck)"}, // A (Wiimote)
+		{Keys::JOY_BACK, "HOME"},
+		{Keys::JOY_START, "+"},
+		{Keys::JOY_GUIDE, "-"},
+		{Keys::JOY_SHOULDER_LEFT, "L"},
+		{Keys::JOY_SHOULDER_RIGHT, "R"},
+		{Keys::JOY_LTRIGGER_FULL, "ZL"},
+		{Keys::JOY_RTRIGGER_FULL, "ZR"},
+
+		// Shared
 		{Keys::JOY_DPAD_UP, "D-Pad Up"},
 		{Keys::JOY_DPAD_DOWN, "D-Pad Down"},
 		{Keys::JOY_DPAD_LEFT, "D-Pad Left"},
-		{Keys::JOY_DPAD_RIGHT, "D-Pad Up"}
+		{Keys::JOY_DPAD_RIGHT, "D-Pad Up"},
+
+		{Keys::JOY_LSTICK, "Left Stick Press"},
+		{Keys::JOY_LSTICK_UP, "Left Stick Up"},
+		{Keys::JOY_LSTICK_DOWN, "Left Stick Down"},
+		{Keys::JOY_LSTICK_LEFT, "Left Stick Left"},
+		{Keys::JOY_LSTICK_RIGHT, "Left Stick Right"},
+
+		{Keys::JOY_RSTICK, "Right Stick Press"},
+		{Keys::JOY_RSTICK_UP, "Right Stick Up"},
+		{Keys::JOY_RSTICK_DOWN, "Right Stick Down"},
+		{Keys::JOY_RSTICK_LEFT, "Right Stick Left"},
+		{Keys::JOY_RSTICK_RIGHT, "Right Stick Right"},
 	};
 }
 

--- a/src/platform/wii/input_buttons.cpp
+++ b/src/platform/wii/input_buttons.cpp
@@ -19,10 +19,11 @@
 #include "input_buttons.h"
 #include "keys.h"
 #include "game_config.h"
-#include "platform/sdl/axis.h"
+
 
 Input::ButtonMappingArray Input::GetDefaultButtonMappings() {
 	return {
+#if USE_SDL==1
 		// Wiimote
 		{DECISION, Keys::JOY_OTHER_0}, // A, shared with Classic Controller (CC)
 		{CANCEL, Keys::JOY_OTHER_1}, // B, shared with CC
@@ -43,7 +44,47 @@ Input::ButtonMappingArray Input::GetDefaultButtonMappings() {
 		{FAST_FORWARD_B, Keys::JOY_OTHER_12}, // R
 		{N5, Keys::JOY_OTHER_13}, // ZL
 		{TOGGLE_FPS, Keys::JOY_OTHER_14}, // ZR
+#else
+#if defined(USE_JOYSTICK) && defined(SUPPORT_JOYSTICK)
+		{UP, Keys::JOY_DPAD_UP},
+		{DOWN, Keys::JOY_DPAD_DOWN},
+		{LEFT, Keys::JOY_DPAD_LEFT},
+		{RIGHT, Keys::JOY_DPAD_RIGHT},
+		{DECISION, Keys::JOY_B},
+		{CANCEL, Keys::JOY_A},
+		{CANCEL, Keys::JOY_Y},
+		{SHIFT, Keys::JOY_X},
+		{N0, Keys::JOY_LSTICK},
+		{N5, Keys::JOY_RSTICK},
+		{DEBUG_ABORT_EVENT, Keys::JOY_SHOULDER_LEFT},
+		{TOGGLE_FPS, Keys::JOY_SHOULDER_RIGHT},
+		{SETTINGS_MENU, Keys::JOY_START},
+		{RESET, Keys::JOY_BACK},
+#endif
 
+#if defined(USE_JOYSTICK_AXIS)  && defined(SUPPORT_JOYSTICK_AXIS)
+		{UP, Keys::JOY_LSTICK_UP},
+		{DOWN, Keys::JOY_LSTICK_DOWN},
+		{LEFT, Keys::JOY_LSTICK_LEFT},
+		{RIGHT, Keys::JOY_LSTICK_RIGHT},
+		{N1, Keys::JOY_RSTICK_DOWN_LEFT},
+		{N2, Keys::JOY_RSTICK_DOWN},
+		{N3, Keys::JOY_RSTICK_DOWN_RIGHT},
+		{N4, Keys::JOY_RSTICK_LEFT},
+		{N6, Keys::JOY_RSTICK_RIGHT},
+		{N7, Keys::JOY_RSTICK_UP_LEFT},
+		{N8, Keys::JOY_RSTICK_UP},
+		{N9, Keys::JOY_RSTICK_UP_RIGHT},
+		{FAST_FORWARD_A, Keys::JOY_RTRIGGER_FULL},
+		{DEBUG_MENU, Keys::JOY_LTRIGGER_FULL},
+#endif
+
+#if defined(USE_TOUCH) && defined(SUPPORT_TOUCH)
+		{MOUSE_LEFT, Keys::ONE_FINGER},
+		{MOUSE_RIGHT, Keys::TWO_FINGERS},
+		{MOUSE_MIDDLE, Keys::THREE_FINGERS},
+#endif
+#endif
 		{UP, Keys::JOY_LSTICK_UP},
 		{DOWN, Keys::JOY_LSTICK_DOWN},
 		{LEFT, Keys::JOY_LSTICK_LEFT},
@@ -97,6 +138,8 @@ void Input::GetSupportedConfig(Game_ConfigInput& cfg) {
 	cfg.gamepad_swap_dpad_with_buttons.SetOptionVisible(true);
 }
 
+#if USE_SDL==1
+#include "platform/sdl/axis.h"
 SdlAxis Input::GetSdlAxis() {
 	// Classic Controller L/R Trigger axis do not report proper values
 	// Handled above as Button 11/12
@@ -104,4 +147,5 @@ SdlAxis Input::GetSdlAxis() {
 		0, 1, 2, 3, -1, -1, false, false
 	};
 }
+#endif
 

--- a/src/platform/wii/main.cpp
+++ b/src/platform/wii/main.cpp
@@ -38,9 +38,6 @@ namespace {
 	bool is_emu = false;
 }
 
-// in sdl-wii
-extern "C" void OGC_ChangeSquare(int xscale, int yscale, int xshift, int yshift);
-
 static void GekkoResetCallback(u32 /* irq */ , void* /* ctx */) {
 	Player::reset_flag = true;
 }
@@ -85,9 +82,6 @@ extern "C" int main(int argc, char* argv[]) {
 	}
 
 	SYS_SetResetCallback(GekkoResetCallback);
-
-	// Eliminate overscan / add 5% borders
-	OGC_ChangeSquare(304, 228, 0, 0);
 
 	// Working directory not correctly handled, provide it manually
 	bool want_cwd = true;


### PR DESCRIPTION
When targeting Wii the possible ``PLAYER_TARGET_PLATFORM`` are now ``SDL2`` (default) and ``SDL1``. SDL1 is still supported for testing purposes (and the code was already written ^^)

For ``PLAYER_AUDIO_BACKEND`` the default is as before ``AESND``, but ``SDL2/SDL1`` can be also selected (I moved the mutex code a bit, hopefully this fixes the random crashes when changing maps).

----

Besides the build system this is not very invasive, only had to change the button mapping and thats all.

_Note_: The CMakeLists changes are quite large because this is already the preparation for the SDL3 support. (initially I had Wii SDL2 and PC SDL3 commit combined)

----

Prebuilt for testing: https://easyrpg.org/downloads/tmp/wii-test.zip  (contains both a SDL2 and a SDL1 build)

- SDL2_Aesnd: The latest build with aesnd audio backend
- SDL2_Audio: The latest build with sdl2audio backend
- SDL1

Before you open SDL2 for the first time delete the file ``/data/easyrpg-player/config.ini`` on your SD card (or when the file is missing just do nothing) or input will be broken.