### PR TITLE
Reduced re-drawing of Window_Command

### DIFF
--- a/src/scene_battle_rpg2k3.cpp
+++ b/src/scene_battle_rpg2k3.cpp
@@ -612,41 +612,26 @@ void Scene_Battle_Rpg2k3::CreateBattleStatusWindow() {
 	status_window->SetZ(Priority_Window + 1);
 }
 
-std::vector<std::string> Scene_Battle_Rpg2k3::GetBattleCommandNames(const Game_Actor* actor) {
-	std::vector<std::string> commands;
+void Scene_Battle_Rpg2k3::GetBattleCommandNames(const Game_Actor* actor, std::vector<std::string>* commands, std::vector<bool>* commands_enabled) {
 	if (actor) {
 		for (auto* cmd: actor->GetBattleCommands()) {
-			commands.push_back(ToString(cmd->name));
+			commands->push_back(ToString(cmd->name));
+			bool is_enabled = !(cmd->type == lcf::rpg::BattleCommand::Type_escape && !IsEscapeAllowedFromActorCommand());
+			commands_enabled->push_back(is_enabled);
 		}
 	}
 	if (Feature::HasRow() && lcf::Data::battlecommands.easyrpg_enable_battle_row_command) {
-		commands.push_back(ToString(lcf::Data::terms.row));
-	}
-
-	return commands;
-}
-
-void Scene_Battle_Rpg2k3::SetBattleCommandsDisable(Window_Command& window, const Game_Actor* actor) {
-	if (actor) {
-		const auto& cmds = actor->GetBattleCommands();
-		for (size_t i = 0; i < cmds.size(); ++i) {
-			auto* cmd = cmds[i];
-			if (cmd->type == lcf::rpg::BattleCommand::Type_escape && !IsEscapeAllowedFromActorCommand()) {
-				window.DisableItem(i);
-			} else {
-				window.EnableItem(i);
-			}
-		}
+		commands->push_back(ToString(lcf::Data::terms.row));
+		commands_enabled->push_back(true);
 	}
 }
 
 void Scene_Battle_Rpg2k3::CreateBattleCommandWindow() {
 	auto* actor = Main_Data::game_party->GetActor(0);
-	auto commands = GetBattleCommandNames(actor);
-
-	command_window.reset(new Window_Command(std::move(commands), option_command_mov));
-
-	SetBattleCommandsDisable(*command_window, actor);
+	std::vector<std::string> commands;
+	std::vector<bool> commands_enabled;
+	GetBattleCommandNames(actor, &commands, &commands_enabled);
+	command_window.reset(new Window_Command(std::move(commands), option_command_mov, -1, &commands_enabled));
 
 	int height = 80;
 
@@ -675,9 +660,10 @@ void Scene_Battle_Rpg2k3::CreateBattleCommandWindow() {
 }
 
 void Scene_Battle_Rpg2k3::RefreshCommandWindow(const Game_Actor* actor) {
-	auto commands = GetBattleCommandNames(actor);
-	command_window->ReplaceCommands(std::move(commands));
-	SetBattleCommandsDisable(*command_window, actor);
+	std::vector<std::string> commands;
+	std::vector<bool> commands_enabled;
+	GetBattleCommandNames(actor, &commands, &commands_enabled);
+	command_window->ReplaceCommands(std::move(commands), &commands_enabled);
 	command_window->SetIndex(-1);
 }
 

--- a/src/scene_battle_rpg2k3.h
+++ b/src/scene_battle_rpg2k3.h
@@ -213,8 +213,7 @@ protected:
 	BattleActionReturn ProcessBattleActionPostEvents(Game_BattleAlgorithm::AlgorithmBase* action);
 	BattleActionReturn ProcessBattleActionFinished(Game_BattleAlgorithm::AlgorithmBase* action);
 
-	std::vector<std::string> GetBattleCommandNames(const Game_Actor* actor);
-	void SetBattleCommandsDisable(Window_Command& window, const Game_Actor* actor);
+	void GetBattleCommandNames(const Game_Actor* actor, std::vector<std::string>* commands, std::vector<bool>* commands_enabled);
 
 	std::unique_ptr<Sprite> ally_cursor, enemy_cursor;
 

--- a/src/window_command.cpp
+++ b/src/window_command.cpp
@@ -33,21 +33,24 @@ static int CalculateWidth(const std::vector<std::string>& commands, int width) {
 	}
 }
 
-Window_Command::Window_Command(std::vector<std::string> in_commands, int width, int max_item) :
+Window_Command::Window_Command(std::vector<std::string> in_commands, int width, int max_item, std::vector<bool>* in_commands_enabled) :
 	Window_Selectable(0, 0, CalculateWidth(in_commands, width), (max_item < 0 ? in_commands.size() : max_item) * 16 + 16)
 {
-	ReplaceCommands(std::move(in_commands));
+	ReplaceCommands(std::move(in_commands), in_commands_enabled);
 }
 
 void Window_Command::Refresh() {
 	contents->Clear();
 	for (int i = 0; i < item_max; i++) {
-		DrawItem(i, IsItemEnabled(i) ? Font::ColorDefault : Font::ColorDisabled);
+		DrawItem(i, GetItemColor(index));
 	}
 }
 
-void Window_Command::DrawItem(int index, Font::SystemColor color) {
+void Window_Command::ClearItem(int index) {
 	contents->ClearRect(Rect(0, menu_item_height * index, contents->GetWidth() - 0, menu_item_height));
+}
+
+void Window_Command::DrawItem(int index, Font::SystemColor color) {
 	contents->TextDraw(0, menu_item_height * index + menu_item_height / 8, color, commands[index]);
 }
 
@@ -60,8 +63,11 @@ void Window_Command::EnableItem(int i) {
 }
 
 void Window_Command::SetItemEnabled(int index, bool enabled) {
-	DrawItem(index, enabled ? Font::ColorDefault : Font::ColorDisabled);
-	commands_enabled[index] = enabled;
+	if (index < commands.size() && commands_enabled[index] != enabled) {
+		commands_enabled[index] = enabled;
+		ClearItem(index);
+		DrawItem(index, GetItemColor(index));
+	}
 }
 
 bool Window_Command::IsItemEnabled(int index) {
@@ -73,21 +79,43 @@ bool Window_Command::IsItemEnabled(int index) {
 }
 
 void Window_Command::SetItemText(unsigned index, std::string_view text) {
-	if (index < commands.size()) {
+	if (index < commands.size() && commands[index].compare(text) != 0) {
 		commands[index] = ToString(text);
-		DrawItem(index, IsItemEnabled(index) ? Font::ColorDefault : Font::ColorDisabled);
+		ClearItem(index);
+		DrawItem(index, GetItemColor(index));
 	}
 }
 
-void Window_Command::ReplaceCommands(std::vector<std::string> in_commands) {
-	commands = std::move(in_commands);
-	commands_enabled.clear();
-	commands_enabled.resize(commands.size(), true);
-	index = 0;
-	item_max = commands.size();
-	const int num_contents = item_max > 0 ? item_max : 1;
-	SetContents(Bitmap::Create(this->width - 16, num_contents * menu_item_height));
+void Window_Command::ReplaceCommands(std::vector<std::string> in_commands, std::vector<bool>* in_commands_enabled) {
+	bool redraw_all = false;
+
+	// If the number of commands changes, then the size of the underlying bitmap 
+	// changes, and everything will need to be redrawn.
+	if (in_commands.size() != commands.size()) {
+		redraw_all = true;
+		commands.resize(in_commands.size(), "");
+		commands_enabled.resize(in_commands.size(), true);
+		item_max = in_commands.size();
+		const int num_contents = item_max > 0 ? item_max : 1;
+		SetContents(Bitmap::Create(this->width - 16, num_contents * menu_item_height));
+	}
+	
 	SetTopRow(0);
 
-	Refresh();
+	for (int i = 0; i < in_commands.size(); i++) {
+		// If NULL was passed for in_commands_enabled, all commands are enabled
+		bool command_enabled_in = in_commands_enabled ? (*in_commands_enabled)[i] : true;
+		if (redraw_all || command_enabled_in != commands_enabled[i] || commands[i].compare(in_commands[i]) != 0) {
+			commands[i] = in_commands[i];
+			commands_enabled[i] = command_enabled_in;
+			if (!redraw_all) {
+				ClearItem(i);
+			}
+			DrawItem(i, GetItemColor(i));
+		}
+	}
 }
+
+Font::SystemColor Window_Command::GetItemColor(int index) {
+	return IsItemEnabled(index) ? Font::ColorDefault : Font::ColorDisabled;
+};

--- a/src/window_command.cpp
+++ b/src/window_command.cpp
@@ -100,6 +100,7 @@ void Window_Command::ReplaceCommands(std::vector<std::string> in_commands, std::
 		SetContents(Bitmap::Create(this->width - 16, num_contents * menu_item_height));
 	}
 	
+	index = 0;
 	SetTopRow(0);
 
 	for (int i = 0; i < in_commands.size(); i++) {

--- a/src/window_command.h
+++ b/src/window_command.h
@@ -35,10 +35,13 @@ public:
 	 * @param width window width, if no width is passed
 	 *              the width is autocalculated.
 	 * @param max_item forces a window height for max_item
-	 *                 items, if no height is passed
-	 *                 the height is autocalculated.
+	 *             	items, if no height is passed
+	 *              the height is autocalculated.
+	 * @param commands_enabled whether each command is 
+	 * 				selectable. if NULL, all commands 
+	 * 				are enabled.
 	 */
-	Window_Command(std::vector<std::string> commands, int width = -1, int max_item = -1);
+	Window_Command(std::vector<std::string> commands, int width = -1, int max_item = -1, std::vector<bool>* commands_enabled=NULL);
 
 	/**
 	 * Refreshes the window contents.
@@ -87,15 +90,19 @@ public:
 	 * Replace all commands with a new command set.
 	 *
 	 * @param commands the commands to replace with
+	 * @param commands_enabled whether each command is selectable. 
+	 * 				if NULL, all commands are enabled.
 	 * @note auto-generating width and height is not supported.
 	 */
-	void ReplaceCommands(std::vector<std::string> commands);
+	void ReplaceCommands(std::vector<std::string> commands, std::vector<bool>* commands_enabled=NULL);
 
 protected:
 	std::vector<std::string> commands;
 	std::vector<bool> commands_enabled;
 
+	virtual void ClearItem(int index);
 	virtual void DrawItem(int index, Font::SystemColor color);
+	Font::SystemColor GetItemColor(int index);
 };
 
 #endif

--- a/src/window_command_horizontal.cpp
+++ b/src/window_command_horizontal.cpp
@@ -39,10 +39,13 @@ Window_Command_Horizontal::Window_Command_Horizontal(std::vector<std::string> in
 	ReplaceCommands(std::move(in_commands));
 }
 
+void Window_Command_Horizontal::ClearItem(int index) {
+	Rect rect = GetItemRect(index);
+	contents->ClearRect(rect);
+}
+
 void Window_Command_Horizontal::DrawItem(int index, Font::SystemColor color) {
 	Rect rect = GetItemRect(index);
-
-	contents->ClearRect(rect);
 	contents->TextDraw(rect.x, rect.y, color, commands[index]);
 }
 

--- a/src/window_command_horizontal.h
+++ b/src/window_command_horizontal.h
@@ -46,6 +46,7 @@ public:
 	void ReplaceCommands(std::vector<std::string> commands);
 
 protected:
+	void ClearItem(int index) override;
 	void DrawItem(int index, Font::SystemColor color) override;
 };
 


### PR DESCRIPTION
Used existing cache of displayed info to skip re-drawing of list items when their state hasn't changed.  This helps with frequent re-drawing of the player character battle command window in particular.

This is similar to, but independent from: https://github.com/EasyRPG/Player/pull/3580
(It turns out, both of these optimizations were needed together to smooth out battle FPS on Xbox)

It should hopefully help with these issues:
https://github.com/EasyRPG/Player/issues/3494
https://github.com/EasyRPG/Player/issues/3497