### PR TITLE
Android: Reload native libraries on resume

### DIFF
--- a/builds/android/app/src/main/java/org/easyrpg/player/BaseActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/BaseActivity.java
@@ -1,23 +1,48 @@
 package org.easyrpg.player;
 
 import android.os.Bundle;
+import android.util.Log;
+
 import androidx.appcompat.app.AppCompatActivity;
 import org.easyrpg.player.settings.SettingsManager;
 
-public class BaseActivity  extends AppCompatActivity {
+/**
+ * This activity is used by the GameBrowser and the settings.
+ */
+public class BaseActivity extends AppCompatActivity {
+    public static Boolean libraryLoaded = false;
+
+    private static void loadNativeLibraries() {
+        if (!libraryLoaded) {
+            try {
+                System.loadLibrary("easyrpg_android");
+                System.loadLibrary("gamebrowser");
+                libraryLoaded = true;
+            } catch (UnsatisfiedLinkError e) {
+                Log.e("EasyRPG Player", "Couldn't load libgamebrowser: " + e.getMessage());
+                throw e;
+            }
+        }
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        // Retrieve User's preferences
-        SettingsManager.init(getApplicationContext());
+        init();
     }
 
     @Override
     protected void onResume() {
         super.onResume();
 
+        init();
+    }
+
+    protected void init() {
         // Retrieve User's preferences
         SettingsManager.init(getApplicationContext());
+
+        loadNativeLibraries();
     }
 }

--- a/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
+++ b/builds/android/app/src/main/java/org/easyrpg/player/game_browser/GameBrowserActivity.java
@@ -44,8 +44,6 @@ import java.util.List;
 
 public class GameBrowserActivity extends BaseActivity
         implements NavigationView.OnNavigationItemSelectedListener {
-    public static Boolean libraryLoaded = false;
-
     private static final int THUMBNAIL_HORIZONTAL_SIZE_DPI = 290;
     private static Game selectedGame;
 
@@ -57,17 +55,6 @@ public class GameBrowserActivity extends BaseActivity
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        if (!libraryLoaded) {
-            try {
-                System.loadLibrary("easyrpg_android");
-                System.loadLibrary("gamebrowser");
-                libraryLoaded = true;
-            } catch (UnsatisfiedLinkError e) {
-                Log.e("EasyRPG Player", "Couldn't load libgamebrowser: " + e.getMessage());
-                throw e;
-            }
-        }
 
         SDL.setContext(getApplicationContext());
 


### PR DESCRIPTION
Otherwise gives UnsatisfiedLinkError when the app was killed due to OOM etc.

Is harmless as you can just restart the app and it will work but its the most common crash in the dev console, so lets fix it...

----

to reproduce you can just background the app while in the settings, then ``am kill org.easyrpg.player`` and selecting "EasyRPG folder" will crash.