### PR TITLE
Fix: Two of new 0.8.1 engine options were not written to the config INI

### DIFF
--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -760,6 +760,8 @@ void Game_Config::WriteToStream(Filesystem_Stream::OutputStream& os) const {
 	player.font1_size.ToIni(os);
 	player.font2.ToIni(os);
 	player.font2_size.ToIni(os);
+	player.log_enabled.ToIni(os);
+	player.screenshot_scale.ToIni(os);
 
 	os << "\n";
 }


### PR DESCRIPTION
Options "_Logging_" & "_Screenshot scaling factor_" in the "_Engine_" section of the settings menu were never written to the INI file & would thus be reset when the Player is restarted.