### PR TITLE
Maniac´s debugging features: GetCommandInterpreterState (GetGameInfo), maniac_event_info & more debugging extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,8 @@ add_library(${PROJECT_NAME} OBJECT
 	src/game_interpreter_battle.h
 	src/game_interpreter_control_variables.cpp
 	src/game_interpreter_control_variables.h
+	src/game_interpreter_debug.cpp
+	src/game_interpreter_debug.h
 	src/game_interpreter.cpp
 	src/game_interpreter.h
 	src/game_interpreter_map.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -158,6 +158,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/game_interpreter_battle.h \
 	src/game_interpreter_control_variables.cpp \
 	src/game_interpreter_control_variables.h \
+	src/game_interpreter_debug.cpp \
+	src/game_interpreter_debug.h \
 	src/game_interpreter_map.cpp \
 	src/game_interpreter_map.h \
 	src/game_interpreter_shared.cpp \

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -50,7 +50,7 @@ namespace FileFinder {
 	 * Type of the project. Used to differentiate between supported games (2kX or EasyRPG)
 	 * and known but unsupported (i.e. newer RPG Makers).
 	 */
-	enum ProjectType {
+	enum class ProjectType {
 		Unknown,
 		// 2kX or EasyRPG
 		Supported,
@@ -62,7 +62,8 @@ namespace FileFinder {
 		WolfRpgEditor,
 		Encrypted2k3Maniacs,
 		RpgMaker95,
-		SimRpgMaker95
+		SimRpgMaker95,
+		LAST
 	};
 
 	constexpr auto kProjectType = lcf::makeEnumTags<ProjectType>(
@@ -77,6 +78,7 @@ namespace FileFinder {
 		"RPG Maker 95",
 		"Sim RPG Maker 95"
 	);
+	static_assert(kProjectType.size() == static_cast<size_t>(ProjectType::LAST));
 
 	/**
 	 * Helper struct combining the project's directory and its type (used by Game Browser)

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -32,7 +32,7 @@ Game_CommonEvent::Game_CommonEvent(int common_event_id) :
 	if (ce->trigger == lcf::rpg::EventPage::Trigger_parallel
 			&& !ce->event_commands.empty()) {
 		interpreter.reset(new Game_Interpreter_Map());
-		interpreter->Push(this);
+		interpreter->Push(this, InterpreterExecutionType::Parallel);
 	}
 
 

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -32,7 +32,7 @@ Game_CommonEvent::Game_CommonEvent(int common_event_id) :
 	if (ce->trigger == lcf::rpg::EventPage::Trigger_parallel
 			&& !ce->event_commands.empty()) {
 		interpreter.reset(new Game_Interpreter_Map());
-		interpreter->Push(this, InterpreterExecutionType::Parallel);
+		interpreter->Push<InterpreterExecutionType::Parallel>(this);
 	}
 
 

--- a/src/game_commonevent.h
+++ b/src/game_commonevent.h
@@ -121,8 +121,7 @@ private:
 	/** Interpreter for parallel common events. */
 	std::unique_ptr<Game_Interpreter_Map> interpreter;
 
-	friend class Scene_Debug;
-	friend class Debug::ParallelInterpreterStates;
+	friend class Game_Interpreter_Inspector;
 };
 
 #endif

--- a/src/game_commonevent.h
+++ b/src/game_commonevent.h
@@ -21,6 +21,7 @@
 // Headers
 #include <string>
 #include <vector>
+#include "game_interpreter_debug.h"
 #include "game_interpreter_map.h"
 #include <lcf/rpg/commonevent.h>
 #include <lcf/rpg/saveeventexecstate.h>
@@ -121,6 +122,7 @@ private:
 	std::unique_ptr<Game_Interpreter_Map> interpreter;
 
 	friend class Scene_Debug;
+	friend class Debug::ParallelInterpreterStates;
 };
 
 #endif

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -587,7 +587,7 @@ AsyncOp Game_Event::Update(bool resume_async) {
 	// the wait will tick by 1 each time the interpreter is invoked.
 	if ((resume_async || GetTrigger() == lcf::rpg::EventPage::Trigger_parallel) && interpreter) {
 		if (!interpreter->IsRunning() && page && !page->event_commands.empty()) {
-			interpreter->Push(this, InterpreterExecutionType::Parallel);
+			interpreter->Push<InterpreterExecutionType::Parallel>(this);
 		}
 		interpreter->Update(!resume_async);
 

--- a/src/game_event.cpp
+++ b/src/game_event.cpp
@@ -587,7 +587,7 @@ AsyncOp Game_Event::Update(bool resume_async) {
 	// the wait will tick by 1 each time the interpreter is invoked.
 	if ((resume_async || GetTrigger() == lcf::rpg::EventPage::Trigger_parallel) && interpreter) {
 		if (!interpreter->IsRunning() && page && !page->event_commands.empty()) {
-			interpreter->Push(this);
+			interpreter->Push(this, InterpreterExecutionType::Parallel);
 		}
 		interpreter->Update(!resume_async);
 

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -219,8 +219,7 @@ private:
 	const lcf::rpg::EventPage* page = nullptr;
 	std::unique_ptr<Game_Interpreter_Map> interpreter;
 
-	friend class Scene_Debug;
-	friend class Debug::ParallelInterpreterStates;
+	friend class Game_Interpreter_Inspector;
 };
 
 inline int Game_Event::GetNumPages() const {

--- a/src/game_event.h
+++ b/src/game_event.h
@@ -24,6 +24,7 @@
 #include "game_character.h"
 #include <lcf/rpg/event.h>
 #include <lcf/rpg/savemapevent.h>
+#include "game_interpreter_debug.h"
 #include "game_interpreter_map.h"
 #include "async_op.h"
 
@@ -219,6 +220,7 @@ private:
 	std::unique_ptr<Game_Interpreter_Map> interpreter;
 
 	friend class Scene_Debug;
+	friend class Debug::ParallelInterpreterStates;
 };
 
 inline int Game_Event::GetNumPages() const {

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -5784,3 +5784,63 @@ int Game_Interpreter::ManiacBitmask(int value, int mask) const {
 
 	return value;
 }
+
+namespace {
+	lcf::rpg::SaveEventExecState const& empty_state = {};
+}
+
+
+lcf::rpg::SaveEventExecState const& Game_Interpreter_Inspector::GetForegroundExecState() {
+	return Game_Interpreter::GetForegroundInterpreter()._state;
+}
+
+lcf::rpg::SaveEventExecState& Game_Interpreter_Inspector::GetForegroundExecStateUnsafe() {
+	return Game_Interpreter::GetForegroundInterpreter()._state;
+}
+
+lcf::rpg::SaveEventExecState const& Game_Interpreter_Inspector::GetExecState(Game_Event const& ev) {
+	if (!ev.interpreter) {
+		return empty_state;
+	}
+	return ev.interpreter->GetState();
+}
+
+lcf::rpg::SaveEventExecState const& Game_Interpreter_Inspector::GetExecState(Game_CommonEvent const& ce) {
+	if (!ce.interpreter) {
+		return empty_state;
+	}
+	return ce.interpreter->GetState();
+}
+
+lcf::rpg::SaveEventExecState& Game_Interpreter_Inspector::GetExecStateUnsafe(Game_Event& ev) {
+	assert(ev.interpreter);
+	return ev.interpreter->_state;
+}
+
+lcf::rpg::SaveEventExecState& Game_Interpreter_Inspector::GetExecStateUnsafe(Game_CommonEvent& ce) {
+	assert(ce.interpreter);
+	return ce.interpreter->_state;
+}
+
+bool Game_Interpreter_Inspector::IsInActiveExcecution(Game_Event const& ev, bool background_only) {
+	if (!background_only) {
+		//TODO
+	}
+	if (!ev.IsActive() || ev.GetTrigger() != lcf::rpg::EventPage::Trigger_parallel) {
+		return false;
+	}
+	auto pg = ev.GetActivePage();
+	if (pg == nullptr || pg->event_commands.empty())
+		return false;
+	return ev.interpreter && ev.interpreter->IsRunning();
+}
+
+bool Game_Interpreter_Inspector::IsInActiveExcecution(Game_CommonEvent const& ce, bool background_only) {
+	if (!background_only) {
+		//TODO
+	}
+	if (!ce.IsWaitingBackgroundExecution(false)) {
+		return false;
+	}
+	return ce.interpreter && ce.interpreter->IsRunning();
+}

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2044,13 +2044,13 @@ std::optional<bool> Game_Interpreter::HandleDynRpgScript(const lcf::rpg::EventCo
 	if (Player::IsPatchDynRpg() || Player::HasEasyRpgExtensions()) {
 		if (com.string.empty() || com.string[0] != '@') {
 			// Not a DynRPG command
-			return std::nullopt;
+			return {};
 		}
 
 		if (!Player::IsPatchDynRpg() && Player::HasEasyRpgExtensions()) {
 			// Only accept commands starting with @easyrpg_
 			if (!StartsWith(com.string, "@easyrpg_")) {
-				return std::nullopt;
+				return {};
 			}
 		}
 
@@ -2073,7 +2073,6 @@ std::optional<bool> Game_Interpreter::HandleDynRpgScript(const lcf::rpg::EventCo
 
 		return Main_Data::game_dynrpg->Invoke(command, this);
 	}
-
 	return {};
 }
 

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -351,7 +351,23 @@ protected:
 	KeyInputState _keyinput;
 	AsyncOp _async_op = {};
 
-	friend class Scene_Debug;
+	friend class Game_Interpreter_Inspector;
+};
+
+class Game_Interpreter_Inspector {
+public:
+	bool IsInActiveExcecution(Game_Event const& ev, bool background_only);
+
+	bool IsInActiveExcecution(Game_CommonEvent const& ce, bool background_only);
+
+	lcf::rpg::SaveEventExecState const& GetForegroundExecState();
+	lcf::rpg::SaveEventExecState& GetForegroundExecStateUnsafe();
+
+	lcf::rpg::SaveEventExecState const& GetExecState(Game_Event const& ev);
+	lcf::rpg::SaveEventExecState const& GetExecState(Game_CommonEvent const& ce);
+
+	lcf::rpg::SaveEventExecState& GetExecStateUnsafe(Game_Event& ev);
+	lcf::rpg::SaveEventExecState& GetExecStateUnsafe(Game_CommonEvent& ce);
 };
 
 inline const lcf::rpg::SaveEventExecFrame* Game_Interpreter::GetFramePtr() const {

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -38,6 +38,9 @@ class Game_Event;
 class Game_CommonEvent;
 class PendingMessage;
 
+
+using InterpreterPush = std::tuple<InterpreterExecutionType, InterpreterEventType>;
+
 /**
  * Game_Interpreter class
  */
@@ -65,14 +68,15 @@ public:
 	void Update(bool reset_loop_count=true);
 
 	void Push(
-			std::vector<lcf::rpg::EventCommand> _list,
-			int _event_id,
-			bool started_by_decision_key = false,
-			int event_page_id = 0
+		InterpreterPush push_info,
+		std::vector<lcf::rpg::EventCommand> _list,
+		int _event_id,
+		int event_page_id = 0
 	);
-	void Push(Game_Event* ev);
-	void Push(Game_Event* ev, const lcf::rpg::EventPage* page, bool triggered_by_decision_key);
-	void Push(Game_CommonEvent* ev);
+
+	void Push(Game_Event* ev, InterpreterExecutionType ex_type);
+	void Push(Game_Event* ev, const lcf::rpg::EventPage* page, InterpreterExecutionType ex_type);
+	void Push(Game_CommonEvent* ev, InterpreterExecutionType ex_type);
 
 	void InputButton();
 	void SetupChoices(const std::vector<std::string>& choices, int indent, PendingMessage& pm);

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -412,7 +412,7 @@ template<InterpreterExecutionType type_ex>
 inline void Game_Interpreter::Push(Game_CommonEvent* ev) {
 	static_assert(type_ex == InterpreterExecutionType::AutoStart || type_ex == InterpreterExecutionType::Parallel
 		|| type_ex == InterpreterExecutionType::Call || type_ex == InterpreterExecutionType::DeathHandler
-		|| type_ex == InterpreterExecutionType::DebugCall, "Unexpected ExecutionType for CommonEvent"
+		|| type_ex == InterpreterExecutionType::DebugCall || type_ex == InterpreterExecutionType::ManiacHook, "Unexpected ExecutionType for CommonEvent"
 	);
 	PushInternal(ev, type_ex);
 }

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -213,7 +213,7 @@ int Game_Interpreter_Battle::ScheduleNextPage(lcf::rpg::TroopPageCondition::Flag
 			continue;
 		}
 		Clear();
-		Push({ ExecutionType::Eval, EventType::None }, page.event_commands, 0); // FIXME: clarify type_src & type_ex for battle events
+		Push<ExecutionType::Eval, EventType::None>(page.event_commands, 0); // FIXME: clarify type_src & type_ex for battle events
 		executed[i] = true;
 		return i + 1;
 	}
@@ -277,7 +277,7 @@ bool Game_Interpreter_Battle::CommandCallCommonEvent(lcf::rpg::EventCommand cons
 		return true;
 	}
 
-	Push(common_event, ExecutionType::Call);
+	Push<ExecutionType::Call>(common_event);
 
 	return true;
 }
@@ -647,7 +647,7 @@ bool Game_Interpreter_Battle::ManiacBattleHook(ManiacBattleHookType hook_type, i
 	}
 	
 	// pushes the common event to be run into the queue of events.
-	maniac_interpreter->Push(common_event, ExecutionType::Call); // FIXME: clarify type_src & type_ex for battle events
+	maniac_interpreter->Push<ExecutionType::Call>(common_event); // FIXME: clarify type_src & type_ex for battle events
 
 	// pushes the change variable events into the interpreters
 	// event queue, so we don't run into a race condition.
@@ -685,7 +685,7 @@ bool Game_Interpreter_Battle::ManiacBattleHook(ManiacBattleHookType hook_type, i
 	}
 
 	// Push is actually "push_back", so this gets added before other events.
-	maniac_interpreter->Push({ ExecutionType::Eval, EventType::None }, pre_commands, 0);  // FIXME: clarify type_src & type_ex for battle events
+	maniac_interpreter->Push<ExecutionType::Eval, EventType::None>(pre_commands, 0);  // FIXME: clarify type_src & type_ex for battle events
 
 	// Necessary to start the sub-event.
 	maniac_interpreter->Update();

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -213,7 +213,7 @@ int Game_Interpreter_Battle::ScheduleNextPage(lcf::rpg::TroopPageCondition::Flag
 			continue;
 		}
 		Clear();
-		Push<ExecutionType::Eval, EventType::None>(page.event_commands, 0); // FIXME: clarify type_src & type_ex for battle events
+		Push<ExecutionType::Action, EventType::BattleEvent>(page.event_commands, 0);
 		executed[i] = true;
 		return i + 1;
 	}
@@ -647,7 +647,7 @@ bool Game_Interpreter_Battle::ManiacBattleHook(ManiacBattleHookType hook_type, i
 	}
 	
 	// pushes the common event to be run into the queue of events.
-	maniac_interpreter->Push<ExecutionType::Call>(common_event); // FIXME: clarify type_src & type_ex for battle events
+	maniac_interpreter->Push<ExecutionType::ManiacHook>(common_event);
 
 	// pushes the change variable events into the interpreters
 	// event queue, so we don't run into a race condition.
@@ -685,7 +685,7 @@ bool Game_Interpreter_Battle::ManiacBattleHook(ManiacBattleHookType hook_type, i
 	}
 
 	// Push is actually "push_back", so this gets added before other events.
-	maniac_interpreter->Push<ExecutionType::Eval, EventType::None>(pre_commands, 0);  // FIXME: clarify type_src & type_ex for battle events
+	maniac_interpreter->Push<ExecutionType::ManiacHook, EventType::None>(pre_commands, 0);
 
 	// Necessary to start the sub-event.
 	maniac_interpreter->Update();

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -33,6 +33,8 @@
 #include <cassert>
 #include "scene_battle.h"
 
+using namespace Game_Interpreter_Shared;
+
 enum BranchBattleSubcommand {
 	eOptionBranchBattleElse = 1
 };
@@ -211,7 +213,7 @@ int Game_Interpreter_Battle::ScheduleNextPage(lcf::rpg::TroopPageCondition::Flag
 			continue;
 		}
 		Clear();
-		Push(page.event_commands, 0);
+		Push({ ExecutionType::Eval, EventType::None }, page.event_commands, 0); // FIXME: clarify type_src & type_ex for battle events
 		executed[i] = true;
 		return i + 1;
 	}
@@ -275,7 +277,7 @@ bool Game_Interpreter_Battle::CommandCallCommonEvent(lcf::rpg::EventCommand cons
 		return true;
 	}
 
-	Push(common_event);
+	Push(common_event, ExecutionType::Call);
 
 	return true;
 }
@@ -643,9 +645,9 @@ bool Game_Interpreter_Battle::ManiacBattleHook(ManiacBattleHookType hook_type, i
 		Output::Warning("CommandManiacControlBattle: Can't call invalid common event {}", common_event_id);
 		return false;
 	}
-
+	
 	// pushes the common event to be run into the queue of events.
-	maniac_interpreter->Push(common_event);
+	maniac_interpreter->Push(common_event, ExecutionType::Call); // FIXME: clarify type_src & type_ex for battle events
 
 	// pushes the change variable events into the interpreters
 	// event queue, so we don't run into a race condition.
@@ -683,7 +685,7 @@ bool Game_Interpreter_Battle::ManiacBattleHook(ManiacBattleHookType hook_type, i
 	}
 
 	// Push is actually "push_back", so this gets added before other events.
-	maniac_interpreter->Push(pre_commands, 0);
+	maniac_interpreter->Push({ ExecutionType::Eval, EventType::None }, pre_commands, 0);  // FIXME: clarify type_src & type_ex for battle events
 
 	// Necessary to start the sub-event.
 	maniac_interpreter->Update();

--- a/src/game_interpreter_debug.cpp
+++ b/src/game_interpreter_debug.cpp
@@ -56,65 +56,51 @@ Debug::ParallelInterpreterStates Debug::ParallelInterpreterStates::GetCachedStat
 	return { ev_ids, ce_ids, state_ev, state_ce };
 }
 
-std::vector<Debug::CallStackItem> Debug::CreateCallStack(const int owner_evt_id, const lcf::rpg::SaveEventExecState& state) {
-	std::vector<CallStackItem> items(state.stack.size());
+std::vector<Debug::CallStackItem> Debug::CreateCallStack(const lcf::rpg::SaveEventExecState& state) {
+	std::vector<CallStackItem> items;
+	items.reserve(state.stack.size());
 
 	for (int i = state.stack.size() - 1; i >= 0; i--) {
-		int evt_id = state.stack[i].event_id;
-		int page_id = 0;
-		if (state.stack[i].maniac_event_id > 0) {
-			evt_id = state.stack[i].maniac_event_id;
-			page_id = state.stack[i].maniac_event_page_id;
-		}
-		if (evt_id == 0 && i == 0)
-			evt_id = owner_evt_id;
+		auto& frame = state.stack[i];
 
-		bool is_calling_ev_ce = false;
+		bool map_has_changed = (frame.event_id == 0 && frame.maniac_event_id > 0);
 
-		//FIXME: There are some currently unimplemented SaveEventExecFrame fields introduced via the ManiacPatch which should be used to properly get event state information
-		if (evt_id == 0 && i > 0) {
-			auto& prev_frame = state.stack[i - 1];
-			auto& com = prev_frame.commands[prev_frame.current_command - 1];
-			if (com.code == 12330) { // CallEvent
-				if (com.parameters[0] == 0) {
-					is_calling_ev_ce = true;
-					evt_id = com.parameters[1];
-				} else if (com.parameters[0] == 3 && Player::IsPatchManiac()) {
-					is_calling_ev_ce = true;
-					evt_id = Main_Data::game_variables->Get(com.parameters[1]);
-				} else if (com.parameters[0] == 4 && Player::IsPatchManiac()) {
-					is_calling_ev_ce = true;
-					evt_id = Main_Data::game_variables->GetIndirect(com.parameters[1]);
-				}
-			}
-		}
-
-		auto item = Debug::CallStackItem();
-		item.stack_item_no = i + 1;
-		item.is_ce = is_calling_ev_ce;
-		item.evt_id = evt_id;
-		item.page_id = page_id;
-		item.name = "";
-		item.cmd_current = state.stack[i].current_command;
-		item.cmd_count = state.stack[i].commands.size();
-
-		if (item.is_ce) {
-			auto* ce = lcf::ReaderUtil::GetElement(lcf::Data::commonevents, item.evt_id);
-			if (ce) {
-				item.name = ToString(ce->name);
-			}
-		} else {
-			auto* ev = Game_Map::GetEvent(evt_id);
-			if (ev) {
-				//FIXME: map could have changed, but map_id isn't available
-				item.name = ToString(ev->GetName());
-			}
-		}
+		Debug::CallStackItem item = {
+			Game_Interpreter_Shared::EasyRpgExecutionType(frame),
+			Game_Interpreter_Shared::EasyRpgEventType(frame),
+			frame.maniac_event_id,
+			frame.maniac_event_page_id,
+			GetEventName(frame),
+			i + 1,					//stack_item_no
+			frame.current_command,	// cmd_current
+			frame.commands.size(),	// cmd_count
+			map_has_changed
+		};
 
 		items.push_back(item);
 	}
 
 	return items;
+}
+
+std::string Debug::GetEventName(const lcf::rpg::SaveEventExecFrame& frame) {
+	switch (Game_Interpreter_Shared::EasyRpgEventType(frame)) {
+		case InterpreterEventType::MapEvent:
+			if (auto* ev = Game_Map::GetEvent(frame.event_id)) {
+				return ToString(ev->GetName());
+			} else if (frame.maniac_event_id > 0) {
+				return fmt::format("[(EV{:04d}) from another map..]", frame.maniac_event_id);
+			}
+			break;
+		case InterpreterEventType::CommonEvent:
+			if (auto* ce = lcf::ReaderUtil::GetElement(lcf::Data::commonevents, frame.maniac_event_id)) {
+				return ToString(ce->name);
+			}
+			break;
+		default:
+			break;
+	}
+	return "";
 }
 
 std::string Debug::FormatEventName(Game_Character const& ch) {

--- a/src/game_interpreter_debug.cpp
+++ b/src/game_interpreter_debug.cpp
@@ -1,0 +1,137 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "game_interpreter_debug.h"
+#include "game_interpreter.h"
+#include "game_battle.h"
+#include "game_map.h"
+#include "main_data.h"
+#include "game_variables.h"
+#include "output.h"
+#include <lcf/reader_util.h>
+
+Debug::ParallelInterpreterStates Debug::ParallelInterpreterStates::GetCachedStates() {
+	std::vector<int> ev_ids;
+	std::vector<int> ce_ids;
+
+	std::vector<lcf::rpg::SaveEventExecState> state_ev;
+	std::vector<lcf::rpg::SaveEventExecState> state_ce;
+
+	if (Game_Map::GetMapId() > 0) {
+		for (auto& ev : Game_Map::GetEvents()) {
+			if (ev.GetTrigger() != lcf::rpg::EventPage::Trigger_parallel || !ev.interpreter)
+				continue;
+			ev_ids.emplace_back(ev.GetId());
+			state_ev.emplace_back(ev.interpreter->GetState());
+		}
+		for (auto& ce : Game_Map::GetCommonEvents()) {
+			if (ce.IsWaitingBackgroundExecution(false)) {
+				ce_ids.emplace_back(ce.common_event_id);
+				state_ce.emplace_back(ce.interpreter->GetState());
+			}
+		}
+	} else if (Game_Battle::IsBattleRunning() && Player::IsPatchManiac()) {
+		//FIXME: Not implemented: battle common events
+	}
+
+	return { ev_ids, ce_ids, state_ev, state_ce };
+}
+
+std::vector<Debug::CallStackItem> Debug::CreateCallStack(const int owner_evt_id, const lcf::rpg::SaveEventExecState& state) {
+	std::vector<CallStackItem> items(state.stack.size());
+
+	for (int i = state.stack.size() - 1; i >= 0; i--) {
+		int evt_id = state.stack[i].event_id;
+		int page_id = 0;
+		if (state.stack[i].maniac_event_id > 0) {
+			evt_id = state.stack[i].maniac_event_id;
+			page_id = state.stack[i].maniac_event_page_id;
+		}
+		if (evt_id == 0 && i == 0)
+			evt_id = owner_evt_id;
+
+		bool is_calling_ev_ce = false;
+
+		//FIXME: There are some currently unimplemented SaveEventExecFrame fields introduced via the ManiacPatch which should be used to properly get event state information
+		if (evt_id == 0 && i > 0) {
+			auto& prev_frame = state.stack[i - 1];
+			auto& com = prev_frame.commands[prev_frame.current_command - 1];
+			if (com.code == 12330) { // CallEvent
+				if (com.parameters[0] == 0) {
+					is_calling_ev_ce = true;
+					evt_id = com.parameters[1];
+				} else if (com.parameters[0] == 3 && Player::IsPatchManiac()) {
+					is_calling_ev_ce = true;
+					evt_id = Main_Data::game_variables->Get(com.parameters[1]);
+				} else if (com.parameters[0] == 4 && Player::IsPatchManiac()) {
+					is_calling_ev_ce = true;
+					evt_id = Main_Data::game_variables->GetIndirect(com.parameters[1]);
+				}
+			}
+		}
+
+		auto item = Debug::CallStackItem();
+		item.stack_item_no = i + 1;
+		item.is_ce = is_calling_ev_ce;
+		item.evt_id = evt_id;
+		item.page_id = page_id;
+		item.name = "";
+		item.cmd_current = state.stack[i].current_command;
+		item.cmd_count = state.stack[i].commands.size();
+
+		if (item.is_ce) {
+			auto* ce = lcf::ReaderUtil::GetElement(lcf::Data::commonevents, item.evt_id);
+			if (ce) {
+				item.name = ToString(ce->name);
+			}
+		} else {
+			auto* ev = Game_Map::GetEvent(evt_id);
+			if (ev) {
+				//FIXME: map could have changed, but map_id isn't available
+				item.name = ToString(ev->GetName());
+			}
+		}
+
+		items.push_back(item);
+	}
+
+	return items;
+}
+
+std::string Debug::FormatEventName(Game_Character const& ch) {
+	switch (ch.GetType()) {
+		case Game_Character::Player:
+			return "Player";
+		case Game_Character::Vehicle:
+		{
+			int type = static_cast<Game_Vehicle const&>(ch).GetVehicleType();
+			assert(type > Game_Vehicle::None && type <= Game_Vehicle::Airship);
+			return Game_Vehicle::TypeNames[type];
+		}
+		case Game_Character::Event:
+		{
+			auto& ev = static_cast<Game_Event const&>(ch);
+			if (ev.GetName().empty()) {
+				return fmt::format("EV{:04d}", ev.GetId());
+			}
+			return fmt::format("EV{:04d} '{}'", ev.GetId(), ev.GetName());
+		}
+		default:
+			assert(false);
+	}
+	return "";
+}

--- a/src/game_interpreter_debug.h
+++ b/src/game_interpreter_debug.h
@@ -57,13 +57,18 @@ namespace Debug {
 	};
 
 	struct CallStackItem {
-		bool is_ce;
+		InterpreterExecutionType type_ex;
+		InterpreterEventType type_ev;
 		int evt_id, page_id;
 		std::string name;
-		int stack_item_no, cmd_current, cmd_count;
+		int stack_item_no, cmd_current;
+		size_t cmd_count;
+		bool map_has_changed;
 	};
 
-	std::vector<CallStackItem> CreateCallStack(const int owner_evt_id, const lcf::rpg::SaveEventExecState& state);
+	std::vector<CallStackItem> CreateCallStack(const lcf::rpg::SaveEventExecState& state);
+
+	std::string GetEventName(const lcf::rpg::SaveEventExecFrame& frame);
 
 	std::string FormatEventName(Game_Character const& ev);
 

--- a/src/game_interpreter_debug.h
+++ b/src/game_interpreter_debug.h
@@ -1,0 +1,71 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef EP_GAME_INTERPRETER_DEBUG
+#define EP_GAME_INTERPRETER_DEBUG
+
+#include "game_interpreter_shared.h"
+#include "game_character.h"
+#include <lcf/rpg/saveeventexecstate.h>
+#include "player.h"
+
+class Game_CommonEvent;
+
+namespace Debug {
+	class ParallelInterpreterStates {
+	private:
+		std::vector<int> ev_ids;
+		std::vector<int> ce_ids;
+
+		std::vector<lcf::rpg::SaveEventExecState> state_ev;
+		std::vector<lcf::rpg::SaveEventExecState> state_ce;
+
+		ParallelInterpreterStates(std::vector<int> ev_ids, std::vector<int> ce_ids,
+			std::vector<lcf::rpg::SaveEventExecState> state_ev, std::vector<lcf::rpg::SaveEventExecState> state_ce)
+		: ev_ids(ev_ids), ce_ids(ce_ids), state_ev(state_ev), state_ce(state_ce) { }
+	public:
+		ParallelInterpreterStates() = default;
+
+		inline int CountEventInterpreters() const { return ev_ids.size(); }
+		inline int CountCommonEventInterpreters() const { return ce_ids.size(); }
+
+		inline int Count() const { return ev_ids.size() + ce_ids.size(); }
+
+		inline std::tuple<const int&, const lcf::rpg::SaveEventExecState&> GetEventInterpreter(int i) const {
+			return std::tie(ev_ids[i], state_ev[i]);
+		}
+		inline std::tuple<const int&, const lcf::rpg::SaveEventExecState&> GetCommonEventInterpreter(int i) const {
+			return std::tie(ce_ids[i], state_ce[i]);
+		}
+
+		static ParallelInterpreterStates GetCachedStates();
+	};
+
+	struct CallStackItem {
+		bool is_ce;
+		int evt_id, page_id;
+		std::string name;
+		int stack_item_no, cmd_current, cmd_count;
+	};
+
+	std::vector<CallStackItem> CreateCallStack(const int owner_evt_id, const lcf::rpg::SaveEventExecState& state);
+
+	std::string FormatEventName(Game_Character const& ev);
+}
+
+#endif

--- a/src/game_interpreter_debug.h
+++ b/src/game_interpreter_debug.h
@@ -66,6 +66,8 @@ namespace Debug {
 	std::vector<CallStackItem> CreateCallStack(const int owner_evt_id, const lcf::rpg::SaveEventExecState& state);
 
 	std::string FormatEventName(Game_Character const& ev);
+
+	std::string FormatEventName(Game_CommonEvent const& ce);
 }
 
 #endif

--- a/src/game_interpreter_shared.h
+++ b/src/game_interpreter_shared.h
@@ -146,6 +146,9 @@ namespace Game_Interpreter_Shared {
 
 	std::optional<bool> GetRuntimeFlag(lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags const& state_runtime_flags, StateRuntimeFlagRef const field_on, StateRuntimeFlagRef const field_off);
 #endif
+
+	ExecutionType ManiacExecutionType(lcf::rpg::SaveEventExecFrame const& frame);
+	EventType ManiacEventType(lcf::rpg::SaveEventExecFrame const& frame);
 }
 
 inline bool Game_Interpreter_Shared::CheckOperator(int val, int val2, int op) {
@@ -182,6 +185,27 @@ inline bool Game_Interpreter_Shared::ManiacCheckContinueLoop(int val, int val2, 
 		default:
 			return false;
 	}
+}
+
+using InterpreterExecutionType = Game_Interpreter_Shared::ExecutionType;
+using InterpreterEventType = Game_Interpreter_Shared::EventType;
+
+inline InterpreterExecutionType Game_Interpreter_Shared::ManiacExecutionType(lcf::rpg::SaveEventExecFrame const& frame) {
+	if (int type_ex = (frame.maniac_event_info & 0xF); type_ex <= static_cast<int>(ExecutionType::BattleParallel)) {
+		return static_cast<InterpreterExecutionType>(type_ex);
+	}
+	return InterpreterExecutionType::Action;
+}
+
+inline InterpreterEventType Game_Interpreter_Shared::ManiacEventType(lcf::rpg::SaveEventExecFrame const& frame) {
+	if ((frame.maniac_event_info & 0x10) > 0) {
+		return InterpreterEventType::MapEvent;
+	} else if ((frame.maniac_event_info & 0x20) > 0) {
+		return InterpreterEventType::CommonEvent;
+	} else if ((frame.maniac_event_info & 0x40) > 0) {
+		return InterpreterEventType::BattleEvent;
+	}
+	return InterpreterEventType::None;
 }
 
 class Game_BaseInterpreterContext {
@@ -243,8 +267,5 @@ protected:
 		return (static_cast<ClassType*>(this)->*CMDFN)(com);
 	}
 };
-
-using InterpreterExecutionType = Game_Interpreter_Shared::ExecutionType;
-using InterpreterEventType = Game_Interpreter_Shared::EventType;
 
 #endif

--- a/src/game_interpreter_shared.h
+++ b/src/game_interpreter_shared.h
@@ -68,7 +68,8 @@ namespace Game_Interpreter_Shared {
 		DeathHandler = 10,
 		/* Event code was dynamically evaluated. (ManiacCallCommand) */
 		Eval,
-		DebugCall
+		DebugCall,
+		ManiacHook
 	};
 	static constexpr auto kExecutionType = lcf::makeEnumTags<ExecutionType>(
 		"Action",

--- a/src/game_interpreter_shared.h
+++ b/src/game_interpreter_shared.h
@@ -40,6 +40,12 @@ namespace Game_Interpreter_Shared {
 		CommonEvent,
 		BattleEvent
 	};
+	static constexpr auto kEventType = lcf::makeEnumTags<EventType>(
+		"None",
+		"MapEvent",
+		"CommonEvent",
+		"BattleEvent"
+	);
 
 	enum class ExecutionType {
 		/*
@@ -64,6 +70,21 @@ namespace Game_Interpreter_Shared {
 		Eval,
 		DebugCall
 	};
+	static constexpr auto kExecutionType = lcf::makeEnumTags<ExecutionType>(
+		"Action",
+		"Touch",
+		"Collision",
+		"AutoStart",
+		"Parallel",
+		"Call",
+		"BattleStart",
+		"BattleParallel",
+		"---",
+		"---",
+		"DeathHandler",
+		"Eval",
+		"DebugCall"
+	);
 
 	/*
 	* Indicates how the target of an interpreter operation (lvalue) should be evaluated.

--- a/src/game_interpreter_shared.h
+++ b/src/game_interpreter_shared.h
@@ -149,6 +149,9 @@ namespace Game_Interpreter_Shared {
 
 	ExecutionType ManiacExecutionType(lcf::rpg::SaveEventExecFrame const& frame);
 	EventType ManiacEventType(lcf::rpg::SaveEventExecFrame const& frame);
+
+	ExecutionType EasyRpgExecutionType(lcf::rpg::SaveEventExecFrame const& frame);
+	EventType EasyRpgEventType(lcf::rpg::SaveEventExecFrame const& frame);
 }
 
 inline bool Game_Interpreter_Shared::CheckOperator(int val, int val2, int op) {
@@ -206,6 +209,15 @@ inline InterpreterEventType Game_Interpreter_Shared::ManiacEventType(lcf::rpg::S
 		return InterpreterEventType::BattleEvent;
 	}
 	return InterpreterEventType::None;
+}
+
+inline InterpreterExecutionType Game_Interpreter_Shared::EasyRpgExecutionType(lcf::rpg::SaveEventExecFrame const& frame) {
+	return static_cast<InterpreterExecutionType>(frame.maniac_event_info & 0xF);
+}
+
+inline InterpreterEventType Game_Interpreter_Shared::EasyRpgEventType(lcf::rpg::SaveEventExecFrame const& frame) {
+	// Same as ManiacEventType, because no special new event types exist at the moment
+	return ManiacEventType(frame);
 }
 
 class Game_BaseInterpreterContext {

--- a/src/game_interpreter_shared.h
+++ b/src/game_interpreter_shared.h
@@ -34,6 +34,37 @@ class Game_BaseInterpreterContext;
 
 namespace Game_Interpreter_Shared {
 
+	enum class EventType {
+		None = 0,
+		MapEvent,
+		CommonEvent,
+		BattleEvent
+	};
+
+	enum class ExecutionType {
+		/*
+		 * MapEvent Triggered by decision key
+		 * (or via custom command EasyRpg_TriggerEventAt)
+		 */
+		Action = 0,
+		Touch,
+		Collision,
+		AutoStart,
+		Parallel,
+		/* Frame was pushed via "CallCommand" */
+		Call,
+		/* Maniac's special CE type "Battle start" */
+		BattleStart,
+		/* Maniac's special CE type "Battle Parallel" */
+		BattleParallel,
+
+		/* 2k3 Death Handler */
+		DeathHandler = 10,
+		/* Event code was dynamically evaluated. (ManiacCallCommand) */
+		Eval,
+		DebugCall
+	};
+
 	/*
 	* Indicates how the target of an interpreter operation (lvalue) should be evaluated.
 	*/
@@ -212,5 +243,8 @@ protected:
 		return (static_cast<ClassType*>(this)->*CMDFN)(com);
 	}
 };
+
+using InterpreterExecutionType = Game_Interpreter_Shared::ExecutionType;
+using InterpreterEventType = Game_Interpreter_Shared::EventType;
 
 #endif

--- a/src/game_interpreter_shared.h
+++ b/src/game_interpreter_shared.h
@@ -38,7 +38,8 @@ namespace Game_Interpreter_Shared {
 		None = 0,
 		MapEvent,
 		CommonEvent,
-		BattleEvent
+		BattleEvent,
+		LAST
 	};
 	static constexpr auto kEventType = lcf::makeEnumTags<EventType>(
 		"None",
@@ -46,6 +47,7 @@ namespace Game_Interpreter_Shared {
 		"CommonEvent",
 		"BattleEvent"
 	);
+	static_assert(kEventType.size() == static_cast<size_t>(EventType::LAST));
 
 	enum class ExecutionType {
 		/*
@@ -69,7 +71,8 @@ namespace Game_Interpreter_Shared {
 		/* Event code was dynamically evaluated. (ManiacCallCommand) */
 		Eval,
 		DebugCall,
-		ManiacHook
+		ManiacHook,
+		LAST
 	};
 	static constexpr auto kExecutionType = lcf::makeEnumTags<ExecutionType>(
 		"Action",
@@ -84,8 +87,10 @@ namespace Game_Interpreter_Shared {
 		"---",
 		"DeathHandler",
 		"Eval",
-		"DebugCall"
+		"DebugCall",
+		"ManiacHook"
 	);
+	static_assert(kExecutionType.size() == static_cast<size_t>(ExecutionType::LAST));
 
 	/*
 	* Indicates how the target of an interpreter operation (lvalue) should be evaluated.

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1393,7 +1393,7 @@ bool Game_Map::UpdateForegroundEvents(MapUpdateAsyncContext& actx) {
 			}
 		}
 		if (run_ce) {
-			interp.Push(run_ce, InterpreterExecutionType::AutoStart);
+			interp.Push<InterpreterExecutionType::AutoStart>(run_ce);
 		}
 
 		Game_Event* run_ev = nullptr;
@@ -1409,21 +1409,21 @@ bool Game_Map::UpdateForegroundEvents(MapUpdateAsyncContext& actx) {
 		}
 		if (run_ev) {
 			if (run_ev->WasStartedByDecisionKey()) {
-				interp.Push(run_ev, InterpreterExecutionType::Action);
+				interp.Push<InterpreterExecutionType::Action>(run_ev);
 			} else {
 				switch (run_ev->GetTrigger()) {
 					case lcf::rpg::EventPage::Trigger_touched:
-						interp.Push(run_ev, InterpreterExecutionType::Touch);
+						interp.Push<InterpreterExecutionType::Touch>(run_ev);
 						break;
 					case lcf::rpg::EventPage::Trigger_collision:
-						interp.Push(run_ev, InterpreterExecutionType::Collision);
+						interp.Push<InterpreterExecutionType::Collision>(run_ev);
 						break;
 					case lcf::rpg::EventPage::Trigger_auto_start:
-						interp.Push(run_ev, InterpreterExecutionType::AutoStart);
+						interp.Push<InterpreterExecutionType::AutoStart>(run_ev);
 						break;
 					case lcf::rpg::EventPage::Trigger_action:
 					default:
-						interp.Push(run_ev, InterpreterExecutionType::Action);
+						interp.Push<InterpreterExecutionType::Action>(run_ev);
 						break;
 				}
 			}
@@ -1576,7 +1576,7 @@ static void OnEncounterEnd(BattleResult result) {
 	auto* ce = lcf::ReaderUtil::GetElement(common_events, Game_Battle::GetDeathHandlerCommonEvent());
 	if (ce) {
 		auto& interp = Game_Map::GetInterpreter();
-		interp.Push(ce, InterpreterExecutionType::DeathHandler);
+		interp.Push<InterpreterExecutionType::DeathHandler>(ce);
 	}
 
 	auto tt = Game_Battle::GetDeathHandlerTeleport();

--- a/src/input_buttons.h
+++ b/src/input_buttons.h
@@ -130,8 +130,8 @@ namespace Input {
 		"FAST_FORWARD_A",
 		"FAST_FORWARD_B",
 		"TOGGLE_FULLSCREEN",
-		"TOGGLE_ZOOM",
-		"BUTTON_COUNT");
+		"TOGGLE_ZOOM");
+	static_assert(kInputButtonNames.size() == static_cast<size_t>(BUTTON_COUNT));
 
 	constexpr auto kInputButtonHelp = lcf::makeEnumTags<InputButton>(
 		"Up Direction",
@@ -175,8 +175,8 @@ namespace Input {
 		"Run the game at x{} speed",
 		"Run the game at x{} speed",
 		"Toggle Fullscreen mode",
-		"Toggle Window Zoom level",
-		"Total Button Count");
+		"Toggle Window Zoom level");
+	static_assert(kInputButtonHelp.size() == static_cast<size_t>(BUTTON_COUNT));
 
 	/**
 	 * Return true if the given button is a system button.
@@ -241,8 +241,8 @@ namespace Input {
 			"RIGHT",
 			"UPLEFT",
 			"UP",
-			"UPRIGHT",
-			"NUM_DIRECTIONS");
+			"UPRIGHT");
+		static_assert(kInputDirectionNames.size() == static_cast<size_t>(NUM_DIRECTIONS));
 	};
 
 	using ButtonMappingArray = FlatUniqueMultiMap<InputButton,Keys::InputKey>;

--- a/src/rtp.h
+++ b/src/rtp.h
@@ -50,7 +50,8 @@ namespace RTP {
 		RPG2003_VladRussian,
 		RPG2003_RpgUniverseSpanishPortuguese,
 		RPG2003_Korean,
-		RPG2003_OfficialTraditionalChinese
+		RPG2003_OfficialTraditionalChinese,
+		LAST
 	};
 
 	constexpr auto kTypes = lcf::makeEnumTags<Type>(
@@ -66,6 +67,7 @@ namespace RTP {
 		"Korean Translation",
 		"Official Traditional Chinese"
 	);
+	static_assert(kTypes.size() == static_cast<size_t>(Type::LAST));
 
 	struct RtpHitInfo {
 		RTP::Type type;

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -1222,7 +1222,6 @@ void Scene_Debug::UpdateInterpreterWindow(int index) {
 	lcf::rpg::SaveEventExecState state_display;
 	std::string first_line = "";
 	bool valid = false;
-	int evt_id = 0;
 
 	auto& bg_states = state_interpreter.background_states;
 
@@ -1241,7 +1240,6 @@ void Scene_Debug::UpdateInterpreterWindow(int index) {
 		for (auto& ce : Game_Map::GetCommonEvents()) {
 			if (ce.GetId() == ce_id) {
 				first_line = Debug::FormatEventName(ce);
-				evt_id = ce_id;
 				valid = true;
 				break;
 			}

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -1219,7 +1219,7 @@ void Scene_Debug::UpdateArrows() {
 }
 
 void Scene_Debug::UpdateInterpreterWindow(int index) {
-	lcf::rpg::SaveEventExecState state;
+	lcf::rpg::SaveEventExecState state_display;
 	std::string first_line = "";
 	bool valid = false;
 	int evt_id = 0;
@@ -1227,15 +1227,17 @@ void Scene_Debug::UpdateInterpreterWindow(int index) {
 	auto& bg_states = state_interpreter.background_states;
 
 	if (index == 1) {
-		state = Game_Interpreter::GetForegroundInterpreter().GetState();
+		state_display = Game_Interpreter::GetForegroundInterpreter().GetState();
 		first_line = Game_Battle::IsBattleRunning() ? "Foreground (Battle)" : "Foreground (Map)";
 		valid = true;
 	} else if (index <= bg_states.CountEventInterpreters()) {
 		const auto& [evt_id, state] = bg_states.GetEventInterpreter(index - 1);
 		first_line = Debug::FormatEventName(*Game_Map::GetEvent(evt_id));
+		state_display = state;
 		valid = true;
 	} else if ((index - bg_states.CountEventInterpreters()) <= bg_states.CountCommonEventInterpreters()) {
 		const auto& [ce_id, state] = bg_states.GetCommonEventInterpreter(index - bg_states.CountEventInterpreters() - 1);
+		state_display = state;
 		for (auto& ce : Game_Map::GetCommonEvents()) {
 			if (ce.GetId() == ce_id) {
 				first_line = Debug::FormatEventName(ce);
@@ -1248,10 +1250,10 @@ void Scene_Debug::UpdateInterpreterWindow(int index) {
 
 	if (valid) {
 		state_interpreter.selected_state = index;
-		interpreter_window->SetStackState(index > bg_states.CountEventInterpreters(), evt_id, first_line, state);
+		interpreter_window->SetStackState(first_line, state_display);
 	} else {
 		state_interpreter.selected_state = -1;
-		interpreter_window->SetStackState(0, 0, "", {});
+		interpreter_window->SetStackState("", {});
 	}
 }
 

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -1128,11 +1128,11 @@ void Scene_Debug::DoCallCommonEvent() {
 	auto& ce = Game_Map::GetCommonEvents()[ceid - 1];
 
 	if (Game_Battle::IsBattleRunning()) {
-		Game_Battle::GetInterpreter().Push(&ce, InterpreterExecutionType::DebugCall);
+		Game_Battle::GetInterpreter().Push<InterpreterExecutionType::DebugCall>(&ce);
 		Scene::PopUntil(Scene::Battle);
 		Output::Debug("Debug Scene Forced execution of common event {} on the battle foreground interpreter.", ce.GetIndex());
 	} else {
-		Game_Map::GetInterpreter().Push(&ce, InterpreterExecutionType::DebugCall);
+		Game_Map::GetInterpreter().Push<InterpreterExecutionType::DebugCall>(&ce);
 		Scene::PopUntil(Scene::Map);
 		Output::Debug("Debug Scene Forced execution of common event {} on the map foreground interpreter.", ce.GetIndex());
 	}
@@ -1157,11 +1157,11 @@ void Scene_Debug::DoCallMapEvent() {
 	}
 
 	if (Game_Battle::IsBattleRunning()) {
-		Game_Battle::GetInterpreter().Push(me, page, InterpreterExecutionType::DebugCall);
+		Game_Battle::GetInterpreter().Push<InterpreterExecutionType::DebugCall>(me, page);
 		Scene::PopUntil(Scene::Battle);
 		Output::Debug("Debug Scene Forced execution of map event {} page {} on the battle foreground interpreter.", me->GetId(), page->ID);
 	} else {
-		Game_Map::GetInterpreter().Push(me, page, InterpreterExecutionType::DebugCall);
+		Game_Map::GetInterpreter().Push<InterpreterExecutionType::DebugCall>(me, page);
 		Scene::PopUntil(Scene::Map);
 		Output::Debug("Debug Scene Forced execution of map event {} page {} on the map foreground interpreter.", me->GetId(), page->ID);
 	}
@@ -1185,7 +1185,7 @@ void Scene_Debug::DoCallBattleEvent() {
 
 	auto& page = troop->pages[page_idx];
 
-	Game_Battle::GetInterpreter().Push({ InterpreterExecutionType::DebugCall, InterpreterEventType::BattleEvent }, page.event_commands, 0, false);
+	Game_Battle::GetInterpreter().Push<InterpreterExecutionType::DebugCall, InterpreterEventType::BattleEvent>(page.event_commands, 0, false);
 	Scene::PopUntil(Scene::Battle);
 	Output::Debug("Debug Scene Forced execution of battle troop {} event page {} on the battle foreground interpreter.", troop->ID, page.ID);
 }

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -1128,11 +1128,11 @@ void Scene_Debug::DoCallCommonEvent() {
 	auto& ce = Game_Map::GetCommonEvents()[ceid - 1];
 
 	if (Game_Battle::IsBattleRunning()) {
-		Game_Battle::GetInterpreter().Push(&ce);
+		Game_Battle::GetInterpreter().Push(&ce, InterpreterExecutionType::DebugCall);
 		Scene::PopUntil(Scene::Battle);
 		Output::Debug("Debug Scene Forced execution of common event {} on the battle foreground interpreter.", ce.GetIndex());
 	} else {
-		Game_Map::GetInterpreter().Push(&ce);
+		Game_Map::GetInterpreter().Push(&ce, InterpreterExecutionType::DebugCall);
 		Scene::PopUntil(Scene::Map);
 		Output::Debug("Debug Scene Forced execution of common event {} on the map foreground interpreter.", ce.GetIndex());
 	}
@@ -1157,11 +1157,11 @@ void Scene_Debug::DoCallMapEvent() {
 	}
 
 	if (Game_Battle::IsBattleRunning()) {
-		Game_Battle::GetInterpreter().Push(me, page, false);
+		Game_Battle::GetInterpreter().Push(me, page, InterpreterExecutionType::DebugCall);
 		Scene::PopUntil(Scene::Battle);
 		Output::Debug("Debug Scene Forced execution of map event {} page {} on the battle foreground interpreter.", me->GetId(), page->ID);
 	} else {
-		Game_Map::GetInterpreter().Push(me, page, false);
+		Game_Map::GetInterpreter().Push(me, page, InterpreterExecutionType::DebugCall);
 		Scene::PopUntil(Scene::Map);
 		Output::Debug("Debug Scene Forced execution of map event {} page {} on the map foreground interpreter.", me->GetId(), page->ID);
 	}
@@ -1185,9 +1185,9 @@ void Scene_Debug::DoCallBattleEvent() {
 
 	auto& page = troop->pages[page_idx];
 
-	Game_Battle::GetInterpreter().Push(page.event_commands, 0, false);
+	Game_Battle::GetInterpreter().Push({ InterpreterExecutionType::DebugCall, InterpreterEventType::BattleEvent }, page.event_commands, 0, false);
 	Scene::PopUntil(Scene::Battle);
-	Output::Debug("Debug Scene Forced execution of battle troop {} event page {} on the map foreground interpreter.", troop->ID, page.ID);
+	Output::Debug("Debug Scene Forced execution of battle troop {} event page {} on the battle foreground interpreter.", troop->ID, page.ID);
 }
 
 void Scene_Debug::DoOpenMenu() {

--- a/src/scene_debug.h
+++ b/src/scene_debug.h
@@ -20,6 +20,7 @@
 
 // Headers
 #include <vector>
+#include "game_interpreter_debug.h"
 #include "scene.h"
 #include "window_command.h"
 #include "window_numberinput.h"
@@ -191,12 +192,8 @@ private:
 
 	void UpdateInterpreterWindow(int index);
 	lcf::rpg::SaveEventExecFrame& GetSelectedInterpreterFrameFromUiState() const;
-	void CacheBackgroundInterpreterStates();
 	struct {
-		std::vector<int> ev;
-		std::vector<int> ce;
-		std::vector<lcf::rpg::SaveEventExecState> state_ev;
-		std::vector<lcf::rpg::SaveEventExecState> state_ce;
+		Debug::ParallelInterpreterStates background_states;
 
 		// Frame-scoped data types introduced in 'ScopedVars' branch
 		// bool show_frame_switches = false;

--- a/src/scene_debug.h
+++ b/src/scene_debug.h
@@ -191,7 +191,7 @@ private:
 	bool interpreter_states_cached = false;
 
 	void UpdateInterpreterWindow(int index);
-	lcf::rpg::SaveEventExecFrame& GetSelectedInterpreterFrameFromUiState() const;
+	lcf::rpg::SaveEventExecFrame const& GetSelectedInterpreterFrameFromUiState() const;
 	struct {
 		Debug::ParallelInterpreterStates background_states;
 

--- a/src/window_gamelist.cpp
+++ b/src/window_gamelist.cpp
@@ -129,7 +129,7 @@ void Window_GameList::DrawItem(int index) {
 
 #ifndef USE_CUSTOM_FILEBUF
 	auto color = Font::ColorDefault;
-	if (ge.type == FileFinder::Unknown) {
+	if (ge.type == FileFinder::ProjectType::Unknown) {
 		color = Font::ColorHeal;
 	} else if (ge.type > FileFinder::ProjectType::Supported) {
 		color = Font::ColorKnockout;

--- a/src/window_interpreter.cpp
+++ b/src/window_interpreter.cpp
@@ -108,7 +108,7 @@ void Window_Interpreter::Refresh() {
 			max_evt_id = item.evt_id;
 		if (item.page_id > max_page_id)
 			max_page_id = item.page_id;
-		if (item.cmd_count > max_cmd_count)
+		if (static_cast<int>(item.cmd_count) > max_cmd_count)
 			max_cmd_count = item.cmd_count;
 	}
 

--- a/src/window_interpreter.cpp
+++ b/src/window_interpreter.cpp
@@ -199,10 +199,13 @@ void Window_Interpreter::DrawDescriptionLines() {
 	rect = GetItemRect(i++);
 	contents->ClearRect(rect);
 
-	auto str_ex_type = std::string(Game_Interpreter_Shared::kExecutionType.tag(static_cast<int>(stack_display_items[0].type_ex)));
-	contents->TextDraw(rect.x, rect.y, Font::ColorDefault, "(");
-	contents->TextDraw(rect.x + 6, rect.y, Font::ColorHeal, str_ex_type);
-	contents->TextDraw(rect.x + 6 * (str_ex_type.length() + 1), rect.y, Font::ColorDefault, ")");
+
+	if (stack_display_items.size() > 0) {
+		auto str_ex_type = std::string(Game_Interpreter_Shared::kExecutionType.tag(static_cast<int>(stack_display_items[0].type_ex)));
+		contents->TextDraw(rect.x, rect.y, Font::ColorDefault, "(");
+		contents->TextDraw(rect.x + 6, rect.y, Font::ColorHeal, str_ex_type);
+		contents->TextDraw(rect.x + 6 * (str_ex_type.length() + 1), rect.y, Font::ColorDefault, ")");
+	}
 	contents->TextDraw(rect.x + rect.width / 2, rect.y, Font::ColorDefault, "Stack Size: ");
 	contents->TextDraw(GetWidth() - 16, rect.y, Font::ColorCritical, std::to_string(state.stack.size()), Text::AlignRight);
 }

--- a/src/window_interpreter.cpp
+++ b/src/window_interpreter.cpp
@@ -199,7 +199,11 @@ void Window_Interpreter::DrawDescriptionLines() {
 	rect = GetItemRect(i++);
 	contents->ClearRect(rect);
 
-	contents->TextDraw(rect.x, rect.y, Font::ColorDefault, "Stack Size: ");
+	auto str_ex_type = std::string(Game_Interpreter_Shared::kExecutionType.tag(static_cast<int>(stack_display_items[0].type_ex)));
+	contents->TextDraw(rect.x, rect.y, Font::ColorDefault, "(");
+	contents->TextDraw(rect.x + 6, rect.y, Font::ColorHeal, str_ex_type);
+	contents->TextDraw(rect.x + 6 * (str_ex_type.length() + 1), rect.y, Font::ColorDefault, ")");
+	contents->TextDraw(rect.x + rect.width / 2, rect.y, Font::ColorDefault, "Stack Size: ");
 	contents->TextDraw(GetWidth() - 16, rect.y, Font::ColorCritical, std::to_string(state.stack.size()), Text::AlignRight);
 }
 

--- a/src/window_interpreter.cpp
+++ b/src/window_interpreter.cpp
@@ -60,6 +60,15 @@ constexpr std::array <RuntimeFlagInfo, 8> runtime_flags = { {
 } };
 #endif
 
+namespace {
+	std::vector<std::string> CreateEmptyLines(int c) {		
+		std::vector<std::string> vars;
+		for (int i = 0; i < c; i++)
+			vars.push_back("");
+		return vars;
+	}
+}
+
 Window_Interpreter::Window_Interpreter(int ix, int iy, int iwidth, int iheight) :
 	Window_Selectable(ix, iy, iwidth, iheight) {
 	column_max = 1;
@@ -99,66 +108,20 @@ void Window_Interpreter::Refresh() {
 
 	int max_cmd_count = 0, max_evt_id = 10, max_page_id = 0;
 
-	for (int i = state.stack.size() - 1; i >= 0; i--) {
-		int evt_id = state.stack[i].event_id;
-		int page_id = 0;
-		if (state.stack[i].maniac_event_id > 0) {
-			evt_id = state.stack[i].maniac_event_id;
-			page_id = state.stack[i].maniac_event_page_id;
-		}
-		if (evt_id == 0 && i == 0)
-			evt_id = display_item.owner_evt_id;
+	stack_display_items = Debug::CreateCallStack(display_item.owner_evt_id, state);
+	if (stack_display_items.size() > 0 && this->display_item.is_ce) {
+		stack_display_items[0].is_ce = true;
+	}
 
-		bool is_calling_ev_ce = false;
+	for (auto it = stack_display_items.begin(); it < stack_display_items.end(); ++it) {
+		auto& item = *it;
 
-		//FIXME: There are some currently unimplemented SaveEventExecFrame fields introduced via the ManiacPatch which should be used to properly get event state information
-		if (evt_id == 0 && i > 0) {
-			auto& prev_frame = state.stack[i - 1];
-			auto& com = prev_frame.commands[prev_frame.current_command - 1];
-			if (com.code == 12330) { // CallEvent
-				if (com.parameters[0] == 0) {
-					is_calling_ev_ce = true;
-					evt_id = com.parameters[1];
-				} else if (com.parameters[0] == 3 && Player::IsPatchManiac()) {
-					is_calling_ev_ce = true;
-					evt_id = Main_Data::game_variables->Get(com.parameters[1]);
-				} else if (com.parameters[0] == 4 && Player::IsPatchManiac()) {
-					is_calling_ev_ce = true;
-					evt_id = Main_Data::game_variables->GetIndirect(com.parameters[1]);
-				}
-			}
-		}
-		if (evt_id > max_evt_id)
-			max_evt_id = evt_id;
-
-		if (page_id > max_page_id)
-			max_page_id = page_id;
-
-		StackItem item = StackItem();
-		item.is_ce = is_calling_ev_ce || (i == 0 && this->display_item.is_ce);
-		item.evt_id = evt_id;
-		item.page_id = page_id;
-		item.name = "";
-		item.cmd_current = state.stack[i].current_command;
-		item.cmd_count = state.stack[i].commands.size();
-
-		if (item.is_ce) {
-			auto* ce = lcf::ReaderUtil::GetElement(lcf::Data::commonevents, item.evt_id);
-			if (ce) {
-				item.name = ToString(ce->name);
-			}
-		} else {
-			auto* ev = Game_Map::GetEvent(evt_id);
-			if (ev) {
-				//FIXME: map could have changed, but map_id isn't available
-				item.name = ToString(ev->GetName());
-			}
-		}
-
-		if (static_cast<int>(state.stack[i].commands.size()) > max_cmd_count)
-			max_cmd_count = state.stack[i].commands.size();
-
-		stack_display_items.push_back(item);
+		if (item.evt_id > max_evt_id)
+			max_evt_id = item.evt_id;
+		if (item.page_id > max_page_id)
+			max_page_id = item.page_id;
+		if (item.cmd_count > max_cmd_count)
+			max_cmd_count = item.cmd_count;
 	}
 
 	item_max = stack_display_items.size() + lines_without_stack;
@@ -257,7 +220,7 @@ void Window_Interpreter::DrawStackLine(int index) {
 	Rect rect = GetItemRect(index + lines_without_stack);
 	contents->ClearRect(rect);
 
-	StackItem& item = stack_display_items[index];
+	Debug::CallStackItem& item = stack_display_items[index];
 
 	contents->TextDraw(rect.x, rect.y, Font::ColorDisabled, fmt::format("[{:0" + std::to_string(digits_stackitemno) + "d}]", state.stack.size() - index));
 	if (item.is_ce) {

--- a/src/window_interpreter.cpp
+++ b/src/window_interpreter.cpp
@@ -60,15 +60,6 @@ constexpr std::array <RuntimeFlagInfo, 8> runtime_flags = { {
 } };
 #endif
 
-namespace {
-	std::vector<std::string> CreateEmptyLines(int c) {		
-		std::vector<std::string> vars;
-		for (int i = 0; i < c; i++)
-			vars.push_back("");
-		return vars;
-	}
-}
-
 Window_Interpreter::Window_Interpreter(int ix, int iy, int iwidth, int iheight) :
 	Window_Selectable(ix, iy, iwidth, iheight) {
 	column_max = 1;

--- a/src/window_interpreter.h
+++ b/src/window_interpreter.h
@@ -73,7 +73,7 @@ public:
 
 	void Update() override;
 
-	void SetStackState(bool is_ce, int owner_evt_id, std::string interpreter_desc, lcf::rpg::SaveEventExecState state);
+	void SetStackState(std::string interpreter_desc, lcf::rpg::SaveEventExecState state);
 	void Refresh();
 	bool IsValid();
 
@@ -90,8 +90,6 @@ protected:
 #endif
 private:
 	struct InterpDisplayItem {
-		bool is_ce = false;
-		int owner_evt_id = 0;
 		std::string desc;
 	};
 

--- a/src/window_interpreter.h
+++ b/src/window_interpreter.h
@@ -18,7 +18,8 @@
 #ifndef EP_WINDOW_INTERPRETER_H
 #define EP_WINDOW_INTERPRETER_H
 
- // Headers
+// Headers
+#include "game_interpreter_debug.h"
 #include "window_command.h"
 #include "game_interpreter_shared.h"
 #include "lcf/rpg/saveeventexecstate.h"
@@ -94,12 +95,6 @@ private:
 		std::string desc;
 	};
 
-	struct StackItem {
-		bool is_ce;
-		int evt_id, page_id;
-		std::string name;
-		int cmd_current, cmd_count;
-	};
 
 	const int lines_without_stack_fixed = 3;
 
@@ -109,10 +104,10 @@ private:
 	int digits_stackitemno = 0, digits_evt_id = 0, digits_page_id = 0, digits_evt_combined_id = 0, digits_cmdcount = 0;
 
 	InterpDisplayItem display_item;
-	std::vector<StackItem> stack_display_items;
 
 	UiSubActionLine sub_actions;
 	std::unique_ptr<Window_Selectable> sub_window_flags;
+	std::vector<Debug::CallStackItem> stack_display_items;
 };
 
 #endif


### PR DESCRIPTION

First two commits of this PR were already included with my recent PR [:Debug_AssertWay](https://github.com/florianessl/Player/tree/Debug_AssertWay). Basically summed up with refactoring work on existing functionality I implemented in the Interpreter Debug Window that has already been merged for a while; and setting the base with a new Debug namespace inside a new file "game_interpreter_debug.cpp"...

Next up (Commit #3): _"Game_Interpreter_Inspector"_ 
Also some refactoring work. This is to clear out some of the "_friend classes_" I've defined previously. The idea is to only allow access to internal interpreter states via this interface & make it clear that any use of these functions is considered unsafe. (I use this for my new experimental work on trying to translate/patch content of running interpreters. Instead of just declaring "_Translation_" as just another friend class of _Game_Event/Game_CommonEvent/Game_Interpreter/etc_. this approach is used..

Then we get to the new stuff:
I've implemented Maniac's "**Get Interpreter State**" sub-command for "**GetGameInfo**". This required me to fully implement the "**_maniac_event_info_**" field & refactor the way commands are pushed to the interpreter, so that an "_ExecutionType_" (Action, AutoStart, Parallel, etc..) + the type of event are always known & can be included inside the saved execution state.
I then went the extra route & did some more refactoring, so that all the outside calls to "Interpreter.Push" can be verified at compile time via static_assert´s. So if anyone tries to do something weird, it won't compile. 

The rest of the commits concern the Debug Scene`s Interpreter Window again, so the full functionality is restored after the refactoring & so that most of the new available state information is used there.