### PR TITLE
Fix --sound-volume incorrectly setting music volume

### DIFF
--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -523,7 +523,7 @@ void Game_Config::LoadFromArgs(CmdlineParser& cp) {
 		}
 		if (cp.ParseNext(arg, 1, "--sound-volume")) {
 			if (arg.ParseValue(0, li_value)) {
-				audio.music_volume.Set(li_value);
+				audio.sound_volume.Set(li_value);
 			}
 			continue;
 		}


### PR DESCRIPTION
As the title says, the `--sound-volume` argument was actually setting the music volume.