### PR TITLE
Extend the "Strings" view in debug screen to display names of StringVars (+ some debug screen adjustments)

### DIFF
--- a/src/game_strings.cpp
+++ b/src/game_strings.cpp
@@ -18,6 +18,7 @@
  // Headers
 #include <regex>
 #include <lcf/encoder.h>
+#include <lcf/reader_util.h>
 #include "async_handler.h"
 #include "game_map.h"
 #include "game_message.h"
@@ -510,3 +511,26 @@ std::optional<std::string> Game_Strings::ManiacsCommandInserterHex(char ch, cons
 
 	return ManiacsCommandInserter(ch, iter, end, escape_char);
 };
+
+int Game_Strings::GetSizeWithLimit() {
+	if (_size < 0) {
+		_size = 0;
+		for (auto& [index, value] : _strings) {
+			assert(index > 0);
+			if (index > _size) {
+				_size = index;
+			}
+		}
+	}
+	return std::max(_size, static_cast<int>(lcf::Data::maniac_string_variables.size()));
+}
+
+std::string_view Game_Strings::GetName(int id) const {
+	const auto* strvar = lcf::ReaderUtil::GetElement(lcf::Data::maniac_string_variables, id);
+
+	if (!strvar) {
+		return {};
+	} else {
+		return strvar->name;
+	}
+}

--- a/src/game_strings.h
+++ b/src/game_strings.h
@@ -77,6 +77,9 @@ public:
 	std::string_view GetWithMode(std::string_view str_data, int mode, int arg, const Game_Variables& variables) const;
 	std::string GetWithModeAndPos(std::string_view str_data, int mode, int arg, int& pos, const Game_Variables& variables);
 
+	int GetSizeWithLimit();
+	std::string_view GetName(int id) const;
+
 #ifdef HAVE_NLOHMANN_JSON
 	nlohmann::ordered_json* ParseJson(int id);
 #endif
@@ -112,6 +115,7 @@ private:
 
 	Strings_t _strings;
 	mutable int _warnings = max_warnings;
+	int _size = -1;
 
 #ifdef HAVE_NLOHMANN_JSON
 	std::unordered_map<int, nlohmann::ordered_json> _json_cache;
