### PR TITLE
New Database terms for Maniacs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,8 +68,6 @@ add_library(${PROJECT_NAME} OBJECT
 	src/baseui.h
 	src/battle_animation.cpp
 	src/battle_animation.h
-	src/battle_message.cpp
-	src/battle_message.h
 	src/bitmap.cpp
 	src/bitmapfont.h
 	src/bitmapfont_glyph.h
@@ -192,6 +190,8 @@ add_library(${PROJECT_NAME} OBJECT
 	src/game_map.h
 	src/game_message.cpp
 	src/game_message.h
+	src/game_message_terms.cpp
+	src/game_message_terms.h
 	src/game_party_base.cpp
 	src/game_party_base.h
 	src/game_party.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -42,8 +42,6 @@ libeasyrpg_player_a_SOURCES = \
 	src/baseui.h \
 	src/battle_animation.cpp \
 	src/battle_animation.h \
-	src/battle_message.cpp \
-	src/battle_message.h \
 	src/bitmap.cpp \
 	src/bitmap.h \
 	src/bitmapfont.h \
@@ -168,6 +166,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/game_map.h \
 	src/game_message.cpp \
 	src/game_message.h \
+	src/game_message_terms.cpp \
+	src/game_message_terms.h \
 	src/game_party.cpp \
 	src/game_party.h \
 	src/game_party_base.cpp \

--- a/src/game_actor.cpp
+++ b/src/game_actor.cpp
@@ -34,6 +34,7 @@
 #include "attribute.h"
 #include "rand.h"
 #include "algo.h"
+#include "game_message_terms.h"
 
 constexpr int max_level_2k = 50;
 constexpr int max_level_2k3 = 99;
@@ -274,7 +275,7 @@ bool Game_Actor::LearnSkill(int skill_id, PendingMessage* pm) {
 		std::sort(data.skills.begin(), data.skills.end());
 
 		if (pm) {
-			pm->PushLine(GetLearningMessage(*skill));
+			pm->PushLine(ActorMessage::GetLearningMessage(*this, *skill));
 		}
 
 		return true;
@@ -790,48 +791,6 @@ void Game_Actor::SetLevel(int _level) {
 
 }
 
-std::string Game_Actor::GetLevelUpMessage(int new_level) const {
-	std::stringstream ss;
-	if (Player::IsRPG2k3E()) {
-		ss << GetName();
-		ss << " " << lcf::Data::terms.level_up << " ";
-		ss << " " << lcf::Data::terms.level << " " << new_level;
-		return ss.str();
-	} else if (Player::IsRPG2kE()) {
-		ss << new_level;
-		return Utils::ReplacePlaceholders(
-			lcf::Data::terms.level_up,
-			Utils::MakeArray('S', 'V', 'U'),
-			Utils::MakeSvArray(GetName(), ss.str(), lcf::Data::terms.level)
-		);
-	} else {
-		std::string particle, space = "";
-		if (Player::IsCP932()) {
-			particle = "は";
-			space += " ";
-		}
-		else {
-			particle = " ";
-		}
-		ss << GetName();
-		ss << particle << lcf::Data::terms.level << " ";
-		ss << new_level << space << lcf::Data::terms.level_up;
-		return ss.str();
-	}
-}
-
-std::string Game_Actor::GetLearningMessage(const lcf::rpg::Skill& skill) const {
-	if (Player::IsRPG2kE()) {
-		return Utils::ReplacePlaceholders(
-			lcf::Data::terms.skill_learned,
-			Utils::MakeArray('S', 'O'),
-			Utils::MakeSvArray(GetName(), skill.name)
-		);
-	}
-
-	return ToString(skill.name) + (Player::IsRPG2k3E() ? " " : "") + ToString(lcf::Data::terms.skill_learned);
-}
-
 void Game_Actor::ChangeLevel(int new_level, PendingMessage* pm) {
 	int old_level = GetLevel();
 	SetLevel(new_level);
@@ -839,7 +798,7 @@ void Game_Actor::ChangeLevel(int new_level, PendingMessage* pm) {
 
 	if (new_level > old_level) {
 		if (pm) {
-			pm->PushLine(GetLevelUpMessage(new_level));
+			pm->PushLine(ActorMessage::GetLevelUpMessage(*this, new_level));
 		}
 
 		// Learn new skills
@@ -1112,7 +1071,7 @@ void Game_Actor::ChangeClass(int new_class_id,
 
 	SetLevel(new_level);
 	if (pm && new_level > 1 && (new_level > prev_level || new_skill != eSkillNoChange)) {
-		pm->PushLine(GetLevelUpMessage(new_level));
+		pm->PushLine(ActorMessage::GetLevelUpMessage(*this, new_level));
 	}
 
 	// RPG_RT always resets EXP when class is changed, even if level unchanged.

--- a/src/game_actor.h
+++ b/src/game_actor.h
@@ -937,9 +937,6 @@ public:
 	 */
 	float GetCriticalHitChance(Weapon weapon = WeaponAll) const override;
 
-	std::string GetLevelUpMessage(int new_level) const;
-	std::string GetLearningMessage(const lcf::rpg::Skill& skill) const;
-
 	BattlerType GetType() const override;
 
 	/**

--- a/src/game_battlealgorithm.cpp
+++ b/src/game_battlealgorithm.cpp
@@ -32,7 +32,7 @@
 #include "game_switches.h"
 #include "game_system.h"
 #include "main_data.h"
-#include "battle_message.h"
+#include "game_message_terms.h"
 #include "output.h"
 #include "player.h"
 #include <lcf/reader_util.h>

--- a/src/game_message_terms.cpp
+++ b/src/game_message_terms.cpp
@@ -628,4 +628,21 @@ std::string GetGoldReceivedMessage(int money) {
 	return ss.str();
 }
 
+std::string GetItemReceivedMessage(const lcf::rpg::Item* item) {
+	// No Output::Warning needed here, reported later when the item is added
+	std::string_view item_name = item ? std::string_view(item->name) : std::string_view("??? BAD ITEM ???");
+
+	if (Feature::HasPlaceholders()) {
+		return Utils::ReplacePlaceholders(
+			lcf::Data::terms.item_recieved,
+			Utils::MakeArray('S'),
+			Utils::MakeSvArray(item_name)
+		);
+	}
+	std::string space = Player::IsRPG2k3E() ? " " : "";
+	std::stringstream ss;
+	ss << item_name << space << lcf::Data::terms.item_recieved;
+	return ss.str();
+}
+
 } // namespace PartyMessage

--- a/src/game_message_terms.cpp
+++ b/src/game_message_terms.cpp
@@ -30,9 +30,20 @@ namespace ActorMessage {
 std::string GetLevelUpMessage(const Game_Actor& actor, int new_level) {
 	std::stringstream ss;
 	if (Player::IsRPG2k3E()) {
+		if (Player::IsPatchManiac() && !lcf::Data::terms.maniac_level_up_a.empty()) {
+			ss << lcf::Data::terms.maniac_level_up_a << " ";
+		}
 		ss << actor.GetName();
 		ss << " " << lcf::Data::terms.level_up << " ";
-		ss << " " << lcf::Data::terms.level << " " << new_level;
+		ss << " " << lcf::Data::terms.level;
+
+		if (Player::IsPatchManiac() && !lcf::Data::terms.maniac_level_up_b.empty()) {
+			ss << " " << lcf::Data::terms.maniac_level_up_b;
+		}
+		ss << " " << new_level;
+		if (Player::IsPatchManiac() && !lcf::Data::terms.maniac_level_up_c.empty()) {
+			ss << lcf::Data::terms.maniac_level_up_c;
+		}
 		return ss.str();
 	} else if (Player::IsRPG2kE()) {
 		ss << new_level;
@@ -64,8 +75,13 @@ std::string GetLearningMessage(const Game_Actor& actor, const lcf::rpg::Skill& s
 			Utils::MakeSvArray(actor.GetName(), skill.name)
 		);
 	}
-
-	return ToString(skill.name) + (Player::IsRPG2k3E() ? " " : "") + ToString(lcf::Data::terms.skill_learned);
+	std::stringstream ss;
+	if (Player::IsPatchManiac() && !lcf::Data::terms.maniac_skill_learned_a.empty()) {
+		ss << lcf::Data::terms.maniac_skill_learned_a << " ";
+	}
+	ss << ToString(skill.name) + (Player::IsRPG2k3E() ? " " : "");
+	ss << ToString(lcf::Data::terms.skill_learned);
+	return ss.str();
 }
 
 } // namespace ActorMessage
@@ -611,6 +627,9 @@ std::string GetExperienceGainedMessage(int exp) {
 	}
 	std::string space = Player::IsRPG2k3E() ? " " : "";
 	std::stringstream ss;
+	if (Player::IsPatchManiac() && !lcf::Data::terms.maniac_exp_received_a.empty()) {
+		ss << lcf::Data::terms.maniac_exp_received_a << " ";
+	}
 	ss << exp << space << lcf::Data::terms.exp_received;
 	return ss.str();
 }
@@ -641,6 +660,9 @@ std::string GetItemReceivedMessage(const lcf::rpg::Item* item) {
 	}
 	std::string space = Player::IsRPG2k3E() ? " " : "";
 	std::stringstream ss;
+	if (Player::IsPatchManiac() && !lcf::Data::terms.maniac_item_received_a.empty()) {
+		ss << lcf::Data::terms.maniac_item_received_a << " ";
+	}
 	ss << item_name << space << lcf::Data::terms.item_recieved;
 	return ss.str();
 }

--- a/src/game_message_terms.h
+++ b/src/game_message_terms.h
@@ -15,14 +15,23 @@
  * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef EP_BATTLE_MESSAGE_H
-#define EP_BATTLE_MESSAGE_H
+#ifndef EP_GAME_MESSAGE_TERMS_H
+#define EP_GAME_MESSAGE_TERMS_H
 
 #include <string>
 #include "string_view.h"
 #include <lcf/rpg/fwd.h>
 
+class Game_Actor;
 class Game_Battler;
+
+namespace ActorMessage {
+
+std::string GetLevelUpMessage(const Game_Actor& actor, int new_level);
+
+std::string GetLearningMessage(const Game_Actor& actor, const lcf::rpg::Skill& skill);
+
+} // namespace ActorMessage
 
 namespace BattleMessage {
 
@@ -115,5 +124,13 @@ std::string GetSelfDestructStartMessage2k3(const Game_Battler& source);
 std::string GetEscapeStartMessage2k3(const Game_Battler& source);
 
 } // namespace BattleMessage
+
+namespace PartyMessage {
+
+std::string GetExperienceGainedMessage(int exp);
+
+std::string GetGoldReceivedMessage(int money);
+
+} // namespace PartyMessage
 
 #endif

--- a/src/game_message_terms.h
+++ b/src/game_message_terms.h
@@ -131,6 +131,8 @@ std::string GetExperienceGainedMessage(int exp);
 
 std::string GetGoldReceivedMessage(int money);
 
+std::string GetItemReceivedMessage(const lcf::rpg::Item* item);
+
 } // namespace PartyMessage
 
 #endif

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -40,7 +40,7 @@
 #include "rand.h"
 #include "autobattle.h"
 #include "enemyai.h"
-#include "battle_message.h"
+#include "game_message_terms.h"
 #include "feature.h"
 
 Scene_Battle_Rpg2k::Scene_Battle_Rpg2k(const BattleArgs& args) :
@@ -1948,38 +1948,16 @@ bool Scene_Battle_Rpg2k::CheckWait() {
 }
 
 void Scene_Battle_Rpg2k::PushExperienceGainedMessage(PendingMessage& pm, int exp) {
-	if (Feature::HasPlaceholders()) {
-		pm.PushLine(
-			Utils::ReplacePlaceholders(
-				lcf::Data::terms.exp_received,
-				Utils::MakeArray('V', 'U'),
-				Utils::MakeSvArray(std::to_string(exp), lcf::Data::terms.exp_short)
-			) + Player::escape_symbol + "."
-		);
-	}
-	else {
-		std::stringstream ss;
-		ss << exp << lcf::Data::terms.exp_received << Player::escape_symbol << ".";
-		pm.PushLine(ss.str());
-	}
+	pm.PushLine(
+		PartyMessage::GetExperienceGainedMessage(exp)
+		+ Player::escape_symbol + ".");
 }
 
 void Scene_Battle_Rpg2k::PushGoldReceivedMessage(PendingMessage& pm, int money) {
+	pm.PushLine(
+		PartyMessage::GetGoldReceivedMessage(money)
+		+ Player::escape_symbol + ".");
 
-	if (Feature::HasPlaceholders()) {
-		pm.PushLine(
-			Utils::ReplacePlaceholders(
-				lcf::Data::terms.gold_recieved_a,
-				Utils::MakeArray('V', 'U'),
-				Utils::MakeSvArray(std::to_string(money), lcf::Data::terms.gold)
-			) + Player::escape_symbol + "."
-		);
-	}
-	else {
-		std::stringstream ss;
-		ss << lcf::Data::terms.gold_recieved_a << " " << money << lcf::Data::terms.gold << lcf::Data::terms.gold_recieved_b << Player::escape_symbol << ".";
-		pm.PushLine(ss.str());
-	}
 }
 
 void Scene_Battle_Rpg2k::PushItemRecievedMessages(PendingMessage& pm, std::vector<int> drops) {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -1961,27 +1961,11 @@ void Scene_Battle_Rpg2k::PushGoldReceivedMessage(PendingMessage& pm, int money) 
 }
 
 void Scene_Battle_Rpg2k::PushItemRecievedMessages(PendingMessage& pm, std::vector<int> drops) {
-	std::stringstream ss;
-
 	for (std::vector<int>::iterator it = drops.begin(); it != drops.end(); ++it) {
 		const lcf::rpg::Item* item = lcf::ReaderUtil::GetElement(lcf::Data::items, *it);
-		// No Output::Warning needed here, reported later when the item is added
-		std::string_view item_name = item ? std::string_view(item->name) : std::string_view("??? BAD ITEM ???");
-
-		if (Feature::HasPlaceholders()) {
-			pm.PushLine(
-				Utils::ReplacePlaceholders(
-					lcf::Data::terms.item_recieved,
-					Utils::MakeArray('S'),
-					Utils::MakeSvArray(item_name)
-				) + Player::escape_symbol + "."
-			);
-		}
-		else {
-			ss.str("");
-			ss << item_name << lcf::Data::terms.item_recieved << Player::escape_symbol << ".";
-			pm.PushLine(ss.str());
-		}
+		pm.PushLine(
+			PartyMessage::GetItemReceivedMessage(item)
+			+ Player::escape_symbol + ".");
 	}
 }
 

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -49,6 +49,7 @@
 #include <algorithm>
 #include <memory>
 #include "feature.h"
+#include "game_message_terms.h"
 
 //#define EP_DEBUG_BATTLE2K3_STATE_MACHINE
 
@@ -1857,14 +1858,11 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionVi
 
 		std::stringstream ss;
 		if (exp > 0) {
-			ss << exp << space << lcf::Data::terms.exp_received;
-			pm.PushLine(ss.str());
+			pm.PushLine(PartyMessage::GetExperienceGainedMessage(exp));
 			pm.PushPageEnd();
 		}
 		if (money > 0) {
-			ss.str("");
-			ss << lcf::Data::terms.gold_recieved_a << " " << money << lcf::Data::terms.gold << lcf::Data::terms.gold_recieved_b;
-			pm.PushLine(ss.str());
+			pm.PushLine(PartyMessage::GetGoldReceivedMessage(money));
 			pm.PushPageEnd();
 		}
 		for (auto& item_id: drops) {

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1856,7 +1856,6 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionVi
 
 		std::string space = Player::IsRPG2k3E() ? " " : "";
 
-		std::stringstream ss;
 		if (exp > 0) {
 			pm.PushLine(PartyMessage::GetExperienceGainedMessage(exp));
 			pm.PushPageEnd();
@@ -1867,12 +1866,7 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionVi
 		}
 		for (auto& item_id: drops) {
 			const lcf::rpg::Item* item = lcf::ReaderUtil::GetElement(lcf::Data::items, item_id);
-			// No Output::Warning needed here, reported later when the item is added
-			std::string_view item_name = item ? std::string_view(item->name) : std::string_view("??? BAD ITEM ???");
-
-			ss.str("");
-			ss << item_name << space << lcf::Data::terms.item_recieved;
-			pm.PushLine(ss.str());
+			pm.PushLine(PartyMessage::GetItemReceivedMessage(item));
 			pm.PushPageEnd();
 		}
 

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1854,8 +1854,6 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionVi
 		pm.PushLine(ToString(lcf::Data::terms.victory) + Player::escape_symbol + "|");
 		pm.PushPageEnd();
 
-		std::string space = Player::IsRPG2k3E() ? " " : "";
-
 		if (exp > 0) {
 			pm.PushLine(PartyMessage::GetExperienceGainedMessage(exp));
 			pm.PushPageEnd();


### PR DESCRIPTION
A few new term fields have been added in the latest version of Maniacs, to provide more customization options for some in-game texts:
- Experience gained
- Level Up
- Items received
- Skill learned

I would have preferred some template strings similar to the ones found in RPG2KE, but they do the job..

I moved those message texts to "battle_commands" which I then renamed to "game_message_terms". The terms code is all over the place & a lot of refactoring should be done here to make localization less of a hassle.
I'm sure this issue came up before & we could use this PR to do also some housekeeping here. 🤔

Maybe move everything related to in-game terms to its own naming scheme? (terms_battle.cpp, terms_actor.cpp, etc.)

New custom fields for _liblcf_:
```
Terms,maniac_item_received_a,f,DBString,0xA1,,0,1,
Terms,maniac_level_up_a,f,DBString,0xA2,,0,1,
Terms,maniac_level_up_b,f,DBString,0xA3,,0,1,
Terms,maniac_level_up_c,f,DBString,0xA4,,0,1,
Terms,maniac_exp_received_a,f,DBString,0xA5,,0,1,
Terms,maniac_skill_learned_a,f,DBString,0xA6,,0,1,
```

![maniac_terms1](https://github.com/user-attachments/assets/932eb2de-66f9-4ddc-a2c4-fdb2f6189ba9)
![maniac_terms2](https://github.com/user-attachments/assets/c778a198-3450-4ad7-95fb-c5800505e52b)
