### PR TITLE
Fix 3436: Consider images with no alpha as Opaque in ComputeImageOpacity.

### DIFF
--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -200,12 +200,16 @@ size_t Bitmap::GetSize() const {
 }
 
 ImageOpacity Bitmap::ComputeImageOpacity() const {
+	if (!GetTransparent()) {
+		return ImageOpacity::Opaque;
+	}
+
 	bool all_opaque = true;
 	bool all_transp = true;
 	bool alpha_1bit = true;
 
 	auto* p = reinterpret_cast<const uint32_t*>(pixels());
-	const auto mask = pixel_format.rgba_to_uint32_t(0, 0, 0, 0xFF);
+	const auto mask = format.rgba_to_uint32_t(0, 0, 0, 0xFF);
 
 	int n = GetSize() / sizeof(uint32_t);
 	for (int i = 0; i < n; ++i ) {
@@ -225,6 +229,10 @@ ImageOpacity Bitmap::ComputeImageOpacity() const {
 }
 
 ImageOpacity Bitmap::ComputeImageOpacity(Rect rect) const {
+	if (!GetTransparent()) {
+		return ImageOpacity::Opaque;
+	}
+
 	bool all_opaque = true;
 	bool all_transp = true;
 	bool alpha_1bit = true;
@@ -234,7 +242,7 @@ ImageOpacity Bitmap::ComputeImageOpacity(Rect rect) const {
 
 	auto* p = reinterpret_cast<const uint32_t*>(pixels());
 	const int stride = pitch() / sizeof(uint32_t);
-	const auto mask = pixel_format.rgba_to_uint32_t(0, 0, 0, 0xFF);
+	const auto mask = format.rgba_to_uint32_t(0, 0, 0, 0xFF);
 
 	int xend = (rect.x + rect.width);
 	int yend = (rect.y + rect.height);


### PR DESCRIPTION
When using pixel format ABGR (prefered on Big Endian) instead of RGBA and the image is considered opaque (no alpha channel), pixman makes the alpha pixels 0x00 instead of 0xFF.

Technically the alpha values are undefined as the image is opaque but our opacity function considered this image as full transparent (because A is 0 everywhere).

This triggered a fast path in the ToneBlit which does nothing when the image is full transparent and causes a "trippy trail" rendering glitch.

Additionally this fixes a glitched Fog effect in the beginning of "Unterwegs in Düsterburg" which only flickered between transparent and full opaque before.

Fix #3436

---

The fix for UiD is cool because that was a long-standing bug where I had no idea where it comes from :)

The ToneBlit rendering bug in IB was not reproducable on the Wii, maybe different pixel format used or somehow different pixman behaviour didn't investigate this further.