### PR TITLE
Change EasyRPG's "SetInterpreterFlag" to make patch overrides temporary

### DIFF
--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -18,13 +18,19 @@
 // Headers
 #include "feature.h"
 #include "player.h"
+#include "game_interpreter_shared.h"
 #include <lcf/data.h>
 
 bool Feature::HasRpg2kBattleSystem() {
 	if (Player::IsRPG2k()) {
 		return true;
 	}
-
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+	using Flags = lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags;
+	if (auto f = Player::GetRuntimeFlag(&Flags::use_rpg2k_battle_system_on, &Flags::use_rpg2k_battle_system_off)) {
+		return *f;
+	}
+#endif
 	return lcf::Data::system.easyrpg_use_rpg2k_battle_system;
 }
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -385,7 +385,7 @@ void Game_Interpreter::Update(bool reset_loop_count) {
 #ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
 	Player::active_interpreter_flags = &_state.easyrpg_runtime_flags;
 	auto flags_guard = lcf::makeScopeGuard([]() {
-		Player::active_interpreter_flags = nullptr;
+		Player::active_interpreter_flags = &Player::interpreter_default_flags;
 	});
 #endif
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2054,6 +2054,8 @@ std::optional<bool> Game_Interpreter::HandleDynRpgScript(const lcf::rpg::EventCo
 
 		return Main_Data::game_dynrpg->Invoke(command, this);
 	}
+
+	return {};
 }
 
 std::optional<bool> Game_Interpreter::HandleDestinyScript(const lcf::rpg::EventCommand& com) {
@@ -2061,12 +2063,12 @@ std::optional<bool> Game_Interpreter::HandleDestinyScript(const lcf::rpg::EventC
 	if (Player::IsPatchDestiny()) {
 		if (com.string.empty() || com.string[0] != '$') {
 			// Not a DestinyScript
-			return std::nullopt;
+			return {};
 		}
 
 		return Main_Data::game_destiny->Main(GetFrame());
 	}
-	return std::nullopt;
+	return {};
 }
 
 bool Game_Interpreter::CommandComment(const lcf::rpg::EventCommand &com) {

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2066,6 +2066,7 @@ std::optional<bool> Game_Interpreter::HandleDestinyScript(const lcf::rpg::EventC
 
 		return Main_Data::game_destiny->Main(GetFrame());
 	}
+	return std::nullopt;
 }
 
 bool Game_Interpreter::CommandComment(const lcf::rpg::EventCommand &com) {

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -310,6 +310,9 @@ protected:
 	void ForegroundTextPush(PendingMessage pm);
 	void EndEventProcessing();
 
+	std::optional<bool> HandleDynRpgScript(const lcf::rpg::EventCommand& com);
+	std::optional<bool> HandleDestinyScript(const lcf::rpg::EventCommand& com);
+
 	FileRequestBinding request_id;
 	enum class Keys {
 		eDown,

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -85,7 +85,7 @@ public:
 	 * Returns the interpreters current state information.
 	 * For saving state into a save file, use GetSaveState instead.
 	 */
-	const lcf::rpg::SaveEventExecState& GetState() const;
+	const lcf::rpg::SaveEventExecState& GetState() const override;
 
 	/**
 	 * Returns a SaveEventExecState needed for the savefile.
@@ -344,6 +344,10 @@ protected:
 
 	int ManiacBitmask(int value, int mask) const;
 
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+	void ClearStateRuntimeFlags();
+#endif
+
 	lcf::rpg::SaveEventExecState _state;
 	KeyInputState _keyinput;
 	AsyncOp _async_op = {};
@@ -397,5 +401,12 @@ inline bool Game_Interpreter::IsAsyncPending() {
 inline AsyncOp Game_Interpreter::GetAsyncOp() const {
 	return _async_op;
 }
+
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+inline void Game_Interpreter::ClearStateRuntimeFlags() {
+	_state.easyrpg_runtime_flags.conf_override_active = false;
+	_state.easyrpg_runtime_flags.flags.fill(false);
+}
+#endif
 
 #endif

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -347,10 +347,6 @@ protected:
 
 	int ManiacBitmask(int value, int mask) const;
 
-#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
-	void ClearStateRuntimeFlags();
-#endif
-
 	lcf::rpg::SaveEventExecState _state;
 	KeyInputState _keyinput;
 	AsyncOp _async_op = {};
@@ -404,12 +400,5 @@ inline bool Game_Interpreter::IsAsyncPending() {
 inline AsyncOp Game_Interpreter::GetAsyncOp() const {
 	return _async_op;
 }
-
-#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
-inline void Game_Interpreter::ClearStateRuntimeFlags() {
-	_state.easyrpg_runtime_flags.conf_override_active = false;
-	_state.easyrpg_runtime_flags.flags.fill(false);
-}
-#endif
 
 #endif

--- a/src/game_interpreter_shared.cpp
+++ b/src/game_interpreter_shared.cpp
@@ -238,6 +238,24 @@ lcf::rpg::MoveCommand Game_Interpreter_Shared::DecodeMove(lcf::DBArray<int32_t>:
 	return cmd;
 }
 
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+
+std::optional<bool> Game_Interpreter_Shared::GetRuntimeFlag(lcf::rpg::SaveEventExecState const& state, StateRuntimeFlagRef const field_on, StateRuntimeFlagRef const field_off) {
+	return GetRuntimeFlag(state.easyrpg_runtime_flags, field_on, field_off);
+}
+
+std::optional<bool> Game_Interpreter_Shared::GetRuntimeFlag(lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags const& state_runtime_flags, StateRuntimeFlagRef const field_on, StateRuntimeFlagRef const field_off) {
+	if (state_runtime_flags.conf_override_active) {
+		if (state_runtime_flags.*field_on)
+			return true;
+		if (state_runtime_flags.*field_off)
+			return false;
+	}
+	return std::nullopt;
+}
+
+#endif
+
 //explicit declarations for target evaluation logic shared between ControlSwitches/ControlVariables/ControlStrings
 template bool Game_Interpreter_Shared::DecodeTargetEvaluationMode<true, false, false, false, false>(lcf::rpg::EventCommand const&, int&, int&, Game_BaseInterpreterContext const&);
 template bool Game_Interpreter_Shared::DecodeTargetEvaluationMode<true, true, true, false, false>(lcf::rpg::EventCommand const&, int&, int&, Game_BaseInterpreterContext const&);

--- a/src/game_interpreter_shared.h
+++ b/src/game_interpreter_shared.h
@@ -21,9 +21,13 @@
 
 #include <lcf/rpg/eventcommand.h>
 #include <lcf/rpg/movecommand.h>
+#include <lcf/rpg/saveeventexecstate.h>
 #include <lcf/rpg/saveeventexecframe.h>
 #include <string_view.h>
 #include "compiler.h"
+#include <optional>
+
+#define ENABLE_DYNAMIC_INTERPRETER_CONFIG
 
 class Game_Character;
 class Game_BaseInterpreterContext;
@@ -103,6 +107,14 @@ namespace Game_Interpreter_Shared {
 	lcf::rpg::MoveCommand DecodeMove(lcf::DBArray<int32_t>::const_iterator& it);
 
 	bool ManiacCheckContinueLoop(int val, int val2, int type, int op);
+
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+	typedef bool lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags::* StateRuntimeFlagRef;
+
+	std::optional<bool> GetRuntimeFlag(lcf::rpg::SaveEventExecState const& state, StateRuntimeFlagRef const field_on, StateRuntimeFlagRef const field_off);
+
+	std::optional<bool> GetRuntimeFlag(lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags const& state_runtime_flags, StateRuntimeFlagRef const field_on, StateRuntimeFlagRef const field_off);
+#endif
 }
 
 inline bool Game_Interpreter_Shared::CheckOperator(int val, int val2, int op) {
@@ -147,7 +159,15 @@ public:
 
 	virtual int GetThisEventId() const = 0;
 	virtual Game_Character* GetCharacter(int event_id, std::string_view origin) const = 0;
+
+	virtual const lcf::rpg::SaveEventExecState& GetState() const = 0;
 	virtual const lcf::rpg::SaveEventExecFrame& GetFrame() const = 0;
+
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+	inline std::optional<bool> GetRuntimeFlag(Game_Interpreter_Shared::StateRuntimeFlagRef const field_on, Game_Interpreter_Shared::StateRuntimeFlagRef const field_off) const {
+		return Game_Interpreter_Shared::GetRuntimeFlag(GetState(), field_on, field_off);
+	};
+#endif
 
 protected:
 	template<bool validate_patches, bool support_range_indirect, bool support_expressions, bool support_bitmask, bool support_scopes, bool support_named = false>

--- a/src/game_interpreter_shared.h
+++ b/src/game_interpreter_shared.h
@@ -109,7 +109,7 @@ namespace Game_Interpreter_Shared {
 	bool ManiacCheckContinueLoop(int val, int val2, int type, int op);
 
 #ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
-	typedef bool lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags::* StateRuntimeFlagRef;
+	using StateRuntimeFlagRef = bool lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags::*;
 
 	std::optional<bool> GetRuntimeFlag(lcf::rpg::SaveEventExecState const& state, StateRuntimeFlagRef const field_on, StateRuntimeFlagRef const field_off);
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -136,7 +136,6 @@ namespace Player {
 	int rng_seed = -1;
 	Game_ConfigPlayer player_config;
 	Game_ConfigGame game_config;
-	lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags* active_interpreter_flags = nullptr;
 #ifdef EMSCRIPTEN
 	std::string emscripten_game_name;
 #endif

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -136,6 +136,7 @@ namespace Player {
 	int rng_seed = -1;
 	Game_ConfigPlayer player_config;
 	Game_ConfigGame game_config;
+	lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags* active_interpreter_flags = nullptr;
 #ifdef EMSCRIPTEN
 	std::string emscripten_game_name;
 #endif

--- a/src/player.h
+++ b/src/player.h
@@ -25,9 +25,11 @@
 #include "game_clock.h"
 #include "game_config.h"
 #include "game_config_game.h"
+#include "game_interpreter_shared.h"
 #include <vector>
 #include <memory>
 #include <cstdint>
+#include <optional>
 
 /**
  * Player namespace.
@@ -297,6 +299,10 @@ namespace Player {
 	 */
 	bool IsPatchDestiny();
 
+	bool IsPatchCommonThisEvent();
+
+	bool IsPatchUnlockPics();
+
 	/**
 	 * @return True when EasyRpg extensions are on
 	 */
@@ -435,6 +441,12 @@ namespace Player {
 	/** Name of game emscripten uses */
 	extern std::string emscripten_game_name;
 #endif
+
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+	extern lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags* active_interpreter_flags;
+
+	std::optional<bool> GetRuntimeFlag(Game_Interpreter_Shared::StateRuntimeFlagRef field_on, Game_Interpreter_Shared::StateRuntimeFlagRef field_off);
+#endif
 }
 
 inline bool Player::IsRPG2k() {
@@ -482,31 +494,89 @@ inline bool Player::IsRPG2k3E() {
 }
 
 inline bool Player::IsRPG2k3Commands() {
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+	using Flags = lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags;
+	if (auto f = GetRuntimeFlag(&Flags::patch_rpg2k3_cmds_on, &Flags::patch_rpg2k3_cmds_off))
+		return *f;
+#endif
 	return (IsRPG2k3() || game_config.patch_rpg2k3_commands.Get());
 }
 
 inline bool Player::IsRPG2k3ECommands() {
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+	using Flags = lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags;
+	if (auto f = GetRuntimeFlag(&Flags::patch_rpg2k3_cmds_on, &Flags::patch_rpg2k3_cmds_off))
+		return *f;
+#endif
 	return (IsRPG2k3E() || game_config.patch_rpg2k3_commands.Get());
 }
 
 inline bool Player::IsPatchDynRpg() {
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+	using Flags = lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags;
+	if (auto f = GetRuntimeFlag(&Flags::patch_dynrpg_on, &Flags::patch_dynrpg_off))
+		return *f;
+#endif
 	return game_config.patch_dynrpg.Get();
 }
 
 inline bool Player::IsPatchManiac() {
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+	using Flags = lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags;
+	if (auto f = GetRuntimeFlag(&Flags::patch_maniac_on, &Flags::patch_maniac_off))
+		return *f;
+#endif
 	return game_config.patch_maniac.Get() > 0;
 }
 
 inline bool Player::IsPatchKeyPatch() {
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+	using Flags = lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags;
+	if (auto f = GetRuntimeFlag(&Flags::patch_keypatch_on, &Flags::patch_keypatch_off))
+		return *f;
+#endif
 	return game_config.patch_key_patch.Get();
 }
 
 inline bool Player::IsPatchDestiny() {
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+	using Flags = lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags;
+	if (auto f = GetRuntimeFlag(&Flags::patch_destiny_on, &Flags::patch_destiny_off))
+		return *f;
+#endif
 	return game_config.patch_destiny.Get();
+}
+
+inline bool Player::IsPatchCommonThisEvent() {
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+	using Flags = lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags;
+	if (auto f = GetRuntimeFlag(&Flags::patch_common_this_event_on, &Flags::patch_common_this_event_off))
+		return *f;
+#endif
+	return game_config.patch_common_this_event.Get();
+}
+
+inline bool Player::IsPatchUnlockPics() {
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+	using Flags = lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags;
+	if (auto f = GetRuntimeFlag(&Flags::patch_unlock_pics_on, &Flags::patch_unlock_pics_off))
+		return *f;
+#endif
+	return game_config.patch_unlock_pics.Get();
 }
 
 inline bool Player::HasEasyRpgExtensions() {
 	return game_config.patch_easyrpg.Get();
 }
+
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+
+inline std::optional<bool> Player::GetRuntimeFlag(Game_Interpreter_Shared::StateRuntimeFlagRef field_on, Game_Interpreter_Shared::StateRuntimeFlagRef field_off) {
+	if (active_interpreter_flags) {
+		return Game_Interpreter_Shared::GetRuntimeFlag(*active_interpreter_flags, field_on, field_off);
+	}
+	return std::nullopt;
+}
+#endif
 
 #endif

--- a/src/player.h
+++ b/src/player.h
@@ -443,7 +443,8 @@ namespace Player {
 #endif
 
 #ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
-	extern lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags* active_interpreter_flags;
+	inline lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags interpreter_default_flags{};
+	inline lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags* active_interpreter_flags = &interpreter_default_flags;
 
 	std::optional<bool> GetRuntimeFlag(Game_Interpreter_Shared::StateRuntimeFlagRef field_on, Game_Interpreter_Shared::StateRuntimeFlagRef field_off);
 #endif
@@ -570,9 +571,9 @@ inline bool Player::HasEasyRpgExtensions() {
 }
 
 #ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
-
 inline std::optional<bool> Player::GetRuntimeFlag(Game_Interpreter_Shared::StateRuntimeFlagRef field_on, Game_Interpreter_Shared::StateRuntimeFlagRef field_off) {
-	if (active_interpreter_flags) {
+	assert(active_interpreter_flags);
+	if (active_interpreter_flags->conf_override_active) {
 		return Game_Interpreter_Shared::GetRuntimeFlag(*active_interpreter_flags, field_on, field_off);
 	}
 	return std::nullopt;

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -622,7 +622,12 @@ void Scene_Debug::vUpdate() {
 				}
 				break;
 			case eInterpreter:
-				if (sz == 2) {
+				if (sz == 3) {
+					auto action = interpreter_window->GetSelectedAction();
+					if (action == Window_Interpreter::UiAction::ShowStackItem) {
+						/* */
+					}
+				} else if (sz == 2) {
 					PushUiInterpreterView();
 				} else if (sz == 1) {
 					if (!interpreter_states_cached) {

--- a/src/window_interpreter.cpp
+++ b/src/window_interpreter.cpp
@@ -44,7 +44,7 @@ namespace {
 struct RuntimeFlagInfo {
 	bool (*config_fn)();
 	Game_Interpreter_Shared::StateRuntimeFlagRef field_on, field_off;
-	char* name;
+	std::string_view name;
 };
 
 using StateFlags = lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags;

--- a/src/window_interpreter.cpp
+++ b/src/window_interpreter.cpp
@@ -315,7 +315,7 @@ void Window_Interpreter::UiSubActionLine::Update(Window_Selectable& parent) {
 		i++;
 
 		while (i != this->index) {
-			if (i >= actions.size())
+			if (i >= static_cast<int>(actions.size()))
 				i = 0;
 			if (visibility_delegates[i]())
 				break;
@@ -363,7 +363,7 @@ namespace {
 void Window_Interpreter::UiSubActionLine::Draw(BitmapRef contents, Rect rect) const {
 	int offset_x = 0;
 
-	for (int i = 0; i < this->actions.size(); i++) {
+	for (int i = 0; i < static_cast<int>(this->actions.size()); i++) {
 		if (!visibility_delegates[i]())
 			continue;
 		TextDrawUnderlined(contents, rect.x + offset_x, rect.y, colors[i], texts[i]);
@@ -391,7 +391,6 @@ void Window_Interpreter::DrawRuntimeFlagsWindow() const {
 
 	int i = 0;
 	for (auto info : runtime_flags) {
-		using Flags = lcf::rpg::SaveEventExecState::EasyRpgStateRuntime_Flags;
 		auto flag = Game_Interpreter_Shared::GetRuntimeFlag(state, info.field_on, info.field_off);;
 		if (!flag) {
 			continue;

--- a/src/window_interpreter.h
+++ b/src/window_interpreter.h
@@ -18,13 +18,55 @@
 #ifndef EP_WINDOW_INTERPRETER_H
 #define EP_WINDOW_INTERPRETER_H
 
-// Headers
+ // Headers
 #include "window_command.h"
+#include "game_interpreter_shared.h"
 #include "lcf/rpg/saveeventexecstate.h"
 #include "lcf/rpg/saveeventexecframe.h"
 
 class Window_Interpreter : public Window_Selectable {
 public:
+	enum UiAction {
+		None = 0,
+		ShowRuntimeFlags = 1,
+		ShowMovementInfo,
+		ShowStackItem
+	};
+
+	class UiSubActionLine {
+	public:
+		UiSubActionLine() {
+
+		}
+
+		UiSubActionLine(std::initializer_list<UiAction> actions, std::initializer_list<std::string> texts,
+			std::initializer_list<Font::SystemColor> colors, std::initializer_list<std::function<bool()>> visibility_delegates) {
+
+			assert(actions.size() == texts.size());
+			assert(actions.size() == colors.size());
+			assert(actions.size() == visibility_delegates.size());
+
+			this->actions = actions;
+			this->texts = texts;
+			this->colors = colors;
+			this->visibility_delegates = visibility_delegates;
+		}
+
+		bool IsVisible() const;
+		void Update(Window_Selectable& parent);
+		void Draw(BitmapRef contents, Rect rect) const;
+		void ClearIndex();
+		UiAction GetSelectedAction() const;
+
+	private:
+		int index = 0;
+
+		std::vector<UiAction> actions;
+		std::vector<std::string> texts;
+		std::vector<Font::SystemColor> colors;
+		std::vector<std::function<bool()>> visibility_delegates;
+	};
+
 	Window_Interpreter(int ix, int iy, int iwidth, int iheight);
 	~Window_Interpreter() override;
 
@@ -34,14 +76,21 @@ public:
 	void Refresh();
 	bool IsValid();
 
-	int GetSelectedStackFrameLine();
+	UiAction GetSelectedAction() const;
+	int GetSelectedStackFrameLine() const;
+
 protected:
+	bool IsHoveringSubActionLine() const;
 	void DrawDescriptionLines();
 	void DrawStackLine(int index);
+
+#ifdef ENABLE_DYNAMIC_INTERPRETER_CONFIG
+	void DrawRuntimeFlagsWindow() const;
+#endif
 private:
 	struct InterpDisplayItem {
-		bool is_ce;
-		int owner_evt_id;
+		bool is_ce = false;
+		int owner_evt_id = 0;
 		std::string desc;
 	};
 
@@ -53,7 +102,7 @@ private:
 	};
 
 	const int lines_without_stack_fixed = 3;
-	
+
 	lcf::rpg::SaveEventExecState state;
 	int lines_without_stack = 0;
 
@@ -61,6 +110,9 @@ private:
 
 	InterpDisplayItem display_item;
 	std::vector<StackItem> stack_display_items;
+
+	UiSubActionLine sub_actions;
+	std::unique_ptr<Window_Selectable> sub_window_flags;
 };
 
 #endif


### PR DESCRIPTION
This PR refactors the EasyRPG feature "**SetInterpreterFlag**" (#3123), similar to the way @Ghabry suggested there, by making use of some new state flags that have been merged into _liblcf_.

See _liblcf_ PRs:
- https://github.com/EasyRPG/liblcf/pull/491
- https://github.com/EasyRPG/liblcf/pull/492

Rather than setting the global config options directly as before, a new field "**easyrpg_runtime_flags**" in the **SaveEventExecState**" struct is used, to make these overrides persist across save/load boundaries.

This makes these config overrides apply only to the Interpreter instance where they have been set, and when the end of the base frame is reached, all of the flags are reset automatically. To make this possible, a new global field "active_interpreter_flags" has been introduced, so the Player functions responsible for restricting use to these custom features can access & consider the state of the active interpreter flags for its check.

## Test Project
[RuntimeFlags.zip](https://github.com/user-attachments/files/19403706/RuntimeFlags.zip)

Set **"EasyRPG.ini"** accordingly, whether you want to test the explicit enabling or disabling of certain patches.
- Talking to the ladies at the "**ON**" section should **always** trigger the test code.
- Talking to the ladies at the "**OFF**" section should **never** trigger the test code.
- Talking to the ladies at the "**---**" section: Here it depends on the patches enabled inside _EasyRPG.ini_.

**Note:** 
Some extra test code has been introduced via a commit, to make it possible to easily test DynRPG & Destiny support using a simple log command. (**@easyrpg_output** would always be possible, even without DynRPG enabled)