### PR TITLE
Fix StringIsAscii by explicitly setting the type to "signed char"

### DIFF
--- a/.github/workflows/stable-compilation.yml
+++ b/.github/workflows/stable-compilation.yml
@@ -19,8 +19,8 @@ defaults:
 
 jobs:
   docker:
-    name: ${{ matrix.image }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.image }} (${{ matrix.os.arch }})
+    runs-on: ${{ matrix.os.name }}
     container:
       image: ${{ matrix.image }}
 
@@ -34,6 +34,18 @@ jobs:
           - ubuntu:22.04  # 3.22.1 | 11.2.0 | 2.0.20 | LTS       (4/27) #
           - debian:12     # 3.25.1 | 12.2.0 | 2.26.5 | stable    (6/26) #
           - ubuntu:24.04  # 3.28.3 | 13.2.0 | 2.30.0 | LTS       (4/29) #
+        os:
+          - arch: x86_64
+            name: ubuntu-latest
+          - arch: arm64
+            name: ubuntu-24.04-arm
+        exclude:
+          - os:
+              arch: arm64
+            image: debian:11
+          - os:
+              arch: arm64
+            image: ubuntu:22.04
 
     steps:
       - name: Install dependencies

--- a/src/utils.h
+++ b/src/utils.h
@@ -436,7 +436,7 @@ inline bool Utils::IsControlCharacter(T ch) {
 }
 
 inline bool Utils::StringIsAscii(std::string_view s) {
-	return std::all_of(s.begin(), s.end(), [](char c) {
+	return std::all_of(s.begin(), s.end(), [](signed char c) {
 		// non-ascii is for signed char in range [-128, 0)
 		return c >= 0;
 	});

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -93,4 +93,14 @@ TEST_CASE("TrimWhitespace") {
 	}
 }
 
+TEST_CASE("StringIsAscii") {
+	REQUIRE(Utils::StringIsAscii("Hello"));
+	REQUIRE(Utils::StringIsAscii("Hello World"));
+	REQUIRE(Utils::StringIsAscii(""));
+
+	REQUIRE_FALSE(Utils::StringIsAscii("Holerö"));
+	REQUIRE_FALSE(Utils::StringIsAscii("こんにちは"));
+	REQUIRE_FALSE(Utils::StringIsAscii("　")); // Full-Width-Space
+}
+
 TEST_SUITE_END();


### PR DESCRIPTION
Turns out "char" is not always signed. Instead it is "implementation defined". In all tests it went unnoticed because x86 is "signed". On ARM it appears to be "unsigned".

This is surprising. For int etc. it is specified to be signed.

Can we just burn the C standard? Who specifies this nonsense?

Fix #3401