### PR TITLE
String ToFile: Sanitize path

### DIFF
--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -177,7 +177,7 @@ std::string FileFinder::MakeCanonical(std::string_view path, int initial_deepnes
 				// Ignore, we are in root
 				--initial_deepness;
 			} else {
-				Output::Debug("Path traversal out of game directory: {}", path);
+				Output::Warning("Path traversal out of game directory: {}", path);
 			}
 		} else if (path_comp.empty() || path_comp == ".") {
 			// ignore

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -216,15 +216,6 @@ namespace FileFinder {
 	Filesystem_Stream::InputStream OpenText(std::string_view name);
 
 	/**
-	* Writes data to a txt file.
-	* If the file exists, it will be overwritten.
-	*
-	* @param name the text file path and name
-	* @param data the content of the text file to be written
-	*/
-	void WriteText(std::string_view name, std::string_view data);
-
-	/**
 	 * Appends name to directory.
 	 *
 	 * @param dir base directory.


### PR DESCRIPTION
- Path is now case insensitive
- Backslash is converted to /
- Forgot "Make Canonical" which allowed writing outside of the game directory

Reported by @Mimigris. Thanks!

---

Another problem we noticed is that overwriting of arbitrary game files is possible. Though the only ultimate way to fix is in general relocating the save directory outside of the game directory. (which would be good style anyway).

