### PR TITLE
Translation fix: Files inside "Text" folder were not translated

### DIFF
--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -424,6 +424,13 @@ std::string find_generic(const DirectoryTree::Args& args) {
 }
 
 std::string find_generic_with_fallback(DirectoryTree::Args& args) {
+	if (!Tr::GetCurrentTranslationId().empty()) {
+		auto tr_fs = Tr::GetCurrentTranslationFilesystem();
+		auto translated_file = tr_fs.FindFile(args);
+		if (!translated_file.empty()) {
+			return translated_file;
+		}
+	}
 	std::string found = FileFinder::Save().FindFile(args);
 	if (found.empty()) {
 		return find_generic(args);
@@ -478,6 +485,14 @@ Filesystem_Stream::InputStream open_generic(std::string_view dir, std::string_vi
 }
 
 Filesystem_Stream::InputStream open_generic_with_fallback(std::string_view dir, std::string_view name, DirectoryTree::Args& args) {
+	if (!Tr::GetCurrentTranslationId().empty()) {
+		auto tr_fs = Tr::GetCurrentTranslationFilesystem();
+		auto is = tr_fs.OpenFile(args);
+		if (is) {
+			return is;
+		}
+	}
+
 	auto is = FileFinder::Save().OpenFile(args);
 	if (!is) { is = open_generic(dir, name, args); }
 	if (!is) {

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -424,13 +424,14 @@ std::string find_generic(const DirectoryTree::Args& args) {
 }
 
 std::string find_generic_with_fallback(DirectoryTree::Args& args) {
-	if (!Tr::GetCurrentTranslationId().empty()) {
-		auto tr_fs = Tr::GetCurrentTranslationFilesystem();
-		auto translated_file = tr_fs.FindFile(args);
-		if (!translated_file.empty()) {
-			return translated_file;
-		}
+	// Searches first in the Save directory (because the game could have written
+	// files there, then in the Game directory.
+	// Disable this behaviour when Game and Save are shared as this breaks the
+	// translation redirection.
+	if (Player::shared_game_and_save_directory) {
+		return find_generic(args);
 	}
+
 	std::string found = FileFinder::Save().FindFile(args);
 	if (found.empty()) {
 		return find_generic(args);

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -460,11 +460,6 @@ std::string FileFinder::FindFont(std::string_view name) {
 	return find_generic(args);
 }
 
-std::string FileFinder::FindText(std::string_view name) {
-	DirectoryTree::Args args = { MakePath("Text", name), TEXT_TYPES, 1, true };
-	return find_generic_with_fallback(args);
-}
-
 Filesystem_Stream::InputStream open_generic(std::string_view dir, std::string_view name, DirectoryTree::Args& args) {
 	if (!Tr::GetCurrentTranslationId().empty()) {
 		auto tr_fs = Tr::GetCurrentTranslationFilesystem();

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -164,14 +164,6 @@ namespace FileFinder {
 	std::string FindFont(std::string_view name);
 
 	/**
-	 * Finds a text file in the current RPG Maker game.
-	 *
-	 * @param name the text path and name.
-	 * @return path to file.
-	 */
-	std::string FindText(std::string_view name);
-
-	/**
 	 * Finds an image file and opens a file handle to it.
 	 * Searches through the current RPG Maker game and the RTP directories.
 	 *

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -123,6 +123,7 @@ namespace Player {
 	uint32_t escape_char;
 	std::string game_title;
 	std::string game_title_original;
+	bool shared_game_and_save_directory = false;
 	std::shared_ptr<Meta> meta;
 	FileExtGuesser::RPG2KFileExtRemap fileext_map;
 	std::string startup_language;
@@ -716,7 +717,9 @@ void Player::CreateGameObjects() {
 
 	std::string game_path = FileFinder::GetFullFilesystemPath(FileFinder::Game());
 	std::string save_path = FileFinder::GetFullFilesystemPath(FileFinder::Save());
-	if (game_path == save_path) {
+	shared_game_and_save_directory = (game_path == save_path);
+
+	if (shared_game_and_save_directory) {
 		Output::DebugStr("Game and Save Directory:");
 		FileFinder::DumpFilesystem(FileFinder::Game());
 	} else {

--- a/src/player.h
+++ b/src/player.h
@@ -403,6 +403,9 @@ namespace Player {
 	/** Original game title, in case it was overriden by a translation. */
 	extern std::string game_title_original;
 
+	/** Indicates whether FileFinder::Game() and Save() point to the same directory. */
+	extern bool shared_game_and_save_directory;
+
 	/** Meta class containing additional external data for this game. */
 	extern std::shared_ptr<Meta> meta;
 


### PR DESCRIPTION
I noticed this after migrating a lot of harcoded strings into json files & trying to translate them..

Files which are fetched via `OpenText()` (Everything inside the _Text_ game folder) would not get translated at all due to their function variant not checking for active translations.

Here's a quick fix...