### PR TITLE
New setting options for screenshots: Periodically take auto-screenshots + option for timestamps in file names

### DIFF
--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -63,10 +63,6 @@ void Game_ConfigPlayer::Hide() {
 	font2.SetOptionVisible(false);
 	font2_size.SetOptionVisible(false);
 #endif
-#if !defined(EMSCRIPTEN)
-	automatic_screenshots.SetOptionVisible(false);
-	automatic_screenshots_interval.SetOptionVisible(false);
-#endif
 	if (automatic_screenshots.IsOptionVisible()) {
 		automatic_screenshots_interval.SetLocked(!automatic_screenshots.Get());
 	}
@@ -680,6 +676,7 @@ void Game_Config::LoadFromStream(Filesystem_Stream::InputStream& is) {
 	player.font2_size.FromIni(ini);
 	player.log_enabled.FromIni(ini);
 	player.screenshot_scale.FromIni(ini);
+	player.screenshot_timestamp.FromIni(ini);
 	player.automatic_screenshots.FromIni(ini);
 	player.automatic_screenshots_interval.FromIni(ini);
 }
@@ -771,6 +768,7 @@ void Game_Config::WriteToStream(Filesystem_Stream::OutputStream& os) const {
 	player.font2_size.ToIni(os);
 	player.log_enabled.ToIni(os);
 	player.screenshot_scale.ToIni(os);
+	player.screenshot_timestamp.ToIni(os);
 	player.automatic_screenshots.ToIni(os);
 	player.automatic_screenshots_interval.ToIni(os);
 

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -63,6 +63,13 @@ void Game_ConfigPlayer::Hide() {
 	font2.SetOptionVisible(false);
 	font2_size.SetOptionVisible(false);
 #endif
+#if !defined(EMSCRIPTEN)
+	automatic_screenshots.SetOptionVisible(false);
+	automatic_screenshots_interval.SetOptionVisible(false);
+#endif
+	if (automatic_screenshots.IsOptionVisible()) {
+		automatic_screenshots_interval.SetLocked(!automatic_screenshots.Get());
+	}
 }
 
 void Game_ConfigVideo::Hide() {
@@ -673,6 +680,8 @@ void Game_Config::LoadFromStream(Filesystem_Stream::InputStream& is) {
 	player.font2_size.FromIni(ini);
 	player.log_enabled.FromIni(ini);
 	player.screenshot_scale.FromIni(ini);
+	player.automatic_screenshots.FromIni(ini);
+	player.automatic_screenshots_interval.FromIni(ini);
 }
 
 void Game_Config::WriteToStream(Filesystem_Stream::OutputStream& os) const {
@@ -762,6 +771,8 @@ void Game_Config::WriteToStream(Filesystem_Stream::OutputStream& os) const {
 	player.font2_size.ToIni(os);
 	player.log_enabled.ToIni(os);
 	player.screenshot_scale.ToIni(os);
+	player.automatic_screenshots.ToIni(os);
+	player.automatic_screenshots_interval.ToIni(os);
 
 	os << "\n";
 }

--- a/src/game_config.h
+++ b/src/game_config.h
@@ -105,7 +105,7 @@ struct Game_ConfigPlayer {
 	BoolConfigParam lang_select_in_title{ "Show language menu on title screen", "Display language menu item on the title screen", "Player", "LanguageInTitle", true };
 	BoolConfigParam log_enabled{ "Logging", "Write diagnostic messages into a logfile", "Player", "Logging", true };
 	RangeConfigParam<int> screenshot_scale { "Screenshot scaling factor", "Scale screenshots by the given factor", "Player", "ScreenshotScale", 1, 1, 24};
-	BoolConfigParam screenshot_timestamp{ "Screenshot timestamp", "Add the current date and time to the file name", "Player", "ScreenshotTimestamp", false };
+	BoolConfigParam screenshot_timestamp{ "Screenshot timestamp", "Add the current date and time to the file name", "Player", "ScreenshotTimestamp", true };
 	BoolConfigParam automatic_screenshots{ "Automatic screenshots", "Periodically take screenshots", "Player", "AutomaticScreenshots", false };
 	RangeConfigParam<int> automatic_screenshots_interval{ "Screenshot interval", "The interval between automatic screenshots (seconds)", "Player", "AutomaticScreenshotsInterval", 30, 1, 999999 };
 

--- a/src/game_config.h
+++ b/src/game_config.h
@@ -105,8 +105,9 @@ struct Game_ConfigPlayer {
 	BoolConfigParam lang_select_in_title{ "Show language menu on title screen", "Display language menu item on the title screen", "Player", "LanguageInTitle", true };
 	BoolConfigParam log_enabled{ "Logging", "Write diagnostic messages into a logfile", "Player", "Logging", true };
 	RangeConfigParam<int> screenshot_scale { "Screenshot scaling factor", "Scale screenshots by the given factor", "Player", "ScreenshotScale", 1, 1, 24};
+	BoolConfigParam screenshot_timestamp{ "Screenshot timestamp", "Add the current date and time to the file name", "Player", "ScreenshotTimestamp", false };
 	BoolConfigParam automatic_screenshots{ "Automatic screenshots", "Periodically take screenshots", "Player", "AutomaticScreenshots", false };
-	RangeConfigParam<int> automatic_screenshots_interval{ "Screenshot interval", "Periodically take screenshots every x seconds", "Player", "AutomaticScreenshotsInterval", 30, 1, 999999 };
+	RangeConfigParam<int> automatic_screenshots_interval{ "Screenshot interval", "The interval between automatic screenshots (seconds)", "Player", "AutomaticScreenshotsInterval", 30, 1, 999999 };
 
 	void Hide();
 };

--- a/src/game_config.h
+++ b/src/game_config.h
@@ -105,6 +105,8 @@ struct Game_ConfigPlayer {
 	BoolConfigParam lang_select_in_title{ "Show language menu on title screen", "Display language menu item on the title screen", "Player", "LanguageInTitle", true };
 	BoolConfigParam log_enabled{ "Logging", "Write diagnostic messages into a logfile", "Player", "Logging", true };
 	RangeConfigParam<int> screenshot_scale { "Screenshot scaling factor", "Scale screenshots by the given factor", "Player", "ScreenshotScale", 1, 1, 24};
+	BoolConfigParam automatic_screenshots{ "Automatic screenshots", "Periodically take screenshots", "Player", "AutomaticScreenshots", false };
+	RangeConfigParam<int> automatic_screenshots_interval{ "Screenshot interval", "Periodically take screenshots every x seconds", "Player", "AutomaticScreenshotsInterval", 30, 1, 999999 };
 
 	void Hide();
 };

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -197,16 +197,13 @@ void Output::Quit() {
 	Game_Config::CloseLogFile();
 }
 
-bool Output::TakeScreenshot() {
+bool Output::TakeScreenshot(bool is_auto_screenshot) {
 #ifdef EMSCRIPTEN
 	Emscripten_Interface::TakeScreenshot();
 	return true;
 #else
-	int index = 0;
-	std::string p;
-	do {
-		p = "screenshot_" + std::to_string(index++) + ".png";
-	} while(FileFinder::Save().Exists(p));
+	auto fs = FileFinder::Save();
+	auto p = GetNextScreenshotName(fs, is_auto_screenshot);
 	return TakeScreenshot(p);
 #endif
 }
@@ -231,6 +228,15 @@ bool Output::TakeScreenshot(std::ostream& os) {
 	} else {
 		return DisplayUi->GetDisplaySurface()->WritePNG(os);
 	}
+}
+
+std::string Output::GetNextScreenshotName(FilesystemView fs, bool is_auto_screenshot) {
+	std::string p;
+	int index = 0;
+	do {
+		p = (is_auto_screenshot ? "auto_" : "screenshot_") + std::to_string(index++) + ".png";
+	} while (fs.Exists(p));
+	return p;
 }
 
 void Output::ToggleLog() {

--- a/src/output.h
+++ b/src/output.h
@@ -45,7 +45,7 @@ namespace Output {
 	/**
 	 * Sets the log level for filtering logs
 	 *
-	 * @param ll the new log level
+	 * @param lvl the new log level
 	 */
 	void SetLogLevel(LogLevel lvl);
 
@@ -64,9 +64,10 @@ namespace Output {
 	/**
 	 * Takes screenshot and save it in the save directory.
 	 *
+	 * @param is_auto_screenshot
 	 * @return true if success, otherwise false.
 	 */
-	bool TakeScreenshot();
+	bool TakeScreenshot(bool is_auto_screenshot = false);
 
 	/**
 	 * Takes screenshot and save it to specified file.
@@ -83,6 +84,15 @@ namespace Output {
 	 * @return true if success, otherwise false.
 	 */
 	bool TakeScreenshot(std::ostream& os);
+
+	/**
+	 * Gets the next available file name for a screenshot
+	 *
+	 * @param fs the output path where to store the file
+	 * @param is_auto_screenshot
+	 * @return the file name
+	 */
+	std::string GetNextScreenshotName(FilesystemView fs, bool is_auto_screenshot);
 
 	/**
 	 * Shows/Hides the output log overlay.

--- a/src/output.h
+++ b/src/output.h
@@ -85,6 +85,8 @@ namespace Output {
 	 */
 	bool TakeScreenshot(std::ostream& os);
 
+	std::string GetScreenshotName(bool is_auto_screenshot);
+
 	/**
 	 * Gets the next available file name for a screenshot
 	 *
@@ -92,7 +94,7 @@ namespace Output {
 	 * @param is_auto_screenshot
 	 * @return the file name
 	 */
-	std::string GetNextScreenshotName(FilesystemView fs, bool is_auto_screenshot);
+	std::string GetNextScreenshotFileName(FilesystemView fs, bool is_auto_screenshot);
 
 	/**
 	 * Shows/Hides the output log overlay.

--- a/src/platform/emscripten/interface.cpp
+++ b/src/platform/emscripten/interface.cpp
@@ -77,7 +77,7 @@ void Emscripten_Interface::TakeScreenshot(bool is_auto_screenshot) {
 	std::ostringstream os;
 	Output::TakeScreenshot(os);
 	std::string screenshot = os.str();
-	std::string filename = GetScreenshotName(is_auto_screenshot);
+	std::string filename = Output::GetScreenshotName(is_auto_screenshot);
 	if (!Player::player_config.screenshot_timestamp.Get()) {
 		filename += "_" + std::to_string(index++) + ".png";
 	} else {

--- a/src/platform/emscripten/interface.cpp
+++ b/src/platform/emscripten/interface.cpp
@@ -72,12 +72,17 @@ void Emscripten_Interface::RefreshScene() {
 	Scene::instance->Refresh();
 }
 
-void Emscripten_Interface::TakeScreenshot() {
+void Emscripten_Interface::TakeScreenshot(bool is_auto_screenshot) {
 	static int index = 0;
 	std::ostringstream os;
 	Output::TakeScreenshot(os);
 	std::string screenshot = os.str();
-	std::string filename = "screenshot_" + std::to_string(index++) + ".png";
+	std::string filename = GetScreenshotName(is_auto_screenshot);
+	if (!Player::player_config.screenshot_timestamp.Get()) {
+		filename += "_" + std::to_string(index++) + ".png";
+	} else {
+		filename += ".png";
+	}
 	EM_ASM_ARGS({
 		Module.api_private.download_js($0, $1, $2);
 	}, screenshot.data(), screenshot.size(), filename.c_str());

--- a/src/platform/emscripten/interface.h
+++ b/src/platform/emscripten/interface.h
@@ -27,7 +27,7 @@ public:
     static void UploadSoundfont();
     static void UploadFont();
     static void RefreshScene();
-	static void TakeScreenshot();
+	static void TakeScreenshot(bool is_auto_screenshot = false);
 	static void Reset();
 	static bool ResetCanvas();
 };

--- a/src/utils.h
+++ b/src/utils.h
@@ -29,6 +29,7 @@
 namespace Utils {
 	constexpr std::string_view DateFormat_YYMMDD = "%y%m%d";
 	constexpr std::string_view DateFormat_HHMMSS = "%H%M%S";
+	constexpr std::string_view DateFormat_YYYYMMDD_HHMMSS = "%Y%m%d_%H%M%S";
 
 	/**
 	 * Converts a string to lower case (ASCII only)

--- a/src/window_settings.cpp
+++ b/src/window_settings.cpp
@@ -434,6 +434,8 @@ void Window_Settings::RefreshEngine() {
 
 	GetFrame().options.back().help2 = fmt::format("Screenshot size: {}x{}",
 		Player::screen_width * cfg.screenshot_scale.Get(), Player::screen_height * cfg.screenshot_scale.Get());
+	AddOption(cfg.automatic_screenshots, [&cfg]() { cfg.automatic_screenshots.Toggle(); });
+	AddOption(cfg.automatic_screenshots_interval, [this, &cfg]() { cfg.automatic_screenshots_interval.Set(GetCurrentOption().current_value); });
 }
 
 void Window_Settings::RefreshEngineFont(bool mincho) {

--- a/src/window_settings.cpp
+++ b/src/window_settings.cpp
@@ -438,7 +438,6 @@ void Window_Settings::RefreshEngine() {
 	auto fmt_sample_name = [](bool is_auto_screenshot) {
 		auto name = Output::GetScreenshotName(is_auto_screenshot);
 		if (Player::player_config.screenshot_timestamp.Get()) {
-			//return name + "[_1].png";
 			return name + ".png";
 		}
 		return name + "_0.png";

--- a/src/window_settings.cpp
+++ b/src/window_settings.cpp
@@ -434,7 +434,23 @@ void Window_Settings::RefreshEngine() {
 
 	GetFrame().options.back().help2 = fmt::format("Screenshot size: {}x{}",
 		Player::screen_width * cfg.screenshot_scale.Get(), Player::screen_height * cfg.screenshot_scale.Get());
+
+	auto fmt_sample_name = [](bool is_auto_screenshot) {
+		auto name = Output::GetScreenshotName(is_auto_screenshot);
+		if (Player::player_config.screenshot_timestamp.Get()) {
+			//return name + "[_1].png";
+			return name + ".png";
+		}
+		return name + "_0.png";
+	};
+
+	AddOption(cfg.screenshot_timestamp, [this, &cfg]() { cfg.screenshot_timestamp.Toggle(); });
+	GetFrame().options.back().help2 = fmt::format("Sample name: {}", fmt_sample_name(false));
+
 	AddOption(cfg.automatic_screenshots, [&cfg]() { cfg.automatic_screenshots.Toggle(); });
+	if (Player::player_config.automatic_screenshots.Get()) {
+		GetFrame().options.back().help2 = fmt::format("Sample name: {}", fmt_sample_name(true));
+	}
 	AddOption(cfg.automatic_screenshots_interval, [this, &cfg]() { cfg.automatic_screenshots_interval.Set(GetCurrentOption().current_value); });
 }
 


### PR DESCRIPTION
### Periodically take automatic screenshots
![screenshot_2](https://github.com/user-attachments/assets/4fdfa98e-ac94-4a34-84da-b014667dfc87)

![screenshot_3](https://github.com/user-attachments/assets/6c292127-21bb-4083-a02c-511acc72b158)

### Timestamps in filenames
This was also requested recently & is pretty easy to implement, so I added this option as well:

![screenshot_20250426_140147](https://github.com/user-attachments/assets/ead63c8b-997e-4de9-a5ba-5b44432b05bd)
If there is a naming conflict (multiple presses of the screenshot key in a single second), file names will still be indexed (starting with "_1.png", rather than "_0.png")
![image](https://github.com/user-attachments/assets/3f4f8730-bec2-44b4-884d-9455378e2ba7)

