### PR TITLE
Encounter rate: Fix off-by-one error

### DIFF
--- a/src/game_player.cpp
+++ b/src/game_player.cpp
@@ -752,7 +752,7 @@ void Game_Player::UpdateEncounterSteps() {
 	const auto ratio = GetTotalEncounterRate() / encounter_steps;
 
 	auto& idx = last_encounter_idx;
-	while (ratio > enc_table[idx+1].ratio) {
+	while (ratio >= enc_table[idx+1].ratio) {
 		++idx;
 	}
 	const auto& row = enc_table[idx];


### PR DESCRIPTION
Honestly not sure if this is 100% correct but it "feels" at least closer to RPG2k3 now when testing.

What matches:
- With EncRate 1 you get a forced encounter (before it was 2)
- With 2 a forced after 2 (before it was 3)

Higher numbers are harder to test due to randomness involved.

Fix #2903