### PR TITLE
Fix off-by-1 in Get Game Info: Get Tile bitfield

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -4184,10 +4184,10 @@ bool Game_Interpreter::CommandManiacGetGameInfo(lcf::rpg::EventCommand const& co
 			int32_t tile_layer = com.parameters[2]; // 0: Lower || 1: Upper
 			Rect tile_coords;
 
-			tile_coords.x = ValueOrVariableBitfield(com.parameters[0], 1, com.parameters[3]);
-			tile_coords.y = ValueOrVariableBitfield(com.parameters[0], 2, com.parameters[4]);
-			tile_coords.width = ValueOrVariableBitfield(com.parameters[0], 3, com.parameters[5]);
-			tile_coords.height = ValueOrVariableBitfield(com.parameters[0], 4, com.parameters[6]);
+			tile_coords.x = ValueOrVariableBitfield(com.parameters[0], 0, com.parameters[3]);
+			tile_coords.y = ValueOrVariableBitfield(com.parameters[0], 1, com.parameters[4]);
+			tile_coords.width = ValueOrVariableBitfield(com.parameters[0], 2, com.parameters[5]);
+			tile_coords.height = ValueOrVariableBitfield(com.parameters[0], 3, com.parameters[6]);
 
 			if (tile_coords.width <= 0 || tile_coords.height <= 0) return true;
 


### PR DESCRIPTION
According to tpc.exe bitfield offsets for Get Tile ID start at 0, not 1. I've modified the test map from #3330 and confirmed (on RPG_RT version 211010, im, patch_en) the command behaves as expected only if the initial offset is 0.

Modified maps with added cases for indirect inputs:
[Modified test map (correct behavior on RPG_RT, wrong on current EasyRPG)](https://github.com/user-attachments/files/23144869/tileid-offby1-test.zip)
[Modified test map adjusted for current EasyRPG (wrong behavior on RPG_RT, works on current EasyRPG)](https://github.com/user-attachments/files/23144871/tileid-offby1-test-bad.zip)
Both maps exhibit the same behavior on RPG_RT and EasyRPG (i.e. the 2nd one produces the exact same wrong results on both) with this PR applied.