### PR TITLE
SDL: Bump Android version

### DIFF
--- a/builds/android/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/builds/android/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -50,22 +50,22 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import androidx.appcompat.app.AppCompatActivity;
-
 import java.util.Hashtable;
 import java.util.Locale;
 
 // EasyRPG additions
 import org.easyrpg.player.R;
+import androidx.appcompat.app.AppCompatActivity;
 
 /**
     SDL Activity
 */
+// EasyRPG modification: extends AppCompatActivity
 public class SDLActivity extends AppCompatActivity implements View.OnSystemUiVisibilityChangeListener {
     private static final String TAG = "SDL";
     private static final int SDL_MAJOR_VERSION = 2;
     private static final int SDL_MINOR_VERSION = 32;
-    private static final int SDL_MICRO_VERSION = 2;
+    private static final int SDL_MICRO_VERSION = 6;
 /*
     // Display InputType.SOURCE/CLASS of events and devices
     //


### PR DESCRIPTION
Slowly these bumps become annoying because there is 0 API change...

Also cleaned up some stuff in SDLActivity (marked it as a easyrpg modification) that was added due to the dark mode and Android 36 edits.