### PR TITLE
New Command 2059 - EasyRPG Zoom

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -46,6 +46,7 @@
 #include "game_screen.h"
 #include "game_interpreter_control_variables.h"
 #include "game_windows.h"
+#include "graphics.h"
 #include "json_helper.h"
 #include "maniac_patch.h"
 #include "spriteset_map.h"
@@ -794,6 +795,8 @@ bool Game_Interpreter::ExecuteCommand(lcf::rpg::EventCommand const& com) {
 			return CommandEasyRpgCloneMapEvent(com);
 		case Cmd::EasyRpg_DestroyMapEvent:
 			return CommandEasyRpgDestroyMapEvent(com);
+		case static_cast<Cmd>(2059):
+			return CommandEasyRpgZoom(com);
 		default:
 			return true;
 	}
@@ -5487,6 +5490,26 @@ bool Game_Interpreter::CommandEasyRpgDestroyMapEvent(lcf::rpg::EventCommand cons
 	int target_event = ValueOrVariable(com.parameters[0], com.parameters[1]);
 
 	_async_op = AsyncOp::MakeDestroyMapEvent(target_event);
+
+	return true;
+}
+
+bool Game_Interpreter::CommandEasyRpgZoom(lcf::rpg::EventCommand const& com) {
+	if (!Player::HasEasyRpgExtensions()) {
+		//return true;
+	}
+
+	int Scale = ValueOrVariable(com.parameters[0], com.parameters[1]);
+	bool OriginAsPercentage = static_cast<bool>(ValueOrVariable(com.parameters[2], com.parameters[3]));
+	int OriginX = ValueOrVariable(com.parameters[4], com.parameters[5]);
+	int OriginY = ValueOrVariable(com.parameters[6], com.parameters[7]);
+
+	Graphics::GetZoomData().SetScale(Scale);
+	Graphics::GetZoomData().SetOriginAsPercentage(OriginAsPercentage);
+	Graphics::GetZoomData().SetOriginX(OriginX);
+	Graphics::GetZoomData().SetOriginY(OriginY);
+
+	//Output::Warning("Zoom: {} Scale: {}, OriginAsPercentage: {}, OriginX: {}, OriginY: {}", Graphics::GetZoomData().GetScale(), Graphics::GetZoomData().IsOriginPercentage(), Graphics::GetZoomData().GetOriginX(), Graphics::GetZoomData().GetOriginY());
 
 	return true;
 }

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -301,6 +301,7 @@ protected:
 	bool CommandEasyRpgProcessJson(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgCloneMapEvent(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgDestroyMapEvent(lcf::rpg::EventCommand const& com);
+	bool CommandEasyRpgZoom(lcf::rpg::EventCommand const& com);
 	bool CommandManiacGetGameInfo(lcf::rpg::EventCommand const& com);
 
 	void SetSubcommandIndex(int indent, int idx);

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -34,6 +34,14 @@
 using namespace std::chrono_literals;
 
 namespace Graphics {
+	namespace {
+		static ZoomData  viewport_scale_instance;
+	}
+
+	ZoomData& GetZoomData() {
+		return viewport_scale_instance;
+	}
+
 	void UpdateTitle();
 
 	std::shared_ptr<Scene> current_scene;

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -18,7 +18,7 @@
 #ifndef EP_GRAPHICS_H
 #define EP_GRAPHICS_H
 
-// Headers
+#include <memory>
 #include <vector>
 #include "bitmap.h"
 #include "drawable.h"
@@ -33,6 +33,33 @@ class Scene;
  * Handles screen drawing.
  */
 namespace Graphics {
+	/**
+	 * Controls viewport scaling and positioning
+	 */
+	class ZoomData {
+	private:
+		int scale_percentage = 100;
+		bool origin_type = true; // true = percentage, false = absolute pixels
+		int origin_x = 50; // center point for scaling
+		int origin_y = 50; // center point for scaling
+
+	public:
+		int GetScale() const { return scale_percentage; }
+		void SetScale(int percentage) { scale_percentage = percentage; }
+
+		bool IsOriginPercentage() const { return origin_type; }
+		void SetOriginAsPercentage(bool is_relative) { origin_type = is_relative; }
+
+		int GetOriginX() const { return origin_x; }
+		void SetOriginX(int x) { origin_x = x; }
+
+		int GetOriginY() const { return origin_y; }
+		void SetOriginY(int y) { origin_y = y; }
+	};
+
+	// Global instance declaration
+	extern ZoomData& GetZoomData();
+
 	/**
 	 * Initializes Graphics.
 	 */


### PR DESCRIPTION
Zooms in and Out the screen.

`The syntax always comes in pairs. The first parameter of each pair indicates whether you are using a direct value or a variable/indirect variable, through ValueOrVariable().`

------------------------

#### Syntax (TPC):
```js
@raw 2059,
      "",          // Not Used.
      0, 0,        // Scale value in percentage (Default is 100%).
      0, 1,        // Origin Type (0 = absolute pixel || 1 =percentage of screen area )
      0, 50,        // Origin X
      0, 50,        // Origin Y
```

#### Example:
```js
@raw 2059, "", 1, 20, 0, 0, 1, 21, 1, 22 // size is var20, absolute pixel, originX is var21, originY is var22
```

-----------------------------------

This command differs from maniacs patch zoom, which is executed per picture layer, and it has a interpolation between zoom states and a "wait for completion" check.