### PR TITLE
Support for runtime patches: MonSca, EncounterRandomnessAlert, EXPlus, GuardRevamp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,8 @@ add_library(${PROJECT_NAME} OBJECT
 	src/game_pictures.h
 	src/game_player.cpp
 	src/game_player.h
+	src/game_runtime_patches.cpp
+	src/game_runtime_patches.h
 	src/game_quit.cpp
 	src/game_quit.h
 	src/game_screen.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -176,6 +176,8 @@ libeasyrpg_player_a_SOURCES = \
 	src/game_pictures.h \
 	src/game_player.cpp \
 	src/game_player.h \
+	src/game_runtime_patches.cpp \
+	src/game_runtime_patches.h \
 	src/game_screen.cpp \
 	src/game_screen.h \
 	src/game_strings.cpp \

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -171,6 +171,9 @@ int VarianceAdjustEffect(int base, int var) {
 }
 
 int AdjustDamageForDefend(int dmg, const Game_Battler& target) {
+	if (RuntimePatches::GuardRevamp::OverrideDamageAdjustment(dmg, target)) {
+		return dmg;
+	}
 	if (target.IsDefending()) {
 		dmg /= 2;
 		if (target.HasStrongDefense()) {

--- a/src/game_config_game.cpp
+++ b/src/game_config_game.cpp
@@ -88,7 +88,8 @@ void Game_ConfigGame::LoadFromArgs(CmdlineParser& cp) {
 			patch_rpg2k3_commands.Lock(false);
 			patch_anti_lag_switch.Lock(0);
 			patch_direct_menu.Lock(0);
-			patch_encounter_random_alert.Lock(0);
+			patch_encounter_random_alert_sw.Lock(0);
+			patch_encounter_random_alert_var.Lock(0);
 			patch_override = true;
 			continue;
 		}
@@ -158,12 +159,12 @@ void Game_ConfigGame::LoadFromArgs(CmdlineParser& cp) {
 		}
 		if (cp.ParseNext(arg, 1, { "--patch-encounter-alert", "--no-patch-encounter-alert" })) {
 			if (arg.ArgIsOn() && arg.ParseValue(0, li_value)) {
-				patch_encounter_random_alert.Set(li_value);
+				patch_encounter_random_alert_var.Set(li_value);
 				patch_override = true;
 			}
 
 			if (arg.ArgIsOff()) {
-				patch_encounter_random_alert.Set(0);
+				patch_encounter_random_alert_var.Set(0);
 				patch_override = true;
 			}
 			continue;
@@ -243,7 +244,7 @@ void Game_ConfigGame::LoadFromStream(Filesystem_Stream::InputStream& is) {
 		patch_override = true;
 	}
 
-	if (patch_encounter_random_alert.FromIni(ini)) {
+	if (patch_encounter_random_alert_var.FromIni(ini)) {
 		patch_override = true;
 	}
 }
@@ -274,7 +275,7 @@ void Game_ConfigGame::PrintActivePatches() {
 	add_int(patch_maniac);
 	add_int(patch_anti_lag_switch);
 	add_int(patch_direct_menu);
-	add_int(patch_encounter_random_alert);
+	add_int(patch_encounter_random_alert_var);
 
 	if (patches.empty()) {
 		Output::Debug("Patch configuration: None");

--- a/src/game_config_game.cpp
+++ b/src/game_config_game.cpp
@@ -88,6 +88,7 @@ void Game_ConfigGame::LoadFromArgs(CmdlineParser& cp) {
 			patch_rpg2k3_commands.Lock(false);
 			patch_anti_lag_switch.Lock(0);
 			patch_direct_menu.Lock(0);
+			patch_encounter_random_alert.Lock(0);
 			patch_override = true;
 			continue;
 		}
@@ -151,6 +152,18 @@ void Game_ConfigGame::LoadFromArgs(CmdlineParser& cp) {
 
 			if (arg.ArgIsOff()) {
 				patch_direct_menu.Set(0);
+				patch_override = true;
+			}
+			continue;
+		}
+		if (cp.ParseNext(arg, 1, { "--patch-encounter-alert", "--no-patch-encounter-alert" })) {
+			if (arg.ArgIsOn() && arg.ParseValue(0, li_value)) {
+				patch_encounter_random_alert.Set(li_value);
+				patch_override = true;
+			}
+
+			if (arg.ArgIsOff()) {
+				patch_encounter_random_alert.Set(0);
 				patch_override = true;
 			}
 			continue;
@@ -229,6 +242,10 @@ void Game_ConfigGame::LoadFromStream(Filesystem_Stream::InputStream& is) {
 	if (patch_direct_menu.FromIni(ini)) {
 		patch_override = true;
 	}
+
+	if (patch_encounter_random_alert.FromIni(ini)) {
+		patch_override = true;
+	}
 }
 
 void Game_ConfigGame::PrintActivePatches() {
@@ -257,6 +274,7 @@ void Game_ConfigGame::PrintActivePatches() {
 	add_int(patch_maniac);
 	add_int(patch_anti_lag_switch);
 	add_int(patch_direct_menu);
+	add_int(patch_encounter_random_alert);
 
 	if (patches.empty()) {
 		Output::Debug("Patch configuration: None");

--- a/src/game_config_game.cpp
+++ b/src/game_config_game.cpp
@@ -25,8 +25,8 @@
 #include "player.h"
 #include <cstring>
 
-Game_ConfigGame Game_ConfigGame::Create(CmdlineParser& cp) {
-	Game_ConfigGame cfg;
+void Game_ConfigGame::Initialize(CmdlineParser& cp) {
+	Game_ConfigGame& cfg = *this;
 
 	auto cli_config = FileFinder::Game().OpenFile(EASYRPG_INI_NAME);
 	if (cli_config) {
@@ -57,8 +57,6 @@ Game_ConfigGame Game_ConfigGame::Create(CmdlineParser& cp) {
 			cfg.engine = Player::EngineRpg2k3 | Player::EngineMajorUpdated | Player::EngineEnglish;
 		}
 	}
-
-	return cfg;
 }
 
 void Game_ConfigGame::LoadFromArgs(CmdlineParser& cp) {

--- a/src/game_config_game.h
+++ b/src/game_config_game.h
@@ -50,6 +50,18 @@ struct Game_ConfigGame {
 	ConfigParam<int> patch_direct_menu{ "Direct Menu", " Allows direct access to subscreens of the default menu", "Patch", "DirectMenu", 0 };
 	ConfigParam<int> patch_encounter_random_alert{ "Encounter Randomness Alert", "Set troop id to a variable and skip random battle", "Patch", "EncounterAlert", 0 };
 
+	ConfigParam<int> patch_monsca_maxhp{ "MonSca", "Scales enemy battle stats by variable value. (MaxHP)", "Patch", "MonSca:MaxHP", 0 };
+	ConfigParam<int> patch_monsca_maxsp{ "MonSca", "Scales enemy battle stats by variable value. (MaxSP)", "Patch", "MonSca:MaxSP", 0 };
+	ConfigParam<int> patch_monsca_atk{ "MonSca", "Scales enemy battle stats by variable value. (Attack)", "Patch", "MonSca:Attack", 0 };
+	ConfigParam<int> patch_monsca_def{ "MonSca", "Scales enemy battle stats by variable value. (Defense)", "Patch", "MonSca:Defense", 0 };
+	ConfigParam<int> patch_monsca_spi{ "MonSca", "Scales enemy battle stats by variable value. (Spirit)", "Patch", "MonSca:Spirit", 0 };
+	ConfigParam<int> patch_monsca_agi{ "MonSca", "Scales enemy battle stats by variable value. (Agility)", "Patch", "MonSca:Agility", 0 };
+	ConfigParam<int> patch_monsca_exp{ "MonSca", "Scales enemy battle stats by variable value. (Gained EXP)", "Patch", "MonSca:Experience", 0 };
+	ConfigParam<int> patch_monsca_gold{ "MonSca", "Scales enemy battle stats by variable value. (Gained Money)", "Patch", "MonSca:Money", 0 };
+	ConfigParam<int> patch_monsca_item{ "MonSca", "Scales enemy battle stats by variable value. (Gained Item)", "Patch", "MonSca:ItemId", 0 };
+	ConfigParam<int> patch_monsca_droprate{ "MonSca", "Scales enemy battle stats by variable value. (Item Drop Rate)", "Patch", "MonSca:ItemDropRate", 0 };
+	ConfigParam<int> patch_monsca_levelscaling{ "MonSca", "Scales enemy battle stats by variable value. (Alternate formula)", "Patch", "MonSca:LevelScaling", 0 };
+
 	// Command line only
 	BoolConfigParam patch_support{ "Support patches", "When OFF all patch support is disabled", "", "", true };
 

--- a/src/game_config_game.h
+++ b/src/game_config_game.h
@@ -48,6 +48,7 @@ struct Game_ConfigGame {
 	BoolConfigParam patch_rpg2k3_commands{ "RPG2k3 Event Commands", "Enable support for RPG2k3 event commands", "Patch", "RPG2k3Commands", false };
 	ConfigParam<int> patch_anti_lag_switch{ "Anti-Lag Switch", "Disable event page refreshes when switch is set", "Patch", "AntiLagSwitch", 0 };
 	ConfigParam<int> patch_direct_menu{ "Direct Menu", " Allows direct access to subscreens of the default menu", "Patch", "DirectMenu", 0 };
+	ConfigParam<int> patch_encounter_random_alert{ "Encounter Randomness Alert", "Set troop id to a variable and skip random battle", "Patch", "EncounterAlert", 0 };
 
 	// Command line only
 	BoolConfigParam patch_support{ "Support patches", "When OFF all patch support is disabled", "", "", true };

--- a/src/game_config_game.h
+++ b/src/game_config_game.h
@@ -67,6 +67,9 @@ struct Game_ConfigGame {
 	ConfigParam<int> patch_explus_var{ "EXPlus", "Boosts party EXP by set percentages", "Patch", "EXPlus:VarExpBoost", 0 };
 	ConfigParam<int> patch_explusplus_var{ "EXPlus", "Allows for setting party index of given actors to a variable", "Patch", "EXPlus:VarActorInParty", 0 };
 
+	ConfigParam<int> patch_guardrevamp_normal{ "GuardRevamp", "Changes damage calculation for defense situations (Normal)", "Patch", "GuardRevamp:NormalDefense", 0 };
+	ConfigParam<int> patch_guardrevamp_strong{ "GuardRevamp", "Changes damage calculation for defense situations (Strong)", "Patch", "GuardRevamp:StrongDefense", 0 };
+
 	// Command line only
 	BoolConfigParam patch_support{ "Support patches", "When OFF all patch support is disabled", "", "", true };
 

--- a/src/game_config_game.h
+++ b/src/game_config_game.h
@@ -49,26 +49,26 @@ struct Game_ConfigGame {
 	ConfigParam<int> patch_anti_lag_switch{ "Anti-Lag Switch", "Disable event page refreshes when switch is set", "Patch", "AntiLagSwitch", 0 };
 	ConfigParam<int> patch_direct_menu{ "Direct Menu", " Allows direct access to subscreens of the default menu", "Patch", "DirectMenu", 0 };
 
-	ConfigParam<int> patch_encounter_random_alert_sw{ "Encounter Randomness Alert", "Set troop id to a variable, activate a switch and skip random battle", "Patch", "EncounterAlert:Switch", 0 };
-	ConfigParam<int> patch_encounter_random_alert_var{ "Encounter Randomness Alert", "Set troop id to a variable, activate a switch and skip random battle", "Patch", "EncounterAlert:Var", 0 };
+	ConfigParam<int> patch_encounter_random_alert_sw{ "Encounter Randomness Alert", "Set troop id to a variable, activate a switch and skip random battle", "Patch", "EncounterAlert.Switch", 0 };
+	ConfigParam<int> patch_encounter_random_alert_var{ "Encounter Randomness Alert", "Set troop id to a variable, activate a switch and skip random battle", "Patch", "EncounterAlert.Var", 0 };
 
-	ConfigParam<int> patch_monsca_maxhp{ "MonSca", "Scales enemy battle stats by variable value. (MaxHP)", "Patch", "MonSca:MaxHP", 0 };
-	ConfigParam<int> patch_monsca_maxsp{ "MonSca", "Scales enemy battle stats by variable value. (MaxSP)", "Patch", "MonSca:MaxSP", 0 };
-	ConfigParam<int> patch_monsca_atk{ "MonSca", "Scales enemy battle stats by variable value. (Attack)", "Patch", "MonSca:Attack", 0 };
-	ConfigParam<int> patch_monsca_def{ "MonSca", "Scales enemy battle stats by variable value. (Defense)", "Patch", "MonSca:Defense", 0 };
-	ConfigParam<int> patch_monsca_spi{ "MonSca", "Scales enemy battle stats by variable value. (Spirit)", "Patch", "MonSca:Spirit", 0 };
-	ConfigParam<int> patch_monsca_agi{ "MonSca", "Scales enemy battle stats by variable value. (Agility)", "Patch", "MonSca:Agility", 0 };
-	ConfigParam<int> patch_monsca_exp{ "MonSca", "Scales enemy battle stats by variable value. (Gained EXP)", "Patch", "MonSca:Experience", 0 };
-	ConfigParam<int> patch_monsca_gold{ "MonSca", "Scales enemy battle stats by variable value. (Gained Money)", "Patch", "MonSca:Money", 0 };
-	ConfigParam<int> patch_monsca_item{ "MonSca", "Scales enemy battle stats by variable value. (Gained Item)", "Patch", "MonSca:ItemId", 0 };
-	ConfigParam<int> patch_monsca_droprate{ "MonSca", "Scales enemy battle stats by variable value. (Item Drop Rate)", "Patch", "MonSca:ItemDropRate", 0 };
-	ConfigParam<int> patch_monsca_levelscaling{ "MonSca", "Scales enemy battle stats by variable value. (Alternate formula)", "Patch", "MonSca:LevelScaling", 0 };
+	ConfigParam<int> patch_monsca_maxhp{ "MonSca", "Scales enemy battle stats by variable value. (MaxHP)", "Patch", "MonSca.MaxHP", 0 };
+	ConfigParam<int> patch_monsca_maxsp{ "MonSca", "Scales enemy battle stats by variable value. (MaxSP)", "Patch", "MonSca.MaxSP", 0 };
+	ConfigParam<int> patch_monsca_atk{ "MonSca", "Scales enemy battle stats by variable value. (Attack)", "Patch", "MonSca.Attack", 0 };
+	ConfigParam<int> patch_monsca_def{ "MonSca", "Scales enemy battle stats by variable value. (Defense)", "Patch", "MonSca.Defense", 0 };
+	ConfigParam<int> patch_monsca_spi{ "MonSca", "Scales enemy battle stats by variable value. (Spirit)", "Patch", "MonSca.Spirit", 0 };
+	ConfigParam<int> patch_monsca_agi{ "MonSca", "Scales enemy battle stats by variable value. (Agility)", "Patch", "MonSca.Agility", 0 };
+	ConfigParam<int> patch_monsca_exp{ "MonSca", "Scales enemy battle stats by variable value. (Gained EXP)", "Patch", "MonSca.Experience", 0 };
+	ConfigParam<int> patch_monsca_gold{ "MonSca", "Scales enemy battle stats by variable value. (Gained Money)", "Patch", "MonSca.Money", 0 };
+	ConfigParam<int> patch_monsca_item{ "MonSca", "Scales enemy battle stats by variable value. (Gained Item)", "Patch", "MonSca.ItemId", 0 };
+	ConfigParam<int> patch_monsca_droprate{ "MonSca", "Scales enemy battle stats by variable value. (Item Drop Rate)", "Patch", "MonSca.ItemDropRate", 0 };
+	ConfigParam<int> patch_monsca_levelscaling{ "MonSca", "Scales enemy battle stats by variable value. (Alternate formula)", "Patch", "MonSca.LevelScaling", 0 };
 
-	ConfigParam<int> patch_explus_var{ "EXPlus", "Boosts party EXP by set percentages", "Patch", "EXPlus:VarExpBoost", 0 };
-	ConfigParam<int> patch_explusplus_var{ "EXPlus", "Allows for setting party index of given actors to a variable", "Patch", "EXPlus:VarActorInParty", 0 };
+	ConfigParam<int> patch_explus_var{ "EXPlus", "Boosts party EXP by set percentages", "Patch", "EXPlus.VarExpBoost", 0 };
+	ConfigParam<int> patch_explusplus_var{ "EXPlus", "Allows for setting party index of given actors to a variable", "Patch", "EXPlus.VarActorInParty", 0 };
 
-	ConfigParam<int> patch_guardrevamp_normal{ "GuardRevamp", "Changes damage calculation for defense situations (Normal)", "Patch", "GuardRevamp:NormalDefense", 0 };
-	ConfigParam<int> patch_guardrevamp_strong{ "GuardRevamp", "Changes damage calculation for defense situations (Strong)", "Patch", "GuardRevamp:StrongDefense", 0 };
+	ConfigParam<int> patch_guardrevamp_normal{ "GuardRevamp", "Changes damage calculation for defense situations (Normal)", "Patch", "GuardRevamp.NormalDefense", 0 };
+	ConfigParam<int> patch_guardrevamp_strong{ "GuardRevamp", "Changes damage calculation for defense situations (Strong)", "Patch", "GuardRevamp.StrongDefense", 0 };
 
 	// Command line only
 	BoolConfigParam patch_support{ "Support patches", "When OFF all patch support is disabled", "", "", true };
@@ -79,9 +79,9 @@ struct Game_ConfigGame {
 	int engine = 0;
 
 	/**
-	 * Create a game config from the config file in the game directory, then loads command line arguments.
+	 * Initializes a game config from the config file in the game directory, then loads command line arguments.
 	 */
-	static Game_ConfigGame Create(CmdlineParser& cp);
+	void Initialize(CmdlineParser& cp);
 
 	/**
 	 * Load configuration values from a stream;

--- a/src/game_config_game.h
+++ b/src/game_config_game.h
@@ -63,6 +63,7 @@ struct Game_ConfigGame {
 	ConfigParam<int> patch_monsca_item{ "MonSca", "Scales enemy battle stats by variable value. (Gained Item)", "Patch", "MonSca.ItemId", 0 };
 	ConfigParam<int> patch_monsca_droprate{ "MonSca", "Scales enemy battle stats by variable value. (Item Drop Rate)", "Patch", "MonSca.ItemDropRate", 0 };
 	ConfigParam<int> patch_monsca_levelscaling{ "MonSca", "Scales enemy battle stats by variable value. (Alternate formula)", "Patch", "MonSca.LevelScaling", 0 };
+	ConfigParam<int> patch_monsca_plus{ "MonSca", "Scale enemies individually based on troop index", "Patch", "MonSca.Plus", 0 };
 
 	ConfigParam<int> patch_explus_var{ "EXPlus", "Boosts party EXP by set percentages", "Patch", "EXPlus.VarExpBoost", 0 };
 	ConfigParam<int> patch_explusplus_var{ "EXPlus", "Allows for setting party index of given actors to a variable", "Patch", "EXPlus.VarActorInParty", 0 };

--- a/src/game_config_game.h
+++ b/src/game_config_game.h
@@ -48,7 +48,9 @@ struct Game_ConfigGame {
 	BoolConfigParam patch_rpg2k3_commands{ "RPG2k3 Event Commands", "Enable support for RPG2k3 event commands", "Patch", "RPG2k3Commands", false };
 	ConfigParam<int> patch_anti_lag_switch{ "Anti-Lag Switch", "Disable event page refreshes when switch is set", "Patch", "AntiLagSwitch", 0 };
 	ConfigParam<int> patch_direct_menu{ "Direct Menu", " Allows direct access to subscreens of the default menu", "Patch", "DirectMenu", 0 };
-	ConfigParam<int> patch_encounter_random_alert{ "Encounter Randomness Alert", "Set troop id to a variable and skip random battle", "Patch", "EncounterAlert", 0 };
+
+	ConfigParam<int> patch_encounter_random_alert_sw{ "Encounter Randomness Alert", "Set troop id to a variable, activate a switch and skip random battle", "Patch", "EncounterAlert:Switch", 0 };
+	ConfigParam<int> patch_encounter_random_alert_var{ "Encounter Randomness Alert", "Set troop id to a variable, activate a switch and skip random battle", "Patch", "EncounterAlert:Var", 0 };
 
 	ConfigParam<int> patch_monsca_maxhp{ "MonSca", "Scales enemy battle stats by variable value. (MaxHP)", "Patch", "MonSca:MaxHP", 0 };
 	ConfigParam<int> patch_monsca_maxsp{ "MonSca", "Scales enemy battle stats by variable value. (MaxSP)", "Patch", "MonSca:MaxSP", 0 };

--- a/src/game_config_game.h
+++ b/src/game_config_game.h
@@ -64,6 +64,9 @@ struct Game_ConfigGame {
 	ConfigParam<int> patch_monsca_droprate{ "MonSca", "Scales enemy battle stats by variable value. (Item Drop Rate)", "Patch", "MonSca:ItemDropRate", 0 };
 	ConfigParam<int> patch_monsca_levelscaling{ "MonSca", "Scales enemy battle stats by variable value. (Alternate formula)", "Patch", "MonSca:LevelScaling", 0 };
 
+	ConfigParam<int> patch_explus_var{ "EXPlus", "Boosts party EXP by set percentages", "Patch", "EXPlus:VarExpBoost", 0 };
+	ConfigParam<int> patch_explusplus_var{ "EXPlus", "Allows for setting party index of given actors to a variable", "Patch", "EXPlus:VarActorInParty", 0 };
+
 	// Command line only
 	BoolConfigParam patch_support{ "Support patches", "When OFF all patch support is disabled", "", "", true };
 

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -329,37 +329,37 @@ inline int Game_Enemy::GetTroopMemberId() const {
 
 inline int Game_Enemy::GetBaseMaxHp() const {
 	auto max_hp = enemy->max_hp;
-	RuntimePatches::MonSca::ModifyMaxHp(max_hp);
+	RuntimePatches::MonSca::ModifyMaxHp(*this, max_hp);
 	return max_hp;
 }
 
 inline int Game_Enemy::GetBaseMaxSp() const {
 	auto max_sp = enemy->max_sp;
-	RuntimePatches::MonSca::ModifyMaxSp(max_sp);
+	RuntimePatches::MonSca::ModifyMaxSp(*this, max_sp);
 	return max_sp;
 }
 
 inline int Game_Enemy::GetBaseAtk(Weapon) const {
 	auto attack = enemy->attack;
-	RuntimePatches::MonSca::ModifyAtk(attack);
+	RuntimePatches::MonSca::ModifyAtk(*this, attack);
 	return attack;
 }
 
 inline int Game_Enemy::GetBaseDef(Weapon) const {
 	auto defense = enemy->defense;
-	RuntimePatches::MonSca::ModifyDef(defense);
+	RuntimePatches::MonSca::ModifyDef(*this, defense);
 	return defense;
 }
 
 inline int Game_Enemy::GetBaseSpi(Weapon) const {
 	auto spirit = enemy->spirit;
-	RuntimePatches::MonSca::ModifySpi(spirit);
+	RuntimePatches::MonSca::ModifySpi(*this, spirit);
 	return spirit;
 }
 
 inline int Game_Enemy::GetBaseAgi(Weapon) const {
 	auto agility = enemy->agility;
-	RuntimePatches::MonSca::ModifyAgi(agility);
+	RuntimePatches::MonSca::ModifyAgi(*this, agility);
 	return agility;
 }
 

--- a/src/game_enemy.h
+++ b/src/game_enemy.h
@@ -20,6 +20,7 @@
 
 // Headers
 #include "game_battler.h"
+#include "game_runtime_patches.h"
 #include "sprite_enemy.h"
 #include "player.h"
 #include <lcf/rpg/enemy.h>
@@ -327,27 +328,39 @@ inline int Game_Enemy::GetTroopMemberId() const {
 }
 
 inline int Game_Enemy::GetBaseMaxHp() const {
-	return enemy->max_hp;
+	auto max_hp = enemy->max_hp;
+	RuntimePatches::MonSca::ModifyMaxHp(max_hp);
+	return max_hp;
 }
 
 inline int Game_Enemy::GetBaseMaxSp() const {
-	return enemy->max_sp;
+	auto max_sp = enemy->max_sp;
+	RuntimePatches::MonSca::ModifyMaxSp(max_sp);
+	return max_sp;
 }
 
 inline int Game_Enemy::GetBaseAtk(Weapon) const {
-	return enemy->attack;
+	auto attack = enemy->attack;
+	RuntimePatches::MonSca::ModifyAtk(attack);
+	return attack;
 }
 
 inline int Game_Enemy::GetBaseDef(Weapon) const {
-	return enemy->defense;
+	auto defense = enemy->defense;
+	RuntimePatches::MonSca::ModifyDef(defense);
+	return defense;
 }
 
 inline int Game_Enemy::GetBaseSpi(Weapon) const {
-	return enemy->spirit;
+	auto spirit = enemy->spirit;
+	RuntimePatches::MonSca::ModifySpi(spirit);
+	return spirit;
 }
 
 inline int Game_Enemy::GetBaseAgi(Weapon) const {
-	return enemy->agility;
+	auto agility = enemy->agility;
+	RuntimePatches::MonSca::ModifyAgi(agility);
+	return agility;
 }
 
 inline int Game_Enemy::GetHp() const {

--- a/src/game_enemyparty.cpp
+++ b/src/game_enemyparty.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include "game_interpreter.h"
 #include "game_enemyparty.h"
+#include "game_runtime_patches.h"
 #include "main_data.h"
 #include <lcf/reader_util.h>
 #include "utils.h"
@@ -102,7 +103,10 @@ int Game_EnemyParty::GetExp() const {
 	int sum = 0;
 	for (auto& enemy: enemies) {
 		if (enemy.IsDead()) {
-			sum += enemy.GetExp();
+			auto exp = enemy.GetExp();
+			RuntimePatches::MonSca::ModifyExpGained(exp);
+
+			sum += exp;
 		}
 	}
 	return sum;
@@ -112,7 +116,10 @@ int Game_EnemyParty::GetMoney() const {
 	int sum = 0;
 	for (auto& enemy: enemies) {
 		if (enemy.IsDead()) {
-			sum += enemy.GetMoney();
+			auto money = enemy.GetMoney();
+			RuntimePatches::MonSca::ModifyMoneyGained(money);
+
+			sum += money;
 		}
 	}
 	return sum;
@@ -121,10 +128,16 @@ int Game_EnemyParty::GetMoney() const {
 void Game_EnemyParty::GenerateDrops(std::vector<int>& out) const {
 	for (auto& enemy: enemies) {
 		if (enemy.IsDead()) {
+			auto drop_id = enemy.GetDropId();
+			RuntimePatches::MonSca::ModifyItemGained(drop_id);
+
 			// Only roll if the enemy has something to drop
-			if (enemy.GetDropId() != 0) {
-				if (Rand::ChanceOf(enemy.GetDropProbability(), 100)) {
-					out.push_back(enemy.GetDropId());
+			if (drop_id > 0) {
+				auto drop_rate = enemy.GetDropProbability();
+				RuntimePatches::MonSca::ModifyItemDropRate(drop_rate);
+
+				if (Rand::ChanceOf(drop_rate, 100)) {
+					out.push_back(drop_id);
 				}
 			}
 		}

--- a/src/game_enemyparty.cpp
+++ b/src/game_enemyparty.cpp
@@ -104,7 +104,7 @@ int Game_EnemyParty::GetExp() const {
 	for (auto& enemy: enemies) {
 		if (enemy.IsDead()) {
 			auto exp = enemy.GetExp();
-			RuntimePatches::MonSca::ModifyExpGained(exp);
+			RuntimePatches::MonSca::ModifyExpGained(enemy, exp);
 
 			sum += exp;
 		}
@@ -117,7 +117,7 @@ int Game_EnemyParty::GetMoney() const {
 	for (auto& enemy: enemies) {
 		if (enemy.IsDead()) {
 			auto money = enemy.GetMoney();
-			RuntimePatches::MonSca::ModifyMoneyGained(money);
+			RuntimePatches::MonSca::ModifyMoneyGained(enemy, money);
 
 			sum += money;
 		}
@@ -129,12 +129,12 @@ void Game_EnemyParty::GenerateDrops(std::vector<int>& out) const {
 	for (auto& enemy: enemies) {
 		if (enemy.IsDead()) {
 			auto drop_id = enemy.GetDropId();
-			RuntimePatches::MonSca::ModifyItemGained(drop_id);
+			RuntimePatches::MonSca::ModifyItemGained(enemy, drop_id);
 
 			// Only roll if the enemy has something to drop
 			if (drop_id > 0) {
 				auto drop_rate = enemy.GetDropProbability();
-				RuntimePatches::MonSca::ModifyItemDropRate(drop_rate);
+				RuntimePatches::MonSca::ModifyItemDropRate(enemy, drop_rate);
 
 				if (Rand::ChanceOf(drop_rate, 100)) {
 					out.push_back(drop_id);

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -3491,6 +3491,7 @@ bool Game_Interpreter::CommandConditionalBranch(lcf::rpg::EventCommand const& co
 		case 0:
 			// Is actor in party
 			result = Main_Data::game_party->IsActorInParty(actor_id);
+			RuntimePatches::EXPlus::StoreActorPosition(actor_id);
 			break;
 		case 1:
 			// Name

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -38,6 +38,7 @@
 #include "game_message.h"
 #include "game_screen.h"
 #include "game_pictures.h"
+#include "game_variables.h"
 #include "scene_battle.h"
 #include "scene_map.h"
 #include <lcf/lmu/reader.h>
@@ -1577,6 +1578,14 @@ bool Game_Map::PrepareEncounter(BattleArgs& args) {
 	}
 
 	args.troop_id = encounters[Rand::GetRandomNumber(0, encounters.size() - 1)];
+
+	if (Player::game_config.patch_encounter_random_alert.Get()) {
+		int var_id = Player::game_config.patch_encounter_random_alert.Get();
+		Main_Data::game_variables->Set(var_id, args.troop_id);
+		Game_Map::SetNeedRefresh(true);
+		Game_Map::Refresh();
+		return false;
+	}
 
 	if (Feature::HasRpg2kBattleSystem()) {
 		if (Rand::ChanceOf(1, 32)) {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1579,11 +1579,8 @@ bool Game_Map::PrepareEncounter(BattleArgs& args) {
 
 	args.troop_id = encounters[Rand::GetRandomNumber(0, encounters.size() - 1)];
 
-	if (Player::game_config.patch_encounter_random_alert.Get()) {
-		int var_id = Player::game_config.patch_encounter_random_alert.Get();
-		Main_Data::game_variables->Set(var_id, args.troop_id);
-		Game_Map::SetNeedRefresh(true);
-		Game_Map::Refresh();
+	if (RuntimePatches::EncounterRandomnessAlert::HandleEncounter(args.troop_id)) {
+		//Cancel the battle setup
 		return false;
 	}
 

--- a/src/game_runtime_patches.cpp
+++ b/src/game_runtime_patches.cpp
@@ -1,0 +1,156 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Headers
+#include "game_runtime_patches.h"
+
+#include "game_config.h"
+#include "game_party.h"
+#include "game_switches.h"
+#include "game_variables.h"
+#include "main_data.h"
+#include "player.h"
+
+namespace RuntimePatches::MonSca {
+#ifndef NO_RUNTIME_PATCHES
+	bool UseLevelBasedFormula() {
+		auto switch_id = Player::game_config.patch_monsca_levelscaling.Get();
+		return switch_id > 0 && Main_Data::game_switches->Get(switch_id);
+	}
+
+	void ApplyScaling(int& val, int mod) {
+		if (mod == 0) {
+			return;
+		}
+		if (UseLevelBasedFormula()) {
+			mod *= Main_Data::game_party->GetAverageLevel();
+		}
+		val *= mod;
+		val /= 1000;
+	}
+#endif
+}
+
+void RuntimePatches::MonSca::ModifyMaxHp(int& val) {
+#ifdef NO_RUNTIME_PATCHES
+	// no-op
+	(void)val;
+	return;
+#endif
+	if (auto var_id = Player::game_config.patch_monsca_maxhp.Get(); var_id > 0) {
+		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+	}
+}
+
+void RuntimePatches::MonSca::ModifyMaxSp(int& val) {
+#ifdef NO_RUNTIME_PATCHES
+	// no-op
+	(void)val;
+	return;
+#endif
+	if (auto var_id = Player::game_config.patch_monsca_maxsp.Get(); var_id > 0) {
+		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+	}
+}
+
+void RuntimePatches::MonSca::ModifyAtk(int& val) {
+#ifdef NO_RUNTIME_PATCHES
+	// no-op
+	(void)val;
+	return;
+#endif
+	if (auto var_id = Player::game_config.patch_monsca_atk.Get(); var_id > 0) {
+		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+	}
+}
+
+void RuntimePatches::MonSca::ModifyDef(int& val) {
+#ifdef NO_RUNTIME_PATCHES
+	// no-op
+	(void)val;
+	return;
+#endif
+	if (auto var_id = Player::game_config.patch_monsca_def.Get(); var_id > 0) {
+		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+	}
+}
+
+void RuntimePatches::MonSca::ModifySpi(int& val) {
+#ifdef NO_RUNTIME_PATCHES
+	// no-op
+	(void)val;
+	return;
+#endif
+	if (auto var_id = Player::game_config.patch_monsca_spi.Get(); var_id > 0) {
+		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+	}
+}
+
+void RuntimePatches::MonSca::ModifyAgi(int& val) {
+#ifdef NO_RUNTIME_PATCHES
+	// no-op
+	(void)val;
+	return;
+#endif
+	if (auto var_id = Player::game_config.patch_monsca_agi.Get(); var_id > 0) {
+		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+	}
+}
+
+void RuntimePatches::MonSca::ModifyExpGained(int& val) {
+#ifdef NO_RUNTIME_PATCHES
+	// no-op
+	(void)val;
+	return;
+#endif
+	if (auto var_id = Player::game_config.patch_monsca_exp.Get(); var_id > 0) {
+		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+	}
+}
+
+void RuntimePatches::MonSca::ModifyMoneyGained(int& val) {
+#ifdef NO_RUNTIME_PATCHES
+	// no-op
+	(void)val;
+	return;
+#endif
+	if (auto var_id = Player::game_config.patch_monsca_gold.Get(); var_id > 0) {
+		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+	}
+}
+
+void RuntimePatches::MonSca::ModifyItemGained(int& item_id) {
+#ifdef NO_RUNTIME_PATCHES
+	// no-op
+	(void)item_id;
+	return;
+#endif
+	if (auto var_id = Player::game_config.patch_monsca_item.Get(); var_id > 0) {
+		item_id += Main_Data::game_variables->Get(var_id);
+	}
+}
+
+void RuntimePatches::MonSca::ModifyItemDropRate(int& val) {
+#ifdef NO_RUNTIME_PATCHES
+	// no-op
+	(void)val;
+	return;
+#endif
+	if (auto var_id = Player::game_config.patch_monsca_droprate.Get(); var_id > 0) {
+		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+	}
+}

--- a/src/game_runtime_patches.cpp
+++ b/src/game_runtime_patches.cpp
@@ -204,7 +204,6 @@ bool RuntimePatches::EncounterRandomnessAlert::HandleEncounter(int troop_id) {
 }
 
 namespace RuntimePatches::MonSca {
-#ifndef NO_RUNTIME_PATCHES
 	bool UseLevelBasedFormula() {
 		auto switch_id = Player::game_config.patch_monsca_levelscaling.Get();
 		return switch_id > 0 && Main_Data::game_switches->Get(switch_id);
@@ -220,7 +219,6 @@ namespace RuntimePatches::MonSca {
 		val *= mod;
 		val /= 1000;
 	}
-#endif
 }
 
 void RuntimePatches::MonSca::ModifyMaxHp(int& val) {
@@ -338,7 +336,7 @@ void RuntimePatches::EXPlus::ModifyExpGain(Game_Actor& actor, int& exp_gain) {
 	// no-op
 	(void)actor;
 	(void)exp_gain;
-	return false;
+	return;
 #endif
 	if (auto base_var_id = Player::game_config.patch_explus_var.Get(); base_var_id > 0) {
 		exp_gain *= (100 + Main_Data::game_variables->Get(base_var_id + actor.GetPartyIndex()));

--- a/src/game_runtime_patches.cpp
+++ b/src/game_runtime_patches.cpp
@@ -23,6 +23,7 @@
 #include "game_party.h"
 #include "game_switches.h"
 #include "game_variables.h"
+#include "game_actor.h"
 #include "main_data.h"
 #include "player.h"
 
@@ -177,5 +178,29 @@ void RuntimePatches::MonSca::ModifyItemDropRate(int& val) {
 #endif
 	if (auto var_id = Player::game_config.patch_monsca_droprate.Get(); var_id > 0) {
 		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+	}
+}
+
+void RuntimePatches::EXPlus::ModifyExpGain(Game_Actor& actor, int& exp_gain) {
+#ifdef NO_RUNTIME_PATCHES
+	// no-op
+	(void)actor;
+	(void)exp_gain;
+	return false;
+#endif
+	if (auto base_var_id = Player::game_config.patch_explus_var.Get(); base_var_id > 0) {
+		exp_gain *= (100 + Main_Data::game_variables->Get(base_var_id + actor.GetPartyIndex()));
+		exp_gain /= 100;
+	}
+}
+
+void RuntimePatches::EXPlus::StoreActorPosition(int actor_id) {
+#ifdef NO_RUNTIME_PATCHES
+	// no-op
+	(void)actor_id;
+	return;
+#endif
+	if (auto var_id = Player::game_config.patch_explusplus_var.Get(); var_id > 0) {
+		Main_Data::game_variables->Set(var_id, Main_Data::game_party->GetActorPositionInParty(actor_id) + 1);
 	}
 }

--- a/src/game_runtime_patches.cpp
+++ b/src/game_runtime_patches.cpp
@@ -24,6 +24,7 @@
 #include "game_variables.h"
 #include "game_actor.h"
 #include "game_battler.h"
+#include "game_enemy.h"
 #include "main_data.h"
 #include "player.h"
 #include "output.h"
@@ -127,7 +128,7 @@ namespace {
 void RuntimePatches::LockPatchesAsDiabled() {
 #ifndef NO_RUNTIME_PATCHES
 	LockPatchArguments<2>(EncounterRandomnessAlert::patch_args);
-	LockPatchArguments<11>(MonSca::patch_args);
+	LockPatchArguments<12>(MonSca::patch_args);
 	LockPatchArguments<2>(EXPlus::patch_args);
 	LockPatchArguments<2>(GuardRevamp::patch_args);
 #endif
@@ -140,7 +141,7 @@ bool RuntimePatches::ParseFromCommandLine(CmdlineParser& cp) {
 		return ParsePatchArguments<2>(cp, arg, EncounterRandomnessAlert::patch_args);
 	}
 	if (cp.ParseNext(arg, 1, { "--patch-monsca", "--no-patch-monsca" })) {
-		return ParsePatchArguments<11>(cp, arg, MonSca::patch_args);
+		return ParsePatchArguments<12>(cp, arg, MonSca::patch_args);
 	}
 	if (cp.ParseNext(arg, 1, { "--patch-explus", "--no-patch-explus" })) {
 		return ParsePatchArguments<2>(cp, arg, EXPlus::patch_args);
@@ -158,7 +159,7 @@ bool RuntimePatches::ParseFromIni(lcf::INIReader& ini) {
 #ifndef NO_RUNTIME_PATCHES
 	bool patch_override = false;
 	patch_override |= ParsePatchFromIni<2>(ini, EncounterRandomnessAlert::patch_args);
-	patch_override |= ParsePatchFromIni<11>(ini, MonSca::patch_args);
+	patch_override |= ParsePatchFromIni<12>(ini, MonSca::patch_args);
 	patch_override |= ParsePatchFromIni<2>(ini, EXPlus::patch_args);
 	patch_override |= ParsePatchFromIni<2>(ini, GuardRevamp::patch_args);
 	return patch_override;
@@ -171,7 +172,7 @@ bool RuntimePatches::ParseFromIni(lcf::INIReader& ini) {
 void RuntimePatches::DetermineActivePatches(std::vector<std::string>& patches) {
 #ifndef NO_RUNTIME_PATCHES
 	PrintPatch<2>(patches, EncounterRandomnessAlert::patch_args);
-	PrintPatch<11>(patches, MonSca::patch_args);
+	PrintPatch<12>(patches, MonSca::patch_args);
 	PrintPatch<2>(patches, EXPlus::patch_args);
 	PrintPatch<2>(patches, GuardRevamp::patch_args);
 #else
@@ -209,7 +210,15 @@ namespace RuntimePatches::MonSca {
 		return switch_id > 0 && Main_Data::game_switches->Get(switch_id);
 	}
 
-	void ApplyScaling(int& val, int mod) {
+	int GetVariableId(Game_Enemy const& enemy, int var_id) {
+		if (Player::game_config.patch_monsca_plus.Get() > 0) {
+			return var_id + enemy.GetTroopMemberId();
+		}
+		return var_id;
+	}
+
+	void ApplyScaling(Game_Enemy const& enemy, int& val, int var_id) {
+		int mod = Main_Data::game_variables->Get(GetVariableId(enemy, var_id));
 		if (mod == 0) {
 			return;
 		}
@@ -221,113 +230,113 @@ namespace RuntimePatches::MonSca {
 	}
 }
 
-void RuntimePatches::MonSca::ModifyMaxHp(int& val) {
+void RuntimePatches::MonSca::ModifyMaxHp(Game_Enemy const& enemy, int& val) {
 #ifdef NO_RUNTIME_PATCHES
 	// no-op
 	(void)val;
 	return;
 #endif
 	if (auto var_id = Player::game_config.patch_monsca_maxhp.Get(); var_id > 0) {
-		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+		ApplyScaling(enemy, val, var_id);
 	}
 }
 
-void RuntimePatches::MonSca::ModifyMaxSp(int& val) {
+void RuntimePatches::MonSca::ModifyMaxSp(Game_Enemy const& enemy, int& val) {
 #ifdef NO_RUNTIME_PATCHES
 	// no-op
 	(void)val;
 	return;
 #endif
 	if (auto var_id = Player::game_config.patch_monsca_maxsp.Get(); var_id > 0) {
-		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+		ApplyScaling(enemy, val, var_id);
 	}
 }
 
-void RuntimePatches::MonSca::ModifyAtk(int& val) {
+void RuntimePatches::MonSca::ModifyAtk(Game_Enemy const& enemy, int& val) {
 #ifdef NO_RUNTIME_PATCHES
 	// no-op
 	(void)val;
 	return;
 #endif
 	if (auto var_id = Player::game_config.patch_monsca_atk.Get(); var_id > 0) {
-		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+		ApplyScaling(enemy, val, var_id);
 	}
 }
 
-void RuntimePatches::MonSca::ModifyDef(int& val) {
+void RuntimePatches::MonSca::ModifyDef(Game_Enemy const& enemy, int& val) {
 #ifdef NO_RUNTIME_PATCHES
 	// no-op
 	(void)val;
 	return;
 #endif
 	if (auto var_id = Player::game_config.patch_monsca_def.Get(); var_id > 0) {
-		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+		ApplyScaling(enemy, val, var_id);
 	}
 }
 
-void RuntimePatches::MonSca::ModifySpi(int& val) {
+void RuntimePatches::MonSca::ModifySpi(Game_Enemy const& enemy, int& val) {
 #ifdef NO_RUNTIME_PATCHES
 	// no-op
 	(void)val;
 	return;
 #endif
 	if (auto var_id = Player::game_config.patch_monsca_spi.Get(); var_id > 0) {
-		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+		ApplyScaling(enemy, val, var_id);
 	}
 }
 
-void RuntimePatches::MonSca::ModifyAgi(int& val) {
+void RuntimePatches::MonSca::ModifyAgi(Game_Enemy const& enemy, int& val) {
 #ifdef NO_RUNTIME_PATCHES
 	// no-op
 	(void)val;
 	return;
 #endif
 	if (auto var_id = Player::game_config.patch_monsca_agi.Get(); var_id > 0) {
-		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+		ApplyScaling(enemy, val, var_id);
 	}
 }
 
-void RuntimePatches::MonSca::ModifyExpGained(int& val) {
+void RuntimePatches::MonSca::ModifyExpGained(Game_Enemy const& enemy, int& val) {
 #ifdef NO_RUNTIME_PATCHES
 	// no-op
 	(void)val;
 	return;
 #endif
 	if (auto var_id = Player::game_config.patch_monsca_exp.Get(); var_id > 0) {
-		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+		ApplyScaling(enemy, val, var_id);
 	}
 }
 
-void RuntimePatches::MonSca::ModifyMoneyGained(int& val) {
+void RuntimePatches::MonSca::ModifyMoneyGained(Game_Enemy const& enemy, int& val) {
 #ifdef NO_RUNTIME_PATCHES
 	// no-op
 	(void)val;
 	return;
 #endif
 	if (auto var_id = Player::game_config.patch_monsca_gold.Get(); var_id > 0) {
-		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+		ApplyScaling(enemy, val, var_id);
 	}
 }
 
-void RuntimePatches::MonSca::ModifyItemGained(int& item_id) {
+void RuntimePatches::MonSca::ModifyItemGained(Game_Enemy const& enemy, int& item_id) {
 #ifdef NO_RUNTIME_PATCHES
 	// no-op
 	(void)item_id;
 	return;
 #endif
 	if (auto var_id = Player::game_config.patch_monsca_item.Get(); var_id > 0) {
-		item_id += Main_Data::game_variables->Get(var_id);
+		 item_id += Main_Data::game_variables->Get(GetVariableId(enemy, var_id));
 	}
 }
 
-void RuntimePatches::MonSca::ModifyItemDropRate(int& val) {
+void RuntimePatches::MonSca::ModifyItemDropRate(Game_Enemy const& enemy, int& val) {
 #ifdef NO_RUNTIME_PATCHES
 	// no-op
 	(void)val;
 	return;
 #endif
 	if (auto var_id = Player::game_config.patch_monsca_droprate.Get(); var_id > 0) {
-		ApplyScaling(val, Main_Data::game_variables->Get(var_id));
+		ApplyScaling(enemy, val, var_id);
 	}
 }
 

--- a/src/game_runtime_patches.cpp
+++ b/src/game_runtime_patches.cpp
@@ -31,7 +31,7 @@
 namespace {
 	template<int C>
 	void LockPatchArguments(std::array<RuntimePatches::PatchArg, C> const& patch_args) {
-		for (auto patch_arg : patch_args) {
+		for (auto& patch_arg : patch_args) {
 			patch_arg.config_param->Lock(0);
 		}
 	}
@@ -39,13 +39,13 @@ namespace {
 	template<int C>
 	bool ParsePatchArguments(CmdlineParser& cp, CmdlineArg arg, std::array<RuntimePatches::PatchArg, C> const& patch_args) {
 		if (arg.ArgIsOff()) {
-			for (auto patch_arg : patch_args) {
+			for (auto& patch_arg : patch_args) {
 				patch_arg.config_param->Set(0);
 			}
 			return true;
 		}
 		if (arg.ArgIsOn()) {
-			for (auto patch_arg : patch_args) {
+			for (auto& patch_arg : patch_args) {
 				patch_arg.config_param->Set(patch_arg.default_value);
 			}
 
@@ -56,7 +56,7 @@ namespace {
 				while ((new_pos = value.rfind(',', pos)) >= 0) {
 					int v = std::atoi(value.substr(pos, new_pos - pos).c_str());
 					patch_args[i++].config_param->Set(v);
-					if (i == patch_args.size()) {
+					if (i == static_cast<int>(patch_args.size())) {
 						break;
 					}
 					pos = new_pos + 1;
@@ -68,7 +68,7 @@ namespace {
 			long li_value = 0;
 			do {
 				parsed = false;
-				for (int i = 0; i < patch_args.size(); ++i) {
+				for (int i = 0; i < static_cast<int>(patch_args.size()); ++i) {
 					if (cp.ParseNext(arg, 1, patch_args[i].cmd_arg)) {
 						parsed = true;
 						if (arg.ParseValue(0, li_value)) {
@@ -80,12 +80,13 @@ namespace {
 
 			return true;
 		}
+		return false;
 	}
 
 	template<int C>
 	bool ParsePatchFromIni(lcf::INIReader& ini, std::array<RuntimePatches::PatchArg, C> const& patch_args) {
 		bool patch_override = false;
-		for (auto patch_arg : patch_args) {
+		for (auto& patch_arg : patch_args) {
 			patch_override |= patch_arg.config_param->FromIni(ini);
 		}
 		return patch_override;
@@ -96,7 +97,7 @@ namespace {
 		assert(patch_args.size() > 0);
 
 		bool is_set = false;
-		for (auto patch_arg : patch_args) {
+		for (auto& patch_arg : patch_args) {
 			if (patch_arg.config_param->Get() > 0) {
 				is_set = true;
 				break;
@@ -112,7 +113,7 @@ namespace {
 		}
 
 		std::string out = fmt::format("{} (", patch_args[0].config_param->GetName());
-		for (int i = 0; i < patch_args.size(); ++i) {
+		for (int i = 0; i < static_cast<int>(patch_args.size()); ++i) {
 			if (i > 0) {
 				out += ", ";
 			}

--- a/src/game_runtime_patches.h
+++ b/src/game_runtime_patches.h
@@ -54,7 +54,7 @@ namespace RuntimePatches {
 	 * This patch skips the normal battle startup logic whenever a random
 	 * encounter would be triggered.
 	 * Instead a switch (default: S[1018]) is set to ON and the troop ID
-	 * is stored into a variable (default: V[3355).
+	 * is stored into a variable (default: V[3355]).
 	 *
 	 * This implementation always triggers a page-refresh for all
 	 * events on the current map.
@@ -78,7 +78,7 @@ namespace RuntimePatches {
 	 * based on the contents of some in-game variables.
 	 * (Default: V[1001] - V[1010])
 	 * 
-	 * When a switch is set (default: S[1001) to ON, an alternative
+	 * When a switch is set (default: S[1001]) to ON, an alternative
 	 * scaling formula, based on the average party level, is used.
 	 *
 	 * Default formula:     val = val * V[...] / 1000

--- a/src/game_runtime_patches.h
+++ b/src/game_runtime_patches.h
@@ -20,6 +20,24 @@
 
 namespace RuntimePatches {
 	/**
+	 * Support for RPG_RT patch 'Encounter Randomness Alert'.
+	 * This patch skips the normal battle startup logic whenever a random
+	 * encounter would be triggered and.
+	 * Instead a switch (default: S[1018]) is set to ON and the troop ID
+	 * is stored into a variable (default: V[3355).
+	 *
+	 * This implementation always triggers a page-refresh for all
+	 * events on the current map.
+	 */
+	namespace EncounterRandomnessAlert {
+		/**
+		 * Sets the configured switch & variable according to ERA´s rules.
+		 * @return if normal battle processing should be skipped.
+		 */
+		bool HandleEncounter(int troop_id);
+	}
+
+	/**
 	 * Support for RPG_RT patch 'MonSca'.
 	 * This patch scales the default battle parameters of an enemy
 	 * based on the contents of some in-game variables.

--- a/src/game_runtime_patches.h
+++ b/src/game_runtime_patches.h
@@ -24,6 +24,7 @@
 
 class Game_Actor;
 class Game_Battler;
+class Game_Enemy;
 
 // When this compile flag is set, all of the evaluation logic for these patches
 // will be disabled, by simply voiding any calls to their function hooks.
@@ -72,7 +73,7 @@ namespace RuntimePatches {
 	}
 
 	/**
-	 * Support for RPG_RT patch 'MonSca'.
+	 * Support for RPG_RT patch 'MonSca' & 'MonScaPlus'.
 	 * This patch scales the default battle parameters of an enemy
 	 * based on the contents of some in-game variables.
 	 * (Default: V[1001] - V[1010])
@@ -82,9 +83,14 @@ namespace RuntimePatches {
 	 *
 	 * Default formula:     val = val * V[...] / 1000
 	 * Alternative formula: val = val * avg_level * V[...] / 1000
+	 *
+	 * Variant 'MonScaPlus':
+	 * If set, the variable IDs used for scaling will be offset
+	 * by the enemy's troop index.
+	 *  -> V[base_var_id + troop_index]
 	 */
 	namespace MonSca {
-		constexpr std::array<PatchArg, 11> patch_args = { {
+		constexpr std::array<PatchArg, 12> patch_args = { {
 			{ Player::game_config.patch_monsca_maxhp, "-maxhp", 1001 },
 			{ Player::game_config.patch_monsca_maxsp, "-maxsp", 1002 },
 			{ Player::game_config.patch_monsca_atk, "-atk", 1003 },
@@ -95,33 +101,34 @@ namespace RuntimePatches {
 			{ Player::game_config.patch_monsca_gold, "-gold", 1008 },
 			{ Player::game_config.patch_monsca_item, "-item", 1009 },
 			{ Player::game_config.patch_monsca_droprate, "-droprate", 1010 },
-			{ Player::game_config.patch_monsca_levelscaling, "-lvlscale", 1001 }
+			{ Player::game_config.patch_monsca_levelscaling, "-lvlscale", 1001 },
+			{ Player::game_config.patch_monsca_plus, "-plus", 0 }
 		} };
 
 		/** Scales an enemies's maximum HP stat, based on the value of variable V[1001] */
-		void ModifyMaxHp(int& val);
+		void ModifyMaxHp(Game_Enemy const& enemy, int& val);
 		/** Scales an enemies's maximum SP stat, based on the value of variable V[1002] */
-		void ModifyMaxSp(int& val);
+		void ModifyMaxSp(Game_Enemy const& enemy, int& val);
 		/** Scales an enemies's attack stat, based on the value of variable V[1003] */
-		void ModifyAtk(int& val);
+		void ModifyAtk(Game_Enemy const& enemy, int& val);
 		/** Scales an enemies's defense stat, based on the value of variable V[1004] */
-		void ModifyDef(int& val);
+		void ModifyDef(Game_Enemy const& enemy, int& val);
 		/** Scales an enemies's spirit stat, based on the value of variable V[1005] */
-		void ModifySpi(int& val);
+		void ModifySpi(Game_Enemy const& enemy, int& val);
 		/** Scales an enemies's agility stat, based on the value of variable V[1006] */
-		void ModifyAgi(int& val);
+		void ModifyAgi(Game_Enemy const& enemy, int& val);
 		/** Scales the experience points gained by defating an enemy, based on the value of variable V[1007] */
-		void ModifyExpGained(int& val);
+		void ModifyExpGained(Game_Enemy const& enemy, int& val);
 		/** Scales the money gained by defating an enemy, based on the value of variable V[1008] */
-		void ModifyMoneyGained(int& val);
+		void ModifyMoneyGained(Game_Enemy const& enemy, int& val);
 		/**
 		 * Modifies the item dropped by defating an enemy, based on the value of variable V[1009]
 		 * In contrast to other modifers of this patch, this skips the normal formula and just
 		 * adds the variable value to the result.
 		 */
-		void ModifyItemGained(int& item_id);
+		void ModifyItemGained(Game_Enemy const& enemy, int& item_id);
 		/** Scales the item drop rate of an enemy, based on the value of variable V[1010] */
-		void ModifyItemDropRate(int& val);
+		void ModifyItemDropRate(Game_Enemy const& enemy, int& val);
 	}
 
 	/**

--- a/src/game_runtime_patches.h
+++ b/src/game_runtime_patches.h
@@ -158,5 +158,32 @@ namespace RuntimePatches {
 		 */
 		void StoreActorPosition(int actor_id);
 	}
+
+	/**
+	 * Support for RPG_RT patch 'GuardRevamp'.
+	 * This patch changes the way the damage adjustment is calculated
+	 * whenever the target of an attack is defending.
+	 *
+	 * Normally this calculation is done by simply dividing the damage
+	 * in half for normal defense situations, and by quartering it
+	 * when the target has the 'strong defense' attribute.
+	 * With 'GuardRevamp' enabled, this is changed to a percentage
+	 * calculation, allowing for more granular control over the output.
+	 * The given default values of '50%', and '25%' would provide
+	 * the same results in most situations.
+	 */
+	namespace GuardRevamp {
+		constexpr std::array<PatchArg, 2> patch_args = { {
+			{ Player::game_config.patch_guardrevamp_normal, "-normal", 50},
+			{ Player::game_config.patch_guardrevamp_strong, "-strong", 25 }
+		} };
+
+		/**
+		 * Adjusts the damage value taken by the given battler according
+		 * the GuardRevamp patches' rules.
+		 * @return if normal damage calculation should skipped.
+		 */
+		bool OverrideDamageAdjustment(int& dmg, const Game_Battler& target);
+	}
 }
 #endif

--- a/src/game_runtime_patches.h
+++ b/src/game_runtime_patches.h
@@ -18,6 +18,7 @@
 #ifndef EP_GAME_RUNTIMEPATCHES_H
 #define EP_GAME_RUNTIMEPATCHES_H
 
+class Game_Actor;
 namespace RuntimePatches {
 	/**
 	 * Support for RPG_RT patch 'Encounter Randomness Alert'.
@@ -74,6 +75,36 @@ namespace RuntimePatches {
 		void ModifyItemGained(int& item_id);
 		/** Scales the item drop rate of an enemy, based on the value of variable V[1010] */
 		void ModifyItemDropRate(int& val);
+	}
+
+	/**
+	 * Support for RPG_RT patch 'EXPlus' & 'EXPLus[+]'.
+	 * This patch allows to individually boost the 4 party members'
+	 * gained experience inside battles by applying an extra percentage
+	 * based on the values of in-game variables.
+	 *  (default: V[3333] for party member #1; the amounts for other
+	 *   party members are read from the subsequent 3 variables)
+	 *
+	 * If the '[+]' option is enabled, a side effect is added to one
+	 * of the Actor clauses of 'CommandConditionalBranch':
+	 *  Whenever this command is used to check for the existence of
+	 *  an actor in the current party, the current party slot (1-4)
+	 *  of this actor is set to an in-game variable. (default: V[3332])
+	 */
+	namespace EXPlus {
+		/**
+		 * Boosts the gained experience points which would be added to
+		 * the given actor's stats by an extra amount which is calculated
+		 * from the value of the in-game variable V[X + party_index - 1].
+		 */
+		void ModifyExpGain(Game_Actor& actor, int& exp_gain);
+
+		/**
+		 * Store's the current party position of the given actor inside
+		 * the configured in-game variable for the '[+]' variant of
+		 * te EXPlus patch.
+		 */
+		void StoreActorPosition(int actor_id);
 	}
 }
 #endif

--- a/src/game_runtime_patches.h
+++ b/src/game_runtime_patches.h
@@ -1,0 +1,61 @@
+/*
+ * This file is part of EasyRPG Player.
+ *
+ * EasyRPG Player is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Player is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Player. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EP_GAME_RUNTIMEPATCHES_H
+#define EP_GAME_RUNTIMEPATCHES_H
+
+namespace RuntimePatches {
+	/**
+	 * Support for RPG_RT patch 'MonSca'.
+	 * This patch scales the default battle parameters of an enemy
+	 * based on the contents of some in-game variables.
+	 * (Default: V[1001] - V[1010])
+	 * 
+	 * When a switch is set (default: S[1001) to ON, an alternative
+	 * scaling formular, based on the average party level is used.
+	 *
+	 * Default formula:     val = val * V[...] / 1000
+	 * Alternative formula: val = val * avg_level * V[...] / 1000
+	 */
+	namespace MonSca {
+		/** Scales an enemies큦 maximum HP stat, based on the value of variable V[1001] */
+		void ModifyMaxHp(int& val);
+		/** Scales an enemies큦 maximum SP stat, based on the value of variable V[1002] */
+		void ModifyMaxSp(int& val);
+		/** Scales an enemies큦 attack stat, based on the value of variable V[1003] */
+		void ModifyAtk(int& val);
+		/** Scales an enemies큦 defense stat, based on the value of variable V[1004] */
+		void ModifyDef(int& val);
+		/** Scales an enemies큦 spirit stat, based on the value of variable V[1005] */
+		void ModifySpi(int& val);
+		/** Scales an enemies큦 agility stat, based on the value of variable V[1006] */
+		void ModifyAgi(int& val);
+		/** Scales the experience points gained by defating an enemy, based on the value of variable V[1007] */
+		void ModifyExpGained(int& val);
+		/** Scales the money gained by defating an enemy, based on the value of variable V[1008] */
+		void ModifyMoneyGained(int& val);
+		/**
+		 * Modifies the item dropped by defating an enemy, based on the value of variable V[1009]
+		 * In contrast to other modifers of this patch, this skips the normal formula and just
+		 * adds the variable value to the result.
+		 */
+		void ModifyItemGained(int& item_id);
+		/** Scales the item drop rate of an enemy, based on the value of variable V[1010] */
+		void ModifyItemDropRate(int& val);
+	}
+}
+#endif

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -677,7 +677,8 @@ Game_Config Player::ParseCommandLine() {
 void Player::CreateGameObjects() {
 	// Parse game specific settings
 	CmdlineParser cp(arguments);
-	game_config = Game_ConfigGame::Create(cp);
+	game_config = Game_ConfigGame();
+	game_config.Initialize(cp);
 
 	// Reinit MIDI
 	MidiDecoder::Reset();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1453,6 +1453,8 @@ Engine options:
  --patch-direct-menu VAR
                       Directly access subscreens of the default menu by setting
                       VAR.
+ --patch-encounter-alert VAR
+                      Set troop id to variable VAR and skip random battles.
  --patch-dynrpg       Enable support of DynRPG patch by Cherry (very limited).
  --patch-easyrpg      Enable EasyRPG extensions.
  --patch-key-patch    Enable Key Patch by Ineluki.

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -882,9 +882,11 @@ Scene_Battle_Rpg2k::SceneActionReturn Scene_Battle_Rpg2k::ProcessSceneActionVict
 
 		pm.PushPageEnd();
 
-		for (auto& ally: ally_battlers) {
-			Game_Actor* actor = static_cast<Game_Actor*>(ally);
-			actor->ChangeExp(actor->GetExp() + exp, &pm);
+		for (int i = 0; i < ally_battlers.size(); ++i) {
+			Game_Actor* actor = static_cast<Game_Actor*>(ally_battlers[i]);
+			int exp_gain = exp;
+			RuntimePatches::EXPlus::ModifyExpGain(*actor, exp_gain);
+			actor->ChangeExp(actor->GetExp() + exp_gain, &pm);
 		}
 		Main_Data::game_party->GainGold(money);
 		for (auto& item: drops) {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -882,7 +882,7 @@ Scene_Battle_Rpg2k::SceneActionReturn Scene_Battle_Rpg2k::ProcessSceneActionVict
 
 		pm.PushPageEnd();
 
-		for (int i = 0; i < ally_battlers.size(); ++i) {
+		for (int i = 0; i < static_cast<int>(ally_battlers.size()); ++i) {
 			Game_Actor* actor = static_cast<Game_Actor*>(ally_battlers[i]);
 			int exp_gain = exp;
 			RuntimePatches::EXPlus::ModifyExpGain(*actor, exp_gain);

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -1880,7 +1880,9 @@ Scene_Battle_Rpg2k3::SceneActionReturn Scene_Battle_Rpg2k3::ProcessSceneActionVi
 
 		for (auto* actor: Main_Data::game_party->GetActors()) {
 			if (actor->Exists()) {
-				actor->ChangeExp(actor->GetExp() + exp, &pm);
+				int exp_gain = exp;
+				RuntimePatches::EXPlus::ModifyExpGain(*actor, exp_gain);
+				actor->ChangeExp(actor->GetExp() + exp_gain, &pm);
 			}
 		}
 


### PR DESCRIPTION
## Detection
_No automatic patch detection yet!_ (Only .INI settings & cmd line args)

This would either require something like my proposed Draft PR #3352 (Extracting patch info from .EXE via known addresses & signatures) or some database of known patch configurations of games (As proposed in Issue #1210)

## Test Game:
[BattlePatches.zip](https://github.com/user-attachments/files/19403624/BattlePatches.zip)

## RPG_RT Patches included in this PR
### MonSca:
This patch scales the default battle parameters of an enemy based on the contents of some in-game variables.
(Default: `V[1001] - V[1010]`)

When a switch is set (default: `S[1001]`) to ON, an alternative scaling formula, based on the average party level, is used.

**Default formula:** `val = val * V[...] / 1000`
**Alternative formula:** val = `val * avg_level * V[...] / 1000`

**Variant 'MonScaPlus':**
If set, the variable IDs used for scaling will be offset by the enemy's troop index.
-> `V[base_var_id + troop_index]`

- https://dev.makerpendium.de/docs/patch_db/patches/mon_sca.htm
- **'Plus' Variant**: https://rmarchiv.de/games/24

### Encounter Randomness Alert
This patch skips the normal battle startup logic whenever a random encounter would be triggered.
Instead a switch (default: `S[1018]`) is set to ON and the troop ID is stored into a variable (default: `V[3355]`).

- https://dev.makerpendium.de/docs/patch_db/patches/encounter_alert.htm
- https://dev.makerpendium.de/docs/patch_db/patches/encounter_alert_mepr.htm

### EXPlus:
This patch allows to individually boost the 4 party members' gained experience inside battles by applying an extra percentage based on the values of in-game variables.
(default: `V[3333]` for party member `#1`; the amounts for other party members are read from the subsequent 3 variables)

If the '[+]' option is enabled, a side effect is added to one of the Actor clauses of 'CommandConditionalBranch':
Whenever this command is used to check for the existence of an actor in the current party, the current party slot (1-4) of this actor is set to an in-game variable. (default: `V[3332]`)

- https://dev.makerpendium.de/docs/patch_db/patches/explus.htm
- https://dev.makerpendium.de/docs/patch_db/patches/explus_plus.htm

### GuardRevamp:
This patch changes the way the damage adjustment is calculated whenever the target of an attack is defending.

 Normally this calculation is done by simply dividing the damage in half for normal defense situations, and by quartering it when the target has the 'strong defense' attribute. With 'GuardRevamp' enabled, this is changed to a percentage calculation, allowing for more granular control over the output. The given default values of '50%', and '25%' would provide the same results in most situations.

- https://dev.makerpendium.de/docs/patch_db/patches/guard_revamp.htm

## Notes
Support for all of these patches can be disabled by setting the compiler flag `NO_RUNTIME_PATCHES`.

Some of the handling of command line args has been refactored, to allow setting patch parameters inidividually.
**Example**: 
`Player.exe --patch-monsca -atk 2003 -exp 2027 -plus --patch-guardrevamp -normal 75 -strong 30`
- enables "**MonScaPlus**" for scaling _attack_ & _experience gains_ by reading from the scaling factors from Variables `V[2003]` & `V[2027]` (+ troop_id for this 'Plus' variant)
- enables "**GuardRevamp**" with a factor of 75% for normal defending & 30% for "**strong**" defend.
