### PR TITLE
Fixes for "OFF Forgotten Dreams"

### DIFF
--- a/bench/rtp.cpp
+++ b/bench/rtp.cpp
@@ -5,7 +5,7 @@
 
 static void BM_InitRtp2k(benchmark::State& state) {
 	Output::SetLogLevel(LogLevel::Error);
-	Player::engine = Player::EngineRpg2k;
+	Player::game_config.engine = Player::EngineRpg2k;
 
 	bool no_rtp_flag = false;
 	bool no_rtp_warning_flag = false;
@@ -13,7 +13,7 @@ static void BM_InitRtp2k(benchmark::State& state) {
 		FileFinder_RTP(no_rtp_flag, no_rtp_warning_flag, "");
 	}
 
-	Player::engine = Player::EngineNone;
+	Player::game_config.engine = Player::EngineNone;
 	Output::SetLogLevel(LogLevel::Debug);
 }
 
@@ -21,7 +21,7 @@ BENCHMARK(BM_InitRtp2k);
 
 static void BM_InitRtp2k3(benchmark::State& state) {
 	Output::SetLogLevel(LogLevel::Error);
-	Player::engine = Player::EngineRpg2k3;
+	Player::game_config.engine = Player::EngineRpg2k3;
 
 	bool no_rtp_flag = false;
 	bool no_rtp_warning_flag = false;
@@ -29,7 +29,7 @@ static void BM_InitRtp2k3(benchmark::State& state) {
 		FileFinder_RTP(no_rtp_flag, no_rtp_warning_flag, "");
 	}
 
-	Player::engine = Player::EngineNone;
+	Player::game_config.engine = Player::EngineNone;
 	Output::SetLogLevel(LogLevel::Debug);
 }
 

--- a/src/exe_reader.h
+++ b/src/exe_reader.h
@@ -64,8 +64,9 @@ public:
 		uint32_t geep_size = 0;
 		MachineType machine_type = MachineType::Unknown;
 		bool is_easyrpg_player = false;
+		int maniac_patch_version = 0;
 
-		int GetEngineType(bool& is_maniac_patch) const;
+		int GetEngineType(int& mp_version) const;
 		void Print() const;
 	};
 
@@ -74,7 +75,7 @@ public:
 private:
 	// Bounds-checked unaligned reader primitives.
 	// In case of out-of-bounds, returns 0 - this will usually result in a harmless error at some other level,
-	//  or a partial correct interpretation.
+	// or a partial correct interpretation.
 	uint8_t GetU8(uint32_t point);
 	uint16_t GetU16(uint32_t point);
 	uint32_t GetU32(uint32_t point);

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -3692,6 +3692,16 @@ bool Game_Interpreter::CommandConditionalBranch(lcf::rpg::EventCommand const& co
 					// Assuming 'true' as Player usually suspends when loosing focus
 					result = true;
 					break;
+				case 3:
+					// File Output available
+					// We return here whether the save directory is usable
+					// Maniacs has a rate limit for too many write operations and this condition
+					// is used to check if the rate limit is reached
+					result = static_cast<bool>(FileFinder::Save());
+					break;
+				default:
+					Output::Warning("ConditionalBranch Maniac: Unknown Op {}", com.parameters[1]);
+					break;
 			}
 		}
 		break;

--- a/src/game_interpreter_control_variables.cpp
+++ b/src/game_interpreter_control_variables.cpp
@@ -288,8 +288,13 @@ int ControlVariables::Other(int op) {
 		case 13:
 			// Patch version
 			if (Player::IsPatchManiac()) {
-				// Latest version before the engine rewrite
-				return 200128;
+				auto var = Player::game_config.patch_maniac.Get();
+				if (var < 10) {
+					// Latest version before the engine rewrite
+					return 200128;
+				}
+
+				return var;
 			}
 			break;
 	}

