### PR TITLE
Fix #3366

### DIFF
--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1038,9 +1038,8 @@ bool Game_Map::IsPassableTile(
 				continue;
 			}
 			if (ev.IsInPosition(x, y) && ev.GetLayer() == lcf::rpg::EventPage::Layers_below) {
-				int tile_id = ev.GetTileId();
-				if (tile_id > 0) {
-					event_tile_id = tile_id;
+				if (ev.HasTileSprite()) {
+					event_tile_id = ev.GetTileId();
 				}
 			}
 		}


### PR DESCRIPTION
When doing passability checks always the first event with a tile graphic is considered.

We skipped tile_id = 0 before which broke a collision check in "Genkido".

Fix #3366