### PR TITLE
Keep current picture sprite shown while the new one is loading

### DIFF
--- a/src/game_pictures.cpp
+++ b/src/game_pictures.cpp
@@ -253,11 +253,6 @@ bool Game_Pictures::Picture::Show(const ShowParams& params) {
 bool Game_Pictures::Show(int id, const ShowParams& params) {
 	auto& pic = GetPicture(id);
 	if (pic.Show(params)) {
-		if (pic.sprite && !pic.data.name.empty()) {
-			// When the name is empty the current image buffer is reused by ShowPicture command (Used by Yume2kki)
-			// In all other cases hide the current image until replaced while doing an Async load
-			pic.sprite->SetVisible(false);
-		}
 		RequestPictureSprite(pic);
 		return true;
 	}


### PR DESCRIPTION
Prevents flickering on multi-picture sequences loaded from a slow source such as a remote server.

Some examples (Yume 2kki 0.127i):
 - background animation in MAP3116 (Rural Starflower Field: Entrance)
 - entry animation in MAP0259 (Square-Square World) → (26, 48) blue fish → MAP3117 (Goldfish Pond)
 - entry animation in MAP2997 (Photographic Field) → (196, 13) door → MAP2998 (Dining Table) 

I've only managed to reproduce the flickering on emscripten.

Sprite hiding appears to have been introduced in 87cad8821de9e6c653dfa1f27a963ea5f6d71c85 (in order to avoid showing stale data from erased pictures?), but 32e9ad4dadfaa62ffa75978e943b2328a4532e2a made unused pictures unload their sprites so I'm not sure why this condition has been kept.