### PR TITLE
Windows & emscripten: Fix SDL3 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -584,6 +584,10 @@ if(PLAYER_TARGET_PLATFORM STREQUAL "SDL3")
 	if(ANDROID)
 		set(PLAYER_BUILD_EXECUTABLE OFF)
 	endif()
+
+	if(WIN32)
+		target_link_libraries(${PROJECT_NAME} "Dwmapi")
+	endif()
 elseif(PLAYER_TARGET_PLATFORM STREQUAL "SDL2")
 	target_sources(${PROJECT_NAME} PRIVATE
 		src/platform/sdl/sdl2_ui.cpp

--- a/resources/emscripten/emscripten-post.js
+++ b/resources/emscripten/emscripten-post.js
@@ -1,18 +1,3 @@
-// Move to different directory to prevent save file collisions in IDBFS
-FS.mkdir("easyrpg");
-FS.chdir("easyrpg");
-
-if (Module.game.length > 0) {
-  FS.mkdir(Module.game);
-  FS.chdir(Module.game);
-}
-
-// Use IDBFS for save file storage when the filesystem was not
-// overwritten by a custom emscripten shell file
-if (Module.saveFs === undefined) {
-  Module.saveFs = IDBFS;
-}
-
 Module.initApi = function() {
   Module.api_private.download_js = function (buffer, size, filename) {
     const blob = new Blob([Module.HEAPU8.slice(buffer, buffer + size)]);

--- a/resources/emscripten/emscripten-pre.js
+++ b/resources/emscripten/emscripten-pre.js
@@ -90,8 +90,23 @@ function parseArgs () {
 }
 
 function onPreRun () {
+  // Move to different directory to prevent save file collisions in IDBFS
+  FS.mkdir("easyrpg");
+  FS.chdir("easyrpg");
+
+  if (Module.game.length > 0) {
+    FS.mkdir(Module.game);
+    FS.chdir(Module.game);
+  }
+
   // Retrieve save directory from persistent storage before using it
   FS.mkdir("Save");
+
+  // Use IDBFS for save file storage when the filesystem was not
+  // overwritten by a custom emscripten shell file
+  if (Module.saveFs === undefined) {
+    Module.saveFs = IDBFS;
+  }
   FS.mount(Module.saveFs, {}, 'Save');
 
   // For preserving the configuration. Shared across website

--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -19,7 +19,7 @@
 #include <fstream>
 #include <map>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #  include <emscripten.h>
 #  include <lcf/reader_util.h>
 #  include <nlohmann/json.hpp>
@@ -45,7 +45,7 @@ namespace {
 	std::unordered_map<std::string, FileRequestAsync> async_requests;
 	std::unordered_map<std::string, std::string> file_mapping;
 	int next_id = 0;
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	int index_version = 1;
 #endif
 
@@ -69,7 +69,7 @@ namespace {
 		return std::make_shared<int>(next_id++);
 	}
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	constexpr size_t ASYNC_MAX_RETRY_COUNT{ 16 };
 
 	struct async_download_context {
@@ -140,7 +140,7 @@ namespace {
 }
 
 void AsyncHandler::CreateRequestMapping(const std::string& file) {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	auto f = FileFinder::Game().OpenInputStream(file);
 	if (!f) {
 		Output::Error("Emscripten: Reading index.json failed");
@@ -263,7 +263,7 @@ bool AsyncHandler::IsFilePending(bool important, bool graphic) {
 }
 
 void AsyncHandler::SaveFilesystem() {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	// Save changed file system
 	EM_ASM({
 		FS.syncfs(function(err) {
@@ -316,7 +316,7 @@ void FileRequestAsync::Start() {
 
 	state = State_Pending;
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	std::string request_path;
 #  ifdef EM_GAME_URL
 	request_path = EM_GAME_URL;
@@ -388,7 +388,7 @@ void FileRequestAsync::Start() {
 }
 
 void FileRequestAsync::UpdateProgress() {
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
 	// Fake download for testing event handlers
 
 	if (!IsReady() && Rand::ChanceOf(1, 100)) {
@@ -435,7 +435,7 @@ void FileRequestAsync::DownloadDone(bool success) {
 	}
 
 	if (success) {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 		if (state == State_Pending) {
 			// Update directory structure (new file was added)
 			if (FileFinder::Game()) {

--- a/src/exe_reader.cpp
+++ b/src/exe_reader.cpp
@@ -17,7 +17,7 @@
 
 // All of this code is unused on EMSCRIPTEN. *Do not use it*!
 
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
 
 #include "exe_reader.h"
 #include "image_bmp.h"

--- a/src/filefinder_rtp.cpp
+++ b/src/filefinder_rtp.cpp
@@ -32,7 +32,7 @@
 #endif
 
 FileFinder_RTP::FileFinder_RTP(bool no_rtp, bool no_rtp_warnings, std::string rtp_path) {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	// No RTP support for emscripten at the moment.
 	disable_rtp = true;
 #else

--- a/src/game_destiny.cpp
+++ b/src/game_destiny.cpp
@@ -19,9 +19,9 @@
 #include "game_destiny.h"
 #include "filefinder.h"
 
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
 #include "exe_reader.h"
-#endif // !EMSCRIPTEN
+#endif // !__EMSCRIPTEN__
 #include "output.h"
 
 using Destiny::InterpretFlag;
@@ -52,7 +52,7 @@ void Game_Destiny::Load()
 	uint32_t floatSize = 0;
 	uint32_t stringSize = 0;
 
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
 	Filesystem_Stream::InputStream exe = FileFinder::Game().OpenFile(EXE_NAME);
 
 	if (exe)
@@ -80,7 +80,7 @@ void Game_Destiny::Load()
 	gameVersion = 0x20000107;
 	extra = 0x01;
 	dwordSize = floatSize = stringSize = 0x64;
-#endif // !EMSCRIPTEN
+#endif // !__EMSCRIPTEN__
 
 	Initialize(dllVersion, language, gameVersion, extra, dwordSize, floatSize, stringSize);
 }

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -52,7 +52,7 @@ public:
 	static Game_Interpreter& GetForegroundInterpreter();
 
 	Game_Interpreter(bool _main_flag = false);
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
 	// No idea why but emscripten will complain about a missing destructor when
 	// using virtual here
 	virtual

--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -1723,7 +1723,7 @@ void Game_Map::SetPositionX(int x, bool reset_panorama) {
 	const int map_width = GetTilesX() * SCREEN_TILE_SIZE;
 	if (LoopHorizontal()) {
 		x = Utils::PositiveModulo(x, map_width);
-		
+
 		// If the map is too small to fit in the screen, add an offset corresponding to the black border's size
 		if (Player::game_config.fake_resolution.Get()) {
 			int map_width_in_pixels = Game_Map::GetTilesX() * TILE_SIZE;
@@ -2016,7 +2016,7 @@ std::string Game_Map::ConstructMapName(int map_id, bool is_easyrpg) {
 }
 
 FileRequestAsync* Game_Map::RequestMap(int map_id) {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	Player::translation.RequestAndAddMap(map_id);
 #endif
 
@@ -2157,7 +2157,7 @@ void Game_Map::Parallax::ResetPositionX() {
 	if (!params.scroll_horz && !LoopHorizontal()) {
 		// What is the width of the panorama to display on screen?
 		int pan_screen_width = Player::screen_width;
-		if (Player::game_config.fake_resolution.Get()) {			
+		if (Player::game_config.fake_resolution.Get()) {
 			int map_width = Game_Map::GetTilesX() * TILE_SIZE;
 			if (map_width < pan_screen_width) {
 				pan_screen_width = map_width;

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -76,7 +76,7 @@ void Graphics::UpdateTitle() {
 		return;
 	}
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	return;
 #else
 	std::string fps;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -26,7 +26,7 @@
 #include <chrono>
 #include <fmt/color.h>
 #include <fmt/ostream.h>
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #  include "platform/emscripten/interface.h"
 #endif
 
@@ -137,7 +137,7 @@ void Output::SetLogCallback(LogCallbackFn fn, LogCallbackUserData userdata) {
 
 static void WriteLog(LogLevel lvl, std::string const& msg, Color const& c = Color()) {
 // skip writing log file
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
 	std::string prefix = Output::LogLevelToString(lvl) + ": ";
 
 	// Every new message is written once to the file.
@@ -198,7 +198,7 @@ void Output::Quit() {
 }
 
 bool Output::TakeScreenshot(bool is_auto_screenshot) {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	Emscripten_Interface::TakeScreenshot(is_auto_screenshot);
 	return true;
 #else
@@ -286,7 +286,7 @@ void Output::ErrorStr(std::string const& err) {
 #if defined (PLAYER_NINTENDO) || defined(__vita__)
 		// stdin is non-blocking
 		Game_Clock::SleepFor(5s);
-#elif defined (EMSCRIPTEN)
+#elif defined (__EMSCRIPTEN__)
 		// Don't show JavaScript Window.prompt from stdin call
 		std::cout << " Process finished.";
 #else

--- a/src/platform/clock.h
+++ b/src/platform/clock.h
@@ -34,7 +34,7 @@ using Platform_Clock = NxClock;
 #elif defined(__vita__)
 #include "platform/psvita/clock.h"
 using Platform_Clock = Psp2Clock;
-#elif defined(EMSCRIPTEN)
+#elif defined(__EMSCRIPTEN__)
 #include "platform/emscripten/clock.h"
 using Platform_Clock = EmscriptenClock;
 #elif defined(USE_LIBRETRO)

--- a/src/platform/sdl/main.cpp
+++ b/src/platform/sdl/main.cpp
@@ -22,8 +22,10 @@
 #include "utils.h"
 #include "output.h"
 
-#if USE_SDL == 3 // This is needed on Windows, SDL wraps main()
+#if USE_SDL == 3
 #  include <SDL3/SDL.h>
+// This is needed on Windows, SDL wraps main()
+#  include <SDL3/SDL_main.h>
 #elif USE_SDL <= 2
 #  include <SDL.h>
 #endif

--- a/src/platform/sdl/sdl2_audio.cpp
+++ b/src/platform/sdl/sdl2_audio.cpp
@@ -26,7 +26,7 @@
 #include <SDL_audio.h>
 #include <SDL_version.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #  include <emscripten.h>
 #endif
 
@@ -75,7 +75,7 @@ Sdl2Audio::Sdl2Audio(const Game_ConfigAudio& cfg) :
 		return;
 	}
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	// Get preferred sample rate from Browser (-> OS)
 	const int frequency = EM_ASM_INT_V({
 		var context;

--- a/src/platform/sdl/sdl2_ui.cpp
+++ b/src/platform/sdl/sdl2_ui.cpp
@@ -28,7 +28,7 @@
 #elif defined(__ANDROID__)
 #  include <jni.h>
 #  include <SDL_system.h>
-#elif defined(EMSCRIPTEN)
+#elif defined(__EMSCRIPTEN__)
 #  include <emscripten.h>
 #elif defined(__WIIU__)
 #  include "platform/wiiu/main.h"
@@ -169,7 +169,7 @@ Sdl2Ui::Sdl2Ui(long width, long height, const Game_Config& cfg) : BaseUi(cfg)
 	// Set the application class name
 	setenv("SDL_VIDEO_X11_WMCLASS", GAME_TITLE, 0);
 #endif
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	SDL_SetHint(SDL_HINT_EMSCRIPTEN_ASYNCIFY, "0");
 	// Only handle keyboard events when the canvas has focus
 	SDL_SetHint(SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT, "#canvas");
@@ -317,7 +317,7 @@ void Sdl2Ui::EndDisplayModeChange() {
 			}
 
 			current_display_mode.effective = true;
-#if defined(EMSCRIPTEN) || defined(__PS4__)
+#if defined(__EMSCRIPTEN__) || defined(__PS4__)
 			SetIsFullscreen(true);
 #else
 			SetIsFullscreen((current_display_mode.flags & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP);
@@ -348,7 +348,7 @@ bool Sdl2Ui::RefreshDisplayMode() {
 		SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
 		#endif
 
-		#if defined(EMSCRIPTEN) || defined(_WIN32)
+		#if defined(__EMSCRIPTEN__) || defined(_WIN32)
 		// FIXME: This will not DPI-scale on Windows due to SDL2 limitations.
 		// Is properly fixed in SDL3. See #2764
 		flags |= SDL_WINDOW_ALLOW_HIGHDPI;
@@ -443,7 +443,7 @@ bool Sdl2Ui::RefreshDisplayMode() {
 		window_sg.Dismiss();
 	} else {
 		// Browser handles fast resizing for emscripten, TODO: use fullscreen API
-#if !defined(EMSCRIPTEN) && !defined(__PS4__)
+#if !defined(__EMSCRIPTEN__) && !defined(__PS4__)
 		bool is_fullscreen = (flags & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP;
 		if (is_fullscreen) {
 			SDL_SetWindowFullscreen(sdl_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
@@ -833,7 +833,7 @@ void Sdl2Ui::ProcessWindowEvent(SDL_Event &evnt) {
 		window.width = evnt.window.data1;
 		window.height = evnt.window.data2;
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 		double display_ratio = emscripten_get_device_pixel_ratio();
 		window.width = static_cast<int>(window.width * display_ratio);
 		window.height = static_cast<int>(window.height * display_ratio);
@@ -887,7 +887,7 @@ void Sdl2Ui::ProcessMouseMotionEvent(SDL_Event& evnt) {
 		return;
 	}
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	double display_ratio = emscripten_get_device_pixel_ratio();
 	mouse_pos.x = (evnt.motion.x * display_ratio - viewport.x) * main_surface->width() / xw;
 	mouse_pos.y = (evnt.motion.y * display_ratio - viewport.y) * main_surface->height() / yh;
@@ -1027,7 +1027,7 @@ void Sdl2Ui::ProcessFingerEvent(SDL_Event& evnt) {
 			return;
 		}
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 		double display_ratio = emscripten_get_device_pixel_ratio();
 		int x = (evnt.tfinger.x * display_ratio - viewport.x) * main_surface->width() / xw;
 		int y = (evnt.tfinger.y * display_ratio - viewport.y) * main_surface->height() / yh;
@@ -1273,7 +1273,7 @@ int FilterUntilFocus(const SDL_Event* evnt) {
 }
 
 void Sdl2Ui::vGetConfig(Game_ConfigVideo& cfg) const {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	cfg.renderer.Lock("SDL2 (Software, Emscripten)");
 #elif defined(__wii__)
 	cfg.renderer.Lock("SDL2 (Software, Wii)");
@@ -1307,7 +1307,7 @@ void Sdl2Ui::vGetConfig(Game_ConfigVideo& cfg) const {
 	cfg.window_zoom.Set(current_display_mode.zoom);
 	cfg.fullscreen.Set(IsFullscreen());
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	// Fullscreen is handled by the browser
 	cfg.fullscreen.SetOptionVisible(false);
 	cfg.fps_limit.SetOptionVisible(false);

--- a/src/platform/sdl/sdl2_ui.cpp
+++ b/src/platform/sdl/sdl2_ui.cpp
@@ -439,13 +439,6 @@ bool Sdl2Ui::RefreshDisplayMode() {
 			return false;
 		}
 
-#ifdef _WIN32
-		HWND window = GetWindowHandle(sdl_window);
-		// Not using the enum names because this will fail to build when not using a recent Windows 11 SDK
-		int window_rounding = 1; // DWMWCP_DONOTROUND
-		DwmSetWindowAttribute(window, 33 /* DWMWA_WINDOW_CORNER_PREFERENCE */, &window_rounding, sizeof(window_rounding));
-#endif
-
 		renderer_sg.Dismiss();
 		window_sg.Dismiss();
 	} else {
@@ -469,6 +462,13 @@ bool Sdl2Ui::RefreshDisplayMode() {
 	// Need to set up icon again, some platforms recreate the window when
 	// creating the renderer (i.e. Windows), see also comment in SetAppIcon()
 	SetAppIcon();
+
+#ifdef _WIN32
+	HWND window = GetWindowHandle(sdl_window);
+	// Not using the enum names because this will fail to build when not using a recent Windows 11 SDK
+	int window_rounding = 1; // DWMWCP_DONOTROUND
+	DwmSetWindowAttribute(window, 33 /* DWMWA_WINDOW_CORNER_PREFERENCE */, &window_rounding, sizeof(window_rounding));
+#endif
 
 	uint32_t sdl_pixel_fmt = GetDefaultFormat();
 	int a, w, h;

--- a/src/platform/sdl/sdl3_audio.cpp
+++ b/src/platform/sdl/sdl3_audio.cpp
@@ -25,7 +25,7 @@
 #include <chrono>
 #include <SDL3/SDL.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #  include <emscripten.h>
 #endif
 
@@ -78,7 +78,7 @@ Sdl3Audio::Sdl3Audio(const Game_ConfigAudio& cfg) :
 		return;
 	}
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	// Get preferred sample rate from Browser (-> OS)
 	const int frequency = EM_ASM_INT_V({
 		var context;

--- a/src/platform/sdl/sdl3_ui.cpp
+++ b/src/platform/sdl/sdl3_ui.cpp
@@ -25,7 +25,6 @@
 
 #ifdef _WIN32
 #  include <windows.h>
-#  include <SDL_syswm.h>
 #  include <dwmapi.h>
 #elif defined(__ANDROID__)
 #  include <jni.h>
@@ -86,14 +85,11 @@ static DynamicFormat GetDynamicFormat(uint32_t fmt) {
 
 #ifdef _WIN32
 HWND GetWindowHandle(SDL_Window* window) {
-	SDL_SysWMinfo wminfo;
-	SDL_VERSION(&wminfo.version)
-	SDL_bool success = SDL_GetWindowWMInfo(window, &wminfo);
-
-	if (success < 0)
-		Output::Error("Wrong SDL version");
-
-	return wminfo.info.win.window;
+	return (HWND)SDL_GetPointerProperty(
+		SDL_GetWindowProperties(window),
+		SDL_PROP_WINDOW_WIN32_HWND_POINTER,
+		NULL
+	);
 }
 #endif
 
@@ -304,9 +300,7 @@ bool Sdl3Ui::RefreshDisplayMode() {
 		#endif
 
 		#if defined(EMSCRIPTEN) || defined(_WIN32)
-		// FIXME: This will not DPI-scale on Windows due to SDL2 limitations.
-		// Is properly fixed in SDL3. See #2764
-		flags |= SDL_WINDOW_ALLOW_HIGHDPI;
+		flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
 		#endif
 
 		// Create our window
@@ -380,13 +374,6 @@ bool Sdl3Ui::RefreshDisplayMode() {
 
 		SDL_SetTextureScaleMode(sdl_texture_game, SDL_SCALEMODE_NEAREST);
 
-#ifdef _WIN32
-		HWND window = GetWindowHandle(sdl_window);
-		// Not using the enum names because this will fail to build when not using a recent Windows 11 SDK
-		int window_rounding = 1; // DWMWCP_DONOTROUND
-		DwmSetWindowAttribute(window, 33 /* DWMWA_WINDOW_CORNER_PREFERENCE */, &window_rounding, sizeof(window_rounding));
-#endif
-
 		renderer_sg.Dismiss();
 		window_sg.Dismiss();
 	} else {
@@ -410,6 +397,13 @@ bool Sdl3Ui::RefreshDisplayMode() {
 	// Need to set up icon again, some platforms recreate the window when
 	// creating the renderer (i.e. Windows), see also comment in SetAppIcon()
 	SetAppIcon();
+
+#ifdef _WIN32
+	HWND window = GetWindowHandle(sdl_window);
+	// Not using the enum names because this will fail to build when not using a recent Windows 11 SDK
+	int window_rounding = 1; // DWMWCP_DONOTROUND
+	DwmSetWindowAttribute(window, 33 /* DWMWA_WINDOW_CORNER_PREFERENCE */, &window_rounding, sizeof(window_rounding));
+#endif
 
 	uint32_t sdl_pixel_fmt = GetDefaultFormat();
 

--- a/src/platform/sdl/sdl3_ui.cpp
+++ b/src/platform/sdl/sdl3_ui.cpp
@@ -29,7 +29,7 @@
 #elif defined(__ANDROID__)
 #  include <jni.h>
 #  include <SDL_system.h>
-#elif defined(EMSCRIPTEN)
+#elif defined(__EMSCRIPTEN__)
 #  include <emscripten.h>
 #elif defined(__WIIU__)
 #  include "platform/wiiu/main.h"
@@ -111,7 +111,7 @@ Sdl3Ui::Sdl3Ui(long width, long height, const Game_Config& cfg) : BaseUi(cfg)
 	// Set the application class name
 	setenv("SDL_VIDEO_X11_WMCLASS", GAME_TITLE, 0);
 #endif
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	SDL_SetHint(SDL_HINT_EMSCRIPTEN_ASYNCIFY, "0");
 	// Only handle keyboard events when the canvas has focus
 	SDL_SetHint(SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT, "#canvas");
@@ -260,7 +260,7 @@ void Sdl3Ui::EndDisplayModeChange() {
 			}
 
 			current_display_mode.effective = true;
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 			SetIsFullscreen(true);
 #else
 			SetIsFullscreen((current_display_mode.flags & SDL_WINDOW_FULLSCREEN) == SDL_WINDOW_FULLSCREEN);
@@ -299,7 +299,7 @@ bool Sdl3Ui::RefreshDisplayMode() {
 		SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
 		#endif
 
-		#if defined(EMSCRIPTEN) || defined(_WIN32)
+		#if defined(__EMSCRIPTEN__) || defined(_WIN32)
 		flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
 		#endif
 
@@ -378,7 +378,7 @@ bool Sdl3Ui::RefreshDisplayMode() {
 		window_sg.Dismiss();
 	} else {
 		// Browser handles fast resizing for emscripten, TODO: use fullscreen API
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
 		bool is_fullscreen = (flags & SDL_WINDOW_FULLSCREEN) == SDL_WINDOW_FULLSCREEN;
 		if (is_fullscreen) {
 			SDL_SetWindowFullscreen(sdl_window, SDL_WINDOW_FULLSCREEN);
@@ -756,7 +756,7 @@ void Sdl3Ui::ProcessWindowEvent(SDL_Event &evnt) {
 		window.width = evnt.window.data1;
 		window.height = evnt.window.data2;
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 		double display_ratio = emscripten_get_device_pixel_ratio();
 		window.width = static_cast<int>(window.width * display_ratio);
 		window.height = static_cast<int>(window.height * display_ratio);
@@ -809,7 +809,7 @@ void Sdl3Ui::ProcessMouseMotionEvent(SDL_Event& evnt) {
 		return;
 	}
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	double display_ratio = emscripten_get_device_pixel_ratio();
 	mouse_pos.x = (evnt.motion.x * display_ratio - viewport.x) * main_surface->width() / xw;
 	mouse_pos.y = (evnt.motion.y * display_ratio - viewport.y) * main_surface->height() / yh;
@@ -949,7 +949,7 @@ void Sdl3Ui::ProcessFingerEvent(SDL_Event& evnt) {
 			return;
 		}
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 		double display_ratio = emscripten_get_device_pixel_ratio();
 		int x = (evnt.tfinger.x * display_ratio - viewport.x) * main_surface->width() / xw;
 		int y = (evnt.tfinger.y * display_ratio - viewport.y) * main_surface->height() / yh;
@@ -1191,7 +1191,7 @@ int FilterUntilFocus(const SDL_Event* evnt) {
 }
 
 void Sdl3Ui::vGetConfig(Game_ConfigVideo& cfg) const {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	cfg.renderer.Lock("SDL2 (Software, Emscripten)");
 #elif defined(__wii__)
 	cfg.renderer.Lock("SDL2 (Software, Wii)");
@@ -1218,7 +1218,7 @@ void Sdl3Ui::vGetConfig(Game_ConfigVideo& cfg) const {
 	cfg.window_zoom.Set(current_display_mode.zoom);
 	cfg.fullscreen.Set(IsFullscreen());
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	// Fullscreen is handled by the browser
 	cfg.fullscreen.SetOptionVisible(false);
 	cfg.fps_limit.SetOptionVisible(false);

--- a/src/platform/sdl/sdl3_ui.cpp
+++ b/src/platform/sdl/sdl3_ui.cpp
@@ -756,12 +756,6 @@ void Sdl3Ui::ProcessWindowEvent(SDL_Event &evnt) {
 		window.width = evnt.window.data1;
 		window.height = evnt.window.data2;
 
-#ifdef __EMSCRIPTEN__
-		double display_ratio = emscripten_get_device_pixel_ratio();
-		window.width = static_cast<int>(window.width * display_ratio);
-		window.height = static_cast<int>(window.height * display_ratio);
-#endif
-
 		window.size_changed = true;
 	}
 }
@@ -809,14 +803,8 @@ void Sdl3Ui::ProcessMouseMotionEvent(SDL_Event& evnt) {
 		return;
 	}
 
-#ifdef __EMSCRIPTEN__
-	double display_ratio = emscripten_get_device_pixel_ratio();
-	mouse_pos.x = (evnt.motion.x * display_ratio - viewport.x) * main_surface->width() / xw;
-	mouse_pos.y = (evnt.motion.y * display_ratio - viewport.y) * main_surface->height() / yh;
-#else
 	mouse_pos.x = (evnt.motion.x - viewport.x) * main_surface->width() / xw;
 	mouse_pos.y = (evnt.motion.y - viewport.y) * main_surface->height() / yh;
-#endif
 
 #else
 	/* unused */
@@ -949,14 +937,8 @@ void Sdl3Ui::ProcessFingerEvent(SDL_Event& evnt) {
 			return;
 		}
 
-#ifdef __EMSCRIPTEN__
-		double display_ratio = emscripten_get_device_pixel_ratio();
-		int x = (evnt.tfinger.x * display_ratio - viewport.x) * main_surface->width() / xw;
-		int y = (evnt.tfinger.y * display_ratio - viewport.y) * main_surface->height() / yh;
-#else
 		int x = (evnt.tfinger.x - viewport.x) * main_surface->width() / xw;
 		int y = (evnt.tfinger.y - viewport.y) * main_surface->height() / yh;
-#endif
 
 		fi->Down(evnt.tfinger.fingerID, x, y);
 	} else if (evnt.type == SDL_EVENT_FINGER_UP) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -27,7 +27,7 @@
 #ifdef _WIN32
 #  include "platform/windows/utils.h"
 #  include <windows.h>
-#elif defined(EMSCRIPTEN)
+#elif defined(__EMSCRIPTEN__)
 #  include <emscripten.h>
 #endif
 
@@ -90,7 +90,7 @@
 #include "platform/android/android.h"
 #endif
 
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
 // This is not used on Emscripten.
 #include "exe_reader.h"
 #endif
@@ -135,7 +135,7 @@ namespace Player {
 	int rng_seed = -1;
 	Game_ConfigPlayer player_config;
 	Game_ConfigGame game_config;
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	std::string emscripten_game_name;
 #endif
 	Game_Clock::time_point last_auto_screenshot;
@@ -217,7 +217,7 @@ void Player::Run() {
 	Game_Clock::ResetFrame(Game_Clock::now());
 
 	// Main loop
-#if defined(USE_LIBRETRO) || defined(EMSCRIPTEN)
+#if defined(USE_LIBRETRO) || defined(__EMSCRIPTEN__)
 	// emscripten implemented in main.cpp
 	// libretro invokes the MainLoop through a retro_run-callback
 #else
@@ -412,7 +412,7 @@ void Player::Exit() {
 	}
 
 	Graphics::UpdateSceneCallback();
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	BitmapRef surface = DisplayUi->GetDisplaySurface();
 	std::string message = "It's now safe to turn off\n      your browser.";
 	DisplayUi->CleanDisplay();
@@ -678,7 +678,7 @@ Game_Config Player::ParseCommandLine() {
 			exit(0);
 			break;
 		}
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 		if (cp.ParseNext(arg, 1, "--game")) {
 			if (arg.NumValues() > 0) {
 				emscripten_game_name = arg.Value(0);
@@ -777,7 +777,7 @@ void Player::CreateGameObjects() {
 	int& engine = game_config.engine;
 	std::unordered_map<Game_Constants::ConstantType, int32_t> game_constant_overrides;
 
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
 	// Attempt reading ExFont and version information from RPG_RT.exe (not supported on Emscripten)
 	std::unique_ptr<EXEReader> exe_reader;
 	const auto exe_file = game_config.engine_path.Get().empty() ? EXE_NAME : game_config.engine_path.Get();
@@ -1358,7 +1358,7 @@ std::string Player::GetEncoding() {
 			if (db) {
 				std::vector<std::string> encodings = lcf::ReaderUtil::DetectEncodings(*db);
 
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
 				for (std::string &enc : encodings) {
 					// Heuristic: Check title graphic, system graphic, cursor SE, title BGM
 					// Pure ASCII is skipped as it provides no added value

--- a/src/player.h
+++ b/src/player.h
@@ -431,7 +431,7 @@ namespace Player {
 	/** game specific configuration */
 	extern Game_ConfigGame game_config;
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	/** Name of game emscripten uses */
 	extern std::string emscripten_game_name;
 #endif

--- a/src/scene_file.cpp
+++ b/src/scene_file.cpp
@@ -31,7 +31,7 @@
 #include <lcf/reader_util.h>
 #include "output.h"
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #  include <emscripten.h>
 #  include "platform/emscripten/interface.h"
 #endif
@@ -148,7 +148,7 @@ void Scene_File::Start() {
 	}
 
 	std::vector<std::string> commands;
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	commands.emplace_back("Download Savegame");
 	commands.emplace_back("Upload Savegame");
 #endif
@@ -200,7 +200,7 @@ void Scene_File::vUpdate() {
 			Main_Data::game_system->SePlay(Main_Data::game_system->GetSystemSE(Main_Data::game_system->SFX_Buzzer));
 		}
 	} else if (Input::IsTriggered(Input::SHIFT)) {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 		extra_commands_window->SetX(SCREEN_TARGET_WIDTH - extra_commands_window->GetWidth() - 8);
 		extra_commands_window->SetY(file_windows[index]->GetY() + 8);
 		extra_commands_window->SetItemEnabled(0, file_windows[index]->IsValid() && file_windows[index]->HasParty());
@@ -297,7 +297,7 @@ bool Scene_File::HandleExtraCommandsWindow() {
 
 	extra_commands_window->Update();
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	if (Input::IsTriggered(Input::DECISION)) {
 		if (extra_commands_window->GetIndex() == 0) {
 			// Download

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -131,7 +131,7 @@ bool Scene_Logo::DetectGame() {
 		FileFinder::SetGameFilesystem(fs);
 	}
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	static bool once = true;
 	if (once) {
 		FileRequestAsync* index = AsyncHandler::RequestFile("index.json");
@@ -225,7 +225,7 @@ std::vector<std::vector<uint8_t>> Scene_Logo::LoadLogos() {
 		}
 	}
 
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
 	if (logos.empty()) {
 		// Attempt reading Logos from RPG_RT.exe (not supported on Emscripten)
 		auto exeis = FileFinder::Game().OpenFile(EXE_NAME);

--- a/src/scene_save.cpp
+++ b/src/scene_save.cpp
@@ -18,7 +18,7 @@
 // Headers
 #include "game_constants.h"
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #  include <emscripten.h>
 #endif
 

--- a/src/scene_settings.cpp
+++ b/src/scene_settings.cpp
@@ -40,7 +40,7 @@
 #include "window_settings.h"
 #include <memory>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #  include <emscripten.h>
 #endif
 

--- a/src/system.h
+++ b/src/system.h
@@ -44,7 +44,7 @@
 #  define SUPPORT_JOYSTICK
 #  define SUPPORT_JOYSTICK_AXIS
 #  define SUPPORT_TOUCH
-#elif defined(EMSCRIPTEN)
+#elif defined(__EMSCRIPTEN__)
 #  define SUPPORT_MOUSE
 #  define SUPPORT_TOUCH
 #  define SUPPORT_JOYSTICK

--- a/src/window_gamelist.cpp
+++ b/src/window_gamelist.cpp
@@ -55,7 +55,7 @@ bool Window_GameList::Refresh(FilesystemView filesystem_base, bool show_dotdot) 
 #endif
 		assert(!dir.second.name.empty() && "VFS BUG: Empty filename in the folder");
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 		if (dir.second.name == "Save") {
 			continue;
 		}
@@ -159,7 +159,7 @@ void Window_GameList::DrawItem(int index) {
 
 void Window_GameList::DrawErrorText(bool show_dotdot) {
 	std::vector<std::string> error_msg = {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 		"Did you type in a wrong URL?",
 		"",
 		"If you think this is an error, contact the owner",
@@ -183,7 +183,7 @@ void Window_GameList::DrawErrorText(bool show_dotdot) {
 
 	int y = (show_dotdot ? 4 + 14 : 0);
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	contents->TextDraw(0, y, Font::ColorKnockout, "The game was not found.");
 #else
 	contents->TextDraw(0, y, Font::ColorKnockout, "No games found in the current directory.");

--- a/src/window_settings.cpp
+++ b/src/window_settings.cpp
@@ -35,7 +35,7 @@
 #include "audio_midi.h"
 #include "audio_generic_midiout.h"
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #  include "platform/emscripten/interface.h"
 #endif
 
@@ -380,7 +380,7 @@ void Window_Settings::RefreshAudioSoundfont() {
 		opt.help2 = "Changes take effect when a new MIDI file is played";
 	}
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	AddOption(MenuItem("<Upload Soundfont>", "Provide a soundfont from your system", ""), [fs]() { Emscripten_Interface::UploadSoundfont(); });
 #elif defined(SUPPORT_FILE_BROWSER)
 	AddOption(MenuItem("<Open Soundfont directory>", "Open the soundfont directory in a file browser", ""), [fs]() { DisplayUi->OpenURL(fs.GetFullPath()); });
@@ -530,7 +530,7 @@ void Window_Settings::RefreshEngineFont(bool mincho) {
 	});
 	set_help2();
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	AddOption(MenuItem("<Upload Font>", "Provide a font from your system", ""), [fs]() { Emscripten_Interface::UploadFont(); });
 #elif defined(SUPPORT_FILE_BROWSER)
 	AddOption(MenuItem("<Open Font directory>", "Open the font directory in a file browser", ""), [fs]() { DisplayUi->OpenURL(fs.GetFullPath()); });
@@ -620,7 +620,7 @@ void Window_Settings::RefreshLicense() {
 #ifdef WANT_FONT_WQY
 	AddOption(MenuItem("WenQuanYi", "WenQuanYi font family (CJK)", "GPLv2+ with FE"), [](){});
 #endif
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	AddOption(MenuItem("Teenyicons", "Tiny minimal 1px icons", "MIT"), [](){});
 #endif
 }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -3,12 +3,12 @@
 
 #include "output.h"
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
 
 int main(int argc, char** argv) {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 	EM_ASM({
 		FS.mkdir(UTF8ToString($0));
 		FS.mount(NODEFS, { root: UTF8ToString($1) }, UTF8ToString($0));


### PR DESCRIPTION
Also the "disable rounding of windows" flag was lost when leaving fullscreen mode.

Fixed this also for SDL2