### PR TITLE
Add config option allowing map loader to prefer RPG Maker files

### DIFF
--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -683,6 +683,7 @@ void Game_Config::LoadFromStream(Filesystem_Stream::InputStream& is) {
 	player.screenshot_timestamp.FromIni(ini);
 	player.automatic_screenshots.FromIni(ini);
 	player.automatic_screenshots_interval.FromIni(ini);
+	player.prefer_easyrpg_map_files.FromIni(ini);
 }
 
 void Game_Config::WriteToStream(Filesystem_Stream::OutputStream& os) const {
@@ -776,6 +777,7 @@ void Game_Config::WriteToStream(Filesystem_Stream::OutputStream& os) const {
 	player.screenshot_timestamp.ToIni(os);
 	player.automatic_screenshots.ToIni(os);
 	player.automatic_screenshots_interval.ToIni(os);
+	player.prefer_easyrpg_map_files.ToIni(os);
 
 	os << "\n";
 }

--- a/src/game_config.h
+++ b/src/game_config.h
@@ -108,6 +108,7 @@ struct Game_ConfigPlayer {
 	BoolConfigParam screenshot_timestamp{ "Screenshot timestamp", "Add the current date and time to the file name", "Player", "ScreenshotTimestamp", true };
 	BoolConfigParam automatic_screenshots{ "Automatic screenshots", "Periodically take screenshots", "Player", "AutomaticScreenshots", false };
 	RangeConfigParam<int> automatic_screenshots_interval{ "Screenshot interval", "The interval between automatic screenshots (seconds)", "Player", "AutomaticScreenshotsInterval", 30, 1, 999999 };
+	BoolConfigParam prefer_easyrpg_map_files{ "Prefer EasyRPG map files", "Attempt to load EasyRPG map files (.emu) first and fall back to RPG Maker map files (.lmu)", "Player", "PreferEasyRpgMapFiles", true };
 
 	void Hide();
 };


### PR DESCRIPTION
Adds a new boolean to the player config: `PreferEasyRpgMapFiles` (default: `true`)

This makes the map loader attempt to load EasyRPG map files first, and fall back to RPG Maker map files on errors. Since it defaults to `true`, this PR retains the existing behavior of the EasyRPG Player, which attempts to load EasyRPG map files first.

I just wanted a way to turn this behavior off in my game, as it creates issues with my VCS setup (essentially, a pre-commit hook that runs lcf2xml on all the files in the project).

QA steps I tried:

* New option set to the default of `1` (true) in config:
  * .emu and .lmu present -> Player loads .emu ✅ 
  * .emu present, .lmu not present -> Player loads .emu ✅ 
  * .emu not present, .lmu present -> Player loads .lmu ✅ 
  * .emu and .lmu not present -> Player crashes with expected error (`Error: Loading of Map Map0001.lmu failed.` -- notice it loaded the .lmu last) ✅ 
* New option set to `0` (false) in config:
  * .emu and .lmu present -> Player loads .lmu ✅ 
  * .emu present, .lmu not present -> Player loads .emu ✅ 
  * .emu not present, .lmu present -> Player loads .lmu ✅ 
  * .emu and .lmu not present -> Player crashes with expected error (`Error: Loading of Map Map0001.emu failed.` -- notice it loaded the .emu last) ✅ 
* New option missing from config uses default value (`1`) ✅ 