### PR TITLE
Always calculate the Panorama Render Offset - Fixes #3342

### DIFF
--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -329,9 +329,13 @@ void Spriteset_Map::CalculatePanoramaRenderOffset() {
 	if (Player::game_config.fake_resolution.Get()) {
 		if (Game_Map::Parallax::FakeXPosition()) {
 			panorama->SetRenderOx((Player::screen_width - SCREEN_TARGET_WIDTH) / 2);
+		} else {
+			panorama->SetRenderOx(0);
 		}
 		if (Game_Map::Parallax::FakeYPosition()) {
 			panorama->SetRenderOy((Player::screen_height - SCREEN_TARGET_HEIGHT) / 2);
+		} else {
+			panorama->SetRenderOy(0);
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes #3342 by always calculating the Panorama Render Offset.

Without this commit, theses actions display a broken Panorama : 
1. Use a "custom resolution" with the "fake resolution mode" (ex. screen width at 416px)
2. Use a Panorama smaller than the screen (ex. width 320 px), the Panorama will be centered (**OK**)
3. Change the Panorama with an image having the same size of the screen (ex. width of 416px), the offset won't be recalculated and the Panorama will keep the previous offset instead of filling the screen (**KO**)