### PR TITLE
New Feature - Play Music From Timestamp

### DIFF
--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -357,6 +357,7 @@ protected:
 	int ManiacBitmask(int value, int mask) const;
 
 	lcf::rpg::SaveEventExecState _state;
+	bool _WatchingMusicState = false;
 	KeyInputState _keyinput;
 	AsyncOp _async_op = {};
 


### PR DESCRIPTION
Very dirty implementation of play music from timestamp.

TPC Syntax:
```cpp
@msg.choice {
    .case "MEMORIZE + TIMESTAMP" {
        @comment "memorize bgm"
        @cmd 11530, "", [0, 10] // [tick_variabletype, tick_variablevalue]
        
    }
    .case "PLAY MEMORIZED W TIMESTAMP" {
        @bgm.stop
        @comment "play memorized bgm"
        @cmd 11540, "", [0, 10] // [tick_variabletype, tick_variablevalue]
        
    }
    .cancel bl {
        
    }
}

```


I runs correctly with wav files. 

MIDI seems to have a glitch: Every time The music resets, the latest tick from the music is understood as 0:
 - first time playing a midi: 0 is 0
- if I reset the song at 9s: 9 is the new 0.
- If I reset the song again: 18s is the new 0.

----------------


(Oh boy, I can see this becoming another feature to never be aproved)