### PR TITLE
Fix:  MP3 detection would always return false for very small files

### DIFF
--- a/src/decoder_mpg123.cpp
+++ b/src/decoder_mpg123.cpp
@@ -230,6 +230,9 @@ bool Mpg123Decoder::IsMp3(Filesystem_Stream::InputStream& stream) {
 	// Read beginning of assumed MP3 file and count errors as an heuristic to detect MP3
 	for (int i = 0; i < 10; ++i) {
 		err = mpg123_read(decoder.handle.get(), buffer, 1024, &done);
+		if (err == MPG123_DONE) {
+			return true;
+		}
 		if (err != MPG123_OK) {
 			err_count += 1;
 		}


### PR DESCRIPTION
I have some old Advocate RTP version installed locally, which shipped with a small _lame.exe_ utility & mp3-encoded sounds to save space.
Never bothered to run it & convert them back to wav. Now I'd get a "Format not supported" for some standard RTP sounds like "cursor1" when they should actually play normally.

Looking into the audio code I first suspected an encoding issue with the LAME version used to encode the files (3.93), but it looks like, the detection loop incorrectly handles the result of the read operation, which correctly delivers the internal "MPG123_DONE" code when its done reading.
This issue only applies to some very small files, like the menuing sounds.

[cursor_se.zip](https://github.com/user-attachments/files/19094375/cursor_se.zip)
