### PR TITLE
Support for ppcomp, LS.dat & BetterAEP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,8 @@ add_library(${PROJECT_NAME} OBJECT
 	src/game_pictures.h
 	src/game_player.cpp
 	src/game_player.h
+	src/game_powerpatch.cpp
+	src/game_powerpatch.h
 	src/game_quit.cpp
 	src/game_quit.h
 	src/game_screen.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -176,6 +176,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/game_pictures.h \
 	src/game_player.cpp \
 	src/game_player.h \
+	src/game_powerpatch.cpp \
+	src/game_powerpatch.h \
 	src/game_screen.cpp \
 	src/game_screen.h \
 	src/game_strings.cpp \

--- a/src/async_op.h
+++ b/src/async_op.h
@@ -43,6 +43,7 @@ class AsyncOp {
 			eTerminateBattle,
 			eSave,
 			eLoad,
+			eLoadParallel,
 			eYield,
 			eYieldRepeat,
 			eCloneMapEvent,
@@ -77,6 +78,9 @@ class AsyncOp {
 
 		/** @return a Load async operation */
 		static AsyncOp MakeLoad(int save_slot);
+
+		/** @return a LoadParallel async operation (to be used for patch compatibility) */
+		static AsyncOp MakeLoadParallel(int save_slot);
 
 		/** @return a Yield for one frame to e.g. fetch an important asset */
 		static AsyncOp MakeYield();
@@ -128,7 +132,7 @@ class AsyncOp {
 
 		/**
 		 * @return the desired slot to save or load
-		 * @pre If GetType() is not eSave or eLoad, the return value is undefined.
+		 * @pre If GetType() is not eSave, eLoad, eLoadParallel, the return value is undefined.
 		 **/
 		 int GetSaveSlot() const;
 
@@ -220,7 +224,7 @@ inline int AsyncOp::GetBattleResult() const {
 }
 
 inline int AsyncOp::GetSaveSlot() const {
-	assert(GetType() == eSave || GetType() == eLoad);
+	assert(GetType() == eSave || GetType() == eLoad || GetType() == eLoadParallel);
 	return _args[0];
 }
 
@@ -303,6 +307,10 @@ inline AsyncOp AsyncOp::MakeSave(int save_slot, int save_result_var) {
 
 inline AsyncOp AsyncOp::MakeLoad(int save_slot) {
 	return AsyncOp(eLoad, save_slot);
+}
+
+inline AsyncOp AsyncOp::MakeLoadParallel(int save_slot) {
+	return AsyncOp(eLoadParallel, save_slot);
 }
 
 inline AsyncOp AsyncOp::MakeYield() {

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -399,16 +399,30 @@ bool FileFinder::HasSavegame() {
 int FileFinder::GetSavegames() {
 	auto fs = Save();
 
-	for (int i = 1; i <= 15; i++) {
-		std::stringstream ss;
-		ss << "Save" << (i <= 9 ? "0" : "") << i << ".lsd";
-		std::string filename = fs.FindFile(ss.str());
+	for (int i = 1; i <= Player::Constants::MaxSaveFiles(); i++) {
+		std::string filename = fs.FindFile(GetSaveFilename(i));
 
 		if (!filename.empty()) {
 			return true;
 		}
 	}
 	return false;
+}
+
+std::string FileFinder::GetSaveFilename(int slot) {
+	std::stringstream ss;
+	ss << "Save" << (slot <= 9 ? "0" : "") << (slot) << ".lsd";
+	return ss.str();
+}
+
+std::string FileFinder::GetSaveFilename(const FilesystemView& fs, int slot, bool validate_exists) {
+	auto filename = GetSaveFilename(slot);
+	auto filename_fs = fs.FindFile(filename);
+
+	if (filename_fs.empty() && !validate_exists) {
+		return filename;
+	}
+	return filename_fs;
 }
 
 std::string find_generic(const DirectoryTree::Args& args) {

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -362,6 +362,9 @@ namespace FileFinder {
 	/** @returns Amount of savegames in the save directory */
 	int GetSavegames();
 
+	std::string GetSaveFilename(int slot);
+	std::string GetSaveFilename(const FilesystemView& fs, int slot, bool validate_exists = true);
+
 	/**
 	 * Known file sizes
 	 */

--- a/src/game_config_game.cpp
+++ b/src/game_config_game.cpp
@@ -88,6 +88,7 @@ void Game_ConfigGame::LoadFromArgs(CmdlineParser& cp) {
 			patch_rpg2k3_commands.Lock(false);
 			patch_anti_lag_switch.Lock(0);
 			patch_direct_menu.Lock(0);
+			patch_better_aep.Lock(0);
 			patch_override = true;
 			continue;
 		}
@@ -151,6 +152,18 @@ void Game_ConfigGame::LoadFromArgs(CmdlineParser& cp) {
 
 			if (arg.ArgIsOff()) {
 				patch_direct_menu.Set(0);
+				patch_override = true;
+			}
+			continue;
+		}
+		if (cp.ParseNext(arg, 1, { "--patch-better-aep", "--no-patch-better-aep" })) {
+			if (arg.ArgIsOn() && arg.ParseValue(0, li_value)) {
+				patch_better_aep.Set(li_value);
+				patch_override = true;
+			}
+
+			if (arg.ArgIsOff()) {
+				patch_better_aep.Set(0);
 				patch_override = true;
 			}
 			continue;
@@ -229,6 +242,10 @@ void Game_ConfigGame::LoadFromStream(Filesystem_Stream::InputStream& is) {
 	if (patch_direct_menu.FromIni(ini)) {
 		patch_override = true;
 	}
+
+	if (patch_better_aep.FromIni(ini)) {
+		patch_override = true;
+	}
 }
 
 void Game_ConfigGame::PrintActivePatches() {
@@ -257,6 +274,7 @@ void Game_ConfigGame::PrintActivePatches() {
 	add_int(patch_maniac);
 	add_int(patch_anti_lag_switch);
 	add_int(patch_direct_menu);
+	add_int(patch_better_aep);
 
 	if (patches.empty()) {
 		Output::Debug("Patch configuration: None");

--- a/src/game_config_game.h
+++ b/src/game_config_game.h
@@ -45,6 +45,7 @@ struct Game_ConfigGame {
 	BoolConfigParam patch_common_this_event{ "Common This Event", "Support \"This Event\" in Common Events", "Patch", "CommonThisEvent", false };
 	BoolConfigParam patch_unlock_pics{ "Unlock Pictures", "Allow picture commands while a message is shown", "Patch", "PicUnlock", false };
 	BoolConfigParam patch_key_patch{ "Ineluki Key Patch", "Support \"Ineluki Key Patch\"", "Patch", "KeyPatch", false };
+	BoolConfigParam patch_key_patch_no_async{ "Ineluki Key Patch", "Force KeyPatch scripts to behave synchronously", "Patch", "KeyPatch.NoAsync", false };
 	BoolConfigParam patch_rpg2k3_commands{ "RPG2k3 Event Commands", "Enable support for RPG2k3 event commands", "Patch", "RPG2k3Commands", false };
 	ConfigParam<int> patch_anti_lag_switch{ "Anti-Lag Switch", "Disable event page refreshes when switch is set", "Patch", "AntiLagSwitch", 0 };
 	ConfigParam<int> patch_direct_menu{ "Direct Menu", " Allows direct access to subscreens of the default menu", "Patch", "DirectMenu", 0 };

--- a/src/game_config_game.h
+++ b/src/game_config_game.h
@@ -49,6 +49,7 @@ struct Game_ConfigGame {
 	BoolConfigParam patch_rpg2k3_commands{ "RPG2k3 Event Commands", "Enable support for RPG2k3 event commands", "Patch", "RPG2k3Commands", false };
 	ConfigParam<int> patch_anti_lag_switch{ "Anti-Lag Switch", "Disable event page refreshes when switch is set", "Patch", "AntiLagSwitch", 0 };
 	ConfigParam<int> patch_direct_menu{ "Direct Menu", " Allows direct access to subscreens of the default menu", "Patch", "DirectMenu", 0 };
+	ConfigParam<int> patch_better_aep{ "BetterAEP", "Emulates the \"BetterAEP\" patch, commonly used for custom title screens.", "Patch", "BetterAEP", 0 };
 
 	// Command line only
 	BoolConfigParam patch_support{ "Support patches", "When OFF all patch support is disabled", "", "", true };

--- a/src/game_config_game.h
+++ b/src/game_config_game.h
@@ -50,6 +50,7 @@ struct Game_ConfigGame {
 	ConfigParam<int> patch_anti_lag_switch{ "Anti-Lag Switch", "Disable event page refreshes when switch is set", "Patch", "AntiLagSwitch", 0 };
 	ConfigParam<int> patch_direct_menu{ "Direct Menu", " Allows direct access to subscreens of the default menu", "Patch", "DirectMenu", 0 };
 	ConfigParam<int> patch_better_aep{ "BetterAEP", "Emulates the \"BetterAEP\" patch, commonly used for custom title screens.", "Patch", "BetterAEP", 0 };
+	ConfigParam<int> patch_custom_save_load{ "BetterAEP", "Emulates the \"BetterAEP\" addon which allows for saving/loading by save slot.", "Patch", "BetterAEP.CustomSaveLoad", 0 };
 
 	// Command line only
 	BoolConfigParam patch_support{ "Support patches", "When OFF all patch support is disabled", "", "", true };

--- a/src/game_config_game.h
+++ b/src/game_config_game.h
@@ -45,7 +45,7 @@ struct Game_ConfigGame {
 	BoolConfigParam patch_common_this_event{ "Common This Event", "Support \"This Event\" in Common Events", "Patch", "CommonThisEvent", false };
 	BoolConfigParam patch_unlock_pics{ "Unlock Pictures", "Allow picture commands while a message is shown", "Patch", "PicUnlock", false };
 	BoolConfigParam patch_key_patch{ "Ineluki Key Patch", "Support \"Ineluki Key Patch\"", "Patch", "KeyPatch", false };
-	BoolConfigParam patch_key_patch_no_async{ "Ineluki Key Patch", "Force KeyPatch scripts to behave synchronously", "Patch", "KeyPatch.NoAsync", false };
+	//BoolConfigParam patch_key_patch_no_async{ "Ineluki Key Patch", "Force KeyPatch scripts to behave synchronously", "Patch", "KeyPatch.NoAsync", false };
 	BoolConfigParam patch_rpg2k3_commands{ "RPG2k3 Event Commands", "Enable support for RPG2k3 event commands", "Patch", "RPG2k3Commands", false };
 	ConfigParam<int> patch_anti_lag_switch{ "Anti-Lag Switch", "Disable event page refreshes when switch is set", "Patch", "AntiLagSwitch", 0 };
 	ConfigParam<int> patch_direct_menu{ "Direct Menu", " Allows direct access to subscreens of the default menu", "Patch", "DirectMenu", 0 };

--- a/src/game_ineluki.cpp
+++ b/src/game_ineluki.cpp
@@ -341,6 +341,13 @@ void Game_Ineluki::Update() {
 	if (mouse_support) {
 		UpdateMouse();
 	}
+	for (auto& [ key, frames ] : Game_PowerPatch::simulate_keypresses) {
+		if (frames == 0) {
+			continue;
+		}
+		Input::GetInputSource()->SimulateKeyPress(key);
+		frames--;
+	}
 }
 
 void Game_Ineluki::UpdateKeys() {

--- a/src/game_ineluki.cpp
+++ b/src/game_ineluki.cpp
@@ -28,6 +28,7 @@
 #include "system.h"
 
 #include <lcf/inireader.h>
+#include <scene_load.h>
 
 namespace {
 #if defined(SUPPORT_KEYBOARD)
@@ -411,6 +412,10 @@ AsyncOp Game_Ineluki::ExecProgram(std::string_view command) {
 		Player::exit_flag = true;
 	} else if (StartsWith(command, "savecount.dat")) {
 		// no-op, detected through saves.script access
+	} else if (StartsWith(command, "ls.dat")) {
+		// (arg1 commonly given for "LS.dat" refers to the version-dependent
+		// virtual address of the RPG_RT loading mechanism)
+		Scene::instance->SetRequestedScene(std::make_shared<Scene_Load>());
 	} else if (StartsWith(command, "ppcomp")) {
 		auto args = Utils::Tokenize(command, [&](char32_t c) { return std::isspace(c); });
 		if (args.size() > 1) {

--- a/src/game_ineluki.cpp
+++ b/src/game_ineluki.cpp
@@ -17,6 +17,7 @@
 
 // Headers
 #include "game_ineluki.h"
+#include "game_powerpatch.h"
 #include "async_handler.h"
 #include "filefinder.h"
 #include "utils.h"
@@ -410,6 +411,11 @@ AsyncOp Game_Ineluki::ExecProgram(std::string_view command) {
 		Player::exit_flag = true;
 	} else if (StartsWith(command, "savecount.dat")) {
 		// no-op, detected through saves.script access
+	} else if (StartsWith(command, "ppcomp")) {
+		auto args = Utils::Tokenize(command, [&](char32_t c) { return std::isspace(c); });
+		if (args.size() > 1) {
+			return Game_PowerPatch::ExecutePPC(Utils::UpperCase(args[1]), Span<std::string>(args).subspan(2));
+		}
 	} else {
 		Output::Warning("Ineluki ExecProgram {}: Not supported", command);
 	}

--- a/src/game_ineluki.h
+++ b/src/game_ineluki.h
@@ -28,6 +28,7 @@
 #include "keys.h"
 #include "string_view.h"
 #include "async_handler.h"
+#include "async_op.h"
 
 /**
  * Implements Ineluki's Key Patch
@@ -52,7 +53,7 @@ public:
 	 * @param ini_file INI file to execute
 	 * @return Whether the file is a valid script
 	 */
-	bool Execute(std::string_view ini_file);
+	AsyncOp Execute(std::string_view ini_file);
 
 	/**
 	 * Executes a file containing a list of script files.
@@ -96,6 +97,8 @@ private:
 	 * @return Whether the file is a valid script
 	 */
 	bool Parse(std::string_view ini_file);
+
+	AsyncOp ExecProgram(std::string_view command);
 
 	struct InelukiCommand {
 		std::string name;

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2044,11 +2044,19 @@ bool Game_Interpreter::CommandEndEventProcessing(lcf::rpg::EventCommand const& /
 	if (auto var_id = Player::game_config.patch_better_aep.Get()) {
 		switch (Main_Data::game_variables->Get(var_id)) {
 			case 1:
+				if (var_id = Player::game_config.patch_custom_save_load.Get()) {
+					if (auto save_slot = Main_Data::game_variables->Get(var_id) > 0) {
+						_async_op = MakeLoadOp("CustomSaveLoad", save_slot);
+						return true;
+					}
+				}
 				Scene::instance->SetRequestedScene(std::make_shared<Scene_Load>());
 				return true;
 			case 2:
 				Player::exit_flag = true;
 				return true;
+			default:
+				break;
 		}
 	}
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -1974,10 +1974,10 @@ bool Game_Interpreter::CommandWait(lcf::rpg::EventCommand const& com) { // code 
 namespace InelukiKeyPatch {
 	bool HandleScriptFile(std::string_view file_name, bool is_music, AsyncOp& async_op) {
 		if (Player::IsPatchKeyPatch() && EndsWith(file_name, ".script")) {
-			if (!Player::game_config.patch_key_patch_no_async.Get()) {
-				// Script will be handled in place of the usual sound processing -> Game_System
-				return false;
-			}
+			//if (!Player::game_config.patch_key_patch_no_async.Get()) {
+			//	// Script will be handled in place of the usual sound processing -> Game_System
+			//	return false;
+			//}
 			// Is a Ineluki Script File
 			FileRequestAsync* request = AsyncHandler::RequestFile(is_music ? "Music" : "Sound", file_name);
 			request->SetImportantFile(true);

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -71,6 +71,7 @@
 #include "baseui.h"
 #include "algo.h"
 #include "rand.h"
+#include <scene_load.h>
 
 using namespace Game_Interpreter_Shared;
 
@@ -2040,6 +2041,17 @@ bool Game_Interpreter::CommandPlaySound(lcf::rpg::EventCommand const& com) { // 
 }
 
 bool Game_Interpreter::CommandEndEventProcessing(lcf::rpg::EventCommand const& /* com */) { // code 12310
+	if (auto var_id = Player::game_config.patch_better_aep.Get()) {
+		switch (Main_Data::game_variables->Get(var_id)) {
+			case 1:
+				Scene::instance->SetRequestedScene(std::make_shared<Scene_Load>());
+				return true;
+			case 2:
+				Player::exit_flag = true;
+				return true;
+		}
+	}
+
 	EndEventProcessing();
 	return true;
 }

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -4277,7 +4277,7 @@ bool Game_Interpreter::CommandManiacGetSaveInfo(lcf::rpg::EventCommand const& co
 	}
 
 	auto savefs = FileFinder::Save();
-	std::string save_name = Scene_Save::GetSaveFilename(savefs, save_number);
+	std::string save_name = FileFinder::GetSaveFilename(savefs, save_number, false);
 	auto save_stream = FileFinder::Save().OpenInputStream(save_name);
 
 	if (!save_stream) {
@@ -4373,7 +4373,7 @@ bool Game_Interpreter::CommandManiacLoad(lcf::rpg::EventCommand const& com) {
 	// When com.parameters[2] is 1 the check whether the file exists is skipped
 	// When skipped and missing RPG_RT will crash
 	auto savefs = FileFinder::Save();
-	std::string save_name = Scene_Save::GetSaveFilename(savefs, slot);
+	std::string save_name = FileFinder::GetSaveFilename(savefs, slot, false);
 	auto save_stream = FileFinder::Save().OpenInputStream(save_name);
 	std::unique_ptr<lcf::rpg::Save> save = lcf::LSD_Reader::Load(save_stream, Player::encoding);
 

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -776,6 +776,13 @@ bool Game_Interpreter_Map::CommandOpenSaveMenu(lcf::rpg::EventCommand const& com
 	auto& frame = GetFrame();
 	auto& index = frame.current_command;
 
+	if (auto var_id = Player::game_config.patch_custom_save_load.Get()) {
+		if (auto save_slot = Main_Data::game_variables->Get(var_id) > 0) {
+			_async_op = AsyncOp::MakeSave(save_slot, -1);
+			return true;
+		}
+	}
+
 	Scene::instance->SetRequestedScene(std::make_shared<Scene_Save>());
 
 	int current_system_function = 0;

--- a/src/game_interpreter_shared.cpp
+++ b/src/game_interpreter_shared.cpp
@@ -37,6 +37,7 @@
 #include <cstdint>
 #include <lcf/rpg/savepartylocation.h>
 #include <lcf/reader_util.h>
+#include <lcf/lsd/reader.h>
 
 using Main_Data::game_switches, Main_Data::game_variables, Main_Data::game_strings;
 
@@ -236,6 +237,55 @@ lcf::rpg::MoveCommand Game_Interpreter_Shared::DecodeMove(lcf::DBArray<int32_t>:
 	}
 
 	return cmd;
+}
+
+std::unique_ptr<lcf::rpg::Save> Game_Interpreter_Shared::ValidateAndLoadSave(const char* caller, const FilesystemView& fs, int save_slot) {
+	bool save_corrupted = false;
+	return ValidateAndLoadSave(caller, fs, save_slot, save_corrupted);
+}
+
+std::unique_ptr<lcf::rpg::Save> Game_Interpreter_Shared::ValidateAndLoadSave(const char* caller, const FilesystemView& fs, int save_slot, bool& save_corrupted) {
+	save_corrupted = false;
+
+	if (save_slot <= 0) {
+		Output::Debug("{}: Invalid save number {}", caller, save_slot);
+		return {};
+	}
+
+	std::string save_name = FileFinder::GetSaveFilename(fs, save_slot, false);
+	auto save_stream = FileFinder::Save().OpenInputStream(save_name);
+
+	if (!save_stream) {
+		Output::Debug("{}: Save not found {}", caller, save_slot);
+		return {};
+	}
+
+	auto save = lcf::LSD_Reader::Load(save_stream, Player::encoding);
+	if (!save) {
+		Output::Debug("{}: Save corrupted {}", caller, save_slot);
+		save_corrupted = true;;
+		return {};
+	}
+	return save;
+}
+
+AsyncOp Game_Interpreter_Shared::MakeLoadOp(const char* caller, int save_slot) {
+	if (save_slot <= 0) {
+		Output::Debug("{}: Invalid save slot {}", caller, save_slot);
+		return {};
+	}
+
+	auto savefs = FileFinder::Save();
+	std::string save_name = FileFinder::GetSaveFilename(savefs, save_slot, false);
+	auto save_stream = FileFinder::Save().OpenInputStream(save_name);
+	std::unique_ptr<lcf::rpg::Save> save = lcf::LSD_Reader::Load(save_stream, Player::encoding);
+
+	if (!save) {
+		Output::Debug("{}: Save not found {}", caller, save_slot);
+		return {};
+	}
+
+	return AsyncOp::MakeLoad(save_slot);
 }
 
 //explicit declarations for target evaluation logic shared between ControlSwitches/ControlVariables/ControlStrings

--- a/src/game_interpreter_shared.cpp
+++ b/src/game_interpreter_shared.cpp
@@ -315,6 +315,25 @@ AsyncOp Game_Interpreter_Shared::MakeLoadOp(const char* caller, int save_slot) {
 	return AsyncOp::MakeLoad(save_slot);
 }
 
+AsyncOp Game_Interpreter_Shared::MakeLoadParallel(const char* caller, int save_slot) {
+	if (save_slot <= 0) {
+		Output::Debug("{}: Invalid save slot {}", caller, save_slot);
+		return {};
+	}
+
+	auto savefs = FileFinder::Save();
+	std::string save_name = FileFinder::GetSaveFilename(savefs, save_slot, false);
+	auto save_stream = FileFinder::Save().OpenInputStream(save_name);
+	std::unique_ptr<lcf::rpg::Save> save = lcf::LSD_Reader::Load(save_stream, Player::encoding);
+
+	if (!save) {
+		Output::Debug("{}: Save not found {}", caller, save_slot);
+		return {};
+	}
+
+	return AsyncOp::MakeLoadParallel(save_slot);
+}
+
 //explicit declarations for target evaluation logic shared between ControlSwitches/ControlVariables/ControlStrings
 template bool Game_Interpreter_Shared::DecodeTargetEvaluationMode<true, false, false, false, false>(lcf::rpg::EventCommand const&, int&, int&, Game_BaseInterpreterContext const&);
 template bool Game_Interpreter_Shared::DecodeTargetEvaluationMode<true, true, true, false, false>(lcf::rpg::EventCommand const&, int&, int&, Game_BaseInterpreterContext const&);

--- a/src/game_interpreter_shared.h
+++ b/src/game_interpreter_shared.h
@@ -109,6 +109,7 @@ namespace Game_Interpreter_Shared {
 
 	std::unique_ptr<lcf::rpg::Save> ValidateAndLoadSave(const char* caller, const FilesystemView& fs, int save_slot);
 	std::unique_ptr<lcf::rpg::Save> ValidateAndLoadSave(const char* caller, const FilesystemView& fs, int save_slot, bool& save_corrupted);
+	int GetLatestSaveSlot(const FilesystemView& fs);
 	AsyncOp MakeLoadOp(const char* caller, int save_slot);
 }
 

--- a/src/game_interpreter_shared.h
+++ b/src/game_interpreter_shared.h
@@ -22,8 +22,11 @@
 #include <lcf/rpg/eventcommand.h>
 #include <lcf/rpg/movecommand.h>
 #include <lcf/rpg/saveeventexecframe.h>
+#include <lcf/rpg/save.h>
 #include <string_view.h>
+#include "async_op.h"
 #include "compiler.h"
+#include "filesystem.h"
 
 class Game_Character;
 class Game_BaseInterpreterContext;
@@ -103,6 +106,10 @@ namespace Game_Interpreter_Shared {
 	lcf::rpg::MoveCommand DecodeMove(lcf::DBArray<int32_t>::const_iterator& it);
 
 	bool ManiacCheckContinueLoop(int val, int val2, int type, int op);
+
+	std::unique_ptr<lcf::rpg::Save> ValidateAndLoadSave(const char* caller, const FilesystemView& fs, int save_slot);
+	std::unique_ptr<lcf::rpg::Save> ValidateAndLoadSave(const char* caller, const FilesystemView& fs, int save_slot, bool& save_corrupted);
+	AsyncOp MakeLoadOp(const char* caller, int save_slot);
 }
 
 inline bool Game_Interpreter_Shared::CheckOperator(int val, int val2, int op) {

--- a/src/game_interpreter_shared.h
+++ b/src/game_interpreter_shared.h
@@ -110,7 +110,18 @@ namespace Game_Interpreter_Shared {
 	std::unique_ptr<lcf::rpg::Save> ValidateAndLoadSave(const char* caller, const FilesystemView& fs, int save_slot);
 	std::unique_ptr<lcf::rpg::Save> ValidateAndLoadSave(const char* caller, const FilesystemView& fs, int save_slot, bool& save_corrupted);
 	int GetLatestSaveSlot(const FilesystemView& fs);
+
+
 	AsyncOp MakeLoadOp(const char* caller, int save_slot);
+
+	/**
+	* Sets up a "Parallel Load" which is a loading operation that is meant to run
+	* in the background while not actually stopping the game's execution.
+	* Note: This is coded to only emulate the behavior of certain RPG_RT patches
+	*  & will likely lead to many unexpected results, depending on the usage.
+	* DO NOT USE this mechanic for implementing load-mechanics in a new game!
+	*/
+	AsyncOp MakeLoadParallel(const char* caller, int save_slot);
 }
 
 inline bool Game_Interpreter_Shared::CheckOperator(int val, int val2, int op) {

--- a/src/game_powerpatch.cpp
+++ b/src/game_powerpatch.cpp
@@ -334,7 +334,7 @@ bool Game_PowerPatch::Execute(PPC_CommandType command, Span<std::string const> a
 					Scene_Title::force_cursor_index = Scene_Title::CommandOptionType::NewGame;
 				}
 			}
-			Player::force_make_to_title_flag = true;
+			//Player::force_make_to_title_flag = true;
 			async_op = AsyncOp::MakeToTitle();
 			break;
 		}

--- a/src/game_powerpatch.cpp
+++ b/src/game_powerpatch.cpp
@@ -1,0 +1,240 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Headers
+#include "game_powerpatch.h"
+#include "filefinder.h"
+#include "utils.h"
+#include "output.h"
+#include "player.h"
+#include "system.h"
+#include "scene_load.h"
+#include "scene_save.h"
+#include "scene_debug.h"
+#include "main_data.h"
+#include "game_interpreter_map.h"
+#include "game_map.h"
+#include "game_switches.h"
+#include "game_variables.h"
+#include <lcf/lsd/reader.h>
+
+namespace {
+	void OverrideSystemMusic(lcf::rpg::Music& music, Span<std::string const>& args) {
+		music.name = args[0];
+		if (args.size() > 1) {
+			music.volume = atoi(args[1].c_str());
+		}
+		if (args.size() > 2) {
+			music.tempo = atoi(args[2].c_str());
+		}
+		if (args.size() > 3) {
+			music.fadein = atoi(args[3].c_str());
+		}
+	}
+
+	void StoreTimestamp(int dest_v, std::tm* tm) {
+		Main_Data::game_variables->Set(dest_v, tm->tm_year + 1900);
+		Main_Data::game_variables->Set(dest_v + 1, tm->tm_mon + 1);
+		Main_Data::game_variables->Set(dest_v + 2, tm->tm_mday);
+		Main_Data::game_variables->Set(dest_v + 3, tm->tm_wday + 1);
+		Main_Data::game_variables->Set(dest_v + 4, tm->tm_hour);
+		Main_Data::game_variables->Set(dest_v + 5, tm->tm_min);
+		Main_Data::game_variables->Set(dest_v + 6, tm->tm_sec);
+	}
+}
+
+AsyncOp Game_PowerPatch::ExecutePPC(std::string_view ppc_cmd, Span<std::string const> args) {
+	auto& cmd = std::find_if(PPC_commands.begin(), PPC_commands.end(), [&ppc_cmd](auto& cmd) {
+		return ppc_cmd == cmd.name;
+	});
+	if (cmd == PPC_commands.end()) {
+		Output::Warning("PPCOMP {}: unknown command", ppc_cmd);
+		return {};
+	}
+
+	if (args.size() < cmd->min_args) {
+		Output::Warning("PPCOMP {}: Missing required arguments (Min: {})", ppc_cmd, cmd->min_args);
+		return {};
+	}
+
+	AsyncOp async_op = {};
+	Output::Debug("Executing PPC: {}", ppc_cmd);
+	if (!Execute(cmd->type, args, async_op)) {
+		Output::Warning("PPCOMP {}: Not supported", ppc_cmd);
+		return {};
+	}
+	return async_op;
+}
+
+bool Game_PowerPatch::Execute(PPC_CommandType command, Span<std::string const> args, AsyncOp& async_op) {
+	using Type = PPC_CommandType;
+
+	switch (command) {
+		case Type::Debug:
+			// Note: PowerPatchCompact has a few nice debug options which might
+			// be neat to also have in EasyRPG's extended debug menu
+			Scene::instance->SetRequestedScene(std::make_shared<Scene_Debug>());
+			break;
+		case Type::Quit:
+			Player::exit_flag = true;
+			break;
+		case Type::Restart:
+			Player::reset_flag = true;
+			break;
+		case Type::Save: {
+			int slot = args.size() >= 1 ? atoi(args[0].c_str()) : 0;
+			int map = args.size() >= 2 ? atoi(args[1].c_str()) : 0;
+			int map_x = args.size() >= 3 ? atoi(args[2].c_str()) : -1;
+			int map_y = args.size() >= 4 ? atoi(args[3].c_str()) : -1;
+
+			auto& fs = FileFinder::Save();
+			if (slot == 0) {
+				slot = Game_Interpreter_Shared::GetLatestSaveSlot(fs);
+			}
+			if (slot <= 0) {
+				Output::Warning("PowerPatch Save: Invalid save slot {}", slot);
+				return true;
+			}
+			//TODO: map_id, map_x, map_y 
+			async_op = AsyncOp::MakeSave(slot, -1);
+			break;
+		}
+		case Type::Load: {
+			int slot = args.size() >= 1 ? atoi(args[0].c_str()) : 0;
+
+			auto& fs = FileFinder::Save();
+			if (slot == 0) {
+				slot = Game_Interpreter_Shared::GetLatestSaveSlot(fs);
+			}
+			auto save = Game_Interpreter_Shared::ValidateAndLoadSave("PowerPatch Load", fs, slot);
+			if (!save) {
+				return true;
+			}
+			// FIXME: In RPG_RT the loading operation happens asynchronously while the
+			// current interpreter is still running. Any other Ineluki scripts might
+			// be executed before the loading process is complete.
+			// This breaks some games, such as "Take it cheesy"
+			//   -> Here, Save01 is loaded automatically, but the interpreter still
+			//      executes a few other script commands right after, which set up
+			//      the mouse patch. As a result, mouse functionality will work normally
+			//      in RPG_RT, but not in EasyRPG Player, which never ran the
+			//      neccessary setup scripts.
+			async_op = Game_Interpreter_Shared::MakeLoadOp("PowerPatch Load", slot);
+			break;
+		}
+		case Type::CheckSave: {
+			int slot = atoi(args[0].c_str());
+			int dest_sw = atoi(args[1].c_str());
+
+			auto exists = !FileFinder::GetSaveFilename(FileFinder::Save(), slot, true).empty();
+			Main_Data::game_switches->Set(dest_sw, exists);
+			break;
+		}
+		case Type::CopySave: {
+			int slot = atoi(args[0].c_str());
+			int dest_slot = atoi(args[1].c_str());
+
+			auto& fs = FileFinder::Save();
+			auto save = Game_Interpreter_Shared::ValidateAndLoadSave("PowerPatch CopySave", fs, slot);
+			if (!save) {
+				return true;
+			}
+			if (dest_slot <= 0) {
+				Output::Warning("PowerPatch CopySave: Invalid save number {}", dest_slot);
+				return true;
+			}
+			//TODO: Not implemented
+			break;
+		}
+		case Type::DeleteSave: {
+			int slot = atoi(args[0].c_str());
+
+			if (slot <= 0) {
+				Output::Warning("PowerPatch DeleteSave: Invalid save number {}", slot);
+				return true;
+			}
+			//TODO: Not implemented
+			break;
+		}
+		case Type::GetSaveDateTime: {
+			int slot = atoi(args[0].c_str());
+			int dest_v = atoi(args[1].c_str());
+
+			auto& fs = FileFinder::Save();
+			auto save = Game_Interpreter_Shared::ValidateAndLoadSave("PowerPatch GetSaveDateTime", fs, slot);
+			if (!save) {
+				return true;
+			}
+			std::time_t t = lcf::LSD_Reader::ToUnixTimestamp(save->title.timestamp);
+			std::tm* tm = std::gmtime(&t);
+			StoreTimestamp(dest_v, tm);
+			break;
+		}
+		case Type::GetSystemDateTime: {
+			int dest_v = atoi(args[0].c_str());
+
+			std::time_t t = lcf::LSD_Reader::GenerateTimestamp();
+			std::tm* tm = std::gmtime(&t);
+			StoreTimestamp(dest_v, tm);
+			break;
+		}
+		case Type::SetGlobalBrightness:
+			// Not implemented.
+			// In some cases, changing the Scene via ppcomp might skip on the transition
+			// routine and leave the screen black in RPG_RT.
+			// This command was added to the patch, to be able to manually set the
+			// internal brightness back to '100'.
+			break;
+		case Type::CallLoadMenu:
+			Scene::instance->SetRequestedScene(std::make_shared<Scene_Load>());
+			break;
+		case Type::CallSaveMenu:
+			Scene::instance->SetRequestedScene(std::make_shared<Scene_Save>());
+			break;
+		case Type::CallGameMenu: {
+			int cursor = args.size() >= 1 ? atoi(args[0].c_str()) : 0;
+			Game_Map::GetInterpreter().RequestMainMenuScene();
+			break;
+		}
+		case Type::CallTitleScreen: {
+			int cursor = args.size() >= 1 ? atoi(args[0].c_str()) : 0;
+			async_op = AsyncOp::MakeToTitle();
+			break;
+		}
+		case Type::SetTitleBGM:
+			OverrideSystemMusic(lcf::Data::system.title_music, args);
+			break;
+		case Type::SetTitleScreen:
+			lcf::Data::system.title_name = lcf::DBString(args[0]);
+			break;
+		case Type::SetGameOverScreen:
+			lcf::Data::system.gameover_name = lcf::DBString(args[0]);
+			break;
+		case Type::UnlockPictures: {
+			int value = atoi(args[0].c_str());
+			if (Player::game_config.patch_unlock_pics.IsLocked()) {
+				Player::game_config.patch_unlock_pics.SetLocked(false);
+			}
+			Player::game_config.patch_unlock_pics.Set(value);
+			break;
+		}
+		default:
+			return false;
+	}
+
+	return true;
+}

--- a/src/game_powerpatch.cpp
+++ b/src/game_powerpatch.cpp
@@ -25,6 +25,8 @@
 #include "scene_load.h"
 #include "scene_save.h"
 #include "scene_debug.h"
+#include "scene_title.h"
+#include "scene_menu.h"
 #include "main_data.h"
 #include "game_interpreter_map.h"
 #include "game_map.h"
@@ -207,14 +209,25 @@ bool Game_PowerPatch::Execute(PPC_CommandType command, Span<std::string const> a
 			Scene::instance->SetRequestedScene(std::make_shared<Scene_Save>());
 			break;
 		case Type::CallGameMenu: {
-			int cursor = args.size() >= 1 ? atoi(args[0].c_str()) : 0;
-			//TODO: implement cursor
-			Game_Map::GetInterpreter().RequestMainMenuScene();
+			if (args.size() >= 1) {
+				if (atoi(args[0].c_str())) {
+					Scene_Menu::force_cursor_index = Scene_Menu::CommandOptionType::Save;
+				} else {
+					Scene_Menu::force_cursor_index = Scene_Menu::CommandOptionType::Item;
+				}
+			}
+			Scene::instance->SetRequestedScene(std::make_shared<Scene_Menu>());
 			break;
 		}
 		case Type::CallTitleScreen: {
-			int cursor = args.size() >= 1 ? atoi(args[0].c_str()) : 0;
-			//TODO: implement cursor
+			if (args.size() >= 1) {
+				if (atoi(args[0].c_str())) {
+					Scene_Title::force_cursor_index = Scene_Title::CommandOptionType::ContinueGame;
+				} else {
+					Scene_Title::force_cursor_index = Scene_Title::CommandOptionType::NewGame;
+				}
+			}
+			Player::force_make_to_title_flag = true;
 			async_op = AsyncOp::MakeToTitle();
 			break;
 		}

--- a/src/game_powerpatch.cpp
+++ b/src/game_powerpatch.cpp
@@ -58,7 +58,7 @@ namespace {
 }
 
 AsyncOp Game_PowerPatch::ExecutePPC(std::string_view ppc_cmd, Span<std::string const> args) {
-	auto& cmd = std::find_if(PPC_commands.begin(), PPC_commands.end(), [&ppc_cmd](auto& cmd) {
+	auto cmd = std::find_if(PPC_commands.begin(), PPC_commands.end(), [&ppc_cmd](auto& cmd) {
 		return ppc_cmd == cmd.name;
 	});
 	if (cmd == PPC_commands.end()) {
@@ -101,7 +101,7 @@ bool Game_PowerPatch::Execute(PPC_CommandType command, Span<std::string const> a
 			int map_x = args.size() >= 3 ? atoi(args[2].c_str()) : -1;
 			int map_y = args.size() >= 4 ? atoi(args[3].c_str()) : -1;
 
-			auto& fs = FileFinder::Save();
+			auto fs = FileFinder::Save();
 			if (slot == 0) {
 				slot = Game_Interpreter_Shared::GetLatestSaveSlot(fs);
 			}
@@ -116,7 +116,7 @@ bool Game_PowerPatch::Execute(PPC_CommandType command, Span<std::string const> a
 		case Type::Load: {
 			int slot = args.size() >= 1 ? atoi(args[0].c_str()) : 0;
 
-			auto& fs = FileFinder::Save();
+			auto fs = FileFinder::Save();
 			if (slot == 0) {
 				slot = Game_Interpreter_Shared::GetLatestSaveSlot(fs);
 			}
@@ -140,7 +140,8 @@ bool Game_PowerPatch::Execute(PPC_CommandType command, Span<std::string const> a
 			int slot = atoi(args[0].c_str());
 			int dest_sw = atoi(args[1].c_str());
 
-			auto exists = !FileFinder::GetSaveFilename(FileFinder::Save(), slot, true).empty();
+			auto fs = FileFinder::Save();
+			auto exists = !FileFinder::GetSaveFilename(fs, slot, true).empty();
 			Main_Data::game_switches->Set(dest_sw, exists);
 			break;
 		}
@@ -148,7 +149,7 @@ bool Game_PowerPatch::Execute(PPC_CommandType command, Span<std::string const> a
 			int slot = atoi(args[0].c_str());
 			int dest_slot = atoi(args[1].c_str());
 
-			auto& fs = FileFinder::Save();
+			auto fs = FileFinder::Save();
 			auto save = Game_Interpreter_Shared::ValidateAndLoadSave("PowerPatch CopySave", fs, slot);
 			if (!save) {
 				return true;
@@ -174,7 +175,7 @@ bool Game_PowerPatch::Execute(PPC_CommandType command, Span<std::string const> a
 			int slot = atoi(args[0].c_str());
 			int dest_v = atoi(args[1].c_str());
 
-			auto& fs = FileFinder::Save();
+			auto fs = FileFinder::Save();
 			auto save = Game_Interpreter_Shared::ValidateAndLoadSave("PowerPatch GetSaveDateTime", fs, slot);
 			if (!save) {
 				return true;

--- a/src/game_powerpatch.cpp
+++ b/src/game_powerpatch.cpp
@@ -124,7 +124,7 @@ bool Game_PowerPatch::Execute(PPC_CommandType command, Span<std::string const> a
 			if (!save) {
 				return true;
 			}
-			// FIXME: In RPG_RT the loading operation happens asynchronously while the
+			// In RPG_RT the loading operation happens asynchronously while the
 			// current interpreter is still running. Any other Ineluki scripts might
 			// be executed before the loading process is complete.
 			// This breaks some games, such as "Take it cheesy"
@@ -133,7 +133,7 @@ bool Game_PowerPatch::Execute(PPC_CommandType command, Span<std::string const> a
 			//      the mouse patch. As a result, mouse functionality will work normally
 			//      in RPG_RT, but not in EasyRPG Player, which never ran the
 			//      neccessary setup scripts.
-			async_op = Game_Interpreter_Shared::MakeLoadOp("PowerPatch Load", slot);
+			async_op = Game_Interpreter_Shared::MakeLoadParallel("PowerPatch Load", slot);
 			break;
 		}
 		case Type::CheckSave: {
@@ -207,11 +207,13 @@ bool Game_PowerPatch::Execute(PPC_CommandType command, Span<std::string const> a
 			break;
 		case Type::CallGameMenu: {
 			int cursor = args.size() >= 1 ? atoi(args[0].c_str()) : 0;
+			//TODO: implement cursor
 			Game_Map::GetInterpreter().RequestMainMenuScene();
 			break;
 		}
 		case Type::CallTitleScreen: {
 			int cursor = args.size() >= 1 ? atoi(args[0].c_str()) : 0;
+			//TODO: implement cursor
 			async_op = AsyncOp::MakeToTitle();
 			break;
 		}

--- a/src/game_powerpatch.h
+++ b/src/game_powerpatch.h
@@ -1,0 +1,99 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_GAME_POWERPATCH_H
+#define EP_GAME_POWERPATCH_H
+
+// Headers
+#include <string>
+
+#include "async_op.h"
+#include "string_view.h"
+#include "span.h"
+
+namespace Game_PowerPatch {
+	enum class PPC_CommandType {
+		Debug,
+		Quit,
+		Restart,
+		Save,
+		Load,
+		CheckSave,
+		CopySave,
+		DeleteSave,
+		GetSaveDateTime,
+		GetSystemDateTime,
+		SetGlobalBrightness,
+		PauseTimer,
+		ChangeScene,
+		CallLoadMenu,
+		CallSaveMenu,
+		CallGameMenu,
+		CallTitleScreen,
+		SimulateKeyPress,
+		ChangeFunctionKey,
+		SetTitleBGM,
+		SetTitleScreen,
+		SetGameOverScreen,
+		UnlockPictures,
+		SetMsgBoxColor,
+		PauseGame,
+		SetVar,
+		LAST
+	};
+
+	AsyncOp ExecutePPC(std::string_view pcc_cmd, Span<std::string const> args);
+
+	bool Execute(PPC_CommandType command, Span<std::string const> args, AsyncOp& async_op);
+
+	struct PPC_Command {
+		PPC_CommandType type;
+		uint8_t min_args;
+		const char* name;
+	};
+
+	static constexpr std::array<PPC_Command, static_cast<size_t>(PPC_CommandType::LAST)> PPC_commands = {{
+		{ PPC_CommandType::Debug,               0, "DEBUG" },
+		{ PPC_CommandType::Quit,                0, "QUIT" },
+		{ PPC_CommandType::Restart,             0, "RESTART" },
+		{ PPC_CommandType::Save,                0, "SAVE" },
+		{ PPC_CommandType::Load,                0, "LOAD" },
+		{ PPC_CommandType::CheckSave,           2, "CHECKSAVE" },
+		{ PPC_CommandType::CopySave,            2, "COPYSAVE" },
+		{ PPC_CommandType::DeleteSave,          1, "DELETESAVE" },
+		{ PPC_CommandType::GetSaveDateTime,     2, "GETSAVEDATETIME" },
+		{ PPC_CommandType::GetSystemDateTime,   1, "GETSYSTEMDATETIME" },
+		{ PPC_CommandType::SetGlobalBrightness, 1, "SETGLOBALBRIGHTNESS" },
+		{ PPC_CommandType::PauseTimer,          1, "PAUSETIMER" },
+		{ PPC_CommandType::ChangeScene,         1, "CHANGESCENE" },
+		{ PPC_CommandType::CallLoadMenu,        0, "CALLLOADMENU" },
+		{ PPC_CommandType::CallSaveMenu,        0, "CALLSAVEMENU" },
+		{ PPC_CommandType::CallGameMenu,        0, "CALLGAMEMENU" },
+		{ PPC_CommandType::CallTitleScreen,     0, "CALLTITLESCREEN" },
+		{ PPC_CommandType::SimulateKeyPress,    0, "SIMULATEKEYPRESS" },
+		{ PPC_CommandType::ChangeFunctionKey,   0, "CHANGEFUNCTIONKEY" },
+		{ PPC_CommandType::SetTitleBGM,         1, "SETTITLEBGM" },
+		{ PPC_CommandType::SetTitleScreen,      1, "SETTITLESCREEN" },
+		{ PPC_CommandType::SetGameOverScreen,   1, "SETGAMEOVERSCREEN" },
+		{ PPC_CommandType::UnlockPictures,      1, "UNLOCKPICTURES" },
+		{ PPC_CommandType::SetMsgBoxColor,      4, "SETMSGBOXCOLOR" },
+		{ PPC_CommandType::PauseGame,           0, "PAUSEGAME" },
+		{ PPC_CommandType::SetVar,              0, "SETVAR" }
+	}};
+};
+
+#endif

--- a/src/game_powerpatch.h
+++ b/src/game_powerpatch.h
@@ -22,6 +22,7 @@
 #include <string>
 
 #include "async_op.h"
+#include "game_ineluki.h"
 #include "string_view.h"
 #include "span.h"
 
@@ -84,7 +85,7 @@ namespace Game_PowerPatch {
 		{ PPC_CommandType::CallSaveMenu,        0, "CALLSAVEMENU" },
 		{ PPC_CommandType::CallGameMenu,        0, "CALLGAMEMENU" },
 		{ PPC_CommandType::CallTitleScreen,     0, "CALLTITLESCREEN" },
-		{ PPC_CommandType::SimulateKeyPress,    0, "SIMULATEKEYPRESS" },
+		{ PPC_CommandType::SimulateKeyPress,    2, "SIMULATEKEYPRESS" },
 		{ PPC_CommandType::ChangeFunctionKey,   0, "CHANGEFUNCTIONKEY" },
 		{ PPC_CommandType::SetTitleBGM,         1, "SETTITLEBGM" },
 		{ PPC_CommandType::SetTitleScreen,      1, "SETTITLESCREEN" },
@@ -94,6 +95,12 @@ namespace Game_PowerPatch {
 		{ PPC_CommandType::PauseGame,           0, "PAUSEGAME" },
 		{ PPC_CommandType::SetVar,              0, "SETVAR" }
 	}};
+
+	/**
+	* Map of simulated keypresses handled via ppcomp
+	* 'int' value refers to remaining frames
+	*/
+	extern std::map<Input::Keys::InputKey, int> simulate_keypresses;
 };
 
 #endif

--- a/src/game_system.cpp
+++ b/src/game_system.cpp
@@ -112,6 +112,10 @@ void Game_System::BgmPlay(lcf::rpg::Music const& bgm) {
 			bgm_pending = true;
 			FileRequestAsync* request = AsyncHandler::RequestFile("Music", bgm.name);
 			music_request_id = request->Bind(&Game_System::OnBgmReady, this);
+			if (EndsWith(bgm.name, ".script")) {
+				// Is a Ineluki Script File
+				request->SetImportantFile(true);
+			}
 			request->Start();
 		}
 	} else {
@@ -533,6 +537,12 @@ void Game_System::OnBgmReady(FileRequestResult* result) {
 		return;
 	} else if (!stream) {
 		Output::Debug("Music not found: {}", result->file);
+		return;
+	}
+
+	if (Player::IsPatchKeyPatch() && EndsWith(result->file, ".script")) {
+		// Is a Ineluki Script File
+		Main_Data::game_ineluki->Execute(result->file);
 		return;
 	}
 

--- a/src/meta.cpp
+++ b/src/meta.cpp
@@ -177,14 +177,13 @@ std::vector<Meta::FileItem> Meta::BuildImportCandidateList(const FilesystemView&
 
 	if (is_match) {
 		// Scan over every possible save file and see if any match.
-		for (int saveId = 0; saveId < 15; saveId++) {
-			std::stringstream ss;
-			ss << "Save" << (saveId <= 8 ? "0" : "") << (saveId + 1) << ".lsd";
+		for (int saveId = 0; saveId < Player::Constants::MaxSaveFiles(); saveId++) {
+			auto filename = FileFinder::GetSaveFilename(saveId + 1);
 
 			// Check for an existing, non-corrupt file with the right mapID
 			// Note that corruptness is checked later (in window_savefile.cpp)
-			if (child_tree.Exists(ss.str())) {
-				auto filePath= child_tree.GetSubPath() + "/" + ss.str();
+			if (child_tree.Exists(filename)) {
+				auto filePath = child_tree.GetSubPath() + "/" + filename;
 				std::unique_ptr<lcf::rpg::Save> savegame = lcf::LSD_Reader::Load(filePath, Player::encoding);
 				if (savegame != nullptr) {
 					if (savegame->party_location.map_id == pivot_map_id || pivot_map_id==0) {

--- a/src/platform/emscripten/interface.cpp
+++ b/src/platform/emscripten/interface.cpp
@@ -28,7 +28,7 @@
 #include "filefinder.h"
 #include "filesystem_stream.h"
 #include "player.h"
-#include "scene_save.h"
+#include "scene.h"
 #include "output.h"
 
 void Emscripten_Interface::Reset() {
@@ -37,7 +37,7 @@ void Emscripten_Interface::Reset() {
 
 bool Emscripten_Interface::DownloadSavegame(int slot) {
 	auto fs = FileFinder::Save();
-	std::string name = Scene_Save::GetSaveFilename(fs, slot);
+	std::string name = FileFinder::GetSaveFilename(fs, slot);
 	auto is = fs.OpenInputStream(name);
 	if (!is) {
 		return false;
@@ -85,7 +85,7 @@ void Emscripten_Interface::TakeScreenshot() {
 
 bool Emscripten_Interface_Private::UploadSavegameStep2(int slot, int buffer_addr, int size) {
 	auto fs = FileFinder::Save();
-	std::string name = Scene_Save::GetSaveFilename(fs, slot);
+	std::string name = FileFinder::GetSaveFilename(fs, slot);
 
 	std::istream is(new Filesystem_Stream::InputMemoryStreamBufView(lcf::Span<uint8_t>(reinterpret_cast<uint8_t*>(buffer_addr), size)));
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -827,6 +827,10 @@ void Player::CreateGameObjects() {
 		if (!FileFinder::Game().FindFile(DESTINY_DLL).empty()) {
 			game_config.patch_destiny.Set(true);
 		}
+
+		if (!FileFinder::Game().FindFile("powerp.oex").empty()) {
+			Output::Warning("This game uses Power Patch and might not run properly.");
+		}
 	}
 
 	game_config.PrintActivePatches();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1613,3 +1613,7 @@ std::string Player::GetEngineVersion() {
 	if (EngineVersion() > 0) return std::to_string(EngineVersion());
 	return std::string();
 }
+
+int32_t Player::Constants::MaxSaveFiles() {
+	return Utils::Clamp<int32_t>(lcf::Data::system.easyrpg_max_savefiles, 3, 99);
+}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -831,6 +831,19 @@ void Player::CreateGameObjects() {
 		if (!FileFinder::Game().FindFile("powerp.oex").empty()) {
 			Output::Warning("This game uses Power Patch and might not run properly.");
 		}
+
+		if (game_config.patch_key_patch.Get()) {
+			auto exe_util_types = Utils::MakeSvArray(".exe", ".dll", ".dat");
+			auto exe_util_names = Utils::MakeSvArray("ppcomp", "sfx", "savecount", "LS");
+
+			for (auto util_name : exe_util_names) {
+				if (!FileFinder::Game().FindFile(util_name, exe_util_types).empty()) {
+					Output::Debug("KeyPatch: Found external program '{}'. Patch scripts will behave synchronously.", util_name);
+					game_config.patch_key_patch_no_async.Set(true);
+					break;
+				}
+			}
+		}
 	}
 
 	game_config.PrintActivePatches();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -832,7 +832,7 @@ void Player::CreateGameObjects() {
 			Output::Warning("This game uses Power Patch and might not run properly.");
 		}
 
-		if (game_config.patch_key_patch.Get()) {
+		/*if (game_config.patch_key_patch.Get()) {
 			auto exe_util_types = Utils::MakeSvArray(".exe", ".dll", ".dat");
 			auto exe_util_names = Utils::MakeSvArray("ppcomp", "sfx");
 
@@ -854,7 +854,7 @@ void Player::CreateGameObjects() {
 					}
 				}
 			}
-		}
+		}*/
 
 		if (Player::game_config.patch_better_aep.Get()) {
 			Player::game_config.new_game.Set(true);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -136,6 +136,7 @@ namespace Player {
 	int rng_seed = -1;
 	Game_ConfigPlayer player_config;
 	Game_ConfigGame game_config;
+	bool force_make_to_title_flag = false;
 #ifdef EMSCRIPTEN
 	std::string emscripten_game_name;
 #endif

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -855,6 +855,10 @@ void Player::CreateGameObjects() {
 				}
 			}
 		}
+
+		if (Player::game_config.patch_better_aep.Get()) {
+			Player::game_config.new_game.Set(true);
+		}
 	}
 
 	game_config.PrintActivePatches();
@@ -1481,6 +1485,9 @@ Engine options:
  --patch-direct-menu VAR
                       Directly access subscreens of the default menu by setting
                       VAR.
+ --patch-better-aep VAR
+                      Emulates the behavior of the "BetterAEP" patch, which
+                      is commonly used for implementing customized title screens.
  --patch-dynrpg       Enable support of DynRPG patch by Cherry (very limited).
  --patch-easyrpg      Enable EasyRPG extensions.
  --patch-key-patch    Enable Key Patch by Ineluki.

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -832,6 +832,12 @@ void Player::CreateGameObjects() {
 			Output::Warning("This game uses Power Patch and might not run properly.");
 		}
 
+		// PowerMode2003 can be detected via the existence of the files "hvm.dll", "fmodex.dll" &
+		// "warp.dll", but some games seem to only ship with the latter of the three.
+		if (!FileFinder::Game().FindFile("warp.dll").empty()) {
+			Output::Warning("This game uses Power Mode 2003 and might not run properly.");
+		}
+
 		/*if (game_config.patch_key_patch.Get()) {
 			auto exe_util_types = Utils::MakeSvArray(".exe", ".dll", ".dat");
 			auto exe_util_names = Utils::MakeSvArray("ppcomp", "sfx");

--- a/src/player.h
+++ b/src/player.h
@@ -415,6 +415,9 @@ namespace Player {
 	/** Translation manager, including list of languages and current translation. */
 	extern Translation translation;
 
+	/** If true, the game will be forced to stay at the title scene, even if the "new_game" option is set. */
+	extern bool force_make_to_title_flag;
+
 	/**
 	 * The default speed modifier applied when the speed up button is pressed
 	 *  Only used for configuring the speedup, don't read this var directly use

--- a/src/player.h
+++ b/src/player.h
@@ -435,6 +435,10 @@ namespace Player {
 	/** Name of game emscripten uses */
 	extern std::string emscripten_game_name;
 #endif
+
+	namespace Constants {
+		int32_t MaxSaveFiles();
+	}
 }
 
 inline bool Player::IsRPG2k() {

--- a/src/player.h
+++ b/src/player.h
@@ -172,7 +172,7 @@ namespace Player {
 	 * @param save_file Savegame file to load
 	 * @param save_id ID of the savegame to load
 	 */
-	void LoadSavegame(const std::string& save_file, int save_id = 0);
+	void LoadSavegame(const std::string& save_file, int save_id = 0, bool load_parallel = false);
 
 	/**
 	 * Starts a new game

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -89,11 +89,7 @@ void Scene_File::UpdateLatestTimestamp(int id, lcf::rpg::Save& savegame) {
 }
 
 void Scene_File::PopulateSaveWindow(Window_SaveFile& win, int id) {
-	// Try to access file
-	std::stringstream ss;
-	ss << "Save" << (id <= 8 ? "0" : "") << (id + 1) << ".lsd";
-
-	std::string file = fs.FindFile(ss.str());
+	std::string file = FileFinder::GetSaveFilename(fs, id + 1);
 
 	if (!file.empty()) {
 		// File found
@@ -123,7 +119,7 @@ void Scene_File::Start() {
 	// Refresh File Finder Save Folder
 	fs = FileFinder::Save();
 
-	for (int i = 0; i < Utils::Clamp<int32_t>(lcf::Data::system.easyrpg_max_savefiles, 3, 99); i++) {
+	for (int i = 0; i < Player::Constants::MaxSaveFiles(); i++) {
 		std::shared_ptr<Window_SaveFile>
 			w(new Window_SaveFile(Player::menu_offset_x, 40 + i * 64, MENU_WIDTH, 64));
 		w->SetIndex(i);

--- a/src/scene_import.cpp
+++ b/src/scene_import.cpp
@@ -54,9 +54,8 @@ void Scene_Import::Start() {
 	CreateHelpWindow();
 	border_top = Scene_File::MakeBorderSprite(32);
 
-	// For consistency, we only show 15 windows
-	// We don't populate them until later (once we've loaded all potential importable files).
-	for (int i = 0; i < 15; i++) {
+	// We don't populate the windows until later (once we've loaded all potential importable files).
+	for (int i = 0; i < Player::Constants::MaxSaveFiles(); i++) {
 		std::shared_ptr<Window_SaveFile>
 			w(new Window_SaveFile(0, 40 + i * 64, Player::screen_width, 64));
 		w->SetIndex(i);
@@ -128,7 +127,7 @@ void Scene_Import::UpdateScanAndProgress() {
 }
 
 void Scene_Import::FinishScan() {
-	for (int i = 0; i < 15; i++) {
+	for (int i = 0; i < Player::Constants::MaxSaveFiles(); i++) {
 		auto w = file_windows[i];
 		PopulateSaveWindow(*w, i);
 		w->Refresh();

--- a/src/scene_load.cpp
+++ b/src/scene_load.cpp
@@ -29,8 +29,7 @@ Scene_Load::Scene_Load() :
 }
 
 void Scene_Load::Action(int index) {
-	std::string save_name = fs.FindFile(fmt::format("Save{:02d}.lsd", index + 1));
-
+	std::string save_name = FileFinder::GetSaveFilename(fs, index + 1);
 	Player::LoadSavegame(save_name, index + 1);
 }
 

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -104,14 +104,9 @@ void Scene_Logo::vUpdate() {
 			Scene::PushTitleScene(true);
 
 			if (Player::load_game_id > 0) {
-				auto save = FileFinder::Save();
+				Output::Debug("Loading Save {}", FileFinder::GetSaveFilename(Player::load_game_id));
 
-				std::stringstream ss;
-				ss << "Save" << (Player::load_game_id <= 9 ? "0" : "") << Player::load_game_id << ".lsd";
-
-				Output::Debug("Loading Save {}", ss.str());
-
-				std::string save_name = save.FindFile(ss.str());
+				std::string save_name = FileFinder::GetSaveFilename(FileFinder::Save(), Player::load_game_id);
 				Player::LoadSavegame(save_name, Player::load_game_id);
 			}
 		}

--- a/src/scene_map.cpp
+++ b/src/scene_map.cpp
@@ -410,7 +410,7 @@ void Scene_Map::OnAsyncSuspend(F&& f, AsyncOp aop, bool is_preupdate) {
 
 	if (aop.GetType() == AsyncOp::eLoad) {
 		auto savefs = FileFinder::Save();
-		std::string save_name = Scene_Save::GetSaveFilename(savefs, aop.GetSaveSlot());
+		std::string save_name = FileFinder::GetSaveFilename(savefs, aop.GetSaveSlot(), false);
 		Player::LoadSavegame(save_name, aop.GetSaveSlot());
 	}
 

--- a/src/scene_map.h
+++ b/src/scene_map.h
@@ -88,6 +88,8 @@ private:
 
 	template <typename F> void OnAsyncSuspend(F&& f, AsyncOp aop, bool is_preupdate);
 
+	bool HandleLoadParallel();
+
 	void UpdateGraphics() override;
 
 	std::unique_ptr<Window_Message> message_window;
@@ -100,6 +102,7 @@ private:
 	bool activate_inn = false;
 	bool inn_started = false;
 	Game_Clock::time_point inn_timer = {};
+	std::string load_parallel_save_name = {};
 };
 
 #endif

--- a/src/scene_menu.cpp
+++ b/src/scene_menu.cpp
@@ -40,6 +40,8 @@ constexpr int menu_command_width = 88;
 constexpr int gold_window_width = 88;
 constexpr int gold_window_height = 32;
 
+Scene_Menu::CommandOptionType Scene_Menu::force_cursor_index = Scene_Menu::CommandOption_None;
+
 Scene_Menu::Scene_Menu(int menu_index) :
 	menu_index(menu_index) {
 	type = Scene::Menu;
@@ -78,28 +80,30 @@ void Scene_Menu::CreateCommandWindow() {
 	// Create Options Window
 	std::vector<std::string> options;
 
+	using Cmd = CommandOptionType;
+
 	if (Player::IsRPG2k()) {
-		command_options.push_back(Item);
-		command_options.push_back(Skill);
-		command_options.push_back(Equipment);
-		command_options.push_back(Save);
+		command_options.push_back(Cmd::Item);
+		command_options.push_back(Cmd::Skill);
+		command_options.push_back(Cmd::Equipment);
+		command_options.push_back(Cmd::Save);
 		if (Player::player_config.settings_in_menu.Get()) {
-			command_options.push_back(Settings);
+			command_options.push_back(Cmd::Settings);
 		}
 		if (Player::debug_flag) {
-			command_options.push_back(Debug);
+			command_options.push_back(Cmd::Debug);
 		}
-		command_options.push_back(Quit);
+		command_options.push_back(Cmd::Quit);
 	} else {
 		for (std::vector<int16_t>::iterator it = lcf::Data::system.menu_commands.begin();
 			it != lcf::Data::system.menu_commands.end(); ++it) {
 				switch (*it) {
-				case Row:
+				case static_cast<int>(Cmd::Row):
 					if (Feature::HasRow()) {
 						command_options.push_back((CommandOptionType)*it);
 					}
 					break;
-				case Wait:
+				case static_cast<int>(Cmd::Wait):
 					if (Feature::HasRpg2k3BattleSystem()) {
 						command_options.push_back((CommandOptionType)*it);
 					}
@@ -110,46 +114,46 @@ void Scene_Menu::CreateCommandWindow() {
 				}
 		}
 		if (Player::player_config.settings_in_menu.Get()) {
-			command_options.push_back(Settings);
+			command_options.push_back(Cmd::Settings);
 		}
 		if (Player::debug_flag) {
-			command_options.push_back(Debug);
+			command_options.push_back(Cmd::Debug);
 		}
-		command_options.push_back(Quit);
+		command_options.push_back(Cmd::Quit);
 	}
 
 	// Add all menu items
 	std::vector<CommandOptionType>::iterator it;
 	for (it = command_options.begin(); it != command_options.end(); ++it) {
 		switch(*it) {
-		case Item:
+		case Cmd::Item:
 			options.push_back(ToString(lcf::Data::terms.command_item));
 			break;
-		case Skill:
+		case Cmd::Skill:
 			options.push_back(ToString(lcf::Data::terms.command_skill));
 			break;
-		case Equipment:
+		case Cmd::Equipment:
 			options.push_back(ToString(lcf::Data::terms.menu_equipment));
 			break;
-		case Save:
+		case Cmd::Save:
 			options.push_back(ToString(lcf::Data::terms.menu_save));
 			break;
-		case Status:
+		case Cmd::Status:
 			options.push_back(ToString(lcf::Data::terms.status));
 			break;
-		case Row:
+		case Cmd::Row:
 			options.push_back(ToString(lcf::Data::terms.row));
 			break;
-		case Order:
+		case Cmd::Order:
 			options.push_back(ToString(lcf::Data::terms.order));
 			break;
-		case Wait:
+		case Cmd::Wait:
 			options.push_back(ToString(Main_Data::game_system->GetAtbMode() == lcf::rpg::SaveSystem::AtbMode_atb_wait ? lcf::Data::terms.wait_on : lcf::Data::terms.wait_off));
 			break;
-		case Settings:
+		case Cmd::Settings:
 			options.push_back("Settings");
 			break;
-		case Debug:
+		case Cmd::Debug:
 			options.push_back("Debug");
 			break;
 		default:
@@ -161,22 +165,30 @@ void Scene_Menu::CreateCommandWindow() {
 	command_window.reset(new Window_Command(options, menu_command_width));
 	command_window->SetX(Player::menu_offset_x);
 	command_window->SetY(Player::menu_offset_y);
-	command_window->SetIndex(menu_index);
+
+	if (force_cursor_index != CommandOption_None) {
+		if (auto idx = GetCommandIndex(force_cursor_index); idx != -1) {
+			command_window->SetIndex(idx);
+		}
+		force_cursor_index = CommandOption_None;
+	} else {
+		command_window->SetIndex(menu_index);
+	}
 
 	// Disable items
 	for (it = command_options.begin(); it != command_options.end(); ++it) {
 		switch(*it) {
-		case Save:
+		case Cmd::Save:
 			// If save is forbidden disable this item
 			if (!Main_Data::game_system->GetAllowSave()) {
 				command_window->DisableItem(it - command_options.begin());
 			}
-		case Wait:
-		case Quit:
-		case Settings:
-		case Debug:
+		case Cmd::Wait:
+		case Cmd::Quit:
+		case Cmd::Settings:
+		case Cmd::Debug:
 			break;
-		case Order:
+		case Cmd::Order:
 			if (Main_Data::game_party->GetActors().size() <= 1) {
 				command_window->DisableItem(it - command_options.begin());
 			}
@@ -191,6 +203,7 @@ void Scene_Menu::CreateCommandWindow() {
 }
 
 void Scene_Menu::UpdateCommand() {
+	using Cmd = CommandOptionType;
 	if (Input::IsTriggered(Input::CANCEL)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
 		Scene::Pop();
@@ -198,7 +211,7 @@ void Scene_Menu::UpdateCommand() {
 		menu_index = command_window->GetIndex();
 
 		switch (command_options[menu_index]) {
-		case Item:
+		case Cmd::Item:
 			if (Main_Data::game_party->GetActors().empty()) {
 				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 			} else {
@@ -206,10 +219,10 @@ void Scene_Menu::UpdateCommand() {
 				Scene::Push(std::make_shared<Scene_Item>());
 			}
 			break;
-		case Skill:
-		case Equipment:
-		case Status:
-		case Row:
+		case Cmd::Skill:
+		case Cmd::Equipment:
+		case Cmd::Status:
+		case Cmd::Row:
 			if (Main_Data::game_party->GetActors().empty()) {
 				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 			} else {
@@ -219,7 +232,7 @@ void Scene_Menu::UpdateCommand() {
 				menustatus_window->SetIndex(0);
 			}
 			break;
-		case Save:
+		case Cmd::Save:
 			if (!Main_Data::game_system->GetAllowSave()) {
 				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 			} else {
@@ -227,7 +240,7 @@ void Scene_Menu::UpdateCommand() {
 				Scene::Push(std::make_shared<Scene_Save>());
 			}
 			break;
-		case Order:
+		case Cmd::Order:
 			if (Main_Data::game_party->GetActors().size() <= 1) {
 				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 			} else {
@@ -235,21 +248,21 @@ void Scene_Menu::UpdateCommand() {
 				Scene::Push(std::make_shared<Scene_Order>());
 			}
 			break;
-		case Wait:
+		case Cmd::Wait:
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 			Main_Data::game_system->ToggleAtbMode();
 			command_window->SetItemText(menu_index,
 				Main_Data::game_system->GetAtbMode() == lcf::rpg::SaveSystem::AtbMode_atb_wait ? lcf::Data::terms.wait_on : lcf::Data::terms.wait_off);
 			break;
-		case Settings:
+		case Cmd::Settings:
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Game_System::SFX_Decision));
 			Scene::Push(std::make_shared<Scene_Settings>());
 			break;
-		case Debug:
+		case Cmd::Debug:
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 			Scene::Push(std::make_shared<Scene_Debug>());
 			break;
-		case Quit:
+		case Cmd::Quit:
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 			Scene::Push(std::make_shared<Scene_End>());
 			break;
@@ -258,6 +271,7 @@ void Scene_Menu::UpdateCommand() {
 }
 
 void Scene_Menu::UpdateActorSelection() {
+	using Cmd = CommandOptionType;
 	if (Input::IsTriggered(Input::CANCEL)) {
 		Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Cancel));
 		command_window->SetActive(true);
@@ -265,7 +279,7 @@ void Scene_Menu::UpdateActorSelection() {
 		menustatus_window->SetIndex(-1);
 	} else if (Input::IsTriggered(Input::DECISION)) {
 		switch (command_options[command_window->GetIndex()]) {
-		case Skill:
+		case Cmd::Skill:
 			if (!menustatus_window->GetActor()->CanAct()) {
 				Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 				return;
@@ -273,15 +287,15 @@ void Scene_Menu::UpdateActorSelection() {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 			Scene::Push(std::make_shared<Scene_Skill>(Main_Data::game_party->GetActors(), menustatus_window->GetIndex()));
 			break;
-		case Equipment:
+		case Cmd::Equipment:
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 			Scene::Push(std::make_shared<Scene_Equip>(Main_Data::game_party->GetActors(), menustatus_window->GetIndex()));
 			break;
-		case Status:
+		case Cmd::Status:
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 			Scene::Push(std::make_shared<Scene_Status>(Main_Data::game_party->GetActors(), menustatus_window->GetIndex()));
 			break;
-		case Row:
+		case Cmd::Row:
 		{
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
 			// Don't allow entire party in the back row.
@@ -312,4 +326,12 @@ void Scene_Menu::UpdateActorSelection() {
 		menustatus_window->SetActive(false);
 		menustatus_window->SetIndex(-1);
 	}
+}
+
+int Scene_Menu::GetCommandIndex(CommandOptionType cmd) const {
+	auto it = std::find(command_options.begin(), command_options.end(), cmd);
+	if (it != command_options.end()) {
+		return (it - command_options.begin());
+	}
+	return -1;
 }

--- a/src/scene_menu.h
+++ b/src/scene_menu.h
@@ -56,7 +56,7 @@ public:
 	void UpdateActorSelection();
 
 	/** Options available in a Rpg2k3 menu. */
-	enum CommandOptionType {
+	enum class CommandOptionType {
 		Item = 1,
 		Skill,
 		Equipment,
@@ -70,6 +70,11 @@ public:
 		Debug = 100,
 		Settings = 101,
 	};
+
+	int GetCommandIndex(CommandOptionType cmd) const;
+
+	static const CommandOptionType CommandOption_None = static_cast<CommandOptionType>(0);
+	static CommandOptionType force_cursor_index;
 
 private:
 	/** Selected index on startup. */

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -65,19 +65,8 @@ void Scene_Save::Action(int index) {
 	Scene::Pop();
 }
 
-std::string Scene_Save::GetSaveFilename(const FilesystemView& fs, int slot_id) {
-	const auto save_file = fmt::format("Save{:02d}.lsd", slot_id);
-
-	std::string filename = fs.FindFile(save_file);
-
-	if (filename.empty()) {
-		filename = save_file;
-	}
-	return filename;
-}
-
 bool Scene_Save::Save(const FilesystemView& fs, int slot_id, bool prepare_save) {
-	const auto filename = GetSaveFilename(fs, slot_id);
+	const auto filename = FileFinder::GetSaveFilename(fs, slot_id, false);
 	Output::Debug("Saving to {}", filename);
 
 	auto save_stream = FileFinder::Save().OpenOutputStream(filename);

--- a/src/scene_save.h
+++ b/src/scene_save.h
@@ -39,7 +39,6 @@ public:
 	void Action(int index) override;
 	bool IsSlotValid(int index) override;
 
-	static std::string GetSaveFilename(const FilesystemView& tree, int slot_id);
 	static bool Save(const FilesystemView& tree, int slot_id, bool prepare_save = true);
 	static bool Save(std::ostream& os, int slot_id, bool prepare_save = true);
 };

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -321,7 +321,7 @@ bool Scene_Title::CheckValidPlayerLocation() {
 }
 
 bool Scene_Title::CheckStartNewGame() {
-	return !Check2k3ShowTitle() || Player::game_config.new_game.Get();
+	return (!Check2k3ShowTitle() || Player::game_config.new_game.Get()) && !Player::force_make_to_title_flag;
 }
 
 void Scene_Title::CommandNewGame() {
@@ -385,4 +385,5 @@ void Scene_Title::OnTitleSpriteReady(FileRequestResult* result) {
 
 void Scene_Title::OnGameStart() {
 	restart_title_cache = true;
+	Player::force_make_to_title_flag = false;
 }

--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -45,6 +45,8 @@
 #include "baseui.h"
 #include <lcf/reader_util.h>
 
+Scene_Title::CommandOptionType Scene_Title::force_cursor_index = Scene_Title::CommandOption_None;
+
 Scene_Title::Scene_Title() {
 	type = Scene::Title;
 }
@@ -108,7 +110,7 @@ void Scene_Title::Continue(SceneType prev_scene) {
 }
 
 void Scene_Title::TransitionIn(SceneType prev_scene) {
-	if (Game_Battle::battle_test.enabled || !Check2k3ShowTitle() || Player::game_config.new_game.Get())
+	if (Game_Battle::battle_test.enabled || CheckStartNewGame())
 		return;
 
 	if (prev_scene == Scene::Load || Player::hide_title_flag) {
@@ -133,7 +135,7 @@ void Scene_Title::vUpdate() {
 		return;
 	}
 
-	if (!Check2k3ShowTitle() || Player::game_config.new_game.Get()) {
+	if (CheckStartNewGame()) {
 		Player::SetupNewGame();
 		if (Player::debug_flag && Player::hide_title_flag) {
 			Scene::Push(std::make_shared<Scene_Load>());
@@ -170,10 +172,24 @@ void Scene_Title::vUpdate() {
 void Scene_Title::Refresh() {
 	// Enable load game if available
 	continue_enabled = FileFinder::HasSavegame();
-	if (continue_enabled) {
+
+	if (force_cursor_index != CommandOption_None) {
+		if (auto idx = GetCommandIndex(force_cursor_index); idx != -1) {
+			command_window->SetIndex(idx);
+		}
+		force_cursor_index = CommandOption_None;
+	} else if (continue_enabled) {
 		command_window->SetIndex(1);
 	}
 	command_window->SetItemEnabled(1, continue_enabled);
+}
+
+int Scene_Title::GetCommandIndex(CommandOptionType cmd) const {
+	auto it = std::find(command_options.begin(), command_options.end(), cmd);
+	if (it != command_options.end()) {
+		return (it - command_options.begin());
+	}
+	return -1;
 }
 
 void Scene_Title::OnTranslationChanged() {
@@ -211,35 +227,59 @@ void Scene_Title::RepositionWindow(Window_Command& window, bool center_vertical)
 void Scene_Title::CreateCommandWindow() {
 	// Create Options Window
 	std::vector<std::string> options;
-	options.push_back(ToString(lcf::Data::terms.new_game));
-	options.push_back(ToString(lcf::Data::terms.load_game));
+
+	using Cmd = CommandOptionType;
 
 	// Reset index to fix issues on reuse.
 	indices = CommandIndices();
 
+	command_options.push_back(Cmd::NewGame);
+	command_options.push_back(Cmd::ContinueGame);
+
 	// Set "Import" based on metadata
 	if (Player::meta->IsImportEnabled()) {
-		options.push_back(Player::meta->GetExVocabImportSaveTitleText());
-		indices.import = indices.exit;
-		indices.exit++;
+		command_options.push_back(Cmd::Import);
 	}
-
 	// Set "Settings" based on the configuration
 	if (Player::player_config.settings_in_title.Get()) {
-		// FIXME: Translation? Not shown by default though
-		options.push_back("Settings");
-		indices.settings = indices.exit;
-		indices.exit++;
+		command_options.push_back(Cmd::Settings);
 	}
-
 	// Set "Translate" based on metadata
 	if (Player::translation.HasTranslations() && Player::player_config.lang_select_in_title.Get()) {
-		options.push_back(Player::meta->GetExVocabTranslateTitleText());
-		indices.translate = indices.exit;
-		indices.exit++;
+		command_options.push_back(Cmd::Translate);
 	}
 
-	options.push_back(ToString(lcf::Data::terms.exit_game));
+	command_options.push_back(Cmd::Exit);
+
+	for (int i = 0; i < command_options.size(); ++i) {
+		switch (command_options[i]) {
+			case Cmd::NewGame:
+				indices.new_game = i;
+				options.push_back(ToString(lcf::Data::terms.new_game));
+				break;
+			case Cmd::ContinueGame:
+				indices.continue_game = i;
+				options.push_back(ToString(lcf::Data::terms.load_game));
+				break;
+			case Cmd::Import:
+				indices.import = i;
+				options.push_back(Player::meta->GetExVocabImportSaveTitleText());
+				break;
+			case Cmd::Settings:
+				indices.settings = i;
+				// FIXME: Translation? Not shown by default though
+				options.push_back("Settings");
+				break;
+			case Cmd::Translate:
+				indices.translate = i;
+				options.push_back(Player::meta->GetExVocabTranslateTitleText());
+				break;
+			case Cmd::Exit:
+				indices.exit = i;
+				options.push_back(ToString(lcf::Data::terms.exit_game));
+				break;
+		}
+	}
 
 	command_window.reset(new Window_Command(options));
 	RepositionWindow(*command_window, Player::hide_title_flag);
@@ -267,7 +307,7 @@ void Scene_Title::PlayTitleMusic() {
 
 bool Scene_Title::CheckEnableTitleGraphicAndMusic() {
 	return Check2k3ShowTitle() &&
-		!Player::game_config.new_game.Get() &&
+		!CheckStartNewGame() &&
 		!Game_Battle::battle_test.enabled &&
 		!Player::hide_title_flag;
 }
@@ -278,6 +318,10 @@ bool Scene_Title::Check2k3ShowTitle() {
 
 bool Scene_Title::CheckValidPlayerLocation() {
 	return (lcf::Data::treemap.start.party_map_id > 0);
+}
+
+bool Scene_Title::CheckStartNewGame() {
+	return !Check2k3ShowTitle() || Player::game_config.new_game.Get();
 }
 
 void Scene_Title::CommandNewGame() {

--- a/src/scene_title.h
+++ b/src/scene_title.h
@@ -80,6 +80,13 @@ public:
 	bool CheckValidPlayerLocation();
 
 	/**
+	 * Checks whether to immediately start into a new game.
+	 *
+	 * @return true if the title screen should be skipped
+	 */
+	bool CheckStartNewGame();
+
+	/**
 	 * Option New Game.
 	 * Starts a new game.
 	 */
@@ -119,6 +126,20 @@ public:
 	 */
 	void OnGameStart();
 
+	enum class CommandOptionType {
+		NewGame = 1,
+		ContinueGame,
+		Import,
+		Settings,
+		Translate,
+		Exit
+	};
+
+	int GetCommandIndex(CommandOptionType cmd) const;
+
+	static const CommandOptionType CommandOption_None = static_cast<CommandOptionType>(0);
+	static CommandOptionType force_cursor_index;
+
 	/**
 	 * Moves a window (typically the New/Continue/Quit menu) to the middle or bottom-center of the screen.
 	 * @param window The window to resposition.
@@ -142,14 +163,17 @@ private:
 	 * Stored in a struct for easy resetting, as Scene_Title can be reused.
 	 */
 	struct CommandIndices {
-		int new_game =  0;
-		int continue_game =  1;
+		int new_game = 0;
+		int continue_game = 1;
 		int import = -1;
 		int settings = -1;
 		int translate = -1;
-		int exit =  2;
+		int exit = 2;
 	};
 	CommandIndices indices;
+
+	 /** Options available in the menu. */
+	std::vector<CommandOptionType> command_options;
 
 	/** Contains the state of continue button. */
 	bool continue_enabled = false;


### PR DESCRIPTION
Support for the "Compact" version of Cherry's PowerPatch features. This version wasn't really a patch but just an external utility program named "**ppcomp.exe**" (sometimes renamed to _ppcomp.dat_ or _ppcomp.dll_) which provided access to some new functions by accessing the memory of the running game process.

### Detecting the original PowerPatch to give info about compatibility

This is not the full version of the original "**Power Patch**", which goes way deeper (including early Lua support) & barely found use in any games. But I also added a small heuristic check to detect the "Full" version & log a warning about limited compatibility:
- This just check for the existence of a file named "**_powerp.oex_**" in the game's root
- Another commit also checks for "**_warp.dll_**" which was bundled with _PowerMode2003_, another popular patch at this particular time period of RPG2003's lifecycle. _(Reversing & documenting the origins/versions of that patch actually seems quite tricky - more about that in a future issue...)_

### Supported PPCOMP functions
- [x] Quitting & Resetting the game ("QUIT", "RESTART")
- [x] Calling of in-game scenes 
  - [x] "DEBUG"
  - [x] "CALLLOADMENU"
  - [x] "CALLSAVEMENU"
  - [x] "CALLGAMEMENU" (+ setting the cursor position)
  - [x] "CALLTITLESCREEN" (+setting the cursor position)
- [x] Enabling / Disabling the "UnlockPictures" patch ("UNLOCKPICTURES")
- [ ] Load / Save operations
  - [x] Loading from source _[slot-id]_ ("LOAD")
  - [x] Saving to target _[slot-id]_ ("SAVE")
  - [x] Checking existence of Save _[slot id]_ ("CHECKSAVE")
  - [ ] Copying individual save files ("COPYSAVE")
  - [ ] Deleting individual save files ("DELETESAVE") _(Would require an update for FileFinder -> #3266 )_
- [x] GetSaveDateTime
- [x] GetSystemDateTime
- [ ] SimulateKeyPress (_Drafted, but not tested yet - allows for simulating keypresses for a targeted amount of time_)
- [ ] ChangeFunctionKey
- [ ] SetMsgBoxColor
- [ ] PauseGame
- [ ] PauseTimer
- [ ] SetVar

 **NOT PLANNED**: 
 - ~SetGlobalBrightness~ _(Apparently this was only implemented to address a blackscreen issue caused by the original patch)_
 - ~ChangeScene~ _(Sounds a bit too dangerous)_

For the remaining features, I only found instances of "DELETESAVE" & "SIMULATEKEYPRESS" actually being used in some archived games.
-> These are still TODO

### Adjustments to Ineluki KeyPatch implementation
- I refactored handling for script execution, so that the encountered _script.wav_ files aren't solely handled in the audio mechanism inside Game_System, but will be handled inside the interpreter, when a PlaySE command comes across them there. This is, so that it is possible to get some context for the result of executed scripts & to properly set the field "_async_op" in some cases.
- Async requests: While a script file isn't yet available, the PlaySE command will result in a "YieldRepeat" async op.
- Added support for _script.wav_ execution for the "PlayBGM" command. This is rarely seen in games, but is still possible & would have resulted in a warning by the Player when it tried to parse a script INI as Music.
- I also added support for the known program "LS.dat" which was another way many games with custom title screens used to call the Load Scene.

### BetterAEP patch support
While testing this implementation, it quickly became obvious, that many games that were using ppcomp, also relied on BetterAEP, and some used this patches' special functionality to access the Load Scene or even exiting the game via command. (Even though ppcomp also had these options).

So I added support for this patch as well:
`Player.exe --patch-better-aep 3350
`So far I've only seen games that use the default var-id of '3350' for this.
-> Issue #1182

### Some games using ppcomp
- La Leyenda Heroen (https://rmarchiv.de/games/2899)
- Mr. Hat (https://rmarchiv.de/games/183)
- Take It Cheesy (https://rmarchiv.de/games/1355)

### Info
- BetterAEP: https://www.makerpendium.de/index.php/Better_AEP
- Power Patch Compact: https://www.makerpendium.de/index.php?title=Power_Patch_Compact (See PDF download for documentation)
- More info about some obscure ppcomp versions was shared by @CherryDT in this issue: https://github.com/EasyRPG/Player/issues/1181