### PR TITLE
Visual Fixes

### DIFF
--- a/src/audio_generic.cpp
+++ b/src/audio_generic.cpp
@@ -221,8 +221,9 @@ bool GenericAudio::PlayOnChannel(BgmChannel& chan, Filesystem_Stream::InputStrea
 	chan.paused = true; // Pause channel so the audio thread doesn't work on it
 	chan.stopped = false; // Unstop channel so the audio thread doesn't delete it
 
+	std::string_view name = filestream.GetName();
 	if (!filestream) {
-		Output::Warning("BGM file not readable: {}", filestream.GetName());
+		Output::Warning("BGM file not readable: {}", name);
 		return false;
 	}
 
@@ -272,7 +273,7 @@ bool GenericAudio::PlayOnChannel(BgmChannel& chan, Filesystem_Stream::InputStrea
 
 		return true;
 	} else {
-		Output::Warning("Couldn't play BGM {}. Format not supported", filestream.GetName());
+		Output::Warning("Couldn't play BGM {}. Format not supported", name);
 	}
 
 	return false;

--- a/src/game_character.cpp
+++ b/src/game_character.cpp
@@ -1054,7 +1054,7 @@ bool Game_Character::CalculateMoveRoute(const CalculateMoveRouteArgs& args) {
 			route.skippable = args.skip_when_failed;
 			route.repeat = false;
 
-			for (SearchNode node2 : list_move) {
+			for (SearchNode const& node2 : list_move) {
 				if (node2.direction >= 0) {
 					lcf::rpg::MoveCommand cmd;
 					cmd.command_id = node2.direction;

--- a/src/plane.cpp
+++ b/src/plane.cpp
@@ -50,11 +50,13 @@ void Plane::Draw(Bitmap& dst) {
 	int src_x = -ox - GetRenderOx();
 	int src_y = -oy - GetRenderOy();
 
+	int offset_x = 0;
+
 	// Apply screen shaking
 	const int shake_x = Main_Data::game_screen->GetShakeOffsetX();
 	const int shake_y = Main_Data::game_screen->GetShakeOffsetY();
 	if (Game_Map::LoopHorizontal()) {
-		src_x += shake_x;
+		offset_x = shake_x;
 	} else {
 		// The panorama occupies the same rectangle as the whole map.
 		// Using coordinates where the top-left of the screen is the origin...
@@ -83,10 +85,17 @@ void Plane::Draw(Bitmap& dst) {
 		dst_rect.width = bg_width;
 
 		// Correct the offset if the top-left corner moved.
-		src_x += shake_x + bg_x;
+		offset_x = shake_x + bg_x;
 	}
 	src_y += shake_y;
 
-	dst.TiledBlit(src_x, src_y, source->GetRect(), *source, dst_rect, 255);
+	dst.TiledBlit(src_x + offset_x, src_y, source->GetRect(), *source, dst_rect, 255);
+	if (offset_x < 0) {
+		auto clear_rect = Rect(dst.GetRect().x, dst.GetRect().y, abs(offset_x), dst.GetRect().height);
+		dst.ClearRect(clear_rect);
+	} else if (offset_x > 0) {
+		auto clear_rect = Rect(dst.GetRect().width - offset_x, dst.GetRect().y, offset_x, dst.GetRect().height);
+		dst.ClearRect(clear_rect);
+	}
 }
 

--- a/src/sprite_timer.cpp
+++ b/src/sprite_timer.cpp
@@ -23,6 +23,7 @@
 #include "game_party.h"
 #include "game_system.h"
 #include "game_battle.h"
+#include "window_message.h"
 #include <player.h>
 
 Sprite_Timer::Sprite_Timer(int which) :
@@ -90,7 +91,7 @@ void Sprite_Timer::Draw(Bitmap& dst) {
 	if (Game_Battle::IsBattleRunning()) {
 		SetY((Player::screen_height / 3 * 2) - 20);
 	}
-	else if (Game_Message::IsMessageActive() && Game_Message::GetRealPosition() == 0) {
+	else if (Game_Message::GetWindow()->GetY() < 20) {
 		SetY(Player::screen_height - 20 - Player::menu_offset_y);
 	}
 	else {

--- a/src/spriteset_battle.cpp
+++ b/src/spriteset_battle.cpp
@@ -31,7 +31,7 @@
 #include "sprite_actor.h"
 #include "sprite_enemy.h"
 
-Spriteset_Battle::Spriteset_Battle(const std::string bg_name, int terrain_id)
+Spriteset_Battle::Spriteset_Battle(std::string bg_name, int terrain_id)
 {
 	background_name = std::move(bg_name);
 

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -189,11 +189,8 @@ void Window_Message::StartMessageProcessing(PendingMessage pm) {
 
 	DebugLog("{}: MSG TEXT \n{}", text);
 
-	auto open_frames = (!IsVisible() && !Game_Battle::IsBattleRunning()) ? message_animation_frames : 0;
-	SetOpenAnimation(open_frames);
-	DebugLog("{}: MSG START OPEN {}", open_frames);
-
-	InsertNewPage();
+	disallow_next_message = true;
+	msg_was_pushed_this_frame = true;
 }
 
 void Window_Message::OnFinishPage() {
@@ -399,7 +396,7 @@ void Window_Message::Update() {
 	if (IsClosing()) { DebugLog("{}: MSG CLOSING"); }
 
 	close_started_this_frame = false;
-	close_finished_this_frame = false;
+	disallow_next_message = false;
 
 	const bool was_closing = IsClosing();
 
@@ -408,10 +405,22 @@ void Window_Message::Update() {
 	gold_window->Update();
 
 	if (was_closing && !IsClosing()) {
-		close_finished_this_frame = true;
+		disallow_next_message = true;
 	}
 
 	if (!IsVisible()) {
+		if (msg_was_pushed_this_frame) {
+			msg_was_pushed_this_frame = false;
+			disallow_next_message = true;
+			return;
+		}
+		if (!text.empty() && text_index == text.data()) {
+			auto open_frames = (!IsVisible() && !Game_Battle::IsBattleRunning()) ? message_animation_frames : 0;
+			SetOpenAnimation(open_frames);
+			DebugLog("{}: MSG START OPEN {}", open_frames);
+			
+			InsertNewPage();
+		}
 		return;
 	}
 

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -165,8 +165,9 @@ protected:
 	// FIXME: This hacky flags exist because RPG_RT likely animates the message window
 	// after the game loop finishes. Our code isn't structured that way, so we must hack
 	// around it.
+	bool msg_was_pushed_this_frame = false;
 	bool close_started_this_frame = false;
-	bool close_finished_this_frame = false;
+	bool disallow_next_message = false;
 
 	/** Frames to wait when a message wait command was used */
 	int wait_count = 0;
@@ -214,8 +215,8 @@ inline AsyncOp Window_Message::GetAsyncOp() const {
 }
 
 inline bool Window_Message::GetAllowNextMessage(bool foreground) const {
-	bool is_active = (IsVisible() || close_finished_this_frame);
-	return foreground ? !is_active || close_started_this_frame : !is_active;
+	bool is_active = (IsVisible() || disallow_next_message);
+	return foreground ? !is_active || (close_started_this_frame && !disallow_next_message): !is_active;
 }
 
 inline int Window_Message::GetMaxLinesPerPage() const {

--- a/src/window_shopbuy.cpp
+++ b/src/window_shopbuy.cpp
@@ -67,6 +67,7 @@ void Window_ShopBuy::DrawItem(int index) {
 
 	if (!item) {
 		Output::Warning("Window ShopBuy: Invalid item ID {}", item_id);
+		return;
 	} else {
 		enabled = item->price <= Main_Data::game_party->GetGold() && Main_Data::game_party->GetItemCount(item_id) < Main_Data::game_party->GetMaxItemCount(item_id);
 		price = item->price;


### PR DESCRIPTION
A few fixes for minor visual glitches in the EasyRPG Player.
(As well as some other fixes for warnings MSVC spat out)

### #2432 / #2932 - Face state not emulated correctly for Message Processing in Parallel events because of the global state of game_system
I added another "hacky flag" in Window_Message (See the FIXME there..) to indicate that a text was pushed in the current frame & renamed an existing one ("close_finished_this_frame").
The initial creation of the window contents has been moved from "StartMessageProcessing" to the Update method. Restructuring the code this way allows us to delay this part of the setup, until the main interpreter scripts have been handled.

I modified Cherry's test project a bit, to also verify that the parsing of variables in the message contents behaves the same:
[faceset-parallel.zip](https://github.com/user-attachments/files/20685485/faceset-parallel.zip)

It might make sense to combine all these boolean flags in Window_Message into some enum field (with descriptive names to improve readability), that describes the current state of the window & just remove the "FIXME" comment. Trying to restructure all the code as suggested there would be a major headache & just break other stuff along the way... :thinking: 

This should also fix some other MessageBox issues that are caused by race conditions between interpreter instances. Have to dig up the issue numbers..

### #3412 - Incorrect positioning of timer overlay
I already went into detail in the comments of this issue.

### #2607 - Parallax background graphics would be rendered on the outside area of the screen when ShakeScreen is applied
While a ShakeScreen effect is active, the area outside of the screen boundaries should not be drawn on.
EasyRPG uses a TiledBlit here, effectively repeating the bitmap everywhere. Could maybe be improved, but I just clear the overdrawn areas afterwards, to emulate RPG_RT behavior.