### PR TITLE
Fix #3415 (Access violation in RM2K battle scene)

### DIFF
--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -136,6 +136,7 @@ public:
 
 	void Start() override;
 	void vUpdate() override;
+	void OnPartyChanged(Game_Actor* actor, bool add) override;
 
 protected:
 	bool UpdateBattleState();

--- a/src/scene_battle_rpg2k.h
+++ b/src/scene_battle_rpg2k.h
@@ -136,7 +136,6 @@ public:
 
 	void Start() override;
 	void vUpdate() override;
-	void OnPartyChanged(Game_Actor* actor, bool add) override;
 
 protected:
 	bool UpdateBattleState();


### PR DESCRIPTION
Fixes the Player crash described in issue #3415

I haven't looked further if a similar problem could occur in the 2k3 battle scene. But I guess the execution of scripts would look quite different there. (And I remember playing plenty of 2k3 games that switch out characters in the standard battle system & never having a similar issue)