### PR TITLE
Maniac CallCommand - Add ResolveEventCommand

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -591,7 +591,7 @@ void Game_Interpreter::SkipToNextConditional(std::initializer_list<Cmd> codes, i
 	}
 
 	for (++index; index < static_cast<int>(list.size()); ++index) {
-		const auto& com = list[index];
+		const auto& com = ResolveEventCommand(list[index]);
 		if (com.indent > indent) {
 			continue;
 		}
@@ -877,17 +877,22 @@ std::vector<std::string> Game_Interpreter::GetChoices(int max_num_choices) {
 	auto& index = frame.current_command;
 
 	// Let's find the choices
-	int current_indent = list[index + 1].indent;
+	if (index + 1 >= static_cast<int>(list.size())) return {};
+
+	auto first_opt = ResolveEventCommand(list[index + 1]);
+	int current_indent = first_opt.indent;
+
 	std::vector<std::string> s_choices;
 	for (int index_temp = index + 1; index_temp < static_cast<int>(list.size()); ++index_temp) {
-		const auto& com = list[index_temp];
+		auto com = ResolveEventCommand(list[index_temp]);
+
 		if (com.indent != current_indent) {
 			continue;
 		}
 
 		if (static_cast<Cmd>(com.code) == Cmd::ShowChoiceOption && com.parameters.size() > 0 && com.parameters[0] < max_num_choices) {
 			// Choice found
-			s_choices.push_back(ToString(list[index_temp].string));
+			s_choices.push_back(ToString(com.string));
 		}
 
 		if (static_cast<Cmd>(com.code) == Cmd::ShowChoiceEnd) {
@@ -927,29 +932,37 @@ bool Game_Interpreter::CommandShowMessage(lcf::rpg::EventCommand const& com) { /
 	++index;
 
 	// Check for continued lines via ShowMessage_2
-	while (index < static_cast<int>(list.size()) && static_cast<Cmd>(list[index].code) == Cmd::ShowMessage_2) {
-		// Add second (another) line
-		pm.PushLine(ToString(list[index].string));
-		++index;
+	while (index < static_cast<int>(list.size())) {
+		auto next_cmd = ResolveEventCommand(list[index]);
+
+		if (static_cast<Cmd>(next_cmd.code) == Cmd::ShowMessage_2) {
+			pm.PushLine(ToString(next_cmd.string));
+			++index;
+		}
+		else {
+			break;
+		}
 	}
 
 	// Handle Choices or number
 	if (index < static_cast<int>(list.size())) {
-		// If next event command is show choices
-		if (static_cast<Cmd>(list[index].code) == Cmd::ShowChoice) {
+		auto next_cmd = ResolveEventCommand(list[index]);
+
+		if (static_cast<Cmd>(next_cmd.code) == Cmd::ShowChoice) {
 			std::vector<std::string> s_choices = GetChoices(4);
 			// If choices fit on screen
 			if (static_cast<int>(s_choices.size()) <= (4 - pm.NumLines())) {
-				pm.SetChoiceCancelType(list[index].parameters[0]);
-				SetupChoices(s_choices, com.indent, pm);
+				pm.SetChoiceCancelType(next_cmd.parameters[0]);
+				SetupChoices(s_choices, next_cmd.indent, pm);
 				++index;
 			}
-		} else if (static_cast<Cmd>(list[index].code) == Cmd::InputNumber) {
 			// If next event command is input number
 			// If input number fits on screen
+		}
+		else if (static_cast<Cmd>(next_cmd.code) == Cmd::InputNumber) {
 			if (pm.NumLines() < 4) {
-				int digits = list[index].parameters[0];
-				int variable_id = list[index].parameters[1];
+				int digits = next_cmd.parameters[0];
+				int variable_id = next_cmd.parameters[1];
 				pm.PushNumInput(variable_id, digits);
 				++index;
 			}
@@ -2076,7 +2089,7 @@ std::optional<bool> Game_Interpreter::HandleDynRpgScript(const lcf::rpg::EventCo
 
 		// Concat everything that is not another command or a new comment block
 		for (size_t i = index + 1; i < list.size(); ++i) {
-			const auto& cmd = list[i];
+			const auto& cmd = ResolveEventCommand(list[i]);
 			if (cmd.code == static_cast<uint32_t>(Cmd::Comment_2) &&
 					!cmd.string.empty() && cmd.string[0] != '@') {
 				command += ToString(cmd.string);
@@ -3802,9 +3815,11 @@ bool Game_Interpreter::CommandJumpToLabel(lcf::rpg::EventCommand const& com) { /
 	int label_id = com.parameters[0];
 
 	for (int idx = 0; (size_t)idx < list.size(); idx++) {
-		if (static_cast<Cmd>(list[idx].code) != Cmd::Label)
+		auto scanned_cmd = ResolveEventCommand(list[idx]);
+
+		if (static_cast<Cmd>(scanned_cmd.code) != Cmd::Label)
 			continue;
-		if (list[idx].parameters.empty() || list[idx].parameters[0] != label_id)
+		if (scanned_cmd.parameters.empty() || scanned_cmd.parameters[0] != label_id)
 			continue;
 		index = idx;
 		break;
@@ -3884,19 +3899,19 @@ bool Game_Interpreter::CommandBreakLoop(lcf::rpg::EventCommand const& /* com */)
 
 	bool has_bug = !Player::IsPatchManiac();
 	if (!has_bug) {
-		SkipToNextConditional({ Cmd::EndLoop }, list[index].indent - 1);
+		SkipToNextConditional({ Cmd::EndLoop }, ResolveEventCommand(list[index]).indent - 1);
 		++index;
 		return true;
 	}
 
 	// This emulates an RPG_RT bug where break loop ignores scopes and
 	// unconditionally jumps to the next EndLoop command.
-	auto pcode = static_cast<Cmd>(list[index].code);
+	auto pcode = static_cast<Cmd>(ResolveEventCommand(list[index]).code);
 	for (++index; index < (int)list.size(); ++index) {
 		if (pcode == Cmd::EndLoop) {
 			break;
 		}
-		pcode = static_cast<Cmd>(list[index].code);
+		pcode = static_cast<Cmd>(ResolveEventCommand(list[index]).code);
 	}
 
 	return true;
@@ -3962,11 +3977,13 @@ bool Game_Interpreter::CommandEndLoop(lcf::rpg::EventCommand const& com) { // co
 
 	// Restart the loop
 	for (int idx = index; idx >= 0; idx--) {
-		if (list[idx].indent > indent)
+		auto scanned_cmd = ResolveEventCommand(list[idx]);
+
+		if (scanned_cmd.indent > indent)
 			continue;
-		if (list[idx].indent < indent)
+		if (scanned_cmd.indent < indent)
 			return false;
-		if (static_cast<Cmd>(list[idx].code) != Cmd::Loop)
+		if (static_cast<Cmd>(scanned_cmd.code) != Cmd::Loop)
 			continue;
 		index = idx;
 		break;
@@ -5461,9 +5478,9 @@ bool Game_Interpreter::CommandManiacWritePicture(lcf::rpg::EventCommand const& c
 	return true;
 }
 
-bool Game_Interpreter::CommandManiacCallCommand(lcf::rpg::EventCommand const& com) {
-	if (!Player::IsPatchManiac()) {
-		return true;
+lcf::rpg::EventCommand Game_Interpreter::ResolveEventCommand(const lcf::rpg::EventCommand& com) {
+	if (static_cast<Cmd>(com.code) != Cmd::Maniac_CallCommand || !Player::IsPatchManiac()) {
+		return com;
 	}
 
 	enum class ProcessingMode {
@@ -5519,22 +5536,21 @@ bool Game_Interpreter::CommandManiacCallCommand(lcf::rpg::EventCommand const& co
 	}
 	default:
 		Output::Warning("Call Command: Unsupported Processing Mode: {}", static_cast<int>(processing_mode));
-		return true;
+		return com;
 	}
 
 	// Finalize command parameters
 	cmd.parameters = lcf::DBArray<int32_t>(values.begin(), values.end());
 
-	// Debug output
-	/*Output::Warning("Processing mode: {}", static_cast<int>(processing_mode));
-	Output::Warning("Command code: {}", cmd.code);
-	Output::Warning("Command string: {}", cmd.string);
-	std::string params_str;
-	for (const auto& param : values) {
-		params_str += " " + std::to_string(param);
+	return cmd;
+}
+
+bool Game_Interpreter::CommandManiacCallCommand(lcf::rpg::EventCommand const& com) {
+	if (!Player::IsPatchManiac()) {
+		return true;
 	}
-	Output::Warning("Command parameters:{}", params_str);
-	Output::Info("--------------------\n");*/
+
+	const auto& cmd = ResolveEventCommand(com);
 
 	// Our implementation pushes a new frame containing the command instead of invoking it directly.
 	// This is incompatible to Maniacs but has a better compatibility with our code.

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -879,12 +879,11 @@ std::vector<std::string> Game_Interpreter::GetChoices(int max_num_choices) {
 	// Let's find the choices
 	if (index + 1 >= static_cast<int>(list.size())) return {};
 
-	auto first_opt = ResolveEventCommand(list[index + 1]);
-	int current_indent = first_opt.indent;
+	int current_indent = ResolveEventCommand(list[index + 1]).indent;
 
 	std::vector<std::string> s_choices;
 	for (int index_temp = index + 1; index_temp < static_cast<int>(list.size()); ++index_temp) {
-		auto com = ResolveEventCommand(list[index_temp]);
+		const auto& com = ResolveEventCommand(list[index_temp]);
 
 		if (com.indent != current_indent) {
 			continue;
@@ -933,7 +932,7 @@ bool Game_Interpreter::CommandShowMessage(lcf::rpg::EventCommand const& com) { /
 
 	// Check for continued lines via ShowMessage_2
 	while (index < static_cast<int>(list.size())) {
-		auto next_cmd = ResolveEventCommand(list[index]);
+		const auto& next_cmd = ResolveEventCommand(list[index]);
 
 		if (static_cast<Cmd>(next_cmd.code) == Cmd::ShowMessage_2) {
 			pm.PushLine(ToString(next_cmd.string));
@@ -946,7 +945,8 @@ bool Game_Interpreter::CommandShowMessage(lcf::rpg::EventCommand const& com) { /
 
 	// Handle Choices or number
 	if (index < static_cast<int>(list.size())) {
-		auto next_cmd = ResolveEventCommand(list[index]);
+		// If next event command is show choices
+		const auto& next_cmd = ResolveEventCommand(list[index]);
 
 		if (static_cast<Cmd>(next_cmd.code) == Cmd::ShowChoice) {
 			std::vector<std::string> s_choices = GetChoices(4);
@@ -956,10 +956,10 @@ bool Game_Interpreter::CommandShowMessage(lcf::rpg::EventCommand const& com) { /
 				SetupChoices(s_choices, next_cmd.indent, pm);
 				++index;
 			}
-			// If next event command is input number
-			// If input number fits on screen
 		}
 		else if (static_cast<Cmd>(next_cmd.code) == Cmd::InputNumber) {
+			// If next event command is input number and
+			// input number fits on screen
 			if (pm.NumLines() < 4) {
 				int digits = next_cmd.parameters[0];
 				int variable_id = next_cmd.parameters[1];
@@ -3815,11 +3815,11 @@ bool Game_Interpreter::CommandJumpToLabel(lcf::rpg::EventCommand const& com) { /
 	int label_id = com.parameters[0];
 
 	for (int idx = 0; (size_t)idx < list.size(); idx++) {
-		auto scanned_cmd = ResolveEventCommand(list[idx]);
+		const auto& next_cmd = ResolveEventCommand(list[idx]);
 
-		if (static_cast<Cmd>(scanned_cmd.code) != Cmd::Label)
+		if (static_cast<Cmd>(next_cmd.code) != Cmd::Label)
 			continue;
-		if (scanned_cmd.parameters.empty() || scanned_cmd.parameters[0] != label_id)
+		if (next_cmd.parameters.empty() || next_cmd.parameters[0] != label_id)
 			continue;
 		index = idx;
 		break;
@@ -3977,13 +3977,13 @@ bool Game_Interpreter::CommandEndLoop(lcf::rpg::EventCommand const& com) { // co
 
 	// Restart the loop
 	for (int idx = index; idx >= 0; idx--) {
-		auto scanned_cmd = ResolveEventCommand(list[idx]);
+		const auto& next_cmd = ResolveEventCommand(list[idx]);
 
-		if (scanned_cmd.indent > indent)
+		if (next_cmd.indent > indent)
 			continue;
-		if (scanned_cmd.indent < indent)
+		if (next_cmd.indent < indent)
 			return false;
-		if (static_cast<Cmd>(scanned_cmd.code) != Cmd::Loop)
+		if (static_cast<Cmd>(next_cmd.code) != Cmd::Loop)
 			continue;
 		index = idx;
 		break;
@@ -5478,7 +5478,7 @@ bool Game_Interpreter::CommandManiacWritePicture(lcf::rpg::EventCommand const& c
 	return true;
 }
 
-lcf::rpg::EventCommand Game_Interpreter::ResolveEventCommand(const lcf::rpg::EventCommand& com) {
+const lcf::rpg::EventCommand& Game_Interpreter::ResolveEventCommand(const lcf::rpg::EventCommand& com) {
 	if (static_cast<Cmd>(com.code) != Cmd::Maniac_CallCommand || !Player::IsPatchManiac()) {
 		return com;
 	}
@@ -5494,7 +5494,7 @@ lcf::rpg::EventCommand Game_Interpreter::ResolveEventCommand(const lcf::rpg::Eve
 	std::vector<int32_t> values;
 
 	// Create command with basic parameters
-	lcf::rpg::EventCommand cmd;
+	lcf::rpg::EventCommand& cmd = resolved_cmd;
 	cmd.code = ValueOrVariableBitfield(com.parameters[0], 0, com.parameters[1]);
 
 	cmd.string = lcf::DBString(CommandStringOrVariableBitfield(com, 0, 3, 4));
@@ -5541,6 +5541,19 @@ lcf::rpg::EventCommand Game_Interpreter::ResolveEventCommand(const lcf::rpg::Eve
 
 	// Finalize command parameters
 	cmd.parameters = lcf::DBArray<int32_t>(values.begin(), values.end());
+
+	// Debug output
+	/*
+	Output::Warning("Processing mode: {}", static_cast<int>(processing_mode));
+	Output::Warning("Command code: {}", cmd.code);
+	Output::Warning("Command string: {}", cmd.string);
+	std::string params_str;
+	for (const auto& param : values) {
+		params_str += " " + std::to_string(param);
+	}
+	Output::Warning("Command parameters:{}", params_str);
+	Output::Info("--------------------\n");
+	*/
 
 	return cmd;
 }

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -5499,6 +5499,9 @@ const lcf::rpg::EventCommand& Game_Interpreter::ResolveEventCommand(const lcf::r
 
 	cmd.string = lcf::DBString(CommandStringOrVariableBitfield(com, 0, 3, 4));
 
+	// Preserve the indentation level so loops and branches can find their pairs
+	cmd.indent = com.indent;
+
 	// Determine processing mode
 	auto processing_mode = static_cast<ProcessingMode>((com.parameters[0] >> 4) & 0b1111);
 
@@ -5565,11 +5568,27 @@ bool Game_Interpreter::CommandManiacCallCommand(lcf::rpg::EventCommand const& co
 
 	const auto& cmd = ResolveEventCommand(com);
 
-	// Our implementation pushes a new frame containing the command instead of invoking it directly.
-	// This is incompatible to Maniacs but has a better compatibility with our code.
-	Push<ExecutionType::Eval, EventType::None>({ cmd }, GetCurrentEventId(), 0);
-
-	return true;
+	switch (static_cast<Cmd>(cmd.code)) {
+		case Cmd::JumpToLabel:
+		case Cmd::Label:
+		case Cmd::Loop:
+		case Cmd::BreakLoop:
+		case Cmd::EndLoop:
+		case Cmd::EndEventProcessing:
+		case Cmd::EraseEvent:
+			// Everything that is flow control must (unfortunately) run inside
+			// current frame
+			return ExecuteCommand(cmd);
+		default: {
+			// In all other cases our implementation is incompatible to Maniacs
+			// and pushes a new frame containing the command instead of invoking
+			// it directly. Is safer to do.
+			auto new_cmd = cmd;
+			new_cmd.indent = 0; // reset the indent
+			Push<ExecutionType::Eval, EventType::None>({ new_cmd }, GetCurrentEventId(), 0);
+			return true;
+		}
+	}
 }
 
 bool Game_Interpreter::CommandEasyRpgSetInterpreterFlag(lcf::rpg::EventCommand const& com) {

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -86,6 +86,13 @@ public:
 	void InputButton();
 	void SetupChoices(const std::vector<std::string>& choices, int indent, PendingMessage& pm);
 
+	/*
+	 * Resolves a Maniac Patch @cmd (Call Command) into the actual EventCommand it represents.
+	 * If the input is not a @cmd, it returns the input copy.
+	 * This handles variables, pointers, and expressions to build the final command.
+	*/
+	lcf::rpg::EventCommand ResolveEventCommand(const lcf::rpg::EventCommand& com);
+
 	bool ExecuteCommand();
 	virtual bool ExecuteCommand(lcf::rpg::EventCommand const& com);
 

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -86,16 +86,18 @@ public:
 	void InputButton();
 	void SetupChoices(const std::vector<std::string>& choices, int indent, PendingMessage& pm);
 
-	/*
+	/**
 	 * Resolves a Maniac Patch @cmd (Call Command) into the actual EventCommand it represents.
-	 * If the input is not a @cmd, it returns the input copy.
-	 * This handles variables, pointers, and expressions to build the final command.
-	*/
-	lcf::rpg::EventCommand ResolveEventCommand(const lcf::rpg::EventCommand& com);
+	 * If the input is not a @cmd it returns the command itself.
+	 * The resolved command is shared and overwritten on subsequent calls.
+	 *
+	 * @param com Command to process
+	 * @return com itself or a parsed Call Command
+	 */
+	const lcf::rpg::EventCommand& ResolveEventCommand(const lcf::rpg::EventCommand& com);
 
 	bool ExecuteCommand();
 	virtual bool ExecuteCommand(lcf::rpg::EventCommand const& com);
-
 
 	/**
 	 * Returns the interpreters current state information.
@@ -368,17 +370,20 @@ protected:
 	KeyInputState _keyinput;
 	AsyncOp _async_op = {};
 
-	private:
-		void PushInternal(
-			InterpreterPush push_info,
-			std::vector<lcf::rpg::EventCommand> _list,
-			int _event_id,
-			int event_page_id = 0
-		);
+	/** Shared instance for ResolveEventCommand */
+	lcf::rpg::EventCommand resolved_cmd;
 
-		void PushInternal(Game_Event* ev, InterpreterExecutionType ex_type);
-		void PushInternal(Game_Event* ev, const lcf::rpg::EventPage* page, InterpreterExecutionType ex_type);
-		void PushInternal(Game_CommonEvent* ev, InterpreterExecutionType ex_type);
+private:
+	void PushInternal(
+		InterpreterPush push_info,
+		std::vector<lcf::rpg::EventCommand> _list,
+		int _event_id,
+		int event_page_id = 0
+	);
+
+	void PushInternal(Game_Event* ev, InterpreterExecutionType ex_type);
+	void PushInternal(Game_Event* ev, const lcf::rpg::EventPage* page, InterpreterExecutionType ex_type);
+	void PushInternal(Game_CommonEvent* ev, InterpreterExecutionType ex_type);
 
 	friend class Game_Interpreter_Inspector;
 };


### PR DESCRIPTION
in maniacs this is a thing:
<img width="890" height="282" alt="image" src="https://github.com/user-attachments/assets/9d5441bb-62cf-4bf8-bbc4-ed1ba32cc745" />


To support it, this PR Introduces the ResolveEventCommand method to process Maniac Patch @cmd (Call Command) event commands, resolving them into their actual form. Refactors interpreter logic to use this method where event commands are accessed, ensuring correct handling of Maniac Patch commands and improving compatibility. Updates function signatures and documentation accordingly.

Test map (dog npc):
[Map0003.zip](https://github.com/user-attachments/files/24127171/Map0003.zip)
