### PR TITLE
Implement undocumented mouse binding for the Ineluki patch

### DIFF
--- a/src/game_ineluki.cpp
+++ b/src/game_ineluki.cpp
@@ -376,7 +376,7 @@ void Game_Ineluki::UpdateKeys() {
 }
 
 void Game_Ineluki::UpdateMouse() {
-#if defined(USE_MOUSE_OR_TOUCH) && defined(SUPPORT_MOUSE_OR_TOUCH)
+#if defined(USE_MOUSE) && defined(SUPPORT_MOUSE)
 	if (Input::IsRawKeyTriggered(Input::Keys::MOUSE_LEFT)) {
 		if ((mouse_decision_binding == MouseReturnMode::Left || mouse_decision_binding == MouseReturnMode::Both)) {
 			Input::SimulateButtonPress(Input::DECISION);

--- a/src/game_ineluki.cpp
+++ b/src/game_ineluki.cpp
@@ -174,6 +174,7 @@ bool Game_Ineluki::Execute(StringView ini_file) {
 		} else if (cmd.name == "registercheatevent") {
 			cheatlist.emplace_back(Utils::LowerCase(cmd.arg), atoi(cmd.arg2.c_str()));
 		} else if (cmd.name == "setmouseasreturn") {
+			// This command is only found in a few uncommon versions of the patch
 			if (!mouse_support) {
 				return true;
 			}
@@ -191,6 +192,7 @@ bool Game_Ineluki::Execute(StringView ini_file) {
 				mouse_decision_binding = MouseReturnMode::None;
 			}
 		} else if (cmd.name == "setmousewheelaskeys") {
+			// This command is only found in a few uncommon versions of the patch
 			if (!mouse_support) {
 				return true;
 			}

--- a/src/game_ineluki.cpp
+++ b/src/game_ineluki.cpp
@@ -173,6 +173,38 @@ bool Game_Ineluki::Execute(StringView ini_file) {
 			// no-op
 		} else if (cmd.name == "registercheatevent") {
 			cheatlist.emplace_back(Utils::LowerCase(cmd.arg), atoi(cmd.arg2.c_str()));
+		} else if (cmd.name == "setmouseasreturn") {
+			if (!mouse_support) {
+				return true;
+			}
+			std::string arg_lower = Utils::LowerCase(cmd.arg);
+			if (arg_lower == "left") {
+				mouse_decision_binding = MouseReturnMode::Left;
+			} else if (arg_lower == "right") {
+				mouse_decision_binding = MouseReturnMode::Right;
+			} else if (arg_lower == "both") {
+				mouse_decision_binding = MouseReturnMode::Both;
+			} else if (arg_lower == "none") {
+				mouse_decision_binding = MouseReturnMode::None;
+			} else {
+				Output::Warning("Ineluki: Invalid value for setMouseAsReturn");
+				mouse_decision_binding = MouseReturnMode::None;
+			}
+		} else if (cmd.name == "setmousewheelaskeys") {
+			if (!mouse_support) {
+				return true;
+			}
+			std::string arg_lower = Utils::LowerCase(cmd.arg);
+			if (arg_lower == "updown") {
+				mouse_wheel_binding = MouseWheelMode::UpDown;
+			} else if (arg_lower == "leftright") {
+				mouse_wheel_binding = MouseWheelMode::LeftRight;
+			} else if (arg_lower == "none") {
+				mouse_wheel_binding = MouseWheelMode::None;
+			} else {
+				Output::Warning("Ineluki: Invalid value for setMouseWheelAsKeys");
+				mouse_wheel_binding = MouseWheelMode::None;
+			}
 		}
 	}
 
@@ -263,6 +295,10 @@ bool Game_Ineluki::Parse(StringView ini_file) {
 		} else if (cmd.name == "registercheatevent") {
 			cmd.arg = ini.Get(section, "cheat", std::string());
 			cmd.arg2 = ini.Get(section, "value", std::string());
+		} else if (cmd.name == "setmouseasreturn") {
+			cmd.arg = ini.Get(section, "value", std::string());
+		} else if (cmd.name == "setmousewheelaskeys") {
+			cmd.arg = ini.Get(section, "value", std::string());
 		} else {
 			Output::Debug("Ineluki: Unknown command {}", cmd.name);
 			valid = false;
@@ -294,10 +330,15 @@ int Game_Ineluki::GetMidiTicks() {
 }
 
 void Game_Ineluki::Update() {
-	if (!key_support) {
-		return;
+	if (key_support) {
+		UpdateKeys();
 	}
+	if (mouse_support) {
+		UpdateMouse();
+	}
+}
 
+void Game_Ineluki::UpdateKeys() {
 	for (const auto& key : keylist_down) {
 		if (Input::IsRawKeyTriggered(key.key)) {
 			output_list.push_back(key.value);
@@ -328,6 +369,32 @@ void Game_Ineluki::Update() {
 			if (pressed.any()) {
 				cheat.index = 0;
 			}
+		}
+	}
+}
+
+void Game_Ineluki::UpdateMouse() {
+	if (Input::IsRawKeyTriggered(Input::Keys::MOUSE_LEFT)) {
+		if ((mouse_decision_binding == MouseReturnMode::Left || mouse_decision_binding == MouseReturnMode::Both)) {
+			Input::SimulateButtonPress(Input::DECISION);
+		}
+	} else if (Input::IsRawKeyTriggered(Input::Keys::MOUSE_RIGHT)) {
+		if ((mouse_decision_binding == MouseReturnMode::Right || mouse_decision_binding == MouseReturnMode::Both)) {
+			Input::SimulateButtonPress(Input::DECISION);
+		}
+	}
+
+	if (Input::IsRawKeyTriggered(Input::Keys::MOUSE_SCROLLUP)) {
+		if (mouse_wheel_binding == MouseWheelMode::UpDown) {
+			Input::SimulateButtonPress(Input::UP);
+		} else if (mouse_wheel_binding == MouseWheelMode::LeftRight) {
+			Input::SimulateButtonPress(Input::LEFT);
+		}
+	} else if (Input::IsRawKeyTriggered(Input::Keys::MOUSE_SCROLLDOWN)) {
+		if (mouse_wheel_binding == MouseWheelMode::UpDown) {
+			Input::SimulateButtonPress(Input::DOWN);
+		} else if (mouse_wheel_binding == MouseWheelMode::LeftRight) {
+			Input::SimulateButtonPress(Input::RIGHT);
 		}
 	}
 }

--- a/src/game_ineluki.cpp
+++ b/src/game_ineluki.cpp
@@ -376,6 +376,7 @@ void Game_Ineluki::UpdateKeys() {
 }
 
 void Game_Ineluki::UpdateMouse() {
+#if defined(USE_MOUSE_OR_TOUCH) && defined(SUPPORT_MOUSE_OR_TOUCH)
 	if (Input::IsRawKeyTriggered(Input::Keys::MOUSE_LEFT)) {
 		if ((mouse_decision_binding == MouseReturnMode::Left || mouse_decision_binding == MouseReturnMode::Both)) {
 			Input::SimulateButtonPress(Input::DECISION);
@@ -399,6 +400,7 @@ void Game_Ineluki::UpdateMouse() {
 			Input::SimulateButtonPress(Input::RIGHT);
 		}
 	}
+#endif
 }
 
 void Game_Ineluki::OnScriptFileReady(FileRequestResult* result) {

--- a/src/game_ineluki.h
+++ b/src/game_ineluki.h
@@ -74,11 +74,21 @@ public:
 	int GetMidiTicks();
 
 	/**
-	 * Updates the key up/down list. Must be called once per update frame.
+	 * Updates the configured input patches. Must be called once per update frame.
 	 */
 	void Update();
 
 private:
+	/**
+	 * Updates the key up/down list.
+	 */
+	void UpdateKeys();
+
+	/**
+	 * Handles virtual key bindings for mouse buttons.
+	 */
+	void UpdateMouse();
+
 	/**
 	 * Parses and caches the script.
 	 *
@@ -122,6 +132,22 @@ private:
 	bool key_support = false;
 	bool mouse_support = false;
 	int mouse_id_prefix = 0;
+
+	enum class MouseReturnMode {
+		None,
+		Left,
+		Right,
+		Both
+	};
+
+	enum class MouseWheelMode {
+		None,
+		UpDown,
+		LeftRight
+	};
+
+	MouseReturnMode mouse_decision_binding = MouseReturnMode::None;
+	MouseWheelMode mouse_wheel_binding = MouseWheelMode::None;
 
 	struct Mapping {
 		Input::Keys::InputKey key;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -408,3 +408,27 @@ void Input::ResetMask() {
 	SetMask(source->GetMask());
 }
 
+void Input::SimulateButtonPress(Input::InputButton button) {
+	switch (button) {
+		case Input::UP:
+		case Input::DOWN:
+		case Input::LEFT:
+		case Input::RIGHT:
+		{
+			// Directional movement has its own input handling
+			// These buttons need to be simulated on a lower level,
+			// or else those movement actions will be overwritten
+			auto& cfg = source->GetConfig();
+			for (auto& bm : cfg.buttons) {
+				if (bm.first == button) {
+					source->SimulateKeyPress(bm.second);
+					break;
+				}
+			}
+			break;
+		}
+		default:
+			break;
+	}
+	UpdateButton(button, true);
+}

--- a/src/input.h
+++ b/src/input.h
@@ -303,6 +303,15 @@ namespace Input {
 	 */
 	 Source* GetInputSource();
 
+	/**
+	* Used to simulate a button press. This is used for
+	* emulating the behavior of some runtime patches.
+	* Buttons for directional movement will be delegated
+	* to the underlying low level input source.
+	* @param button The input button which should be registered as being 'pressed'
+	*/
+	void SimulateButtonPress(Input::InputButton button);
+
 	/** Buttons press time (in frames). */
 	extern std::array<int, BUTTON_COUNT> press_time;
 

--- a/src/input_source.cpp
+++ b/src/input_source.cpp
@@ -64,9 +64,10 @@ void Input::UiSource::DoUpdate(bool system_only) {
 		}
 
 		if (!system_only || Input::IsSystemButton(bm.first)) {
-			pressed_buttons[bm.first] = pressed_buttons[bm.first] || keystates[bm.second];
+			pressed_buttons[bm.first] = pressed_buttons[bm.first] || keystates[bm.second] || keystates_virtual[bm.second];
 		}
 	}
+	keystates_virtual = {};
 
 	Record();
 
@@ -328,6 +329,10 @@ void Input::Source::AddRecordingData(Input::RecordingData type, StringView data)
 	if (record_log) {
 		*record_log << static_cast<char>(type) << " " << data << "\n";
 	}
+}
+
+void Input::Source::SimulateKeyPress(Input::Keys::InputKey key) {
+	keystates_virtual[key] = true;
 }
 
 void Input::LogSource::UpdateSystem() {

--- a/src/input_source.h
+++ b/src/input_source.h
@@ -139,6 +139,12 @@ namespace Input {
 		const KeyStatus& GetMask() const { return keymask; }
 		KeyStatus& GetMask() { return keymask; }
 
+		/**
+		* Emulate a key being pressed.
+		* @param key
+		*/
+		void SimulateKeyPress(Input::Keys::InputKey key);
+
 	protected:
 		void Record();
 		void UpdateGamepad();
@@ -152,6 +158,7 @@ namespace Input {
 
 		KeyStatus keystates;
 		KeyStatus keymask;
+		KeyStatus keystates_virtual;
 		Point mouse_pos;
 		AnalogInput analog_input;
 


### PR DESCRIPTION
While going through different versions of harmony.dll, I found a few special versions of the Ineluki patch.
Most of them were just copy-protected preview versions, which were handed out to some devs, before the key patch was actually released to the public. Those have limited functionality & will refuse to work, if some of the game files do not match the expected values.

Just for documentation purposes, the unique versions I found on rmarchiv's data are:
- 1.2.0.50 **Gekiganger** (Used in the keypatch demo)
- 1.2.0.50 **Kelven** "a" (Used in "Die Bücher Luzifers 2")
- 1.2.0.50 **Kelven** "b" (Used in "Aliminator")
- 1.2.0.50 **Sunny** (Used in "Der Feind")
- 1.2.0.50 **KoA Angel** (Used in "Yoshis Maze Mania")
- 1.2.0.00 **Neo23** (Apparently used in a Moleboxed "Megaman" game by the developer)

The interesting one is the last version, custom-developed for "Neo23". But apparently, another version later surfaced, without the unique "copy-protection" for Neo23, and the same internal compilation date (2004-07-05), which differs by nearly half a year from the most commonly used keypatch version.

This DLL has two additional commands:
- _setMouseAsReturn_
- _setMouseWheelAsKeys_

...which feature a few options for binding mouse keys & the mouse wheel to common input buttons.
Usage of the mouse wheel is already possible in some menus in the Player, but I went & completely implemented the key bindings anyway. (This can be tested in-game in Rutipa's Quest 9 when you have control of the player. Save & restart, the game forgets to deactivate the mouse patch a second time, so the character can now be moved via the mouse wheel..)

This patch is used in the games **Vortex** & both versions of **Rutipa's Quest 9**.