### PR TITLE
StringVar: address popLine edge case behavior to match maniacs

### DIFF
--- a/src/game_strings.cpp
+++ b/src/game_strings.cpp
@@ -282,8 +282,12 @@ StringView Game_Strings::PopLine(Str_Params params, int offset, int string_out_i
 
 	Set(params, ss.str().substr(str.length() - offset));
 
-	params.string_id = string_out_id;
-	Set(params, result);
+	// the maniacs implementation is to always preserve the mutated base string
+	// so in the case where the out_id matches the base string id, the popped line is discarded.
+	if (string_out_id != params.string_id) {
+		params.string_id = string_out_id;
+		Set(params, result);
+	}
 	return Get(params.string_id);
 }
 


### PR DESCRIPTION
Handles an edge case with the maniacs `t[a] .popLine t[b]` string function.
Per the spec, the first line of `t[a]` is removed, and written to `t[b]`. 
However, in cases where `a` equals `b`, easyrpg currently differs from easyrpg.
Maniacs will preserve the mutated base string (`t[a]`) and discard the popped line, whereas easyrpg will write the popped to the base string.

This merge handles the edge case to align with maniacs.

I.e.
`t[1] .asg "one
two
three"
t[1] .popLine t[1]
@msg.show "\t[1]"`

the Player currently would display:
```
one
```

and with this change, should now display:
```
two
three
```
which matches the maniacs implementation.