### PR TITLE
Revert "Refactored window_message, so that page setup is handled afte…

### DIFF
--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -190,8 +190,11 @@ void Window_Message::StartMessageProcessing(PendingMessage pm) {
 
 	DebugLog("{}: MSG TEXT \n{}", text);
 
-	disallow_next_message = true;
-	msg_was_pushed_this_frame = true;
+	auto open_frames = (!IsVisible() && !Game_Battle::IsBattleRunning()) ? message_animation_frames : 0;
+	SetOpenAnimation(open_frames);
+	DebugLog("{}: MSG START OPEN {}", open_frames);
+
+	InsertNewPage();
 }
 
 void Window_Message::OnFinishPage() {
@@ -416,7 +419,7 @@ void Window_Message::Update() {
 	if (IsClosing()) { DebugLog("{}: MSG CLOSING"); }
 
 	close_started_this_frame = false;
-	disallow_next_message = false;
+	close_finished_this_frame = false;
 
 	const bool was_closing = IsClosing();
 
@@ -425,22 +428,10 @@ void Window_Message::Update() {
 	gold_window->Update();
 
 	if (was_closing && !IsClosing()) {
-		disallow_next_message = true;
+		close_finished_this_frame = true;
 	}
 
 	if (!IsVisible()) {
-		if (msg_was_pushed_this_frame) {
-			msg_was_pushed_this_frame = false;
-			disallow_next_message = true;
-			return;
-		}
-		if (!text.empty() && text_index == text.data()) {
-			auto open_frames = (!IsVisible() && !Game_Battle::IsBattleRunning()) ? message_animation_frames : 0;
-			SetOpenAnimation(open_frames);
-			DebugLog("{}: MSG START OPEN {}", open_frames);
-			
-			InsertNewPage();
-		}
 		return;
 	}
 

--- a/src/window_message.h
+++ b/src/window_message.h
@@ -165,9 +165,8 @@ protected:
 	// FIXME: This hacky flags exist because RPG_RT likely animates the message window
 	// after the game loop finishes. Our code isn't structured that way, so we must hack
 	// around it.
-	bool msg_was_pushed_this_frame = false;
 	bool close_started_this_frame = false;
-	bool disallow_next_message = false;
+	bool close_finished_this_frame = false;
 
 	/** Frames to wait when a message wait command was used */
 	int wait_count = 0;
@@ -215,8 +214,8 @@ inline AsyncOp Window_Message::GetAsyncOp() const {
 }
 
 inline bool Window_Message::GetAllowNextMessage(bool foreground) const {
-	bool is_active = (IsVisible() || disallow_next_message);
-	return foreground ? !is_active || (close_started_this_frame && !disallow_next_message): !is_active;
+	bool is_active = (IsVisible() || close_finished_this_frame);
+	return foreground ? !is_active || close_started_this_frame : !is_active;
 }
 
 inline int Window_Message::GetMaxLinesPerPage() const {


### PR DESCRIPTION
…r the foreground interpreter has been processed (Fix #2432 / #2932)"

This reverts commit 8cbb694c37d1a7d2b986c3403b5208972a36af73.

---

This patch breaks too many stuff, already discovered two in a few days:

Going to bed at the beginning of "Human's Red Destiny" #3518  (that issue is something else)

The pictures shown next to the message boxes in [EP_Test.zip](https://github.com/user-attachments/files/25482046/EP_Test.zip) fade out too early (should be at the end of the message)

