### PR TITLE
Extracting patched constants from RPG_RT / WhiteDragon patch compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ add_library(${PROJECT_NAME} OBJECT
 	src/dynrpg_textplugin.h
 	src/enemyai.cpp
 	src/enemyai.h
+	src/exe_constants.h
 	src/exe_reader.cpp
 	src/exe_reader.h
 	src/exfont.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -89,6 +89,7 @@ libeasyrpg_player_a_SOURCES = \
 	src/dynrpg_textplugin.cpp \
 	src/enemyai.cpp \
 	src/enemyai.h \
+	src/exe_constants.h \
 	src/exe_reader.cpp \
 	src/exe_reader.h \
 	src/exfont.h \

--- a/src/exe_constants.h
+++ b/src/exe_constants.h
@@ -24,136 +24,212 @@
 
 namespace ExeConstants {
 
-	using Type = Player::GameConstantType;
+	constexpr size_t MAX_SIZE_CHK_PRE = 4;
 
 	struct CodeAddressInfoU32 {
 		int32_t default_val;
 		size_t code_offset;
-		std::vector<uint8_t> pre_data;
+		size_t size_pre_data;
+		std::array<uint8_t, MAX_SIZE_CHK_PRE> pre_data;
+
+		constexpr CodeAddressInfoU32(int32_t default_val, size_t code_offset) :
+			default_val(default_val), code_offset(code_offset), size_pre_data(0), pre_data({ 0,0,0,0 }) {
+		}
+		constexpr CodeAddressInfoU32(int32_t default_val, size_t code_offset, uint8_t pre_data) :
+			default_val(default_val), code_offset(code_offset), size_pre_data(1), pre_data({ pre_data, 0, 0, 0 }) {
+		}
+		constexpr CodeAddressInfoU32(int32_t default_val, size_t code_offset, std::array<uint8_t, 2> pre_data) :
+			default_val(default_val), code_offset(code_offset), size_pre_data(2), pre_data({ pre_data[0], pre_data[1], 0, 0 }) {
+		}
+		constexpr CodeAddressInfoU32(int32_t default_val, size_t code_offset, std::array<uint8_t, 3> pre_data) :
+			default_val(default_val), code_offset(code_offset), size_pre_data(3), pre_data({ pre_data[0], pre_data[1], pre_data[2], 0 }) {
+		}
+		constexpr CodeAddressInfoU32(int32_t default_val, size_t code_offset, std::array<uint8_t, 4> pre_data) :
+			default_val(default_val), code_offset(code_offset), size_pre_data(4), pre_data({ pre_data[0], pre_data[1], pre_data[2], pre_data[3]}) {
+		}
 	};
 
-	using code_address_map = std::vector<std::pair<Type, struct CodeAddressInfoU32>>;
+	using code_address = std::pair<Player::GameConstantType, struct CodeAddressInfoU32>;
+	using code_address_map = std::array<code_address, static_cast<size_t>(Player::GameConstantType::LAST)>;
 
 #define ADD_EAX_ESI 0x03, 0xC6
 #define MOV_EBX		0xB9
 #define MOV_ECX		0xB9
 #define MOV_EDX		0xBA
 #define SUB_EDX_EBX 0x2B, 0xD3
+#define CMP_DWORD_ESP 0x81, 0x7C, 0x24
 
-#define DEPENDS_ON_PREVIOUS { 0xFF, 0xFF }
+#define DEPENDS_ON_PREVIOUS { 0xFF, 0xFF, 0x00, 0xFF }
 
-	const auto magic_prev = std::vector<uint8_t>(DEPENDS_ON_PREVIOUS);
+	constexpr auto magic_prev = std::array<uint8_t, 4 >(DEPENDS_ON_PREVIOUS);
 
-	/*
-
-		1.08 .CODE -> offset + 0x400
-		 999 : E7 03 00 00
-		9999 : 0F 27 00 00
-
-	*/
-
+	template<Player::GameConstantType T>
+	constexpr code_address map(int32_t default_val, size_t code_offset, uint8_t pre_1) {
+		return { T, CodeAddressInfoU32(default_val, code_offset, pre_1) };
+	}
+	template<Player::GameConstantType T>
+	constexpr code_address map(int32_t default_val, size_t code_offset, uint8_t pre_1, uint8_t pre_2) {
+		return { T, CodeAddressInfoU32(default_val, code_offset,  std::array<uint8_t, 2> { pre_1, pre_2 }) };
+	}
+	template<Player::GameConstantType T>
+	constexpr code_address map(int32_t default_val, size_t code_offset, uint8_t pre_1, uint8_t pre_2, uint8_t pre_3) {
+		return { T, CodeAddressInfoU32(default_val, code_offset,  std::array<uint8_t, 3> { pre_1, pre_2, pre_3 }) };
+	}
+	template<Player::GameConstantType T>
+	constexpr code_address map(int32_t default_val, size_t code_offset, uint8_t pre_1, uint8_t pre_2, uint8_t pre_3, uint8_t pre_4) {
+		return { T, CodeAddressInfoU32(default_val, code_offset,  std::array<uint8_t, 4> { pre_1, pre_2, pre_3, pre_4 }) };
+	}
+	template<Player::GameConstantType T>
+	constexpr code_address not_def() {
+		return { T, CodeAddressInfoU32(0, 0) };
+	}
 }
+
 namespace ExeConstants::RT_2K {
 
-	const code_address_map const_addresses_103b = {
-		{
-			Type::TitleX,
-			{ 160, 0x06CC39, { MOV_EDX } }
-		}, {
-			Type::TitleY,
-			{ 148, 0x06CC40, { SUB_EDX_EBX, MOV_EBX } }
-		}, {
-			Type::TitleHiddenX,
-			{ 160, 0x06CC5B, { MOV_EDX } }
-		}, {
-			Type::TitleHiddenY,
-			{  88, 0x06CC62, { SUB_EDX_EBX, MOV_EBX } }
-		}
-	};
+	using T = Player::GameConstantType;
+	
+	constexpr code_address_map const_addresses_103b = {{
+		map<T::MinVarLimit>            ( -999999, 0x08560C, CMP_DWORD_ESP, 0x10),
+		map<T::MaxVarLimit>            (  999999, 0x085636, CMP_DWORD_ESP, 0x10),
 
-	const code_address_map const_addresses_105b = {
-		{
-			Type::TitleX,
-			{ 160, 0x06E091, { MOV_EDX } }
-		}, {
-			Type::TitleY,
-			{ 148, 0x06E098, { SUB_EDX_EBX, MOV_EBX } }
-		}, {
-			Type::TitleHiddenX,
-			{ 160, 0x06E0B3, { MOV_EDX } }
-		}, {
-			Type::TitleHiddenY,
-			{  88, 0x06E0BA, { SUB_EDX_EBX, MOV_EBX } }
-		}
-	};
+		map<T::TitleX>                 (     160, 0x06CC39, MOV_EDX),
+		map<T::TitleY>                 (     148, 0x06CC40, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleHiddenX>           (     160, 0x06CC5B, MOV_EDX),
+		map<T::TitleHiddenY>           (      88, 0x06CC62, SUB_EDX_EBX, MOV_EBX),
 
-	const code_address_map const_addresses_106 = {
-		{
-			Type::TitleX,
-			{ 160, 0x06D1B9, { MOV_EDX } }
-		}, {
-			Type::TitleY,
-			{ 148, 0x06D1C0, { SUB_EDX_EBX, MOV_EBX } }
-		}, {
-			Type::TitleHiddenX,
-			{ 160, 0x06D1DB, { MOV_EDX } }
-		}, {
-			Type::TitleHiddenY,
-			{  88, 0x06D1E2, { SUB_EDX_EBX, MOV_EBX } }
-		}
-	};
+		not_def<T::MaxActorHP>(),
+		not_def<T::MaxActorSP>(),
+		not_def<T::MaxEnemyHP>(),
+		not_def<T::MaxEnemySP>(),
+		not_def<T::MaxStatBattleValue>(),
+		not_def<T::MaxStatBaseValue>(),
+		not_def<T::MaxDamageValue>(),
+		not_def<T::MaxExpValue>(),
+		not_def<T::MaxLevel>(),
+		not_def<T::MaxGoldValue>(),
+		not_def<T::MaxItemCount>(),
+		not_def<T::MaxSaveFiles>()
+	}};
+
+	constexpr code_address_map const_addresses_105b = {{
+		map<T::MinVarLimit>            ( -999999, 0x0842A4, CMP_DWORD_ESP, 0x10),
+		map<T::MaxVarLimit>            (  999999, 0x0842D2, CMP_DWORD_ESP, 0x10),
+
+		map<T::TitleX>                 (     160, 0x06E091, MOV_EDX),
+		map<T::TitleY>                 (     148, 0x06E098, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleHiddenX>           (     160, 0x06E0B3, MOV_EDX),
+		map<T::TitleHiddenY>           (      88, 0x06CC62, SUB_EDX_EBX, MOV_EBX),
+
+		not_def<T::MaxActorHP>(),
+		not_def<T::MaxActorSP>(),
+		not_def<T::MaxEnemyHP>(),
+		not_def<T::MaxEnemySP>(),
+		not_def<T::MaxStatBattleValue>(),
+		not_def<T::MaxStatBaseValue>(),
+		not_def<T::MaxDamageValue>(),
+		not_def<T::MaxExpValue>(),
+		not_def<T::MaxLevel>(),
+		not_def<T::MaxGoldValue>(),
+		not_def<T::MaxItemCount>(),
+		not_def<T::MaxSaveFiles>()
+	}};
+
+	constexpr code_address_map const_addresses_106 = {{
+		map<T::MinVarLimit>            ( -999999, 0x085978, CMP_DWORD_ESP, 0x10),
+		map<T::MaxVarLimit>            (  999999, 0x0859A2, CMP_DWORD_ESP, 0x10),
+
+		map<T::TitleX>                 (     160, 0x06D1B9, MOV_EDX),
+		map<T::TitleY>                 (     148, 0x06D1C0, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleHiddenX>           (     160, 0x06D1DB, MOV_EDX),
+		map<T::TitleHiddenY>           (      88, 0x06D1E2, SUB_EDX_EBX, MOV_EBX),
+
+		not_def<T::MaxActorHP>(),
+		not_def<T::MaxActorSP>(),
+		not_def<T::MaxEnemyHP>(),
+		not_def<T::MaxEnemySP>(),
+		not_def<T::MaxStatBattleValue>(),
+		not_def<T::MaxStatBaseValue>(),
+		not_def<T::MaxDamageValue>(),
+		not_def<T::MaxExpValue>(),
+		not_def<T::MaxLevel>(),
+		not_def<T::MaxGoldValue>(),
+		not_def<T::MaxItemCount>(),
+		not_def<T::MaxSaveFiles>()
+	}};
 }
 
 namespace ExeConstants::RT_2K3 {
 
-	const code_address_map const_addresses_104 = {
-		{
-			Type::TitleX,
-			{ 160, 0x08A849, { MOV_EDX } }
-		}, {
-			Type::TitleY,
-			{ 148, 0x08A850, { SUB_EDX_EBX, MOV_EBX } }
-		}, {
-			Type::TitleHiddenX,
-			{ 160, 0x08A86B, { MOV_EDX } }
-		}, {
-			Type::TitleHiddenY,
-			{  88, 0x08A872, { SUB_EDX_EBX, MOV_EBX } }
-		}
-	};
+	using T = Player::GameConstantType;
 
-	const code_address_map const_addresses_106 = {
-		{
-			Type::TitleX,
-			{ 160, 0x08F76D, { MOV_EDX } }
-		}, {
-			Type::TitleY,
-			{ 148, 0x08F774, { SUB_EDX_EBX, MOV_EBX } }
-		}, {
-			Type::TitleHiddenX,
-			{ 160, 0x08F78F, { MOV_EDX } }
-		}, {
-			Type::TitleHiddenY,
-			{  88, 0x08F796, { SUB_EDX_EBX, MOV_EBX } }
-		}
-	};
+	constexpr code_address_map const_addresses_104 = {{
+		map<T::MinVarLimit>            (-9999999, 0x0A5CB3, CMP_DWORD_ESP, 0x10),
+		map<T::MaxVarLimit>            ( 9999999, 0x0A5CDD, CMP_DWORD_ESP, 0x10),
 
-	const code_address_map const_addresses_108 = {
-		{
-			Type::TitleX,
-			{ 160, 0x08F821, { MOV_EDX } }
-		}, {
-			Type::TitleY,
-			{ 148, 0x08F828, { SUB_EDX_EBX, MOV_EBX } }
-		}, {
-			Type::TitleHiddenX,
-			{ 160, 0x08F843, { MOV_EDX } }
-		}, {
-			Type::TitleHiddenY,
-			{  88, 0x08F84A, { SUB_EDX_EBX, MOV_EBX } }
-		}
-	};
+		map<T::TitleX>                 (     160, 0x08A849, MOV_EDX),
+		map<T::TitleY>                 (     148, 0x08A850, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleHiddenX>           (     160, 0x08A86B, MOV_EDX),
+		map<T::TitleHiddenY>           (      88, 0x08A872, SUB_EDX_EBX, MOV_EBX),
+
+		not_def<T::MaxActorHP>(),
+		not_def<T::MaxActorSP>(),
+		not_def<T::MaxEnemyHP>(),
+		not_def<T::MaxEnemySP>(),
+		not_def<T::MaxStatBattleValue>(),
+		not_def<T::MaxStatBaseValue>(),
+		not_def<T::MaxDamageValue>(),
+		not_def<T::MaxExpValue>(),
+		not_def<T::MaxLevel>(),
+		not_def<T::MaxGoldValue>(),
+		not_def<T::MaxItemCount>(),
+		not_def<T::MaxSaveFiles>()
+	}};
+	
+	constexpr code_address_map const_addresses_106 = {{
+		map<T::MinVarLimit>            (-9999999, 0x0AC0F7, CMP_DWORD_ESP, 0x10),
+		map<T::MaxVarLimit>            ( 9999999, 0x0AC121, CMP_DWORD_ESP, 0x10),
+
+		map<T::TitleX>                 (     160, 0x08F76D, MOV_EDX),
+		map<T::TitleY>                 (     148, 0x08F774, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleHiddenX>           (     160, 0x08F78F, MOV_EDX),
+		map<T::TitleHiddenY>           (      88, 0x08F796, SUB_EDX_EBX, MOV_EBX),
+
+		not_def<T::MaxActorHP>(),
+		not_def<T::MaxActorSP>(),
+		not_def<T::MaxEnemyHP>(),
+		not_def<T::MaxEnemySP>(),
+		not_def<T::MaxStatBattleValue>(),
+		not_def<T::MaxStatBaseValue>(),
+		not_def<T::MaxDamageValue>(),
+		not_def<T::MaxExpValue>(),
+		not_def<T::MaxLevel>(),
+		not_def<T::MaxGoldValue>(),
+		not_def<T::MaxItemCount>(),
+		not_def<T::MaxSaveFiles>()
+	}};
+	
+	constexpr code_address_map const_addresses_108 = {{
+		map<T::MinVarLimit>            (-9999999, 0x0AC36B, CMP_DWORD_ESP, 0x10),
+		map<T::MaxVarLimit>            ( 9999999, 0x0AC395, CMP_DWORD_ESP, 0x10),
+
+		map<T::TitleX>                 (     160, 0x08F821, MOV_EDX),
+		map<T::TitleY>                 (     148, 0x08F828, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleHiddenX>           (     160, 0x08F843, MOV_EDX),
+		map<T::TitleHiddenY>           (      88, 0x08F84A, SUB_EDX_EBX, MOV_EBX),
+
+		not_def<T::MaxActorHP>(),
+		not_def<T::MaxActorSP>(),
+		not_def<T::MaxEnemyHP>(),
+		not_def<T::MaxEnemySP>(),
+		not_def<T::MaxStatBattleValue>(),
+		not_def<T::MaxStatBaseValue>(),
+		not_def<T::MaxDamageValue>(),
+		not_def<T::MaxExpValue>(),
+		not_def<T::MaxLevel>(),
+		not_def<T::MaxGoldValue>(),
+		not_def<T::MaxItemCount>(),
+		not_def<T::MaxSaveFiles>()
+	}};
 }
-
-
 #endif

--- a/src/exe_constants.h
+++ b/src/exe_constants.h
@@ -1,0 +1,76 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_EXE_CONSTANTS_H
+#define EP_EXE_CONSTANTS_H
+
+#include <cstdint>
+#include <vector>
+#include "player.h"
+
+namespace ExeConstants {
+
+	using Type = Player::GameConstantType;
+
+	struct CodeAddressInfoU32 {
+		int32_t default_val;
+		size_t code_offset;
+		std::vector<uint8_t> pre_data;
+	};
+
+	using code_address_map = std::vector<std::pair<Type, struct CodeAddressInfoU32>>;
+
+#define ADD_EAX_ESI 0x03, 0xC6
+#define MOV_EBX		0xB9
+#define MOV_ECX		0xB9
+#define MOV_EDX		0xBA
+#define SUB_EDX_EBX 0x2B, 0xD3
+
+#define DEPENDS_ON_PREVIOUS { 0xFF, 0xFF }
+
+	const auto magic_prev = std::vector<uint8_t>(DEPENDS_ON_PREVIOUS);
+
+	/*
+
+		1.08 .CODE -> offset + 0x400
+		 999 : E7 03 00 00
+		9999 : 0F 27 00 00
+
+	*/
+
+	const code_address_map const_addresses_106 = {
+	};
+
+	const code_address_map const_addresses_108 = {
+		{
+			Type::TitleX,
+			{ 160, 0x08F821, { MOV_EDX } }
+		}, {
+			Type::TitleY,
+			{ 148, 0x08F828, { SUB_EDX_EBX, MOV_EBX } }
+		}, {
+			Type::TitleHiddenX,
+			{ 160, 0x08F843, { MOV_EDX } }
+		}, {
+			Type::TitleHiddenY,
+			{ 88, 0x08F84A, { SUB_EDX_EBX, MOV_EBX } }
+		}
+	};
+}
+
+
+#endif

--- a/src/exe_constants.h
+++ b/src/exe_constants.h
@@ -24,6 +24,22 @@
 
 namespace ExeConstants {
 
+	enum class KnownPatchConfigurations {
+		//Rm2k_Italian_40,		// Italian "RPG Maker 4.0" patch
+		Rm2k3_Italian_108,		// Italian "WhiteDragon" patch
+		//QP_StatDelimiter,
+		LAST
+	};
+	static constexpr auto kKnownPatchConfigurations = lcf::makeEnumTags<KnownPatchConfigurations>(
+		//"Rm2k Italian 4.0",
+		"Rm2k3 Italian 1.08"
+		//"QuickPatch StatDelimiter"
+	);
+
+	static_assert(kKnownPatchConfigurations.size() == static_cast<size_t>(KnownPatchConfigurations::LAST));
+
+	using patch_config = std::map<Player::GameConstantType, int32_t>;
+
 	constexpr size_t MAX_SIZE_CHK_PRE = 4;
 
 	struct CodeAddressInfoU32 {
@@ -287,5 +303,27 @@ namespace ExeConstants::RT_2K3 {
 		not_def<T::MaxItemCount>(),
 		not_def<T::MaxSaveFiles>()
 	}};
+}
+
+namespace ExeConstants {
+	using T = Player::GameConstantType;
+
+	std::map<KnownPatchConfigurations, patch_config> known_patch_configurations = {
+		{
+			KnownPatchConfigurations::Rm2k3_Italian_108, {
+				{ T::MinVarLimit,	-999999999 },
+				{ T::MaxVarLimit,	 999999999 },
+				{ T::MaxEnemyHP,	 999999999 },
+				{ T::MaxEnemySP,     999999999 },
+				{ T::MaxActorHP,	     99999 },
+				{ T::MaxActorSP,          9999 },
+				{ T::MaxAtkBaseValue,     9999 },
+				{ T::MaxDefBaseValue,     9999 },
+				{ T::MaxSpiBaseValue,     9999 },
+				{ T::MaxAgiBaseValue,     9999 },
+				{ T::MaxDamageValue,     99999 },
+				{ T::MaxGoldValue,     9999999 }
+		}}
+	};
 }
 #endif

--- a/src/exe_constants.h
+++ b/src/exe_constants.h
@@ -52,7 +52,90 @@ namespace ExeConstants {
 
 	*/
 
+}
+namespace ExeConstants::RT_2K {
+
+	const code_address_map const_addresses_103b = {
+		{
+			Type::TitleX,
+			{ 160, 0x06CC39, { MOV_EDX } }
+		}, {
+			Type::TitleY,
+			{ 148, 0x06CC40, { SUB_EDX_EBX, MOV_EBX } }
+		}, {
+			Type::TitleHiddenX,
+			{ 160, 0x06CC5B, { MOV_EDX } }
+		}, {
+			Type::TitleHiddenY,
+			{  88, 0x06CC62, { SUB_EDX_EBX, MOV_EBX } }
+		}
+	};
+
+	const code_address_map const_addresses_105b = {
+		{
+			Type::TitleX,
+			{ 160, 0x06E091, { MOV_EDX } }
+		}, {
+			Type::TitleY,
+			{ 148, 0x06E098, { SUB_EDX_EBX, MOV_EBX } }
+		}, {
+			Type::TitleHiddenX,
+			{ 160, 0x06E0B3, { MOV_EDX } }
+		}, {
+			Type::TitleHiddenY,
+			{  88, 0x06E0BA, { SUB_EDX_EBX, MOV_EBX } }
+		}
+	};
+
 	const code_address_map const_addresses_106 = {
+		{
+			Type::TitleX,
+			{ 160, 0x06D1B9, { MOV_EDX } }
+		}, {
+			Type::TitleY,
+			{ 148, 0x06D1C0, { SUB_EDX_EBX, MOV_EBX } }
+		}, {
+			Type::TitleHiddenX,
+			{ 160, 0x06D1DB, { MOV_EDX } }
+		}, {
+			Type::TitleHiddenY,
+			{  88, 0x06D1E2, { SUB_EDX_EBX, MOV_EBX } }
+		}
+	};
+}
+
+namespace ExeConstants::RT_2K3 {
+
+	const code_address_map const_addresses_104 = {
+		{
+			Type::TitleX,
+			{ 160, 0x08A849, { MOV_EDX } }
+		}, {
+			Type::TitleY,
+			{ 148, 0x08A850, { SUB_EDX_EBX, MOV_EBX } }
+		}, {
+			Type::TitleHiddenX,
+			{ 160, 0x08A86B, { MOV_EDX } }
+		}, {
+			Type::TitleHiddenY,
+			{  88, 0x08A872, { SUB_EDX_EBX, MOV_EBX } }
+		}
+	};
+
+	const code_address_map const_addresses_106 = {
+		{
+			Type::TitleX,
+			{ 160, 0x08F76D, { MOV_EDX } }
+		}, {
+			Type::TitleY,
+			{ 148, 0x08F774, { SUB_EDX_EBX, MOV_EBX } }
+		}, {
+			Type::TitleHiddenX,
+			{ 160, 0x08F78F, { MOV_EDX } }
+		}, {
+			Type::TitleHiddenY,
+			{  88, 0x08F796, { SUB_EDX_EBX, MOV_EBX } }
+		}
 	};
 
 	const code_address_map const_addresses_108 = {
@@ -67,7 +150,7 @@ namespace ExeConstants {
 			{ 160, 0x08F843, { MOV_EDX } }
 		}, {
 			Type::TitleHiddenY,
-			{ 88, 0x08F84A, { SUB_EDX_EBX, MOV_EBX } }
+			{  88, 0x08F84A, { SUB_EDX_EBX, MOV_EBX } }
 		}
 	};
 }

--- a/src/exe_constants.h
+++ b/src/exe_constants.h
@@ -53,11 +53,13 @@ namespace ExeConstants {
 	using code_address_map = std::array<code_address, static_cast<size_t>(Player::GameConstantType::LAST)>;
 
 #define ADD_EAX_ESI 0x03, 0xC6
-#define MOV_EBX		0xB9
+#define ADD_EDX_ESI 0x03, 0xD6
+#define MOV_EAX		0xB8
 #define MOV_ECX		0xB9
 #define MOV_EDX		0xBA
 #define SUB_EDX_EBX 0x2B, 0xD3
 #define CMP_DWORD_ESP 0x81, 0x7C, 0x24
+#define CMP_ESI		0x81, 0xFE
 
 #define DEPENDS_ON_PREVIOUS { 0xFF, 0xFF, 0x00, 0xFF }
 
@@ -94,9 +96,9 @@ namespace ExeConstants::RT_2K {
 		map<T::MaxVarLimit>            (  999999, 0x085636, CMP_DWORD_ESP, 0x10),
 
 		map<T::TitleX>                 (     160, 0x06CC39, MOV_EDX),
-		map<T::TitleY>                 (     148, 0x06CC40, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleY>                 (     148, 0x06CC40, SUB_EDX_EBX, MOV_ECX),
 		map<T::TitleHiddenX>           (     160, 0x06CC5B, MOV_EDX),
-		map<T::TitleHiddenY>           (      88, 0x06CC62, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleHiddenY>           (      88, 0x06CC62, SUB_EDX_EBX, MOV_ECX),
 
 		not_def<T::MaxActorHP>(),
 		not_def<T::MaxActorSP>(),
@@ -126,9 +128,9 @@ namespace ExeConstants::RT_2K {
 		map<T::MaxVarLimit>            (  999999, 0x0842D2, CMP_DWORD_ESP, 0x10),
 
 		map<T::TitleX>                 (     160, 0x06E091, MOV_EDX),
-		map<T::TitleY>                 (     148, 0x06E098, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleY>                 (     148, 0x06E098, SUB_EDX_EBX, MOV_ECX),
 		map<T::TitleHiddenX>           (     160, 0x06E0B3, MOV_EDX),
-		map<T::TitleHiddenY>           (      88, 0x06CC62, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleHiddenY>           (      88, 0x06CC62, SUB_EDX_EBX, MOV_ECX),
 
 		not_def<T::MaxActorHP>(),
 		not_def<T::MaxActorSP>(),
@@ -158,9 +160,9 @@ namespace ExeConstants::RT_2K {
 		map<T::MaxVarLimit>            (  999999, 0x0859A2, CMP_DWORD_ESP, 0x10),
 
 		map<T::TitleX>                 (     160, 0x06D1B9, MOV_EDX),
-		map<T::TitleY>                 (     148, 0x06D1C0, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleY>                 (     148, 0x06D1C0, SUB_EDX_EBX, MOV_ECX),
 		map<T::TitleHiddenX>           (     160, 0x06D1DB, MOV_EDX),
-		map<T::TitleHiddenY>           (      88, 0x06D1E2, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleHiddenY>           (      88, 0x06D1E2, SUB_EDX_EBX, MOV_ECX),
 
 		not_def<T::MaxActorHP>(),
 		not_def<T::MaxActorSP>(),
@@ -195,9 +197,9 @@ namespace ExeConstants::RT_2K3 {
 		map<T::MaxVarLimit>            ( 9999999, 0x0A5CDD, CMP_DWORD_ESP, 0x10),
 
 		map<T::TitleX>                 (     160, 0x08A849, MOV_EDX),
-		map<T::TitleY>                 (     148, 0x08A850, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleY>                 (     148, 0x08A850, SUB_EDX_EBX, MOV_ECX),
 		map<T::TitleHiddenX>           (     160, 0x08A86B, MOV_EDX),
-		map<T::TitleHiddenY>           (      88, 0x08A872, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleHiddenY>           (      88, 0x08A872, SUB_EDX_EBX, MOV_ECX),
 
 		not_def<T::MaxActorHP>(),
 		not_def<T::MaxActorSP>(),
@@ -227,9 +229,9 @@ namespace ExeConstants::RT_2K3 {
 		map<T::MaxVarLimit>            ( 9999999, 0x0AC121, CMP_DWORD_ESP, 0x10),
 
 		map<T::TitleX>                 (     160, 0x08F76D, MOV_EDX),
-		map<T::TitleY>                 (     148, 0x08F774, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleY>                 (     148, 0x08F774, SUB_EDX_EBX, MOV_ECX),
 		map<T::TitleHiddenX>           (     160, 0x08F78F, MOV_EDX),
-		map<T::TitleHiddenY>           (      88, 0x08F796, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleHiddenY>           (      88, 0x08F796, SUB_EDX_EBX, MOV_ECX),
 
 		not_def<T::MaxActorHP>(),
 		not_def<T::MaxActorSP>(),
@@ -259,29 +261,29 @@ namespace ExeConstants::RT_2K3 {
 		map<T::MaxVarLimit>            ( 9999999, 0x0AC395, CMP_DWORD_ESP, 0x10),
 
 		map<T::TitleX>                 (     160, 0x08F821, MOV_EDX),
-		map<T::TitleY>                 (     148, 0x08F828, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleY>                 (     148, 0x08F828, SUB_EDX_EBX, MOV_ECX),
 		map<T::TitleHiddenX>           (     160, 0x08F843, MOV_EDX),
-		map<T::TitleHiddenY>           (      88, 0x08F84A, SUB_EDX_EBX, MOV_EBX),
+		map<T::TitleHiddenY>           (      88, 0x08F84A, SUB_EDX_EBX, MOV_ECX),
 
-		not_def<T::MaxActorHP>(),
-		not_def<T::MaxActorSP>(),
+		map<T::MaxActorHP>             (    9999, 0x0B612B, MOV_ECX), /* 0x0B818B */
+		map<T::MaxActorSP>             (     999, 0x0B619D, MOV_ECX), /* 0x0B81AD */
 		not_def<T::MaxEnemyHP>(),
 		not_def<T::MaxEnemySP>(),
 
-		not_def<T::MaxAtkBaseValue>(),
-		not_def<T::MaxDefBaseValue>(),
-		not_def<T::MaxSpiBaseValue>(),
-		not_def<T::MaxAgiBaseValue>(),
+		map<T::MaxAtkBaseValue>        (     999, 0x0B6236, MOV_ECX), /* 0xB81CC */
+		map<T::MaxDefBaseValue>        (     999, 0x0B649C, MOV_ECX), /* 0xB81EB */
+		map<T::MaxSpiBaseValue>        (     999, 0x0B654C, MOV_ECX), /* 0xB820A */
+		map<T::MaxAgiBaseValue>        (     999, 0x0B65F2, MOV_ECX), /* 0xB8229 */
+		
+		map<T::MaxAtkBattleValue>      (    9999, 0x0BEB3C, MOV_ECX),
+		map<T::MaxDefBattleValue>      (    9999, 0x0BEC08, MOV_ECX),
+		map<T::MaxSpiBattleValue>      (    9999, 0x0BECD1, MOV_ECX),
+		map<T::MaxAgiBattleValue>      (    9999, 0x0BED6D, MOV_ECX),
 
-		not_def<T::MaxAtkBattleValue>(),
-		not_def<T::MaxDefBattleValue>(),
-		not_def<T::MaxSpiBattleValue>(),
-		not_def<T::MaxAgiBattleValue>(),
-
-		not_def<T::MaxDamageValue>(),
-		not_def<T::MaxExpValue>(),
+		map<T::MaxDamageValue>         (    9999, 0x9C03C, MOV_EAX),
+		map<T::MaxExpValue>            ( 9999999, 0x0B5CC3, CMP_ESI),
 		not_def<T::MaxLevel>(),
-		not_def<T::MaxGoldValue>(),
+		map<T::MaxGoldValue>           (  999999, 0x0A5754, ADD_EDX_ESI, MOV_EAX),
 		not_def<T::MaxItemCount>(),
 		not_def<T::MaxSaveFiles>()
 	}};

--- a/src/exe_constants.h
+++ b/src/exe_constants.h
@@ -102,8 +102,17 @@ namespace ExeConstants::RT_2K {
 		not_def<T::MaxActorSP>(),
 		not_def<T::MaxEnemyHP>(),
 		not_def<T::MaxEnemySP>(),
-		not_def<T::MaxStatBattleValue>(),
-		not_def<T::MaxStatBaseValue>(),
+
+		not_def<T::MaxAtkBaseValue>(),
+		not_def<T::MaxDefBaseValue>(),
+		not_def<T::MaxSpiBaseValue>(),
+		not_def<T::MaxAgiBaseValue>(),
+
+		not_def<T::MaxAtkBattleValue>(),
+		not_def<T::MaxDefBattleValue>(),
+		not_def<T::MaxSpiBattleValue>(),
+		not_def<T::MaxAgiBattleValue>(),
+
 		not_def<T::MaxDamageValue>(),
 		not_def<T::MaxExpValue>(),
 		not_def<T::MaxLevel>(),
@@ -125,8 +134,17 @@ namespace ExeConstants::RT_2K {
 		not_def<T::MaxActorSP>(),
 		not_def<T::MaxEnemyHP>(),
 		not_def<T::MaxEnemySP>(),
-		not_def<T::MaxStatBattleValue>(),
-		not_def<T::MaxStatBaseValue>(),
+
+		not_def<T::MaxAtkBaseValue>(),
+		not_def<T::MaxDefBaseValue>(),
+		not_def<T::MaxSpiBaseValue>(),
+		not_def<T::MaxAgiBaseValue>(),
+
+		not_def<T::MaxAtkBattleValue>(),
+		not_def<T::MaxDefBattleValue>(),
+		not_def<T::MaxSpiBattleValue>(),
+		not_def<T::MaxAgiBattleValue>(),
+
 		not_def<T::MaxDamageValue>(),
 		not_def<T::MaxExpValue>(),
 		not_def<T::MaxLevel>(),
@@ -148,8 +166,17 @@ namespace ExeConstants::RT_2K {
 		not_def<T::MaxActorSP>(),
 		not_def<T::MaxEnemyHP>(),
 		not_def<T::MaxEnemySP>(),
-		not_def<T::MaxStatBattleValue>(),
-		not_def<T::MaxStatBaseValue>(),
+
+		not_def<T::MaxAtkBaseValue>(),
+		not_def<T::MaxDefBaseValue>(),
+		not_def<T::MaxSpiBaseValue>(),
+		not_def<T::MaxAgiBaseValue>(),
+
+		not_def<T::MaxAtkBattleValue>(),
+		not_def<T::MaxDefBattleValue>(),
+		not_def<T::MaxSpiBattleValue>(),
+		not_def<T::MaxAgiBattleValue>(),
+
 		not_def<T::MaxDamageValue>(),
 		not_def<T::MaxExpValue>(),
 		not_def<T::MaxLevel>(),
@@ -176,8 +203,17 @@ namespace ExeConstants::RT_2K3 {
 		not_def<T::MaxActorSP>(),
 		not_def<T::MaxEnemyHP>(),
 		not_def<T::MaxEnemySP>(),
-		not_def<T::MaxStatBattleValue>(),
-		not_def<T::MaxStatBaseValue>(),
+
+		not_def<T::MaxAtkBaseValue>(),
+		not_def<T::MaxDefBaseValue>(),
+		not_def<T::MaxSpiBaseValue>(),
+		not_def<T::MaxAgiBaseValue>(),
+
+		not_def<T::MaxAtkBattleValue>(),
+		not_def<T::MaxDefBattleValue>(),
+		not_def<T::MaxSpiBattleValue>(),
+		not_def<T::MaxAgiBattleValue>(),
+
 		not_def<T::MaxDamageValue>(),
 		not_def<T::MaxExpValue>(),
 		not_def<T::MaxLevel>(),
@@ -199,8 +235,17 @@ namespace ExeConstants::RT_2K3 {
 		not_def<T::MaxActorSP>(),
 		not_def<T::MaxEnemyHP>(),
 		not_def<T::MaxEnemySP>(),
-		not_def<T::MaxStatBattleValue>(),
-		not_def<T::MaxStatBaseValue>(),
+
+		not_def<T::MaxAtkBaseValue>(),
+		not_def<T::MaxDefBaseValue>(),
+		not_def<T::MaxSpiBaseValue>(),
+		not_def<T::MaxAgiBaseValue>(),
+
+		not_def<T::MaxAtkBattleValue>(),
+		not_def<T::MaxDefBattleValue>(),
+		not_def<T::MaxSpiBattleValue>(),
+		not_def<T::MaxAgiBattleValue>(),
+
 		not_def<T::MaxDamageValue>(),
 		not_def<T::MaxExpValue>(),
 		not_def<T::MaxLevel>(),
@@ -222,8 +267,17 @@ namespace ExeConstants::RT_2K3 {
 		not_def<T::MaxActorSP>(),
 		not_def<T::MaxEnemyHP>(),
 		not_def<T::MaxEnemySP>(),
-		not_def<T::MaxStatBattleValue>(),
-		not_def<T::MaxStatBaseValue>(),
+
+		not_def<T::MaxAtkBaseValue>(),
+		not_def<T::MaxDefBaseValue>(),
+		not_def<T::MaxSpiBaseValue>(),
+		not_def<T::MaxAgiBaseValue>(),
+
+		not_def<T::MaxAtkBattleValue>(),
+		not_def<T::MaxDefBattleValue>(),
+		not_def<T::MaxSpiBattleValue>(),
+		not_def<T::MaxAgiBattleValue>(),
+
 		not_def<T::MaxDamageValue>(),
 		not_def<T::MaxExpValue>(),
 		not_def<T::MaxLevel>(),

--- a/src/exe_reader.cpp
+++ b/src/exe_reader.cpp
@@ -547,9 +547,22 @@ std::map<Player::GameConstantType, int32_t> EXEReader::GetOverridenGameConstants
 		}
 	};
 
-	//TODO: do a proper version check prior to doing these reads
-	check_address_map(ExeConstants::const_addresses_106);
-	check_address_map(ExeConstants::const_addresses_108);
+	if (file_info.code_size == 0x96600) {
+		check_address_map(ExeConstants::RT_2K::const_addresses_103b);
+	} else if (file_info.code_size == 0x96E00) {
+		check_address_map(ExeConstants::RT_2K::const_addresses_105b);
+	} else if (file_info.code_size == 0x96A00) {
+		check_address_map(ExeConstants::RT_2K::const_addresses_106);
+	}
+
+
+	if (file_info.code_size == 0xC0800) {
+		check_address_map(ExeConstants::RT_2K3::const_addresses_104);
+	} else if (file_info.code_size == 0xC8A00) {
+		check_address_map(ExeConstants::RT_2K3::const_addresses_106);
+	} else if (file_info.code_size == 0xC8E00) {
+		check_address_map(ExeConstants::RT_2K3::const_addresses_108);
+	}
 
 	return game_constants;
 }

--- a/src/exe_reader.cpp
+++ b/src/exe_reader.cpp
@@ -568,7 +568,7 @@ std::map<Player::GameConstantType, int32_t> EXEReader::GetOverridenGameConstants
 				log_version_rm2k("DonM 1.03b");
 				check_address_map(ExeConstants::RT_2K::const_addresses_103b);
 			} else {
-				// Might also be build 'RTIcon-2000JP-16.png 2000-05-07	'
+				// Might also be build '2000-05-07'
 			}
 			break;
 		case 0x96E00:

--- a/src/exe_reader.h
+++ b/src/exe_reader.h
@@ -71,6 +71,14 @@ public:
 
 	const FileInfo& GetFileInfo();
 
+	struct CodeAddressInfoU32 {
+		uint32_t default_val;
+		size_t code_offset;
+		std::vector<uint8_t> pre_data, post_data;
+	};
+
+	std::map<Player::GameConstantType, int32_t> GetOverridenGameConstants();
+
 private:
 	// Bounds-checked unaligned reader primitives.
 	// In case of out-of-bounds, returns 0 - this will usually result in a harmless error at some other level,
@@ -86,6 +94,8 @@ private:
 	// 0 if resource section was unfindable.
 	uint32_t resource_ofs = 0;
 	uint32_t resource_rva = 0;
+
+	uint32_t code_ofs = 0;
 
 	FileInfo file_info;
 	Filesystem_Stream::InputStream corefile;

--- a/src/exe_reader.h
+++ b/src/exe_reader.h
@@ -71,12 +71,6 @@ public:
 
 	const FileInfo& GetFileInfo();
 
-	struct CodeAddressInfoU32 {
-		uint32_t default_val;
-		size_t code_offset;
-		std::vector<uint8_t> pre_data, post_data;
-	};
-
 	std::map<Player::GameConstantType, int32_t> GetOverridenGameConstants();
 
 private:

--- a/src/exe_reader.h
+++ b/src/exe_reader.h
@@ -64,6 +64,8 @@ public:
 		uint32_t geep_size = 0;
 		MachineType machine_type = MachineType::Unknown;
 		bool is_easyrpg_player = false;
+		uint32_t code_ofs = 0;
+		uint32_t entrypoint = 0;
 
 		int GetEngineType(bool& is_maniac_patch) const;
 		void Print() const;
@@ -88,8 +90,6 @@ private:
 	// 0 if resource section was unfindable.
 	uint32_t resource_ofs = 0;
 	uint32_t resource_rva = 0;
-
-	uint32_t code_ofs = 0;
 
 	FileInfo file_info;
 	Filesystem_Stream::InputStream corefile;

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -43,14 +43,6 @@ int Game_Actor::MaxSpValue() const {
 	return Player::Constants::MaxActorSpValue();
 }
 
-int Game_Actor::MaxStatBattleValue() const {
-	return Player::Constants::MaxStatBattleValue();
-}
-
-int Game_Actor::MaxStatBaseValue() const {
-	return Player::Constants::MaxStatBaseValue();
-}
-
 int Game_Actor::MaxExpValue() const {
 	return Player::Constants::MaxExpValue();
 }
@@ -488,7 +480,7 @@ int Game_Actor::GetBaseAtk(Weapon weapon, bool mod, bool equip) const {
 		ForEachEquipment<true,true>(GetWholeEquipment(), [&](auto& item) { n += item.atk_points1; }, weapon);
 	}
 
-	return Utils::Clamp(n, 1, MaxStatBaseValue());
+	return Utils::Clamp(n, 1, Player::Constants::MaxAtkBaseValue());
 }
 
 int Game_Actor::GetBaseAtk(Weapon weapon) const {
@@ -511,7 +503,7 @@ int Game_Actor::GetBaseDef(Weapon weapon, bool mod, bool equip) const {
 		ForEachEquipment<true,true>(GetWholeEquipment(), [&](auto& item) { n += item.def_points1; }, weapon);
 	}
 
-	return Utils::Clamp(n, 1, MaxStatBaseValue());
+	return Utils::Clamp(n, 1, Player::Constants::MaxDefBaseValue());
 }
 
 int Game_Actor::GetBaseDef(Weapon weapon) const {
@@ -534,7 +526,7 @@ int Game_Actor::GetBaseSpi(Weapon weapon, bool mod, bool equip) const {
 		ForEachEquipment<true,true>(GetWholeEquipment(), [&](auto& item) { n += item.spi_points1; }, weapon);
 	}
 
-	return Utils::Clamp(n, 1, MaxStatBaseValue());
+	return Utils::Clamp(n, 1, Player::Constants::MaxSpiBaseValue());
 }
 
 int Game_Actor::GetBaseSpi(Weapon weapon) const {
@@ -557,7 +549,7 @@ int Game_Actor::GetBaseAgi(Weapon weapon, bool mod, bool equip) const {
 		ForEachEquipment<true,true>(GetWholeEquipment(), [&](auto& item) { n += item.agi_points1; }, weapon);
 	}
 
-	return Utils::Clamp(n, 1, MaxStatBaseValue());
+	return Utils::Clamp(n, 1, Player::Constants::MaxAgiBaseValue());
 }
 
 int Game_Actor::GetBaseAgi(Weapon weapon) const {
@@ -1134,11 +1126,6 @@ static int ClampMaxSpMod(int sp, const Game_Actor* actor) {
 	return Utils::Clamp(sp, -limit, limit);
 }
 
-static int ClampStatMod(int value, const Game_Actor* actor) {
-	auto limit = actor->MaxStatBaseValue();
-	return Utils::Clamp(value, -limit, limit);
-}
-
 void Game_Actor::SetBaseMaxHp(int maxhp) {
 	int new_hp_mod = data.hp_mod + (maxhp - GetBaseMaxHp());
 	data.hp_mod = ClampMaxHpMod(new_hp_mod, this);
@@ -1165,22 +1152,22 @@ int Game_Actor::SetSp(int sp) {
 
 void Game_Actor::SetBaseAtk(int atk) {
 	int new_attack_mod = data.attack_mod + (atk - GetBaseAtk());
-	data.attack_mod = ClampStatMod(new_attack_mod, this);
+	data.attack_mod = Utils::Clamp(new_attack_mod, -Player::Constants::MaxAtkBaseValue(), Player::Constants::MaxAtkBaseValue());
 }
 
 void Game_Actor::SetBaseDef(int def) {
 	int new_defense_mod = data.defense_mod + (def - GetBaseDef());
-	data.defense_mod = ClampStatMod(new_defense_mod, this);
+	data.defense_mod = Utils::Clamp(new_defense_mod, -Player::Constants::MaxDefBaseValue(), Player::Constants::MaxDefBaseValue());
 }
 
 void Game_Actor::SetBaseSpi(int spi) {
 	int new_spirit_mod = data.spirit_mod + (spi - GetBaseSpi());
-	data.spirit_mod = ClampStatMod(new_spirit_mod, this);
+	data.spirit_mod = Utils::Clamp(new_spirit_mod, -Player::Constants::MaxSpiBaseValue(), Player::Constants::MaxSpiBaseValue());
 }
 
 void Game_Actor::SetBaseAgi(int agi) {
 	int new_agility_mod = data.agility_mod + (agi - GetBaseAgi());
-	data.agility_mod = ClampStatMod(new_agility_mod, this);
+	data.agility_mod = Utils::Clamp(new_agility_mod, -Player::Constants::MaxAgiBaseValue(), Player::Constants::MaxAgiBaseValue());
 }
 
 Game_Actor::RowType Game_Actor::GetBattleRow() const {

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -35,47 +35,24 @@
 #include "rand.h"
 #include "algo.h"
 
-constexpr int max_level_2k = 50;
-constexpr int max_level_2k3 = 99;
-
 int Game_Actor::MaxHpValue() const {
-	auto& val = lcf::Data::system.easyrpg_max_actor_hp;
-	if (val == -1) {
-		return Player::IsRPG2k() ? 999 : 9999;
-	}
-	return val;
+	return Player::Constants::MaxActorHpValue();
 }
 
 int Game_Actor::MaxSpValue() const {
-	auto& val = lcf::Data::system.easyrpg_max_actor_sp;
-	if (val == -1) {
-		return 999;
-	}
-	return val;
+	return Player::Constants::MaxActorSpValue();
 }
 
 int Game_Actor::MaxStatBattleValue() const {
-	auto& val = lcf::Data::system.easyrpg_max_stat_battle_value;
-	if (val == -1) {
-		return 9999;
-	}
-	return val;
+	return Player::Constants::MaxStatBattleValue();
 }
 
 int Game_Actor::MaxStatBaseValue() const {
-	auto& val = lcf::Data::system.easyrpg_max_stat_base_value;
-	if (val == -1) {
-		return 999;
-	}
-	return val;
+	return Player::Constants::MaxStatBaseValue();
 }
 
 int Game_Actor::MaxExpValue() const {
-	auto& val = lcf::Data::system.easyrpg_max_exp;
-	if (val == -1) {
-		return Player::IsRPG2k() ? 999999 : 9999999;
-	}
-	return val;
+	return Player::Constants::MaxExpValue();
 }
 
 Game_Actor::Game_Actor(int actor_id) {
@@ -744,11 +721,7 @@ int Game_Actor::GetAccessoryId() const {
 }
 
 int Game_Actor::GetMaxLevel() const {
-	int max_level = Player::IsRPG2k() ? max_level_2k : max_level_2k3;
-	if (lcf::Data::system.easyrpg_max_level > -1) {
-		max_level = lcf::Data::system.easyrpg_max_level;
-	}
-	return Utils::Clamp<int32_t>(max_level, 1, dbActor->final_level);
+	return Utils::Clamp<int32_t>(Player::Constants::MaxLevel(), 1, dbActor->final_level);
 }
 
 void Game_Actor::SetExp(int _exp) {

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -55,10 +55,6 @@ public:
 
 	int MaxSpValue() const override;
 
-	int MaxStatBattleValue() const override;
-
-	int MaxStatBaseValue() const override;
-
 	int MaxExpValue() const;
 
 	virtual PermanentStates GetPermanentStates() const override;

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -425,7 +425,7 @@ public:
 
 	/**
 	 * Sets exp of actor.
-	 * The value is adjusted to the boundary 0 up 999999.
+	 * The value is adjusted to the boundary 0 up to a maximum (dependent on engine type & patch).
 	 * Other actor attributes are not altered. Use ChangeExp to do a proper
 	 * experience change.
 	 *

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -52,7 +52,7 @@
 #include "feature.h"
 
 static inline int MaxDamageValue() {
-	return lcf::Data::system.easyrpg_max_damage == -1 ? (Player::IsRPG2k() ? 999 : 9999) : lcf::Data::system.easyrpg_max_damage;
+	return Player::Constants::MaxDamageValue();
 }
 
 Game_BattleAlgorithm::AlgorithmBase::AlgorithmBase(Type ty, Game_Battler* source, Game_Battler* target) :

--- a/src/game_battler.cpp
+++ b/src/game_battler.cpp
@@ -544,35 +544,35 @@ static int AdjustParam(int base, int mod, int maxval, Span<const int16_t> states
 }
 
 int Game_Battler::CalcValueAfterAtkStates(int value) const {
-	return AdjustParam(value, 0, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_attack);
+	return AdjustParam(value, 0, Player::Constants::MaxAtkBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_attack);
 }
 
 int Game_Battler::CalcValueAfterDefStates(int value) const {
-	return AdjustParam(value, 0, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_defense);
+	return AdjustParam(value, 0, Player::Constants::MaxDefBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_defense);
 }
 
 int Game_Battler::CalcValueAfterSpiStates(int value) const {
-	return AdjustParam(value, 0, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_spirit);
+	return AdjustParam(value, 0, Player::Constants::MaxSpiBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_spirit);
 }
 
 int Game_Battler::CalcValueAfterAgiStates(int value) const {
-	return AdjustParam(value, 0, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_agility);
+	return AdjustParam(value, 0, Player::Constants::MaxAgiBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_agility);
 }
 
 int Game_Battler::GetAtk(Weapon weapon) const {
-	return AdjustParam(GetBaseAtk(weapon), atk_modifier, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_attack);
+	return AdjustParam(GetBaseAtk(weapon), atk_modifier, Player::Constants::MaxAtkBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_attack);
 }
 
 int Game_Battler::GetDef(Weapon weapon) const {
-	return AdjustParam(GetBaseDef(weapon), def_modifier, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_defense);
+	return AdjustParam(GetBaseDef(weapon), def_modifier, Player::Constants::MaxDefBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_defense);
 }
 
 int Game_Battler::GetSpi(Weapon weapon) const {
-	return AdjustParam(GetBaseSpi(weapon), spi_modifier, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_spirit);
+	return AdjustParam(GetBaseSpi(weapon), spi_modifier, Player::Constants::MaxSpiBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_spirit);
 }
 
 int Game_Battler::GetAgi(Weapon weapon) const {
-	return AdjustParam(GetBaseAgi(weapon), agi_modifier, MaxStatBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_agility);
+	return AdjustParam(GetBaseAgi(weapon), agi_modifier, Player::Constants::MaxAgiBattleValue(), GetInflictedStates(), &lcf::rpg::State::affect_agility);
 }
 
 int Game_Battler::GetDisplayX() const {

--- a/src/game_battler.h
+++ b/src/game_battler.h
@@ -77,10 +77,6 @@ public:
 
 	virtual int MaxSpValue() const = 0;
 
-	virtual int MaxStatBattleValue() const = 0;
-
-	virtual int MaxStatBaseValue() const = 0;
-
 	/**
 	 * Gets if battler has a state.
 	 *

--- a/src/game_config_game.cpp
+++ b/src/game_config_game.cpp
@@ -78,6 +78,16 @@ void Game_ConfigGame::LoadFromArgs(CmdlineParser& cp) {
 			}
 			continue;
 		}
+		if (cp.ParseNext(arg, 1, "--engine-path")) {
+			if (arg.NumValues() > 0) {
+				std::string path = arg.Value(0);
+				path = FileFinder::MakeCanonical(path, 0);
+				if (!path.empty()) {
+					engine_path.Set(path);
+				}
+			}
+			continue;
+		}
 		if (cp.ParseNext(arg, 0, "--no-patch")) {
 			patch_support.Set(false);
 			patch_dynrpg.Lock(false);
@@ -192,6 +202,7 @@ void Game_ConfigGame::LoadFromStream(Filesystem_Stream::InputStream& is) {
 
 	new_game.FromIni(ini);
 	engine_str.FromIni(ini);
+	engine_path.FromIni(ini);
 	fake_resolution.FromIni(ini);
 
 	if (patch_easyrpg.FromIni(ini)) {

--- a/src/game_config_game.h
+++ b/src/game_config_game.h
@@ -37,6 +37,7 @@ struct Game_ConfigGame {
 
 	BoolConfigParam new_game{ "Start new game", "Skips the title screen and starts a new game directly", "Game", "NewGame", false };
 	StringConfigParam engine_str{ "Engine", "", "Game", "Engine", std::string() };
+	StringConfigParam engine_path{ "Engine Path", "Sets the executable to be used by the engine auto-detection", "Game", "EnginePath", std::string() };
 	BoolConfigParam fake_resolution{ "Fake Metrics", "Makes games run on higher resolutions (with some success)", "Game", "FakeResolution", false };
 	BoolConfigParam patch_easyrpg{ "EasyRPG", "EasyRPG Engine Extensions", "Patch", "EasyRPG", false };
 	BoolConfigParam patch_destiny{ "Destiny Patch", "", "Patch", "Destiny", false };

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -55,14 +55,6 @@ int Game_Enemy::MaxSpValue() const {
 	return Player::Constants::MaxEnemySpValue();
 }
 
-int Game_Enemy::MaxStatBattleValue() const {
-	return Player::Constants::MaxStatBattleValue();
-}
-
-int Game_Enemy::MaxStatBaseValue() const {
-	return Player::Constants::MaxStatBaseValue();
-}
-
 int Game_Enemy::GetStateProbability(int state_id) const {
 	int rate = 1; // Enemies have only B as the default state rank
 

--- a/src/game_enemy.cpp
+++ b/src/game_enemy.cpp
@@ -48,35 +48,19 @@ Game_Enemy::Game_Enemy(const lcf::rpg::TroopMember* member)
 }
 
 int Game_Enemy::MaxHpValue() const {
-	auto& val = lcf::Data::system.easyrpg_max_enemy_hp;
-	if (val == -1) {
-		return Player::IsRPG2k() ? 9999 : 99999;
-	}
-	return val;
+	return Player::Constants::MaxEnemyHpValue();
 }
 
 int Game_Enemy::MaxSpValue() const {
-	auto& val = lcf::Data::system.easyrpg_max_enemy_sp;
-	if (val == -1) {
-		return 9999;
-	}
-	return val;
+	return Player::Constants::MaxEnemySpValue();
 }
 
 int Game_Enemy::MaxStatBattleValue() const {
-	auto& val = lcf::Data::system.easyrpg_max_stat_battle_value;
-	if (val == -1) {
-		return 9999;
-	}
-	return val;
+	return Player::Constants::MaxStatBattleValue();
 }
 
 int Game_Enemy::MaxStatBaseValue() const {
-	auto& val = lcf::Data::system.easyrpg_max_stat_base_value;
-	if (val == -1) {
-		return 999;
-	}
-	return val;
+	return Player::Constants::MaxStatBaseValue();
 }
 
 int Game_Enemy::GetStateProbability(int state_id) const {

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -41,10 +41,6 @@ public:
 
 	int MaxSpValue() const override;
 
-	int MaxStatBattleValue() const override;
-
-	int MaxStatBaseValue() const override;
-
 	Point GetOriginalPosition() const override;
 
 	void ResetBattle() override;

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -161,7 +161,7 @@ int Game_Party::GetItemTotalCount(int item_id) const {
 int Game_Party::GetMaxItemCount(int item_id) const {
 	const lcf::rpg::Item* item = lcf::ReaderUtil::GetElement(lcf::Data::items, item_id);
 	if (!item || item->easyrpg_max_count == -1) {
-		return (lcf::Data::system.easyrpg_max_item_count == -1 ? 99 : lcf::Data::system.easyrpg_max_item_count);
+		return Player::Constants::MaxItemCount();
 	} else {
 		return item->easyrpg_max_count;
 	}
@@ -169,12 +169,12 @@ int Game_Party::GetMaxItemCount(int item_id) const {
 
 void Game_Party::GainGold(int n) {
 	data.gold = data.gold + n;
-	data.gold = std::min<int32_t>(std::max<int32_t>(data.gold, 0), 999999);
+	data.gold = std::min<int32_t>(std::max<int32_t>(data.gold, 0), Player::Constants::MaxGoldValue());
 }
 
 void Game_Party::LoseGold(int n) {
 	data.gold = data.gold - n;
-	data.gold = std::min<int32_t>(std::max<int32_t>(data.gold, 0), 999999);
+	data.gold = std::min<int32_t>(std::max<int32_t>(data.gold, 0), Player::Constants::MaxGoldValue());
 }
 
 void Game_Party::AddItem(int item_id, int amount) {

--- a/src/game_variables.h
+++ b/src/game_variables.h
@@ -34,10 +34,10 @@ public:
 	using Variables_t = std::vector<Var_t>;
 
 	static constexpr int max_warnings = 10;
-	static constexpr Var_t min_2k = -999999;
-	static constexpr Var_t max_2k = 999999;
-	static constexpr Var_t min_2k3 = -9999999;
-	static constexpr Var_t max_2k3 = 9999999;
+	static constexpr Var_t min_2k = -999'999;
+	static constexpr Var_t max_2k = 999'999;
+	static constexpr Var_t min_2k3 = -9'999'999;
+	static constexpr Var_t max_2k3 = 9'999'999;
 
 	Game_Variables(Var_t minval, Var_t maxval);
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -892,22 +892,9 @@ void Player::ResetGameObjects() {
 	Main_Data::game_switches = std::make_unique<Game_Switches>();
 	Main_Data::game_switches->SetLowerLimit(lcf::Data::switches.size());
 
-	auto min_var = lcf::Data::system.easyrpg_variable_min_value;
-	if (min_var == 0) {
-		if ((Player::game_config.patch_maniac.Get() & 1) == 1) {
-			min_var = std::numeric_limits<Game_Variables::Var_t>::min();
-		} else {
-			min_var = Player::IsRPG2k3() ? Game_Variables::min_2k3 : Game_Variables::min_2k;
-		}
-	}
-	auto max_var = lcf::Data::system.easyrpg_variable_max_value;
-	if (max_var == 0) {
-		if ((Player::game_config.patch_maniac.Get() & 1) == 1) {
-			max_var = std::numeric_limits<Game_Variables::Var_t>::max();
-		} else {
-			max_var = Player::IsRPG2k3() ? Game_Variables::max_2k3 : Game_Variables::max_2k;
-		}
-	}
+	int32_t min_var, max_var;
+	Player::Constants::GetVariableLimits(min_var, max_var);
+
 	Main_Data::game_variables = std::make_unique<Game_Variables>(min_var, max_var);
 	Main_Data::game_variables->SetLowerLimit(lcf::Data::variables.size());
 
@@ -1596,4 +1583,107 @@ int Player::EngineVersion() {
 std::string Player::GetEngineVersion() {
 	if (EngineVersion() > 0) return std::to_string(EngineVersion());
 	return std::string();
+}
+
+void Player::Constants::GetVariableLimits(Var_t& min_var, Var_t& max_var) {
+	min_var = lcf::Data::system.easyrpg_variable_min_value;
+	if (min_var == 0) {
+		if (Player::IsPatchManiac()) {
+			min_var = std::numeric_limits<Game_Variables::Var_t>::min();
+		} else {
+			min_var = Player::IsRPG2k3() ? Game_Variables::min_2k3 : Game_Variables::min_2k;
+		}
+	}
+	max_var = lcf::Data::system.easyrpg_variable_max_value;
+	if (max_var == 0) {
+		if (Player::IsPatchManiac()) {
+			max_var = std::numeric_limits<Game_Variables::Var_t>::max();
+		} else {
+			max_var = Player::IsRPG2k3() ? Game_Variables::max_2k3 : Game_Variables::max_2k;
+		}
+	}
+}
+
+int32_t Player::Constants::MaxActorHpValue() {
+	auto& val = lcf::Data::system.easyrpg_max_actor_hp;
+	if (val == -1) {
+		return Player::IsRPG2k() ? 999 : 9'999;
+	}
+	return val;
+}
+
+int32_t Player::Constants::MaxActorSpValue() {
+	auto& val = lcf::Data::system.easyrpg_max_actor_sp;
+	if (val == -1) {
+		return 999;
+	}
+	return val;
+}
+
+int32_t Player::Constants::MaxEnemyHpValue() {
+	auto& val = lcf::Data::system.easyrpg_max_enemy_hp;
+	if (val == -1) {
+		return Player::IsRPG2k() ? 9'999 : 99'999;
+	}
+	return val;
+}
+
+int32_t Player::Constants::MaxEnemySpValue() {
+	auto& val = lcf::Data::system.easyrpg_max_enemy_sp;
+	if (val == -1) {
+		return 9'999;
+	}
+	return val;
+}
+
+int32_t Player::Constants::MaxStatBaseValue() {
+	auto& val = lcf::Data::system.easyrpg_max_stat_base_value;
+	if (val == -1) {
+		return 999;
+	}
+	return val;
+}
+
+int32_t Player::Constants::MaxStatBattleValue() {
+	auto& val = lcf::Data::system.easyrpg_max_stat_battle_value;
+	if (val == -1) {
+		return 9'999;
+	}
+	return val;
+}
+
+int32_t Player::Constants::MaxDamageValue() {
+	auto& val = lcf::Data::system.easyrpg_max_damage;
+	if (val == -1) {
+		return (Player::IsRPG2k() ? 999 : 9'999);
+	}
+	return val;
+}
+
+int32_t Player::Constants::MaxExpValue() {
+	auto& val = lcf::Data::system.easyrpg_max_exp;
+	if (val == -1) {
+		return Player::IsRPG2k() ? 999'999 : 9'999'999;
+	}
+	return val;
+}
+
+int32_t Player::Constants::MaxLevel() {
+	int max_level = Player::IsRPG2k() ? max_level_2k : max_level_2k3;
+	if (lcf::Data::system.easyrpg_max_level > -1) {
+		max_level = lcf::Data::system.easyrpg_max_level;
+	}
+	return max_level;
+}
+
+int32_t Player::Constants::MaxGoldValue() {
+	return 999'999;
+}
+
+int32_t Player::Constants::MaxItemCount() {
+	return (lcf::Data::system.easyrpg_max_item_count == -1 ? 99 : lcf::Data::system.easyrpg_max_item_count);
+}
+
+int32_t Player::Constants::MaxSaveFiles() {
+	return Utils::Clamp<int32_t>(lcf::Data::system.easyrpg_max_savefiles, 3, 99);
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1625,7 +1625,7 @@ void Player::Constants::GetVariableLimits(Var_t& min_var, Var_t& max_var) {
 		}
 	}
 	max_var = lcf::Data::system.easyrpg_variable_max_value;
-	TryGetOverriddenConstant(GameConstantType::MaxVarLimit, min_var);
+	TryGetOverriddenConstant(GameConstantType::MaxVarLimit, max_var);
 	if (max_var == 0) {
 		if (Player::IsPatchManiac()) {
 			max_var = std::numeric_limits<Game_Variables::Var_t>::max();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1586,10 +1586,16 @@ std::string Player::GetEngineVersion() {
 }
 
 void Player::Constants::GetVariableLimits(Var_t& min_var, Var_t& max_var) {
+
+	static constexpr Var_t min_2k3_patch_italiano = -999'999'999;
+	static constexpr Var_t max_2k3_patch_italiano = 999'999'999;
+
 	min_var = lcf::Data::system.easyrpg_variable_min_value;
 	if (min_var == 0) {
 		if (Player::IsPatchManiac()) {
 			min_var = std::numeric_limits<Game_Variables::Var_t>::min();
+		} else if (Player::IsPatchItalian()) {
+			min_var = min_2k3_patch_italiano;
 		} else {
 			min_var = Player::IsRPG2k3() ? Game_Variables::min_2k3 : Game_Variables::min_2k;
 		}
@@ -1598,6 +1604,8 @@ void Player::Constants::GetVariableLimits(Var_t& min_var, Var_t& max_var) {
 	if (max_var == 0) {
 		if (Player::IsPatchManiac()) {
 			max_var = std::numeric_limits<Game_Variables::Var_t>::max();
+		} else if (Player::IsPatchItalian()) {
+			max_var = max_2k3_patch_italiano;
 		} else {
 			max_var = Player::IsRPG2k3() ? Game_Variables::max_2k3 : Game_Variables::max_2k;
 		}
@@ -1623,6 +1631,9 @@ int32_t Player::Constants::MaxActorSpValue() {
 int32_t Player::Constants::MaxEnemyHpValue() {
 	auto& val = lcf::Data::system.easyrpg_max_enemy_hp;
 	if (val == -1) {
+		if (Player::IsPatchItalian()) {
+			return 999'999'999;
+		}
 		return Player::IsRPG2k() ? 9'999 : 99'999;
 	}
 	return val;
@@ -1631,6 +1642,9 @@ int32_t Player::Constants::MaxEnemyHpValue() {
 int32_t Player::Constants::MaxEnemySpValue() {
 	auto& val = lcf::Data::system.easyrpg_max_enemy_sp;
 	if (val == -1) {
+		if (Player::IsPatchItalian()) {
+			return 999'999'999;
+		}
 		return 9'999;
 	}
 	return val;
@@ -1639,6 +1653,9 @@ int32_t Player::Constants::MaxEnemySpValue() {
 int32_t Player::Constants::MaxStatBaseValue() {
 	auto& val = lcf::Data::system.easyrpg_max_stat_base_value;
 	if (val == -1) {
+		if (Player::IsPatchItalian()) {
+			return 9'999;
+		}
 		return 999;
 	}
 	return val;
@@ -1655,6 +1672,9 @@ int32_t Player::Constants::MaxStatBattleValue() {
 int32_t Player::Constants::MaxDamageValue() {
 	auto& val = lcf::Data::system.easyrpg_max_damage;
 	if (val == -1) {
+		if (Player::IsPatchItalian()) {
+			return 99'999;
+		}
 		return (Player::IsRPG2k() ? 999 : 9'999);
 	}
 	return val;
@@ -1677,6 +1697,9 @@ int32_t Player::Constants::MaxLevel() {
 }
 
 int32_t Player::Constants::MaxGoldValue() {
+	if (Player::IsPatchItalian()) {
+		return 9'999'999;
+	}
 	return 999'999;
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -844,7 +844,7 @@ void Player::CreateGameObjects() {
 
 	Constants::ResetOverrides();
 	if (game_constant_overrides.size() > 0) {
-		for (auto it = game_constant_overrides.begin(); it != game_constant_overrides.end();) {
+		for (auto it = game_constant_overrides.begin(); it != game_constant_overrides.end();++it) {
 			Constants::OverrideGameConstant(it->first, it->second);
 		}
 		Constants::PrintActiveOverrides();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1679,23 +1679,86 @@ int32_t Player::Constants::MaxEnemySpValue() {
 	return val;
 }
 
-int32_t Player::Constants::MaxStatBaseValue() {
+int32_t Player::Constants::MaxAtkBaseValue() {
 	auto& val = lcf::Data::system.easyrpg_max_stat_base_value;
-	TryGetOverriddenConstant(GameConstantType::MaxStatBaseValue, val);
+	TryGetOverriddenConstant(GameConstantType::MaxAtkBaseValue, val);
 	if (val == -1) {
 		if (Player::IsPatchItalian()) {
 			return 9'999;
 		}
-		return 999;
+		return max_stat_base_value;
 	}
 	return val;
 }
 
-int32_t Player::Constants::MaxStatBattleValue() {
-	auto& val = lcf::Data::system.easyrpg_max_stat_battle_value;
-	TryGetOverriddenConstant(GameConstantType::MaxStatBattleValue, val);
+int32_t Player::Constants::MaxDefBaseValue() {
+	auto& val = lcf::Data::system.easyrpg_max_stat_base_value;
+	TryGetOverriddenConstant(GameConstantType::MaxDefBaseValue, val);
 	if (val == -1) {
-		return 9'999;
+		if (Player::IsPatchItalian()) {
+			return 9'999;
+		}
+		return max_stat_base_value;
+	}
+	return val;
+}
+
+int32_t Player::Constants::MaxSpiBaseValue() {
+	auto& val = lcf::Data::system.easyrpg_max_stat_base_value;
+	TryGetOverriddenConstant(GameConstantType::MaxSpiBaseValue, val);
+	if (val == -1) {
+		if (Player::IsPatchItalian()) {
+			return 9'999;
+		}
+		return max_stat_base_value;
+	}
+	return val;
+}
+
+int32_t Player::Constants::MaxAgiBaseValue() {
+	auto& val = lcf::Data::system.easyrpg_max_stat_base_value;
+	TryGetOverriddenConstant(GameConstantType::MaxAgiBaseValue, val);
+	if (val == -1) {
+		if (Player::IsPatchItalian()) {
+			return 9'999;
+		}
+		return max_stat_base_value;
+	}
+	return val;
+}
+
+int32_t Player::Constants::MaxAtkBattleValue() {
+	auto& val = lcf::Data::system.easyrpg_max_stat_battle_value;
+	TryGetOverriddenConstant(GameConstantType::MaxAtkBattleValue, val);
+	if (val == -1) {
+		return max_stat_battle_value;
+	}
+	return val;
+}
+
+int32_t Player::Constants::MaxDefBattleValue() {
+	auto& val = lcf::Data::system.easyrpg_max_stat_battle_value;
+	TryGetOverriddenConstant(GameConstantType::MaxDefBattleValue, val);
+	if (val == -1) {
+		return max_stat_battle_value;
+	}
+	return val;
+}
+
+int32_t Player::Constants::MaxSpiBattleValue() {
+	auto& val = lcf::Data::system.easyrpg_max_stat_battle_value;
+	TryGetOverriddenConstant(GameConstantType::MaxSpiBattleValue, val);
+	if (val == -1) {
+		return max_stat_battle_value;
+	}
+	return val;
+}
+
+int32_t Player::Constants::MaxAgiBattleValue() {
+	auto& val = lcf::Data::system.easyrpg_max_stat_battle_value;
+	TryGetOverriddenConstant(GameConstantType::MaxAgiBattleValue, val);
+	if (val == -1) {
+		return max_stat_battle_value;
 	}
 	return val;
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1585,12 +1585,17 @@ std::string Player::GetEngineVersion() {
 	return std::string();
 }
 
+namespace Player::Constants {
+	std::map<GameConstantType, int32_t> constant_overrides;
+}
+
 void Player::Constants::GetVariableLimits(Var_t& min_var, Var_t& max_var) {
 
 	static constexpr Var_t min_2k3_patch_italiano = -999'999'999;
 	static constexpr Var_t max_2k3_patch_italiano = 999'999'999;
 
 	min_var = lcf::Data::system.easyrpg_variable_min_value;
+	TryGetOverriddenConstant(GameConstantType::MinVarLimit, min_var);
 	if (min_var == 0) {
 		if (Player::IsPatchManiac()) {
 			min_var = std::numeric_limits<Game_Variables::Var_t>::min();
@@ -1601,6 +1606,7 @@ void Player::Constants::GetVariableLimits(Var_t& min_var, Var_t& max_var) {
 		}
 	}
 	max_var = lcf::Data::system.easyrpg_variable_max_value;
+	TryGetOverriddenConstant(GameConstantType::MaxVarLimit, min_var);
 	if (max_var == 0) {
 		if (Player::IsPatchManiac()) {
 			max_var = std::numeric_limits<Game_Variables::Var_t>::max();
@@ -1614,6 +1620,7 @@ void Player::Constants::GetVariableLimits(Var_t& min_var, Var_t& max_var) {
 
 int32_t Player::Constants::MaxActorHpValue() {
 	auto& val = lcf::Data::system.easyrpg_max_actor_hp;
+	TryGetOverriddenConstant(GameConstantType::MaxActorHP, val);
 	if (val == -1) {
 		return Player::IsRPG2k() ? 999 : 9'999;
 	}
@@ -1622,6 +1629,7 @@ int32_t Player::Constants::MaxActorHpValue() {
 
 int32_t Player::Constants::MaxActorSpValue() {
 	auto& val = lcf::Data::system.easyrpg_max_actor_sp;
+	TryGetOverriddenConstant(GameConstantType::MaxActorSP, val);
 	if (val == -1) {
 		return 999;
 	}
@@ -1630,6 +1638,7 @@ int32_t Player::Constants::MaxActorSpValue() {
 
 int32_t Player::Constants::MaxEnemyHpValue() {
 	auto& val = lcf::Data::system.easyrpg_max_enemy_hp;
+	TryGetOverriddenConstant(GameConstantType::MaxEnemyHP, val);
 	if (val == -1) {
 		if (Player::IsPatchItalian()) {
 			return 999'999'999;
@@ -1641,6 +1650,7 @@ int32_t Player::Constants::MaxEnemyHpValue() {
 
 int32_t Player::Constants::MaxEnemySpValue() {
 	auto& val = lcf::Data::system.easyrpg_max_enemy_sp;
+	TryGetOverriddenConstant(GameConstantType::MaxEnemySP, val);
 	if (val == -1) {
 		if (Player::IsPatchItalian()) {
 			return 999'999'999;
@@ -1652,6 +1662,7 @@ int32_t Player::Constants::MaxEnemySpValue() {
 
 int32_t Player::Constants::MaxStatBaseValue() {
 	auto& val = lcf::Data::system.easyrpg_max_stat_base_value;
+	TryGetOverriddenConstant(GameConstantType::MaxStatBaseValue, val);
 	if (val == -1) {
 		if (Player::IsPatchItalian()) {
 			return 9'999;
@@ -1663,6 +1674,7 @@ int32_t Player::Constants::MaxStatBaseValue() {
 
 int32_t Player::Constants::MaxStatBattleValue() {
 	auto& val = lcf::Data::system.easyrpg_max_stat_battle_value;
+	TryGetOverriddenConstant(GameConstantType::MaxStatBattleValue, val);
 	if (val == -1) {
 		return 9'999;
 	}
@@ -1671,6 +1683,7 @@ int32_t Player::Constants::MaxStatBattleValue() {
 
 int32_t Player::Constants::MaxDamageValue() {
 	auto& val = lcf::Data::system.easyrpg_max_damage;
+	TryGetOverriddenConstant(GameConstantType::MaxDamageValue, val);
 	if (val == -1) {
 		if (Player::IsPatchItalian()) {
 			return 99'999;
@@ -1682,6 +1695,7 @@ int32_t Player::Constants::MaxDamageValue() {
 
 int32_t Player::Constants::MaxExpValue() {
 	auto& val = lcf::Data::system.easyrpg_max_exp;
+	TryGetOverriddenConstant(GameConstantType::MaxExpValue, val);
 	if (val == -1) {
 		return Player::IsRPG2k() ? 999'999 : 9'999'999;
 	}
@@ -1690,6 +1704,9 @@ int32_t Player::Constants::MaxExpValue() {
 
 int32_t Player::Constants::MaxLevel() {
 	int max_level = Player::IsRPG2k() ? max_level_2k : max_level_2k3;
+	if (TryGetOverriddenConstant(GameConstantType::MaxLevel, max_level)) {
+		return max_level;
+	}
 	if (lcf::Data::system.easyrpg_max_level > -1) {
 		max_level = lcf::Data::system.easyrpg_max_level;
 	}
@@ -1697,16 +1714,42 @@ int32_t Player::Constants::MaxLevel() {
 }
 
 int32_t Player::Constants::MaxGoldValue() {
+	int32_t max_gold = 999'999;
+	if (TryGetOverriddenConstant(GameConstantType::MaxGoldValue, max_gold)) {
+		return max_gold;
+	}
 	if (Player::IsPatchItalian()) {
 		return 9'999'999;
 	}
-	return 999'999;
+	return max_gold;
 }
 
 int32_t Player::Constants::MaxItemCount() {
-	return (lcf::Data::system.easyrpg_max_item_count == -1 ? 99 : lcf::Data::system.easyrpg_max_item_count);
+	int32_t max_item_count = (lcf::Data::system.easyrpg_max_item_count == -1 ? 99 : lcf::Data::system.easyrpg_max_item_count);;
+	TryGetOverriddenConstant(GameConstantType::MaxItemCount, max_item_count);
+	return max_item_count;
 }
 
 int32_t Player::Constants::MaxSaveFiles() {
-	return Utils::Clamp<int32_t>(lcf::Data::system.easyrpg_max_savefiles, 3, 99);
+	int32_t max_savefiles = Utils::Clamp<int32_t>(lcf::Data::system.easyrpg_max_savefiles, 3, 99);
+	TryGetOverriddenConstant(GameConstantType::MaxSaveFiles, max_savefiles);
+	return max_savefiles;
+}
+
+bool Player::Constants::TryGetOverriddenConstant(GameConstantType const_type, int32_t& out_value) {
+	auto it = constant_overrides.find(const_type);
+	if (it != constant_overrides.end()) {
+		out_value = (*it).second;
+	}
+	return it != constant_overrides.end();
+}
+
+void Player::Constants::OverrideGameConstant(GameConstantType const_type, int32_t value) {
+	constant_overrides[const_type] = value;
+}
+
+void Player::Constants::ResetOverrides() {
+	constant_overrides.clear();
+}
+
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -767,7 +767,8 @@ void Player::CreateGameObjects() {
 #ifndef EMSCRIPTEN
 	// Attempt reading ExFont and version information from RPG_RT.exe (not supported on Emscripten)
 	std::unique_ptr<EXEReader> exe_reader;
-	auto exeis = FileFinder::Game().OpenFile(EXE_NAME);
+	const auto exe_file = game_config.engine_path.Get().empty() ? EXE_NAME : game_config.engine_path.Get();
+	auto exeis = FileFinder::Game().OpenFile(exe_file);
 
 	if (exeis) {
 		exe_reader.reset(new EXEReader(std::move(exeis)));
@@ -1414,6 +1415,8 @@ Engine options:
                        rpg2k3     - RPG Maker 2003 (v1.00 - v1.04)
                        rpg2k3v105 - RPG Maker 2003 (v1.05 - v1.09a)
                        rpg2k3e    - RPG Maker 2003 (English release, v1.12)
+ --engine-path EXE    Set a custom path for the executable which is to be used
+                      by the automatic engine detection.
  --font1 FILE         Font to use for the first font. The system graphic of the
                       game determines whether font 1 or 2 is used.
  --font1-size PX      Size of font 1 in pixel. The default is 12.

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -768,6 +768,11 @@ void Player::CreateGameObjects() {
 	// Attempt reading ExFont and version information from RPG_RT.exe (not supported on Emscripten)
 	std::unique_ptr<EXEReader> exe_reader;
 	const auto exe_file = game_config.engine_path.Get().empty() ? EXE_NAME : game_config.engine_path.Get();
+
+	if (!game_config.engine_path.Get().empty()) {
+		Output::Debug("Using specified .EXE '{}' for engine detection", exe_file);
+	}
+
 	auto exeis = FileFinder::Game().OpenFile(exe_file);
 
 	if (exeis) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1610,16 +1610,11 @@ namespace Player::Constants {
 
 void Player::Constants::GetVariableLimits(Var_t& min_var, Var_t& max_var) {
 
-	static constexpr Var_t min_2k3_patch_italiano = -999'999'999;
-	static constexpr Var_t max_2k3_patch_italiano = 999'999'999;
-
 	min_var = lcf::Data::system.easyrpg_variable_min_value;
 	TryGetOverriddenConstant(GameConstantType::MinVarLimit, min_var);
 	if (min_var == 0) {
 		if (Player::IsPatchManiac()) {
 			min_var = std::numeric_limits<Game_Variables::Var_t>::min();
-		} else if (Player::IsPatchItalian()) {
-			min_var = min_2k3_patch_italiano;
 		} else {
 			min_var = Player::IsRPG2k3() ? Game_Variables::min_2k3 : Game_Variables::min_2k;
 		}
@@ -1629,8 +1624,6 @@ void Player::Constants::GetVariableLimits(Var_t& min_var, Var_t& max_var) {
 	if (max_var == 0) {
 		if (Player::IsPatchManiac()) {
 			max_var = std::numeric_limits<Game_Variables::Var_t>::max();
-		} else if (Player::IsPatchItalian()) {
-			max_var = max_2k3_patch_italiano;
 		} else {
 			max_var = Player::IsRPG2k3() ? Game_Variables::max_2k3 : Game_Variables::max_2k;
 		}
@@ -1659,9 +1652,6 @@ int32_t Player::Constants::MaxEnemyHpValue() {
 	auto& val = lcf::Data::system.easyrpg_max_enemy_hp;
 	TryGetOverriddenConstant(GameConstantType::MaxEnemyHP, val);
 	if (val == -1) {
-		if (Player::IsPatchItalian()) {
-			return 999'999'999;
-		}
 		return Player::IsRPG2k() ? 9'999 : 99'999;
 	}
 	return val;
@@ -1671,9 +1661,6 @@ int32_t Player::Constants::MaxEnemySpValue() {
 	auto& val = lcf::Data::system.easyrpg_max_enemy_sp;
 	TryGetOverriddenConstant(GameConstantType::MaxEnemySP, val);
 	if (val == -1) {
-		if (Player::IsPatchItalian()) {
-			return 999'999'999;
-		}
 		return 9'999;
 	}
 	return val;
@@ -1683,9 +1670,6 @@ int32_t Player::Constants::MaxAtkBaseValue() {
 	auto& val = lcf::Data::system.easyrpg_max_stat_base_value;
 	TryGetOverriddenConstant(GameConstantType::MaxAtkBaseValue, val);
 	if (val == -1) {
-		if (Player::IsPatchItalian()) {
-			return 9'999;
-		}
 		return max_stat_base_value;
 	}
 	return val;
@@ -1695,9 +1679,6 @@ int32_t Player::Constants::MaxDefBaseValue() {
 	auto& val = lcf::Data::system.easyrpg_max_stat_base_value;
 	TryGetOverriddenConstant(GameConstantType::MaxDefBaseValue, val);
 	if (val == -1) {
-		if (Player::IsPatchItalian()) {
-			return 9'999;
-		}
 		return max_stat_base_value;
 	}
 	return val;
@@ -1707,9 +1688,6 @@ int32_t Player::Constants::MaxSpiBaseValue() {
 	auto& val = lcf::Data::system.easyrpg_max_stat_base_value;
 	TryGetOverriddenConstant(GameConstantType::MaxSpiBaseValue, val);
 	if (val == -1) {
-		if (Player::IsPatchItalian()) {
-			return 9'999;
-		}
 		return max_stat_base_value;
 	}
 	return val;
@@ -1719,9 +1697,6 @@ int32_t Player::Constants::MaxAgiBaseValue() {
 	auto& val = lcf::Data::system.easyrpg_max_stat_base_value;
 	TryGetOverriddenConstant(GameConstantType::MaxAgiBaseValue, val);
 	if (val == -1) {
-		if (Player::IsPatchItalian()) {
-			return 9'999;
-		}
 		return max_stat_base_value;
 	}
 	return val;
@@ -1767,9 +1742,6 @@ int32_t Player::Constants::MaxDamageValue() {
 	auto& val = lcf::Data::system.easyrpg_max_damage;
 	TryGetOverriddenConstant(GameConstantType::MaxDamageValue, val);
 	if (val == -1) {
-		if (Player::IsPatchItalian()) {
-			return 99'999;
-		}
 		return (Player::IsRPG2k() ? 999 : 9'999);
 	}
 	return val;
@@ -1799,9 +1771,6 @@ int32_t Player::Constants::MaxGoldValue() {
 	int32_t max_gold = 999'999;
 	if (TryGetOverriddenConstant(GameConstantType::MaxGoldValue, max_gold)) {
 		return max_gold;
-	}
-	if (Player::IsPatchItalian()) {
-		return 9'999'999;
 	}
 	return max_gold;
 }

--- a/src/player.h
+++ b/src/player.h
@@ -66,8 +66,17 @@ namespace Player {
 		MaxActorSP,
 		MaxEnemyHP,
 		MaxEnemySP,
-		MaxStatBaseValue,
-		MaxStatBattleValue,
+
+		MaxAtkBaseValue,
+		MaxDefBaseValue,
+		MaxSpiBaseValue,
+		MaxAgiBaseValue,
+
+		MaxAtkBattleValue,
+		MaxDefBattleValue,
+		MaxSpiBattleValue,
+		MaxAgiBattleValue,
+
 		MaxDamageValue,
 		MaxExpValue,
 		MaxLevel,
@@ -94,8 +103,17 @@ namespace Player {
 		"MaxActorSP",
 		"MaxEnemyHP",
 		"MaxEnemySP",
-		"MaxStatBaseValue",
-		"MaxStatBattleValue",
+
+		"MaxAtkBaseValue",
+		"MaxDefBaseValue",
+		"MaxSpiBaseValue",
+		"MaxAgiBaseValue",
+
+		"MaxAtkBattleValue",
+		"MaxDefBattleValue",
+		"MaxSpiBattleValue",
+		"MaxAgiBattleValue",
+
 		"MaxDamageValue",
 		"MaxExpValue",
 		"MaxLevel",
@@ -488,6 +506,11 @@ namespace Player {
 		static constexpr int32_t max_level_2k = 50;
 		static constexpr int32_t max_level_2k3 = 99;
 
+		static constexpr int32_t max_hp_2k = 999;
+		static constexpr int32_t max_hp_2k3 = 9'999;
+		static constexpr int32_t max_stat_base_value = 999;
+		static constexpr int32_t max_stat_battle_value = 9'999;
+
 		void GetVariableLimits(Var_t& min_var, Var_t& max_var);
 
 		int32_t MaxActorHpValue();
@@ -496,8 +519,16 @@ namespace Player {
 		int32_t MaxEnemyHpValue();
 		int32_t MaxEnemySpValue();
 
-		int32_t MaxStatBaseValue();
-		int32_t MaxStatBattleValue();
+		int32_t MaxAtkBaseValue();
+		int32_t MaxDefBaseValue();
+		int32_t MaxSpiBaseValue();
+		int32_t MaxAgiBaseValue();
+
+		int32_t MaxAtkBattleValue();
+		int32_t MaxDefBattleValue();
+		int32_t MaxSpiBattleValue();
+		int32_t MaxAgiBattleValue();
+
 		int32_t MaxDamageValue();
 
 		int32_t MaxExpValue();

--- a/src/player.h
+++ b/src/player.h
@@ -59,6 +59,40 @@ namespace Player {
 		PatchOverride = 1 << 16
 	};
 
+	enum class GameConstantType {
+		MinVarLimit,
+		MaxVarLimit,
+		MaxActorHP,
+		MaxActorSP,
+		MaxEnemyHP,
+		MaxEnemySP,
+		MaxStatBaseValue,
+		MaxStatBattleValue,
+		MaxDamageValue,
+		MaxExpValue,
+		MaxLevel,
+		MaxGoldValue,
+		MaxItemCount,
+		MaxSaveFiles
+	};
+
+	static constexpr auto kGameConstantType = lcf::makeEnumTags<GameConstantType>(
+		"MinVarLimit",
+		"MaxVarLimit",
+		"MaxActorHP",
+		"MaxActorSP",
+		"MaxEnemyHP",
+		"MaxEnemySP",
+		"MaxStatBaseValue",
+		"MaxStatBattleValue",
+		"MaxDamageValue",
+		"MaxExpValue",
+		"MaxLevel",
+		"MaxGoldValue",
+		"MaxItemCount",
+		"MaxSaveFiles"
+	);
+
 	/**
 	 * Initializes EasyRPG Player.
 	 *
@@ -455,6 +489,12 @@ namespace Player {
 		int32_t MaxGoldValue();
 		int32_t MaxItemCount();
 		int32_t MaxSaveFiles();
+
+		extern std::map<GameConstantType, int32_t> constant_overrides;
+
+		bool TryGetOverriddenConstant(GameConstantType const_type, int32_t& out_value);
+		void OverrideGameConstant(GameConstantType const_type, int32_t value);
+		void ResetOverrides();
 	}
 }
 
@@ -535,6 +575,4 @@ inline bool Player::IsPatchItalian() {
 inline bool Player::HasEasyRpgExtensions() {
 	return game_config.patch_easyrpg.Get();
 }
-
-
 #endif

--- a/src/player.h
+++ b/src/player.h
@@ -73,7 +73,18 @@ namespace Player {
 		MaxLevel,
 		MaxGoldValue,
 		MaxItemCount,
-		MaxSaveFiles
+		MaxSaveFiles,
+
+		/** X-coordinate of the title scene command window (HAlign: Center) */
+		TitleX,
+		/** Y-coordinate of the title scene command window (VAlign: Top) */
+		TitleY,
+		/** X-coordinate of the title scene command window when the title graphic is hidden (HAlign: Center) */
+		TitleHiddenX,
+		/** Y-coordinate of the title scene command window when the title graphic is hidden (VAlign: Top) */
+		TitleHiddenY,
+
+		LAST
 	};
 
 	static constexpr auto kGameConstantType = lcf::makeEnumTags<GameConstantType>(
@@ -90,8 +101,14 @@ namespace Player {
 		"MaxLevel",
 		"MaxGoldValue",
 		"MaxItemCount",
-		"MaxSaveFiles"
+		"MaxSaveFiles",
+		"TitleCmdWnd_X",
+		"TitleCmdWnd_Y",
+		"TitleHiddenCmdWnd_X",
+		"TitleHiddenCmdWnd_Y"
 	);
+
+	static_assert(Player::kGameConstantType.size() == static_cast<size_t>(GameConstantType::LAST));
 
 	/**
 	 * Initializes EasyRPG Player.

--- a/src/player.h
+++ b/src/player.h
@@ -298,6 +298,8 @@ namespace Player {
 	 */
 	bool IsPatchDestiny();
 
+	bool IsPatchItalian();
+
 	/**
 	 * @return True when EasyRpg extensions are on
 	 */
@@ -524,8 +526,15 @@ inline bool Player::IsPatchDestiny() {
 	return game_config.patch_destiny.Get();
 }
 
+
+inline bool Player::IsPatchItalian() {
+	return false;
+	//return game_config.patch_italian.Get();
+}
+
 inline bool Player::HasEasyRpgExtensions() {
 	return game_config.patch_easyrpg.Get();
 }
+
 
 #endif

--- a/src/player.h
+++ b/src/player.h
@@ -25,6 +25,7 @@
 #include "game_clock.h"
 #include "game_config.h"
 #include "game_config_game.h"
+#include "game_variables.h"
 #include <vector>
 #include <memory>
 #include <cstdint>
@@ -427,6 +428,32 @@ namespace Player {
 	/** Name of game emscripten uses */
 	extern std::string emscripten_game_name;
 #endif
+
+	namespace Constants {
+		using Var_t = int32_t;
+
+		static constexpr int32_t max_level_2k = 50;
+		static constexpr int32_t max_level_2k3 = 99;
+
+		void GetVariableLimits(Var_t& min_var, Var_t& max_var);
+
+		int32_t MaxActorHpValue();
+		int32_t MaxActorSpValue();
+
+		int32_t MaxEnemyHpValue();
+		int32_t MaxEnemySpValue();
+
+		int32_t MaxStatBaseValue();
+		int32_t MaxStatBattleValue();
+		int32_t MaxDamageValue();
+
+		int32_t MaxExpValue();
+		int32_t MaxLevel();
+
+		int32_t MaxGoldValue();
+		int32_t MaxItemCount();
+		int32_t MaxSaveFiles();
+	}
 }
 
 inline bool Player::IsRPG2k() {

--- a/src/player.h
+++ b/src/player.h
@@ -367,8 +367,6 @@ namespace Player {
 	 */
 	bool IsPatchDestiny();
 
-	bool IsPatchItalian();
-
 	/**
 	 * @return True when EasyRpg extensions are on
 	 */
@@ -613,12 +611,6 @@ inline bool Player::IsPatchKeyPatch() {
 
 inline bool Player::IsPatchDestiny() {
 	return game_config.patch_destiny.Get();
-}
-
-
-inline bool Player::IsPatchItalian() {
-	return false;
-	//return game_config.patch_italian.Get();
 }
 
 inline bool Player::HasEasyRpgExtensions() {

--- a/src/player.h
+++ b/src/player.h
@@ -495,6 +495,7 @@ namespace Player {
 		bool TryGetOverriddenConstant(GameConstantType const_type, int32_t& out_value);
 		void OverrideGameConstant(GameConstantType const_type, int32_t value);
 		void ResetOverrides();
+		void PrintActiveOverrides();
 	}
 }
 

--- a/src/scene_equip.cpp
+++ b/src/scene_equip.cpp
@@ -135,12 +135,10 @@ void Scene_Equip::UpdateStatusWindow() {
 		}
 		add_item(current_item, 1);
 
-		int limit = actor.MaxStatBaseValue();
-
-		atk = Utils::Clamp(atk, 1, limit);
-		def = Utils::Clamp(def, 1, limit);
-		spi = Utils::Clamp(spi, 1, limit);
-		agi = Utils::Clamp(agi, 1, limit);
+		atk = Utils::Clamp(atk, 1, Player::Constants::MaxAtkBaseValue());
+		def = Utils::Clamp(def, 1, Player::Constants::MaxDefBaseValue());
+		spi = Utils::Clamp(spi, 1, Player::Constants::MaxSpiBaseValue());
+		agi = Utils::Clamp(agi, 1, Player::Constants::MaxAgiBaseValue());
 
 		atk = actor.CalcValueAfterAtkStates(atk);
 		def = actor.CalcValueAfterDefStates(def);

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -168,7 +168,7 @@ void Scene_File::RefreshWindows() {
 }
 
 void Scene_File::Refresh() {
-	for (int i = 0; i < Utils::Clamp<int32_t>(lcf::Data::system.easyrpg_max_savefiles, 3, 99); i++) {
+	for (int i = 0; i < Player::Constants::MaxSaveFiles(); i++) {
 		Window_SaveFile *w = file_windows[i].get();
 		PopulateSaveWindow(*w, i);
 		w->Refresh();

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -123,7 +123,7 @@ void Scene_File::Start() {
 	// Refresh File Finder Save Folder
 	fs = FileFinder::Save();
 
-	for (int i = 0; i < Utils::Clamp<int32_t>(lcf::Data::system.easyrpg_max_savefiles, 3, 99); i++) {
+	for (int i = 0; i < Player::Constants::MaxSaveFiles(); i++) {
 		std::shared_ptr<Window_SaveFile>
 			w(new Window_SaveFile(Player::menu_offset_x, 40 + i * 64, MENU_WIDTH, 64));
 		w->SetIndex(i);

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -226,12 +226,29 @@ void Scene_Title::CreateTitleGraphic() {
 }
 
 void Scene_Title::RepositionWindow(Window_Command& window, bool center_vertical) {
+	int title_x = 160;
 	if (!center_vertical) {
-		window.SetX(Player::screen_width / 2 - window.GetWidth() / 2);
-		window.SetY(Player::screen_height * 53 / 60 - window.GetHeight());
+		int title_y = 148;
+		if (Player::Constants::TryGetOverriddenConstant(Player::GameConstantType::TitleX, title_x)
+			|| Player::Constants::TryGetOverriddenConstant(Player::GameConstantType::TitleY, title_y)) {
+			// RPG_RT aligns its command window as "CenterTop"
+			window.SetX(title_x - window.GetWidth() / 2 + Player::menu_offset_x);
+			window.SetY(title_y + Player::menu_offset_y);
+		} else {
+			window.SetX(Player::screen_width / 2 - window.GetWidth() / 2);
+			window.SetY(Player::screen_height * 53 / 60 - window.GetHeight());
+		}
 	} else {
-		window.SetX(Player::screen_width / 2 - window.GetWidth() / 2);
-		window.SetY(Player::screen_height / 2 - window.GetHeight() / 2);
+		int title_y = 88;
+		if (Player::Constants::TryGetOverriddenConstant(Player::GameConstantType::TitleHiddenX, title_x)
+			|| Player::Constants::TryGetOverriddenConstant(Player::GameConstantType::TitleHiddenY, title_y)) {
+			// RPG_RT aligns its command window as "CenterTop"
+			window.SetX(title_x - window.GetWidth() / 2 + Player::menu_offset_x);
+			window.SetY(title_y + Player::menu_offset_y);
+		} else {
+			window.SetX(Player::screen_width / 2 - window.GetWidth() / 2);
+			window.SetY(Player::screen_height / 2 - window.GetHeight() / 2);
+		}
 	}
 }
 

--- a/src/window_equipstatus.cpp
+++ b/src/window_equipstatus.cpp
@@ -114,7 +114,9 @@ void Window_EquipStatus::DrawParameter(int cx, int cy, int type) {
 	}
 
 	// Check if 4 digits are needed instead of 3
-	int limit = actor.MaxStatBaseValue();
+	int limit = std::max(Player::Constants::MaxAtkBaseValue(), Player::Constants::MaxDefBaseValue());
+	limit = std::max(limit, Player::Constants::MaxSpiBaseValue());
+	limit = std::max(limit, Player::Constants::MaxAgiBaseValue());
 	bool more_space_needed = (Player::IsRPG2k3() && limit >= 500) || limit >= 1000;
 
 	// Draw Term

--- a/src/window_shopparty.cpp
+++ b/src/window_shopparty.cpp
@@ -22,6 +22,7 @@
 #include "game_actor.h"
 #include "window_shopparty.h"
 #include "output.h"
+#include "player.h"
 #include <lcf/reader_util.h>
 #include "sprite_character.h"
 
@@ -101,12 +102,10 @@ static int CmpEquip(const Game_Actor* actor, const lcf::rpg::Item* new_item) {
 	}
 	add_item(new_item, 1);
 
-	int limit = actor->MaxStatBaseValue();
-
-	atk = Utils::Clamp(atk, 1, limit);
-	def = Utils::Clamp(def, 1, limit);
-	spi = Utils::Clamp(spi, 1, limit);
-	agi = Utils::Clamp(agi, 1, limit);
+	atk = Utils::Clamp(atk, 1, Player::Constants::MaxAtkBaseValue());
+	def = Utils::Clamp(def, 1, Player::Constants::MaxDefBaseValue());
+	spi = Utils::Clamp(spi, 1, Player::Constants::MaxSpiBaseValue());
+	agi = Utils::Clamp(agi, 1, Player::Constants::MaxAgiBaseValue());
 
 	int new_score = atk + def + spi + agi;
 

--- a/tests/game_actor.cpp
+++ b/tests/game_actor.cpp
@@ -113,8 +113,6 @@ static void testLimits(int hp, int base, int battle) {
 		auto actor = MakeActor(1, 1, 99, 1, 1, 1, 1, 1, 1);
 
 		REQUIRE_EQ(actor.MaxHpValue(), hp);
-		REQUIRE_EQ(actor.MaxStatBaseValue(), base);
-		REQUIRE_EQ(actor.MaxStatBattleValue(), battle);
 	}
 
 	SUBCASE("base limits") {

--- a/tests/game_enemy.cpp
+++ b/tests/game_enemy.cpp
@@ -56,8 +56,6 @@ static void testLimits(int hp, int base, int battle) {
 	auto& enemy = MakeEnemy(1, 100, 10, 11, 12, 13, 14);
 
 	REQUIRE_EQ(enemy.MaxHpValue(), hp);
-	REQUIRE_EQ(enemy.MaxStatBaseValue(), base);
-	REQUIRE_EQ(enemy.MaxStatBattleValue(), battle);
 
 	SUBCASE("up") {
 		enemy.SetAtkModifier(999999);


### PR DESCRIPTION
This PR moves some of the commonly patched constant values inside a new namespace "Player::Constants" and adds a new mechanism to the ExeReader, which tries to extract these from several known RPG_RT versions.
The validity of the values is verified by checking some of the previous bytes in the .CODE segment, whenever the reader is trying to extract a constant value from a known Hex location. 
Because many of the disassembled code segments look very similar across versions, it should prove quite easy to determine the exact code locations for other RPG_RT versions.

### Starting the Player with custom runtime versions
To make it easier to test this feature, I also implemented a new command argument "--engine-path" (See Issue #3166 )

Usage:
`
Player.exe --test-play --engine-path RT_rm2k3_advo_108_en.dat
`
(At least for the way I organized my different RPG_RT versions. Supply any path to a custom .EXE here)

### Constants supported in this DRAFT:

#### Versions of RPG_RT supported:
- RM2K: 1.03b, 1.05b, 1.06 (Don Miguel's installer versions)
- RM2K3: 1.04, 1.06, 1.08 (All the known versions translated by RPG Advocate, I was able to find)

#### Constant values extracted:
- Minimum & Maximum valid range bounds for Variable IDs
- X/Y location of command window on Title screens
- Maximum upper bounds for experience (only rm2k3-v1.08)
- Maximum gold value (only rm2k3-v1.08)
- Maximum damage value (only rm2k3-v1.08)
- Maximum Actor HP/SP (only rm2k3-v1.08)
- Maximum Base Atk/Def/Spi/Agi (only rm2k3-v1.08)
- Maximum effective (Battle) Atk/Def/Spi/Agi (only rm2k3-v1.08)

### Documentation used for this feature:

- https://www.makerpendium.de/index.php?title=RPG_RT.exe
- https://www.makerpendium.de/index.php?title=RM_Limit_Changer
- Cherry's "Hyper Patcher"
- Cross referencing rm2k3 1.08 with the associated Italian "WhiteDragon" patch.
- And my own disassembly of several RT versions

### Observations regarding the battle stats:

These took some effort to debug & extract, and all of the code locations should definitely be verified by some other person who has more experience in the inner workings of the battle system.

At the moment, battle-related constant locations are only supplied for rm2k3 v1.08 .

 #### Battle Stat Split
Even though they all share the same value, RPG_RT has different constant locations for the base stats: Atk, Def, Agi, Spi.
Thus they can be individually patched. Tools like "RM Limit Changer" make it even possible to change these values individually.
So I decided to split the Player constants for "MaxBaseStatValue" & "MaxBattleStatValue" into those 4 types each.
But: If I understood the disassembly correctly, the code which would be responsible for calculating skill effects uses a single constant location for all of these. So some battle-related calculations might differ in EasyRPG when these values are patched.

#### Inconsistent clamping of bounds
When applying a modifier to a base stat ("SetBaseAtk", etc.. in EasyRPG code), the resulting value is clamped between -999 & 999. EasyRPG´s code uses a single value to represent both the lower & upper bounds of this operation.
But it might be possible for patches (And I verified this for the WhiteDragon patch) to omit patching one of these values. WhiteDragon only patches the positive values, so setting a new Atk value would actually clamp the modifier value between -999 & 9999 instead in RPG_RT. I chose not to extract the negative values individually, to make the result more correct. But there might be edge cases where calculations would differ from RPG_RT. :/

#### Max Enemy HP/SP just editor limitations?
I was looking for these values in my disassembly but wasn't able to find a candidate. Maybe these upper bounds should be removed from the Player code?

#### Rm2k3: CommandChangeClass actually uses the effective "Battle" stats instead of "Base" stats?
This might be one of countless bugs related to the Rm2k3 battle system. It looks like whenever a class is changed in RPG_RT, a constant of '9999' is used for clamping, instead of the proper '999' which would be used for base stats. I could be wrong, because I barely have any documentation on this mangled code, and the values used here might actually be the right ones (so that only the wrong upper bound is used here). Can anyone with more knowledge on the inner workings of the battle system verify that?