### PR TITLE
Compiler fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -779,6 +779,10 @@ endif()
 # Shared by homebrew platforms
 if(NINTENDO_3DS OR NINTENDO_WII OR NINTENDO_WIIU OR NINTENDO_WIIU OR NINTENDO_SWITCH OR VITA)
 	target_compile_options(${PROJECT_NAME} PUBLIC -fno-exceptions -fno-rtti)
+	if(VITA)
+		# This optimisation is unstable on Vita (crashes at the end of MainLoop)
+		target_compile_options(${PROJECT_NAME} PUBLIC -fno-optimize-sibling-calls)
+	endif()
 	set(CMAKE_DL_LIBS "") # hack4icu!
 	set(PLAYER_ENABLE_TESTS OFF)
 	option(PLAYER_VERSIONED_PACKAGES "Create zip packages with versioned name (for internal use)" ON)

--- a/builds/cmake/CMakePresetsBase.json
+++ b/builds/cmake/CMakePresetsBase.json
@@ -24,7 +24,7 @@
 			"displayName": "build RelWithDebInfo",
 			"hidden": true,
 			"cacheVariables": {
-				"CMAKE_BUILD_TYPE": "ReleaseWithDebInfo"
+				"CMAKE_BUILD_TYPE": "RelWithDebInfo"
 			}
 		},
 		{

--- a/builds/cmake/Modules/PlayerConfigureWindows.cmake
+++ b/builds/cmake/Modules/PlayerConfigureWindows.cmake
@@ -24,3 +24,9 @@ if(MSVC)
 	# Interpret character literals as UTF-8
 	add_compile_options("/utf-8")
 endif()
+
+if (CMAKE_GENERATOR MATCHES "Visual Studio" AND CMAKE_CONFIGURATION_TYPES)
+	# Multi-Config is not supported due to limitations in the CMake Find Scripts
+	# Remove all configuration types except the current build type
+	set(CMAKE_CONFIGURATION_TYPES ${CMAKE_BUILD_TYPE})
+endif()


### PR DESCRIPTION
Fixes a dumb typo in the Presets breaking RelWithDebInfo (Making it a Debug build >.>).

And Rinnegatamante told me to pass ``-fno-optimize-sibling-calls`` for the Vita build because that optimisation can cause crashes: Can confirm. With that flag set the MainLoop does not randomly crash anymore :shrug:  (that appears to be a general problem on Vita, other homebrew uses the same flag)