### PR TITLE
New Operations for ControlVariables / "ControlVariablesEx"

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -598,7 +598,7 @@ bool Game_Interpreter::ExecuteCommand(lcf::rpg::EventCommand const& com) {
 		case Cmd::ControlSwitches:
 			return CmdSetup<&Game_Interpreter::CommandControlSwitches, 4>(com);
 		case Cmd::ControlVars:
-			return CmdSetup<&Game_Interpreter::CommandControlVariables, 7>(com);
+			return CmdSetup<&Game_Interpreter::CommandControlVariables<false>, 7>(com);
 		case Cmd::TimerOperation:
 			return CmdSetup<&Game_Interpreter::CommandTimerOperation, 5>(com);
 		case Cmd::ChangeGold:

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1070,7 +1070,7 @@ bool Game_Interpreter::CommandControlVariables(lcf::rpg::EventCommand const& com
 	int operand = com.parameters[4];
 
 	if constexpr (EasyRpgEx) {
-		if (EP_UNLIKELY(operand >= 200) && !ControlVariables::EasyRpgExCommand(com, value)) {
+		if (EP_UNLIKELY(operand >= 200) && !ControlVariables::EasyRpgExCommand(com, value, *this)) {
 			return true;
 		}
 	} else {

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -205,6 +205,7 @@ protected:
 	bool CommandShowChoiceEnd(lcf::rpg::EventCommand const& com);
 	bool CommandInputNumber(lcf::rpg::EventCommand const& com);
 	bool CommandControlSwitches(lcf::rpg::EventCommand const& com);
+	template<bool EasyRpgEx = false>
 	bool CommandControlVariables(lcf::rpg::EventCommand const& com);
 	bool CommandTimerOperation(lcf::rpg::EventCommand const& com);
 	bool CommandChangeGold(lcf::rpg::EventCommand const& com);
@@ -297,6 +298,7 @@ protected:
 	bool CommandManiacSetGameOption(lcf::rpg::EventCommand const& com);
 	bool CommandManiacControlStrings(lcf::rpg::EventCommand const& com);
 	bool CommandManiacCallCommand(lcf::rpg::EventCommand const& com);
+	bool CommandEasyRpgControlVariablesEx(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgSetInterpreterFlag(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgProcessJson(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgCloneMapEvent(lcf::rpg::EventCommand const& com);

--- a/src/game_interpreter_control_variables.cpp
+++ b/src/game_interpreter_control_variables.cpp
@@ -512,6 +512,7 @@ bool ControlVariables::EasyRpgExCommand(lcf::rpg::EventCommand const& com, int& 
 			*/
 			value = DateTime(static_cast<DateTimeOp>(com.parameters[5]));
 			break;
+		/*
 		case 211: // eVarOperand_EasyRpg_ActiveMapInfo
 			value = ActiveMapInfo(static_cast<ActiveMapInfoOp>(com.parameters[5]));
 			break;
@@ -530,6 +531,7 @@ bool ControlVariables::EasyRpgExCommand(lcf::rpg::EventCommand const& com, int& 
 			value = InspectMapTreeInfo(static_cast<InspectMapTreeInfoOp>(com.parameters[5]), map_id, arg1);
 			break;
 		}
+		*/
 		case 213: //eVarOperand_EasyRpg_MessageSystemState
 			value = MessageSystemState(static_cast<MessageSystemStateOp>(com.parameters[5]));
 			break;
@@ -576,6 +578,7 @@ int ControlVariables::DateTime(DateTimeOp op) {
 	return 0;
 }
 
+/*
 int ControlVariables::ActiveMapInfo(ActiveMapInfoOp op) {
 	switch (op)
 	{
@@ -672,6 +675,7 @@ int ControlVariables::InspectMapTreeInfo(InspectMapTreeInfoOp op, int map_id, in
 	Output::Warning("ControlVariables::InspectMapTreeInfo: Unknown op {}", static_cast<int>(op));
 	return 0;
 }
+*/
 
 int ControlVariables::MessageSystemState(MessageSystemStateOp op) {
 	switch (op)

--- a/src/game_interpreter_control_variables.cpp
+++ b/src/game_interpreter_control_variables.cpp
@@ -621,8 +621,8 @@ int ControlVariables::InspectMapTreeInfo(InspectMapTreeInfoOp op, int map_id, in
 		case InspectMapTreeInfoOp::Troop_Id:
 		{
 			// TODO: provide a way to conveniently copy values into a range of variables ("ControlVarArrayEx"?) 
-			if (arg1 >= 0 && arg1 < static_cast<int>(map_info.encounters.size())) {
-				return map_info.encounters[arg1].troop_id;
+			if (arg1 >= 1 && arg1 <= static_cast<int>(map_info.encounters.size())) {
+				return map_info.encounters[arg1 - 1].troop_id;
 			}
 			return 0;
 		}
@@ -634,7 +634,7 @@ int ControlVariables::InspectMapTreeInfo(InspectMapTreeInfoOp op, int map_id, in
 		case InspectMapTreeInfoOp::Arena_Height:
 		{
 			// TODO: provide a way to conveniently copy values into a range of variables ("ControlVarArrayEx"?) 
-			if (arg1 < 0) {
+			if (arg1 <= 0) {
 				return 0;
 			}
 
@@ -642,7 +642,7 @@ int ControlVariables::InspectMapTreeInfo(InspectMapTreeInfoOp op, int map_id, in
 			for (unsigned int i = 0; i < lcf::Data::treemap.maps.size(); ++i) {
 				auto& map = lcf::Data::treemap.maps[i];
 				if (map.parent_map == map_info.ID && map.type == lcf::rpg::TreeMap::MapType_area) {
-					if (arg1 < cnt_arenas) {
+					if (arg1 <= cnt_arenas) {
 						cnt_arenas++;
 						continue;
 					}

--- a/src/game_interpreter_control_variables.cpp
+++ b/src/game_interpreter_control_variables.cpp
@@ -487,3 +487,61 @@ int ControlVariables::Divmul(int arg1, int arg2, int arg3) {
 int ControlVariables::Between(int arg1, int arg2, int arg3) {
 	return (arg1 >= arg2 && arg2 <= arg3) ? 0 : 1;
 }
+
+//
+// New EasyRpgEx operations
+//
+
+bool ControlVariables::EasyRpgExCommand(lcf::rpg::EventCommand const& com, int& value) {
+	int operand = com.parameters[4];
+
+	switch (operand) {
+		case 210: // eVarOperand_EasyRpg_DateTime
+			//
+			// Possible method for a string-based lookup (inspired by Jetrotal's initial suggestion):
+			/*
+			ControlVariables::DateTimeOp op;
+			if (!com.string.empty() && kDateTimeOpTags.etag(com.string.c_str(), op)) {
+				value = DateTime(op);
+			}
+			*/
+			value = DateTime(static_cast<DateTimeOp>(com.parameters[5]));
+		default:
+			Output::Warning("ControlVariables: Unsupported operand {}", com.parameters[5]);
+			return false;
+	}
+
+	return true;
+}
+
+int ControlVariables::DateTime(DateTimeOp op) {
+	std::time_t t = std::time(nullptr);
+	std::tm* tm = std::localtime(&t);
+
+	switch (op)
+	{
+		case DateTimeOp::Year:
+			return tm->tm_year + 1900;
+		case DateTimeOp::Month:
+			return tm->tm_mon + 1;
+		case DateTimeOp::Day:
+			return tm->tm_mday;
+		case DateTimeOp::Hour:
+			return tm->tm_hour;
+		case DateTimeOp::Minute:
+			return tm->tm_min;
+		case DateTimeOp::Second:
+			return tm->tm_sec;
+		case DateTimeOp::WeekDay:
+			return tm->tm_wday + 1;
+		case DateTimeOp::DayOfYear:
+			return tm->tm_yday + 1;
+		case DateTimeOp::IsDayLightSavings:
+			return tm->tm_isdst;
+		case DateTimeOp::TimeStamp:
+			return t;
+	}
+
+	Output::Warning("ControlVariables::GetTime: Unknown op {}", static_cast<int>(op));
+	return 0;
+}

--- a/src/game_interpreter_control_variables.cpp
+++ b/src/game_interpreter_control_variables.cpp
@@ -621,7 +621,7 @@ int ControlVariables::InspectMapTreeInfo(InspectMapTreeInfoOp op, int map_id, in
 		case InspectMapTreeInfoOp::Troop_Id:
 		{
 			// TODO: provide a way to conveniently copy values into a range of variables ("ControlVarArrayEx"?) 
-			if (arg1 >= 0 && arg1 < map_info.encounters.size()) {
+			if (arg1 >= 0 && arg1 < static_cast<int>(map_info.encounters.size())) {
 				return map_info.encounters[arg1].troop_id;
 			}
 			return 0;
@@ -660,6 +660,8 @@ int ControlVariables::InspectMapTreeInfo(InspectMapTreeInfoOp op, int map_id, in
 							return map.area_rect.r - map.area_rect.l;
 						case InspectMapTreeInfoOp::Arena_Height:
 							return map.area_rect.b - map.area_rect.t;
+						default:
+							break;
 					}
 				}
 			}
@@ -723,6 +725,8 @@ int ControlVariables::MessageWindowState(MessageWindowStateOp op) {
 				if (window->GetPendingMessage().ShowGoldWindow())
 					return 3;
 				return 0;
+			case MessageWindowStateOp::IsMessageActive:
+				break;
 		}
 	}
 

--- a/src/game_interpreter_control_variables.cpp
+++ b/src/game_interpreter_control_variables.cpp
@@ -21,6 +21,7 @@
 #include "game_enemyparty.h"
 #include "game_ineluki.h"
 #include "game_interpreter.h"
+#include "game_map.h"
 #include "game_party.h"
 #include "game_player.h"
 #include "game_system.h"
@@ -492,7 +493,9 @@ int ControlVariables::Between(int arg1, int arg2, int arg3) {
 // New EasyRpgEx operations
 //
 
-bool ControlVariables::EasyRpgExCommand(lcf::rpg::EventCommand const& com, int& value) {
+bool ControlVariables::EasyRpgExCommand(lcf::rpg::EventCommand const& com, int& value, const Game_BaseInterpreterContext& interpreter) {
+	using namespace Game_Interpreter_Shared;
+
 	int operand = com.parameters[4];
 
 	switch (operand) {
@@ -506,6 +509,25 @@ bool ControlVariables::EasyRpgExCommand(lcf::rpg::EventCommand const& com, int& 
 			}
 			*/
 			value = DateTime(static_cast<DateTimeOp>(com.parameters[5]));
+			break;
+		case 211: // eVarOperand_EasyRpg_ActiveMapInfo
+			value = ActiveMapInfo(static_cast<ActiveMapInfoOp>(com.parameters[5]));
+			break;
+		case 212: // eVarOperand_EasyRpg_InspectMapTreeInfo
+		{
+			int map_id = 0, arg1 = 0;
+			if (com.parameters.size() >= 9) {
+				map_id = ValueOrVariableBitfield(com.parameters[8], 0, com.parameters[6], interpreter);
+				arg1 = ValueOrVariableBitfield(com.parameters[8], 1, com.parameters[7], interpreter);
+			} else if (com.parameters.size() == 8) {
+				arg1 = com.parameters[7];
+			}
+			if (map_id == 0) {
+				map_id = Game_Map::GetMapId();
+			}
+			value = InspectMapTreeInfo(static_cast<InspectMapTreeInfoOp>(com.parameters[5]), map_id, arg1);
+			break;
+		}
 		default:
 			Output::Warning("ControlVariables: Unsupported operand {}", com.parameters[5]);
 			return false;
@@ -543,5 +565,100 @@ int ControlVariables::DateTime(DateTimeOp op) {
 	}
 
 	Output::Warning("ControlVariables::GetTime: Unknown op {}", static_cast<int>(op));
+	return 0;
+}
+
+int ControlVariables::ActiveMapInfo(ActiveMapInfoOp op) {
+	switch (op)
+	{
+		case ActiveMapInfoOp::MapTileWidth:
+			return Game_Map::GetTilesX();
+		case ActiveMapInfoOp::MapTileHeight:
+			return Game_Map::GetTilesY();
+		case ActiveMapInfoOp::LoopHorizontal:
+			return Game_Map::LoopHorizontal();
+		case ActiveMapInfoOp::LoopVertical:
+			return Game_Map::LoopVertical();
+	}
+
+	Output::Warning("ControlVariables::ActiveMapInfo: Unknown op {}", static_cast<int>(op));
+	return 0;
+}
+
+int ControlVariables::InspectMapTreeInfo(InspectMapTreeInfoOp op, int map_id, int arg1) {
+	auto& map_info = Game_Map::GetMapInfo(map_id);
+	if (map_info.ID == 0) {
+		return 0;
+	}
+
+	switch (op)
+	{
+		case InspectMapTreeInfoOp::ParentMap:
+			return map_info.parent_map;
+		case InspectMapTreeInfoOp::OriginalEncounterSteps:
+			return map_info.encounter_steps;
+		case InspectMapTreeInfoOp::CountTroops:
+			return map_info.encounters.size();;
+		case InspectMapTreeInfoOp::CountArenas:
+		{
+			int cnt_arenas = 0;
+			for (unsigned int i = 0; i < lcf::Data::treemap.maps.size(); ++i) {
+				auto& map = lcf::Data::treemap.maps[i];
+				if (map.parent_map == map_info.ID && map.type == lcf::rpg::TreeMap::MapType_area) {
+					cnt_arenas++;
+				}
+			}
+			return cnt_arenas;
+		}
+		case InspectMapTreeInfoOp::Troop_Id:
+		{
+			// TODO: provide a way to conveniently copy values into a range of variables ("ControlVarArrayEx"?) 
+			if (arg1 >= 0 && arg1 < map_info.encounters.size()) {
+				return map_info.encounters[arg1].troop_id;
+			}
+			return 0;
+		}
+		case InspectMapTreeInfoOp::Arena_Top:
+		case InspectMapTreeInfoOp::Arena_Left:
+		case InspectMapTreeInfoOp::Arena_Bottom:
+		case InspectMapTreeInfoOp::Arena_Right:
+		case InspectMapTreeInfoOp::Arena_Width:
+		case InspectMapTreeInfoOp::Arena_Height:
+		{
+			// TODO: provide a way to conveniently copy values into a range of variables ("ControlVarArrayEx"?) 
+			if (arg1 < 0) {
+				return 0;
+			}
+
+			int cnt_arenas = 0;
+			for (unsigned int i = 0; i < lcf::Data::treemap.maps.size(); ++i) {
+				auto& map = lcf::Data::treemap.maps[i];
+				if (map.parent_map == map_info.ID && map.type == lcf::rpg::TreeMap::MapType_area) {
+					if (arg1 < cnt_arenas) {
+						cnt_arenas++;
+						continue;
+					}
+					switch (op)
+					{
+						case InspectMapTreeInfoOp::Arena_Top:
+							return map.area_rect.t;
+						case InspectMapTreeInfoOp::Arena_Left:
+							return map.area_rect.l;
+						case InspectMapTreeInfoOp::Arena_Bottom:
+							return map.area_rect.b;
+						case InspectMapTreeInfoOp::Arena_Right:
+							return map.area_rect.r;
+						case InspectMapTreeInfoOp::Arena_Width:
+							return map.area_rect.r - map.area_rect.l;
+						case InspectMapTreeInfoOp::Arena_Height:
+							return map.area_rect.b - map.area_rect.t;
+					}
+				}
+			}
+			return 0;
+		}
+	}
+
+	Output::Warning("ControlVariables::InspectMapTreeInfo: Unknown op {}", static_cast<int>(op));
 	return 0;
 }

--- a/src/game_interpreter_control_variables.h
+++ b/src/game_interpreter_control_variables.h
@@ -49,7 +49,7 @@ namespace ControlVariables {
 	//
 	// New EasyRpgEx operations
 	//
-	bool EasyRpgExCommand(lcf::rpg::EventCommand const& com, int& value);
+	bool EasyRpgExCommand(lcf::rpg::EventCommand const& com, int& value, const Game_BaseInterpreterContext& interpreter);
 
 	enum class DateTimeOp {
 		Year = 0,
@@ -76,6 +76,29 @@ namespace ControlVariables {
 		"gettimestamp"
 	);
 	int DateTime(DateTimeOp op);
+
+	enum ActiveMapInfoOp {
+		MapTileWidth = 0,
+		MapTileHeight,
+		LoopHorizontal,
+		LoopVertical
+	};
+	int ActiveMapInfo(ActiveMapInfoOp op);
+
+	enum InspectMapTreeInfoOp {
+		ParentMap = 0,
+		OriginalEncounterSteps,
+		CountTroops,
+		CountArenas,
+		Troop_Id,
+		Arena_Top,
+		Arena_Left,
+		Arena_Bottom,
+		Arena_Right,
+		Arena_Width,
+		Arena_Height
+	};
+	int InspectMapTreeInfo(InspectMapTreeInfoOp op, int map_id, int arg1);
 }
 
 #endif

--- a/src/game_interpreter_control_variables.h
+++ b/src/game_interpreter_control_variables.h
@@ -99,6 +99,29 @@ namespace ControlVariables {
 		Arena_Height
 	};
 	int InspectMapTreeInfo(InspectMapTreeInfoOp op, int map_id, int arg1);
+
+	enum MessageSystemStateOp {
+		IsMessageTransparent = 0,
+		IsMessagePositionFixed,
+		IsContinueEvents,
+		MessagePosition,
+		IsMessageFaceRightPosition
+	};
+	int MessageSystemState(MessageSystemStateOp op);
+
+	enum MessageWindowStateOp {
+		IsMessageActive = 0,
+		IsFaceActive,
+		CanContinue,
+		WindowTop,
+		WindowLeft,
+		WindowBottom,
+		WindowRight,
+		WindowWidth,
+		WindowHeight,
+		WindowType
+	};
+	int MessageWindowState(MessageWindowStateOp op);
 }
 
 #endif

--- a/src/game_interpreter_control_variables.h
+++ b/src/game_interpreter_control_variables.h
@@ -45,6 +45,37 @@ namespace ControlVariables {
 	int Muldiv(int arg1, int arg2, int arg3);
 	int Divmul(int arg1, int arg2, int arg3);
 	int Between(int arg1, int arg2, int arg3);
+
+	//
+	// New EasyRpgEx operations
+	//
+	bool EasyRpgExCommand(lcf::rpg::EventCommand const& com, int& value);
+
+	enum class DateTimeOp {
+		Year = 0,
+		Month,
+		Day,
+		Hour,
+		Minute,
+		Second,
+		WeekDay,
+		DayOfYear,
+		IsDayLightSavings,
+		TimeStamp
+	};
+	static constexpr auto kDateTimeOpTags = lcf::makeEnumTags<DateTimeOp>(
+		"getyear",
+		"getmonth",
+		"getday",
+		"gethour",
+		"getminute",
+		"getsecond",
+		"getweekday",
+		"getyearday",
+		"getdaylightsavings",
+		"gettimestamp"
+	);
+	int DateTime(DateTimeOp op);
 }
 
 #endif


### PR DESCRIPTION
Some suggested new operations for a custom "**ControlVariablesEx**" command.
(These are currently disabled for the vanilla one, Command Code '2022' has to be used)

### '210': DateTime: Jetrotal's "_GetTime_" command
Cherry Picked & refactored Jetrotal's extension from PR #3124 , so it can be used like any other variable operation.
In the comments I included a suggestion, for how this could be adapted to also allow name-based lookup via strings.

### ~'211': ActiveMapInfo~
~_Width_ & _Height_ are two important infos about the current map I've long desired for ControlVariables.
I've seen that in the meantime, some new Maniac command has been added, that also finally allows access to these, but that seems to be a specialized command that has its own rules..
And with these considered, access to LoopHorizontal / LoopVertical could also prove very useful. (I can think of at least one case, at least)~

### ~'212': InspectMapInfo~
~This command provides access to some information that is stored inside the map tree.
It could still be expanded in functionality, but the most useful one (for my own purposes at least), I think would be the ability, to read Troop information from the current Map.
While I was developing the "_Community Edition_" for Vampires Dawn this was a pretty annoying hindrance, because I wanted to implement an easy way to just switch between normal RNG battles & overworld encounters. I basically had to write a custom code generation tool to be able to do so...~

### '213': MessageSystemInfo
Provides basic info about the system settings for message boxes.

### '214': MessageWindowInfo
Provides some information about a currently active message window.
Another issue I had, while developing a parallel event, that occassionaly displays some popup information. Normally, you haven't got an easy option of knowing if a message window is currently active & if so, where on the screen it is.
You can't really react & redirect your custom drawn picture/strings/etc. to another part of the screen, so that it won't overlap with the system textbox.