### PR TITLE
Libretro fixes and one hotfix for YNOnline Users with loooong playtimes

### DIFF
--- a/src/platform/libretro/ui.cpp
+++ b/src/platform/libretro/ui.cpp
@@ -371,7 +371,7 @@ RETRO_API void retro_get_system_info(struct retro_system_info* info) {
 	info->library_name = GAME_TITLE;
 	info->library_version = PLAYER_VERSION_FULL;
 	info->need_fullpath = true;
-	info->valid_extensions = "ldb|zip|easyrpg";
+	info->valid_extensions = "ldb|zip|lzh|easyrpg";
 	info->block_extract = true;
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -86,7 +86,7 @@
 #include "message_overlay.h"
 #include "audio_midi.h"
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__) && !defined(USE_LIBRETRO)
 #include "platform/android/android.h"
 #endif
 
@@ -376,7 +376,7 @@ void Player::Update(bool update_scene) {
 		Scene::instance->Update();
 	}
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__) && !defined(USE_LIBRETRO)
 	EpAndroid::invoke();
 #endif
 }

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -421,7 +421,7 @@ void Scene_Battle_Rpg2k3::UpdateAnimations() {
 		}
 	}
 
-	auto frame_counter = Main_Data::game_system->GetFrameCounter();
+	auto frame_counter = static_cast<uint32_t>(Main_Data::game_system->GetFrameCounter());
 
 	bool ally_set = false;
 	if (status_window->GetActive()

--- a/src/tilemap_layer.cpp
+++ b/src/tilemap_layer.cpp
@@ -143,7 +143,7 @@ static constexpr uint8_t BlockD_Subtiles_IDS[50][2][2][2] = {
 // Set of neighboring autotiles -> autotile variant
 // Each neighbor is represented by a single bit (1 - same autotile, 0 - any other case)
 // The bits are ordered as follows (from most to least significant bit): NW N NE W E SW S SE
-static const std::unordered_map<uint8_t, int> AUTOTILE_D_VARIANTS_MAP = { //it also works with A 
+static const std::unordered_map<uint8_t, int> AUTOTILE_D_VARIANTS_MAP = { //it also works with A
 	{0b11111111, 0},
 	{0b01111111, 1},
 	{0b11011111, 2},
@@ -285,7 +285,7 @@ void TilemapLayer::Draw(Bitmap& dst, uint8_t z_order, int render_ox, int render_
 	};
 
 	// FIXME: When Game_Map singleton is made an object we can remove this null check
-	const auto frames = Main_Data::game_system ? Main_Data::game_system->GetFrameCounter() : 0;
+	const auto frames = Main_Data::game_system ? static_cast<uint32_t>(Main_Data::game_system->GetFrameCounter()) : 0u;
 	auto animation_step_c = (frames / 6) % 4;
 	auto animation_step_ab = frames / animation_speed;
 	if (animation_type) {


### PR DESCRIPTION
Guess @Mimigris should also test this a bit.

I only hacked the frame counter to overflow after about two seconds. Works for me (it renders are usual, thats not the RPG_RT behaviour but who cares).