### PR TITLE
Fix crash when using the clone event command on eventless map

### DIFF
--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -576,7 +576,11 @@ const lcf::rpg::Event* Game_Map::FindEventById(const std::vector<lcf::rpg::Event
 }
 
 int Game_Map::GetNextAvailableEventId() {
-	return map->events.back().ID + 1;
+	if (map->events.empty()) {
+		return 1;
+	} else {
+		return map->events.back().ID + 1;
+	}
 }
 
 void Game_Map::PrepareSave(lcf::rpg::Save& save) {


### PR DESCRIPTION
We were trying to get the back item of the events vector even when it was empty before.