### PR TITLE
Interpreter: Implement Maniac SetGameOption operation 1 (variable count)

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -2818,10 +2818,7 @@ bool Game_Interpreter::CommandShowPicture(lcf::rpg::EventCommand const& com) { /
 			pic_id = ValueOrVariable(com.parameters[17], pic_id);
 		}
 		if (com.parameters[19] != 0) {
-			int var = 0;
-			if (Main_Data::game_variables->IsValid(com.parameters[19])) {
-				var = Main_Data::game_variables->Get(com.parameters[19]);
-			}
+			int var = Main_Data::game_variables->Get(com.parameters[19]);
 			params.name = PicPointerPatch::ReplaceName(params.name, var, com.parameters[18]);
 		}
 
@@ -5011,6 +5008,7 @@ bool Game_Interpreter::CommandManiacSetGameOption(lcf::rpg::EventCommand const& 
 	//int value = ValueOrVariable(com.parameters[0], com.parameters[2]);
 
 	switch (operation) {
+		case 1: // Set variable count (noop, Player auto-expands the variable array on access)
 		case 2: // Change Picture Limit (noop, we support arbitrary amount of pictures)
 			break;
 		default:


### PR DESCRIPTION
maniac: Fix PicPointer variable lookup in CommandShowPicture

The IsValid guard was unnecessary since Get() already returns 0 safely
for out-of-bounds variable IDs. Removing it also fixes the case where
the variable array hasn't grown yet to the requested index.

SetGameOption operation 1 is now a no-op since the Player auto-expands
the variable array on Set(), making pre-allocation unnecessary.

Remove the redundant IsValid guard before Get() in CommandShowPicture's PicPointer handling — Get() already returns 0 safely for any variable ID. Implement SetGameOption operation 1 as a no-op since the variable array auto-expands on write.