### PR TITLE
Several fixes for the CloneMapEvent/DestroyMapEvent commands

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -5656,6 +5656,10 @@ bool Game_Interpreter::CommandEasyRpgDestroyMapEvent(lcf::rpg::EventCommand cons
 
 	int target_event = ValueOrVariable(com.parameters[0], com.parameters[1]);
 
+	if (target_event == 0 || target_event == Game_Character::CharThisEvent) {
+		target_event = GetThisEventId();
+	}
+
 	_async_op = AsyncOp::MakeDestroyMapEvent(target_event);
 
 	return true;

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -478,7 +478,7 @@ bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int
 		}), new_event);
 
 	auto game_event = Game_Event(GetMapId(), &*insert_it);
-	game_event.data()->easyrpg_clone_event_id = source_event->ID;
+	game_event.data()->easyrpg_clone_event_id = src_event_id;
 	game_event.data()->easyrpg_clone_map_id = src_map_id;
 
 	events.insert(

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -241,16 +241,20 @@ void Game_Map::SetupFromSave(
 
 	if (is_map_save_compat) {
 		std::vector<int> destroyed_event_ids;
-		for (size_t i = 0, j = 0; i < events.size();++i) {
+
+		for (size_t i = 0, j = 0; i < events.size() && j < map_info.events.size(); ++i) {
 			auto& ev = events[i];
 			auto& save_ev = map_info.events[j];
 			if (ev.GetId() == save_ev.ID) {
 				ev.SetSaveData(save_ev);
 				++j;
 			} else {
-				assert(save_ev.ID > ev.GetId());
-				// assume that the event has been destroyed during gameplay via "DestroyMapEvent"
-				destroyed_event_ids.emplace_back(ev.GetId());
+				if (save_ev.ID > ev.GetId()) {
+					// assume that the event has been destroyed during gameplay via "DestroyMapEvent"
+					destroyed_event_ids.emplace_back(ev.GetId());
+				} else {
+					Output::Debug("SetupFromSave: Unexpected ID {}/{}", save_ev.ID, ev.GetId());
+				}
 			}
 		}
 		for (size_t i = 0; i < destroyed_event_ids.size(); ++i) {

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -240,10 +240,42 @@ void Game_Map::SetupFromSave(
 	}
 
 	if (is_map_save_compat) {
-		for (size_t i = 0; i < std::min(map->events.size(), map_info.events.size()); ++i) {
+		std::vector<int> destroyed_event_ids;
+		for (size_t i = 0, j = 0; i < events.size();++i) {
 			auto& ev = events[i];
-			ev.SetSaveData(map_info.events[i]);
+			auto& save_ev = map_info.events[j];
+			if (ev.GetId() == save_ev.ID) {
+				ev.SetSaveData(save_ev);
+				++j;
+			} else {
+				assert(save_ev.ID > ev.GetId());
+				// assume that the event has been destroyed during gameplay via "DestroyMapEvent"
+				destroyed_event_ids.emplace_back(ev.GetId());
+			}
 		}
+		for (size_t i = 0; i < destroyed_event_ids.size(); ++i) {
+			DestroyMapEvent(destroyed_event_ids[i], true);
+		}
+		if (destroyed_event_ids.size() > 0) {
+			UpdateUnderlyingEventReferences();
+		}
+	}
+
+	// Handle cloned events in a separate loop, regardless of "is_map_save_compat"
+	if (Player::HasEasyRpgExtensions()) {
+		for (size_t i = 0; i < map_info.events.size(); ++i) {
+			auto& save_ev = map_info.events[i];
+			bool is_cloned_evt = save_ev.easyrpg_clone_map_id > 0 || save_ev.easyrpg_clone_event_id > 0;
+			if (is_cloned_evt && CloneMapEvent(
+				save_ev.easyrpg_clone_map_id, save_ev.easyrpg_clone_event_id,
+				save_ev.position_x, save_ev.position_y,
+				save_ev.ID, "")) { // FIXME: Customized event names for saved events aren't part of liblcf/SaveMapEvent at the moment & thus cannot be restored
+				if (auto new_event = GetEvent(save_ev.ID); new_event != nullptr) {
+					new_event->SetSaveData(save_ev);
+				}
+			}
+		}
+		UpdateUnderlyingEventReferences();
 	}
 	map_info.events.clear();
 	interpreter->Clear();

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -491,8 +491,10 @@ bool Game_Map::CloneMapEvent(int src_map_id, int src_event_id, int target_x, int
 	AddEventToCache(new_event);
 
 	Scene_Map* scene = (Scene_Map*)Scene::Find(Scene::Map).get();
-	scene->spriteset->Refresh();
-	SetNeedRefresh(true);
+	if (scene) {
+		scene->spriteset->Refresh();
+		SetNeedRefresh(true);
+	}
 
 	return true;
 }


### PR DESCRIPTION
Fixes following issues with these EasyRPG-commands:

- Cloned & destroyed events were not considered by the map setup code which is responsible for loading savegame data. This was especially dangerous if a pre-existing map event has been destroyed because the code assumed both the original & the savegame data vectors of events to be both the same size & in the same order, with no skipping of IDs.
- Added check before refresh of "scene": If the **CloneMapEvent** function was called from inside the map setup code, the map scene might not be created yet.
- Fix #3393 
- Sometimes **CloneMapEvent** would write garbage data into the field "_easyrpg_clone_event_id_" due to an invalid pointer (Vector reallocation issue)

### Test project:
[CloneDestroyMapEventTest.zip](https://github.com/user-attachments/files/19967104/CloneDestroyMapEventTest.zip)