### PR TITLE
Implement Maniacs Battle Common Events (Second Try)

### DIFF
--- a/src/game_battle.cpp
+++ b/src/game_battle.cpp
@@ -20,6 +20,7 @@
 #include <lcf/data.h>
 #include "player.h"
 #include "game_actors.h"
+#include "game_commonevent.h"
 #include "game_enemyparty.h"
 #include "game_message.h"
 #include "game_party.h"
@@ -43,6 +44,8 @@ namespace Game_Battle {
 	std::string background_name;
 
 	std::unique_ptr<Game_Interpreter_Battle> interpreter;
+	std::vector<Game_CommonEvent> common_events;
+
 	/** Contains battle related sprites */
 	std::unique_ptr<Spriteset_Battle> spriteset;
 
@@ -76,9 +79,18 @@ void Game_Battle::Init(int troop_id) {
 	animation_actors.reset();
 	animation_enemies.reset();
 
+	InitCommonEvents();
 
 	for (auto* actor: Main_Data::game_party->GetActors()) {
 		actor->ResetEquipmentStates(true);
+	}
+}
+
+void Game_Battle::InitCommonEvents() {
+	common_events.clear();
+	common_events.reserve(lcf::Data::commonevents.size());
+	for (const lcf::rpg::CommonEvent& ev : lcf::Data::commonevents) {
+		common_events.emplace_back(ev.ID, false);
 	}
 }
 
@@ -88,6 +100,7 @@ void Game_Battle::Quit() {
 	}
 
 	interpreter.reset();
+	common_events.clear();
 	spriteset.reset();
 	animation_actors.reset();
 	animation_enemies.reset();
@@ -274,6 +287,10 @@ Game_Interpreter& Game_Battle::GetInterpreter() {
 Game_Interpreter_Battle& Game_Battle::GetInterpreterBattle() {
 	assert(interpreter);
 	return *interpreter;
+}
+
+std::vector<Game_CommonEvent>& Game_Battle::GetCommonEvents() {
+	return common_events;
 }
 
 void Game_Battle::SetTerrainId(int id) {

--- a/src/game_battle.h
+++ b/src/game_battle.h
@@ -48,6 +48,11 @@ namespace Game_Battle {
 	 */
 	void Init(int troop_id);
 
+	/**
+	 * Initializes Common Events.
+	 */
+	void InitCommonEvents();
+
 	/** @return true if a battle is currently running */
 	bool IsBattleRunning();
 
@@ -140,6 +145,13 @@ namespace Game_Battle {
 	 * @return the battle game interpreter.
 	 */
 	Game_Interpreter_Battle& GetInterpreterBattle();
+
+	/**
+	 * Gets common events list.
+	 *
+	 * @return common events list.
+	 */
+	std::vector<Game_CommonEvent>& GetCommonEvents();
 
 	void SetTerrainId(int id);
 	int GetTerrainId();

--- a/src/game_commonevent.cpp
+++ b/src/game_commonevent.cpp
@@ -17,28 +17,37 @@
 
 // Headers
 #include "game_commonevent.h"
+#include "game_interpreter_battle.h"
 #include "game_map.h"
 #include "game_switches.h"
 #include "game_interpreter_map.h"
 #include "main_data.h"
 #include <lcf/reader_util.h>
 #include <cassert>
+#include <lcf/rpg/commonevent.h>
+#include <lcf/rpg/eventcommand.h>
 
-Game_CommonEvent::Game_CommonEvent(int common_event_id) :
-	common_event_id(common_event_id)
+Game_CommonEvent::Game_CommonEvent(int common_event_id, bool on_map) :
+	common_event_id(common_event_id), on_map(on_map)
 {
 	auto* ce = lcf::ReaderUtil::GetElement(lcf::Data::commonevents, common_event_id);
 
-	if (ce->trigger == lcf::rpg::EventPage::Trigger_parallel
+	if (on_map && ce->trigger == lcf::rpg::CommonEvent::Trigger_parallel
 			&& !ce->event_commands.empty()) {
 		interpreter.reset(new Game_Interpreter_Map());
 		interpreter->Push<InterpreterExecutionType::Parallel>(this);
 	}
 
-
+	if (!on_map && ce->trigger == lcf::rpg::CommonEvent::Trigger_maniac_battle_parallel
+			&& !ce->event_commands.empty()) {
+		interpreter.reset(new Game_Interpreter_Battle(false));
+		interpreter->Push<InterpreterExecutionType::BattleParallel>(this);
+	}
 }
 
 void Game_CommonEvent::SetSaveData(const lcf::rpg::SaveEventExecState& data) {
+	assert(on_map);
+
 	// RPG_RT Savegames have empty stacks for parallel events.
 	// We are LSD compatible but don't load these into interpreter.
 	if (!data.stack.empty() && !data.stack.front().commands.empty()) {
@@ -94,11 +103,13 @@ std::vector<lcf::rpg::EventCommand>& Game_CommonEvent::GetList() {
 }
 
 lcf::rpg::SaveEventExecState Game_CommonEvent::GetSaveData() {
+	assert(on_map);
+
 	lcf::rpg::SaveEventExecState state;
 	if (interpreter) {
 		state = interpreter->GetSaveState();
 	}
-	if (GetTrigger() == lcf::rpg::EventPage::Trigger_parallel && state.stack.empty()) {
+	if (GetTrigger() == lcf::rpg::CommonEvent::Trigger_parallel && state.stack.empty()) {
 		// RPG_RT always stores an empty stack frame for parallel events.
 		state.stack.push_back({});
 	}
@@ -107,13 +118,24 @@ lcf::rpg::SaveEventExecState Game_CommonEvent::GetSaveData() {
 
 bool Game_CommonEvent::IsWaitingForegroundExecution() const {
 	auto* ce = lcf::ReaderUtil::GetElement(lcf::Data::commonevents, common_event_id);
-	return ce->trigger == lcf::rpg::EventPage::Trigger_auto_start &&
+	return ce->trigger == lcf::rpg::CommonEvent::Trigger_automatic &&
+		(!ce->switch_flag || Main_Data::game_switches->Get(ce->switch_id))
+		&& !ce->event_commands.empty();
+}
+
+bool Game_CommonEvent::IsWaitingBattleStartExecution() const {
+	auto* ce = lcf::ReaderUtil::GetElement(lcf::Data::commonevents, common_event_id);
+	return ce->trigger == lcf::rpg::CommonEvent::Trigger_maniac_battle_start &&
 		(!ce->switch_flag || Main_Data::game_switches->Get(ce->switch_id))
 		&& !ce->event_commands.empty();
 }
 
 bool Game_CommonEvent::IsWaitingBackgroundExecution(bool force_run) const {
 	auto* ce = lcf::ReaderUtil::GetElement(lcf::Data::commonevents, common_event_id);
-	return ce->trigger == lcf::rpg::EventPage::Trigger_parallel &&
+	const auto trigger = on_map ?
+		lcf::rpg::CommonEvent::Trigger_parallel :
+		lcf::rpg::CommonEvent::Trigger_maniac_battle_parallel;
+
+	return ce->trigger == trigger &&
 		(force_run || !ce->switch_flag || Main_Data::game_switches->Get(ce->switch_id));
 }

--- a/src/game_commonevent.h
+++ b/src/game_commonevent.h
@@ -38,7 +38,7 @@ public:
 	 *
 	 * @param common_event_id database common event ID.
 	 */
-	explicit Game_CommonEvent(int common_event_id);
+	explicit Game_CommonEvent(int common_event_id, bool on_map = true);
 
 	/**
 	 * Set savegame data.
@@ -109,19 +109,31 @@ public:
 	/** @return true if waiting for foreground execution */
 	bool IsWaitingForegroundExecution() const;
 
+	/** @return true if waiting for execution when battle starts */
+	bool IsWaitingBattleStartExecution() const;
+
 	/**
 	 * @param force_run force the event to execute even if conditions not met.
 	 * @return true if waiting for background execution
 	 */
 	bool IsWaitingBackgroundExecution(bool force_run) const;
 
+	const Game_Interpreter* GetInterpreter() const;
+
 private:
 	int common_event_id;
 
+	/** Indicates whether these common events run on the map (false = on battle) */
+	bool on_map;
+
 	/** Interpreter for parallel common events. */
-	std::unique_ptr<Game_Interpreter_Map> interpreter;
+	std::unique_ptr<Game_Interpreter> interpreter;
 
 	friend class Game_Interpreter_Inspector;
 };
+
+inline const Game_Interpreter* Game_CommonEvent::GetInterpreter() const {
+	return interpreter.get();
+}
 
 #endif

--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -144,6 +144,11 @@ void Game_Interpreter::PushInternal(
 	_state.stack.push_back(std::move(frame));
 }
 
+void Game_Interpreter::SetState(const lcf::rpg::SaveEventExecState& save) {
+	Clear();
+	_state = save;
+	_keyinput.fromSave(save);
+}
 
 void Game_Interpreter::KeyInputState::fromSave(const lcf::rpg::SaveEventExecState& save) {
 	*this = {};

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -89,12 +89,19 @@ public:
 	bool ExecuteCommand();
 	virtual bool ExecuteCommand(lcf::rpg::EventCommand const& com);
 
-
 	/**
 	 * Returns the interpreters current state information.
 	 * For saving state into a save file, use GetSaveState instead.
 	 */
 	const lcf::rpg::SaveEventExecState& GetState() const override;
+
+	/**
+	 * Sets up the interpreter with given state.
+	 *
+	 * @param save event to load.
+	 *
+	 */
+	void SetState(const lcf::rpg::SaveEventExecState& save);
 
 	/**
 	 * Returns a SaveEventExecState needed for the savefile.
@@ -122,7 +129,7 @@ public:
 	void ClearOriginalEventId();
 
 	/** Return true if the interpreter is waiting for an async operation and needs to be resumed */
-	bool IsAsyncPending();
+	bool IsAsyncPending() const;
 
 	/** Return true if the interpreter is waiting for an async operation and needs to be resumed */
 	AsyncOp GetAsyncOp() const;
@@ -412,6 +419,7 @@ inline void Game_Interpreter::Push(Game_Event* ev, const lcf::rpg::EventPage* pa
 template<InterpreterExecutionType type_ex>
 inline void Game_Interpreter::Push(Game_CommonEvent* ev) {
 	static_assert(type_ex == InterpreterExecutionType::AutoStart || type_ex == InterpreterExecutionType::Parallel
+		|| type_ex == InterpreterExecutionType::BattleStart || type_ex == InterpreterExecutionType::BattleParallel
 		|| type_ex == InterpreterExecutionType::Call || type_ex == InterpreterExecutionType::DeathHandler
 		|| type_ex == InterpreterExecutionType::DebugCall || type_ex == InterpreterExecutionType::ManiacHook, "Unexpected ExecutionType for CommonEvent"
 	);
@@ -457,7 +465,7 @@ inline int Game_Interpreter::GetLoopCount() const {
 	return loop_count;
 }
 
-inline bool Game_Interpreter::IsAsyncPending() {
+inline bool Game_Interpreter::IsAsyncPending() const {
 	return GetAsyncOp().IsActive();
 }
 

--- a/src/game_interpreter_battle.cpp
+++ b/src/game_interpreter_battle.cpp
@@ -77,8 +77,8 @@ Game_Interpreter_Battle::Game_Interpreter_Battle(Span<const lcf::rpg::TroopPage>
 	maniac_interpreter.reset(new Game_Interpreter_Battle());
 }
 
-Game_Interpreter_Battle::Game_Interpreter_Battle()
-	: Game_Interpreter(true)
+Game_Interpreter_Battle::Game_Interpreter_Battle(bool main_flag)
+	: Game_Interpreter(main_flag)
 {
 }
 

--- a/src/game_interpreter_battle.h
+++ b/src/game_interpreter_battle.h
@@ -40,7 +40,7 @@ class Game_Interpreter_Battle : public Game_Interpreter
 {
 public:
 	explicit Game_Interpreter_Battle(Span<const lcf::rpg::TroopPage> pages);
-	explicit Game_Interpreter_Battle();
+	explicit Game_Interpreter_Battle(bool main_flag = true);
 
 	int GetNumPages() const;
 

--- a/src/game_interpreter_control_variables.cpp
+++ b/src/game_interpreter_control_variables.cpp
@@ -135,7 +135,7 @@ int ControlVariables::Actor(int op, int actor_id) {
 		case 16:
 			// ATB
 			if (Player::IsPatchManiac()) {
-				return actor->GetAtbGauge();
+				return actor->GetAtbGauge() * 100 / actor->GetMaxAtbGauge();
 			}
 			break;
 	}

--- a/src/game_interpreter_map.cpp
+++ b/src/game_interpreter_map.cpp
@@ -83,12 +83,6 @@ enum InnSubcommand {
 
 using namespace Game_Interpreter_Shared;
 
-void Game_Interpreter_Map::SetState(const lcf::rpg::SaveEventExecState& save) {
-	Clear();
-	_state = save;
-	_keyinput.fromSave(save);
-}
-
 void Game_Interpreter_Map::OnMapChange() {
 	// When we change the map, we reset all event id's to 0.
 	for (auto& frame: _state.stack) {

--- a/src/game_interpreter_map.h
+++ b/src/game_interpreter_map.h
@@ -39,14 +39,6 @@ public:
 	using Game_Interpreter::Game_Interpreter;
 
 	/**
-	 * Sets up the interpreter with given state.
-	 *
-	 * @param save event to load.
-	 *
-	 */
-	void SetState(const lcf::rpg::SaveEventExecState& save);
-
-	/**
 	 * Called when we change maps.
 	 */
 	void OnMapChange();
@@ -87,12 +79,6 @@ private:
 	bool CommandEasyRpgPathfinder(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgWaitForSingleMovement(lcf::rpg::EventCommand const& com);
 	AsyncOp ContinuationShowInnStart(int indent, int choice_result, int price);
-
-	bool CommandSmartMoveRoute(
-		lcf::rpg::EventCommand const& com,
-		int maxRouteStepsDefault, int maxSearchStepsDefault,
-		int abortIfAlreadyMovingDefault
-	);  // Internal generic path finder function.
 
 	static std::vector<Game_Character*> pending;
 };

--- a/src/scene_battle.cpp
+++ b/src/scene_battle.cpp
@@ -25,6 +25,7 @@
 #include "player.h"
 #include "transition.h"
 #include "game_battlealgorithm.h"
+#include "game_commonevent.h"
 #include "game_interpreter_battle.h"
 #include "game_message.h"
 #include "game_system.h"
@@ -270,11 +271,7 @@ void Scene_Battle::UpdateUi() {
 	Game_Message::Update();
 }
 
-bool Scene_Battle::UpdateEvents() {
-	auto& interp = Game_Battle::GetInterpreterBattle();
-	interp.Update();
-	status_window->Refresh();
-
+bool Scene_Battle::CheckInterpreter(const Game_Interpreter_Battle& interp) {
 	if (interp.IsForceFleeEnabled()) {
 		if (state != State_Escape) {
 			SetState(State_Escape);
@@ -302,6 +299,37 @@ bool Scene_Battle::UpdateEvents() {
 	return true;
 }
 
+bool Scene_Battle::UpdateEvents() {
+	auto& interp = Game_Battle::GetInterpreterBattle();
+	interp.Update();
+	status_window->Refresh();
+
+	return CheckInterpreter(Game_Battle::GetInterpreterBattle());
+}
+
+bool Scene_Battle::UpdateCommonEvents() {
+	if (!Player::IsPatchManiac()) {
+		return true;
+	}
+
+	auto& common_events = Game_Battle::GetCommonEvents();
+
+	// TODO: Async handling not properly implemented
+	// Async requests that yield the Web Player will not work correctly
+	for (auto& ce: common_events) {
+		ce.Update(false);
+		const auto* interp = static_cast<const Game_Interpreter_Battle*>(ce.GetInterpreter());
+		if (interp && !CheckInterpreter(*interp)) {
+			status_window->Refresh();
+			return false;
+		}
+	}
+
+	status_window->Refresh();
+
+	return true;
+}
+
 bool Scene_Battle::UpdateTimers() {
 	const int timer1 = Main_Data::game_party->GetTimerSeconds(Game_Party::Timer1);
 	const int timer2 = Main_Data::game_party->GetTimerSeconds(Game_Party::Timer2);
@@ -321,6 +349,25 @@ bool Scene_Battle::UpdateTimers() {
 
 void Scene_Battle::UpdateGraphics() {
 	Game_Battle::UpdateGraphics();
+}
+
+bool Scene_Battle::ScheduleNextBattleBeginCommonEvent() {
+	if (!Player::IsPatchManiac()) {
+		return false;
+	}
+
+	auto& common_events = Game_Battle::GetCommonEvents();
+
+	for (size_t i = last_scheduled_start_battle_event + 1; i < common_events.size(); ++i) {
+		auto& ce = common_events[i];
+		last_scheduled_start_battle_event = i;
+		if (ce.IsWaitingBattleStartExecution()) {
+			Game_Battle::GetInterpreterBattle().Push<InterpreterExecutionType::BattleParallel>(&ce);
+			return true;
+		}
+	}
+
+	return false;
 }
 
 bool Scene_Battle::IsWindowMoving() {

--- a/src/scene_battle.h
+++ b/src/scene_battle.h
@@ -28,6 +28,7 @@
 #include "drawable.h"
 #include "game_actor.h"
 #include "game_enemy.h"
+#include "game_interpreter_battle.h"
 #include "scene.h"
 #include "spriteset_battle.h"
 #include "window_help.h"
@@ -84,9 +85,13 @@ public:
 	void UpdateScreen();
 	void UpdateBattlers();
 	void UpdateUi();
+	bool CheckInterpreter(const Game_Interpreter_Battle& interp);
 	bool UpdateEvents();
+	bool UpdateCommonEvents();
 	bool UpdateTimers();
 	void UpdateGraphics() override;
+
+	bool ScheduleNextBattleBeginCommonEvent();
 
 	void Continue(SceneType prev_scene) override;
 	void TransitionIn(SceneType prev_scene) override;
@@ -154,7 +159,7 @@ protected:
 
 	/**
 	 * Executed when selection an action (normal, skill, item, ...) and
-	 * (if needed) choosing an attack target was finished. 
+	 * (if needed) choosing an attack target was finished.
 	 *
 	 * @param for_battler Battler whose action was selected.
 	 */
@@ -205,6 +210,9 @@ protected:
 
 	/** Options available in the menu. */
 	std::vector<BattleOptionType> battle_options;
+
+	/** ID of last invoked start battle event */
+	int last_scheduled_start_battle_event = -1;
 };
 
 inline bool Scene_Battle::IsEscapeAllowed() const {

--- a/src/scene_battle_rpg2k.cpp
+++ b/src/scene_battle_rpg2k.cpp
@@ -220,6 +220,7 @@ void Scene_Battle_Rpg2k::vUpdate() {
 		}
 	}
 
+	UpdateCommonEvents();
 	Game_Battle::UpdateGraphics();
 }
 
@@ -234,6 +235,10 @@ void Scene_Battle_Rpg2k::NextTurn() {
 
 bool Scene_Battle_Rpg2k::CheckBattleEndAndScheduleEvents() {
 	if (CheckBattleEndConditions()) {
+		return false;
+	}
+
+	if (ScheduleNextBattleBeginCommonEvent()) {
 		return false;
 	}
 

--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -987,6 +987,7 @@ void Scene_Battle_Rpg2k3::vUpdate() {
 		}
 	}
 
+	UpdateCommonEvents();
 	UpdateAnimations();
 	UpdateGraphics();
 }
@@ -1029,6 +1030,10 @@ bool Scene_Battle_Rpg2k3::CheckBattleEndAndScheduleEvents(EventTriggerType tt, G
 	}
 
 	if (CheckBattleEndConditions()) {
+		return false;
+	}
+
+	if (ScheduleNextBattleBeginCommonEvent()) {
 		return false;
 	}
 


### PR DESCRIPTION
See #3307 with the difference that it hooks directly into our `Game_CommonEvent` class to make the parallel events execute as intended.

Imo this is closer than #3307 but still not perfect, especially when the Parallel events show messages. When no messages are shown it appears to be... okay (?)

---

**I need testers for this!** I don't really know of alot of games that use this Battle stuff and are not 100 million lines of event voodoo. So this is hard to test.

**Your task**: Throw this Player PR at games that use this feature and _even better_ figure out where it fails in the event code.

When I don't get enough useful reports this PR will never be merged as I won't integrate untested code into the Player. Thank you for your attention.

---

Also noticed a bug in the Get ATB function: It must return the percentage

