### PR TITLE
Allow specifying where the languages folder is

### DIFF
--- a/resources/unix/easyrpg-player.6.adoc
+++ b/resources/unix/easyrpg-player.6.adoc
@@ -84,6 +84,10 @@ NOTE: For games that only use ASCII (English games) use '1252'.
 *--language* _LANG_::
   Loads the game translation in language/'LANG' folder.
 
+*--language-path* _PATH_::
+  Use the translations at 'PATH' instead of the translations
+  in the game's language folder.
+
 *--load-game-id* _ID_::
   Skip the title scene and load Save__ID__.lsd ('ID' is padded to two digits).
 

--- a/src/filefinder.cpp
+++ b/src/filefinder.cpp
@@ -61,6 +61,7 @@ namespace {
 	std::shared_ptr<Filesystem> root_fs;
 	FilesystemView game_fs;
 	FilesystemView save_fs;
+	FilesystemView lang_fs;
 }
 
 FilesystemView FileFinder::Game() {
@@ -128,6 +129,14 @@ FilesystemView FileFinder::Save() {
 
 void FileFinder::SetSaveFilesystem(FilesystemView filesystem) {
 	save_fs = filesystem;
+}
+
+FilesystemView FileFinder::Language() {
+	return lang_fs;
+}
+
+void FileFinder::SetLanguageFilesystem(FilesystemView filesystem) {
+	lang_fs = filesystem;
 }
 
 FilesystemView FileFinder::Root() {

--- a/src/filefinder.h
+++ b/src/filefinder.h
@@ -132,6 +132,20 @@ namespace FileFinder {
 	void SetSaveFilesystem(FilesystemView filesystem);
 
 	/**
+	 * A filesystem handle for file access inside the languages directory.
+	 *
+	 * @return Language filesystem handle
+	 */
+	FilesystemView Language();
+
+	/**
+	 * Sets the language filesystem.
+	 *
+	 * @param filesystem Language filesystem to use.
+	 */
+	void SetLanguageFilesystem(FilesystemView filesystem);
+
+	/**
 	 * Finds an image file in the current RPG Maker game.
 	 *
 	 * @param dir directory to check.

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -554,6 +554,16 @@ Game_Config Player::ParseCommandLine() {
 			}
 			continue;
 		}
+		if (cp.ParseNext(arg, 1, "--language-path") && arg.NumValues() > 0) {
+			if (arg.NumValues() > 0) {
+				auto langfs = FileFinder::Root().Create(FileFinder::MakeCanonical(arg.Value(0), 0));
+				if (!langfs) {
+					Output::Error("Invalid --language-path {}", arg.Value(0));
+				}
+				FileFinder::SetLanguageFilesystem(langfs);
+			}
+			continue;
+		}
 		if (cp.ParseNext(arg, 1, "--save-path")) {
 			if (arg.NumValues() > 0) {
 				auto savefs = FileFinder::Root().Create(FileFinder::MakeCanonical(arg.Value(0), 0));
@@ -1449,6 +1459,8 @@ Engine options:
  --font-path PATH     The path in which the settings scene looks for fonts.
                       The default is config-path/Font.
  --language LANG      Load the game translation in language/LANG folder.
+ --language-path PATH Use the translations at PATH instead of the translations
+                      in the language folder.
  --load-game-id N     Skip the title scene and load SaveN.lsd (N is padded to
                       two digits).
  --log-file FILE      Path to the logfile. The Player will write diagnostic

--- a/src/translation.cpp
+++ b/src/translation.cpp
@@ -90,13 +90,17 @@ void Translation::InitTranslations()
 	// Reset
 	Reset();
 
-	// Determine if the "languages" directory exists, and convert its case.
-	auto fs = FileFinder::Game();
-	auto game_tree = fs.ListDirectory();
-	for (const auto& tr_name : *game_tree) {
-		if (tr_name.first == TRDIR_NAME) {
-			translation_root_fs = fs.Subtree(tr_name.second.name);
-			break;
+	// Try the command-line --language-path option first before checking Language folder.
+	translation_root_fs = FileFinder::Language();
+	if (!translation_root_fs) {
+		// Determine if the "languages" directory exists, and convert its case.
+		auto fs = FileFinder::Game();
+		auto game_tree = fs.ListDirectory();
+		for (const auto& tr_name : *game_tree) {
+			if (tr_name.first == TRDIR_NAME) {
+				translation_root_fs = fs.Subtree(tr_name.second.name);
+				break;
+			}
 		}
 	}
 	if (translation_root_fs) {


### PR DESCRIPTION
This pull request adds a command line option, --language-path, which allows users to specify where the folder with all of the different language translations is.

The folder containing translations is currently only accessible in the Language folder inside of the game folder, but this often isn't convenient when the game files and the translations files are downloaded from different places. I often make a symlink to resolve this issue, but symlink support is dubious on Windows.