### PR TITLE
Add IgnoreAbsentBattleAnimationFlash to Player config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /easyrpg-player
 /Player.app
+/EasyRPG Player.app
 *.a
 *.elf
 *.o
@@ -8,6 +9,7 @@
 *.bak
 
 # cmake
+.cmake/
 /Makefile
 CMakeFiles/
 CMakeScripts/
@@ -19,6 +21,17 @@ CPackSourceConfig.cmake
 CTestTestfile.cmake
 cmake_install.cmake
 install_manifest.txt
+.deps/
+.dirstamp
+.version-append
+.version-git
+aclocal.m4
+autom4te.cache/
+builds/autoconf/
+config.h
+config.h.in
+config.status
+stamp-h1
 
 # msvc / Windows
 *.vcxproj*

--- a/src/battle_animation.cpp
+++ b/src/battle_animation.cpp
@@ -208,6 +208,7 @@ void BattleAnimation::UpdateScreenFlash() {
 }
 
 void BattleAnimation::UpdateTargetFlash() {
+	if (Player::player_config.ignore_absent_battle_animation_flash.Get() && target_flash_timing == -1) return;
 	int r, g, b, p;
 	UpdateFlashGeneric(target_flash_timing, r, g, b, p);
 	FlashTargets(r, g, b, p);

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -684,6 +684,7 @@ void Game_Config::LoadFromStream(Filesystem_Stream::InputStream& is) {
 	player.automatic_screenshots.FromIni(ini);
 	player.automatic_screenshots_interval.FromIni(ini);
 	player.prefer_easyrpg_map_files.FromIni(ini);
+	player.ignore_absent_battle_animation_flash.FromIni(ini);
 }
 
 void Game_Config::WriteToStream(Filesystem_Stream::OutputStream& os) const {
@@ -778,6 +779,7 @@ void Game_Config::WriteToStream(Filesystem_Stream::OutputStream& os) const {
 	player.automatic_screenshots.ToIni(os);
 	player.automatic_screenshots_interval.ToIni(os);
 	player.prefer_easyrpg_map_files.ToIni(os);
+	player.ignore_absent_battle_animation_flash.ToIni(os);
 
 	os << "\n";
 }

--- a/src/game_config.h
+++ b/src/game_config.h
@@ -109,6 +109,7 @@ struct Game_ConfigPlayer {
 	BoolConfigParam automatic_screenshots{ "Automatic screenshots", "Periodically take screenshots", "Player", "AutomaticScreenshots", false };
 	RangeConfigParam<int> automatic_screenshots_interval{ "Screenshot interval", "The interval between automatic screenshots (seconds)", "Player", "AutomaticScreenshotsInterval", 30, 1, 999999 };
 	BoolConfigParam prefer_easyrpg_map_files{ "Prefer EasyRPG map files", "Attempt to load EasyRPG map files (.emu) first and fall back to RPG Maker map files (.lmu)", "Player", "PreferEasyRpgMapFiles", true };
+	BoolConfigParam ignore_absent_battle_animation_flash{ "Ignore absent battle animation flash", "In RPG Maker, Battle Animations may override flashes on an event, even if the animation does not utilize flashes. Disables that behavior if true.", "Player", "IgnoreAbsentBattleAnimationFlash", false };
 
 	void Hide();
 };


### PR DESCRIPTION
It is common for developers to use the `Flash Event` command rapidly in order to tint the player's sprite.

If a developer uses the `Show Animation` command at the same time, the animation will override the flash from `Flash Event`, even if the animation does not contain any flashes. This behavior is present in both RPG Maker 2003 and EasyRPG.

In my game for example, I am using Flash Event to darken the player sprite in a dark cave map. Also, when the player equips any item anywhere in the game, I play an animation using Show Animation. If the player equips an item in the cave map, despite the animation not containing any flashing, the Flash Event command appears to stop working for the duration of the animation. This causes the player sprite to appear untinted briefly.

----

This PR adds a new option to the Player config: `IgnoreAbsentBattleAnimationFlash` (default: false -- retains prior behavior)

When `true`, battle animations that do not contain flashes will not override flashes from other sources, including Flash Event. Battle animations that do contain flashes still behave as before.

If this isn't the kind of change you want to pull in, feel free to reject, I just needed this for my game and thought others might run into the same issue, as tinting the player is fairly common in Yume Nikki fan games.