### PR TITLE
libretro: increase ANDROID_API to 21 for android builds

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -850,7 +850,7 @@
 			"name": "android-armeabi-v7a-parent",
 			"cacheVariables": {
 				"CMAKE_ANDROID_ARCH_ABI": "armeabi-v7a",
-				"CMAKE_ANDROID_API": "16"
+				"CMAKE_ANDROID_API": "21"
 			},
 			"inherits": "android-user",
 			"hidden": true
@@ -970,7 +970,7 @@
 			"name": "android-x86-parent",
 			"cacheVariables": {
 				"CMAKE_ANDROID_ARCH_ABI": "x86",
-				"CMAKE_ANDROID_API": "16"
+				"CMAKE_ANDROID_API": "21"
 			},
 			"inherits": "android-user",
 			"hidden": true

--- a/builds/cmake/CMakePresets.json.template
+++ b/builds/cmake/CMakePresets.json.template
@@ -85,7 +85,7 @@
 			"displayName": "Android armeabi-v7a",
 			"cacheVariables": {
 				"CMAKE_ANDROID_ARCH_ABI": "armeabi-v7a",
-				"CMAKE_ANDROID_API": "16"
+				"CMAKE_ANDROID_API": "21"
 			},
 			"inherits": "android-user",
 			"easyrpg_platforms": ["libretro"]
@@ -105,7 +105,7 @@
 			"displayName": "Android x86",
 			"cacheVariables": {
 				"CMAKE_ANDROID_ARCH_ABI": "x86",
-				"CMAKE_ANDROID_API": "16"
+				"CMAKE_ANDROID_API": "21"
 			},
 			"inherits": "android-user",
 			"easyrpg_platforms": ["libretro"]


### PR DESCRIPTION
https://github.com/libretro/easyrpg-libretro/issues/63

We now use NDK 29 on the libretro buildbot which does not support API level 16.

Hopefully fixes this:

```
Preparing ARMeabi-v7a toolchain **** Building zlib **** CMake Error at /opt/android-sdk-linux/cmake/3.30.3/share/cmake-3.30/Modules/Platform/Android-Determine.cmake:503 (message): Android: The API level 16 is not supported by the NDK. Choose one in the range of [21, 35].
```

There might be further issues after this.