@@ -134,6 +138,9 @@ inline void Game_Strings::Set(Str_Params params, std::string_view string) {
 			return;
 		} else {
 			_strings[params.string_id] = ins_string;
+			if (params.string_id > _size) {
+				_size = params.string_id;
+			}
 		}
 	} else {
 		it->second = ins_string;
@@ -146,6 +153,7 @@ inline void Game_Strings::Set(Str_Params params, std::string_view string) {
 
 inline void Game_Strings::SetData(Strings_t s) {
 	_strings = std::move(s);
+	_size = -1;
 
 #ifdef HAVE_NLOHMANN_JSON
 	_json_cache.clear();
@@ -160,7 +168,9 @@ inline void Game_Strings::SetData(const std::vector<lcf::DBString>& s) {
 		}
 		++i;
 	}
-
+	if ((i - 1) > _size) {
+		_size = i - 1;
+	}
 #ifdef HAVE_NLOHMANN_JSON
 	_json_cache.clear();
 #endif

--- a/src/game_strings.h
+++ b/src/game_strings.h
@@ -120,6 +120,8 @@ private:
 #ifdef HAVE_NLOHMANN_JSON
 	std::unordered_map<int, nlohmann::ordered_json> _json_cache;
 #endif
+	friend class Scene_Debug;
+	friend class Window_VarList;
 };
 
 inline void Game_Strings::Set(Str_Params params, std::string_view string) {

--- a/src/lcf/data.h
+++ b/src/lcf/data.h
@@ -61,6 +61,7 @@ namespace Data {
 	extern rpg::System& system;
 	extern std::vector<rpg::Switch>& switches;
 	extern std::vector<rpg::Variable>& variables;
+	extern std::vector<rpg::StringVariable>& maniac_string_variables;
 	/** @} */
 
 	/** TreeMap (lmt) */

--- a/src/lcf_data.cpp
+++ b/src/lcf_data.cpp
@@ -33,6 +33,7 @@ namespace Data {
 	rpg::System& system = data.system;
 	std::vector<rpg::Switch>& switches = data.switches;
 	std::vector<rpg::Variable>& variables = data.variables;
+	std::vector<rpg::StringVariable>& maniac_string_variables = data.maniac_string_variables;
 
 	rpg::TreeMap treemap;
 }
@@ -56,6 +57,7 @@ void Data::Clear() {
 	system = rpg::System();
 	switches.clear();
 	variables.clear();
+	maniac_string_variables.clear();
 	treemap.active_node = 0;
 	treemap.maps.clear();
 	treemap.tree_order.clear();

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -203,11 +203,7 @@ void Scene_Debug::SetupUiRangeList() {
 	range_index = idx.range_index;
 	range_page = idx.range_page;
 
-	//if (mode == eInterpreter && (state_interpreter.show_frame_switches || state_interpreter.show_frame_vars)) {
-	//	var_window->SetMode(state_interpreter.show_frame_switches ? Window_VarList::eFrameSwitch : Window_VarList::eFrameVariable);
-	//} else {
-		var_window->SetMode(vmode);
-	//}
+	var_window->SetMode(vmode);
 	UpdateDetailWindow();
 
 	range_window->SetIndex(range_index);
@@ -335,7 +331,7 @@ void Scene_Debug::Pop() {
 	stringview_window->SetVisible(false);
 	interpreter_window->SetActive(false);
 
-	if (mode == eInterpreter /* && !(state_interpreter.show_frame_switches || state_interpreter.show_frame_vars) */) {
+	if (mode == eInterpreter) {
 		interpreter_window->SetIndex(-1);
 		interpreter_window->SetVisible(true);
 		var_window->SetVisible(false);
@@ -391,8 +387,6 @@ void Scene_Debug::Pop() {
 			interpreter_window->SetIndex(frame.value - 1);
 			var_window->SetVisible(false);
 			interpreter_window->SetVisible(true);
-			//state_interpreter.show_frame_switches = false;
-			//state_interpreter.show_frame_vars = false;
 			break;
 	}
 
@@ -615,22 +609,7 @@ void Scene_Debug::vUpdate() {
 				}
 				break;
 			case eInterpreter:
-				if (sz == 3) {
-					if (state_interpreter.selected_frame >= 0) {
-						/*std::vector<std::string> choices;
-						std::vector<bool> choices_enabled;
-
-						choices.push_back("FrameSwitches");
-						choices.push_back("FrameVariables");
-
-						choices_enabled.push_back(GetSelectedInterpreterFrameFromUiState().easyrpg_frame_switches.size() > 0);
-						choices_enabled.push_back(GetSelectedInterpreterFrameFromUiState().easyrpg_frame_variables.size() > 0);
-
-						PushUiChoices(choices, choices_enabled);*/
-					} else {
-						Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
-					}
-				} else if (sz == 2) {
+				if (sz == 2) {
 					PushUiInterpreterView();
 				} else if (sz == 1) {
 					if (!interpreter_states_cached) {
@@ -853,12 +832,6 @@ void Scene_Debug::UpdateRangeListWindow() {
 			break;
 		case eInterpreter:
 		{
-			//if (state_interpreter.show_frame_switches || state_interpreter.show_frame_vars) {
-			//	for (int i = 0; i < 10; i++) {
-			//		const auto st = range_page * 100 + i * 10 + 1;
-			//		addItem(fmt::format("{}[{:03d}-{:03d}]", state_interpreter.show_frame_switches ? "FSw" : "FVr", st, st + 9));
-			//	}
-			//} else {
 				int skip_items = range_page * 10;
 				int count_items = 0;
 				if (range_page == 0) {
@@ -885,7 +858,6 @@ void Scene_Debug::UpdateRangeListWindow() {
 					addItem(fmt::format("{}CE{:04d}: {}", state_interpreter.state_ce[i].wait_movement ? "(W) " : "", ce_id, ce->name));
 					count_items++;
 				}
-			//}
 		}
 		break;
 		default:
@@ -899,16 +871,7 @@ void Scene_Debug::UpdateRangeListWindow() {
 
 void Scene_Debug::UpdateDetailWindow() {
 	if (mode == eInterpreter) {
-		//if (state_interpreter.show_frame_switches || state_interpreter.show_frame_vars) {
-		//	auto & interpreter_frame = GetSelectedInterpreterFrameFromUiState();
-		//	var_window->SetInterpreterFrame(&interpreter_frame);
-		//	var_window->UpdateList(GetSelectedIndexFromRange());
-		//
-		//	interpreter_window->SetVisible(false);
-		//	interpreter_window->SetActive(false);
-		//} else {
-			UpdateInterpreterWindow(GetSelectedIndexFromRange());
-		//}
+		UpdateInterpreterWindow(GetSelectedIndexFromRange());
 	} else {
 		var_window->UpdateList(GetSelectedIndexFromRange());
 	}
@@ -916,14 +879,8 @@ void Scene_Debug::UpdateDetailWindow() {
 
 void Scene_Debug::RefreshDetailWindow() {
 	if (mode == eInterpreter) {
-		//if (state_interpreter.show_frame_switches || state_interpreter.show_frame_vars) {
-		//	var_window->Refresh();
-		//} else {
-			//var_window->SetInterpreterFrame(nullptr);
-			interpreter_window->Refresh();
-		//}
+		interpreter_window->Refresh();
 	} else {
-		//var_window->SetInterpreterFrame(nullptr);
 		var_window->Refresh();
 	}
 }
@@ -1011,16 +968,8 @@ int Scene_Debug::GetLastPage() const {
 			num_elements = Main_Data::game_strings->GetSizeWithLimit();
 			break;
 		case eInterpreter:
-			//if (state_interpreter.show_frame_switches) {
-			//	auto & interpreter_frame = GetSelectedInterpreterFrameFromUiState();
-			//	return interpreter_frame.easyrpg_frame_switches.size();
-			//} else if (state_interpreter.show_frame_vars) {
-			//		auto & interpreter_frame = GetSelectedInterpreterFrameFromUiState();
-			//		return interpreter_frame.easyrpg_frame_variables.size();
-			//} else {
-				num_elements = 1 + state_interpreter.ev.size() + state_interpreter.ce.size();
-				return (static_cast<int>(num_elements) - 1) / 10;
-			//}
+			num_elements = 1 + state_interpreter.ev.size() + state_interpreter.ce.size();
+			return (static_cast<int>(num_elements) - 1) / 10;
 		default:
 			break;
 	}

--- a/src/scene_debug.cpp
+++ b/src/scene_debug.cpp
@@ -290,7 +290,20 @@ void Scene_Debug::PushUiStringView() {
 	stringview_window->SetVisible(true);
 
 	Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Decision));
+
+#ifdef HAVE_NLOHMANN_JSON
+	auto& json_cache = Main_Data::game_strings->_json_cache;
+
+	auto it = json_cache.find(str_id);
+	if (it != json_cache.end()) {
+		stringview_window->SetDisplayData(value, it->second);
+	} else {
+		stringview_window->SetDisplayData(value);
+	}
+#else
 	stringview_window->SetDisplayData(value);
+#endif
+
 	stringview_window->SetIndex(0);
 	stringview_window->Refresh();
 }

--- a/src/scene_debug.h
+++ b/src/scene_debug.h
@@ -111,12 +111,13 @@ private:
 	/** Creates interpreter window. */
 	void CreateInterpreterWindow();
 
-
 	/** Get the last page for the current mode */
-	int GetLastPage();
+	int GetLastPage() const;
 
 	/** Get the first item number for the selected range */
 	int GetSelectedIndexFromRange() const;
+
+	int GetSelectedIndexFromRange(Window_VarList::Mode window_mode, int range_page, int range_index) const;
 
 	void RestoreRangeSelectionFromSelectedValue(int value);
 
@@ -175,6 +176,8 @@ private:
 	void PushUiInterpreterView();
 
 	Window_VarList::Mode GetWindowMode() const;
+	static constexpr Window_VarList::Mode GetWindowMode(Mode mode);
+
 	void UpdateFrameValueFromUi();
 	void UpdateDetailWindow();
 	void RefreshDetailWindow();
@@ -183,9 +186,6 @@ private:
 
 	void UpdateArrows();
 	int arrow_frame = 0;
-
-	bool strings_cached = false;
-	std::vector<lcf::DBString> strings;
 
 	bool interpreter_states_cached = false;
 
@@ -205,5 +205,32 @@ private:
 		int selected_frame = -1;
 	} state_interpreter;
 };
+
+constexpr Window_VarList::Mode Scene_Debug::GetWindowMode(Mode mode) {
+	switch (mode) {
+		case eSwitch:
+			return Window_VarList::eSwitch;
+		case eVariable:
+			return Window_VarList::eVariable;
+		case eItem:
+			return Window_VarList::eItem;
+		case eBattle:
+			return Window_VarList::eTroop;
+		case eMap:
+			return Window_VarList::eMap;
+		case eFullHeal:
+			return Window_VarList::eHeal;
+		case eLevel:
+			return Window_VarList::eLevel;
+		case eCallCommonEvent:
+			return Window_VarList::eCommonEvent;
+		case eCallMapEvent:
+			return Window_VarList::eMapEvent;
+		case eString:
+			return Window_VarList::eString;
+		default:
+			return Window_VarList::eNone;
+	}
+}
 
 #endif

--- a/src/window_stringview.h
+++ b/src/window_stringview.h
@@ -21,6 +21,10 @@
 // Headers
 #include "window_command.h"
 
+#ifdef HAVE_NLOHMANN_JSON
+#include <nlohmann/json.hpp>
+#endif
+
 class Window_StringView : public Window_Selectable {
 public:
 	Window_StringView(int ix, int iy, int iwidth, int iheight);
@@ -31,20 +35,38 @@ public:
 	void SetDisplayData(std::string_view data);
 	std::string GetDisplayData(bool eval_cmds);
 
+#ifdef HAVE_NLOHMANN_JSON
+	void SetDisplayData(std::string_view data, const nlohmann::ordered_json& json_data);
+#endif
+
 	void Refresh();
 protected:
 	void DrawCmdLines();
 	void DrawLine(int index);
+
+	int GetReservedLineCount() const;
 private:
-	const int top_lines_reserved = 2, max_str_length = 42;
-	bool auto_linebreak = false, cmd_eval = false;
+	const int max_str_length = 42;
+	bool auto_linebreak = false, cmd_eval = false, pretty_print = false;
 
 	std::string display_data_raw;
+#ifdef HAVE_NLOHMANN_JSON
+	const nlohmann::ordered_json* json_data;
+#endif
 
 	std::vector<std::string> lines;
 	std::vector<int> line_numbers;
 
 	int line_count = 0, line_no_max_digits = 0;
 };
+
+inline int Window_StringView::GetReservedLineCount() const {
+#ifdef HAVE_NLOHMANN_JSON
+	if (this->json_data) {
+		return 3;
+	}
+#endif
+	return 2;
+}
 
 #endif

--- a/src/window_varlist.cpp
+++ b/src/window_varlist.cpp
@@ -312,6 +312,20 @@ void Window_VarList::DrawStringVarItem(int index, int y) {
 	const int space_reserved = (GetDigitCount() + 2);
 	int x = space_reserved * 6, max_len_vals = 32 - space_reserved;
 
+	bool is_json = false;
+#ifdef HAVE_NLOHMANN_JSON
+	auto& json_cache = Main_Data::game_strings->_json_cache;
+	is_json = json_cache.find(first_var + index) != json_cache.end();
+#endif
+
+	if (is_json) {
+		if (show_detail) {
+			contents->TextDraw(GetWidth() - 16, y, Font::ColorHeal, "[JSON]", Text::AlignRight);
+		} else {
+			contents->TextDraw(GetWidth() - 16, y, Font::ColorHeal, "[J]", Text::AlignRight);
+		}
+	}
+
 	if (show_detail) {
 		x = 6;
 		y += menu_item_height;

--- a/src/window_varlist.cpp
+++ b/src/window_varlist.cpp
@@ -206,7 +206,7 @@ void Window_VarList::UpdateList(int first_value){
 }
 
 void Window_VarList::SetItemText(unsigned index, std::string_view text) {
-	if (index < item_max) {
+	if (static_cast<int>(index) < item_max) {
 		items[index] = ToString(text);
 	}
 }
@@ -339,7 +339,7 @@ void Window_VarList::DrawStringVarItem(int index, int y) {
 			value.replace(pos, 1, "\\n");
 			pos += 3;
 		}
-		if (value.length() > max_len_vals) {
+		if (static_cast<int>(value.length()) > max_len_vals) {
 			value = value.substr(0, max_len_vals - 3) + "...";
 		}
 		if (show_detail) {

--- a/src/window_varlist.h
+++ b/src/window_varlist.h
@@ -19,9 +19,9 @@
 #define EP_WINDOW_VARLIST_H
 
 // Headers
-#include "window_command.h"
+#include "window_selectable.h"
 
-class Window_VarList : public Window_Command
+class Window_VarList : public Window_Selectable
 {
 public:
 	enum Mode {
@@ -43,8 +43,10 @@ public:
 	 *
 	 * @param commands commands to display.
 	 */
-	Window_VarList(std::vector<std::string> commands);
+	Window_VarList();
 	~Window_VarList() override;
+
+	void Update() override;
 
 	/**
 	 * UpdateList.
@@ -53,25 +55,46 @@ public:
 	 */
 	void UpdateList(int first_value);
 
+	void UpdateCursorRect() override;
+
 	/**
 	 * Refreshes the window contents.
 	 */
 	void  Refresh();
 
+	int GetItemIndex() const;
+
+	void SetItemIndex(int index);
+
 	/**
 	 * Indicate what to display.
 	 *
 	 * @param mode the mode to set.
-	 * @param max_length_strings maximum size for items (Used for Strings)
 	 */
-	void SetMode(Mode mode, int max_length_strings = 0);
+	void SetMode(Mode mode);
 
 	/**
 	 * Returns the current mode.
 	 */
 	Mode GetMode() const;
 
+	void SetShowDetail(bool show_detail);
+
+	bool GetShowDetail() const;
+
+	void SetItemText(unsigned index, std::string_view text);
+
+	static constexpr std::string_view GetPrefix(Mode mode);
+	static constexpr int GetItemCount(Mode mode, bool show_detail);
+	static constexpr int GetDigitCount(Mode mode);
+
+	static int GetNumElements(Mode mode);
+
+	int GetItemCount() const;
+	int GetDigitCount() const;
 private:
+
+	void DrawItem(int index, Font::SystemColor color);
 
 	/**
 	 * Draws the value of a variable standing on a row.
@@ -80,15 +103,76 @@ private:
 	 */
 	void DrawItemValue(int index);
 
+	void DrawStringVarItem(int index, int y);
+
+	std::vector<std::string> items;
 	Mode mode = eNone;
-	int first_var = 0, max_length_strings = 0;
+	int first_var = 0;
+	bool show_detail = false;
+	bool suspend_cursor_refresh = false;
 
 	bool DataIsValid(int range_index);
-
 };
+
+constexpr std::string_view Window_VarList::GetPrefix(Mode mode) {
+	switch (mode) {
+		case eSwitch:
+			return "Sw";
+		case eVariable:
+			return "Vr";
+		case eItem:
+			return "It";
+		case eTroop:
+			return "Bt";
+		case eMap:
+			return "Mp";
+		case eCommonEvent:
+			return "Ce";
+		case eMapEvent:
+			return "Me";
+		case eString:
+			return "St";
+		default:
+			break;
+	}
+	assert(false);
+}
+
+constexpr int Window_VarList::GetItemCount(Mode mode, bool show_detail) {
+	switch (mode) {
+		case eString:
+			if (show_detail) {
+				return 5;
+			}
+			break;
+		default:
+			break;
+	}
+	return 10;
+}
+
+constexpr int Window_VarList::GetDigitCount(Mode mode) {
+	return 4;
+}
+
+inline int Window_VarList::GetItemCount() const {
+	return GetItemCount(mode, show_detail);
+}
+
+inline int Window_VarList::GetDigitCount() const {
+	return GetDigitCount(mode);
+}
 
 inline Window_VarList::Mode Window_VarList::GetMode() const {
 	return mode;
+}
+
+inline bool Window_VarList::GetShowDetail() const {
+	return show_detail;
+}
+
+inline void Window_VarList::SetShowDetail(bool show_detail) {
+	this->show_detail = show_detail;
 }
 
 #endif

--- a/src/window_varlist.h
+++ b/src/window_varlist.h
@@ -133,9 +133,9 @@ constexpr std::string_view Window_VarList::GetPrefix(Mode mode) {
 		case eString:
 			return "St";
 		default:
-			break;
+			assert(false);
+			return {};
 	}
-	assert(false);
 }
 
 constexpr int Window_VarList::GetItemCount(Mode mode, bool show_detail) {
@@ -151,7 +151,7 @@ constexpr int Window_VarList::GetItemCount(Mode mode, bool show_detail) {
 	return 10;
 }
 
-constexpr int Window_VarList::GetDigitCount(Mode mode) {
+constexpr int Window_VarList::GetDigitCount(Mode /* mode */) {
 	return 4;
 }
 


### PR DESCRIPTION
Self-explanatory, but I also included some refactors of the existing var_window, to make it more useful for displaying certain kinds of data that might need more than a single line.
(My ScopedVars branch for example, would also display multiple lines per scoped variable type)

StringVar names have been added with ManiacPatch 241028 & also provide a useful way to detect this major update without having to rely on reading the EXE:
```
if (lcf::Data::maniac_string_variables.size() > 0) {
    mp_version = MP_24;
}
```
(Even if no StringVars are used, at least one list entry will be included in this new LDB field by default)

### Updated Strings view

By default, the view stays as before:
![screenshot_206](https://github.com/user-attachments/assets/863de878-762c-41e5-9a39-e8250c628061)

And by pressing SHIFT, it toggles to the new display mode that displays individual entries over two lines & includes the var name:
![screenshot_207](https://github.com/user-attachments/assets/61e21c81-7218-4f02-8c8d-28308ddb0b74)


### Another new addition:

Previously, displaying data for Switches/Variables above the ID 9999 would overflow the text:
![screenshot_211](https://github.com/user-attachments/assets/a1c00b6a-e70a-4154-838b-9805e4438310)

This has been adjusted, by shortening the prefix to a single character + changing the way the text is formatted:
![screenshot_210](https://github.com/user-attachments/assets/b34b80af-3c6f-4d40-b2a0-45a39ab5259f)