### PR TITLE
Pathfinder Command: fix GCC 15 -Wnonnull warning 

### DIFF
--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -945,7 +945,7 @@ bool Game_Interpreter_Map::CommandEasyRpgPathfinder(lcf::rpg::EventCommand const
 		int var = ValueOrVariable(com.parameters[11], com.parameters[12]);
 		int num_events_ids = Main_Data::game_variables->Get(var);
 		auto lst = Main_Data::game_variables->GetRange(var + 1, num_events_ids);
-		std::copy(lst.begin(), lst.end(), event_id_ignore_list.begin());
+		std::copy(lst.begin(), lst.end(), std::back_inserter(event_id_ignore_list));
 		ni = 13;
 	}
 	args.event_id_ignore_list = event_id_ignore_list;

--- a/src/game_variables.cpp
+++ b/src/game_variables.cpp
@@ -211,6 +211,7 @@ void Game_Variables::WriteArray(const int first_id_a, const int last_id_a, const
 
 std::vector<Var_t> Game_Variables::GetRange(int variable_id, int length) {
 	std::vector<Var_t> vars;
+	vars.reserve(length);
 	for (int i = 0; i < length; ++i) {
 		vars.push_back(Get(variable_id + i));
 	}


### PR DESCRIPTION
`event_id_ignore_list.begin()` pointed at an empty vector. I don't have a game to test this with, but it looks like it should not have worked before.