### PR TITLE
Translation Extensions & Issues Pt 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,8 @@ add_library(${PROJECT_NAME} OBJECT
 	src/scene_import.h
 	src/scene_item.cpp
 	src/scene_item.h
+	src/scene_language.cpp
+	src/scene_language.h
 	src/scene_load.cpp
 	src/scene_load.h
 	src/scene_logo.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -287,6 +287,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/scene_gameover.h \
 	src/scene_item.cpp \
 	src/scene_item.h \
+	src/scene_language.cpp \
+	src/scene_language.h \
 	src/scene_load.cpp \
 	src/scene_load.h \
 	src/scene_logo.cpp \

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -664,6 +664,8 @@ void Game_Config::LoadFromStream(Filesystem_Stream::InputStream& is) {
 	player.settings_autosave.FromIni(ini);
 	player.settings_in_title.FromIni(ini);
 	player.settings_in_menu.FromIni(ini);
+	player.lang_select_on_start.FromIni(ini);
+	player.lang_select_in_title.FromIni(ini);
 	player.show_startup_logos.FromIni(ini);
 	player.font1.FromIni(ini);
 	player.font1_size.FromIni(ini);
@@ -751,13 +753,13 @@ void Game_Config::WriteToStream(Filesystem_Stream::OutputStream& os) const {
 	player.settings_autosave.ToIni(os);
 	player.settings_in_title.ToIni(os);
 	player.settings_in_menu.ToIni(os);
+	player.lang_select_on_start.ToIni(os);
+	player.lang_select_in_title.ToIni(os);
 	player.show_startup_logos.ToIni(os);
 	player.font1.ToIni(os);
 	player.font1_size.ToIni(os);
 	player.font2.ToIni(os);
 	player.font2_size.ToIni(os);
-	player.log_enabled.ToIni(os);
-	player.screenshot_scale.ToIni(os);
 
 	os << "\n";
 }

--- a/src/game_config.h
+++ b/src/game_config.h
@@ -58,6 +58,14 @@ namespace ConfigEnum {
 		All
 	};
 
+	enum class StartupLangSelect {
+		Never,
+		/* Shows language screen when no saves are found */
+		FirstStartup,
+		/* Always show the language screen before the title */
+		Always
+	};
+
 	enum class ShowFps {
 		/** Do not show */
 		OFF,
@@ -89,6 +97,12 @@ struct Game_ConfigPlayer {
 	RangeConfigParam<int> font1_size { "Font 1 Size", "", "Player", "Font1Size", 12, 6, 16};
 	PathConfigParam font2 { "Font 2", "The game chooses whether it wants font 1 or 2", "Player", "Font2", "" };
 	RangeConfigParam<int> font2_size { "Font 2 Size", "", "Player", "Font2Size", 12, 6, 16};
+	EnumConfigParam<ConfigEnum::StartupLangSelect, 3> lang_select_on_start{
+		"Startup Language Select", "Show the language select before starting the game", "Player", "StartupLangSelect", ConfigEnum::StartupLangSelect::FirstStartup ,
+		Utils::MakeSvArray("Never", "FirstStartup", "Always"),
+		Utils::MakeSvArray("never", "firststartup", "always"),
+		Utils::MakeSvArray("Never show language menu on start", "Show language menu on first start (when no save files are found)", "Always show the language menu prior to the title screen") };
+	BoolConfigParam lang_select_in_title{ "Show language menu on title screen", "Display language menu item on the title screen", "Player", "LanguageInTitle", true };
 	BoolConfigParam log_enabled{ "Logging", "Write diagnostic messages into a logfile", "Player", "Logging", true };
 	RangeConfigParam<int> screenshot_scale { "Screenshot scaling factor", "Scale screenshots by the given factor", "Player", "ScreenshotScale", 1, 1, 24};
 

--- a/src/game_config.h
+++ b/src/game_config.h
@@ -97,11 +97,11 @@ struct Game_ConfigPlayer {
 	RangeConfigParam<int> font1_size { "Font 1 Size", "", "Player", "Font1Size", 12, 6, 16};
 	PathConfigParam font2 { "Font 2", "The game chooses whether it wants font 1 or 2", "Player", "Font2", "" };
 	RangeConfigParam<int> font2_size { "Font 2 Size", "", "Player", "Font2Size", 12, 6, 16};
-	EnumConfigParam<ConfigEnum::StartupLangSelect, 3> lang_select_on_start{
-		"Startup Language Select", "Show the language select before starting the game", "Player", "StartupLangSelect", ConfigEnum::StartupLangSelect::FirstStartup ,
-		Utils::MakeSvArray("Never", "FirstStartup", "Always"),
-		Utils::MakeSvArray("never", "firststartup", "always"),
-		Utils::MakeSvArray("Never show language menu on start", "Show language menu on first start (when no save files are found)", "Always show the language menu prior to the title screen") };
+	EnumConfigParam<ConfigEnum::StartupLangSelect, 3> lang_select_on_start {
+		"Startup Language Menu", "Show language menu before booting up a game", "Player", "StartupLangSelect", ConfigEnum::StartupLangSelect::FirstStartup,
+		Utils::MakeSvArray("Never", "First Start", "Always"),
+		Utils::MakeSvArray("never", "FirstStartup", "always"),
+		Utils::MakeSvArray("Never show language menu on start", "Show on first start (when no save files are found)", "Always show language menu prior to the title screen") };
 	BoolConfigParam lang_select_in_title{ "Show language menu on title screen", "Display language menu item on the title screen", "Player", "LanguageInTitle", true };
 	BoolConfigParam log_enabled{ "Logging", "Write diagnostic messages into a logfile", "Player", "Logging", true };
 	RangeConfigParam<int> screenshot_scale { "Screenshot scaling factor", "Scale screenshots by the given factor", "Player", "ScreenshotScale", 1, 1, 24};

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -51,6 +51,8 @@
 #include "scene_shop.h"
 #include "scene_debug.h"
 #include "scene_gameover.h"
+#include "scene_settings.h"
+#include "scene_language.h"
 #include "scene.h"
 #include "graphics.h"
 #include "input.h"
@@ -161,17 +163,14 @@ bool Game_Interpreter_Map::RequestMainMenuScene(int subscreen_id, int actor_inde
 			Scene::instance->SetRequestedScene(std::make_shared<Scene_Order>());
 			return true;
 		}
-	/*
 	case 6: // Settings
 		Scene::instance->SetRequestedScene(std::make_shared<Scene_Settings>());
 		return true;
 	case 7: // Language
-		Scene::instance->SetRequestedScene(std::make_shared<Scene_Language>());
+		if (Player::translation.HasTranslations()) {
+			Scene::instance->SetRequestedScene(std::make_shared<Scene_Language>());
+		}
 		return true;
-	case 8: // Debug
-		Scene::instance->SetRequestedScene(std::make_shared<Scene_Debug>());
-		return true;
-		*/
 	}
 
 	Scene::instance->SetRequestedScene(std::make_shared<Scene_Menu>());

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -122,6 +122,7 @@ namespace Player {
 	std::string escape_symbol;
 	uint32_t escape_char;
 	std::string game_title;
+	std::string game_title_original;
 	std::shared_ptr<Meta> meta;
 	FileExtGuesser::RPG2KFileExtRemap fileext_map;
 	std::string startup_language;
@@ -737,16 +738,7 @@ void Player::CreateGameObjects() {
 		}
 	}
 
-	std::stringstream title;
-	if (!game_title.empty()) {
-		Output::Debug("Loading game {}", game_title);
-		title << game_title << " - ";
-		Input::AddRecordingData(Input::RecordingData::GameTitle, game_title);
-	} else {
-		Output::Debug("Could not read game title.");
-	}
-	title << GAME_TITLE;
-	DisplayUi->SetTitle(title.str());
+	UpdateTitle(game_title);
 
 	if (no_rtp_warning_flag) {
 		Output::Debug("Game does not need RTP (FullPackageFlag=1)");
@@ -850,6 +842,28 @@ void Player::CreateGameObjects() {
 	if (Player::IsPatchDestiny()) {
 		Main_Data::game_destiny->Load();
 	}
+}
+
+void Player::UpdateTitle(std::string new_game_title) {
+	if (!game_title.empty() && game_title != new_game_title) {
+		if (game_title_original == new_game_title) {
+			game_title_original = "";
+		} else {
+			game_title_original = game_title;
+		}
+		game_title = new_game_title;
+	}
+
+	std::stringstream title;
+	if (!game_title.empty()) {
+		Output::Debug("Loading game {}", game_title);
+		title << new_game_title << " - ";
+		Input::AddRecordingData(Input::RecordingData::GameTitle, game_title);
+	} else {
+		Output::Debug("Could not read game title.");
+	}
+	title << GAME_TITLE;
+	DisplayUi->SetTitle(title.str());
 }
 
 bool Player::ChangeResolution(int width, int height) {

--- a/src/player.h
+++ b/src/player.h
@@ -303,6 +303,11 @@ namespace Player {
 	bool HasEasyRpgExtensions();
 
 	/**
+	 * Update the game title displayed in the Player's UI
+	 */
+	void UpdateTitle(std::string new_game_title);
+
+	/**
 	 * @return Running engine version. 2000 for RPG2k and 2003 for RPG2k3
 	 */
 	int EngineVersion();
@@ -394,6 +399,9 @@ namespace Player {
 
 	/** Game title. */
 	extern std::string game_title;
+
+	/** Original game title, in case it was overriden by a translation. */
+	extern std::string game_title_original;
 
 	/** Meta class containing additional external data for this game. */
 	extern std::shared_ptr<Meta> meta;

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -29,7 +29,9 @@
 #include "game_interpreter.h"
 #include "game_system.h"
 #include "main_data.h"
+#include "scene_language.h"
 #include "scene_settings.h"
+#include "scene_title.h"
 #include "game_map.h"
 
 #ifndef NDEBUG
@@ -265,6 +267,12 @@ void Scene::Push(std::shared_ptr<Scene> const& new_scene, bool pop_stack_top) {
 	DEBUG_VALIDATE("Push");
 }
 
+std::shared_ptr<Scene> Scene::Peek() {
+	if (instances.size() == 1)
+		return nullptr;
+	return instances[instances.size() - 2];
+}
+
 void Scene::Pop() {
 	old_instances.push_back(instances.back());
 	instances.pop_back();
@@ -353,6 +361,19 @@ inline void Scene::DebugValidate(const char* caller) {
 	if (instances[0]->type != Null) {
 		Output::Error("Scene.instances[0] is of type={} in the Scene instances stack!", scene_names[instances[0]->type]);
 	}
+}
+
+void Scene::PushTitleScene(bool pop_stack_top) {
+	auto title_scene = Scene::Find(Scene::Title);
+	if (title_scene) {
+		return;
+	}
+
+	if (!Player::startup_language.empty()) {
+		Player::translation.SelectLanguage(Player::startup_language);
+	}
+
+	Scene::Push(std::make_shared<Scene_Title>(), pop_stack_top);
 }
 
 bool Scene::ReturnToTitleScene() {

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -67,7 +67,9 @@ const char Scene::scene_names[SceneMax][12] =
 	"Logo",
 	"Order",
 	"GameBrowser",
-	"Teleport"
+	"Teleport",
+	"Settings",
+	"Language"
 };
 
 enum PushPopOperation {
@@ -98,6 +100,7 @@ lcf::rpg::SaveSystem::Scene Scene::rpgRtSceneFromSceneType(SceneType t) {
 		case Order:
 		case End:
 		case Settings:
+		case LanguageMenu:
 			return lcf::rpg::SaveSystem::Scene_menu;
 		case File:
 		case Save:

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -24,6 +24,7 @@
 #include "player.h"
 #include "output.h"
 #include "audio.h"
+#include "filefinder.h"
 #include "transition.h"
 #include "game_actors.h"
 #include "game_interpreter.h"
@@ -371,6 +372,12 @@ void Scene::PushTitleScene(bool pop_stack_top) {
 
 	if (!Player::startup_language.empty()) {
 		Player::translation.SelectLanguage(Player::startup_language);
+	} else if (Player::translation.HasTranslations()) {
+		if (Player::player_config.lang_select_on_start.Get() == ConfigEnum::StartupLangSelect::Always
+			|| (!FileFinder::HasSavegame() && Player::player_config.lang_select_on_start.Get() == ConfigEnum::StartupLangSelect::FirstStartup)) {
+			Scene::Push(std::make_shared<Scene_Language>(), pop_stack_top);
+			return;
+		}
 	}
 
 	Scene::Push(std::make_shared<Scene_Title>(), pop_stack_top);

--- a/src/scene.h
+++ b/src/scene.h
@@ -162,6 +162,14 @@ public:
 	static void Push(std::shared_ptr<Scene> const& new_scene, bool pop_stack_top = false);
 
 	/**
+	 * Finds the the scene previous to the current, top-most one and
+	 * returns it without popping it from the stack.
+	 *
+	 * @return the scene found, or NULL if the current scene is already the top.
+	 */
+	static std::shared_ptr<Scene> Peek();
+
+	/**
 	 * Removes the scene that is on the top of the stack.
 	 */
 	static void Pop();
@@ -247,6 +255,12 @@ public:
 
 	/** Decrement delay frames by 1 if we're waiting */
 	void UpdateDelayFrames();
+
+	/**
+	 * Pushes the title screen onto the stack to boot up the game.
+	 * If there already is a title scene ín the stack, this function exits without doing anything.
+	 */
+	static void PushTitleScene(bool pop_stack_top = false);
 
 	/**
 	 * Pops the stack until the title screen and sets proper delay.

--- a/src/scene.h
+++ b/src/scene.h
@@ -59,7 +59,7 @@ public:
 		GameBrowser,
 		Teleport,
 		Settings,
-		Translation,
+		LanguageMenu,
 		SceneMax
 	};
 

--- a/src/scene.h
+++ b/src/scene.h
@@ -59,6 +59,7 @@ public:
 		GameBrowser,
 		Teleport,
 		Settings,
+		Translation,
 		SceneMax
 	};
 

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -28,7 +28,6 @@
 #include "input.h"
 #include "player.h"
 #include "scene_logo.h"
-#include "scene_title.h"
 #include "bitmap.h"
 #include "audio.h"
 #include "output.h"
@@ -242,8 +241,5 @@ void Scene_GameBrowser::BootGame() {
 		return;
 	}
 
-	if (!Player::startup_language.empty()) {
-		Player::translation.SelectLanguage(Player::startup_language);
-	}
-	Scene::Push(std::make_shared<Scene_Title>());
+	Scene::PushTitleScene();
 }

--- a/src/scene_gamebrowser.cpp
+++ b/src/scene_gamebrowser.cpp
@@ -58,6 +58,7 @@ void Scene_GameBrowser::Continue(SceneType /* prev_scene */) {
 	Player::RestoreBaseResolution();
 
 	Player::game_title = "";
+	Player::game_title_original = "";
 
 	Font::ResetDefault();
 

--- a/src/scene_language.cpp
+++ b/src/scene_language.cpp
@@ -29,6 +29,7 @@
 #include "player.h"
 #include "baseui.h"
 #include "output.h"
+#include "scene_title.h"
 #include "utils.h"
 #include "scene_end.h"
 #include "window_about.h"
@@ -182,8 +183,7 @@ void Scene_Language::ChangeLanguage(const std::string& lang_str) {
 }
 
 void Scene_Language::PopOrTitle() {
-	auto peek_scene = Scene::Peek();
-	if (!peek_scene || peek_scene->type == SceneType::Null || peek_scene->type == SceneType::Logo) {
+	if (!Find(Title)) {
 		Scene::Push(std::make_shared<Scene_Title>(), true);
 	} else {
 		Scene::Pop();

--- a/src/scene_language.cpp
+++ b/src/scene_language.cpp
@@ -170,14 +170,8 @@ void Scene_Language::ChangeLanguage(const std::string& lang_str) {
 
 	// First change the language
 	Player::translation.SelectLanguage(lang_str);
-}
-
-void Scene_Language::OnTranslationChanged() {
-	Start();
 
 	PopOrTitle();
-
-	Scene::OnTranslationChanged();
 }
 
 void Scene_Language::PopOrTitle() {

--- a/src/scene_language.cpp
+++ b/src/scene_language.cpp
@@ -148,6 +148,8 @@ void Scene_Language::vUpdate() {
 
 void Scene_Language::OnTranslationChanged() {
 	Main_Data::game_system->ReloadSystemGraphic();
+
+	Scene::OnTranslationChanged();
 }
 
 void Scene_Language::OnTitleSpriteReady(FileRequestResult* result) {

--- a/src/scene_language.cpp
+++ b/src/scene_language.cpp
@@ -93,8 +93,7 @@ void Scene_Language::CreateTranslationWindow() {
 			win.SetText("");
 		}
 	};
-	translate_window->SetX(Player::screen_width / 2 - translate_window->GetWidth() / 2);
-	translate_window->SetY(Player::screen_height / 2 - translate_window->GetHeight() / 2);
+	Scene_Title::RepositionWindow(*translate_window, Player::hide_title_flag);
 
 	if (Player::IsRPG2k3E() && lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent) {
 		translate_window->SetBackOpacity(160);

--- a/src/scene_language.cpp
+++ b/src/scene_language.cpp
@@ -15,6 +15,7 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 #include "scene_language.h"
+#include "scene_logo.h"
 #include "audio.h"
 #include "bitmap.h"
 #include "input.h"
@@ -63,7 +64,7 @@ void Scene_Language::CreateTitleGraphic() {
 void Scene_Language::CreateTranslationWindow() {
 	// Build a list of 'Default' and all known languages.
 	std::vector<std::string> lang_names;
-	lang_names.push_back("Default");
+	lang_names.push_back("Default Language");
 	lang_dirs.push_back("");
 	lang_helps.push_back("Play the game in its original language.");
 
@@ -136,9 +137,12 @@ void Scene_Language::vUpdate() {
 	else if (Input::IsTriggered(Input::CANCEL)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
 
+		auto peek_scene = Scene::Peek();
+		if (!peek_scene || peek_scene->type == SceneType::Null || peek_scene->type == SceneType::Logo) {
+			Transition::instance().InitErase(Transition::TransitionFadeOut, this);
+		}
 		Scene::Pop();
 	}
-
 }
 
 void Scene_Language::OnTitleSpriteReady(FileRequestResult* result) {
@@ -160,7 +164,7 @@ void Scene_Language::ChangeLanguage(const std::string& lang_str) {
 
 	// No-op?
 	if (lang_str == Player::translation.GetCurrentLanguage().lang_dir) {
-		Scene::Pop();
+		PopOrTitle();
 		return;
 	}
 
@@ -171,7 +175,16 @@ void Scene_Language::ChangeLanguage(const std::string& lang_str) {
 void Scene_Language::OnTranslationChanged() {
 	Start();
 
-	Scene::Pop();
+	PopOrTitle();
 
 	Scene::OnTranslationChanged();
+}
+
+void Scene_Language::PopOrTitle() {
+	auto peek_scene = Scene::Peek();
+	if (!peek_scene || peek_scene->type == SceneType::Null || peek_scene->type == SceneType::Logo) {
+		Scene::Push(std::make_shared<Scene_Title>(), true);
+	} else {
+		Scene::Pop();
+	}
 }

--- a/src/scene_language.cpp
+++ b/src/scene_language.cpp
@@ -45,7 +45,7 @@
 #endif
 
 Scene_Language::Scene_Language() {
-	Scene::type = Scene::Translation;
+	Scene::type = Scene::LanguageMenu;
 }
 
 void Scene_Language::CreateTitleGraphic() {

--- a/src/scene_language.cpp
+++ b/src/scene_language.cpp
@@ -1,0 +1,177 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "scene_language.h"
+#include "audio.h"
+#include "bitmap.h"
+#include "input.h"
+#include "game_system.h"
+#include "cache.h"
+#include "input_buttons.h"
+#include "input_source.h"
+#include "keys.h"
+#include "main_data.h"
+#include "options.h"
+#include "player.h"
+#include "baseui.h"
+#include "output.h"
+#include "utils.h"
+#include "scene_end.h"
+#include "window_about.h"
+#include "window_command_horizontal.h"
+#include "window_help.h"
+#include "window_input_settings.h"
+#include "window_numberinput.h"
+#include "window_selectable.h"
+#include "window_settings.h"
+#include <memory>
+
+#ifdef EMSCRIPTEN
+#  include <emscripten.h>
+#endif
+
+Scene_Language::Scene_Language() {
+	Scene::type = Scene::Translation;
+}
+
+void Scene_Language::CreateTitleGraphic() {
+	// Load Title Graphic
+	if (lcf::Data::system.title_name.empty()) {
+		return;
+	}
+	title = std::make_unique<Sprite>();
+	FileRequestAsync* request = AsyncHandler::RequestFile("Title", lcf::Data::system.title_name);
+	request->SetGraphicFile(true);
+	request_id = request->Bind(&Scene_Language::OnTitleSpriteReady, this);
+	request->Start();
+}
+
+
+void Scene_Language::CreateTranslationWindow() {
+	// Build a list of 'Default' and all known languages.
+	std::vector<std::string> lang_names;
+	lang_names.push_back("Default");
+	lang_dirs.push_back("");
+	lang_helps.push_back("Play the game in its original language.");
+
+	// Push menu entries with the display name, but also save the directory location and help text.
+	for (const Language& lg : Player::translation.GetLanguages()) {
+		lang_names.push_back(lg.lang_name);
+		lang_dirs.push_back(lg.lang_dir);
+		lang_helps.push_back(lg.lang_desc);
+	}
+
+	// Allow overwriting text of the default language
+	const Language& def = Player::translation.GetDefaultLanguage();
+	if (!def.lang_name.empty()) {
+		lang_names.front() = def.lang_name;
+	}
+	if (!def.lang_desc.empty()) {
+		lang_helps.front() = def.lang_desc;
+	}
+
+	translate_window = std::make_unique<Window_Command>(lang_names, -1, lang_names.size() > 9 ? 9 : lang_names.size());
+	translate_window->UpdateHelpFn = [this](Window_Help& win, int index) {
+		if (index >= 0 && index < static_cast<int>(lang_helps.size())) {
+			win.SetText(lang_helps[index]);
+		}
+		else {
+			win.SetText("");
+		}
+	};
+	translate_window->SetX(Player::screen_width / 2 - translate_window->GetWidth() / 2);
+	translate_window->SetY(Player::screen_height / 2 - translate_window->GetHeight() / 2);
+
+	if (Player::IsRPG2k3E() && lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent) {
+		translate_window->SetBackOpacity(160);
+	}
+
+	translate_window->SetVisible(false);
+}
+
+void Scene_Language::CreateHelpWindow() {
+	help_window.reset(new Window_Help(0, 0, Player::screen_width, 32));
+
+	if (Player::IsRPG2k3E() && lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent) {
+		help_window->SetBackOpacity(160);
+	}
+
+	help_window->SetVisible(false);
+	translate_window->SetHelpWindow(help_window.get());
+}
+
+void Scene_Language::Start() {
+	CreateTitleGraphic();
+	CreateTranslationWindow();
+	CreateHelpWindow();
+
+	translate_window->SetActive(true);
+	translate_window->SetVisible(true);
+	help_window->SetVisible(true);
+}
+
+
+void Scene_Language::vUpdate() {
+	translate_window->Update();
+	help_window->Update();
+
+
+	if (Input::IsTriggered(Input::DECISION)) {
+		int index = translate_window->GetIndex();
+		ChangeLanguage(lang_dirs.at(index));
+	}
+	else if (Input::IsTriggered(Input::CANCEL)) {
+		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
+
+		Scene::Pop();
+	}
+
+}
+
+void Scene_Language::OnTitleSpriteReady(FileRequestResult* result) {
+	BitmapRef bitmapRef = Cache::Title(result->file);
+
+	title->SetBitmap(bitmapRef);
+
+	// If the title sprite doesn't fill the screen, center it to support custom resolutions
+	if (bitmapRef->GetWidth() < Player::screen_width) {
+		title->SetX(Player::menu_offset_x);
+	}
+	if (bitmapRef->GetHeight() < Player::screen_height) {
+		title->SetY(Player::menu_offset_y);
+	}
+}
+
+void Scene_Language::ChangeLanguage(const std::string& lang_str) {
+	Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
+
+	// No-op?
+	if (lang_str == Player::translation.GetCurrentLanguage().lang_dir) {
+		Scene::Pop();
+		return;
+	}
+
+	// First change the language
+	Player::translation.SelectLanguage(lang_str);
+}
+
+void Scene_Language::OnTranslationChanged() {
+	Start();
+
+	Scene::Pop();
+
+	Scene::OnTranslationChanged();
+}

--- a/src/scene_language.h
+++ b/src/scene_language.h
@@ -45,8 +45,6 @@ public:
 	void Start() override;
 	void vUpdate() override;
 
-	void OnTranslationChanged() override;
-
 private:
 
 	/**

--- a/src/scene_language.h
+++ b/src/scene_language.h
@@ -45,6 +45,8 @@ public:
 	void Start() override;
 	void vUpdate() override;
 
+	void OnTranslationChanged() override;
+
 private:
 
 	/**
@@ -83,6 +85,7 @@ private:
 	std::unique_ptr<Sprite> title;
 	FileRequestBinding request_id;
 	int input_reset_counter = 0;
+	bool shutdown = false;
 
 	Window_Settings::UiMode mode = Window_Settings::eNone;
 };

--- a/src/scene_language.h
+++ b/src/scene_language.h
@@ -68,6 +68,7 @@ private:
 	void CreateTitleGraphic();
 	void OnTitleSpriteReady(FileRequestResult* result);
 
+	void PopOrTitle();
 
 	/** Displays all available translations (languages). */
 	std::unique_ptr<Window_Command> translate_window;

--- a/src/scene_language.h
+++ b/src/scene_language.h
@@ -1,0 +1,92 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_SCENE_LANGUAGE_H
+#define EP_SCENE_LANGUAGE_H
+
+ // Headers
+#include <vector>
+#include "scene.h"
+#include "window_command.h"
+#include "window_command_horizontal.h"
+#include "window_about.h"
+#include "window_selectable.h"
+#include "window_settings.h"
+#include "window_input_settings.h"
+#include "async_handler.h"
+#include "sprite.h"
+#include "game_config.h"
+
+/**
+ * Scene allowing configuration of system state.
+ */
+class Scene_Language : public Scene {
+
+public:
+	/**
+	 * Constructor.
+	 */
+	Scene_Language();
+
+	void Start() override;
+	void vUpdate() override;
+
+	void OnTranslationChanged() override;
+
+private:
+
+	/**
+	 * Creates the Window displaying available translations.
+	 */
+	void CreateTranslationWindow();
+
+	/**
+	 * Creates the Help window and hides it
+	 */
+	void CreateHelpWindow();
+
+	/**
+	 * Picks a new language based and switches to it.
+	 * @param lang_str If the empty string, switches the game to 'No Translation'. Otherwise, switch to that translation by name.
+	 */
+	void ChangeLanguage(const std::string& lang_str);
+
+	void CreateTitleGraphic();
+	void OnTitleSpriteReady(FileRequestResult* result);
+
+
+	/** Displays all available translations (languages). */
+	std::unique_ptr<Window_Command> translate_window;
+
+	/** Displays help text for a given language **/
+	std::unique_ptr<Window_Help> help_window;
+
+	/** Contains directory names for each language; entry 0 is resverd for the default (no) translation */
+	std::vector<std::string> lang_dirs;
+
+	/** Contains help strings for each language; entry 0 is resverd for the default (no) translation */
+	std::vector<std::string> lang_helps;
+
+	std::unique_ptr<Sprite> title;
+	FileRequestBinding request_id;
+	int input_reset_counter = 0;
+
+	Window_Settings::UiMode mode = Window_Settings::eNone;
+};
+
+
+#endif

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -25,7 +25,6 @@
 #include "input.h"
 #include "options.h"
 #include "player.h"
-#include "scene_title.h"
 #include "scene_gamebrowser.h"
 #include "scene_settings.h"
 #include "output.h"
@@ -102,10 +101,8 @@ void Scene_Logo::vUpdate() {
 				}
 			}
 
-			if (!Player::startup_language.empty()) {
-				Player::translation.SelectLanguage(Player::startup_language);
-			}
-			Scene::Push(std::make_shared<Scene_Title>(), true);
+			Scene::PushTitleScene(true);
+
 			if (Player::load_game_id > 0) {
 				auto save = FileFinder::Save();
 

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -184,7 +184,7 @@ void Scene_Map::TransitionOut(SceneType next_scene) {
 	if (next_scene != Scene::Battle
 			&& next_scene != Scene::Debug
 			&& next_scene != Scene::Settings
-			&& next_scene != Scene::Translation) {
+			&& next_scene != Scene::LanguageMenu) {
 		screen_erased_by_event = false;
 	}
 

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -183,7 +183,8 @@ void Scene_Map::TransitionOut(SceneType next_scene) {
 
 	if (next_scene != Scene::Battle
 			&& next_scene != Scene::Debug
-			&& next_scene != Scene::Settings) {
+			&& next_scene != Scene::Settings
+			&& next_scene != Scene::Translation) {
 		screen_erased_by_event = false;
 	}
 

--- a/src/scene_settings.cpp
+++ b/src/scene_settings.cpp
@@ -260,6 +260,7 @@ void Scene_Settings::vUpdate() {
 		case Window_Settings::eSave:
 		case Window_Settings::eEnd:
 		case Window_Settings::eAbout:
+		case Window_Settings::eLanguage: // fix compiler warning, not implemented
 			break;
 		case Window_Settings::eMain:
 			UpdateMain();

--- a/src/scene_settings.cpp
+++ b/src/scene_settings.cpp
@@ -71,7 +71,7 @@ void Scene_Settings::CreateMainWindow() {
 		{ Window_Settings::eSave,	"<Save Settings>"}
 	});
 
-	if (Player::translation.HasTranslations() && Scene::Peek()->type != SceneType::Title && Scene::Peek()->type != SceneType::Translation) {
+	if (Player::translation.HasTranslations() && Scene::Peek()->type != Scene::Title && Scene::Peek()->type != Scene::LanguageMenu) {
 		root_options.insert(root_options.begin() + 3, { Window_Settings::eLanguage, "Language" });
 	}
 

--- a/src/scene_settings.h
+++ b/src/scene_settings.h
@@ -90,6 +90,8 @@ private:
 	int input_reset_counter = 0;
 
 	Window_Settings::UiMode mode = Window_Settings::eNone;
+
+	std::vector<std::pair<Window_Settings::UiMode, std::string>> root_options;
 };
 
 

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -119,7 +119,7 @@ void Scene_Title::TransitionIn(SceneType prev_scene) {
 }
 
 void Scene_Title::Suspend(Scene::SceneType scene_type) {
-	if (scene_type == Scene::Settings || scene_type == Scene::Translation) {
+	if (scene_type == Scene::Settings || scene_type == Scene::LanguageMenu) {
 		restart_title_cache = true;
 	}
 

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -233,7 +233,7 @@ void Scene_Title::CreateCommandWindow() {
 	}
 
 	// Set "Translate" based on metadata
-	if (Player::translation.HasTranslations()) {
+	if (Player::translation.HasTranslations() && Player::player_config.lang_select_in_title.Get()) {
 		options.push_back(Player::meta->GetExVocabTranslateTitleText());
 		indices.translate = indices.exit;
 		indices.exit++;

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -23,6 +23,7 @@
 #include "options.h"
 #include "scene_settings.h"
 #include "scene_title.h"
+#include "scene_language.h"
 #include "audio.h"
 #include "audio_secache.h"
 #include "cache.h"
@@ -77,20 +78,8 @@ void Scene_Title::Start() {
 	}
 
 	CreateCommandWindow();
-	CreateTranslationWindow();
-	CreateHelpWindow();
 }
 
-void Scene_Title::CreateHelpWindow() {
-	help_window.reset(new Window_Help(0, 0, Player::screen_width, 32));
-
-	if (Player::IsRPG2k3E() && lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent) {
-		help_window->SetBackOpacity(160);
-	}
-
-	help_window->SetVisible(false);
-	translate_window->SetHelpWindow(help_window.get());
-}
 
 void Scene_Title::Continue(SceneType prev_scene) {
 	Main_Data::game_system->ResetSystemGraphic();
@@ -130,7 +119,7 @@ void Scene_Title::TransitionIn(SceneType prev_scene) {
 }
 
 void Scene_Title::Suspend(Scene::SceneType scene_type) {
-	if (scene_type == Scene::Settings) {
+	if (scene_type == Scene::Settings || scene_type == Scene::Translation) {
 		restart_title_cache = true;
 	}
 
@@ -152,43 +141,28 @@ void Scene_Title::vUpdate() {
 		return;
 	}
 
-	if (active_window == 0) {
-		command_window->Update();
-	} else {
-		translate_window->Update();
-	}
+	command_window->Update();
 
 	if (Input::IsTriggered(Input::DECISION)) {
-		if (active_window == 0) {
-			int index = command_window->GetIndex();
-			if (index == indices.new_game) {  // New Game
-				CommandNewGame();
-			} else if (index == indices.continue_game) {  // Load Game
-				CommandContinue();
-			} else if (index == indices.import) {  // Import (multi-part games)
-				CommandImport();
-			} else if (index == indices.settings) {
-				CommandSettings();
-			} else if (index == indices.translate) { // Choose a Translation (Language)
-				CommandTranslation();
-			} else if (index == indices.exit) {  // Exit Game
-				CommandShutdown();
-			}
-		} else if (active_window == 1) {
-			int index = translate_window->GetIndex();
-			ChangeLanguage(lang_dirs.at(index));
+		int index = command_window->GetIndex();
+		if (index == indices.new_game) {  // New Game
+			CommandNewGame();
+		} else if (index == indices.continue_game) {  // Load Game
+			CommandContinue();
+		} else if (index == indices.import) {  // Import (multi-part games)
+			CommandImport();
+		} else if (index == indices.settings) {
+			CommandSettings();
+		} else if (index == indices.translate) { // Choose a Translation (Language)
+			CommandTranslation();
+		} else if (index == indices.exit) {  // Exit Game
+			CommandShutdown();
 		}
 	} else if (Input::IsTriggered(Input::SHIFT)) {
 		// For emscripten: Allow accessing the load scene for file upload with Shift
 		int index = command_window->GetIndex();
 		if (index == indices.continue_game) {
 			CommandContinue();
-		}
-	} else if (Input::IsTriggered(Input::CANCEL)) {
-		if (active_window == 1) {
-			// Switch back
-			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
-			HideTranslationWindow();
 		}
 	}
 }
@@ -206,7 +180,6 @@ void Scene_Title::OnTranslationChanged() {
 	Start();
 
 	command_window->SetIndex(indices.translate);
-	HideTranslationWindow();
 
 	Scene::OnTranslationChanged();
 }
@@ -285,46 +258,6 @@ void Scene_Title::CreateCommandWindow() {
 	command_window->SetVisible(true);
 }
 
-void Scene_Title::CreateTranslationWindow() {
-	// Build a list of 'Default' and all known languages.
-	std::vector<std::string> lang_names;
-	lang_names.push_back("Default Language");
-	lang_dirs.push_back("");
-	lang_helps.push_back("Play the game in its original language.");
-
-	// Push menu entries with the display name, but also save the directory location and help text.
-	for (const Language& lg : Player::translation.GetLanguages()) {
-		lang_names.push_back(lg.lang_name);
-		lang_dirs.push_back(lg.lang_dir);
-		lang_helps.push_back(lg.lang_desc);
-	}
-
-	// Allow overwriting text of the default language
-	const Language& def = Player::translation.GetDefaultLanguage();
-	if (!def.lang_name.empty()) {
-		lang_names.front() = def.lang_name;
-	}
-	if (!def.lang_desc.empty()) {
-		lang_helps.front() = def.lang_desc;
-	}
-
-	translate_window = std::make_unique<Window_Command>(lang_names, -1, lang_names.size() > 9 ? 9 : lang_names.size());
-	translate_window->UpdateHelpFn = [this](Window_Help& win, int index) {
-		if (index >= 0 && index < static_cast<int>(lang_helps.size())) {
-			win.SetText(lang_helps[index]);
-		} else {
-			win.SetText("");
-		}
-	};
-	RepositionWindow(*translate_window, Player::hide_title_flag);
-
-	if (Player::IsRPG2k3E() && lcf::Data::battlecommands.transparency == lcf::rpg::BattleCommands::Transparency_transparent) {
-		translate_window->SetBackOpacity(160);
-	}
-
-	translate_window->SetVisible(false);
-}
-
 void Scene_Title::PlayTitleMusic() {
 	// Workaround Android problem: BGM doesn't start when game is started again
 	Main_Data::game_system->BgmStop();
@@ -383,31 +316,7 @@ void Scene_Title::CommandSettings() {
 void Scene_Title::CommandTranslation() {
 	Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 
-	// Switch windows
-	active_window = 1;
-	command_window->SetVisible(false);
-	translate_window->SetVisible(true);
-	help_window->SetVisible(true);
-}
-
-void Scene_Title::ChangeLanguage(const std::string& lang_str) {
-	Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
-
-	// No-op?
-	if (lang_str == Player::translation.GetCurrentLanguage().lang_dir) {
-		HideTranslationWindow();
-		return;
-	}
-
-	// First change the language
-	Player::translation.SelectLanguage(lang_str);
-}
-
-void Scene_Title::HideTranslationWindow() {
-	active_window = 0;
-	command_window->SetVisible(true);
-	translate_window->SetVisible(false);
-	help_window->SetVisible(false);
+	Scene::Push(std::make_unique<Scene_Language>());
 }
 
 void Scene_Title::CommandShutdown() {

--- a/src/scene_title.h
+++ b/src/scene_title.h
@@ -119,15 +119,15 @@ public:
 	 */
 	void OnGameStart();
 
-private:
-	void OnTitleSpriteReady(FileRequestResult* result);
-
 	/**
 	 * Moves a window (typically the New/Continue/Quit menu) to the middle or bottom-center of the screen.
 	 * @param window The window to resposition.
 	 * @param center_vertical If true, the menu will be centered vertically. Otherwise, it will be at the bottom of the screen.
 	 */
-	void RepositionWindow(Window_Command& window, bool center_vertical);
+	static void RepositionWindow(Window_Command& window, bool center_vertical);
+
+private:
+	void OnTitleSpriteReady(FileRequestResult* result);
 
 	/** Displays the options of the title scene. */
 	std::unique_ptr<Window_Command> command_window;

--- a/src/scene_title.h
+++ b/src/scene_title.h
@@ -55,16 +55,6 @@ public:
 	void CreateCommandWindow();
 
 	/**
-	 * Creates the Window displaying available translations.
-	 */
-	void CreateTranslationWindow();
-
-	/**
-	 * Creates the Help window and hides it
-	 */
-	void CreateHelpWindow();
-
-	/**
 	 * Plays the title music.
 	 */
 	void PlayTitleMusic();
@@ -139,38 +129,11 @@ private:
 	 */
 	void RepositionWindow(Window_Command& window, bool center_vertical);
 
-	/**
-	 * Picks a new language based and switches to it.
-	 * @param lang_str If the empty string, switches the game to 'No Translation'. Otherwise, switch to that translation by name.
-	 */
-	void ChangeLanguage(const std::string& lang_str);
-
-	void HideTranslationWindow();
-
 	/** Displays the options of the title scene. */
 	std::unique_ptr<Window_Command> command_window;
 
-	/** Displays all available translations (languages). */
-	std::unique_ptr<Window_Command> translate_window;
-
-	/** Displays help text for a given language **/
-	std::unique_ptr<Window_Help> help_window;
-
-	/** Contains directory names for each language; entry 0 is resverd for the default (no) translation */
-	std::vector<std::string> lang_dirs;
-
-	/** Contains help strings for each language; entry 0 is resverd for the default (no) translation */
-	std::vector<std::string> lang_helps;
-
 	/** Background graphic. */
 	std::unique_ptr<Sprite> title;
-
-	/**
-	 * Current active window
-	 *   0 = command
-	 *   1 = translate
-	 */
-	int active_window = 0;
 
 	/**
 	 * Offsets for each selection, in case "Import" or "Translate" is enabled.

--- a/src/translation.cpp
+++ b/src/translation.cpp
@@ -168,7 +168,7 @@ void Translation::SelectLanguage(StringView lang_id)
 	if (!lang_id.empty()) {
 		auto root = GetRootTree();
 		if (!root) {
-			Output::Error("Cannot load translation. 'Language' folder does not exist");
+			Output::Warning("Cannot load translation. 'Language' folder does not exist");
 			return;
 		}
 

--- a/src/translation.cpp
+++ b/src/translation.cpp
@@ -26,6 +26,7 @@
 #include <lcf/rpg/map.h>
 #include "lcf/rpg/mapinfo.h"
 
+#include "baseui.h"
 #include "cache.h"
 #include "font.h"
 #include "main_data.h"
@@ -116,6 +117,7 @@ void Translation::InitTranslations()
 				item.lang_desc = ini.GetString("Language", "Description", "");
 				item.lang_code = ini.GetString("Language", "Code", "");
 				item.lang_term = ini.GetString("Language", "Term", "Language");
+				item.game_title = ini.GetString("Language", "GameTitle", "");
 				item.use_builtin_font = Utils::LowerCase(ini.GetString("Language", "Font", "")) == "builtin";
 
 				if (item.lang_dir == "default") {
@@ -220,6 +222,12 @@ void Translation::SelectLanguageAsync(FileRequestResult*, StringView lang_id) {
 		RewriteTreemapNames();
 		RewriteBattleEventMessages();
 		RewriteCommonEventMessages();
+	}
+
+	if (!current_language.game_title.empty()) {
+		Player::UpdateTitle(current_language.game_title);
+	} else if (!Player::game_title_original.empty()) {
+		Player::UpdateTitle(Player::game_title_original);
 	}
 
 	// Reset the cache, so that all images load fresh.

--- a/src/translation.h
+++ b/src/translation.h
@@ -151,6 +151,7 @@ struct Language {
 	std::string lang_desc; // Helper text to show when the menu is highlighted
 	std::string lang_code; // Language code used by font selection and input scene
 	std::string lang_term; // Term to use for "Language"
+	std::string game_title; // Translated game title
 	bool use_builtin_font = false;
 };
 

--- a/src/window_settings.cpp
+++ b/src/window_settings.cpp
@@ -427,6 +427,8 @@ void Window_Settings::RefreshEngine() {
 	AddOption(cfg.settings_autosave, [&cfg](){ cfg.settings_autosave.Toggle(); });
 	AddOption(cfg.settings_in_title, [&cfg](){ cfg.settings_in_title.Toggle(); });
 	AddOption(cfg.settings_in_menu, [&cfg](){ cfg.settings_in_menu.Toggle(); });
+	AddOption(cfg.lang_select_on_start, [this, &cfg]() { cfg.lang_select_on_start.Set(static_cast<ConfigEnum::StartupLangSelect>(GetCurrentOption().current_value)); });
+	AddOption(cfg.lang_select_in_title, [&cfg](){ cfg.lang_select_in_title.Toggle(); });
 	AddOption(cfg.log_enabled, [&cfg]() { cfg.log_enabled.Toggle(); });
 	AddOption(cfg.screenshot_scale, [this, &cfg](){ cfg.screenshot_scale.Set(GetCurrentOption().current_value); });
 

--- a/src/window_settings.h
+++ b/src/window_settings.h
@@ -51,6 +51,7 @@ public:
 		eSave,
 		eEnd,
 		eAbout,
+		eLanguage,
 		eLastMode
 	};
 


### PR DESCRIPTION
This PR collects all the minor patches I've done recently on the Player´s translation feature.
Basically I've split my working branch into 3, depending on how deep the changes would go.

Pt.2 would contain some changes to liblcf, to be able to store the selected language setting inside savefiles
Pt.3 is highly experimental & does all the unsafe, live patching of the interpreter state, to be able to switch languages mid-game

And if Pt.3 works out, maybe I'll proceed to experiment with some sort of AI-based auto-translation feature. Let's see.  

### Opening the language selection menu via custom command (Issue #2945):

Previously, the language selection has been hardcoded to be part of the title scene. This was an issue for games that use the "NewGame" flag & implemented their own title screen in-engine.
This PR implements a new scene type for the langue menu and also adds a way for this custom scene to be accessed via either of the currently provided "custom menu" options:
- Maniac patch extension to **_"Open Save menu"_** (Code 11910) -> param[0] = 207 (Patch "Maniac" & "EasyRpg Extensions" have to be active)
- **_"DirectMenu"_** patch -> [Patch variable] = 7

Also, I added support for accessing EasyRPGs "Settings" menu in this manner. This was previously commented out, but can now also be accessed via both of these ways, by using value "206" (Save Menu Cmd) or "6" (DirectMenuPatch)

### Turning of the "Language" menu on title screen.

See feature request here: https://community.easyrpg.org/t/turning-off-the-menu-option-created-by-translation/1277

Two new config options have been added:
- "LanguageInTitle"
- "StartupLangSelect"

"LanguageInTitle" can be used to remove the "Language" options from the title screen entirely, similarly to the previously existing 'SettingsInTitle' config option.

As an alternative, a new way of accessing the Language select scene has been added via the "StartupLangSelect" option. If set, the menu is shown right before the actual title screen of the game is boot up.
Options are: _"Never", "FirstStartup", "Always"._ 
"FirstStartup" will try to look for existing save files & only show the language screen, if none are found.


### Generate only a warning when no Language folder is found (Issue #3213)

As described in the issue, the player would generate an error & thus force the Player to exit, if it was started with the "--language" option for a game where no "Language" folder exists. This would also be an issue for loading up a savegame where the "translation" field is set.


### Translating a game's title (Issue #3097)

A new field in "meta.ini" can be used to translate the game title into different languages. As in the vanilla RPG_RT.ini, the name for this option is "GameTitle".

### Dynamic language switching in-game

In addition to the custom ways of accessing the language menu in-engine, I also added a new option to EasyRPG´s F1 Settings screen. This can't be deactivated at the moment, maybe another config-flag should be added for this? :thinking: 
This doesn't change the way translation is handled in-game (yet), so for the language-switch to be fully active, one has to leave the current map, so that the Player can properly refresh any currently active events.

For a futue PR I'd like to overhaul the way the language-switch works when in-game, so that even currently active interpreter stacks can be fully switched to another translation. I'll probably add a new command too for this, so prepare for some weird test game experiences where the game just randomly switches between languages in unexpected ways. xD

----

Fix #2945 
Fix #3097 
Fix #3213 
