### PR TITLE
TriggerEventAt: Add flag to configure "Face Player" behaviour

### DIFF
--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -871,7 +871,15 @@ bool Game_Interpreter_Map::CommandEasyRpgTriggerEventAt(lcf::rpg::EventCommand c
 	int x = ValueOrVariable(com.parameters[0], com.parameters[1]);
 	int y = ValueOrVariable(com.parameters[2], com.parameters[3]);
 
-	Main_Data::game_player->TriggerEventAt(x, y);
+	// backwards compatible with old (shorter) command
+	bool face_player = true;
+
+	if (com.parameters.size() > 4) {
+		int flags = com.parameters[4];
+		face_player = (flags & 1) > 0;
+	}
+
+	Main_Data::game_player->TriggerEventAt(x, y, GetFrame().triggered_by_decision_key, face_player);
 
 	return true;
 }

--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -428,7 +428,7 @@ bool Game_Player::CheckActionEvent() {
 	return result || got_action;
 }
 
-bool Game_Player::CheckEventTriggerHere(TriggerSet triggers, bool triggered_by_decision_key) {
+bool Game_Player::CheckEventTriggerHere(TriggerSet triggers, bool triggered_by_decision_key, bool face_player) {
 	if (InAirship()) {
 		return false;
 	}
@@ -444,13 +444,13 @@ bool Game_Player::CheckEventTriggerHere(TriggerSet triggers, bool triggered_by_d
 				&& trigger >= 0
 				&& triggers[trigger]) {
 			SetEncounterCalling(false);
-			result |= ev.ScheduleForegroundExecution(triggered_by_decision_key, true);
+			result |= ev.ScheduleForegroundExecution(triggered_by_decision_key, face_player);
 		}
 	}
 	return result;
 }
 
-bool Game_Player::CheckEventTriggerThere(TriggerSet triggers, int x, int y, bool triggered_by_decision_key) {
+bool Game_Player::CheckEventTriggerThere(TriggerSet triggers, int x, int y, bool triggered_by_decision_key, bool face_player) {
 	if (InAirship()) {
 		return false;
 	}
@@ -465,7 +465,7 @@ bool Game_Player::CheckEventTriggerThere(TriggerSet triggers, int x, int y, bool
 				&& trigger >= 0
 				&& triggers[trigger]) {
 			SetEncounterCalling(false);
-			result |= ev.ScheduleForegroundExecution(triggered_by_decision_key, true);
+			result |= ev.ScheduleForegroundExecution(triggered_by_decision_key, face_player);
 		}
 	}
 	return result;
@@ -927,6 +927,6 @@ void Game_Player::UpdatePan() {
 	data()->pan_current_y -= dy;
 }
 
-bool Game_Player::TriggerEventAt(int x, int y) {
-	return CheckEventTriggerThere({ lcf::rpg::EventPage::Trigger_action }, x, y, true);
+bool Game_Player::TriggerEventAt(int x, int y, bool triggered_by_decision_key, bool face_player) {
+	return CheckEventTriggerThere({ lcf::rpg::EventPage::Trigger_action }, x, y, triggered_by_decision_key, face_player);
 }

--- a/src/game_player.h
+++ b/src/game_player.h
@@ -60,7 +60,7 @@ public:
 	TeleportTarget GetTeleportTarget() const;
 	void ResetTeleportTarget(TeleportTarget tt = {});
 
-	bool TriggerEventAt(int x, int y);
+	bool TriggerEventAt(int x, int y, bool triggered_by_decision_key, bool face_player);
 
 	/**
 	 * Sets the map, position and direction that the game player must have after the teleport is over
@@ -163,8 +163,8 @@ private:
 	void UpdatePan();
 	void UpdateEncounterSteps();
 	bool CheckActionEvent();
-	bool CheckEventTriggerHere(TriggerSet triggers, bool triggered_by_decision_key);
-	bool CheckEventTriggerThere(TriggerSet triggers, int x, int y, bool triggered_by_decision_key);
+	bool CheckEventTriggerHere(TriggerSet triggers, bool triggered_by_decision_key, bool face_player = true);
+	bool CheckEventTriggerThere(TriggerSet triggers, int x, int y, bool triggered_by_decision_key, bool face_player = true);
 	bool GetOnVehicle();
 	bool GetOffVehicle();
 	bool UpdateAirship();

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -839,7 +839,7 @@ void TilemapLayer::RecalculateAutotile(int x, int y, int tile_id) {
 		return neighbors;
 		};
 
-	auto processBlock = [&](int blockType, int blockStride, int blockBase, auto isSameAutotileFn) {
+	auto processBlock = [&](int /*blockType*/, int blockStride, int blockBase, auto isSameAutotileFn) {
 		uint8_t neighbors = calculateNeighbors(isSameAutotileFn);
 		int block = (tile_id - blockBase) / blockStride;
 		int variant = AUTOTILE_D_VARIANTS_MAP.at(neighbors);


### PR DESCRIPTION
@florianessl noticed a while ago that events always face the Player when being called via this command which is inconvenient.

I added a flag to disable it :).

The "Triggered By Decision Key" state is now forwarded from the source event.

-----

I'm hosting the Editor Plugin here now: https://github.com/Ghabry/EasyRpgCommands/releases/tag/2025-01-20