### PR TITLE
New Command 2059 - Game Loader Command

### DIFF
--- a/src/game_interpreter.cpp
+++ b/src/game_interpreter.cpp
@@ -825,6 +825,8 @@ bool Game_Interpreter::ExecuteCommand(lcf::rpg::EventCommand const& com) {
 			return CmdSetup<&Game_Interpreter::CommandEasyRpgCloneMapEvent, 10>(com);
 		case Cmd::EasyRpg_DestroyMapEvent:
 			return CmdSetup<&Game_Interpreter::CommandEasyRpgDestroyMapEvent, 2>(com);
+		case static_cast<Cmd>(2059):
+			return CmdSetup<&Game_Interpreter::CommandEasyRpgLoadGame, 4>(com);
 		default:
 			return true;
 	}
@@ -5929,6 +5931,117 @@ bool Game_Interpreter::CommandEasyRpgDestroyMapEvent(lcf::rpg::EventCommand cons
 	_async_op = AsyncOp::MakeDestroyMapEvent(target_event);
 
 	return true;
+}
+
+// Helper function for parsing MS-DOS style string with quotes and arguments
+static std::vector<std::string> ParseCLIString(const std::string& cmdline) {
+	std::vector<std::string> args;
+	std::string current;
+	bool in_quotes = false;
+
+	for (char c : cmdline) {
+		if (c == '"') {
+			in_quotes = !in_quotes;
+		}
+		else if (c == ' ' && !in_quotes) {
+			if (!current.empty()) {
+				args.push_back(current);
+				current.clear();
+			}
+		}
+		else {
+			current += c;
+		}
+	}
+	if (!current.empty()) args.push_back(current);
+
+	return args;
+}
+
+bool Game_Interpreter::CommandEasyRpgLoadGame(lcf::rpg::EventCommand const& com) {
+	if (!Player::HasEasyRpgExtensions()) {
+		return true;
+	}
+
+	// [0] Exit Behavior Type (0: Constant, 1: Variable)
+	// [1] Exit Behavior Value (0: Exit, 1: Parent Title, 2: Parent Map/Savestate)
+	int exit_behavior = ValueOrVariable(com.parameters[0], com.parameters[1]);
+
+	// [2] Target String Type (0: String Literal, 1: String Var Const, 2: String Var from Var)
+	// [3] Target String Value (Ignored for 0, otherwise ID of String Var)
+	std::string cmd;
+	if (com.parameters[2] == 0) {
+		cmd = ToString(com.string);
+		cmd = PendingMessage::ApplyTextInsertingCommands(cmd, Player::escape_char, Game_Message::CommandCodeInserter);
+	}
+	else {
+		int str_var_id = ValueOrVariable(com.parameters[2] - 1, com.parameters[3]);
+		cmd = ToString(Main_Data::game_strings->Get(str_var_id));
+	}
+
+	std::vector<std::string> parsed_args = ParseCLIString(cmd);
+	if (parsed_args.empty()) {
+		Output::Warning("CommandEasyRpgLoadGame: Empty game string.");
+		return true;
+	}
+
+
+
+	std::string subgame_path = parsed_args[0];
+
+	auto new_fs = FileFinder::Game().Create(subgame_path);
+	if (!new_fs || FileFinder::GetProjectType(new_fs) > FileFinder::ProjectType::Supported) {
+		Output::Warning("CommandEasyRpgLoadGame: Invalid game path or unsupported engine: {}", subgame_path);
+		return true;
+	}
+
+	Player::ParentGame parent;
+	parent.arguments = Player::arguments;
+	parent.game_fs = FileFinder::Game();
+	parent.save_fs = FileFinder::Save();
+	parent.exit_behavior = exit_behavior;
+	parent.save_slot = 900000; // Store states in a dedicated/invisible slot
+
+	GetFrame().current_command++;
+
+	if (exit_behavior == 2) {
+		Scene_Save::Save(parent.save_fs, parent.save_slot, true);
+	}
+	Player::parent_games.push_back(parent);
+
+	std::vector<std::string> final_args = { "easyrpg-player" };
+	final_args.insert(final_args.end(), parsed_args.begin() + 1, parsed_args.end());
+	Player::arguments = final_args;
+
+	Player::load_game_id = 0;
+	for (size_t i = 1; i < parsed_args.size(); ++i) {
+		if (parsed_args[i] == "--load-game-id" && i + 1 < parsed_args.size()) {
+			Player::load_game_id = std::stoi(parsed_args[i + 1]);
+		}
+		else if (parsed_args[i] == "--test-play") {
+			Player::debug_flag = true;
+		}
+	}
+
+	// Clear active transitions to prevent dangling pointers
+	Transition::instance().Init(Transition::TransitionNone, nullptr, 0, false);
+
+	Main_Data::game_system->BgmStop();
+	Cache::ClearAll();
+	AudioSeCache::Clear();
+	MidiDecoder::Reset();
+	lcf::Data::Clear();
+
+	Player::RestoreBaseResolution();
+	Player::has_custom_resolution = false;
+
+	FileFinder::SetGameFilesystem(new_fs);
+	FileFinder::SetSaveFilesystem(FilesystemView());
+
+	Scene::PopUntil(Scene::Null);
+	Scene::Push(std::make_shared<Scene_Logo>());
+
+	return false; // Yield interpreter cleanly
 }
 
 Game_Interpreter& Game_Interpreter::GetForegroundInterpreter() {

--- a/src/game_interpreter.h
+++ b/src/game_interpreter.h
@@ -26,6 +26,10 @@
 #include "game_character.h"
 #include "game_actor.h"
 #include "game_interpreter_shared.h"
+#include "audio_secache.h"
+#include "audio_midi.h"
+#include "scene_logo.h"
+#include "scene_save.h"
 #include <lcf/dbarray.h>
 #include <lcf/rpg/fwd.h>
 #include <lcf/rpg/eventcommand.h>
@@ -311,6 +315,7 @@ protected:
 	bool CommandEasyRpgProcessJson(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgCloneMapEvent(lcf::rpg::EventCommand const& com);
 	bool CommandEasyRpgDestroyMapEvent(lcf::rpg::EventCommand const& com);
+	bool CommandEasyRpgLoadGame(lcf::rpg::EventCommand const& com);
 	bool CommandManiacGetGameInfo(lcf::rpg::EventCommand const& com);
 
 	void SetSubcommandIndex(int indent, int idx);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -76,6 +76,7 @@
 #include "game_quit.h"
 #include "scene_settings.h"
 #include "scene_title.h"
+#include "scene_save.h"
 #include "instrumentation.h"
 #include "transition.h"
 #include <lcf/scope_guard.h>
@@ -135,15 +136,18 @@ namespace Player {
 	int rng_seed = -1;
 	Game_ConfigPlayer player_config;
 	Game_ConfigGame game_config;
+
+	std::vector<ParentGame> parent_games;
+
 #ifdef __EMSCRIPTEN__
 	std::string emscripten_game_name;
 #endif
+
+	std::vector<std::string> arguments;
 	Game_Clock::time_point last_auto_screenshot;
 }
 
 namespace {
-	std::vector<std::string> arguments;
-
 	// Overwritten by --encoding
 	std::string forced_encoding;
 
@@ -167,7 +171,7 @@ void Player::Init(std::vector<std::string> args) {
 #endif
 
 	// First parse command line arguments
-	arguments = args;
+	Player::arguments = args;
 	auto cfg = ParseCommandLine();
 
 	// Display a nice version string
@@ -270,6 +274,10 @@ void Player::MainLoop() {
 	Scene::old_instances.clear();
 
 	if (!Transition::instance().IsActive() && Scene::instance->type == Scene::Null) {
+		if (!Player::parent_games.empty()) {
+			Player::RestoreParentGame();
+			return;
+		}
 		Exit();
 		return;
 	}
@@ -1657,4 +1665,46 @@ int Player::EngineVersion() {
 std::string Player::GetEngineVersion() {
 	if (EngineVersion() > 0) return std::to_string(EngineVersion());
 	return std::string();
+}
+
+
+void Player::RestoreParentGame() {
+	if (parent_games.empty()) return;
+
+	ParentGame parent = parent_games.back();
+	parent_games.pop_back();
+
+	Transition::instance().Init(Transition::TransitionNone, nullptr, 0, false);
+
+	Main_Data::game_system->BgmStop();
+	Cache::ClearAll();
+	AudioSeCache::Clear();
+	MidiDecoder::Reset();
+	lcf::Data::Clear();
+
+	Player::RestoreBaseResolution();
+	Player::has_custom_resolution = false;
+
+	Player::game_title = "";
+	Player::game_title_original = "";
+	Player::translation.Reset();
+	Font::ResetDefault();
+
+	FileFinder::SetGameFilesystem(parent.game_fs);
+	FileFinder::SetSaveFilesystem(parent.save_fs);
+	Player::arguments = parent.arguments;
+
+	Scene::PopUntil(Scene::Null);
+
+	if (parent.exit_behavior == 2) {
+		Player::load_game_id = parent.save_slot;
+		Scene::Push(std::make_shared<Scene_Logo>());
+	}
+	else if (parent.exit_behavior == 1) {
+		Player::load_game_id = 0;
+		Scene::Push(std::make_shared<Scene_Logo>());
+	}
+	else {
+		Player::exit_flag = true;
+	}
 }

--- a/src/player.h
+++ b/src/player.h
@@ -408,6 +408,9 @@ namespace Player {
 	/** Original game title, in case it was overriden by a translation. */
 	extern std::string game_title_original;
 
+	/** Command line arguments. */
+	extern std::vector<std::string> arguments;
+
 	/** Indicates whether FileFinder::Game() and Save() point to the same directory. */
 	extern bool shared_game_and_save_directory;
 
@@ -430,6 +433,18 @@ namespace Player {
 
 	/** game specific configuration */
 	extern Game_ConfigGame game_config;
+
+	struct ParentGame {
+		std::vector<std::string> arguments;
+		FilesystemView game_fs;
+		FilesystemView save_fs;
+		int exit_behavior;
+		int save_slot;
+	};
+
+	extern std::vector<ParentGame> parent_games;
+
+	void RestoreParentGame();
 
 #ifdef __EMSCRIPTEN__
 	/** Name of game emscripten uses */

--- a/src/transition.h
+++ b/src/transition.h
@@ -115,10 +115,10 @@ public:
 
 	bool FromErase() const;
 	bool ToErase() const;
+	void Init(Type type, Scene* linked_scene, int duration, bool erase);
 
 private:
 	Transition();
-	void Init(Type type, Scene *linked_scene, int duration, bool erase);
 
 	const uint32_t size_random_blocks = 4;
 


### PR DESCRIPTION
This command allows loading another game hosted in the same folder of current game. Useful for having a game split into chapters, or gamejams.

Syntax:

```js
@raw 2059, "[path and flags]",
0,1, // [0] Exit Behavior Type // [1] Exit Behavior Value (0: Exit, 1: Parent Title, 2: Parent Map/Savestate)
2,3 // [2] Target String Type // [3] Target String Value (Ignored for 0, otherwise ID of String Var)

```

example:
```js
@raw 2059, "dons_adventure", 0, 2 // loads dons_adventure, and return back to parent_game's previous map when closing it.

@raw 2059, """dons adventure"" --language EN", 1, 100 // when having space or using flag arguments "" "" is needed. also when leaving child game, what's happen is decided by variable 100

```


A test project that uses it:
[demo_loader.zip](https://github.com/user-attachments/files/30019882/demo_loader.zip)

