### PR TITLE
Process JSON Command - Refactor JSON path handling and root support

### DIFF
--- a/tests/json.cpp
+++ b/tests/json.cpp
@@ -17,7 +17,7 @@ TEST_CASE("Get Value") {
 	auto obj = load("obj.json");
 	auto get = [&](std::string_view path) {
 		return Json_Helper::GetValue(obj, path);
-		};
+	};
 
 	CHECK_EQ(get("/name"), "Aina");
 	CHECK_EQ(get("/level"), "5");
@@ -39,12 +39,12 @@ TEST_CASE("Set Value") {
 
 	auto get = [&](std::string_view path) {
 		return Json_Helper::GetValue(obj, path);
-		};
+	};
 
 	auto set = [&](std::string_view path, std::string_view value) {
 		Json_Helper::SetValue(obj, path, value);
 		CHECK_EQ(get(path), value);
-		};
+	};
 
 	set("/name", "Easy");
 	set("/level", "A");
@@ -66,7 +66,7 @@ TEST_CASE("Get Length") {
 
 	auto len = [&](std::string_view path) {
 		return Json_Helper::GetLength(obj, path);
-		};
+	};
 
 	CHECK_EQ(len("/name"), 0);
 	CHECK_EQ(len("/atk"), 5);
@@ -79,7 +79,7 @@ TEST_CASE("Get Keys") {
 
 	auto keys = [&](std::string_view path) {
 		return Json_Helper::GetKeys(obj, path);
-		};
+	};
 
 	CHECK_EQ(keys("/name"), std::vector<std::string>());
 	CHECK_EQ(keys("/atk"), std::vector<std::string>{"0", "1", "2", "3", "4"});
@@ -92,7 +92,7 @@ TEST_CASE("Get Type") {
 
 	auto check = [&](std::string_view path) {
 		return Json_Helper::GetType(obj, path);
-		};
+	};
 
 	CHECK_EQ(check("/name"), "string");
 	CHECK_EQ(check("/atk"), "array");
@@ -108,7 +108,7 @@ TEST_CASE("Get Path") {
 
 	auto path = [&](std::string_view path) {
 		return Json_Helper::GetPath(obj, path);
-		};
+	};
 
 	// Function isn't fully implemented yet and not used by the Player
 	CHECK_EQ(path("Aina"), "/name");
@@ -119,50 +119,49 @@ TEST_CASE("Get Path") {
 	CHECK_EQ(Json_Helper::GetPath(obj, "/missing"), "");
 }
 
+TEST_CASE("Remove Root Element") {
+	// Clears the object
+	auto obj = load("obj.json");
+	Json_Helper::RemoveValue(obj, "/");
+	CHECK_EQ(obj.dump(), "{}");
+}
+
 TEST_CASE("Remove Value") {
-	// Test removing the root element, which should clear the object to {}
-	{
-		auto obj = load("obj.json");
-		Json_Helper::RemoveValue(obj, "/");
-		CHECK_EQ(obj.dump(), "{}");
-	}
+	auto obj = load("obj.json");
+
+	auto remove = [&](std::string_view path) {
+		Json_Helper::RemoveValue(obj, path);
+	};
 
 	// Test removing a top-level key
 	{
-		auto obj = load("obj.json");
-		auto expected = load("obj.json");
-		expected.erase("name");
-
-		Json_Helper::RemoveValue(obj, "/name");
-		CHECK_EQ(obj.dump(), expected.dump());
+		auto orig = obj;
+		remove("/name");
+		orig.erase("name");
+		CHECK_EQ(obj.dump(), orig.dump());
 	}
 
 	// Test removing an element from an array
 	{
-		auto obj = load("obj.json");
-		auto expected = load("obj.json");
-		expected["atk"].erase(1);
-
-		Json_Helper::RemoveValue(obj, "/atk/1");
-		CHECK_EQ(obj.dump(), expected.dump());
+		auto orig = obj;
+		remove("/atk/1");
+		orig["atk"].erase(1);
+		CHECK_EQ(obj.dump(), orig.dump());
 	}
 
 	// Test removing a key from a nested object
 	{
-		auto obj = load("obj.json");
-		auto expected = load("obj.json");
-		expected["skills"][0].erase("name");
-
-		Json_Helper::RemoveValue(obj, "/skills/0/name");
-		CHECK_EQ(obj.dump(), expected.dump());
+		auto orig = obj;
+		remove("/skills/0/name");
+		orig["skills"][0].erase("name");
+		CHECK_EQ(obj.dump(), orig.dump());
 	}
 
 	// Test that removing a non-existent path does nothing
 	{
-		auto obj = load("obj.json");
-		auto expected = load("obj.json");
+		auto orig = obj;
 		Json_Helper::RemoveValue(obj, "/missing_path");
-		CHECK_EQ(obj.dump(), expected.dump());
+		CHECK_EQ(obj.dump(), orig.dump());
 	}
 }
 
@@ -171,7 +170,7 @@ TEST_CASE("Push Value") {
 
 	auto push = [&](std::string_view path, std::string_view value) {
 		Json_Helper::PushValue(obj, path, value);
-		};
+	};
 
 	auto orig = obj.dump();
 	push("/name", "Easy");
@@ -190,7 +189,7 @@ TEST_CASE("Pop Value") {
 		CHECK_EQ(!json_obj.empty(), success);
 
 		return element;
-		};
+	};
 
 	CHECK_EQ(pop("/atk"), "20");
 	CHECK_EQ(pop("/atk"), "30");
@@ -210,7 +209,7 @@ TEST_CASE("Contains") {
 
 	auto check = [&](std::string_view path) {
 		return Json_Helper::Contains(obj, path);
-		};
+	};
 
 	CHECK_EQ(check("/"), true);
 	CHECK_EQ(check("/name"), true);


### PR DESCRIPTION
@Mimigris found some missing usecases for Process JSON command. One of them related to missing access to the root of a JSON, for things like `GetKeys("/")`

This PR Introduces a helper to handle JSON path resolution, including root path ('/'), and refactors all relevant functions to use it. Improves consistency, reduces code duplication, and adds explicit handling for root object operations in GetValue, SetValue, RemoveValue, Contains, and related methods.