### PR TITLE
Extend hash list of known startup logos

### DIFF
--- a/src/exe_reader.cpp
+++ b/src/exe_reader.cpp
@@ -28,19 +28,21 @@
 
 namespace {
 	// hashes of known RPG_RT startup logos
-	std::array<uint32_t, 29> logo_crc32 = {
+	std::array<uint32_t, 33> logo_crc32 = {
 		0xdf3d86a7, 0x2ece66f9, 0x2fe0de56, 0x25c4618f, 0x91b2635a,
 
 		/*
-			Note: The values below have been extracted from a wide range of
-			bootleg versions of RPG_RT.exe that	have historically been in
-			circulation in various communities (either as part of an Editor
-			translation or patch). The specified version strings here refer
-			to the info given in either the recovered Installer packages
-			or is taken from accompanying Readme files & do not necessarily
-			give reliable information about the actual, original RPG_RT
-			version on which these translations & patches were based on!
+		The values below have been extracted from a wide range of
+		bootleg versions of RPG_RT.exe that have historically been in
+		circulation in various communities (either as part of an Editor
+		translation or patch). The specified version strings here refer
+		to the info given in either the recovered Installer packages
+		or is taken from accompanying Readme files & do not necessarily
+		give reliable information about the actual, original RPG_RT
+		version on which these translations & patches were based on!
 		*/
+		// Recompressed, unaltered RPG2000 logos
+		0x6a88587e, 0x4beedd9a, 0x1c7f224b,
 		// Hellsoft's bootleg "RPG Maker PRO 1.05"
 		0x5ae12b1c, 0x3d1cb5f1, 0x04a7f11a,
 		// Hellsoft's bootleg "RPG Maker PRO 1.10"
@@ -66,7 +68,11 @@ namespace {
 		// Italian "RPG Maker 4.0" Patch of Rm2k
 		0x8afe1239,
 		// Brazilian version of Rm2k3-1.0.9.1
-		0x089fb7d8
+		0x089fb7d8,
+		// Spezial-Patch by Rikku2000 (1.51 with swapped logo)
+		0x806b6877,
+		// Gnaf's Picture Patch (1.50 with swapped logo)
+		0xc5e846a7
 	};
 }
 

--- a/src/exe_reader.cpp
+++ b/src/exe_reader.cpp
@@ -28,11 +28,15 @@
 
 namespace {
 	// hashes of known RPG_RT startup logos
-	std::array<uint32_t, 17> logo_crc32 = {
+	std::array<uint32_t, 27> logo_crc32 = {
 		0xdf3d86a7, 0x2ece66f9, 0x2fe0de56, 0x25c4618f, 0x91b2635a,
 
+		// Hellsoft's bootleg "RPG Maker PRO 1.05"
+		0x5ae12b1c, 0x3d1cb5f1, 0x04a7f11a,
+		// Hellsoft's bootleg "RPG Maker PRO 1.10"
+		0x9307807f, 0x652529ec, 0x5e73987b,
 		// Hellsoft's bootleg "RPG Maker PRO 1.15"
-		0x9307807f, 0x2e8271cb, 0x5e73987b,
+		0x2e8271cb,
 		// Hellsoft's translation of Rm2k3-1.0.4
 		0x59ab3986,
 		// French "Rabbi-Bodom" translation of Rm2k3-1.0.9.1
@@ -42,7 +46,13 @@ namespace {
 		// Thai "House of the Dev" translation of Rm2k
 		0xa8be4ed3, 0xc75ccc6d, 0xcea40e5f,
 		// Thai "Somprasongk Team" translation of Rm2k3-1.0.6
-		0xc9b2e174
+		0xc9b2e174,
+		// Italian Translation of Rm2k (Matteo S.& Christian C.)
+		0x1a1ed6dd, 0xad73ccf5, 0x4ad55e84,
+		// Italian "RPG Maker 4.0" Patch of Rm2k
+		0x8afe1239,
+		// Brazilian version of Rm2k3-1.0.9.1
+		0x089fb7d8
 	};
 }
 

--- a/src/exe_reader.cpp
+++ b/src/exe_reader.cpp
@@ -28,7 +28,16 @@
 
 namespace {
 	// hashes of known RPG_RT startup logos
-	std::array<uint32_t, 5> logo_crc32 = { 0xdf3d86a7, 0x2ece66f9, 0x2fe0de56, 0x25c4618f, 0x91b2635a };
+	std::array<uint32_t, 10> logo_crc32 = {
+		0xdf3d86a7, 0x2ece66f9, 0x2fe0de56, 0x25c4618f, 0x91b2635a,
+
+		// Hellsoft's bootleg "RPG Maker PRO 1.15"
+		0x9307807f, 0x2e8271cb, 0x5e73987b,
+		// Hellsoft's translation of Rm2k3-1.0.4
+		0x59ab3986,
+		// French "Rabbi-Bodom" translation of Rm2k3-1.0.9.1
+		0x476138cb
+	};
 }
 
 EXEReader::EXEReader(Filesystem_Stream::InputStream core) : corefile(std::move(core)) {

--- a/src/exe_reader.cpp
+++ b/src/exe_reader.cpp
@@ -28,17 +28,31 @@
 
 namespace {
 	// hashes of known RPG_RT startup logos
-	std::array<uint32_t, 27> logo_crc32 = {
+	std::array<uint32_t, 29> logo_crc32 = {
 		0xdf3d86a7, 0x2ece66f9, 0x2fe0de56, 0x25c4618f, 0x91b2635a,
 
+		/*
+			Note: The values below have been extracted from a wide range of
+			bootleg versions of RPG_RT.exe that	have historically been in
+			circulation in various communities (either as part of an Editor
+			translation or patch). The specified version strings here refer
+			to the info given in either the recovered Installer packages
+			or is taken from accompanying Readme files & do not necessarily
+			give reliable information about the actual, original RPG_RT
+			version on which these translations & patches were based on!
+		*/
 		// Hellsoft's bootleg "RPG Maker PRO 1.05"
 		0x5ae12b1c, 0x3d1cb5f1, 0x04a7f11a,
 		// Hellsoft's bootleg "RPG Maker PRO 1.10"
 		0x9307807f, 0x652529ec, 0x5e73987b,
 		// Hellsoft's bootleg "RPG Maker PRO 1.15"
 		0x2e8271cb,
-		// Hellsoft's translation of Rm2k3-1.0.4
+		// Hellsoft's translation of Rm2k3: "1.0.2"
+		0x4e3f7560,
+		// Hellsoft's translation of Rm2k3: "1.0.4" & "1.0.7"
 		0x59ab3986,
+		// Hellsoft's translation of Rm2k3: "1.0.8" & "1.0.9"
+		0xd333b2dd,
 		// French "Rabbi-Bodom" translation of Rm2k3-1.0.9.1
 		0x476138cb,
 		// "Thaiware" translation of Rm2k

--- a/src/exe_reader.cpp
+++ b/src/exe_reader.cpp
@@ -28,7 +28,7 @@
 
 namespace {
 	// hashes of known RPG_RT startup logos
-	std::array<uint32_t, 10> logo_crc32 = {
+	std::array<uint32_t, 17> logo_crc32 = {
 		0xdf3d86a7, 0x2ece66f9, 0x2fe0de56, 0x25c4618f, 0x91b2635a,
 
 		// Hellsoft's bootleg "RPG Maker PRO 1.15"
@@ -36,7 +36,13 @@ namespace {
 		// Hellsoft's translation of Rm2k3-1.0.4
 		0x59ab3986,
 		// French "Rabbi-Bodom" translation of Rm2k3-1.0.9.1
-		0x476138cb
+		0x476138cb,
+		// "Thaiware" translation of Rm2k
+		0x29efaf6a, 0xfeb8f6b2, 0x265855ad,
+		// Thai "House of the Dev" translation of Rm2k
+		0xa8be4ed3, 0xc75ccc6d, 0xcea40e5f,
+		// Thai "Somprasongk Team" translation of Rm2k3-1.0.6
+		0xc9b2e174
 	};
 }
 


### PR DESCRIPTION
This PR adds some CRC hashes of known bootleg logos.

All of these were extracted from different RPG_RT versions which were originally bundled with setups from the French & Spanish communities.


### Hellsoft´s bootleg "RPG Maker PRO 1.15"
(Retitled "PRO" version of Rm2k because they previously retitled their version of RM95 as "2000")

![screenshot_184](https://github.com/user-attachments/assets/9367ab3d-1925-4534-b4ca-446a428880e3) ![screenshot_186](https://github.com/user-attachments/assets/7f0c4a2d-4823-4ce6-bd51-27ba4f40f5b8) ![screenshot_187](https://github.com/user-attachments/assets/3939b660-930a-4b4b-a929-a0d4e29904ac)

### Hellsoft´s translation of Rm2k3 v1.0.4
![screenshot_189](https://github.com/user-attachments/assets/68ab084d-84a7-4aa2-9132-608eb88a15d5)

### French "Rabbi-Bodom" translation of Rm2k3 v1.0.9.1
![screenshot_190](https://github.com/user-attachments/assets/f6522a9e-7a81-40da-93a5-0359123dcf1f)