--- a/src/game_system.h
+++ b/src/game_system.h
@@ -547,7 +547,7 @@ inline bool Game_System::GetMessageEventMessageActive() {
 }
 
 inline bool Game_System::IsLoadedThisFrame() const {
-	return loaded_frame_count + 1 == data.frame_count;
+	return loaded_frame_count != 0 && loaded_frame_count + 1 == data.frame_count;
 }
 
 inline Game_System::AtbMode Game_System::GetAtbMode() {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -776,10 +776,10 @@ void Player::CreateGameObjects() {
 		if (engine == EngineNone) {
 			auto version_info = exe_reader->GetFileInfo();
 			version_info.Print();
-			bool is_patch_maniac;
-			engine = version_info.GetEngineType(is_patch_maniac);
+			int maniac_patch_version;
+			engine = version_info.GetEngineType(maniac_patch_version);
 			if (!game_config.patch_override) {
-				game_config.patch_maniac.Set(is_patch_maniac);
+				game_config.patch_maniac.Set(maniac_patch_version);
 			}
 		}
 
@@ -829,8 +829,8 @@ void Player::CreateGameObjects() {
 			Output::Debug("This game uses DynRPG. Depending on the plugins used it will not run properly.");
 		}
 
-		if (!FileFinder::Game().FindFile("accord.dll").empty()) {
-			game_config.patch_maniac.Set(true);
+		if (!FileFinder::Game().FindFile("accord.dll").empty() && !Player::IsPatchManiac()) {
+			game_config.patch_maniac.Set(1);
 		}
 
 		if (!FileFinder::Game().FindFile(DESTINY_DLL).empty()) {
@@ -919,18 +919,18 @@ void Player::ResetGameObjects() {
 
 	auto min_var = lcf::Data::system.easyrpg_variable_min_value;
 	if (min_var == 0) {
-		if ((Player::game_config.patch_maniac.Get() & 1) == 1) {
-			min_var = std::numeric_limits<Game_Variables::Var_t>::min();
-		} else {
+		if (!Player::IsPatchManiac() || Player::game_config.patch_maniac.Get() == 2) {
 			min_var = Player::IsRPG2k3() ? Game_Variables::min_2k3 : Game_Variables::min_2k;
+		} else {
+			min_var = std::numeric_limits<Game_Variables::Var_t>::min();
 		}
 	}
 	auto max_var = lcf::Data::system.easyrpg_variable_max_value;
 	if (max_var == 0) {
-		if ((Player::game_config.patch_maniac.Get() & 1) == 1) {
-			max_var = std::numeric_limits<Game_Variables::Var_t>::max();
-		} else {
+		if (!Player::IsPatchManiac() || Player::game_config.patch_maniac.Get() == 2) {
 			max_var = Player::IsRPG2k3() ? Game_Variables::max_2k3 : Game_Variables::max_2k;
+		} else {
+			max_var = std::numeric_limits<Game_Variables::Var_t>::max();
 		}
 	}
 	Main_Data::game_variables = std::make_unique<Game_Variables>(min_var, max_var);


### PR DESCRIPTION
This game has various checks which makes the game fail to run with a loud jump scare when EasyRPG is detected...

<img width="640" height="480" alt="screenshot_20250731_125546" src="https://github.com/user-attachments/assets/976c9c2d-0d30-4e8f-972c-9405fbadc855" />

```
// Maniac Patch version check
// This PR: Implemented in "Maniac Patch: Extract the patch version number out of the EXE section"
@> Control Variables: V[0104] = Version of Maniac Patch
@> Conditional Branch: Playtest mode is active
@> Conditional Branch: V[0104] != 230831

// Call Command (already supported)
@> Call Command: 10220, , [0, 104, 0, 0, 0, 80085]

// Useless Output check (This PR)
@> Conditional Branch: Can output file

// Tileset Get Game Info (added by jetrotal a while ago)
@> Get Game Info: Tileset ID -> V[0104]

// Interpreter State (recently added by florianessl)
@> Get Game Info: Interpreter, Current(0) -> V[0104]

// This is not supported because it uses a Parallel PP
// but battle has no enemy so it ends immediately
@> Control Switches: S[0307:monkey] = ON
@> Battle Processing: Normal, [0006:--------------------]
@> Control Switches: S[0307:monkey] = OFF
```

There was also a bug which launched a battle right after starting the game because checking "Was just loaded" reported "true" on Frame 0.

----

What is not implemented are Battle Common Events. The only relevant I found is this one which removes the "Row" Battle Command and always forces the ATB mode to "Wait".

So not supporting this is not game breaking.

```
@> Battle Command EX: -Row, [Fight, Auto]
@> Conditional Branch: ATB mode is Wait ON
  @> Toggle ATB Wait Mode
  @> Conditional Branch: Playtest mode is active
    @> Change Skills: [0001:The batter], + [0002:Wide Angle]
    @>
   : Branch End
  @>
 : Branch End
```
