### PR TITLE
Imrprove heuristics check to detect broken RM2000-based fonts

### DIFF
--- a/src/font.cpp
+++ b/src/font.cpp
@@ -33,6 +33,7 @@
 #  include FT_BITMAP_H
 #  include FT_MODULE_H
 #  include FT_TRUETYPE_TABLES_H
+#  include FT_FONT_FORMATS_H
 #endif
 
 #ifdef HAVE_HARFBUZZ
@@ -311,6 +312,32 @@ FTFont::FTFont(Filesystem_Stream::InputStream is, int size, bool bold, bool ital
 	if (!strcmp(face->family_name, "RM2000") || !strcmp(face->family_name, "RMG2000")) {
 		// Workaround for bad kerning in RM2000 and RMG2000 fonts
 		rm2000_workaround = true;
+	} else if (!FT_HAS_COLOR(face) && FT_HAS_FIXED_SIZES(face)) {
+		auto font_format = FT_Get_Font_Format(face);
+		if (!strcmp(font_format, "Windows FNT")) {
+			static constexpr std::array<std::pair<char32_t, int>, 4> glyphs = {{
+				{ 'h', 6},
+				{ 'l', 4},
+				{ 'I', 15},
+				{ ' ', 15}
+			}};
+			// Check some metrics to identify custom fonts which were based
+			// on the broken RM2000 font & thus also need the same workaround
+			rm2000_workaround = true;
+			for (int i = 0; i < glyphs.size(); ++i) {
+				auto glyph_index = FT_Get_Char_Index(face, std::get<0>(glyphs[i]));
+
+				if (glyph_index == 0 || FT_Load_Glyph(face, glyph_index, FT_LOAD_MONOCHROME | FT_LOAD_TARGET_MONO) != FT_Err_Ok) {
+					rm2000_workaround = false;
+					break;
+				}
+				auto advance_x = Utils::RoundTo<int>(face->glyph->advance.x / 64.0);
+				if (advance_x != std::get<1>(glyphs[i])) {
+					rm2000_workaround = false;
+					break;
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This came up in yesterday's discussion on EasyRPGs chat:

The Mexican fangame "Necklace of Elements" (https://rmarchiv.de/games/3824) uses its own custom font that was based on the broken RM2000.fon file which needs to be interpreted & rendered with a fixed size of 6 pixels.

**EasyRPG loading up this custom "TLOZFONT":**
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/826100e7-ead8-45d9-8a6d-604d940af8d7" />

Previously, the Player only checked for the font's name which was replaced in this case, so some other heuristics are needed to identify it.

This PR adds a new check, that loads up some glyph sizes and checks if the characters for uppercase  **'I'** & **' '** are unusually wide (15 pixels) while other characters (**'h'**, lowercase **'l'**) have a fixed size of **6** & **4** respectively.
