### PR TITLE
Fix MP3 heuristic check

### DIFF
--- a/src/decoder_mpg123.cpp
+++ b/src/decoder_mpg123.cpp
@@ -230,8 +230,8 @@ bool Mpg123Decoder::IsMp3(Filesystem_Stream::InputStream& stream) {
 	// Read beginning of assumed MP3 file and count errors as an heuristic to detect MP3
 	for (int i = 0; i < 10; ++i) {
 		err = mpg123_read(decoder.handle.get(), buffer, 1024, &done);
-		if (err == MPG123_DONE) {
-			return true;
+		if (err == MPG123_DONE && done != 0) {
+			return err_count == 0;
 		}
 		if (err != MPG123_OK) {
 			err_count += 1;


### PR DESCRIPTION
Fixing two issues with the refactored MP3 heuristic check:
- For some files (I mostly noticed this with ModTracker files) the IsMp3() heuristic would now yield wrong positives, because for some reason _mpg123_read_ would immediately result in a status 'DONE without actually reading data.
- Other small non-mp3 files might yield a single error before resulting in a DONE & still pass the allowed err_count of '3'.

Fixes #3380