### PR TITLE
Maniacs Patch - Zoom Command

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -4402,6 +4402,7 @@ bool Game_Interpreter::CommandManiacZoom(lcf::rpg::EventCommand const& com) {
 		SetupWaitFrames(duration);
 	}
 
+	Output::Debug("Maniac Zoom: CenterX {}, CenterY {}, Rate {}, Duration {}, Layer {}", center_x, center_y, rate, duration, layer);
 	return true;
 }
 

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -812,6 +812,8 @@ bool Game_Interpreter::ExecuteCommand(lcf::rpg::EventCommand const& com) {
 			return CmdSetup<&Game_Interpreter::CommandManiacGetGameInfo, 8>(com);
 		case Cmd::EasyRpg_SetInterpreterFlag:
 			return CmdSetup<&Game_Interpreter::CommandEasyRpgSetInterpreterFlag, 2>(com);
+		case static_cast<Cmd>(3032): // Maniac_Zoom
+			return CmdSetup<&Game_Interpreter_Map::CommandManiacZoom, 7>(com);
 		case Cmd::EasyRpg_ProcessJson:
 			return CmdSetup<&Game_Interpreter::CommandEasyRpgProcessJson, 8>(com);
 		case Cmd::EasyRpg_CloneMapEvent:
@@ -4360,6 +4362,45 @@ bool Game_Interpreter::CommandManiacGetGameInfo(lcf::rpg::EventCommand const& co
 	}
 
 	Game_Map::SetNeedRefresh(true);
+
+	return true;
+}
+
+bool Game_Interpreter::CommandManiacZoom(lcf::rpg::EventCommand const& com) {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	if (com.parameters.size() < 7) {
+		Output::Warning("Maniac Zoom: Insufficient parameters");
+		return true;
+	}
+
+	// Parameter[0] contains the modes packed in 4-bit chunks
+	int center_x = ValueOrVariableBitfield(com, 0, 0, 1);
+	int center_y = ValueOrVariableBitfield(com, 0, 1, 2);
+	int rate = ValueOrVariableBitfield(com, 0, 2, 3);
+	int duration = ValueOrVariableBitfield(com, 0, 3, 4);
+	int layer = ValueOrVariableBitfield(com, 0, 4, 5);
+	bool wait = com.parameters[6] != 0;
+
+	// Maniacs Patch behavior: Rate < 0 is invalid/ignored usually, but safe to clamp to 100%
+	if (rate < 0) {
+		rate = 100;
+	}
+
+	// Layer 0 indicates cancellation/reset in Maniacs
+	if (layer <= 0) {
+		layer = 0;
+		// Reset rate to 100% when disabling to ensure clean state, 
+		rate = 100;
+	}
+
+	Main_Data::game_screen->SetZoom(center_x, center_y, rate, duration, layer);
+
+	if (wait && duration > 0) {
+		SetupWaitFrames(duration);
+	}
 
 	return true;
 }

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -311,6 +311,7 @@ protected:
 	bool CommandEasyRpgCloneMapEvent(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgDestroyMapEvent(lcf::rpg::EventCommand const& com);
 	bool CommandManiacGetGameInfo(lcf::rpg::EventCommand const& com);
+	bool CommandManiacZoom(lcf::rpg::EventCommand const& com);
 
 	void SetSubcommandIndex(int indent, int idx);
 	uint8_t& ReserveSubcommandIndex(int indent);

--- a/src/game_screen.h
+++ b/src/game_screen.h
@@ -132,6 +132,15 @@ public:
 	 */
 	void CancelBattleAnimation();
 
+	// Maniac Zoom Support
+	void SetZoom(int x, int y, int rate, int duration, int layer);
+	void UpdateZoom();
+
+	int GetZoomLayer() const { return maniac_zoom_layer; }
+	double GetZoomRate() const { return maniac_zoom_current_rate; }
+	int GetZoomX() const { return Utils::RoundTo<int>(maniac_zoom_current_x); }
+	int GetZoomY() const { return Utils::RoundTo<int>(maniac_zoom_current_y); }
+
 	/**
 	 * Whether or not a battle animation is currently playing.
 	 */
@@ -193,6 +202,17 @@ private:
 
 protected:
 	std::vector<Particle> particles;
+
+	// Maniac Zoom State
+	double maniac_zoom_current_x = 0.0;
+	double maniac_zoom_current_y = 0.0;
+	int maniac_zoom_target_x = 0;
+	int maniac_zoom_target_y = 0;
+
+	double maniac_zoom_current_rate = 1.0;
+	double maniac_zoom_target_rate = 1.0;
+	int maniac_zoom_time_left = 0;
+	int maniac_zoom_layer = 0; // 0 = Disabled
 
 	void StopWeather();
 	void UpdateRain();

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -127,7 +127,7 @@ static Drawable::Z_t GetZForManiacLayer(int layer) {
 	if (layer >= 10) return std::numeric_limits<Drawable::Z_t>::max();
 
 	// Layer 9 (Windows) includes Message Text (Overlay)
-	if (layer == 9) return Priority_Overlay;
+	if (layer == 9) return Priority_Frame;
 
 	// For layers 1-8, the range ends just before the start of the *next* logical layer group.
 	Drawable::Z_t next_layer_start = 0;


### PR DESCRIPTION
Implements Maniac Zoom support, allowing zooming of specific map layers with configurable center, rate, duration, and layer Itself. 

- Adds new interpreter command: 3032
- zoom state management in Game_Screen: SetZoom() and UpdateZoom()
- and rendering logic in Graphics to apply zoom transforms to selected layers:  GetZForManiacLayer() - It has a weird reordenation of those entries, Graphics::LocalDraw()

-----------------------

Right now lacks support on savefiles.