### PR TITLE
Fix Mosaic and Wave, and other transition issues

### DIFF
--- a/src/transition.cpp
+++ b/src/transition.cpp
@@ -211,7 +211,7 @@ void Transition::Draw(Bitmap& dst) {
 	case TransitionFadeIn:
 	case TransitionFadeOut:
 		dst.Blit(0, 0, *screen1, screen1->GetRect(), 255);
-		dst.Blit(0, 0, *screen2, screen2->GetRect(), 255 * (current_frame + 1) / (total_frames - 2);
+		dst.Blit(0, 0, *screen2, screen2->GetRect(), 255 * (current_frame + 1) / (total_frames - 2));
 		break;
 	case TransitionRandomBlocks:
 	case TransitionRandomBlocksDown:


### PR DESCRIPTION
See #3446

Fix the following:
- First frame not rendered because Update is called before Draw.
- Duration is wrong (too short).
- Stretching (bottom right extension) in Mosaic, due to the random offset range being incorrect.
- Background trailing in Wave due to blitting "nothing".
- Depth (horizontal movement) is 30 fps in Wave because Percentage is integer (truncation).
Phase (vertical movement) is wrong in half of the frames for the same reason.
- Blind visibly starts 5 frames late, and pacing is 4+6 instead of 5.
- Stripes are 30 fps like Depth.
- The scale is wrong in Zoom.
- Most of the other transitions (like Scroll and Combine/Division) are "choppy" (but not 30 fps like Stripes).

All transitions are frame-based now.
Percentage was removed



